### PR TITLE
Work with browser zoom

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -47,6 +47,8 @@ body {
 
 #grid {
   background: @black1;
+  height: 100vh;
+  overflow: hidden;
   position: relative;
 
   -webkit-touch-callout: none; /* iOS Safari */
@@ -64,32 +66,57 @@ body #grid * {
   }
 }
 
-#buttons {
-  position: absolute;
-  left: 0px;
-}
-
-.specialButton {
-  margin-right: 4px;
-
-  &#integrationTestSignal {
-    display: inline-block;
+#canvas {
+  display: block;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+  .node {
+    position: absolute;
   }
 }
 
-#darkErrors {
-  color: red;
+#buttons {
+  bottom: 0;
+  left: 0px;
+  position: absolute;
+
+  .specialButton {
+    margin-right: 4px;
+    &#integrationTestSignal {
+      display: inline-block;
+    }
+  }
+}
+
+#status {
+  &.error {
+    color: red;
+  }
 }
 
 .as-pointer {
   cursor: pointer;
 }
 
-
 .verb-link {
   &:hover {
     color: @orange;
     text-decoration: underline;
+  }
+}
+
+.axis {
+  background: #777;
+  height: 200%;
+  position: absolute;
+  transform: translate(0, -50%);
+  width: 1px;
+  &.horizontal {
+    height: 1px;
+    transform: translate(-50%, 0);
+    width: 200%;
   }
 }
 


### PR DESCRIPTION
We'd like the editor to work when the user's browser is at zoom levels other than 100% [Trello](https://trello.com/c/fGojkYsi/497-editor-doesnt-work-at-any-zoom-level-except-100)

Research found the editor breaking at non-100% zoom levels is likely due to a [longstanding SVG bug in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=510819).

We decided to refactor the view to stop using SVG in favor of plain HTML.

In this PR the editor has had all `<svg>` use removed and replaced with `<div>` that are absolutely positioned. The editor now works as expected at non-100% zoom levels.