### PR TITLE
Redirect HTTP to HTTPs.

### DIFF
--- a/server/libbackend/server.ml
+++ b/server/libbackend/server.ml
@@ -483,6 +483,35 @@ let static_handler uri =
   S.respond_file ~fname ()
 
 
+(* Proxies that terminate HTTPs should give us X-Forwarded-Proto: http
+   or X-Forwarded-Proto: https.
+
+   Return the URI, adding the scheme to the URI if there is an X-Forwarded-Proto. *)
+let with_x_forwarded_proto req =
+  match Header.get (CRequest.headers req) "X-Forwarded-Proto" with
+  | Some proto -> Uri.with_scheme
+                   (CRequest.uri req)
+                   (Some proto)
+  | None -> CRequest.uri req
+
+let redirect_to uri =
+  let proto = uri
+              |> Uri.scheme
+              |> Option.value ~default:"" in
+  let parts = uri
+              |> Uri.host
+              |> Option.value ~default:""
+              |> (fun h -> String.split h '.')
+  in
+  match (proto, parts) with
+  | ("http", ["builtwithdark"; "com"; ])
+  | ("http", [_; "builtwithdark"; "com"; ]) ->
+     (* If it's http and on a domain that can be served with https,
+        we want to redirect to the same url but with the scheme
+        replaced by "https". *)
+     Some "https" |> Uri.with_scheme uri |> Some
+  | _ -> None
+
 let server () =
   let stop,stopper = Lwt.wait () in
 
@@ -579,55 +608,56 @@ let server () =
             (* caught by a handle_error a bit lower *)
             user_page_handler ~execution_id ~host ~ip ~uri ~body req
       in
-
-      match (req |> CRequest.uri |> Uri.path, host) with
-      (* This seems like it should be moved closer to the admin handler,
-       * but don't do that - that makes Lwt swallow our exceptions. *)
-      | (_, Some host) ->
-         auth_then_handle ~execution_id req host handler
-      | ("/", None) -> (* for GKE health check *)
-        (match Dbconnection.status () with
-         | `Healthy ->
-           if (not !ready) (* ie. liveness check has found a service with 2 minutes of failing readiness checks *)
-           then begin
-             Log.infO "Liveness check found unready service, returning unavailable";
-             respond ~execution_id `Service_unavailable "Service not ready"
-           end
-           else
-             respond ~execution_id `OK "Hello internal overlord"
-         | `Disconnected -> respond ~execution_id `Service_unavailable "Sorry internal overlord")
-      | ("/ready", None) ->
-        (match Dbconnection.status () with
-         | `Healthy ->
-           if !ready
-           then
-             respond ~execution_id `OK "Hello internal overlord"
-           else begin
-             (* exception here caught by handle_error *)
-             Canvas.check_tier_one_hosts ();
-             Log.infO "All canvases loaded correctly - Service ready";
-             ready := true;
-             respond ~execution_id `OK "Hello internal overlord"
-           end
-         | `Disconnected -> respond ~execution_id `Service_unavailable "Sorry internal overlord")
-      | ("/pkill", None) -> (* for GKE graceful termination *)
-        if !shutdown (* note: this is a ref, not a boolean `not` *)
-        then
-          (shutdown := true;
-           Log.infO "shutdown"
-             ~data:"Received shutdown request - shutting down"
-             ~params:["execution_id", string_of_int execution_id];
-           (* k8s gives us 30 seconds, so ballpark 2s for overhead *)
-           Lwt_unix.sleep 28.0 >>= fun _ ->
-           Lwt.wakeup stopper ();
-           respond ~execution_id `OK "Terminated")
-        else
-          (Log.infO "shutdown"
-             ~data:"Received redundant shutdown request - already shutting down"
-             ~params:["execution_id", string_of_int execution_id];
-           respond ~execution_id `OK "Terminated")
-      | (_, None) -> (* for GKE health check *)
-        respond ~execution_id `Not_found "Not found"
+      match redirect_to (with_x_forwarded_proto req) with
+      | Some x -> S.respond_redirect ~uri:x ()
+      | _ -> match (req |> CRequest.uri |> Uri.path, host) with
+            (* This seems like it should be moved closer to the admin handler,
+             * but don't do that - that makes Lwt swallow our exceptions. *)
+            | (_, Some host) ->
+               auth_then_handle ~execution_id req host handler
+            | ("/", None) -> (* for GKE health check *)
+               (match Dbconnection.status () with
+                | `Healthy ->
+                   if (not !ready) (* ie. liveness check has found a service with 2 minutes of failing readiness checks *)
+                   then begin
+                       Log.infO "Liveness check found unready service, returning unavailable";
+                       respond ~execution_id `Service_unavailable "Service not ready"
+                     end
+                   else
+                     respond ~execution_id `OK "Hello internal overlord"
+                | `Disconnected -> respond ~execution_id `Service_unavailable "Sorry internal overlord")
+            | ("/ready", None) ->
+               (match Dbconnection.status () with
+                | `Healthy ->
+                   if !ready
+                   then
+                     respond ~execution_id `OK "Hello internal overlord"
+                   else begin
+                       (* exception here caught by handle_error *)
+                       Canvas.check_tier_one_hosts ();
+                       Log.infO "All canvases loaded correctly - Service ready";
+                       ready := true;
+                       respond ~execution_id `OK "Hello internal overlord"
+                     end
+                | `Disconnected -> respond ~execution_id `Service_unavailable "Sorry internal overlord")
+            | ("/pkill", None) -> (* for GKE graceful termination *)
+               if !shutdown (* note: this is a ref, not a boolean `not` *)
+               then
+                 (shutdown := true;
+                  Log.infO "shutdown"
+                    ~data:"Received shutdown request - shutting down"
+                    ~params:["execution_id", string_of_int execution_id];
+                  (* k8s gives us 30 seconds, so ballpark 2s for overhead *)
+                  Lwt_unix.sleep 28.0 >>= fun _ ->
+                  Lwt.wakeup stopper ();
+                  respond ~execution_id `OK "Terminated")
+               else
+                 (Log.infO "shutdown"
+                    ~data:"Received redundant shutdown request - already shutting down"
+                    ~params:["execution_id", string_of_int execution_id];
+                  respond ~execution_id `OK "Terminated")
+            | (_, None) -> (* for GKE health check *)
+               respond ~execution_id `Not_found "Not found"
     with e -> handle_error ~include_internals:false e
 
   in

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -760,6 +760,26 @@ let t_uuid_string_roundtrip () =
          DList [p1; p2;] -> compare_dval p1 p2
        | _ -> 1)
 
