### PR TITLE
Use the updated model in the integration tests in bs.

### DIFF
--- a/client2/src/Main.ml
+++ b/client2/src/Main.ml
@@ -63,7 +63,7 @@ let init (flagString: string) (location : Web.Location.location) : model * msg C
   if shouldRunIntegrationTest then
     ( m2
     , Cmd.batch
-        [RPC.integrationRPC m (contextFromModel m) integrationTestName
+        [RPC.integrationRPC m2 (contextFromModel m2) integrationTestName
         ]
     )
   else


### PR DESCRIPTION
This was causing the integration tests to fail in bucklescript, since they weren't getting the model with the filled-in csrf token. This matches the elm logic: the updated m2 should get used for the integration test code paths.