### PR TITLE
Fix inverted logic

### DIFF
--- a/server/bin/cron_checker.ml
+++ b/server/bin/cron_checker.ml
@@ -12,7 +12,7 @@ let () =
     then
       not (Sys.argv.(1) = "--no-health-check")
     else
-      false
+      true
   in
   if run_health_check_server then
     Lwt.async begin

--- a/server/bin/queue_worker.ml
+++ b/server/bin/queue_worker.ml
@@ -12,7 +12,7 @@ let () =
     then
       not (Sys.argv.(1) = "--no-health-check")
     else
-      false
+      true
   in
   if run_health_check_server then
     Lwt.async begin


### PR DESCRIPTION
When we pass no argument, we _should_ run the health check.