### PR TITLE
Add UUID module to userspace

### DIFF
--- a/client/Autocomplete.elm
+++ b/client/Autocomplete.elm
@@ -532,7 +532,7 @@ generateFromModel m a =
                   , "Url"
                   , "Date"
                   , "Password"
-                  , "ID"
+                  , "UUID"
                   ]
                     dbs =
                       m.toplevels

--- a/client/RPC.elm
+++ b/client/RPC.elm
@@ -293,6 +293,7 @@ encodeTipe t =
         THasMany s -> ev "THasMany" [JSE.string s]
         TDbList a -> ev "TDbList" [encodeTipe a]
         TPassword -> ev "TPassword" []
+        TUuid -> ev "TUuid" []
 
 encodeUserFunctionParameter : UserFunctionParameter -> JSE.Value
 encodeUserFunctionParameter p =

--- a/client/Runtime.elm
+++ b/client/Runtime.elm
@@ -83,6 +83,7 @@ tipe2str t =
     TTitle -> "Title"
     TUrl -> "Url"
     TPassword -> "Password"
+    TUuid -> "UUID"
     TBelongsTo s -> s
     THasMany s -> "[" ++ s ++ "]"
     TDbList a -> "[" ++ (tipe2str a) ++ "]"
@@ -100,6 +101,7 @@ str2tipe t =
           "boolean" -> TBool
           "password" -> TPassword
           "id" -> TID
+          "uuid" -> TUuid
           "null" -> todo "not implemented yet"
           "any" -> todo "not implemented yet"
           "list" -> todo "not implemented yet"
@@ -132,6 +134,7 @@ str2tipe t =
   "error" -> TError
   "password" -> TPassword
   "id" -> TID
+  "uuid" -> TUuid
   other ->
     if String.startsWith "[" other && String.endsWith "]" other
     then

--- a/client/Types.elm
+++ b/client/Types.elm
@@ -44,6 +44,7 @@ type Tipe = TInt
           | TTitle
           | TUrl
           | TPassword
+          | TUuid
           | TBelongsTo String
           | THasMany String
           | TDbList Tipe

