### PR TITLE
Fix the DB focus

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -429,7 +429,7 @@ updateMod mod (m, cmd) =
         processAutocompleteMods m3 [ ACRegenerate ]
 
       UpdateToplevels tls updateCurrent ->
-        let m2 = List.foldl (flip Toplevel.upsert) m tls
+        let m2 = TL.upsertAll m tls
             -- Bring back the TL being edited, so we don't lose work
             -- done since the API call.
             m3 = case tlidOf m.cursorState of
@@ -1257,9 +1257,9 @@ update_ msg m =
              , MakeCmd (Entry.focusEntry m)
              ]
       else
-        let m2 = { m | toplevels = m.toplevels ++ newToplevels
-                     , userFunctions = userFuncs }
-            newState = processFocus m2 focus
+        let m2 = TL.upsertAll m newToplevels
+            m3 = { m2 | userFunctions = userFuncs }
+            newState = processFocus m3 focus
         in Many [ UpdateToplevels newToplevels True
                 , UpdateAnalysis newAnalysis
                 , SetGlobalVariables globals

--- a/client/Toplevel.elm
+++ b/client/Toplevel.elm
@@ -58,6 +58,10 @@ upsert m tl =
   then { m | toplevels = m.toplevels ++ [tl] }
   else updated
 
+upsertAll : Model -> List Toplevel -> Model
+upsertAll m tls =
+  List.foldl (flip upsert) m tls
+
 remove : Model -> Toplevel -> Model
 remove m tl =
   { m | toplevels = List.filter ((/=) tl) m.toplevels }


### PR DESCRIPTION
When adding a new line in a DB toplevel, we go to it using FocusNext. However,
FocusNext relies on having a correct set of toplevels, which we did not have
because we just appended the new toplevels to the end instead of overwriting the
existing ones. So we were looking at the old toplevels, finding the old DB
definition, and then finding the next focus in that one.
