### PR TITLE
Set path / for cookies explicitly.

### DIFF
--- a/server/libbackend/server.ml
+++ b/server/libbackend/server.ml
@@ -470,6 +470,7 @@ let authenticate_then_handle ~(execution_id: Types.id) handler req =
            let headers = Auth.Session.to_cookie_hdrs
                            ~http_only:true
                            ~secure:https_only_cookie
+                           ~path:"/"
                            Auth.Session.cookie_key session
            in
            over_headers_promise ~f:(fun h -> Header.add_list h headers)

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -1000,8 +1000,8 @@ let t_authenticate_then_handle_code_and_cookie () =
        ; Req.make (Uri.of_string "http://test.builtwithdark.com/a/test")
     ])
 
-    [ 200, Some "Max-Age=604800; secure; httponly"
-    ; 200, Some "Max-Age=604800; httponly"
+    [ 200, Some "Max-Age=604800; path=/; secure; httponly"
+    ; 200, Some "Max-Age=604800; path=/; httponly"
     ; 401, None
     ; 401, None
     ; 401, None


### PR DESCRIPTION
Right now users get into situations where they have multiple session cookies for darklang.com, one for /a and one for /api:

![20180924-160927](https://user-images.githubusercontent.com/490421/45984084-4982fc00-c014-11e8-98bd-0edfc719c19a.png)
![20180924-160920](https://user-images.githubusercontent.com/490421/45984085-4982fc00-c014-11e8-812e-da32c4f6b5ee.png)


That's because of how the default "path" parameter in cookies gets set by default. We can set it to be "/", so that the same cookies work on every path.