### PR TITLE
move the routing table above TLs.

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -1166,9 +1166,9 @@ body #grid * {
 // [spec](https://trello.com/c/EDCiXGjq/732-z-indexing-part-2)
 // - buttons => 70
 // - entry box => 60
+// - routing table => 55
 // - dragging node => 50
 // - selected node => 40
-// - routing table => 35
 // - unselected node => 20
 
 #buttons {
@@ -1176,7 +1176,7 @@ body #grid * {
 }
 
 .viewing-table {
-  z-index: 35;
+  z-index: 55;
 }
 
 .entry {


### PR DESCRIPTION
We want the routing table to appear above TLs. [Trello](https://trello.com/c/sqgHPRPU/1044-z-index-of-green-data-overlaps-the-routing-table-routing-table-always-on-top)