### PR TITLE
Fix string entry

### DIFF
--- a/client2/__tests__/porting_test.ml
+++ b/client2/__tests__/porting_test.ml
@@ -14,4 +14,25 @@ let () =
       expect (toOption ~sentinel:(-1) 4) |> toEqual (Some 4)
     );
   );
+
+  describe "String.dropRight" (fun () ->
+    test "it returns the empty string when passed the empty string" (fun () ->
+      expect (String.dropRight 50 "") |> toEqual ("")
+    );
+    test "it returns the passed string when told to drop 0" (fun () ->
+      expect (String.dropRight 0 "foo") |> toEqual ("foo")
+    );
+    test "it returns the passed string when told to drop a negative number" (fun () ->
+      expect (String.dropRight (-2) "foo") |> toEqual ("foo")
+    );
+    test "it drops the correct number of items when the number < length" (fun () ->
+      expect (String.dropRight 2 "foo") |> toEqual ("f")
+    );
+    test "it returns the empty string when told to drop a number == length" (fun () ->
+      expect (String.dropRight 3 "foo") |> toEqual ("")
+    );
+    test "it returns the empty string when told to drop a number > length" (fun () ->
+      expect (String.dropRight 5555 "foo") |> toEqual ("")
+    );
+  );
   ()

--- a/client2/src/Porting.ml
+++ b/client2/src/Porting.ml
@@ -329,8 +329,11 @@ module String = struct
     | s -> Some (String.get s 0, String.sub s 1 (String.length s - 1))
   let dropLeft (from: int) (s: string) : string =
     Js.String.substr ~from s
-  let dropRight (from: int) (s: string) : string =
-    Js.String.sliceToEnd ~from s
+  let dropRight (num: int) (s: string) : string =
+    if num < 1 then
+      s
+    else
+      Js.String.slice ~from:0 ~to_:(-num) s
   let split (delimiter : string) (s: string) : string list =
     Js.String.split delimiter s
     |> Belt.List.fromArray
@@ -467,7 +470,7 @@ module Native = struct
     ; bottom: int
     }
 
-  type list_pos = 
+  type list_pos =
     { atoms : rect list
     ; nested : rect list
     }


### PR DESCRIPTION
Our String.dropRight port was wrong, causing us to append a `"`
every time we appended to the Autocomplete.