### PR TITLE
Fix deserialization bug affecting gracey/dabblefox-news

### DIFF
--- a/server/libexecution/types.ml
+++ b/server/libexecution/types.ml
@@ -12,6 +12,8 @@ type 'a or_blank = Blank of id
                  | Filled of id * 'a
                  [@@deriving eq, compare, show, yojson, sexp, bin_io]
 
+(* DO NOT CHANGE THE ORDER ON THESE!!!! IT WILL BREAK THE SERIALIZER *)
+(* add to the bottom *)
 type tipe_ =
   | TAny (* extra type meaning anything *)
   | TInt
@@ -31,12 +33,13 @@ type tipe_ =
   | TDate
   | TTitle
   | TUrl
-  | TPassword
   (* Storage related hackery *)
   | TBelongsTo of string
   | THasMany of string
   | TDbList of tipe_
+  | TPassword
   [@@deriving eq, compare, show, yojson, sexp, bin_io]
+(* DO NOT CHANGE THE ORDER ON THESE!!!! IT WILL BREAK THE SERIALIZER *)
 
 module RuntimeT = struct
   type fnname = string [@@deriving eq, compare, yojson, show, sexp, bin_io]

--- a/server/serialization/b33bd2652b55fd925a72ab4c13d2d845
+++ b/server/serialization/b33bd2652b55fd925a72ab4c13d2d845
@@ -1,0 +1,555 @@
+(Exp
+ (Base list
+  ((Exp
+    (Variant
+     ((SetHandler
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp
+         (Record
+          ((tlid (Exp (Base int ())))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int ()))))
+               (Filled
+                ((Exp (Base int ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                   ()))))))))
+           (spec
+            (Exp
+             (Record
+              ((module_
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (modifier
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (types
+                (Exp
+                 (Record
+                  ((input
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled
+                        ((Exp (Base int ()))
+                         (Exp
+                          (Application
+                           (Exp
+                            (Variant
+                             ((Empty ()) (Any ()) (String ()) (Int ())
+                              (Obj
+                               ((Exp
+                                 (Base list
+                                  ((Exp
+                                    (Tuple
+                                     ((Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Base string ())))))))
+                                      (Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Rec_app 0 ()))))))))))))))))))
+                           ()))))))))
+                   (output
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled
+                        ((Exp (Base int ()))
+                         (Exp
+                          (Application
+                           (Exp
+                            (Variant
+                             ((Empty ()) (Any ()) (String ()) (Int ())
+                              (Obj
+                               ((Exp
+                                 (Base list
+                                  ((Exp
+                                    (Tuple
+                                     ((Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Base string ())))))))
+                                      (Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Rec_app 0 ()))))))))))))))))))
+                           ())))))))))))))))))))))
+      (CreateDB
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp (Base string ()))))
+      (AddDBCol
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base int ()))))
+      (SetDBColName
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (SetDBColType
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (DeleteTL ((Exp (Base int ()))))
+      (MoveTL
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))))
+      (SetFunction
+       ((Exp
+         (Record
+          ((tlid (Exp (Base int ())))
+           (metadata
+            (Exp
+             (Record
+              ((name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (parameters
+                (Exp
+                 (Base list
+                  ((Exp
+                    (Record
+                     ((name
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ())) (Exp (Base string ()))))))))
+                      (tipe
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ()))
+                            (Exp
+                             (Application
+                              (Exp
+                               (Variant
+                                ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                                 (TNull ()) (TChar ()) (TStr ()) (TList ())
+                                 (TObj ()) (TIncomplete ()) (TError ())
+                                 (TBlock ()) (TResp ()) (TDB ()) (TID ())
+                                 (TDate ()) (TTitle ()) (TUrl ())
+                                 (TBelongsTo ((Exp (Base string ()))))
+                                 (THasMany ((Exp (Base string ()))))
+                                 (TDbList ((Exp (Rec_app 0 ()))))
+                                 (TPassword ()))))
+                              ()))))))))
+                      (block_args (Exp (Base list ((Exp (Base string ()))))))
+                      (optional (Exp (Base bool ())))
+                      (description (Exp (Base string ()))))))))))
+               (return_type
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled
+                    ((Exp (Base int ()))
+                     (Exp
+                      (Application
+                       (Exp
+                        (Variant
+                         ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                          (TNull ()) (TChar ()) (TStr ()) (TList ())
+                          (TObj ()) (TIncomplete ()) (TError ()) (TBlock ())
+                          (TResp ()) (TDB ()) (TID ()) (TDate ()) (TTitle ())
+                          (TUrl ()) (TBelongsTo ((Exp (Base string ()))))
+                          (THasMany ((Exp (Base string ()))))
+                          (TDbList ((Exp (Rec_app 0 ())))) (TPassword ()))))
+                       ()))))))))
+               (description (Exp (Base string ())))
+               (infix (Exp (Base bool ())))))))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int ()))))
+               (Filled
+                ((Exp (Base int ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                   ())))))))))))))
+      (ChangeDBColName
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (ChangeDBColType
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (UndoTL ((Exp (Base int ())))) (RedoTL ((Exp (Base int ()))))
+      (InitDBMigration
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base int ()))
+        (Exp (Base int ())) (Exp (Variant ((ChangeColType ()))))))
+      (SetExpr
+       ((Exp (Base int ())) (Exp (Base int ()))
+        (Exp
+         (Variant
+          ((Blank ((Exp (Base int ()))))
+           (Filled
+            ((Exp (Base int ()))
+             (Exp
+              (Application
+               (Exp
+                (Variant
+                 ((If
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Thread
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FnCall
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (Variable ((Exp (Base string ()))))
+                  (Let
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Lambda
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Value ((Exp (Base string ()))))
+                  (FieldAccess
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))))
+                  (ObjectLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Tuple
+                         ((Exp
+                           (Variant
+                            ((Blank ((Exp (Base int ()))))
+                             (Filled
+                              ((Exp (Base int ())) (Exp (Base string ())))))))
+                          (Exp
+                           (Variant
+                            ((Blank ((Exp (Base int ()))))
+                             (Filled
+                              ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                  (ListLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FeatureFlag
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+               ())))))))))
+      (TLSavepoint ((Exp (Base int ()))))))))))


### PR DESCRIPTION
This fixes a bug introduced by e701ba2c.

The bug:

* `TPassword` was added before the end of the variant, changing the tag numbers for the following 3 variants in the binary serialized format.
* The only places that use serialized `tipes` are `user_fn`'s `return_tipe` and the `tipe` of a  `ufn_param`.
* `return_tipe` is currently unused and set to `TAny` so could not be the problem.
* The 3 tags that were after `TPassword`, `[TBelongsTo, THasMany, TDbList]` are internal tipes specific to Databases which are not valid types for the parameters to a function.
* The two instances of the bug that I verified both erroneously had `TBelongsTo` as parameters to user functions. This was due to them having values for the param tipe field which fell through to this case of `tipe_of_string` https://github.com/darklang/dark/blob/65fe0a86bf562efac7f515dcd2517c2a5bd3106b/server/libexecution/dval.ml#L72-L80 
    -  dabblefox-news had a parameter with the type called `post`. It's unclear how it ended up with a type like this, other than the obvious explanation that there's a DB called `Post` and at some point either the type entry autocomplete or the extract function functionality had a bug that allowed it.
    - similarly, gracey had a type called `datastor` [sic] which _almost_ matches `datastore` but does not.

