### PR TITLE
Fix integration test runner - correctly report the exit code

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -105,5 +105,9 @@ TEST_HOST="integration-tests:$PORT" \
     "chrome:headless" \
     integration-tests/tests.js 2> ${DARK_CONFIG_RUN_DIR}/integration_error.log
 
+RESULT=$?
+
 # Fix xunit output for CircleCI flaky-tests stats
 sed -i 's/ (screenshots: .*)"/"/' ${TEST_RESULTS_XML}
+
+exit $RESULT


### PR DESCRIPTION
I broke this in #90.