### PR TITLE
Nginx config for darklang.com; ingress and service.

### DIFF
--- a/scripts/support/builtwithdark.yaml
+++ b/scripts/support/builtwithdark.yaml
@@ -145,3 +145,31 @@ spec:
     servicePort: 80
   tls:
     - secretName: bwd-tls
+---
+# There need to be separate services and ingresses for darklang.com
+# so that we can serve with the correct TLS key
+kind: Service
+apiVersion: v1
+metadata:
+  name: darklang-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: bwd-app
+  ports:
+    - name: darklang-nodeport-port
+      protocol: TCP
+      port: 80
+      targetPort: http-proxy-port
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: darklang-tls-ingress
+spec:
+  backend:
+    serviceName: darklang-nodeport
+    servicePort: 80
+  tls:
+    - secretName: darklang-tls
+---

--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -1,4 +1,16 @@
 server {
+  listen 8000;
+  server_name darklang.com;
+  location / {
+    # redirect http to https.
+    if ($http_x_forwarded_proto = "http") {
+      rewrite ^(.*)$ https://$server_name$1 permanent;
+    }
+    proxy_pass https://darklang-com.netlify.com;
+  }
+}
+
+server {
   listen 8000 default_server;
   listen [::]:8000 default_server;
 


### PR DESCRIPTION
This changes the nginx configuration to proxy (all routes of) darklang.com to netlify, and lets it get served as a service with a separate ingress (and so a separate IP) in Kubernetes.

This isn't exactly working configuration -- I need to create and install the darkalng-tls cert -- but it shouldn't make any changes to production right now anyway. Once get and install the tls cert, create a new static IP, and once we point DNS at this new IP, traffic will start hitting nginx. Once all of that's done, however, all responses should be materially the same as before.