### PR TITLE
Make TL header more stable

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -773,6 +773,7 @@ body #grid * {
 // -- this is a demo hack
 .spec-header .entry form {
   margin-top: 0px;
+  position: relative;
 }
 
 .db .entry form {


### PR DESCRIPTION
The big issue here is `min-width: 6ch`.. moving in/out of entering state is making short things jump up to 6ch. [Trello](https://trello.com/c/eiUq6l3b/893-handlers-header-specs-jump-around-a-lot-when-editing-filling-them)