### PR TITLE
Remove remainder of old types, now that they are migrated

### DIFF
--- a/server/libbackend/canvas.ml
+++ b/server/libbackend/canvas.ml
@@ -325,47 +325,21 @@ let check_all_hosts () : unit =
       List.iter (Op.tlid_oplists2oplist !c.ops)
         ~f:(validate_op host))
 
-let remove_dtdeprecated op =
-  match op with
-  | Op.SetHandler (htlid, pos,
-      { tlid; ast; spec =
-                    { module_
-                    ; name
-                    ; modifier
-                    ; types = { input = Filled (iid, _)
-                              ; output = Filled (oid, _)
-                              }
-                    }
-     }) ->
-      Op.SetHandler (htlid, pos,
-        { tlid
-        ; ast
-        ; spec = { module_
-                 ; name
-                 ; modifier
-                 ; types = { input = Blank iid
-                           ; output = Blank oid }}})
-  | _ -> op
-
-
 let migrate_all_hosts () : unit =
-  let hosts = Serialize.current_hosts () in
-
-  List.iter hosts
-    ~f:(fun host ->
-      let c = load_all host [] in
-
-      (* check ops *)
-      List.iter (Op.tlid_oplists2oplist !c.ops)
-        ~f:(validate_op host);
-
-      let new_ops =
-        (Op.tlid_oplists2oplist !c.ops)
-        |> List.map ~f:remove_dtdeprecated
-        |> Op.oplist2tlid_oplists
-      in
-      c := { !c with ops = new_ops};
-      save_all !c);
-
+  (* let hosts = Serialize.current_hosts () in *)
+  (*  *)
+  (* List.iter hosts *)
+  (*   ~f:(fun host -> *)
+  (*     let c = load_all host [] in *)
+  (*  *)
+  (*     (* check ops *) *)
+  (*     List.iter (Op.tlid_oplists2oplist !c.ops) *)
+  (*       ~f:(validate_op host); *)
+  (*  *)
+  (*     let new_ops = *)
+  (*     in *)
+  (*     c := { !c with ops = new_ops}; *)
+  (*     save_all !c); *)
+  (*  *)
   ()
 

--- a/server/libexecution/types.ml
+++ b/server/libexecution/types.ml
@@ -107,10 +107,7 @@ and expr = nexpr or_blank [@@deriving eq, compare, yojson, show, sexp, bin_io]
   module HandlerT = struct
 
 (* DO NOT CHANGE BELOW WITHOUT READING docs/oplist-serialization.md *)
