### PR TITLE
fixes click to select item in autocomplete.

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -994,7 +994,10 @@ update_ msg m =
     AutocompleteClick value ->
       case unwrapCursorState m.cursorState of
         Entering cursor ->
-          Entry.submit m cursor Entry.StayHere
+          let complete = m.complete
+              newcomplete = { complete | value = value }
+              newm = { m | complete = newcomplete } in
+          Entry.submit newm cursor Entry.StayHere
         _ -> NoChange
 
 

--- a/client/ViewEntry.elm
+++ b/client/ViewEntry.elm
@@ -110,7 +110,9 @@ normalEntryHtml placeholder ac =
                   name = Autocomplete.asName item
               in Html.li
                 [ Attrs.class <| "autocomplete-item" ++ hlClass
-                , eventNoPropagation "mouseup"
+                , nothingMouseEvent "mouseup"
+                , nothingMouseEvent "mousedown"
+                , eventNoPropagation "click"
                     (\_ -> AutocompleteClick name)
                 ]
                 [ Html.text name


### PR DESCRIPTION
Clicking items in the autocomplete list does nothing. It should be equivalent to arrowing to the item and pressing enter. This PR makes that change. [Trello](https://trello.com/c/w2Lew5Fu/972-clicking-on-an-autocomplete-entry-doesnt-work)