### PR TITLE
Executing functions was multiply broken. This fixes it.

### DIFF
--- a/client/Main.elm
+++ b/client/Main.elm
@@ -1589,8 +1589,10 @@ update_ msg m =
       DisplayError <| "Success! " ++ msg_
 
     ExecuteFunctionRPCCallback params (Ok (dval, hash)) ->
+      let tl = TL.getTL m params.tlid in
       Many [ UpdateTraceFunctionResult params.tlid params.traceID params.callerID params.fnName hash dval
            , ExecutingFunctionComplete [(params.tlid, params.callerID)]
+           , RequestAnalysis [tl]
            ]
 
     ExecuteFunctionCancel tlid id ->

--- a/server/libbackend/stored_function_result.ml
+++ b/server/libbackend/stored_function_result.ml
@@ -30,7 +30,8 @@ let load ~canvas_id ~trace_id tlid : function_result list =
      FROM function_results
      WHERE canvas_id = $1
        AND trace_id = $2
-       AND tlid = $3"
+       AND tlid = $3
+     ORDER BY timestamp DESC"
     ~params:[ Db.Uuid canvas_id
             ; Db.Uuid trace_id
             ; Db.ID tlid

--- a/server/libexecution/ast.ml
+++ b/server/libexecution/ast.ml
@@ -509,6 +509,11 @@ and exec_fn ~(engine:engine) ~(state: exec_state)
     then DIncomplete
     else if paramsErroneous arglist
     then DError "Fn called with an error as an argument"
+    else if engine.ctx = Preview && not fn.preview_execution_safe
+    then
+      (match state.load_fn_result sfr_desc arglist with
+      | Some (result, _ts) -> result
+      | _ -> DIncomplete)
     else
       let state =
         { state with fail_fn = Some (Lib.fail_fn fnname fn arglist) }


### PR DESCRIPTION
- When we executed functions, we got the result but we didnt rerun the analysis.

- We didnt order the results from the DB so we picked the wrong result when the
  params were equal

- When executing analysis on the client, we ran preview-unsafe functions instead
  of looking up their results

All in all, weren't looking for the results, then we got the wrong ones, and
when we got the right ones we weren't looking again. Whew.