### PR TITLE
[WIP] Remove Native random calls for 0.19

### DIFF
--- a/client/Defaults.elm
+++ b/client/Defaults.elm
@@ -3,6 +3,7 @@ module Defaults exposing (..)
 -- builtin
 -- lib
 import Dict
+import Random
 
 -- dark
 import Types exposing (..)
@@ -95,4 +96,5 @@ defaultModel = { error = Nothing
                , featureFlags = Dict.empty
                , lockedHandlers = []
                , canvas = defaultCanvas
+               , seed = Random.initialSeed 0
                }

--- a/client/Main.elm
+++ b/client/Main.elm
@@ -2,7 +2,51 @@ port module Main exposing (..)
 
 
 -- builtins
+import AST
+import Analysis
+import Autocomplete as AC
+import Blank as B
+import Clipboard
+import Commands
+import DB
+import DarkKeyboard
+import Defaults
+import Editor
+import Entry
+import FeatureFlags
+import Functions
+import Http
+import IntegrationTest
+import JSON
+import Json.Decode as JSD
+import Json.Encode as JSE
+import Json.Encode.Extra as JSEE
+import Keyboard.Key as Key
 import Maybe
+import Mouse
+import Navigation
+import PageVisibility
+import Pointer as P
+import Prelude exposing (..)
+import RPC
+import Random.Steps
+import Refactor exposing (WrapLoc(..))
+import Random
+import Runtime
+import Selection
+import String.Extra as SE
+import Sync
+import Task
+import Time
+import Toplevel as TL
+import Types exposing (..)
+import Url
+import Util
+import VariantTesting exposing (parseVariantTestsFromQueryString)
+import View
+import Viewport
+import Window
+import Window.Events exposing (onWindow)
 
 -- lib
 import Json.Decode as JSD
@@ -109,7 +153,7 @@ init {editorState, complete} location =
         |> Maybe.withDefault m.currentPage
 
       canvas = m.canvas
-      newCanvas = 
+      newCanvas =
         case page of
           Toplevels pos -> { canvas | offset = pos }
           Fn _ pos -> { canvas | fnOffset = pos }
@@ -625,6 +669,8 @@ updateMod mod (m, cmd) =
         fn m ! []
       AutocompleteMod mod ->
         processAutocompleteMods m [mod]
+      SetSeed seed ->
+        ({m | seed = seed}, Cmd.none)
       -- applied from left to right
       Many mods -> List.foldl updateMod (m, Cmd.none) mods
 
@@ -724,8 +770,15 @@ update_ msg m =
                 then
                   case tl.data of
                     TLDB _ ->
-                      RPC ([ AddDBCol tlid (gid ()) (gid ())]
-                          , FocusNext tlid Nothing)
+                      let
+                          (randomInts, nextSeed) = Random.Steps.two Util.randomInt m.seed
+                          firstID = ID randomInts.first
+                          secondID = ID randomInts.second
+                      in
+                      Many [ RPC ([ AddDBCol tlid firstID secondID]
+                                  , FocusNext tlid Nothing)
+                           , SetSeed nextSeed
+                           ]
                     TLHandler h ->
                       case mId of
                         Just id ->
@@ -1552,7 +1605,8 @@ update_ msg m =
 
     CreateHandlerFrom404 (space, path, modifier, _) ->
       let center = findCenter m
-          anId = gtlid ()
+          (randomInt, nextSeed) = Random.step Util.randomInt m.seed
+          anId = TLID randomInt
           aPos = center
           aHandler =
             { ast = B.new ()
@@ -1568,14 +1622,18 @@ update_ msg m =
             , tlid = anId
             }
       in
-        RPC ([SetHandler anId aPos aHandler], FocusNothing)
+        Many [ RPC ([SetHandler anId aPos aHandler], FocusNothing)
+             , SetSeed nextSeed
+             ]
     CreateRouteHandler ->
       let center = findCenter m
         in Entry.submitOmniAction m center NewHTTPHandler
     CreateFunction ->
-      let ufun = Refactor.generateEmptyFunction ()
-        in RPC ( [ SetFunction ufun ]
-               , FocusPageAndCursor (Fn ufun.tlid Defaults.fnPos) m.cursorState)
+      let (ufun, nextSeed) = Refactor.generateEmptyFunction m.seed
+        in Many [ RPC ( [ SetFunction ufun ]
+                      , FocusPageAndCursor (Fn ufun.tlid Defaults.fnPos) m.cursorState)
+                , SetSeed nextSeed
+                ]
     LockHandler tlid isLocked ->
       Editor.updateLockedHandlers tlid isLocked m
     _ -> NoChange

--- a/client/Nineteen/String.elm
+++ b/client/Nineteen/String.elm
@@ -1,0 +1,7 @@
+
+module Nineteen.String exposing (fromInt)
+
+
+fromInt : Int -> String
+fromInt int =
+    toString int

