### PR TITLE
Fix toOption argument order confusion

### DIFF
--- a/client2/__tests__/porting_test.ml
+++ b/client2/__tests__/porting_test.ml
@@ -1,0 +1,17 @@
+open! Porting
+open Types
+open Autocomplete
+open Prelude
+open Jest
+open Expect
+
+let () =
+  describe "toOption" (fun () ->
+    test "it returns None when the value equals a sentinel" (fun () ->
+      expect (toOption ~sentinel:3 3) |> toEqual (None)
+    );
+    test "it returns (Some value) when the value does not equal the sentinel" (fun () ->
+      expect (toOption ~sentinel:(-1) 4) |> toEqual (Some 4)
+    );
+  );
+  ()

--- a/client2/src/Porting.ml
+++ b/client2/src/Porting.ml
@@ -39,7 +39,7 @@ end
 let toString (v : 'a) : string =
   Js.String.make v
 
-let toOption (value: 'a) (sentinel: 'a) : 'a option =
+let toOption ~(sentinel: 'a) (value: 'a) : 'a option =
   if value = sentinel
   then None
   else Some value
@@ -64,7 +64,7 @@ module List = struct
     l
     |> Array.of_list
     |> Js.Array.findIndex ((=) a)
-    |> toOption (-1)
+    |> toOption ~sentinel:(-1)
   let rec last (l : 'a list) : 'a option =
     match l with
     | [] -> None


### PR DESCRIPTION
This broke `elemIndex` which was breaking some as yet un-pushed autocomplete tests.

It might also have broken this that relied on index in lists, such as the clicking bug we noticed. (https://trello.com/c/6fFeAgDv/38-selecting-the-wrong-toplevel-when-we-click-on-it)