### PR TITLE
Fix param overlap on multiline functions

### DIFF
--- a/client/ViewCode.elm
+++ b/client/ViewCode.elm
@@ -224,15 +224,21 @@ viewNExpr d id vs config e =
 
     FnCall name exprs sendToRail ->
       let width = approxNWidth e
-          viewTooWideArg name_ d_ e_ =
+          ve name_ d_ e_ = 
+            let tooLong = width > 120
+            in
             Html.div
-              [ Attrs.class "arg-on-new-line" ]
-              [ Html.div [ Attrs.class "param-name" ] [ Html.text name_ ]
-              , vExprTw d_ e_
+              [ Attrs.classList
+                  [("fn-param", True)
+                  , ("is-filled", B.isF e_)
+                  , ("arg-on-new-line", tooLong)
+                  ]
+              , Attrs.attribute "param-name" name_ ]
+              [
+                if tooLong 
+                then vExprTw d_ e_
+                else vExpr d_ e_
               ]
-          ve name_ = if width > 120
-                    then viewTooWideArg name_
-                    else vExpr
           fnname parens =
             let withP name_ = if parens then "(" ++ name_ ++ ")" else name_ in
             case String.split "::" name of

--- a/server/static/base.less
+++ b/server/static/base.less
@@ -785,21 +785,32 @@ body #grid * {
   }
 
   .fncall {
-    .arg-on-new-line {
-      .layout-block;
-      margin-top: 8px;
 
-      &:first-child {
-        margin-top: 0;
+    .fn-param {
+      .layout-inline;
+
+      &.is-filled {
+        &::after {
+          content: attr(param-name);
+          display: block;
+          width: auto;
+          position: relative;
+          bottom: 0;
+          left: 10px;
+          font-size: 10px;
+          color: @grey2;
+          font-style: italic;
+        }
       }
 
-      .param-name {
-        display: inline-block;
-        color: @grey2;
-        font-size: 85%;
-        min-width: 16ch;
-        width: auto;
-        margin-right: 2px;
+      &.arg-on-new-line {
+        .layout-block;
+
+        margin-top: 16px;
+
+        &:first-child {
+          margin-top: 0;
+        }
       }
     }
 


### PR DESCRIPTION
1. Instead of absolutely positioning param name outside of param box, position param name div and arg div side by side as inline-blocks. So even if the param name is long it won't overlap with the argument blocks.

2. add additional vertical spacing between the params to make them look nicer ^_^

![screen shot 2018-09-17 at 11 19 33 am](https://user-images.githubusercontent.com/244152/45641891-980c2580-ba6b-11e8-81db-2fe6815c1635.png)
