### PR TITLE
fixed overlapping lvs for string values.

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -594,9 +594,8 @@ body #grid * {
     .quote {
       display: inline-block;
     }
-    position: relative;
     .computed-value-value {
-      bottom: 0px;
+      bottom: 30px;
     }
   }
 


### PR DESCRIPTION
Fixes visual bug originally reported by Daniel in #users slack channel. Introduced by #40. [Trello](https://trello.com/c/QevMP8JT/1054-string-live-values-overlapping-body-of-tls-in-some-cases)

After: 
<img width="614" alt="screenshot 2018-07-11 16 56 20" src="https://user-images.githubusercontent.com/583594/42605186-79af693c-852b-11e8-8b6d-c88756427e04.png">
