### PR TITLE
cron-checker gets its own NetworkPolicy.

### DIFF
--- a/scripts/support/cronchecker.yaml
+++ b/scripts/support/cronchecker.yaml
@@ -95,7 +95,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
-  name: qw-network-policy
+  name: cc-network-policy
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
in #272 I wrote a NetworkPolicy, but I named it `qw-network-policy` by accident; it overwrites the queue-worker one. This updates it to have a separate name.