### PR TITLE
Fix deps for static/darkjs.bc.js

### DIFF
--- a/server/bin/jbuild
+++ b/server/bin/jbuild
@@ -42,7 +42,7 @@
 (alias
  (
   (name darkjs)
-  (deps (darkjs.bc.js))
+  (deps (darkjs.bc.js (universe)))
   (action (system "cp darkjs.bc.js ../../../static/"))))
 
 


### PR DESCRIPTION
Even if there is no change to frontend ocaml code, we need to ensure
that darkjs.bc.js is copied to server/static.

This broke CI because the cache didn't require a recompile, so there was no copy, causing integration tests to not have the `darkAnalysis` var available.