### PR TITLE
NetworkPolicy to block http://metadata.

### DIFF
--- a/scripts/support/builtwithdark.yaml
+++ b/scripts/support/builtwithdark.yaml
@@ -115,3 +115,20 @@ spec:
   backend:
     serviceName: bwd-nodeport
     servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: bwd-network-policy
+spec:
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.0.0/16
+  podSelector:
+    matchLabels:
+      app: bwd-app


### PR DESCRIPTION
`http://metadata` on Google Container Engine (including GKE) reveals a lot of things, namely the environment variables used to start the GCE container. On GKE, that's the Kubernetes node, so it reveals all of the environment variables used to start the Kubernetes kubelet, including a private RSA key that I believe is used to secure communications between the kubelet and the master.

Because we give an http client to Dark users, they can GET `'http://metadata/computeMetadata/v1/instance/attributes/kube-env'`, and get access to that secret.

Here's a [Kubernetes NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to prevent outbound traffic to all of the[ RFC 3927 link-local addresses](https://tools.ietf.org/html/rfc3927), one of which `http://metadata` points at.

Kubernetes NetworkPolicies [require a network plugin to work;](https://kubernetes.io/docs/concepts/services-networking/network-policies/) fortunately GKE clusters have an option in the UI to turn on [Calico](https://www.projectcalico.org/), which works as a Kubernetes plugin to provide NetworkPolicies.

I tested this NetworkPolicy out by starting a cluster in GKE, turning on Calico inside of it, and executing the following shell session. I haven't tested it against a real Dark cluster, but I think it will work the same in that context.
```
dark@dark-dev:~/app$ kubectl create -f - <<EOF
apiVersion: extensions/v1beta1
kind: NetworkPolicy
metadata:
  name: test-network-policy
spec:
  policyTypes:
  - Egress
  egress:
  - to:
    - ipBlock:
        cidr: 0.0.0.0/0
        except:
        - 169.254.0.0/16
  podSelector:
    matchLabels:
      app: bwd-app
EOF
networkpolicy.extensions/test-network-policy created
dark@dark-dev:~/app$ kubectl run example --labels="app=bwd-app" --image=nginx
deployment.apps/example created
dark@dark-dev:~/app$ kubectl exec -it name-z-587799f56f-cdd2w -- bash^C
dark@dark-dev:~/app$ kubectl get pod
NAME                       READY     STATUS    RESTARTS   AGE
example-64bbf588c4-8dblb   1/1       Running   0          8s
dark@dark-dev:~/app$ kubectl exec -it example-64bbf588c4-8dblb  -- bash
root@example-64bbf588c4-8dblb:/# apt-get update && apt-get install -y curl
[...]
root@example-64bbf588c4-8dblb:/# timeout 5 curl http://metadata; echo $?
124
root@example-64bbf588c4-8dblb:/# curl google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
root@example-64bbf588c4-8dblb:/# 
```