### PR TITLE
stop stealing the blank's content on tab :)

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -690,19 +690,28 @@ update_ msg m =
                 Key.Tab ->
                   case cursor of
                     Filling tlid p ->
-                      let name = AC.getValue m.complete
-                          tabMod = if event.shiftKey
-                                   then Selection.enterPrevBlank m tlid (Just p)
-                                   else Selection.enterNextBlank m tlid (Just p)
-                          enterMod = if AC.isLargeStringEntry m.complete
-                                     then AutocompleteMod (ACSetQuery m.complete.value)
-                                     else Entry.submit m cursor Entry.ContinueThread name
-                      in
-                      if String.length name < 1
+                      if AC.isLargeStringEntry m.complete
                       then
-                        tabMod
+                        AutocompleteMod <| ACAppendQuery "\t"
                       else
-                        enterMod
+                        let content = AC.getValue m.complete
+                            hasContent = content
+                                       |> String.length
+                                       |> (<) 0
+                        in
+                        if event.shiftKey
+                        then
+                          if hasContent
+                          then
+                            NoChange
+                          else
+                            Selection.enterPrevBlank m tlid (Just p)
+                        else
+                          if hasContent
+                          then
+                            Entry.submit m cursor Entry.ContinueThread content
+                          else
+                            Selection.enterNextBlank m tlid (Just p)
                     Creating _ -> NoChange
 
                 Key.Unknown c ->


### PR DESCRIPTION
The tab key's better behaved here. [Trello](https://trello.com/c/WGSUJbEK/524-tab-shouldnt-take-contents)

| Key Press | Blank State | Modification|
|---|---|---|
| Tab | Has content | as if enter key
| Tab | Empty content | as if tab
| Shift + Tab | Has content | ~as if tab back~ no change
| Shift + Tab | Empty content | ~no change~ as if tab back
| Tab | in large string entry | insert a tab character