### PR TITLE
Graceful autocomplete input growth

### DIFF
--- a/client/ViewEntry.elm
+++ b/client/ViewEntry.elm
@@ -91,9 +91,7 @@ stringEntryHtml ac =
     if Autocomplete.isSmallStringEntry ac
     then
       Html.div
-      [ Attrs.class "string-entry small-string-entry"
-      , widthInCh (length + 3)
-      ]
+      [ Attrs.class "string-entry small-string-entry" ]
       [
         Html.form
         [ Events.onSubmit (EntrySubmitMsg)
@@ -149,7 +147,6 @@ normalEntryHtml placeholder ac =
                     |> (\l -> if l == 0
                               then max (String.length placeholder) 6
                               else l)
-                    |> (+) 3
       searchInput = Html.input [ Attrs.id Defaults.entryID
                                , Events.onInput EntryInputMsg
                                , Attrs.style [("text-indent", inCh indentWidth)]
@@ -157,12 +154,10 @@ normalEntryHtml placeholder ac =
                                , Attrs.placeholder placeholder
                                , Attrs.spellcheck False
                                , Attrs.autocomplete False
-                               , widthInCh searchWidth
                                ] []
       suggestionInput = Html.input [ Attrs.id "suggestionBox"
                                    , Attrs.disabled True
                                    , Attrs.value suggestion
-                                   , widthInCh searchWidth
                                    ] []
 
       input = Html.div
@@ -172,15 +167,11 @@ normalEntryHtml placeholder ac =
               [searchInput, suggestionInput]
 
       viewForm = Html.form
-                 [ Events.onSubmit (EntrySubmitMsg)
-                 , widthInCh searchWidth
-                 ]
+                 [ Events.onSubmit (EntrySubmitMsg) ]
                  [ input, autocomplete ]
 
       wrapper = Html.div
-                [ Attrs.class "entry"
-                , widthInCh searchWidth
-                ]
+                [ Attrs.class "entry" ]
                 [ viewForm ]
   in wrapper
 

--- a/server/static/base.less
+++ b/server/static/base.less
@@ -612,26 +612,31 @@ body #grid * {
     margin-top: -12px;
 
     #search-container {
+      border-bottom: @blank-underline;
       font-size: 8pt;
       height: 15px;
-      border-bottom: @blank-underline;
+      min-width: 8ch;
       position: relative;
+      // width: 100px;
       #entry-box {
         // as much like the blank box as possible
-        vertical-align: baseline;
-        padding-right: 1ch;
-        min-width: 8ch;
-        color: @grey3;
-
-        z-index: 20;
-        position: relative;
         background: transparent;
+        color: transparent;
+        direction: rtl;
+        padding-right: 1ch;
+        position: relative;
+        text-align: left;
+        text-shadow: 0 0 0 @grey3;
+        vertical-align: baseline;
+        width: 100%;
+        z-index: 20;
       }
       #suggestionBox {
+        background: @selected-background;
+        left: 0;
         position: absolute;
         top: 0;
-        left: 0;
-        background: @selected-background;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
The autocomplete input box has been eating a char heavy diet and it shows strain as flickering as its width grows. We want it to keep eating as much as it wants, and to grow more gracefully. [Trello](https://trello.com/c/DW2fm5DG/614-figure-out-css-to-stop-input-fields-from-scrolling-when-there-is-more-text-than-there-is-room-for)

There's some big time CSS ✨ stuff here, some light property alphabetization, and it works in Chrome.