### PR TITLE
Don't store_fn_result for preview safe functions

### DIFF
--- a/server/libexecution/ast.ml
+++ b/server/libexecution/ast.ml
@@ -537,7 +537,9 @@ and exec_fn ~(engine:engine) ~(state: exec_state)
             * this, give it a nice exception via RT.error.  *)
            Exception.reraise e)
       in
-      state.store_fn_result sfr_desc arglist result;
+      (* there's no point storing data we'll never ask for *)
+      if not fn.preview_execution_safe then
+        state.store_fn_result sfr_desc arglist result;
       result
 
 


### PR DESCRIPTION
```
postgres=> select c.name, tlid, fnname, SUM(pg_column_size(value)) as total, MAX(pg_column_size(value)) as max, AVG(pg_column_size(value)) as mean from function_results join canvases c on c.id = canvas_id group by c.name, fnname, tlid order by total desc limit 109
postgres-> ;
       name        |    tlid    |        fnname         |   total    |   max    |          mean
-------------------+------------+-----------------------+------------+----------+------------------------
 dabblefox-temp    |  821417404 | DB::fetchBy           | 5007407732 |  1042829 |    351569.734746893211
 dabblefox-temp    |  821417404 | List::sortBy          | 4879902948 |  1014501 |    342617.633082917925
```

that `List::sortBy` is useless and it's nearly half of our total DB size.