### PR TITLE
make live values only as wide as their content.

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -947,7 +947,7 @@ body #grid * {
   right: calc(~"100% + 2px");
   .default;
   max-width: 500px;
-  width: 400px;
+  width: max-content;
   white-space: normal;
   word-wrap: break-word;
 }


### PR DESCRIPTION
Live values will have width auto set to their content size up to a max width, where they'll line wrap. [Trello](https://trello.com/c/XlC91NIc/884-make-livevalues-not-take-the-full-space-if-they-dont-need-to)

<img width="1103" alt="screen shot 2018-05-16 at 4 25 51 pm" src="https://user-images.githubusercontent.com/583594/40148984-d32c19f6-5925-11e8-9459-8712942d819a.png">
