### PR TITLE
dockerignore client2/node_modules, drops docker context from 500MB to…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ gcp-rundir
 gcp-persistdir
 gcp-builddir
 sqldump*.gz
+client2/node_modules


### PR DESCRIPTION
… 32MB on my machine