### PR TITLE
String::htmlEscape in Dark

### DIFF
--- a/server/libexecution/libstd.ml
+++ b/server/libexecution/libstd.ml
@@ -1151,6 +1151,22 @@ let fns : Lib.shortfn list = [
   }
   ;
 
+  { pns = ["String::htmlEscape"]
+  ; ins = []
+  ; p = [par "html" TStr]
+  ; r = TStr
+  ; d = "Escape an untrusted string in order to include it safely in HTML output."
+  ; f = InProcess
+          (function
+           | (_, [DStr s]) -> DStr (Util.html_escape s)
+           | args -> fail args)
+  ; pr = None
+  ; ps = false
+  }
+  ;
+
+
+
   (* ====================================== *)
   (* List *)
   (* ====================================== *)

--- a/server/libexecution/util.ml
+++ b/server/libexecution/util.ml
@@ -87,3 +87,19 @@ let charset (headers: (string * string) list)
 
 
 
+(* ------------------- *)
+(* html *)
+(* ------------------- *)
+let html_escape (html : string) : string =
+  String.concat_map html
+    (fun c -> match c with
+             '<' -> "&lt;"
+           | '>' -> "&gt;"
+           | '&' -> "&amp;"
+           (* include these for html-attribute-escaping
+              even though they're not strictly necessary
+              for html-escaping proper. *)
+           | '"' -> "&quot;"
+           (* &apos; doesn't work in IE.... *)
+           | '\'' -> "&#x27;"
+           | _ -> String.of_char c)

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -693,6 +693,16 @@ let t_password_json_round_trip_backwards () =
   AT.check AT.string "Passwords deserialize and serialize if there's no redaction."
     json (json |> Dval.dval_of_json_string |> Dval.dval_to_json_string ~redact:false)
 
+let t_html_escaping () =
+  let oplist = [ "(String::htmlEscape 'test<>&\\\"\\\'')"
+                 |> ast_for
+                 |> handler
+                 |> hop
+               ] in
+  check_dval "html escaping works"
+    (execute_ops oplist)
+    (DStr "test&lt;&gt;&amp;&quot;&#x27;")
+
 let suite =
   [ "hmac signing works", `Quick, t_hmac_signing
   ; "undo", `Quick, t_undo
@@ -729,6 +739,7 @@ let suite =
     t_password_json_round_trip_forwards
   ; "Passwords deserialize and serialize if there's no redaction.", `Quick,
     t_password_json_round_trip_backwards
+  ; "HTML escaping works reasonably", `Quick, t_html_escaping
   ]
 
 let () =


### PR DESCRIPTION
When I was writing my password example (#56) I noticed that it was difficult to escape strings so they'd be safe to include in HTML. There will probably be some future work here around templating and types. But for now this seems like low-hanging fruit to enable customers to write less-dangerous applications on Dark.

Here's the safer login example on my local instance:

![](https://thumbs.gfycat.com/BlaringFamousIrishdraughthorse-max-14mb.gif)
![20180727-105641](https://user-images.githubusercontent.com/490421/43338740-2e6bb094-918c-11e8-8e6c-8918cc7d5534.png)
