### PR TITLE
Prevent clickjacking with a CSP header.

### DIFF
--- a/server/libbackend/server.ml
+++ b/server/libbackend/server.ml
@@ -409,6 +409,15 @@ let admin_handler ~(execution_id: Types.id) ~(host: string) ~(uri: Uri.t) ~stopp
   let verb = req |> CRequest.meth in
   let text_plain_resp_headers =
     Header.init_with "Content-type" "text/html; charset=utf-8"
+    |> (fun h -> Header.add h "Content-security-policy"
+                   (* Don't allow any other websites to put this in an iframe;
+                      this prevents "clickjacking" attacks.
+                      https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet#Content-Security-Policy:_frame-ancestors_Examples
+                      It would be nice to use CSP to limit where we can load scripts etc from,
+                      but right now we load from CDNs, <script> tags, etc. So the only thing
+                      we could do is script-src: 'unsafe-inline', which doesn't offer us
+                      any additional security. *)
+                "frame-ancestors 'none';")
   in
   let utf8 = "application/json; charset=utf-8" in
   match (verb, Uri.path uri) with


### PR DESCRIPTION
If an attacker can embed "builtwithdark.com" in an iframe on a site they control, they can trick the user into clicking and typing into builtwithdark.com. [This kind of attack is called "clickjacking".](https://en.wikipedia.org/wiki/Clickjacking) We can fix this with a `Content-security-policy` HTTP header that prevents these pages from being embedded in iframes entirely.

We could also use `Content-security-policy` to protect against XSS attacks by restricting how and where scripts and other resources can be loaded; however, right now we load resources from everywhere, including CDNs, inline `<script>s`, and base64 `data:` URIs. It might be worth developing some discipline around this so that we _can_ prevent XSS with `Content-Security-Policy`, but now doesn't seem like the time.