### PR TITLE
disable left param names for multiline functions for now

### DIFF
--- a/client/ViewCode.elm
+++ b/client/ViewCode.elm
@@ -226,9 +226,7 @@ viewNExpr d id vs config e =
       let width = approxNWidth e
           viewTooWideArg name_ d_ e_ =
             Html.div
-              [ Attrs.attribute "param-name" name_
-              ,  Attrs.class "arg-on-new-line"
-              ]
+              [ Attrs.class "arg-on-new-line" ]
               [ vExprTw d_ e_ ]
           ve name_ = if width > 120
                     then viewTooWideArg name_


### PR DESCRIPTION
merging in since it's a one line change on dom attrs.