+let t_redirect_to () =
+  AT.check (AT.list (AT.option AT.string)) "redirect_to works"
+    (List.map
+       ~f:(fun x -> x |> Uri.of_string |> Server.redirect_to |> Option.map ~f:Uri.to_string)
+       [ "http://example.com"
+       ; "http://builtwithdark.com"
+       ; "https://builtwithdark.com"
+       ; "http://test.builtwithdark.com"
+       ; "https://test.builtwithdark.com"
+       ; "http://test.builtwithdark.com/x/y?z=a"
+       ])
+    [ None
+    ; Some "https://builtwithdark.com"
+    ; None
+    ; Some "https://test.builtwithdark.com"
+    ; None
+    ; Some "https://test.builtwithdark.com/x/y?z=a"
+    ]
+
+
 let suite =
   [ "hmac signing works", `Quick, t_hmac_signing
   ; "undo", `Quick, t_undo
@@ -802,6 +822,7 @@ let suite =
     t_authenticate_user
   ; "UUIDs round-trip to the DB", `Quick, t_uuid_db_roundtrip
   ; "UUIDs round-trip to/from strings", `Quick, t_uuid_string_roundtrip
+  ; "Server.redirect_to works", `Quick, t_redirect_to
   ]
 
 let () =


### PR DESCRIPTION
This redirects HTTP requests if the request is to `builtwithdark.com` or `*.builtwithdark.com` _and_ the request definitely came from the client by HTTP.

It determines whether the request came from the client by HTTP by checking [`X-Forwarded-Proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), which is  a loosely-standardized way for load balancers to tell their servers which protocol the client communicated with them.

I haven't gotten the chance to confirm whether GKE Ingresses set `X-Forwarded-Proto`, and whether they set it for both `http` and `https`. This PR shouldn't do anything if Ingresses fail to do either of those things. Checking that now, but in case I don't get the chance to before leaving for the week here's this PR.