### PR TITLE
Don't issue and don't accept DUMMY_CSRF.

### DIFF
--- a/server/libbackend/auth.ml
+++ b/server/libbackend/auth.ml
@@ -13,12 +13,6 @@ module Session = struct
   (* We store two values alongside each other in the session.value:
      one, the username; and two, the current CSRF token. These are
      stored as a JSON map with values "username" and "csrf_token".
-
-     Because CSRF tokens exist that predate this change (previously,
-     just the username was stored, we default username_for to
-
-     We can remove this hacks one week from when this is merged,
-     since the session default cookie max-age is one week.
    *)
   let new_for_username username =
     generate backend
@@ -34,25 +28,14 @@ module Session = struct
             ]))
 
   let username_for session =
-    try
-      session.value
-      |> Yojson.Basic.from_string
-      |> Yojson.Basic.Util.member "username"
-      |> Yojson.Basic.Util.to_string
-    with e ->
-      (* If there's not valid json in the database,
-         we should assume it's just a username. *)
-      session.value
+    session.value
+    |> Yojson.Basic.from_string
+    |> Yojson.Basic.Util.member "username"
+    |> Yojson.Basic.Util.to_string
 
   let csrf_token_for session =
-    try
-      session.value
-      |> Yojson.Basic.from_string
-      |> Yojson.Basic.Util.member "csrf_token"
-      |> Yojson.Basic.Util.to_string
-    with e ->
-      (* If there's not valid json in the database,
-         this user has not been issued a CSRF token.
-         So, we'll just issue a dummy token. *)
-      "DUMMY_CSRF"
+    session.value
+    |> Yojson.Basic.from_string
+    |> Yojson.Basic.Util.member "csrf_token"
+    |> Yojson.Basic.Util.to_string
 end


### PR DESCRIPTION
This is a follow-up to #256. That changeset starts accepting and issuing CSRF tokens, but still allows clients with sessions with no CSRF tokens. Don't deploy  this until after late evening November 6th; 7 days from now is when all of the existing sessions will have expired.