### PR TITLE
Use `--profile release` in CI; `--profile dev` otherwise

### DIFF
--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -104,9 +104,14 @@ def ocaml_build():
                   , "@darkjs"
                   ])
 
+  if os.environ.get("CI"):
+      compilation_profile = "release"
+  else:
+      compilation_profile = "dev"
+
   build = "unbuffer" \
         + " dune build" \
-        + " --profile dev" \
+        + " --profile " + compilation_profile \
         + " --display short" \
         + " --root server" \
         + " -j 8 " \


### PR DESCRIPTION
--profile release vs dev results in server/_build/static/darkjs.bc.js
going from 9.5M to 800K