### PR TITLE
Add mkdir .config to Dockerfile so it's owned by dark and not root (when

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,8 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER dark
 WORKDIR /home/dark
 RUN mkdir bin
+# otherwise this gets created by the mount, and it'll be owned by root if your docker host os is linux
+RUN mkdir .config
 
 ############################
 # Locales


### PR DESCRIPTION
.config/gcloud gets mounted)