### PR TITLE
On my laptop, fswatch was working, but is no more. Forcing -m poll_mo…

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -90,6 +90,13 @@ do
     # endless IsDir and PlatformSpecific ("This event maps a platform-specific
     # event that has no corresponding flag.") events
     FSWATCH+=" --event=Created --event=Updated --event=Removed --event=Renamed --event=MovedFrom --event=MovedTo"
+
+    # ismith seeing poll_monitor work more reliably than inotify on his laptop
+    # (`fswatch -x -r *` with default inotify only shows IsDir and
+    # PlatformSpecific events)
+    if [[ "$FSWATCH_MONITOR" != "" ]]; then
+        FSWATCH+=" -m ${FSWATCH_MONITOR}"
+    fi
   esac
 done
 


### PR DESCRIPTION
…nitor fixes it.

Specifically, I was getting events for IsDir and PlatformSpecific, and
nothing else, which is not helpful. Not sure why.

In theory, inotify (default on linux) has worse performance than
poll_monitor; in practice, for a 28k file repo, this should be fine.
http://emcrisostomo.github.io/fswatch/doc/1.5.1/html/fswatch/Monitors.html#The-Poll-Monitor:
"The authors’ experience indicates that fswatch requires approximately
150 MB of RAM memory to observe a hierarchy of 500,000 files with a
minimum path length of 32 characters. A common bottleneck of the poll
monitor is disk access, since stat()-ing a great number of files may
take a huge amount of time."