### PR TITLE
Remove User_db.count

### DIFF
--- a/server/libbackend/user_db.ml
+++ b/server/libbackend/user_db.ml
@@ -464,21 +464,6 @@ let delete_all ~state (db: db) =
             ; Int db.version
             ; Int current_dark_version]
 
-let count (db: db) =
-  (* covered by idx_user_data_current_data_for_tlid *)
-  Db.fetch_one
-    ~name:"count"
-    "SELECT COUNT(*) AS c
-     FROM user_data
-     WHERE table_tlid = $1
-     AND user_version = $2
-     AND dark_version = $3"
-    ~params:[ ID db.tlid
-            ; Int db.version
-            ; Int current_dark_version]
-  |> List.hd_exn
-  |> int_of_string
-
 (* ------------------------- *)
 (* locked/unlocked (not _locking_) *)
 (* ------------------------- *)

--- a/server/libbackend/user_db.mli
+++ b/server/libbackend/user_db.mli
@@ -15,7 +15,6 @@ val query : state:exec_state -> magic:bool -> DbT.db -> (string * dval) list -> 
 val query_by_one : state:exec_state -> magic:bool -> DbT.db -> string -> dval -> dval
 val delete : state:exec_state -> DbT.db -> string -> unit
 val delete_all : state:exec_state -> DbT.db -> unit
-val count : DbT.db -> int
 
 (* Deprecated: only used in legacy in deprecated libdb *)
 val update : state:exec_state -> DbT.db -> dval_map -> unit


### PR DESCRIPTION
This doesn't get called anywhere, but it's kind of dangerous and misleading to leave around, since it takes a user db as an argument but doesn't check the canvas id (i.e., the same bug as #307).