### PR TITLE
Autocomplete & function versioning fixes

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -1143,11 +1143,17 @@ body #grid * {
 .versioned-function {
   display: inline-block;
   vertical-align: baseline;
-  
+
   .version {
     font-size: 0.6rem;
     color: @grey2;
     margin-left: 2px;
+  }
+}
+
+.ast div .selected {
+  .versioned-function .version {
+    color: @green;
   }
 }
 


### PR DESCRIPTION
I merged a bunch of trello cards into one PR because they are all related.
But i separated each card into their own commit. 
The only non-carded commit is https://github.com/darklang/dark/pull/238/commits/536c3a24faaee3c3c7f5d93f3e5c5cfe8901b5a3
which is in response to ian's v0 change. I told him not to worry about it looking ugly, and I'll fix it here.

[fn name is a different size than the autocomplete box](https://trello.com/c/pp0HIaFf) : 
https://github.com/darklang/dark/pull/238/commits/a2f4ad7ee43837723c7b1b5c7cf1fdd00c288e5d

[Remove the extra space in the autocomplete list](https://trello.com/c/O75dubwI) : 
https://github.com/darklang/dark/pull/238/commits/90dbfd43c431ea7adcdc02cd8545758837811bac

[if function call is selected, change version number to same color as function name.](https://trello.com/c/krLuuz8b) : https://github.com/darklang/dark/pull/238/commits/3bf08bcb7cbdbd9b64a7fadf708aab6373239699