### PR TITLE
Prevent the frontend from deleting locked DBs

### DIFF
--- a/client/Selection.elm
+++ b/client/Selection.elm
@@ -312,10 +312,14 @@ delete m tlid mId =
                             , RPC ([DeleteTL tlid], FocusNothing)
                             , Deselect
                             ]
-        TLDB _ -> Many [ RemoveToplevel tl
-                       , RPC ([DeleteTL tlid], FocusNothing)
-                       , Deselect
-                       ]
+        TLDB _ ->
+          if DB.isLocked m tlid
+          then NoChange
+          else
+            Many [ RemoveToplevel tl
+                 , RPC ([DeleteTL tlid], FocusNothing)
+                 , Deselect
+                 ]
         TLFunc _ -> Error ("Cannot delete functions!")
     Just id ->
       let newID = gid ()


### PR DESCRIPTION
The backend seems to allow changes to locked DBs, so not making a change there.