### PR TITLE
Fix Entry showing twice in feature flags

### DIFF
--- a/client/ViewCode.elm
+++ b/client/ViewCode.elm
@@ -499,7 +499,7 @@ viewNExpr d id vs config e =
     in
       div vs
         [ wc "flagged shown"]
-        [ vExpr 0 (if condResult then b else a)
+        [ viewExpr 0 { vs | showEntry = False } [] (if condResult then b else a)
         , fontAwesome "flag"
         , Html.div
           [


### PR DESCRIPTION
When a feature flag is being shown, we show either a or b twice, once in the
feature flag box, and once in the AST. When we show b twice, since b isn't
created yet, we'll have two entry boxes.

This solves it by only showing the entry box in the feature flag itself.

This has the downside that if you double-click on the ast node, it will open the
entry box in the feature flag, which I think is fine?