### PR TITLE
Add DB::getAll_v2 and DB::getAllWithKeys_v1

### DIFF
--- a/server/libbackend/libdb2.ml
+++ b/server/libbackend/libdb2.ml
@@ -163,9 +163,37 @@ let replacements = [
             let db = find_db state.dbs dbname in
             User_db.get_all ~state ~magic:false db
           | args -> fail args))
-
-  (* previously called `DB::keys` *)
   ;
+  ( "DB::getAll_v2"
+  , InProcess
+      (function
+          | (state, [DDB dbname]) ->
+            let results =
+              let db = find_db state.dbs dbname in
+              User_db.get_all ~state ~magic:false db
+            in
+            (match results with
+             | DList xs ->
+               xs
+               |> List.map
+                 ~f:(function
+                     | DList [x;y] -> y
+                     | _ ->
+                       Exception.internal "bad format from User_db.query")
+               |> DList
+             | _ ->
+               Exception.internal "bad format from User_db.query")
+          | args -> fail args))
+  ;
+  ( "DB::getAllWithKeys_v1"
+  , InProcess
+      (function
+          | (state, [DDB dbname]) ->
+            let db = find_db state.dbs dbname in
+            User_db.get_all ~state ~magic:false db
+          | args -> fail args))
+  ;
+  (* previously called `DB::keys` *)
   ( "DB::schemaFields_v1"
   , InProcess
       (function

--- a/server/libexecution/libdb2.ml
+++ b/server/libexecution/libdb2.ml
@@ -138,6 +138,31 @@ let fns : Lib.shortfn list = [
   ; f = NotClientAvailable
   ; pr = None
   ; ps = false
+  ; dep = true
+  }
+  ;
+
+  { pns = ["DB::getAll_v2"]
+  ; ins = []
+  ; p = [par "table" TDB]
+  ; r = TList
+  ; d = "Fetch all the values in `table`."
+  ; f = NotClientAvailable
+  ; pr = None
+  ; ps = false
+  ; dep = false
+  }
+  ;
+
+  { pns = ["DB::getAllWithKeys_v1"]
+  ; ins = []
+  ; p = [par "table" TDB]
+  ; r = TList
+  ; d = "Fetch all the values in `table`. Returns a list of lists such that the inner
+        lists are pairs of [key, value]. ie. [[key, value], [key, value]]"
+  ; f = NotClientAvailable
+  ; pr = None
+  ; ps = false
   ; dep = false
   }
   ;


### PR DESCRIPTION
Did the most simple thing in the interest of time. 

I do think we want to re-think this API post-strangeloop to expose a Map/Dict rather than a [(Key, Value)] alist.