### PR TITLE
Fix FF icon jumping on string state changes

### DIFF
--- a/client/ViewBlankOr.elm
+++ b/client/ViewBlankOr.elm
@@ -66,7 +66,7 @@ nested = wc "nested"
 
 text : ViewState -> List HtmlConfig -> String -> Html.Html Msg
 text vs c str =
-  div vs c [Html.text str]
+  div vs c <| [Html.div [Attrs.class "quote quote-start"] []] ++ [Html.text str] ++ [Html.div [Attrs.class "quote quote-end"] []]
 
 keyword : ViewState -> List HtmlConfig -> String -> Html.Html Msg
 keyword vs c name =

--- a/server/static/base.less
+++ b/server/static/base.less
@@ -586,26 +586,28 @@ body #grid * {
     border: 0;
     font-size: @code-font-size;
     margin: 0;
-    padding-left: 1.5ch;
-    padding-right: 1.5ch;
-    position: relative;
-    &::before {
-      content: "“";
-      .string-style;
+    .quote {
       display: inline-block;
-      left: 0;
-      position: absolute;
-      top: 0;
-      width: 1.5ch;
     }
-    &::after{
-      content: "”";
-      .string-style;
+  }
+
+  .quote {
+    .string-style;
+    display: none;
+    width: 1.5ch;
+    &.quote-start {
+      left: 0;
+      top: 0;
+      &:before {
+        content: "“";
+      }
+    }
+    &.quote-end {
       bottom: 0;
-      display: inline-block;
-      position: absolute;
       right: 0;
-      width: 1.5ch;
+      &:before {
+        content: "”";
+      }
     }
   }
 
@@ -947,10 +949,6 @@ body #grid * {
     top: 0;
     width: 100%;
   }
-  & + .feature-flag {
-    right: -2px;
-    top: inherit;
-  }
 }
 
 
@@ -1012,10 +1010,6 @@ body #grid * {
   position: absolute;
   right: -16px;
   .right-button;
-}
-
-.tstr .feature-flag {
-  top: 0;
 }
 
 .parameter-btn {


### PR DESCRIPTION
Here we fix the FF icon jumping in/out the TL box when moving state in/out entering. [Trello](https://trello.com/c/hRYAT5sl/948-fix-feature-flag-icon-positioning-to-stay-on-the-right-outside-the-tl-box)

(Still outstanding issues with FF icon position for multiline strings [trello](https://trello.com/c/e6UQIIBg/951-fix-feature-flag-icon-jumping-to-top-of-multi-line-input-in-out-of-entering-state) but marginal improvement here.) 