### PR TITLE
Fix the ordering of the remaining nested if-else blocks

### DIFF
--- a/client2/src/Main.ml
+++ b/client2/src/Main.ml
@@ -758,15 +758,15 @@ let update_ (msg : msg) (m : model) : modification =
                   Selection.selectPreviousSibling m tlid mId
                 else NoChange
             | Key.C ->
-                if event.ctrlKey then
-                  let mPd = Option.map (TL.findExn tl) mId in
-                  Clipboard.copy m tl mPd
-                else if event.ctrlKey && event.altKey then
+                if event.ctrlKey && event.altKey then
                   match mId with
                   | None -> NoChange
                   | Some id ->
                       let pd = TL.findExn tl id in
                       Refactor.wrap WIfCond m tl pd
+                else if event.ctrlKey then
+                  let mPd = Option.map (TL.findExn tl) mId in
+                  Clipboard.copy m tl mPd
                 else NoChange
             | Key.V ->
                 if event.ctrlKey then
@@ -802,32 +802,32 @@ let update_ (msg : msg) (m : model) : modification =
                       Refactor.wrap WLetBody m tl pd
                 else NoChange
             | Key.L ->
-                if event.ctrlKey then
-                  match mId with
-                  | None -> NoChange
-                  | Some id ->
-                      let pd = TL.findExn tl id in
-                      Refactor.wrap WLetRHS m tl pd
-                else if event.ctrlKey && event.shiftKey then
+                if event.ctrlKey && event.shiftKey then
                   match mId with
                   | None -> NoChange
                   | Some id ->
                       let pd = TL.findExn tl id in
                       Refactor.extractVariable m tl pd
-                else NoChange
-            | Key.I ->
-                if event.ctrlKey then
+                else if event.ctrlKey then
                   match mId with
                   | None -> NoChange
                   | Some id ->
                       let pd = TL.findExn tl id in
-                      Refactor.wrap WIfThen m tl pd
-                else if event.ctrlKey && event.altKey then
+                      Refactor.wrap WLetRHS m tl pd
+                else NoChange
+            | Key.I ->
+                if event.ctrlKey && event.altKey then
                   match mId with
                   | None -> NoChange
                   | Some id ->
                       let pd = TL.findExn tl id in
                       Refactor.wrap WIfElse m tl pd
+                else if event.ctrlKey then
+                  match mId with
+                  | None -> NoChange
+                  | Some id ->
+                      let pd = TL.findExn tl id in
+                      Refactor.wrap WIfThen m tl pd
                 else NoChange
             | Key.E ->
                 if event.altKey then
@@ -848,15 +848,24 @@ let update_ (msg : msg) (m : model) : modification =
                   else NoChange )
             | _ -> NoChange )
         | Entering cursor -> (
-            if event.altKey then
+            if event.ctrlKey then
               match event.keyCode with
-              | Key.E -> (
-                match cursor with
-                | Creating pos -> NoChange
-                | Filling (tlid, id) ->
+              | Key.P -> AutocompleteMod ACSelectUp
+              | Key.N -> AutocompleteMod ACSelectDown
+              | Key.Enter ->
+                if AC.isSmallStringEntry m.complete then
+                  Many
+                    [ AutocompleteMod (ACAppendQuery "\n")
+                    ; MakeCmd (Entry.focusEntry m) ]
+                else if AC.isLargeStringEntry m.complete then
+                  Entry.submit m cursor Entry.StayHere
+                else NoChange
+              | Key.V -> (
+                  match cursor with
+                  | Creating pos -> Clipboard.newFromClipboard m pos
+                  | Filling (tlid, p) ->
                     let tl = TL.getTL m tlid in
-                    let pd = TL.findExn tl id in
-                    Refactor.toggleOnRail m tl pd )
+                    Clipboard.paste m tl p )
               | _ -> NoChange
             else if event.shiftKey && event.keyCode = Key.Enter then
               match cursor with
@@ -867,24 +876,16 @@ let update_ (msg : msg) (m : model) : modification =
                   | TLHandler h -> Entry.submit m cursor Entry.StartThread
                   | TLFunc f -> Entry.submit m cursor Entry.StartThread )
               | Creating _ -> Entry.submit m cursor Entry.StartThread
-            else if event.ctrlKey then
+
+            else if event.altKey then
               match event.keyCode with
-              | Key.P -> AutocompleteMod ACSelectUp
-              | Key.N -> AutocompleteMod ACSelectDown
-              | Key.Enter ->
-                  if AC.isSmallStringEntry m.complete then
-                    Many
-                      [ AutocompleteMod (ACAppendQuery "\n")
-                      ; MakeCmd (Entry.focusEntry m) ]
-                  else if AC.isLargeStringEntry m.complete then
-                    Entry.submit m cursor Entry.StayHere
-                  else NoChange
-              | Key.V -> (
+              | Key.E -> (
                 match cursor with
-                | Creating pos -> Clipboard.newFromClipboard m pos
-                | Filling (tlid, p) ->
+                | Creating pos -> NoChange
+                | Filling (tlid, id) ->
                     let tl = TL.getTL m tlid in
-                    Clipboard.paste m tl p )
+                    let pd = TL.findExn tl id in
+                    Refactor.toggleOnRail m tl pd )
               | _ -> NoChange
             else
               match event.keyCode with
@@ -917,10 +918,10 @@ let update_ (msg : msg) (m : model) : modification =
                     else
                       let content = AC.getValue m.complete in
                       let hasContent = content |> String.length |> ( < ) 0 in
-                      if hasContent then Entry.submit m cursor Entry.GotoNext
-                      else if event.shiftKey then
+                      if event.shiftKey then
                         if hasContent then NoChange
                         else Selection.enterPrevBlank m tlid (Some p)
+                      else if hasContent then Entry.submit m cursor Entry.GotoNext
                       else Selection.enterNextBlank m tlid (Some p)
                 | Creating _ -> NoChange )
               | Key.Unknown c ->


### PR DESCRIPTION
There was a bug in the elm2ocaml compiler which caused nested if statements to be printed in the wrong order. Some were covered in a previous PR - this does the rest. I did it by going through all nested if statements and making the ordering the same as in the Elm app.