### PR TITLE
Backport indentation, shadowing, and some tuple fixes from 0.19 to 0.18

### DIFF
--- a/client/Analysis.elm
+++ b/client/Analysis.elm
@@ -57,8 +57,8 @@ cursor_ cursors tlid =
   |> Maybe.withDefault 0
 
 setCursor : Model -> TLID -> Int -> Model
-setCursor m tlid cursor =
-  let newCursors = Dict.insert (deTLID tlid) cursor m.tlCursors in
+setCursor m tlid cursorNum =
+  let newCursors = Dict.insert (deTLID tlid) cursorNum m.tlCursors in
   { m | tlCursors =  newCursors}
 
 
@@ -141,15 +141,12 @@ getArguments m tlid traceID callerID =
       analyses = Dict.get traceID m.analyses
       dvals =
         case analyses of
-          Just analyses ->
+          Just analyses_ ->
             List.filterMap
-              (\id -> Dict.get (deID id) analyses.liveValues)
+              (\id -> Dict.get (deID id) analyses_.liveValues)
               argIDs
           Nothing -> []
   in
   if List.length dvals == List.length argIDs
   then Just dvals
   else Nothing
-
-
-

--- a/client/Autocomplete.elm
+++ b/client/Autocomplete.elm
@@ -466,16 +466,16 @@ generateFromModel m a =
             |> Maybe.map P.toID
             |> Maybe.andThen (Analysis.getCurrentLiveValue m tlid)
             -- don't filter on incomplete values
-            |> Maybe.andThen (\dv -> if dv == DIncomplete
+            |> Maybe.andThen (\dv_ -> if dv_ == DIncomplete
                                      then Nothing
-                                     else Just dv)
+                                     else Just dv_)
       fields =
         case dv of
-          Just dv ->
-            case (a.target, RT.typeOf dv) of
+          Just dv_ ->
+            case (a.target, RT.typeOf dv_) of
               (Just (_, p), TObj) ->
                 if P.typeOf p == Field
-                then dvalFields dv
+                then dvalFields dv_
                 else []
               _ -> []
           Nothing -> []
@@ -535,12 +535,12 @@ generateFromModel m a =
         |> List.filter
           (\fn ->
              case dv of
-               Just dv ->
+               Just dv_ ->
                  if isThreadMember
                  then
-                   Nothing /= findCompatibleThreadParam fn (RT.typeOf dv)
+                   Nothing /= findCompatibleThreadParam fn (RT.typeOf dv_)
                  else
-                   Nothing /= findParamByType fn (RT.typeOf dv)
+                   Nothing /= findParamByType fn (RT.typeOf dv_)
                Nothing -> True)
         |> List.map ACFunction
 
@@ -575,16 +575,16 @@ generateFromModel m a =
                 ]
               DBColType ->
                 let builtins =
-                  [ "String"
-                  , "Int"
-                  , "Boolean"
-                  , "Float"
-                  , "Title"
-                  , "Url"
-                  , "Date"
-                  , "Password"
-                  , "UUID"
-                  ]
+                      [ "String"
+                      , "Int"
+                      , "Boolean"
+                      , "Float"
+                      , "Title"
+                      , "Url"
+                      , "Date"
+                      , "Password"
+                      , "UUID"
+                      ]
                     compound =
                       List.map
                         (\s -> "[" ++ s ++ "]")
@@ -722,4 +722,3 @@ selectSharedPrefix ac =
   if sp == "" then NoChange
   else
     AutocompleteMod <| ACSetQuery sp
-

--- a/client/Editor.elm
+++ b/client/Editor.elm
@@ -49,10 +49,10 @@ updateLockedHandlers tlid lockHandler m =
   let tl = TL.getTL m tlid
   in case tl.data of
     TLHandler _ ->
-    let lockedList =
-      if lockHandler then
-        tlid :: m.lockedHandlers
-      else
-        List.filter (\t -> t /= tlid) m.lockedHandlers
-    in SetLockedHandlers lockedList
+      let lockedList =
+            if lockHandler then
+              tlid :: m.lockedHandlers
+            else
+              List.filter (\t -> t /= tlid) m.lockedHandlers
+      in SetLockedHandlers lockedList
     _ -> NoChange

--- a/client/Entry.elm
+++ b/client/Entry.elm
@@ -62,7 +62,7 @@ createFunction : Model -> FnName -> Maybe Expr
 createFunction m name =
   let blanks count = LE.initialize count (\_ -> B.new ())
       fn = m.complete.functions
-           |> List.filter (\fn -> fn.name == name)
+           |> List.filter (\fn_ -> fn_.name == name)
            |> List.head
   in
     case fn of
@@ -348,7 +348,7 @@ submit m cursor action =
           replace new =
             tl
             |> TL.replace pd new
-            |> \tl -> save tl new
+            |> \tl_ -> save tl_ new
       in
       case pd of
         PDBColType ct ->
@@ -408,10 +408,10 @@ submit m cursor action =
                 -- blank. Then get the parent structure from the new ID
                 wrapped =
                   case parent of
-                    F id (FieldAccess lhs rhs) ->
+                    F id_ (FieldAccess lhs rhs) ->
                       B.newF (
                         FieldAccess
-                          (F id (FieldAccess lhs (B.newF fieldname)))
+                          (F id_ (FieldAccess lhs (B.newF fieldname)))
                           (B.new ()))
                     _ -> impossible ("should be a field", parent)
                 new = PExpr wrapped
