### PR TITLE
Less multiline string editing visual shift

### DIFF
--- a/client/ViewEntry.elm
+++ b/client/ViewEntry.elm
@@ -8,6 +8,7 @@ module ViewEntry exposing (viewEntry, entryHtml)
 import Html
 import Html.Attributes as Attrs
 import Html.Events as Events
+import List
 import String.Extra as SE
 
 -- dark
@@ -60,6 +61,14 @@ stringEntryHtml ac =
       length = value
                |> String.length
                |> max 1 -- need this to be at least 1 for the cursor to blink?
+      longestLineLength = value
+                          |> String.split "\n"
+                          |> List.map (\line ->
+                            Util.replace "\t" "        " line -- replace tabs with 8 ch for ch counting
+                            |> String.length)
+                          |> List.foldr max 1
+                          -- |> (\n -> (-) n 2)
+                          -- |> max 1
 
 
       smallInput =
@@ -88,6 +97,7 @@ stringEntryHtml ac =
                       , nothingMouseEvent "mouseclick"
                       , nothingMouseEvent "mousedown"
                       , Attrs.rows (1 + SE.countOccurrences "\n" value)
+                      , widthInCh longestLineLength
                       , Attrs.autocomplete False
                       ] []
     in

--- a/server/static/base.less
+++ b/server/static/base.less
@@ -819,8 +819,18 @@ body #grid * {
     right: 0;
     width: 1.5ch;
   }
+  &.big-string-entry {
+    padding-left: 0;
+    padding-right: 0;
+    &::before {
+      width: 0;
+    }
+    &::after{
+      width: 0;
+    }
+  }
   .string-container {
-    display: inline-block;
+    display: block;
     margin: 0;
     padding: 0;
     position: relative;
@@ -839,9 +849,10 @@ body #grid * {
   }
   textarea {
     color: @purple !important;
+    display: block;
     overflow: hidden;
     resize: none;
-    text-indent: 1.5ch;
+    text-indent: 1ch;
   }
   #fluidWidthSpan {
     .string-style;


### PR DESCRIPTION
In pursuit of less visual shifting around, here's multiline strings taking up the same amount of space before and after entering. [Trello](https://trello.com/c/ujTWchGI/771-multi-line-strings-should-appear-the-same-when-editing-as-when-displayed)