### PR TITLE
Pass CIRCLE_BRANCH thru to container

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -126,6 +126,10 @@ if [ ! -v CI ]; then
   CI=
 fi
 
+if [ ! -v CIRCLE_BRANCH ]; then
+  CIRCLE_BRANCH=
+fi
+
 ./scripts/support/create-dark-dev-network
 
 # --------------
@@ -146,6 +150,7 @@ $FSWATCH | docker run \
              --env HOST_PWD=$PWD \
              --env IN_DEV_CONTAINER=true \
              --env CI=$CI \
+             --env CIRCLE_BRANCH=$CIRCLE_BRANCH \
              $POLL_FREQ \
              -v pgconf:/etc/postgresql \
              -v pglogs:/var/log/postgresql \


### PR DESCRIPTION
Problem: still running in bucklescript mode on master.

Reason: we don't set CIRCLE_BRANCH in the container

Solution: set CIRCLE_BRANCH in the container