@@ -440,7 +440,7 @@ submit m cursor action =
           ast
           |> AST.replace pd new
           |> AST.maybeExtendObjectLiteralAt new
-          |> \ast -> saveAst ast new
+          |> \ast_ -> saveAst ast_ new
         PExpr e ->
           case tl.data of
             TLHandler h ->
@@ -455,8 +455,8 @@ submit m cursor action =
               in
               saveAst newast (PExpr newexpr)
 
-            TLDB db ->
-              case db.activeMigration of
+            TLDB db_ ->
+              case db_.activeMigration of
                 Nothing -> NoChange
                 Just am ->
                   if List.member pd (AST.allData am.rollback)

--- a/client/FeatureFlags.elm
+++ b/client/FeatureFlags.elm
@@ -60,7 +60,6 @@ end m id pick =
 
 toggle : Model -> ID ->  Bool -> Modification
 toggle m id isExpanded =
-  TweakModel (\m -> {
-    m | featureFlags = Dict.insert (deID id) isExpanded m.featureFlags
+  TweakModel (\m_ -> {
+    m_ | featureFlags = Dict.insert (deID id) isExpanded m_.featureFlags
   })
-  

--- a/client/Functions.elm
+++ b/client/Functions.elm
@@ -127,8 +127,8 @@ replaceParamName search replacement uf =
               case replacement of
                 PParamName new ->
                   let newP =
-                    metadata.parameters
-                    |> List.map (\p -> { p | name = B.replace sId new p.name })
+                        metadata.parameters
+                        |> List.map (\p -> { p | name = B.replace sId new p.name })
                   in
                       { metadata | parameters = newP }
                 _ -> metadata
@@ -180,8 +180,8 @@ replaceParamTipe search replacement uf =
               case replacement of
                 PParamTipe new ->
                   let newP =
-                    metadata.parameters
-                    |> List.map (\p -> { p | tipe = B.replace sId new p.tipe })
+                        metadata.parameters
+                        |> List.map (\p -> { p | tipe = B.replace sId new p.tipe })
                   in
                       { metadata | parameters = newP }
                 _ -> metadata
@@ -200,12 +200,12 @@ replaceMetadataField old new uf =
 extend : UserFunction -> UserFunction
 extend uf =
   let newParam =
-      { name = B.new ()
-      , tipe = B.new ()
-      , block_args = []
-      , optional = False
-      , description = ""
-      }
+        { name = B.new ()
+        , tipe = B.new ()
+        , block_args = []
+        , optional = False
+        , description = ""
+        }
       metadata = uf.metadata
       newMetadata =
         { metadata | parameters = (uf.metadata.parameters ++ [newParam]) }
@@ -222,5 +222,3 @@ removeParameter uf ufp =
         { metadata | parameters = params }
   in
       { uf | metadata = newM }
-
-

--- a/client/IntegrationTest.elm
+++ b/client/IntegrationTest.elm
@@ -274,11 +274,8 @@ ellen_hello_world_demo m =
              |> deMaybe "hw2"
              |> .spec
   in
-  case (spec.module_, spec.name, spec.modifier, onlyExpr m) of
-    ( F _ "HTTP"
-    , F _ "/hello"
-    , F _ "GET"
-    , Value "\"Hello world!\"") ->
+  case ((spec.module_, spec.name), (spec.modifier, onlyExpr m)) of
+    ((F _ "HTTP", F _ "/hello"), (F _ "GET", Value "\"Hello world!\"")) ->
       pass
     other -> fail other
 
@@ -300,9 +297,7 @@ editing_headers m =
              |> .spec
   in
   case (spec.module_, spec.name, spec.modifier) of
-    ( F _ "HTTP"
-    , F _ "/myroute"
-    , F _ "GET") ->
+    ( F _ "HTTP", F _ "/myroute", F _ "GET") ->
       pass
     other -> fail other
 
@@ -325,10 +320,10 @@ case_sensitivity m =
                TLDB {name, cols} ->
                  case (name, cols) of
                    ( "TestUnicode"
-                   , [ (F _ "cOlUmNnAmE", F _ "Str")
+                     , [ (F _ "cOlUmNnAmE", F _ "Str")
                      , (Blank _, Blank _)
                      ]
-                   ) -> pass
+                     ) -> pass
                    other -> fail other
                TLHandler h ->
                  case h.ast of
@@ -413,8 +408,8 @@ rename_db_fields m =
       TLDB {name, cols} ->
         case cols of
           [ (F id "field6", F _ "String")
-          , (F _ "field2", F _ "String")
-          , (Blank _, Blank _)] ->
+           , (F _ "field2", F _ "String")
+           , (Blank _, Blank _)] ->
             case m.cursorState of
               Selecting _ (Just sid) ->
                 if sid == id
@@ -434,8 +429,8 @@ rename_db_type m =
       TLDB {name, cols} ->
         case cols of
           [ (F id "field1", F _ "String")
-          , (F _ "field2", F _ "Int")
-          , (Blank _, Blank _)] ->
+           , (F _ "field2", F _ "Int")
+           , (Blank _, Blank _)] ->
             case m.cursorState of
               Selecting _ (Just sid) ->
                 if sid == id
