### PR TITLE
Add a script to authorize kubectl from a shell in the dev container

### DIFF
--- a/scripts/gcp-authorize-kubectl
+++ b/scripts/gcp-authorize-kubectl
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+. ./scripts/support/assert-in-container $0 $@
+
+set -euo pipefail
+
+PROJECT="balmy-ground-195100"
+ZONE="us-west1"
+CLUSTER="darkcluster1"
+
+gcloud container clusters get-credentials projects/$PROJECT/zones/$ZONE/clusters/$CLUSTER --zone=$ZONE


### PR DESCRIPTION
This solves a regular personal annoyance of `$ run-in-docker bash` being unable to do `kubectl` after a rebuild/some time passes