### PR TITLE
Bring scroll control to keyboard again

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -622,7 +622,7 @@ updateMod mod (m, cmd) =
         ({ m | executingFunctions = nexecutingFunctions }, Cmd.none)
       SetLockedHandlers locked ->
         ({ m | lockedHandlers = locked }, Cmd.none)
-      MoveCanvasToPos canvas page pos ->
+      MoveCanvasTo canvas page pos ->
         let canvas2 =
           case page of
             Toplevels _ -> { canvas | offset = pos }

--- a/client/Types.elm
+++ b/client/Types.elm
@@ -549,7 +549,7 @@ type Modification = DisplayAndReportHttpError String Http.Error
                   | ExecutingFunctionRPC TLID ID
                   | ExecutingFunctionComplete (List (TLID, ID))
                   | SetLockedHandlers (List TLID)
-                  | MoveCanvasToPos CanvasProps Page Pos
+                  | MoveCanvasTo CanvasProps Page Pos
                   -- designed for one-off small changes
                   | TweakModel (Model -> Model)
 

--- a/client/Viewport.elm
+++ b/client/Viewport.elm
@@ -68,7 +68,7 @@ moveRight m =
 
 moveToOrigin : Model -> Modification
 moveToOrigin m =
-  MoveCanvasToPos m.canvas m.currentPage Defaults.initialPos
+  MoveCanvasTo m.canvas m.currentPage Defaults.initialPos
 
 moveCanvasBy : Model -> (List Int) -> Modification
 moveCanvasBy m deltaCoords =
@@ -82,4 +82,4 @@ moveCanvasBy m deltaCoords =
           Toplevels _ -> c.offset
           Fn _ _ -> c.fnOffset
       pos = subPos offset d
-  in MoveCanvasToPos c m.currentPage pos
+  in MoveCanvasTo c m.currentPage pos


### PR DESCRIPTION
Problem: When I changed the way canvas scroll position is stored, i forgot to propagate changes of the new scroll controls to the keyboard ctrl handlers

Solution: UP/DOWN/RIGHT/LEFT arrow keys should control canvas position.
Ctrl + (A,E,F,B) moves the canvas by a bigger step increment.