### PR TITLE
More NetworkPolicies.

### DIFF
--- a/scripts/support/builtwithdark.yaml
+++ b/scripts/support/builtwithdark.yaml
@@ -115,25 +115,28 @@ spec:
       protocol: TCP
       port: 80
       targetPort: http-proxy-port
-
-
 ---
 apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
   name: bwd-network-policy
 spec:
+  podSelector:
+    matchLabels:
+      app: bwd-app
   policyTypes:
   - Egress
+  - Ingress
   egress:
   - to:
     - ipBlock:
         cidr: 0.0.0.0/0
         except:
         - 169.254.0.0/16
-  podSelector:
-    matchLabels:
-      app: bwd-app
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: 8000
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -172,4 +175,3 @@ spec:
     servicePort: 80
   tls:
     - secretName: darklang-tls
----

--- a/scripts/support/cronchecker.yaml
+++ b/scripts/support/cronchecker.yaml
@@ -91,3 +91,22 @@ spec:
 #########################
 # End postgres proxy config
 #########################
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: qw-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: cron-checker
+  policyTypes:
+  - Egress
+  - Ingress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.0.0/16
+  ingress:

--- a/scripts/support/queueworker.yaml
+++ b/scripts/support/queueworker.yaml
@@ -85,7 +85,22 @@ spec:
         - name: cloudsql-instance-credentials
           secret:
             secretName: cloudsql-instance-credentials
-
-#########################
-# End postgres proxy config
-#########################
+---
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  name: qw-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: qw-worker
+  policyTypes:
+  - Egress
+  - Ingress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 169.254.0.0/16
+  ingress:


### PR DESCRIPTION
This changes the bwd-app NetworkPolicy to only allow ingress on port 8000 (i.e., through nginx). This prevents the rest of the cluster from having access to /pkill etc. It doesn't prevent health or readiness checks, or graceful shutdown.

It also adds the rule that prevents GCP metadata access (i.e., from #72) to the queueworker and cronchecker. Previously, Dark code executed on these configurations (i.e., in a cron, or triggered by an event) had access to the GCP metadata. 

This also paves the way for locking down Dark HTTP -- if we tunnel it out to another service in the cluster, we need to make sure that service can't just get access back to the other apps.