### PR TITLE
fixed toplevel placement.

### DIFF
--- a/client/Entry.elm
+++ b/client/Entry.elm
@@ -119,7 +119,8 @@ submit m cursor action value =
                         |> Maybe.map P.toID
                         |> Maybe.map (FocusExact tlid)
                         |> Maybe.withDefault (FocusNext tlid Nothing)
-                op = SetHandler tlid pos { ast = newAst
+                -- NB: pos.y - 20 offsets for the request cursor "above" the toplevel
+                op = SetHandler tlid { pos | y = pos.y - 20 } { ast = newAst
                                          , spec = newHandlerSpec ()
                                          }
             in RPC ([op], focus)


### PR DESCRIPTION
Toplevels are getting placed slightly below where the user clicks because the request cursor takes up some space in the box. [Trello](https://trello.com/c/LvMQuTPm/608-when-creating-a-tl-for-the-first-time-the-ast-box-should-be-lined-up-with-exactly-where-we-were)

The request cursor is 20px high, so we'll place toplevels 20px higher than the click to account for the request cursor's space.