### PR TITLE
Cleanup old traces until yesterday.

### DIFF
--- a/server/libbackend/canvas.ml
+++ b/server/libbackend/canvas.ml
@@ -377,17 +377,14 @@ let migrate_all_hosts () : unit =
 
 let cleanup_old_traces () : unit =
   let hosts = Serialize.current_hosts () in
-  (* Go back a bit to account for clock skew and wiggle room. *)
-  let time = Time.sub (Time.now ()) (Time.Span.create ~hr:36 ()) in
 
   List.iter hosts
     ~f:(fun host ->
-        (Log.inspecT "host" host;
         let owner = Account.for_host host in
         let canvas_id = Serialize.fetch_canvas_id owner host in
         let keep = Stored_event.get_all_recent_canvas_traceids canvas_id in
-        Log.inspecT "keep" keep;
-        Stored_event.trim_events ~canvas_id ~keep ~before:time ();
-        Stored_function_result.trim_results ~canvas_id ~keep ~before:time ()))
+        (Log.inspecT "host" (host, List.count keep);
+        Stored_event.trim_events ~canvas_id ~keep ();
+        Stored_function_result.trim_results ~canvas_id ~keep ()))
 
 

--- a/server/libbackend/stored_event.ml
+++ b/server/libbackend/stored_event.ml
@@ -93,14 +93,13 @@ let get_all_recent_canvas_traceids (canvas_id: Uuidm.t) =
   |> List.map ~f:(get_recent_event_traceids ~canvas_id)
   |> List.concat
 
-let trim_events ~(canvas_id: Uuidm.t) ~(keep: Analysis_types.traceid list) ~before () =
+let trim_events ~(canvas_id: Uuidm.t) ~(keep: Analysis_types.traceid list) () =
   Db.run
     ~name:"stored_event.trim_events"
     "DELETE FROM stored_events
      WHERE canvas_id = $1
-       AND timestamp < $2
-       AND NOT (trace_id = ANY (string_to_array($3, $4)::uuid[]))"
+       AND timestamp < CURRENT_TIMESTAMP
+       AND NOT (trace_id = ANY (string_to_array($2, $3)::uuid[]))"
     ~params:[ Uuid canvas_id
-            ; Time before
             ; List (List.map ~f:(fun u -> Db.Uuid u) keep)
             ; String Db.array_separator]

--- a/server/libbackend/stored_event.mli
+++ b/server/libbackend/stored_event.mli
@@ -40,7 +40,6 @@ val get_all_recent_canvas_traceids :
 val trim_events :
   canvas_id:Uuidm.t ->
   keep:(Analysis_types.traceid list) ->
-  before:Types.RuntimeT.time ->
   unit ->
   unit
 

--- a/server/libbackend/stored_function_result.ml
+++ b/server/libbackend/stored_function_result.ml
@@ -41,14 +41,13 @@ let load ~canvas_id ~trace_id tlid : function_result list =
         (fnname, id_of_string id, hash, Dval.unsafe_dval_of_json_string dval)
       | _ -> Exception.internal "Bad DB format for stored_functions_results.load")
 
-let trim_results ~(canvas_id: Uuidm.t) ~(keep: Analysis_types.traceid list) ~before () =
+let trim_results ~(canvas_id: Uuidm.t) ~(keep: Analysis_types.traceid list) () =
   Db.run
     ~name:"stored_function_result.trim_results"
     "DELETE FROM function_results
      WHERE canvas_id = $1
-       AND timestamp < $2
-       AND NOT (trace_id = ANY (string_to_array($3, $4)::uuid[]))"
+       AND timestamp < CURRENT_TIMESTAMP
+       AND NOT (trace_id = ANY (string_to_array($2, $3)::uuid[]))"
     ~params:[ Uuid canvas_id
-            ; Time before
             ; List (List.map ~f:(fun u -> Db.Uuid u) keep)
             ; String Db.array_separator]

--- a/server/libbackend/stored_function_result.mli
+++ b/server/libbackend/stored_function_result.mli
@@ -22,7 +22,6 @@ val load :
 val trim_results :
   canvas_id:Uuidm.t ->
   keep:(Analysis_types.traceid list) ->
-  before:Types.RuntimeT.time ->
   unit ->
   unit
 


### PR DESCRIPTION
As the amount of traffic increases, the amount of requests in the last day will be huge.

Originally, I meant to delete traces more than an hour old, with an hour chosen
so that we wouldn't have any clock skew issues. However, I made it 36
hours when I was testing and didn't move it back. Then I realized I can use the
DB time and avoid clock skew altogether.