### PR TITLE
When evaluating live values, FF condition evaluates incorrectly

### DIFF
--- a/server/libexecution/ast_analysis.ml
+++ b/server/libexecution/ast_analysis.ml
@@ -330,7 +330,7 @@ let rec exec ~(engine: engine)
        call name id argvals false
 
      | Filled (id, If (cond, ifbody, elsebody))
-     | Filled (id, FeatureFlag (_, cond, ifbody, elsebody)) ->
+     | Filled (id, FeatureFlag (_, cond, elsebody, ifbody)) ->
        (match ctx with
         | Preview ->
           (* In the case of a preview trace execution, we want the 'if' expression as


### PR DESCRIPTION
If the condition is True, it should bring you to case B.
For static evaluation, that was the case.

But it's returning case A for evaluation of conditions involving live values.

![screen shot 2018-08-24 at 1 46 24 pm](https://user-images.githubusercontent.com/244152/44607125-31655600-a7a4-11e8-8edd-e6d2c308c559.png)