### PR TITLE
Alice/bug dbtype entry

### DIFF
--- a/client/Entry.elm
+++ b/client/Entry.elm
@@ -320,8 +320,10 @@ submit m cursor action =
           then Select tlid (Just id)
           else if B.isBlank ct
           then
-            wrapID [ SetDBColType tlid id value
-                   , AddDBCol tlid (gid ()) (gid ())]
+            RPC ([
+                SetDBColType tlid id value
+                , AddDBCol tlid (gid ()) (gid ())
+              ], FocusNothing)
           else
             wrapID [ ChangeDBColType tlid id value]
 


### PR DESCRIPTION
Ideally I would like the pointer to go to the name of the new field created by AddDBCol, but because it has yet to be created I am not sure if that is even possible as it will also involve PRC syncing.

I've already tried

`
let newColNameId = gid ()
in wrap [SetDBColType tlid id value, AddDBCol tlid newColNameId (gid ())] (Just newColNameId)
`

But it doesn't work because I suspect that i was unable to resolve the ID since the field hasn't been created yet. I am not sure if the NextAction.StartThread can solve it.
I created a ticket to look into making this possible: https://trello.com/c/jLHIDj6p

What do you think will the be ETA in making the pointer to go the not yet created field?