### PR TITLE
Admins can access canvases owned by others.

### DIFF
--- a/server/libbackend/account.ml
+++ b/server/libbackend/account.ml
@@ -88,7 +88,10 @@ let can_access_operations ~(username:username) : bool =
   is_admin ~username
 
 let can_edit_canvas ~(auth_domain:string) ~(username:username) : bool =
-  String.Caseless.equal username auth_domain || String.Caseless.equal "demo" auth_domain
+  String.Caseless.equal username auth_domain
+  || String.Caseless.equal "demo" auth_domain
+  || is_admin username
+ 
 
 type permissions = CanEdit | CanAccessOperations | NoPermission
 let get_permissions ~(auth_domain:string) ~(username:username) () : permissions =

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -1037,12 +1037,15 @@ let t_admin_handler_ui () =
        ; "test", "test-something"
        (* arbitrary canvas belonging to another user *)
        ; "test", "test_admin"
+       (* admin can look at test *)
+       ; "test_admin", "test"
        ])
 
     [ 200
     ; 200
     ; 200
     ; 401
+    ; 200
     ]
 
 let t_admin_handler_ops () =


### PR DESCRIPTION
I broke this with #172 because I misunderstood the logic and there were no tests :)

Added a test and restored the behavior.