### PR TITLE
Move sodium dependency to libbackend

### DIFF
--- a/server/libbackend/init.ml
+++ b/server/libbackend/init.ml
@@ -18,6 +18,7 @@ let init ~run_side_effects =
                  @ Libevent.fns
                  @ Libhttp.fns
                  @ Libhttpclient.fns
+                 @ Libcrypto.fns
                  (* @ Libtwitter.fns  *)
       in
 

--- a/server/libbackend/jbuild
+++ b/server/libbackend/jbuild
@@ -39,6 +39,7 @@
                 session
                 session-postgresql-lwt
                 session-cohttp-lwt
+                sodium
                 threads
                 uutf
                 yojson

--- a/server/libbackend/libcrypto.ml
+++ b/server/libbackend/libcrypto.ml
@@ -1,0 +1,75 @@
+open Core_kernel
+open Libexecution
+
+open Lib
+open Runtime
+open Types.RuntimeT
+
+module Hash = Sodium.Password_hash.Bytes
+
+
+let fns : Lib.shortfn list = [
+  (* ====================================== *)
+  (* Password *)
+  (* ====================================== *)
+  { pns = ["Password::hash"]
+  ; ins = []
+  ; p = [par "pw" TStr]
+  ; r = TPassword
+  ; d = "Hash a password into a Password by salting and hashing it. \
+         This uses libsodium's crypto_pwhash_str under the hood, which is \
+         based on argon2."
+  ; f = InProcess
+          (function
+           | (_, [DStr s]) -> s
+                             |> Bytes.of_string
+                             (* wipe_to_password is a confusing name
+                                but it's the only way to get a `password'
+                                from a `bytes'. It also wipes the `bytes',
+                                but passwords in memory is a little outside
+                                of our threat model right now. *)
+                             |> Hash.wipe_to_password
+                             (* libsodium authors recommend the `interactive'
+                                parameter set for interactive, online uses:
+                                https://download.libsodium.org/doc/password_hashing/the_argon2i_function.html
+                                and the general advice is to use the highest
+                                numbers whose performance works for your use-case.
+                                `interactive' takes about half a second on my laptop,
+                                whereas the the `moderate' parameter set takes 3s
+                                and the `sensitive' parameter set takes 12s.
+                                -lizzie.
+                              *)
+                             (* libsodium's crypto_pwhash_str, which is what this
+                                calls eventually, transparently salts:
+                                https://github.com/jedisct1/libsodium/blob/d49d7e8d4f4dd8df593beb9e715e7bc87bc74108/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c#L187 *)
+                             |> Hash.hash_password Sodium.Password_hash.interactive
+                             |> DPassword
+           | args -> fail args)
+
+  ; pr = None
+  ; ps = true
+  }
+  ;
+
+  { pns = ["Password::check"]
+  ; ins = []
+  ; p = [par "existingpwr" TPassword; par "rawpw" TStr]
+  ; r = TBool
+  ; d = "Check whether a Password matches a raw password String \
+         safely. This uses libsodium's pwhash under the hood, which is \
+         based on argon2."
+  ; f = InProcess
+        (function
+         | (_, [DPassword existingpw; DStr rawpw])
+           -> rawpw
+             |> Bytes.of_string
+             |> Hash.wipe_to_password
+             |> Hash.verify_password_hash existingpw
+             |> DBool
+         | args -> fail args)
+  ; pr = None
+  ; ps = true
+  }
+  ;
+]
+

--- a/server/libexecution/jbuild
+++ b/server/libexecution/jbuild
@@ -25,8 +25,7 @@
                 ppx_deriving.std
                 ppx_deriving_yojson
                 ppx_deriving_yojson.runtime
-                ppx_sexp_conv
-                sodium))
+                ppx_sexp_conv))
   )
 )
 

--- a/server/libexecution/libstd.ml
+++ b/server/libexecution/libstd.ml
@@ -3,7 +3,6 @@ open Core_kernel
 open Lib
 open Types.RuntimeT
 module RT = Runtime
-module Hash = Sodium.Password_hash.Bytes
 
 let list_repeat = Util.list_repeat
 
@@ -1733,66 +1732,4 @@ let fns : Lib.shortfn list = [
   }
   ;
 
-  (* ====================================== *)
-  (* Password *)
-  (* ====================================== *)
-  { pns = ["Password::hash"]
-  ; ins = []
-  ; p = [par "pw" TStr]
-  ; r = TPassword
-  ; d = "Hash a password into a Password by salting and hashing it. \
-         This uses libsodium's crypto_pwhash_str under the hood, which is \
-         based on argon2."
-  ; f = InProcess
-          (function
-           | (_, [DStr s]) -> s
-                             |> Bytes.of_string
-                             (* wipe_to_password is a confusing name
-                                but it's the only way to get a `password'
-                                from a `bytes'. It also wipes the `bytes',
-                                but passwords in memory is a little outside
-                                of our threat model right now. *)
-                             |> Hash.wipe_to_password
-                             (* libsodium authors recommend the `interactive'
-                                parameter set for interactive, online uses:
-                                https://download.libsodium.org/doc/password_hashing/the_argon2i_function.html
-                                and the general advice is to use the highest
-                                numbers whose performance works for your use-case.
-                                `interactive' takes about half a second on my laptop,
-                                whereas the the `moderate' parameter set takes 3s
-                                and the `sensitive' parameter set takes 12s.
-                                -lizzie.
-                              *)
-                             (* libsodium's crypto_pwhash_str, which is what this
-                                calls eventually, transparently salts:
-                                https://github.com/jedisct1/libsodium/blob/d49d7e8d4f4dd8df593beb9e715e7bc87bc74108/src/libsodium/crypto_pwhash/argon2/pwhash_argon2i.c#L187 *)
-                             |> Hash.hash_password Sodium.Password_hash.interactive
-                             |> DPassword
-           | args -> fail args)
-
-  ; pr = None
-  ; ps = true
-  }
-  ;
-
-  { pns = ["Password::check"]
-  ; ins = []
-  ; p = [par "existingpwr" TPassword; par "rawpw" TStr]
-  ; r = TBool
-  ; d = "Check whether a Password matches a raw password String \
-         safely. This uses libsodium's pwhash under the hood, which is \
-         based on argon2."
-  ; f = InProcess
-        (function
-         | (_, [DPassword existingpw; DStr rawpw])
-           -> rawpw
-             |> Bytes.of_string
-             |> Hash.wipe_to_password
-             |> Hash.verify_password_hash existingpw
-             |> DBool
-         | args -> fail args)
-  ; pr = None
-  ; ps = true
-  }
-  ;
 ]


### PR DESCRIPTION
Sodium has a dependency on libsodium, the C library, which is an issue for @jonathan-laurent compiling libexecution to js.

Added a trello ticket (https://trello.com/c/gbIwkNv3/122-how-do-we-handle-front-end-unsafe-code-like-crypto-dependencies-in-ocaml-js) to think about the problem, but for now moved it out of libbackend.
