### PR TITLE
Add demo account

### DIFF
--- a/server/libbackend/account.ml
+++ b/server/libbackend/account.ml
@@ -90,6 +90,8 @@ let get_permissions ~(auth_domain:string) ~(username:username) () : permissions 
   then CanAccessOperations
   else if String.Caseless.equal username auth_domain
   then CanEdit
+  else if String.Caseless.equal "demo" auth_domain
+  then CanEdit
   else NoPermission
 
 let can_access_operations ~(username:username) : bool =


### PR DESCRIPTION
Adds a demo account. The password is in the 1password admin vault, but you can access and edit this domain using any account (I tested using the test credentials in tests.js).