--- a/server/libbackend/user_db.ml
+++ b/server/libbackend/user_db.ml
@@ -222,6 +222,7 @@ and type_check_and_map_dependents ~belongs_to ~has_many ~state (db: db) (obj: dv
           | (TList, DList _) -> data
           | (TDbList _, DList _) -> data
           | (TPassword, DPassword _) -> data
+          | (TUuid, DUuid _) -> data
           | (TBelongsTo table, any_dval) ->
             (* the belongs_to function needs to type check any_dval *)
             belongs_to table any_dval

--- a/server/libexecution/dval.ml
+++ b/server/libexecution/dval.ml
@@ -44,6 +44,7 @@ let rec tipe_to_string t : string =
   | THasMany s -> "[" ^ s ^ "]"
   | TDbList tipe -> "[" ^ (tipe_to_string tipe) ^ "]"
   | TPassword -> "Password"
+  | TUuid -> "UUID"
 
 let rec tipe_of_string str : tipe =
   match String.lowercase str with
@@ -69,6 +70,7 @@ let rec tipe_of_string str : tipe =
   | "title" -> TTitle
   | "url" -> TUrl
   | "password" -> TPassword
+  | "uuid" -> TUuid
   | _ -> (* otherwise *)
     if String.is_prefix str "["  && String.is_suffix str "]"
     then
@@ -89,6 +91,7 @@ and parse_list_tipe (list_tipe : string) : tipe =
   | "boolean" -> TDbList TBool
   | "password" -> TDbList TPassword
   | "id" -> TDbList TID
+  | "uuid" -> TDbList TUuid
   | "obj" -> Exception.internal "todo"
   | "block" -> Exception.internal "todo"
   | "incomplete" -> Exception.internal "todo"
@@ -120,6 +123,7 @@ let tipe_of (dv : dval) : tipe =
   | DTitle _ -> TTitle
   | DUrl _ -> TUrl
   | DPassword _ -> TPassword
+  | DUuid _ -> TUuid
 
 
 let tipename (dv: dval) : string =
@@ -158,6 +162,7 @@ let as_string (dv : dval) : string =
   | DUrl url -> url
   | DDB db -> db.name
   | DError msg -> msg
+  | DUuid uuid -> Uuidm.to_string uuid
   | _ -> "<" ^ (dv |> tipename) ^ ">"
 
 let as_literal (dv : dval) : string =
@@ -175,7 +180,7 @@ let is_stringable (dv : dval) : bool =
   match dv with
   | DBlock _ | DIncomplete | DError _
   | DID _ | DDate _ | DTitle _ | DUrl _
-  | DPassword _ | DDB _ -> true
+  | DPassword _ | DDB _ | DUuid _ -> true
   |  _ -> is_primitive dv
 
 (* A simple representation, showing primitives as their expected literal
@@ -342,6 +347,7 @@ let rec dval_of_yojson_ (json : Yojson.Safe.json) : dval =
     | "password" -> v |> B64.decode |> Bytes.of_string |> DPassword
     | "db" -> Exception.user "Can't deserialize DBs"
     | "block" -> Exception.user "Can't deserialize blocks"
+    | "uuid" -> DUuid (Uuidm.of_string v |> Option.value_exn)
     | _ -> Exception.user ("Can't deserialize type: " ^ tipe)
     )
   | `Assoc alist ->
@@ -394,6 +400,7 @@ let rec dval_to_yojson ?(livevalue=false) ?(redact=true) (dv : dval) : Yojson.Sa
   | DPassword hashed -> if redact
                        then wrap_user_type `Null
                        else hashed |> Bytes.to_string |> B64.encode |> wrap_user_str
+  | DUuid uuid -> wrap_user_str (Uuidm.to_string uuid)
 
 let is_json_primitive (dv: dval) : bool =
   match dv with

--- a/server/libexecution/libstd.ml
+++ b/server/libexecution/libstd.ml
@@ -1167,14 +1167,14 @@ let fns : Lib.shortfn list = [
   { pns = ["String::toUUID"]
   ; ins = []
   ; p = [par "uuid" TStr]
-  ; r = TID
+  ; r = TUuid
   ; d = "Parse a UUID of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX from \
          the input `uuid` string"
   ; f = InProcess
           (function
            | (_, [DStr s]) ->
              (match Uuidm.of_string s with
-              | Some id -> DID id
+              | Some id -> DUuid id
               | None ->
                 Exception.user
                   "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
@@ -1754,11 +1754,11 @@ let fns : Lib.shortfn list = [
   { pns = ["Uuid::generate"]
   ; ins = []
   ; p = []
-  ; r = TID
+  ; r = TUuid
   ; d = "Generate a new UUID v4 according to RFC 4122"
   ; f = InProcess
         (function
-         | (_, []) -> DID (Uuidm.v `V4)
+         | (_, []) -> DUuid (Uuidm.v `V4)
          | args -> fail args)
   ; pr = None
   (* similarly to Date::now, it's not particularly fun for this to change

--- a/server/libexecution/types.ml
+++ b/server/libexecution/types.ml
@@ -38,6 +38,7 @@ type tipe_ =
   | THasMany of string
   | TDbList of tipe_
   | TPassword
+  | TUuid
   [@@deriving eq, compare, show, yojson, sexp, bin_io]
 (* DO NOT CHANGE THE ORDER ON THESE!!!! IT WILL BREAK THE SERIALIZER *)
 
@@ -180,6 +181,7 @@ and expr = nexpr or_blank [@@deriving eq, compare, yojson, show, sexp, bin_io]
     | DTitle of string
     | DUrl of string
     | DPassword of Bytes.t
+    | DUuid of uuid
     [@@deriving show, sexp, eq, compare]
   type dval_list = dval list [@@deriving show]
 

--- a/server/serialization/1e11a67c7898df8ba374deb309d6a9b7
+++ b/server/serialization/1e11a67c7898df8ba374deb309d6a9b7
@@ -1,0 +1,556 @@
+(Exp
+ (Base list
+  ((Exp
+    (Variant
+     ((SetHandler
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp
+         (Record
+          ((tlid (Exp (Base int ())))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int ()))))
+               (Filled
+                ((Exp (Base int ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                   ()))))))))
+           (spec
+            (Exp
+             (Record
+              ((module_
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (modifier
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (types
+                (Exp
+                 (Record
+                  ((input
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled
+                        ((Exp (Base int ()))
+                         (Exp
+                          (Application
+                           (Exp
+                            (Variant
+                             ((Empty ()) (Any ()) (String ()) (Int ())
+                              (Obj
+                               ((Exp
+                                 (Base list
+                                  ((Exp
+                                    (Tuple
+                                     ((Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Base string ())))))))
+                                      (Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Rec_app 0 ()))))))))))))))))))
+                           ()))))))))
+                   (output
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled
+                        ((Exp (Base int ()))
+                         (Exp
+                          (Application
+                           (Exp
+                            (Variant
+                             ((Empty ()) (Any ()) (String ()) (Int ())
+                              (Obj
+                               ((Exp
+                                 (Base list
+                                  ((Exp
+                                    (Tuple
+                                     ((Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Base string ())))))))
+                                      (Exp
+                                       (Variant
+                                        ((Blank ((Exp (Base int ()))))
+                                         (Filled
+                                          ((Exp (Base int ()))
+                                           (Exp (Rec_app 0 ()))))))))))))))))))
+                           ())))))))))))))))))))))
+      (CreateDB
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp (Base string ()))))
+      (AddDBCol
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base int ()))))
+      (SetDBColName
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (SetDBColType
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (DeleteTL ((Exp (Base int ()))))
+      (MoveTL
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))))
+      (SetFunction
+       ((Exp
+         (Record
+          ((tlid (Exp (Base int ())))
+           (metadata
+            (Exp
+             (Record
+              ((name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (parameters
+                (Exp
+                 (Base list
+                  ((Exp
+                    (Record
+                     ((name
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ())) (Exp (Base string ()))))))))
+                      (tipe
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ()))
+                            (Exp
+                             (Application
+                              (Exp
+                               (Variant
+                                ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                                 (TNull ()) (TChar ()) (TStr ()) (TList ())
+                                 (TObj ()) (TIncomplete ()) (TError ())
+                                 (TBlock ()) (TResp ()) (TDB ()) (TID ())
+                                 (TDate ()) (TTitle ()) (TUrl ())
+                                 (TBelongsTo ((Exp (Base string ()))))
+                                 (THasMany ((Exp (Base string ()))))
+                                 (TDbList ((Exp (Rec_app 0 ()))))
+                                 (TPassword ()) (TUuid ()))))
+                              ()))))))))
+                      (block_args (Exp (Base list ((Exp (Base string ()))))))
+                      (optional (Exp (Base bool ())))
+                      (description (Exp (Base string ()))))))))))
+               (return_type
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled
+                    ((Exp (Base int ()))
+                     (Exp
+                      (Application
+                       (Exp
+                        (Variant
+                         ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                          (TNull ()) (TChar ()) (TStr ()) (TList ())
+                          (TObj ()) (TIncomplete ()) (TError ()) (TBlock ())
+                          (TResp ()) (TDB ()) (TID ()) (TDate ()) (TTitle ())
+                          (TUrl ()) (TBelongsTo ((Exp (Base string ()))))
+                          (THasMany ((Exp (Base string ()))))
+                          (TDbList ((Exp (Rec_app 0 ())))) (TPassword ())
+                          (TUuid ()))))
+                       ()))))))))
+               (description (Exp (Base string ())))
+               (infix (Exp (Base bool ())))))))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int ()))))
+               (Filled
+                ((Exp (Base int ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                   ())))))))))))))
+      (ChangeDBColName
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (ChangeDBColType
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (UndoTL ((Exp (Base int ())))) (RedoTL ((Exp (Base int ()))))
+      (InitDBMigration
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base int ()))
+        (Exp (Base int ())) (Exp (Variant ((ChangeColType ()))))))
+      (SetExpr
+       ((Exp (Base int ())) (Exp (Base int ()))
+        (Exp
+         (Variant
+          ((Blank ((Exp (Base int ()))))
+           (Filled
+            ((Exp (Base int ()))
+             (Exp
+              (Application
+               (Exp
+                (Variant
+                 ((If
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Thread
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FnCall
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (Variable ((Exp (Base string ()))))
+                  (Let
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Lambda
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Value ((Exp (Base string ()))))
+                  (FieldAccess
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))))
+                  (ObjectLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Tuple
+                         ((Exp
+                           (Variant
+                            ((Blank ((Exp (Base int ()))))
+                             (Filled
+                              ((Exp (Base int ())) (Exp (Base string ())))))))
+                          (Exp
+                           (Variant
+                            ((Blank ((Exp (Base int ()))))
+                             (Filled
+                              ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                  (ListLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FeatureFlag
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+               ())))))))))
+      (TLSavepoint ((Exp (Base int ()))))))))))

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -732,14 +732,14 @@ let t_uuid_db_roundtrip () =
   clear_test_data ();
   let ast =
     ast_for "(let i (Uuid::generate)
-               (let _ (DB::insert (obj (uuid i)) Ids)
-                 (let fetched (. (List::head (DB::fetchAll Ids)) uuid)
+               (let _ (DB::insert (obj (uu i)) Ids)
+                 (let fetched (. (List::head (DB::fetchAll Ids)) uu)
                    (i fetched))))"
   in
   let oplist = [ Op.CreateDB (dbid, pos, "Ids")
                ; Op.AddDBCol (dbid, 11, 12)
-               ; Op.SetDBColName (dbid, 11, "uuid")
-               ; Op.SetDBColType (dbid, 12, "ID")
+               ; Op.SetDBColName (dbid, 11, "uu")
+               ; Op.SetDBColType (dbid, 12, "UUID")
                ; hop (handler ast)
                ] in
   AT.check AT.int "A generated UUID can round-trip from the DB"


### PR DESCRIPTION
Adds a function to generate UUIDs along, and a function to parse stringified UUIDs.
Allows users to store things of type `id` in their database. 
Tests for DB + string round-trips included.

fun fact: i can't use `uuid` for the type everywhere (yet) because Daniel's front-end code depends on receiving some Dark storage ids as `{ "type": "id", "value": "XXXXX-XXX..." }` and i didn't want to break it yet. i don't exactly have a good way to solve this without breaking his code? womp.