### PR TITLE
fix entry box appearing below other elements.

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -867,6 +867,7 @@ body #grid * {
     position: absolute;
     text-align: initial;
     width: 350px;
+    z-index: 1;
 
     .autocomplete-item {
       background: @black2;


### PR DESCRIPTION
Fixes visual bug originally reported by Daniel in #users slack channel. [Trello](https://trello.com/c/pDK1tu8y/1053-autocomplete-box-under-string-elements)

After: 
<img width="789" alt="screenshot 2018-07-11 16 04 22" src="https://user-images.githubusercontent.com/583594/42603887-a3b4c134-8524-11e8-9b00-17430caf98fd.png">
