### PR TITLE
Don't allow the server/_build directory to sync

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -40,6 +40,9 @@ if [ -v CI ]; then
   MOUNTS="--volumes-from vols"
 else
   MOUNTS="--mount type=bind,src=$PWD,dst=/home/dark/app"
+  # Avoid docker syncing everything to the host, slowing compiles down by 5x
+  MOUNTS+=" -v /home/dark/app/server/_build"
+
   if [[ -e "../conduit-frontend" ]]; then
     MOUNTS="$MOUNTS --mount type=bind,src=$PWD/../conduit-frontend,dst=/home/dark/conduit-frontend"
   fi

--- a/scripts/support/build-server
+++ b/scripts/support/build-server
@@ -141,6 +141,7 @@ def main():
       global run_tests
       run_tests = True
 
+  run_or_fail("sudo chown dark:dark server/_build")
   run_or_fail("scripts/support/write-config-file")
   run_or_fail("scripts/support/allow-docker-access")
   if compile:


### PR DESCRIPTION
Our build is slow on docker partially because of the amount of syncs in the
build directory, which is really slow because docker syncs it to the host.

There are a number of solutions to this, including:

- mounting an app2 directory and using unison to sync to a separate build
  directory (complex)
- using docker-sync for a similar purpose (complex)
- using docker's "cached" or "delagated" consistency mount flags (helpful, but
  not much).

However, this is really simple, and really effective.

I initially tried this using tmpfs instead, and it didn't have any additional
benefit but required more RAM so I removed it.