### PR TITLE
Add a list of important canvases

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ This is a list of customers and canvases which matter at the moment. If a canvas
 - gracey
 - ian-httpbin
 - paul-slackermuse
+- listo
 
 I'm not sure about the following?
 - dabblefox-7-11?
@@ -237,4 +238,5 @@ I'm not sure about the following?
 - tom
 - mike-brickbreaker
 - rohankanchana-brickbreaker
+- listo-altitude
 


### PR DESCRIPTION
In the last retro we discussed having a list of users whose stuff we didn't want to break.

I went through the list of canvases and this is what I found. I have open questions so please comment below.