### PR TITLE
Backspace out of string entry

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -883,7 +883,15 @@ update_ msg m =
                   if sp == "" then NoChange
                   else
                     AutocompleteMod <| ACSetQuery sp
-
+                Key.Backspace ->
+                  case cursor of
+                    Filling tlid id ->
+                      if m.complete.value == "\"\""
+                      then
+                        AutocompleteMod <| ACSetQuery ""
+                      else
+                        NoChange
+                    _ -> NoChange
                 key ->
                   NoChange
 


### PR DESCRIPTION
Hitting backspace in an empty string takes us back to empty autocomplete state. [Trello](https://trello.com/c/51ZhekBz/795-cant-backspace-out-of-being-a-string)