### PR TITLE
Prevent Dark code from curling anything other than HTTP/HTTPS.

### DIFF
--- a/server/libbackend/httpclient.ml
+++ b/server/libbackend/httpclient.ml
@@ -94,6 +94,10 @@ let http_call (url: string) (query_params : (string * string list) list)
       C.set_writefunction c responsefn;
       C.set_httpheader c headers;
       C.set_headerfunction c headerfn;
+      (* Don't let users curl to e.g. file://; just HTTP and HTTPs. *)
+      C.set_protocols c [C.CURLPROTO_HTTP; C.CURLPROTO_HTTPS;];
+      (* Seems like redirects can be used to get around the above list... *)
+      C.set_redirprotocols c [C.CURLPROTO_HTTP; C.CURLPROTO_HTTPS;];
 
       (match verb with
        | PUT ->


### PR DESCRIPTION
For example, currently, users can curl `file://` urls. The file content won't make it to an end user, since curl of `file://`s doesn't get you a 2xx response code, but the file content makes it to a user-visible error. This means that users can exploit this to read any file the unix user `dark` can read. For example, `account.ml`, or `/etc/passwd`:

![dark-file-url-scheme-close-up](https://user-images.githubusercontent.com/490421/43426468-9328935a-940a-11e8-9338-49279eecba81.png)

[More about this kind of security issue here.](https://curl.haxx.se/libcurl/security.html)