### PR TITLE
Fix space insert

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -777,11 +777,7 @@ update_ msg m =
                   if m.complete.value == "="
                   || AC.isStringEntry m.complete
                   then
-                    case devent.selectionStart of
-                      Just idx ->
-                        let newQ = SE.insertAt " " (idx + 1) m.complete.value in
-                        AutocompleteMod <| ACSetQuery newQ
-                      Nothing -> AutocompleteMod <| ACAppendQuery " "
+                    NoChange
                   else
                     let name = AC.getValue m.complete
                     in Entry.submit m cursor Entry.ContinueThread name

--- a/server/static/base.less
+++ b/server/static/base.less
@@ -810,7 +810,6 @@ body #grid * {
     position: absolute;
     top: 0;
     width: 100%;
-    white-space: nowrap;
   }
 }
 

--- a/server/templates/ui.html
+++ b/server/templates/ui.html
@@ -24,10 +24,11 @@
 
     <script type="text/javascript">
       function stopKeys(event) {
-        if (
-            event.keyCode == 9 // Tab
-         || event.keyCode == 32 // Space
-         ) {
+        if (event.keyCode == 9) { // Tab
+           event.preventDefault();
+        }
+        if (event.keyCode == 32 // Space
+          && event.target.parentNode.className != "string-container") {
            event.preventDefault();
         }
         if (


### PR DESCRIPTION
This fixes space insertion in string inputs. It does not fix tab insertion. [Trello](https://trello.com/c/i09JVrOT/698-inserting-tab-and-space-chars-during-entry-advances-the-caret-to-the-end-of-the-input)