### PR TITLE
Have nginx 403 on /pkill, so it's not world-accessible.

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -2,6 +2,9 @@ server {
   listen 8000 default_server;
   listen [::]:8000 default_server;
 
+  location =/pkill {
+    return 403;
+  }
   location / {
     gzip on;
     ## nginx assumes proxies can't handle gzip. That's wrong in our case;


### PR DESCRIPTION
Hey @IanConnolly what do you think about this solution?

(/pkill on the Dark backend is used by kubernetes to gracefully shut down the server; currently it's world-accessible, so anyone can shut down arbitrary machines. This makes the nginx proxy, now the only thing exposed to the world, block it.)