### PR TITLE
added z-index to routing table

### DIFF
--- a/client/View.elm
+++ b/client/View.elm
@@ -96,6 +96,11 @@ viewTL m tl =
         if Just tl.id == tlidOf m.cursorState
         then "selected"
         else ""
+      boxClasses =
+        case m.cursorState of
+          Dragging tlid _ _ _ ->
+            if tlid == tl.id then ["dragging"] else []
+          _ -> []
       class =
         [ selected
         , toString (deTLID tl.id)
@@ -105,7 +110,7 @@ viewTL m tl =
         |> String.join " "
       html =
         Html.div
-          [Attrs.class "sidebar-box"] -- see comment in css
+          [Attrs.class <| String.join " " (boxClasses ++ ["sidebar-box"])] -- see comment in css
           [Html.div
             (Attrs.class class :: events)
             (body ++ data)

--- a/server/static/base.less
+++ b/server/static/base.less
@@ -724,6 +724,10 @@ body #grid * {
 .sidebar-box {
   position: relative;
   z-index: 10;
+  &.dragging {
+    z-index: 30;
+
+  }
 }
 
 .selected[title] {


### PR DESCRIPTION
The routing table's a really great UI element that wasn't getting its due respect. We're fixing this by giving it a background to stand out from the fray, and enshrining its seniority with a high `z-index`. [Trello](https://trello.com/c/jSvSWSmk/602-add-z-index-and-non-transparent-background-on-http-404-table)

<img width="431" alt="screen shot 2018-04-12 at 3 29 14 pm" src="https://user-images.githubusercontent.com/583594/38707466-4c61e2c2-3e66-11e8-9693-f8a7afa2d6bb.png">
