### PR TITLE
Don't set Access-Control-Allow-Origin: * in errors.

### DIFF
--- a/server/libbackend/server.ml
+++ b/server/libbackend/server.ml
@@ -769,17 +769,16 @@ let server () =
           with _ -> "UNHANDLED ERROR: real_err"
         in
         Log.erroR real_err ~bt ~params:["execution_id", Log.dump execution_id];
-        let resp_headers = Cohttp.Header.of_list [cors] in
         match e with
         | Exception.DarkException e when e.tipe = EndUser ->
-           respond ~resp_headers ~execution_id `Bad_request e.short
+           respond ~execution_id `Bad_request e.short
         | _ ->
            let body =
              if include_internals
              then real_err
              else "Dark Internal Error"
            in
-           respond ~resp_headers ~execution_id `Internal_server_error body
+           respond ~execution_id `Internal_server_error body
       with e ->
         let bt = Exception.get_backtrace () in
         Rollbar.last_ditch e ~bt "handle_error" (Types.show_id execution_id);


### PR DESCRIPTION
Since errors can leak important information or secrets, and `Access-Control-Allow-Origin: * ` makes this route easier to call from Javascript from other sites, I think it's worth taking out. It's pretty marginal, but I don't see why we would ever want or need it anyway.