### PR TITLE
Revert the revert that fixed the build last night

### DIFF
--- a/scripts/support/builtwithdark.yaml
+++ b/scripts/support/builtwithdark.yaml
@@ -115,3 +115,20 @@ spec:
   backend:
     serviceName: bwd-nodeport
     servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: bwd-network-policy
+spec:
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.0.0/16
+  podSelector:
+    matchLabels:
+      app: bwd-app


### PR DESCRIPTION
I merged https://github.com/darklang/dark/pull/72 last night. It broke the build in Circle since the deploy user didn't have permissions to create, list, or update NetworkPolicies. I reverted it last night to fix the build.

@IanConnolly  added the `container.networkPolicies` permissions to the "CircleCI deployment role" after I asked him today (I don't have the GCloud permissions to do it).  You can verify that [here](https://console.cloud.google.com/iam-admin/roles/details/projects%3Cbalmy-ground-195100%3Croles%3CCircleCIDeploy?project=balmy-ground-195100).

The deploy should work now, so this reverts the revert I made last night.
 