-    type n_dtdeprecated = Empty
-                        | Any
-                        [@@deriving eq, compare, show, yojson, sexp, bin_io]
-    and dtdeprecated = n_dtdeprecated or_blank
+    type dtdeprecated = int or_blank
                        [@@deriving eq, compare, show, yojson, sexp, bin_io]
 
     type spec_types = { input : dtdeprecated

--- a/server/serialization/f98d9b367f9da6689cbd71348ca719de
+++ b/server/serialization/f98d9b367f9da6689cbd71348ca719de
@@ -1,0 +1,536 @@
+(Exp
+ (Base list
+  ((Exp
+    (Variant
+     ((SetHandler
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp
+         (Record
+          ((tlid (Exp (Base int ())))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int ()))))
+               (Filled
+                ((Exp (Base int ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (FnCallSendToRail
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                   ()))))))))
+           (spec
+            (Exp
+             (Record
+              ((module_
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (modifier
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (types
+                (Exp
+                 (Record
+                  ((input
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base int ()))))))))
+                   (output
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base int ())))))))))))))))))))))
+      (CreateDB
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp (Base string ()))))
+      (AddDBCol
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base int ()))))
+      (SetDBColName
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (SetDBColType
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (DeleteTL ((Exp (Base int ()))))
+      (MoveTL
+       ((Exp (Base int ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))))
+      (SetFunction
+       ((Exp
+         (Record
+          ((tlid (Exp (Base int ())))
+           (metadata
+            (Exp
+             (Record
+              ((name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled ((Exp (Base int ())) (Exp (Base string ()))))))))
+               (parameters
+                (Exp
+                 (Base list
+                  ((Exp
+                    (Record
+                     ((name
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ())) (Exp (Base string ()))))))))
+                      (tipe
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ()))
+                            (Exp
+                             (Application
+                              (Exp
+                               (Variant
+                                ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                                 (TNull ()) (TChar ()) (TStr ()) (TList ())
+                                 (TObj ()) (TIncomplete ()) (TError ())
+                                 (TBlock ()) (TResp ()) (TDB ()) (TID ())
+                                 (TDate ()) (TTitle ()) (TUrl ())
+                                 (TBelongsTo ((Exp (Base string ()))))
+                                 (THasMany ((Exp (Base string ()))))
+                                 (TDbList ((Exp (Rec_app 0 ()))))
+                                 (TPassword ()) (TUuid ()) (TOption ())
+                                 (TErrorRail ()))))
+                              ()))))))))
+                      (block_args (Exp (Base list ((Exp (Base string ()))))))
+                      (optional (Exp (Base bool ())))
+                      (description (Exp (Base string ()))))))))))
+               (return_type
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int ()))))
+                   (Filled
+                    ((Exp (Base int ()))
+                     (Exp
+                      (Application
+                       (Exp
+                        (Variant
+                         ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                          (TNull ()) (TChar ()) (TStr ()) (TList ())
+                          (TObj ()) (TIncomplete ()) (TError ()) (TBlock ())
+                          (TResp ()) (TDB ()) (TID ()) (TDate ()) (TTitle ())
+                          (TUrl ()) (TBelongsTo ((Exp (Base string ()))))
+                          (THasMany ((Exp (Base string ()))))
+                          (TDbList ((Exp (Rec_app 0 ())))) (TPassword ())
+                          (TUuid ()) (TOption ()) (TErrorRail ()))))
+                       ()))))))))
+               (description (Exp (Base string ())))
+               (infix (Exp (Base bool ())))))))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int ()))))
+               (Filled
+                ((Exp (Base int ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int ()))))
+                                 (Filled
+                                  ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int ()))))
+                           (Filled
+                            ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                      (FnCallSendToRail
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int ()))))
+                              (Filled
+                               ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                   ())))))))))))))
+      (ChangeDBColName
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (ChangeDBColType
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base string ()))))
+      (UndoTL ((Exp (Base int ())))) (RedoTL ((Exp (Base int ()))))
+      (InitDBMigration
+       ((Exp (Base int ())) (Exp (Base int ())) (Exp (Base int ()))
+        (Exp (Base int ())) (Exp (Variant ((ChangeColType ()))))))
+      (SetExpr
+       ((Exp (Base int ())) (Exp (Base int ()))
+        (Exp
+         (Variant
+          ((Blank ((Exp (Base int ()))))
+           (Filled
+            ((Exp (Base int ()))
+             (Exp
+              (Application
+               (Exp
+                (Variant
+                 ((If
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Thread
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FnCall
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (Variable ((Exp (Base string ()))))
+                  (Let
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Lambda
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled
+                           ((Exp (Base int ())) (Exp (Base string ()))))))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (Value ((Exp (Base string ()))))
+                  (FieldAccess
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))))
+                  (ObjectLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Tuple
+                         ((Exp
+                           (Variant
+                            ((Blank ((Exp (Base int ()))))
+                             (Filled
+                              ((Exp (Base int ())) (Exp (Base string ())))))))
+                          (Exp
+                           (Variant
+                            ((Blank ((Exp (Base int ()))))
+                             (Filled
+                              ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+                  (ListLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FeatureFlag
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int ()))))
+                       (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))
+                  (FnCallSendToRail
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int ()))))
+                          (Filled ((Exp (Base int ())) (Exp (Rec_app 0 ())))))))))))))))
+               ())))))))))
+      (TLSavepoint ((Exp (Base int ()))))
+      (DeleteFunction ((Exp (Base int ()))))))))))


### PR DESCRIPTION
These types don't exist anymore, so removing from the types.

Have confirmed that serialization still works.