### PR TITLE
Sort JSON before pattern-matching it.

### DIFF
--- a/server/libexecution/dval.ml
+++ b/server/libexecution/dval.ml
@@ -313,7 +313,8 @@ let tipe_to_yojson (t: tipe) : Yojson.Safe.json =
   `String (t |> tipe_to_string |> String.lowercase)
 
 let rec dval_of_yojson_ (json : Yojson.Safe.json) : dval =
-  match json with
+  (* sort so this isn't key-order-dependent. *)
+  match Yojson.Safe.sort json with
   | `Int i -> DInt i
   | `Float f -> DFloat f
   | `Bool b -> DBool b

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -611,6 +611,19 @@ let t_analysis_not_empty () =
      |> Tuple.T2.get2
      |> List.length)
 
+let t_dval_of_yojson_doesnt_care_about_order () =
+  check_dval "dval_of_json_string doesn't care about key order"
+    (Dval.dval_of_json_string
+       "{
+         \"type\": \"url\",
+         \"value\": \"https://example.com\"
+        }")
+    (Dval.dval_of_json_string
+       "{
+         \"value\": \"https://example.com\",
+         \"type\": \"url\"
+        }")
+
 
 let suite =
   [ "hmac signing works", `Quick, t_hmac_signing
@@ -636,6 +649,8 @@ let suite =
   ; "Nulls allowed in DB", `Quick, t_nulls_allowed_in_db
   ; "Nulls for missing column", `Quick, t_nulls_added_to_missing_column
   ; "Analysis not empty", `Quick, t_analysis_not_empty
+  ; "Parsing JSON to DVals doesn't care about key order", `Quick,
+    t_dval_of_yojson_doesnt_care_about_order
   ]
 
 let () =


### PR DESCRIPTION
Since we pattern-match on `Assoc`,  this code depended on the key order of JSON objects, which isn't stable. We can use `Yojson.Safe.sort` to make sure all of the keys are in a well-defined order before pattern-matching.

Included a test that failed before adding the `Yojson.Safe.sort`.

This might even be browser-dependent, since the Elm frontend uses `JSON.stringify`.

I'm not going to spend time trying to develop an exploit, but this kind of bug can lead to vulnerabilities -- see especially ["langsec", a language-theoretic approach to finding vulnerabilities](http://langsec.org/).