### PR TITLE
Make dates work on the frontend

### DIFF
--- a/server/libexecution/util.ml
+++ b/server/libexecution/util.ml
@@ -17,10 +17,11 @@ let uuid_of_string (id: string) : Uuidm.t =
   |> Option.value_exn ~message:("Bad UUID: " ^ id)
 
 let isostring_of_date (d: Time.t) : string =
-  Libtarget.date_to_isostring d
+  let date, sec = Time.to_date_ofday ~zone:Time.Zone.utc d in
+  (Date.to_string date) ^ "T" ^ (Time.Ofday.to_sec_string sec) ^ "Z"
 
 let date_of_isostring (str: string) : Time.t =
-  Libtarget.date_of_isostring str
+  Time.of_string str
 
 let string_replace (search: string) (replace: string) (str: string) : string =
   String.Search_pattern.replace_all (String.Search_pattern.create search) ~in_:str ~with_:replace

--- a/server/libtarget.js/libtarget.ml
+++ b/server/libtarget.js/libtarget.ml
@@ -16,12 +16,6 @@ let digest256 (input: string) : string =
   |> dark_targetjs_digest256
   |> Js.to_string
 
-let date_to_isostring (d: Core_kernel.Time.t) : string =
-  ""
-
-let date_of_isostring (str: string) : Core_kernel.Time.t =
-  Core_kernel.Time.now ()
-
 let regexp_replace ~(pattern: string) ~(replacement: string) (str: string) : string =
   Regexp.global_replace (Regexp.regexp pattern) str replacement
 

--- a/server/libtarget.ocaml/libtarget.ml
+++ b/server/libtarget.ocaml/libtarget.ml
@@ -11,13 +11,6 @@ let digest256 (input: string) : string =
 let digest384 (input: string) : string =
   sha ~f:Nocrypto.Hash.SHA384.digest input
 
-let date_to_isostring (d: Core_kernel.Time.t) : string =
-  (* for conduit tests. May do something different later *)
-  Core.Time.format d "%FT%TZ" ~zone:Core.Time.Zone.utc
-
-let date_of_isostring (str: string) : Core_kernel.Time.t =
-  Core.Time.parse str ~fmt:"%FT%TZ" ~zone:Core.Time.Zone.utc
-
 let regexp_replace ~(pattern: string) ~(replacement: string) (str: string) : string =
   Re2.replace_exn (Re2.create_exn pattern) str
     ~f:(fun _ -> replacement)

--- a/server/libtarget/libtarget.mli
+++ b/server/libtarget/libtarget.mli
@@ -5,9 +5,6 @@ val digest384 : string -> string
 val digest256 : string -> string
 
 
-val date_of_isostring : string -> Core_kernel.Time.t
-val date_to_isostring : Core_kernel.Time.t -> string
-
 val regexp_replace : pattern:string -> replacement:string -> string -> string
 
 val string_split : sep:string -> string -> string list


### PR DESCRIPTION
I hadn't implemented Date parsing in libtarget.js yet, but it turns out there's enough in Core_kernel that I didn't have to do it target-specifically.