### PR TITLE
Bug fix for dragging crash

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -756,8 +756,8 @@ update_ msg m =
       case m.state of
         Deselected ->
           Select targetTLID (Just targetID)
-        Dragging _ _ _ _ ->
-          Util.impossible "dragging should've concluded before here" NoChange
+        Dragging _ _ _ origState ->
+          SetState origState
         Entering cursor ->
           case cursor of
             Filling _ fillingID ->


### PR DESCRIPTION
I'd thought all dragging would be done before reaching this case, however turns out this isn't true. Dragging can still be the state here when drags are initiated by clicking on the blankor. So instead of crashing, let's conclude the drag.