### PR TITLE
Deploy an nginx 'sidecar' that proxies and gzips

### DIFF
--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -37,6 +37,7 @@ gcloud container clusters get-credentials projects/$PROJECT/zones/$ZONE/clusters
 
 # env vars (replace existing configmap or make a new one)
 (kubectl create configmap gke-dark-prod --from-env-file config/gke-builtwithdark -o yaml --dry-run | kubectl replace -f -) ||  kubectl create configmap gke-dark-prod --from-env-file config/gke-builtwithdark
+(kubectl create configmap nginx --from-file=scripts/support/nginx.conf -o yaml --dry-run | kubectl replace -f -) ||  kubectl create configmap nginx --from-file=scripts/support/nginx.conf
 
 
 # make sure deployment matches current understanding

--- a/scripts/support/builtwithdark.yaml
+++ b/scripts/support/builtwithdark.yaml
@@ -82,10 +82,21 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
 
+        - name: http-proxy
+          image: nginx:1.15.3
+          ports:
+            - name: http-proxy-port
+              containerPort: 8000
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: nginx-conf
       volumes:
         - name: cloudsql-instance-credentials
           secret:
             secretName: cloudsql-instance-credentials
+        - name: nginx-conf
+          configMap:
+            name: nginx
 
 #########################
 # End postgres proxy config
@@ -103,7 +114,7 @@ spec:
     - name: bwd-nodeport-port
       protocol: TCP
       port: 80
-      targetPort: bwd-ctr-port
+      targetPort: http-proxy-port
 
 
 ---

--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -1,0 +1,26 @@
+server {
+  listen 8000 default_server;
+  listen [::]:8000 default_server;
+
+  location / {
+    gzip on;
+    ## nginx assumes proxies can't handle gzip. That's wrong in our case;
+    ## the gke load-balancer will handle it fine, and in fact needs a gzipped
+    ## response to gzip.
+    ## http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_proxied
+    gzip_proxied any;
+    ## gzip these mine types. some other types of files are already gzipped
+    ## in a content-aware way (e.g. png, jpeg) so it probably doesn't make
+    ## sense to re-gzip them. (text/html isn't in this configuration file
+    ## because it's always there, and including it makes nginx warn. )
+    gzip_types text/plain text/css application/javascript application/json;
+    # don't gzip small files.
+    gzip_min_length 1024;
+    ## otherwise it'll be 'localhost'
+    proxy_set_header Host $host;
+    ## all other headers should get passed by default, including, for example
+    ## x-forwarded-for and x-forwarded-proto, so that the OCaml application
+    ## can know what the user or end-user visited.
+    proxy_pass http://localhost:80/;
+  }
+}


### PR DESCRIPTION
This deploys an nginx instance in every pod (i.e., for every running Dark server). This nginx instance listens on port 8000, proxies everything to port 80 (i.e., the Dark server) and gzips the responses (if the client has an Accept-encoding indicating it can receive gzip).

Gzipping everything isn't usually a win, since many file formats don't benefit much from being compressed, and for small files times might be dominated by zipping and unzipping rather than network transfer. I chose some parameters for the compression that made sense to me, namely gzipping text, html, css, javascript, and json, and only if the response >=1k. This helps a lot: it reduces elm.js, for example from 1078796 bytes to 226285, 20% (!) of the original.

Deploying an nginx in every pod isn't the most elegant solution but it works well and is operationally simple. We could also have nginx ingresses [with a plugin](https://github.com/kubernetes/ingress-nginx), but I don't understand all of the moving parts there, and setting it up seems operationally difficult.

This way also has some operational advantages: when we deploy new pods with new nginx configurations we get a cleaner deploy process, and don't have to worry about whether a new ingress configuration plays nicely with an old version of the code.

I deployed a cluster on 35.190.10.39 with the script in #150. If you put the following in /etc/hosts, you can try it out.
```
35.190.10.39	builtwithdark.com
```

proof that it works:

![20180913-172623](https://user-images.githubusercontent.com/490421/45522803-381b3380-b77a-11e8-8016-17834d41e3d6.png)
