### PR TITLE
Upgrade testcafe to fix integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -260,6 +260,7 @@ ENV TERM=xterm-256color
 ######################
 # Quick hacks here, to avoid massive recompiles
 ######################
+RUN yarn add testcafe@0.22.0
 
 ############################
 # Finish


### PR DESCRIPTION
Integration tests are failing for an unknown reason when trying to load the
page. (Realistically, it's quite likely that darkjs.bc.js is taking a long time
to load). When investigating the error on github, i saw it suggested that new
versions of testcafe do better with the error message (it's currently using the
"DNS" error message which is incorrect).