@@ -530,7 +525,7 @@ feature_flag_in_function m =
               (F _ (Value "5"))
               (F _ (Value "3")))
             ,F _ (Value "5")]) NoRail
-        ) -> pass
+            ) -> pass
           -- TODO: validate result should evaluate true turnging  5 + 5 --> 3 + 5 == 8
           -- let res = Analysis.getLiveValue m f.tlid id
           -- in case res of
@@ -625,11 +620,11 @@ editing_starts_a_thread_with_shift_enter : Model -> TestResult
 editing_starts_a_thread_with_shift_enter m =
   case (m.cursorState, onlyExpr m) of
     ( Entering (Filling _ id1)
-    , Let _ (F _ (Thread [ F _ (Value "52")
+     , Let _ (F _ (Thread [ F _ (Value "52")
                            , Blank id2
                            ]))
             _
-    ) ->
+     ) ->
       if id1 == id2
       then pass
       else fail (m.cursorState, onlyExpr m)
@@ -640,7 +635,7 @@ object_literals_work : Model -> TestResult
 object_literals_work m =
   case (m.cursorState, onlyExpr m) of
     (Entering (Filling tlid id)
-    , ObjectLiteral [ (F _ "k1", Blank _)
+     , ObjectLiteral [ (F _ "k1", Blank _)
                     , (F _ "k2", F _ (Value "2"))
                     , (F _ "k3", F _ (Value "3"))
                     , (F _ "k4", Blank _ )

--- a/client/JSON.elm
+++ b/client/JSON.elm
@@ -251,13 +251,13 @@ encodeList enc l =
 encodeHttpError : Http.Error -> JSE.Value
 encodeHttpError e =
   let encodeResponse r =
-      JSE.object [ ("url", JSE.string r.url)
-                 , ("status", JSE.object [ ("code", JSE.int r.status.code)
-                                         , ("message", JSE.string r.status.message)
-                                         ])
-                 , ("headers", JSEE.dict identity JSE.string r.headers)
-                 , ("body", JSE.string r.body)
-                 ]
+        JSE.object [ ("url", JSE.string r.url)
+                   , ("status", JSE.object [ ("code", JSE.int r.status.code)
+                                           , ("message", JSE.string r.status.message)
+                                           ])
+                   , ("headers", JSEE.dict identity JSE.string r.headers)
+                   , ("body", JSE.string r.body)
+                   ]
   in
   case e of
     Http.BadUrl url ->
@@ -277,5 +277,3 @@ encodeHttpError e =
                  , ("message", JSE.string msg)
                  , ("response", encodeResponse response)
                  ]
-
-

--- a/client/Main.elm
+++ b/client/Main.elm
@@ -681,7 +681,7 @@ processAutocompleteMods m mods =
           then Debug.log "autocompletemod update" mods
           else mods
       complete = List.foldl
-        (\mod complete -> AC.update m mod complete)
+        (\mod complete_ -> AC.update m mod complete_)
         m.complete
         mods
       focus = case unwrapCursorState m.cursorState of
@@ -1090,10 +1090,10 @@ update_ msg m =
                   if event.key == Just "."
                   && isFieldAccessDot m m.complete.value
                   then
-                    let c = m.complete
+                    let c_ = m.complete
                         -- big hack to for Entry.submit to see field
                         -- access
-                        newC = { c | value = AC.getValue c ++ "."
+                        newC = { c_ | value = AC.getValue c_ ++ "."
                                            , index = -1}
                         newM = { m | complete = newC }
                     in
@@ -1515,8 +1515,8 @@ update_ msg m =
               , newState
               ]
 
-    SaveTestRPCCallback (Ok msg) ->
-      DisplayError <| "Success! " ++ msg
+    SaveTestRPCCallback (Ok msg_) ->
+      DisplayError <| "Success! " ++ msg_
 
     ExecuteFunctionRPCCallback params (Ok (dval, hash)) ->
       Many [ UpdateTraceFunctionResult params.tlid params.traceID params.callerID params.fnName hash dval
@@ -1562,8 +1562,8 @@ update_ msg m =
     GetAnalysisRPCCallback (Err err) ->
       DisplayAndReportHttpError "GetAnalysis" err
 
-    JSError msg ->
-      DisplayError ("Error in JS: " ++ msg)
+    JSError msg_ ->
+      DisplayError ("Error in JS: " ++ msg_)
 
     WindowResize x y ->
       -- just receiving the subscription will cause a redraw, which uses
@@ -1596,10 +1596,10 @@ update_ msg m =
       NoChange
 
     PageVisibilityChange vis ->
-      TweakModel (\m -> { m | visibility = vis })
+      TweakModel (\m_ -> { m_ | visibility = vis })
 
     PageFocusChange vis ->
-      TweakModel (\m -> { m | visibility = vis })
+      TweakModel (\m_ -> { m_ | visibility = vis })
 
     CreateHandlerFrom404 {space, path, modifier} ->
       let center = findCenter m
@@ -1634,7 +1634,7 @@ update_ msg m =
 
     EnablePanning pan ->
       let c = m.canvas
-      in TweakModel (\m -> { m | canvas = { c | enablePan = pan } } )
+      in TweakModel (\m_ -> { m_ | canvas = { c | enablePan = pan } } )
 
     _ -> NoChange
 

--- a/client/RPC.elm
+++ b/client/RPC.elm
@@ -168,13 +168,13 @@ tlidOf op =
 encodeOps : List Op -> JSE.Value
 encodeOps ops =
   ops
-  |> (\ops ->
-        case ops of
-          [UndoTL _] -> ops
-          [RedoTL _] -> ops
-          [] -> ops
+  |> (\ops_ ->
+        case ops_ of
+          [UndoTL _] -> ops_
+          [RedoTL _] -> ops_
+          [] -> ops_
           _ ->
-            let savepoints = ops
+            let savepoints = ops_
                              |> List.map tlidOf
                              |> List.map TLSavepoint
             in savepoints ++ ops)
@@ -630,13 +630,13 @@ decodeDBMigration =
 decodeDB : JSD.Decoder DB
 decodeDB =
   let toDB tlid name cols version old active =
-      { tlid = TLID tlid
-      , name = name
-      , cols = cols
-      , version = version
-      , oldMigrations = old
-      , activeMigration = active
-      }
+        { tlid = TLID tlid
+        , name = name
+        , cols = cols
+        , version = version
+        , oldMigrations = old
+        , activeMigration = active
+        }
   in
   JSDP.decode toDB
   |> JSDP.required "tlid" JSD.int
@@ -736,10 +736,10 @@ decodeUserFunctionMetadata =
 decodeUserFunction : JSD.Decoder UserFunction
 decodeUserFunction =
   let toUserFn id meta ast =
-      { tlid = id
-      , metadata = meta
-      , ast = ast
-      }
+        { tlid = id
+        , metadata = meta
+        , ast = ast
+        }
   in
       JSDP.decode toUserFn
       |> JSDP.required "tlid" decodeTLID
@@ -788,7 +788,7 @@ decodeTraces =
 decodeTrace : JSD.Decoder Trace
 decodeTrace =
   let toTrace id input functionResults =
-    { id = id, input = input, functionResults = functionResults }
+        { id = id, input = input, functionResults = functionResults }
   in
   JSDP.decode toTrace
   |> JSDP.required "id" JSD.string
@@ -917,7 +917,7 @@ printDval dv =
     DOption opt ->
       case opt of
         Nothing -> wrapUserType JSE.null
-        Just dv -> wrapUserType (encodeDval dv)
+        Just dv_ -> wrapUserType (encodeDval dv_)
     DErrorRail _ -> wrapUserType JSE.null
 
 
@@ -1039,5 +1039,3 @@ encodeDval dv =
         Just dv -> ev "Just" [encodeDval dv]
       ]
     DErrorRail dv -> ev "DErrorRail" [encodeDval dv]
-
-

--- a/client/Runtime.elm
+++ b/client/Runtime.elm
@@ -207,13 +207,13 @@ toRepr_ oldIndent dv =
     DPassword s -> wrap s
     DBlock -> asType
     DIncomplete -> asType
-    DResp (Redirect url, dv) -> "302 " ++ url ++ nl ++ toRepr_ indent dv
-    DResp (Response (code, hs), dv) ->
+    DResp (Redirect url, dv_) -> "302 " ++ url ++ nl ++ toRepr_ indent dv_
+    DResp (Response (code, hs), dv_) ->
       let headers = objToString (List.map (Tuple.mapSecond DStr) hs) in
       toString code ++ " " ++ headers ++ nl ++ toRepr dv
     DOption Nothing -> "Nothing"
-    DOption (Just dv) -> "Some " ++ (toRepr dv)
-    DErrorRail dv -> wrap (toRepr dv)
+    DOption (Just dv_) -> "Some " ++ (toRepr dv_)
+    DErrorRail dv_ -> wrap (toRepr dv_)
     -- TODO: newlines and indentation
     DList l ->
       if l == []
@@ -235,5 +235,3 @@ extractErrorMessage lv =
   --   |> Maybe.map .short
   --   |> Maybe.withDefault lv.value
   -- else lv.value
-
-

--- a/client/Selection.elm
+++ b/client/Selection.elm
@@ -45,7 +45,7 @@ selectNextToplevel m cur =
   let tls = List.map .id m.toplevels
       next =
         cur
-        |> Maybe.andThen (\cur -> Util.listNextWrap cur tls)
+        |> Maybe.andThen (\cur_ -> Util.listNextWrap cur_ tls)
   in
   case next of
     Just nextId -> Select nextId Nothing
@@ -56,7 +56,7 @@ selectPrevToplevel m cur =
   let tls = List.map .id m.toplevels
       next =
         cur
-        |> Maybe.andThen (\cur -> Util.listPreviousWrap cur tls)
+        |> Maybe.andThen (\cur_ -> Util.listPreviousWrap cur_ tls)
   in
   case next of
     Just nextId -> Select nextId Nothing
@@ -274,7 +274,7 @@ enterNextBlank m tlid cur =
   in
   pd
   |> TL.getNextBlank tl
-  |> Maybe.map (\pd -> Enter (Filling tlid (P.toID pd)))
+  |> Maybe.map (\pd_ -> Enter (Filling tlid (P.toID pd_)))
   |> Maybe.withDefault NoChange
 
 selectPrevBlank : Model -> TLID -> (Maybe ID) -> Modification
@@ -294,7 +294,7 @@ enterPrevBlank m tlid cur =
   in
   pd
   |> TL.getPrevBlank tl
-  |> Maybe.map (\pd -> Enter (Filling tlid (P.toID pd)))
+  |> Maybe.map (\pd_ -> Enter (Filling tlid (P.toID pd_)))
   |> Maybe.withDefault NoChange
 
 
@@ -373,7 +373,4 @@ enter m tlid id =
         then
           DB.initFieldTypeMigration m tl d
         else enterMods
-      pd -> enterMods
-
-
-
+      _ -> enterMods

--- a/client/SpecHeaders.elm
+++ b/client/SpecHeaders.elm
@@ -13,7 +13,7 @@ spaceOf : HandlerSpec -> HandlerSpace
 spaceOf hs =
   let spaceOfStr s =
         let lwr =
-            String.toLower s
+              String.toLower s
         in
             if lwr == "http"
             then HSHTTP
@@ -61,6 +61,3 @@ allData spec =
   [ PEventName spec.name
   , PEventSpace spec.module_
   , PEventModifier spec.modifier]
-
-
-

--- a/client/SpecTypes.elm
+++ b/client/SpecTypes.elm
@@ -26,7 +26,10 @@ replaceInType : PointerData -> PointerData -> DarkType -> DarkType
 replaceInType pd replacement dt =
   -- This needs to check the entire Flagged structure, as in
   -- AST.replace.
-  let _ = todo ("replaceInType", pd, replacement, dt) in
+  let _ = todo { msg = "replaceInType"
+               , pointerData = pd
+               , replacement = replacement
+               , darkType= dt } in
   if B.toID dt == P.toID pd
   then
     case replacement of
@@ -107,5 +110,3 @@ siblings p t =
         |> List.concat
 
     _ -> []
-
-

--- a/client/Toplevel.elm
+++ b/client/Toplevel.elm
@@ -185,8 +185,8 @@ clonePointerData pd =
     PDarkType dt -> todo ("clonePointerData", pd)
     PDarkTypeField dt -> todo ("clonePointerData", pd)
     PFFMsg msg -> PFFMsg (B.clone identity msg)
-    PFnName name -> PFnName (B.clone identity name)
-    PParamName name -> PParamName (B.clone identity name)
+    PFnName name_ -> PFnName (B.clone identity name_)
+    PParamName name_ -> PParamName (B.clone identity name_)
     PParamTipe tipe -> PParamTipe (B.clone identity tipe)
 
 -------------------------
@@ -207,9 +207,9 @@ blanksWhere fn tl =
 getNextBlank : Toplevel -> Predecessor -> Successor
 getNextBlank tl pred =
   case pred of
-    Just pred ->
+    Just pred_ ->
       let ps = allData tl
-          index = LE.elemIndex pred ps |> Maybe.withDefault (-1)
+          index = LE.elemIndex pred_ ps |> Maybe.withDefault (-1)
           remaining = List.drop (index+1) ps
           blanks = List.filter P.isBlank remaining in
       blanks
@@ -220,9 +220,9 @@ getNextBlank tl pred =
 getPrevBlank : Toplevel -> Successor -> Predecessor
 getPrevBlank tl next =
   case next of
-    Just next ->
+    Just next_ ->
       let ps = allData tl
-          index = LE.elemIndex next ps |> Maybe.withDefault (List.length ps)
+          index = LE.elemIndex next_ ps |> Maybe.withDefault (List.length ps)
           remaining = List.take index ps
           blanks = List.filter P.isBlank remaining in
       blanks
@@ -398,7 +398,7 @@ replace p replacement tl =
     PDBColType tipe ->
       tl
       -- SetDBColType tl.id id (tipe |> B.toMaybe |> deMaybe "replace - tipe")
-    PDBColName name ->
+    PDBColName _ ->
       tl
       -- SetDBColName tl.id id (name |> B.toMaybe |> deMaybe "replace - name")
     PFFMsg bo ->

--- a/client/Url.elm
+++ b/client/Url.elm
@@ -67,7 +67,7 @@ maybeUpdateScrollUrl m =
   if pos /= state.lastPos
   then
     Many
-      [ TweakModel (\m -> { m | urlState = { state | lastPos = pos } })
+      [ TweakModel (\m_ -> { m_ | urlState = { state | lastPos = pos } })
       , MakeCmd (Navigation.modifyUrl (urlOf m.currentPage pos))
       ]
   else NoChange

--- a/client/View.elm
+++ b/client/View.elm
@@ -28,8 +28,7 @@ import Autocomplete
 
 view : Model -> Html.Html Msg
 view m =
-  let (w, h) = Util.windowSize ()
-      attributes =
+  let attributes =
         [ Attrs.id "grid"
         , Events.onWithOptions
         "mouseup"
@@ -66,9 +65,9 @@ viewCanvas m =
 
         canvasTransform =
           let offset =
-            case m.currentPage of
-              Toplevels _ -> m.canvas.offset
-              Fn _ _ -> m.canvas.fnOffset
+                case m.currentPage of
+                  Toplevels _ -> m.canvas.offset
+                  Fn _ _ -> m.canvas.fnOffset
           in "translate(" ++ (String.fromInt offset.x) ++ "px, " ++ (String.fromInt offset.y) ++ "px)"
 
         allDivs = asts ++ entry
@@ -140,8 +139,8 @@ viewTL_ m tlid =
         else ""
       boxClasses =
         case m.cursorState of
-          Dragging tlid _ _ _ ->
-            if tlid == tl.id then ["dragging"] else []
+          Dragging tlid_ _ _ _ ->
+            if tlid_ == tl.id then ["dragging"] else []
           _ -> []
       class =
         [ selected

--- a/client/ViewBlankOr.elm
+++ b/client/ViewBlankOr.elm
@@ -202,8 +202,8 @@ div vs configs content =
                         then [viewFeatureFlag]
                         else []
       editFnHtml = case editFn of
-                     Just editFn ->
-                       [viewEditFn editFn showFeatureFlag]
+                     Just editFn_ ->
+                       [viewEditFn editFn_ showFeatureFlag]
                      Nothing -> if showFeatureFlag then [viewCreateFn] else []
       rightSideHtml =
         Html.div

--- a/client/ViewCode.elm
+++ b/client/ViewCode.elm
@@ -162,10 +162,10 @@ viewRopArrow vs =
 
 viewNExpr : Int -> ID -> Viewer NExpr
 viewNExpr d id vs config e =
-  let vExpr d = viewExpr d vs []
-      vExprTw d =
+  let vExpr d_ = viewExpr d_ vs []
+      vExprTw d_ =
         let vs2 = { vs | tooWide = True } in
-        viewExpr d vs2 []
+        viewExpr d_ vs2 []
       t = text vs
       n c = div vs (nested :: c)
       a c = text vs (atom :: c)
@@ -224,17 +224,17 @@ viewNExpr d id vs config e =
 
     FnCall name exprs sendToRail ->
       let width = approxNWidth e
-          viewTooWideArg name d e =
+          viewTooWideArg name_ d_ e_ =
             Html.div
-              [ Attrs.attribute "param-name" name
+              [ Attrs.attribute "param-name" name_
               ,  Attrs.class "arg-on-new-line"
               ]
-              [ vExprTw d e ]
-          ve name = if width > 120
-                    then viewTooWideArg name
+              [ vExprTw d_ e_ ]
+          ve name_ = if width > 120
+                    then viewTooWideArg name_
                     else vExpr
           fnname parens =
-            let withP name = if parens then "(" ++ name ++ ")" else name in
+            let withP name_ = if parens then "(" ++ name_ ++ ")" else name_ in
             case String.split "::" name of
               [mod, justname] ->
                 n [wc "namegroup", atom]
@@ -273,8 +273,8 @@ viewNExpr d id vs config e =
           isComplete v =
             v
             |> getLiveValue vs.currentResults.liveValues
-            |> \v ->
-                 case v of
+            |> \v_ ->
+                 case v_ of
                    Nothing -> False
                    Just (DError _) -> False
                    Just DIncomplete -> False
@@ -300,32 +300,32 @@ viewNExpr d id vs config e =
                    , nothingMouseEvent "mousedown"
                    , nothingMouseEvent "dblclick"
                    ]
-          (bClass, bEvent, bTitle, bIcon) =
+          {class, event, title, icon} =
             if buttonUnavailable
-            then ("execution-button-unavailable"
-                 , []
-                 , "Cannot run: some parameters are incomplete"
-                 , exeIcon)
+            then { class = "execution-button-unavailable"
+                 , event = []
+                 , title = "Cannot run: some parameters are incomplete"
+                 , icon = exeIcon }
             else if buttonNeeded
-            then ("execution-button-needed"
-                  , events
-                  , "Click to execute function"
-                  , exeIcon)
+            then { class = "execution-button-needed"
+                 , event = events
+                 , title = "Click to execute function"
+                 , icon = exeIcon }
             else
-              ("execution-button-repeat"
-              , events
-              , "Click to execute function again"
-              , "redo")
+              { class = "execution-button-repeat"
+              , event = events
+              , title = "Click to execute function again"
+              , icon = "redo" }
           executingClass = if showExecuting then " is-executing" else ""
           button =
             if not showButton
             then []
             else
               [ Html.div
-                ([ Attrs.class ("execution-button " ++ bClass ++ executingClass)
-                 , Attrs.title bTitle
-                 ] ++ bEvent)
-                [fontAwesome bIcon]
+                ([ Attrs.class ("execution-button " ++ class ++ executingClass)
+                 , Attrs.title title
+                 ] ++ event)
+                [fontAwesome icon]
               ]
 
           fnDiv parens =
@@ -342,7 +342,7 @@ viewNExpr d id vs config e =
           ]
         _ ->
           let args = List.map2
-                       (\p e -> ve p.name incD e)
+                       (\p e_ -> ve p.name incD e_)
                        fn.parameters
                        exprs
 
@@ -360,15 +360,15 @@ viewNExpr d id vs config e =
 
     Thread exprs ->
       let pipe = a [wc "thread pipe"] "|>"
-          texpr e =
-            let id = B.toID e
+          texpr e_ =
+            let id_ = B.toID e_
                 dopts =
                   if d == 0
-                  then [ClickSelectAs id, ComputedValueAs id]
-                  else [ClickSelectAs id]
+                  then [ClickSelectAs id_, ComputedValueAs id_]
+                  else [ClickSelectAs id_]
             in
             n ([wc "threadmember"] ++ dopts)
-              [pipe, vExpr 0 e]
+              [pipe, vExpr 0 e_]
       in
       n (wc "threadexpr" :: mo :: config)
         (List.map texpr exprs)
@@ -389,15 +389,15 @@ viewNExpr d id vs config e =
       let open = a [wc "openbracket"] "["
           close = a [wc "closebracket"] "]"
           comma = a [wc "comma"] ","
-          lexpr e =
-            let id = B.toID e
+          lexpr e_ =
+            let id_ = B.toID e_
                 dopts =
                   if d == 0
-                  then [ClickSelectAs id, ComputedValueAs id]
-                  else [ClickSelectAs id]
+                  then [ClickSelectAs id_, ComputedValueAs id_]
+                  else [ClickSelectAs id_]
             in
             n ([wc "listelem"] ++ dopts)
-              [vExpr 0 e]
+              [vExpr 0 e_]
           new = List.map lexpr exprs
                 |> List.intersperse comma
       in
@@ -415,8 +415,8 @@ viewNExpr d id vs config e =
       n (wc "object" :: mo :: config)
         ([open] ++ List.map pexpr pairs ++ [close])
 
-    FeatureFlag msg cond a b ->
-      let exprLabel msg = Html.label [ Attrs.class "expr-label" ] [ Html.text msg ]
+    FeatureFlag msg cond a_ b_ ->
+      let exprLabel msg_ = Html.label [ Attrs.class "expr-label" ] [ Html.text msg_ ]
 
           isExpanded =
             let mv = Dict.get (deID id) vs.featureFlags
@@ -490,25 +490,25 @@ viewNExpr d id vs config e =
             Html.div
             [ Attrs.class "row expressions" ]
             [
-              exprBlock "Case A" pickA a
-              , exprBlock "Case B" pickB b
+              exprBlock "Case A" pickA a_
+              , exprBlock "Case B" pickB b_
             ]
 
-    in
-      div vs
-        [ wc "flagged shown"]
-        [ viewExpr 0 { vs | showEntry = False } [] (if condResult then b else a)
-        , fontAwesome "flag"
-        , Html.div
-          [
-            Attrs.class ("feature-flag" ++ (if isExpanded then " expand" else ""))
+      in
+        div vs
+          [ wc "flagged shown"]
+          [ viewExpr 0 { vs | showEntry = False } [] (if condResult then b_ else a_)
+          , fontAwesome "flag"
+          , Html.div
+            [
+              Attrs.class ("feature-flag" ++ (if isExpanded then " expand" else ""))
+            ]
+            [
+              titleBar
+              , blockCondition
+              , expressions
+            ]
           ]
-          [
-            titleBar
-            , blockCondition
-            , expressions
-          ]
-        ]
 
 
 isExecuting : ViewState -> ID -> Bool

--- a/client/ViewDB.elm
+++ b/client/ViewDB.elm
@@ -52,14 +52,14 @@ viewDB vs db =
         db.cols
         |> List.map (\(n, t) ->
           let migration =
-              db.activeMigration
-              |> Maybe.andThen
-                   (\am ->
-                     if am.target == B.toID n
-                     || am.target == B.toID t
-                     then Just (viewDBMigration vs am)
-                     else Nothing)
-              |> ME.toList
+                db.activeMigration
+                |> Maybe.andThen
+                     (\am ->
+                       if am.target == B.toID n
+                       || am.target == B.toID t
+                       then Just (viewDBMigration vs am)
+                       else Nothing)
+                |> ME.toList
           in
           Html.div
             [ Attrs.class "col" ]

--- a/client/ViewData.elm
+++ b/client/ViewData.elm
@@ -38,19 +38,19 @@ asValue inputValue =
 viewInputs : ViewState -> ID -> List (Html.Html Msg)
 viewInputs vs (ID astID) =
   let traceToHtml idx trace =
-    let value = asValue trace.input
-        -- Note: the following tlCursors are very different things.
-        isActive = (Analysis.cursor_ vs.tlCursors vs.tl.id) == idx
-        -- Note: this is not the same tlCursor as above
-        hoverID = tlCursorID vs.tl.id idx
-        isHover = vs.hovering == Just hoverID
-        astTipe = Dict.get trace.id vs.analyses
-                  |> Maybe.map .liveValues
-                  |> Maybe.andThen (Dict.get astID)
-                  |> Maybe.map RT.typeOf
-                  |> Maybe.withDefault TIncomplete
-    in
-    viewInput vs.tl.id idx value isActive isHover astTipe
+        let value = asValue trace.input
+            -- Note: the following tlCursors are very different things.
+            isActive = (Analysis.cursor_ vs.tlCursors vs.tl.id) == idx
+            -- Note: this is not the same tlCursor as above
+            hoverID = tlCursorID vs.tl.id idx
+            isHover = vs.hovering == Just hoverID
+            astTipe = Dict.get trace.id vs.analyses
+                      |> Maybe.map .liveValues
+                      |> Maybe.andThen (Dict.get astID)
+                      |> Maybe.map RT.typeOf
+                      |> Maybe.withDefault TIncomplete
+        in
+        viewInput vs.tl.id idx value isActive isHover astTipe
   in
   List.indexedMap traceToHtml vs.traces
 
@@ -66,7 +66,7 @@ viewData vs ast =
           _ -> Nothing
   in
   case selectedValue of
-    Just selectedValue ->
+    Just _ ->
       [ Html.div
           [Attrs.class "view-data live-view-selection-active"]
           [ Html.ul
@@ -82,4 +82,3 @@ viewData vs ast =
               requestEls
           ]
       ]
-

--- a/client/ViewEntry.elm
+++ b/client/ViewEntry.elm
@@ -34,9 +34,9 @@ viewEntry m =
 stringEntryHtml : Autocomplete -> StringEntryWidth -> Html.Html Msg
 stringEntryHtml ac width =
   let maxWidthChars =
-      case width of -- max-width rules from CSS
-        StringEntryNormalWidth -> 120
-        StringEntryShortWidth -> 40
+        case width of -- max-width rules from CSS
+          StringEntryNormalWidth -> 120
+          StringEntryShortWidth -> 40
       value = Util.transformToStringEntry ac.value
       longestLineLength = value
                           |> String.split "\n"

--- a/client/ViewRoutingTable.elm
+++ b/client/ViewRoutingTable.elm
@@ -7,7 +7,6 @@ import Html
 import Html.Attributes as Attrs
 import List.Extra as LE
 import Maybe.Extra as ME
-import Tuple2 as T2
 import Nineteen.String as String
 
 -- dark
@@ -41,7 +40,7 @@ spaceName tl =
 
 splitBySpace : List Toplevel -> List (String, List Toplevel)
 splitBySpace tls =
-  let spaceName tl = tl
+  let spaceName_ tl = tl
                      |> TL.asHandler
                      |> Maybe.map .spec
                      |> Maybe.map .module_
@@ -49,13 +48,13 @@ splitBySpace tls =
                      |> Maybe.withDefault missingEventSpaceDesc
   in
   tls
-  |> List.sortBy spaceName
-  |> LE.groupWhile (\a b -> spaceName a == spaceName b)
+  |> List.sortBy spaceName_
+  |> LE.groupWhile (\a b -> spaceName_ a == spaceName_ b)
   |> List.map (\hs ->
                  let space = hs
                              |> List.head
                              |> deMaybe "splitBySpace"
-                             |> spaceName
+                             |> spaceName_
                 in
                  (space, hs))
 
@@ -96,7 +95,7 @@ collapseByVerb es =
                        [] -> [curr]
                        prev :: rest ->
                          let new =
-                           { prev | verbs = prev.verbs ++ curr.verbs }
+                               { prev | verbs = prev.verbs ++ curr.verbs }
                          in new :: rest
                 ) [])
   |> List.concat
@@ -142,7 +141,7 @@ ordering a b =
     ("HTTP", _) -> LT
     (_, "HTTP") -> GT
     -- to the end
-    (a, b) ->
+    _ ->
       if a == missingEventRouteDesc
       then GT
       else if b == missingEventRouteDesc
@@ -218,12 +217,12 @@ viewRoutes tls collapse showLink showUndo =
   tls
   |> splitBySpace
   |> List.sortWith (\(a,_) (b,_) -> ordering a b)
-  |> List.map (T2.map tl2entry)
+  |> List.map (Tuple.mapSecond tl2entry)
   |> (\entries ->
        if collapse == CollapseVerbs
-       then List.map (T2.map collapseByVerb) entries
+       then List.map (Tuple.mapSecond collapseByVerb) entries
        else entries)
-  |> List.map (T2.map prefixify)
+  |> List.map (Tuple.mapSecond prefixify)
   |> List.map (viewGroup showLink showUndo)
 
 viewDeletedTLs : List Toplevel -> Html.Html Msg
@@ -301,11 +300,11 @@ tlLink pos class name =
     [Html.text name]
 
 fnLink : UserFunction -> Bool -> String -> Html.Html Msg
-fnLink fn isUsed text =
+fnLink fn isUsed text_ =
   Url.linkFor
     (Fn fn.tlid Defaults.fnPos)
     (if isUsed then "default-link" else "default-link unused")
-    [Html.text text]
+    [Html.text text_]
 
 
 

--- a/client/ViewUtils.elm
+++ b/client/ViewUtils.elm
@@ -61,10 +61,10 @@ createVS m tl = { tl = tl
                           case TL.find tl i of
                             Just (PExpr exp) ->
                               let cursorSubsumedByHover =
-                                exp
-                                |> AST.allData
-                                |> List.map P.toID
-                                |> List.member cur
+                                    exp
+                                    |> AST.allData
+                                    |> List.map P.toID
+                                    |> List.member cur
                               in
                                   if cursorSubsumedByHover
                                   then Nothing
@@ -159,7 +159,7 @@ widthInCh : Int -> Html.Attribute Msg
 widthInCh w =
   w
   |> inCh
-  |> \w -> Attrs.style [("width", w)]
+  |> \w_ -> Attrs.style [("width", w_)]
 
 
 blankOrLength : BlankOr String -> Int


### PR DESCRIPTION
@IanConnolly as requested! These are all just changes demanded by the Elm compiler in 0.19.

It's not _all_ of the shadowing/indentation fixes I'm sure, as the compiler only hands out about 2 errors at a time.

This should make that PR more manageable though.