--- a/client/Pointer.elm
+++ b/client/Pointer.elm
@@ -6,7 +6,6 @@ import Maybe
 -- dark
 import Types exposing (..)
 import Blank as B
-import Prelude exposing (..)
 import Runtime
 
 ------------------------
@@ -50,10 +49,6 @@ typeOf pd =
     PParamName _ -> ParamName
     PParamTipe _ -> ParamTipe
 
-
-emptyD : PointerType -> PointerData
-emptyD pt =
-  emptyD_ (gid()) pt
 
 toID : PointerData -> ID
 toID pd =
@@ -158,4 +153,3 @@ strmap fn pd =
     PFnName d -> PFnName (fn FnName d)
     PParamName d -> PParamName (fn ParamName d)
     PParamTipe _ -> pd
-

--- a/client/Prelude.elm
+++ b/client/Prelude.elm
@@ -58,9 +58,6 @@ deTLID (TLID i) = i
 gid : () -> ID -- Generate ID
 gid unit = ID (Util.random unit)
 
-gtlid : () -> TLID -- Generate ID
-gtlid unit = TLID (Util.random unit)
-
 
 --------------------------------------
 -- Crashing

--- a/client/Random/Steps.elm
+++ b/client/Random/Steps.elm
@@ -1,0 +1,266 @@
+module Random.Steps exposing
+    ( one
+    , two
+    , three
+    , four
+    , five
+    , six
+    , seven
+    , eight
+    , nine
+    , ten
+    )
+
+import Random
+
+
+{-| All of the (Two - Ten) types contain that many values of the same type
+-}
+type alias Two a =
+    { first : a
+    , second : a
+    }
+
+
+type alias Three a =
+    { first : a
+    , second : a
+    , third : a
+    }
+
+
+type alias Four a =
+    { first : a
+    , second : a
+    , third : a
+    , fourth : a
+    }
+
+
+type alias Five a =
+    { first : a
+    , second : a
+    , third : a
+    , fourth : a
+    , fifth : a
+    }
+
+
+type alias Six a =
+    { first : a
+    , second : a
+    , third : a
+    , fourth : a
+    , fifth : a
+    , sixth : a
+    }
+
+
+type alias Seven a =
+    { first : a
+    , second : a
+    , third : a
+    , fourth : a
+    , fifth : a
+    , sixth : a
+    , seventh : a
+    }
+
+
+type alias Eight a =
+    { first : a
+    , second : a
+    , third : a
+    , fourth : a
+    , fifth : a
+    , sixth : a
+    , seventh : a
+    , eighth : a
+    }
+
+
+type alias Nine a =
+    { first : a
+    , second : a
+    , third : a
+    , fourth : a
+    , fifth : a
+    , sixth : a
+    , seventh : a
+    , eighth : a
+    , ninth : a
+    }
+
+
+type alias Ten a =
+    { first : a
+    , second : a
+    , third : a
+    , fourth : a
+    , fifth : a
+    , sixth : a
+    , seventh : a
+    , eighth : a
+    , ninth : a
+    , tenth : a
+    }
+
+
+{-| All of the (one - ten) functions generate a type holding that many values
+Note: Elm 0.19 only supports tuples that are maximum 3-tuples
+-}
+one : Random.Generator a -> Random.Seed -> ( a, Random.Seed )
+one gen seed =
+    stepOne (\x -> x) gen seed
+
+
+two : Random.Generator a -> Random.Seed -> ( Two a, Random.Seed )
+two gen seed =
+    stepTwo Two gen seed
+
+
+three : Random.Generator a -> Random.Seed -> ( Three a, Random.Seed )
+three gen seed =
+    stepThree Three gen seed
+
+
+four : Random.Generator a -> Random.Seed -> ( Four a, Random.Seed )
+four gen seed =
+    stepFour Four gen seed
+
+
+five : Random.Generator a -> Random.Seed -> ( Five a, Random.Seed )
+five gen seed =
+    stepFive Five gen seed
+
+
+six : Random.Generator a -> Random.Seed -> ( Six a, Random.Seed )
+six gen seed =
+    stepSix Six gen seed
+
+
+seven : Random.Generator a -> Random.Seed -> ( Seven a, Random.Seed )
+seven gen seed =
+    stepSeven Seven gen seed
+
+
+eight : Random.Generator a -> Random.Seed -> ( Eight a, Random.Seed )
+eight gen seed =
+    stepEight Eight gen seed
+
+
+nine : Random.Generator a -> Random.Seed -> ( Nine a, Random.Seed )
+nine gen seed =
+    stepNine Nine gen seed
+
+
+ten : Random.Generator a -> Random.Seed -> ( Ten a, Random.Seed )
+ten gen seed =
+    stepTen Ten gen seed
+
+
+{-| All of the stepX (stepOne - stepTen) functions
+just let you generate x random values.
+
+For example:
+
+    stepThree (,,) Util.randomInt (Random.initialSeed 0)
+        => ( ( 5, 24, 12 ), nextSeed )
+
+etc...
+
+-}
+stepOne : (a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepOne f gen seed =
+    Random.step gen seed
+        |> Tuple.mapFirst f
+
+
+stepTwo : (a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepTwo f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepOne nextF gen nextSeed
+
+
+stepThree : (a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepThree f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepTwo nextF gen nextSeed
+
+
+stepFour : (a -> a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepFour f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepThree nextF gen nextSeed
+
+
+stepFive : (a -> a -> a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepFive f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepFour nextF gen nextSeed
+
+
+stepSix : (a -> a -> a -> a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepSix f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepFive nextF gen nextSeed
+
+
+stepSeven : (a -> a -> a -> a -> a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepSeven f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepSix nextF gen nextSeed
+
+
+stepEight : (a -> a -> a -> a -> a -> a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepEight f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepSeven nextF gen nextSeed
+
+
+stepNine : (a -> a -> a -> a -> a -> a -> a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepNine f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepEight nextF gen nextSeed
+
+
+stepTen : (a -> a -> a -> a -> a -> a -> a -> a -> a -> a -> b) -> Random.Generator a -> Random.Seed -> ( b, Random.Seed )
+stepTen f gen seed =
+    let
+        ( nextF, nextSeed ) =
+            Random.step gen seed
+                |> Tuple.mapFirst f
+    in
+    stepNine nextF gen nextSeed

--- a/client/Types.elm
+++ b/client/Types.elm
@@ -2,13 +2,15 @@ module Types exposing (..)
 
 -- builtin
 import Dict exposing (Dict)
-import Http
 import Dom
-import Navigation
-import Mouse
-import Time exposing (Time)
-import PageVisibility
+import Http
 import Json.Decode as JSD
+import Keyboard.Event exposing (KeyboardEvent)
+import Mouse
+import Navigation
+import PageVisibility
+import Random
+import Time exposing (Time)
 
 -- libs
 import Keyboard.Event exposing (KeyboardEvent)
@@ -484,6 +486,7 @@ type alias Model = { error : Maybe String
                    , featureFlags: FlagsVS
                    , lockedHandlers: List TLID
                    , canvas: CanvasProps
+                   , seed: Random.Seed
                    }
 
 -- Values that we serialize
@@ -549,6 +552,7 @@ type Modification = DisplayAndReportHttpError String Http.Error
                   | SetLockedHandlers (List TLID)
                   -- designed for one-off small changes
                   | TweakModel (Model -> Model)
+                  | SetSeed Random.Seed
 
 -----------------------------
 -- Flags / function types

--- a/client/Util.elm
+++ b/client/Util.elm
@@ -3,6 +3,7 @@ module Util exposing (..)
 -- builtin
 import Regex
 import Char
+import Random
 
 -- lib
 import List.Extra as LE
@@ -20,6 +21,13 @@ windowSize a = let size = Native.Window.size a
 
 random : () -> Int
 random a = Native.Random.random a
+
+{-| A `Random` generator for `Int`s within the app
+used throughout the app for things like new IDs, new Blanks, etc
+-}
+randomInt : Random.Generator Int
+randomInt =
+    Random.int 0 2147483647
 
 htmlSize : String -> (Float, Float)
 htmlSize str = let size = Native.Size.size str

--- a/client/ViewCode.elm
+++ b/client/ViewCode.elm
@@ -2,6 +2,7 @@ module ViewCode exposing (viewExpr, viewDarkType, viewHandler)
 
 -- builtin
 import Dict
+import Nineteen.String
 
 -- lib
 import Html
@@ -151,9 +152,10 @@ viewRopArrow vs =
   in
   Html.node
     "rop-arrow"
-    -- Force the rop-webcomponent to update to fix the size
-    [ VirtualDom.attribute "update" (Util.random () |> toString)
-    , VirtualDom.attribute "tlid" (toString (deTLID vs.tl.id))]
+    -- TODO: fix this in the component, as it's too expensive to generate a
+    -- new random number for every view and pass it in if we call this function.
+    [ VirtualDom.attribute "update" "true"
+    , deTLID vs.tl.id |> Nineteen.String.fromInt |> VirtualDom.attribute "tlid"]
     [svg]
 
 


### PR DESCRIPTION
This removes random usages of Native/Kernel code. This allows the codebase to move forward towards the 0.19 migration.


Note: This is a reopen of the earlier PR I made that was tracking a branch with formatting changes. If you'd like to see the commit history, [you can see it there](https://github.com/darklang/dark/pull/135)

