### PR TITLE
Remove the bwd-ingress from builtwithdark.yaml.

### DIFF
--- a/scripts/support/builtwithdark.yaml
+++ b/scripts/support/builtwithdark.yaml
@@ -108,15 +108,6 @@ spec:
 
 ---
 apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: bwd-ingress
-spec:
-  backend:
-    serviceName: bwd-nodeport
-    servicePort: 80
----
-apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: bwd-network-policy


### PR DESCRIPTION
This is left over from #67; since we now have `bwd-tls-ingress` and we've switched all of the DNS over from this ingress, it's no longer necessary.