### PR TITLE
Add cache keys to all events on the Vdom

### DIFF
--- a/client2/src/Patched_tea_html.ml
+++ b/client2/src/Patched_tea_html.ml
@@ -1,0 +1,11 @@
+open Tea
+
+(* TODO(ian): push to fork + upstream *)
+let onWithOptions ?(key="") eventName (options: Tea_html.options) decoder =
+  Tea_html.onCB eventName key (fun event ->
+    if options.stopPropagation then event##stopPropagation () |> ignore;
+    if options.preventDefault then event##preventDefault () |> ignore;
+    event
+    |> Tea_json.Decoder.decodeEvent decoder
+    |> Tea_result.result_to_option
+  )

--- a/client2/src/Prelude.ml
+++ b/client2/src/Prelude.ml
@@ -2,8 +2,10 @@ open! Porting
 open Types
 
 let deID (ID i : id) : int = i
+let showID (ID i) = string_of_int i
 
 let deTLID (TLID i : tlid) : int = i
+let showTLID (TLID i) = string_of_int i
 
 let gid (unit : unit) : id = ID (Util.random unit)
 

--- a/client2/src/View.ml
+++ b/client2/src/View.ml
@@ -8,7 +8,6 @@ open Types
 type viewState = ViewUtils.viewState
 type htmlConfig = ViewBlankOr.htmlConfig
 let idConfigs = ViewBlankOr.idConfigs
-let eventNoPropagation = ViewUtils.eventNoPropagation
 let fontAwesome = ViewUtils.fontAwesome
 let viewText = ViewBlankOr.viewText
 let wc = ViewBlankOr.wc
@@ -30,9 +29,18 @@ let viewTL_ (m : model) (tlid : tlid) : msg Html.html =
         ([ViewFunction.viewFunction vs f], ViewData.viewData vs f.ufAST)
   in
   let events =
-    [ eventNoPropagation "mousedown" (fun x -> ToplevelMouseDown (tl.id, x))
-    ; eventNoPropagation "mouseup" (fun x -> ToplevelMouseUp (tl.id, x))
-    ; eventNoPropagation "click" (fun x -> ToplevelClick (tl.id, x)) ]
+    [ ViewUtils.eventNoPropagation
+        ~key:("tlmd-" ^ showTLID tl.id)
+        "mousedown"
+        (fun x -> ToplevelMouseDown (tl.id, x))
+    ; ViewUtils.eventNoPropagation
+        ~key:("tlmu-" ^ showTLID tl.id)
+        "mouseup"
+        (fun x -> ToplevelMouseUp (tl.id, x))
+    ; ViewUtils.eventNoPropagation
+        ~key:("tlc-" ^ showTLID tl.id)
+        "click"
+        (fun x -> ToplevelClick (tl.id, x)) ]
   in
   let selected =
     if Some tl.id = tlidOf m.cursorState then "selected" else ""

--- a/client2/src/ViewBlankOr.ml
+++ b/client2/src/ViewBlankOr.ml
@@ -35,7 +35,7 @@ let renderLiveValue (vs : ViewUtils.viewState) (id : id option) : string =
 
 let viewFeatureFlag : msg Html.html =
   Html.div
-    [Html.class' "flag"; ViewUtils.eventNoPropagation "click" (fun _ -> StartFeatureFlag)]
+    [Html.class' "flag"; ViewUtils.eventNoPropagation ~key:"sff" "click" (fun _ -> StartFeatureFlag)]
     [ViewUtils.fontAwesome "flag"]
 
 let viewEditFn (tlid : tlid) (hasFlagAlso : bool) : msg Html.html =
@@ -48,7 +48,7 @@ let viewEditFn (tlid : tlid) (hasFlagAlso : bool) : msg Html.html =
 
 let viewCreateFn : msg Html.html =
   Html.div
-    [Html.class' "exfun"; ViewUtils.eventNoPropagation "click" (fun _ -> ExtractFunction)]
+    [Html.class' "exfun"; ViewUtils.eventNoPropagation ~key:"ef" "click" (fun _ -> ExtractFunction)]
     [ViewUtils.fontAwesome "share-square"]
 
 let div (vs : ViewUtils.viewState) (configs : htmlConfig list)
@@ -110,10 +110,10 @@ let div (vs : ViewUtils.viewState) (configs : htmlConfig list)
   let events =
     match clickAs with
     | Some id ->
-        [ ViewUtils.eventNoPropagation "click" (fun x -> BlankOrClick (vs.tl.id, id, x))
-        ; ViewUtils.eventNoPropagation "dblclick" (fun x -> BlankOrDoubleClick (vs.tl.id, id, x))
-        ; ViewUtils.eventNoPropagation "mouseenter" (fun x -> BlankOrMouseEnter (vs.tl.id, id, x))
-        ; ViewUtils.eventNoPropagation "mouseleave" (fun x -> BlankOrMouseLeave (vs.tl.id, id, x)) ]
+        [ ViewUtils.eventNoPropagation "click" ~key:("bcc-" ^ showTLID vs.tl.id ^ "-" ^ showID id) (fun x -> BlankOrClick (vs.tl.id, id, x))
+        ; ViewUtils.eventNoPropagation "dblclick" ~key:("bcdc-" ^ showTLID vs.tl.id ^ "-" ^ showID id) (fun x -> BlankOrDoubleClick (vs.tl.id, id, x))
+        ; ViewUtils.eventNoPropagation "mouseenter" ~key:("me-" ^ showTLID vs.tl.id ^ "-" ^ showID id) (fun x -> BlankOrMouseEnter (vs.tl.id, id, x))
+        ; ViewUtils.eventNoPropagation "mouseleave" ~key:("ml-" ^ showTLID vs.tl.id ^ "-" ^ showID id) (fun x -> BlankOrMouseLeave (vs.tl.id, id, x)) ]
     | _ -> []
   in
   let liveValueAttr =

--- a/client2/src/ViewCode.ml
+++ b/client2/src/ViewCode.ml
@@ -9,7 +9,6 @@ module SA = Svg.Attributes
 type viewState = ViewUtils.viewState
 type htmlConfig = ViewBlankOr.htmlConfig
 let idConfigs = ViewBlankOr.idConfigs
-let eventNoPropagation = ViewUtils.eventNoPropagation
 let fontAwesome = ViewUtils.fontAwesome
 let viewText = ViewBlankOr.viewText
 let wc = ViewBlankOr.wc
@@ -212,7 +211,10 @@ and viewNExpr (d : int) (id : id) (vs : viewState) (config : htmlConfig list)
       let showExecuting = isExecuting vs id in
       let exeIcon = "play" in
       let events =
-        [ eventNoPropagation "click" (fun _ ->
+        [ ViewUtils.eventNoPropagation
+            ~key:("efb-" ^ (showTLID vs.tl.id) ^ "-" ^ (showID id) ^ "-" ^ name)
+            "click"
+            (fun _ ->
               ExecuteFunctionButton (vs.tl.id, id, name) )
         ; ViewUtils.nothingMouseEvent "mouseup"
         ; ViewUtils.nothingMouseEvent "mousedown"
@@ -312,7 +314,10 @@ and viewNExpr (d : int) (id : id) (vs : viewState) (config : htmlConfig list)
           [ Html.class' "icon pick-a parameter-btn info"
           ; Vdom.attribute "" "data-content" "Use Case A"
           ; Html.title "delete Feature Flag & use Case A"
-          ; eventNoPropagation "click" (fun _ -> EndFeatureFlag (id, PickA)) ]
+          ; ViewUtils.eventNoPropagation
+              ~key:("effa-" ^ showID id)
+              "click"
+              (fun _ -> EndFeatureFlag (id, PickA)) ]
           [fontAwesome "check"]
       in
       let pickB =
@@ -320,20 +325,29 @@ and viewNExpr (d : int) (id : id) (vs : viewState) (config : htmlConfig list)
           [ Html.class' "icon pick-b parameter-btn info"
           ; Vdom.attribute "" "data-content" "Use Case B"
           ; Html.title "delete Feature Flag & use Case B"
-          ; eventNoPropagation "click" (fun _ -> EndFeatureFlag (id, PickB)) ]
+          ; ViewUtils.eventNoPropagation
+              ~key:("effb-" ^ showID id)
+              "click"
+              (fun _ -> EndFeatureFlag (id, PickB)) ]
           [fontAwesome "check"]
       in
       let hideModal =
         Html.div
           [ Vdom.attribute "" "data-content" "Hide ff details"
-          ; eventNoPropagation "click" (fun _ -> ToggleFeatureFlag (id, false))
+          ; ViewUtils.eventNoPropagation
+              ~key:("tfff-" ^ showID id)
+              "click"
+              (fun _ -> ToggleFeatureFlag (id, false))
           ]
           [fontAwesome "minus"]
       in
       let expandModal =
         Html.div
           [ Vdom.attribute "" "data-content" "Show ff details"
-          ; eventNoPropagation "click" (fun _ -> ToggleFeatureFlag (id, true))
+          ; ViewUtils.eventNoPropagation
+              ~key:("tfft-" ^ showID id)
+              "click"
+              (fun _ -> ToggleFeatureFlag (id, true))
           ]
           [fontAwesome "flag"]
       in
@@ -418,7 +432,10 @@ let viewHandler (vs : viewState) (h : handler) : msg Html.html list =
     Html.div
       [ Html.classList
           [("handler-lock", true); ("is-locked", vs.handlerLocked)]
-      ; eventNoPropagation "click" (fun _ ->
+      ; ViewUtils.eventNoPropagation
+          ~key:("lh-" ^ (showTLID vs.tlid) ^ "-" ^ (string_of_bool vs.handlerLocked))
+          "click"
+          (fun _ ->
             LockHandler (vs.tlid, not vs.handlerLocked) ) ]
       [fontAwesome (if vs.handlerLocked then "lock" else "lock-open")]
   in

--- a/client2/src/ViewDB.ml
+++ b/client2/src/ViewDB.ml
@@ -3,10 +3,10 @@ open! Porting
 module B = Blank
 module Attrs = Html.Attributes
 open Types
+open Prelude
 type viewState = ViewUtils.viewState
 type htmlConfig = ViewBlankOr.htmlConfig
 let idConfigs = ViewBlankOr.idConfigs
-let eventNoPropagation = ViewUtils.eventNoPropagation
 let fontAwesome = ViewUtils.fontAwesome
 let wc = ViewBlankOr.wc
 
@@ -33,7 +33,10 @@ let viewDBCol (vs : viewState) (isMigra : bool) (tlid : tlid)
       if B.isF n || B.isF t then
         [ Html.div
             [ Html.class' "delete-col"
-            ; eventNoPropagation "click" (fun _ ->
+            ; ViewUtils.eventNoPropagation
+                ~key:("dcidb-" ^ (showTLID tlid) ^ "-" ^ (n |> B.toID |> showID))
+                "click"
+                (fun _ ->
                   DeleteColInDB (tlid, B.toID n) ) ]
             [fontAwesome "minus-circle"] ]
       else []
@@ -71,7 +74,10 @@ let viewDBMigration (migra : dBMigration) (db : dB) (vs : viewState) :
   let cancelBtn =
     Html.button
       [ Attrs.disabled false
-      ; eventNoPropagation "click" (fun _ -> AbandonMigration db.dbTLID) ]
+      ; ViewUtils.eventNoPropagation
+          ~key:("am-" ^ (showTLID db.dbTLID))
+          "click"
+          (fun _ -> AbandonMigration db.dbTLID) ]
       [Html.text "cancel"]
   in
   let migrateBtn =
@@ -88,7 +94,10 @@ let viewDB (vs : viewState) (db : dB) : msg Html.html list =
   let locked =
     if vs.dbLocked && db.activeMigration = None then
       Html.div
-        [eventNoPropagation "click" (fun _ -> StartMigration db.dbTLID)]
+        [ViewUtils.eventNoPropagation
+           ~key:("sm-" ^ (showTLID db.dbTLID))
+           "click"
+           (fun _ -> StartMigration db.dbTLID)]
         [fontAwesome "lock"]
     else fontAwesome "unlock"
   in

--- a/client2/src/ViewData.ml
+++ b/client2/src/ViewData.ml
@@ -13,10 +13,13 @@ let viewInput (tlid : tlid) (idx : int) (value : string) (isActive : bool)
   let tipeClassName = "tipe-" ^ RT.tipe2str tipe in
   let tipeClass = [Html.class' tipeClassName] in
   let classes = activeClass @ hoverClass @ tipeClass in
+  let eventKey constructor tlid id =
+    constructor ^ "-" ^ (showTLID tlid) ^ "-" ^ (string_of_int id)
+  in
   let events =
-    [ ViewUtils.eventNoPropagation "click" (fun x -> DataClick (tlid, idx, x))
-    ; ViewUtils.eventNoPropagation "mouseenter" (fun x -> DataMouseEnter (tlid, idx, x))
-    ; ViewUtils.eventNoPropagation "mouseleave" (fun x -> DataMouseLeave (tlid, idx, x)) ]
+    [ ViewUtils.eventNoPropagation ~key:(eventKey "dc" tlid idx) "click" (fun x -> DataClick (tlid, idx, x))
+    ; ViewUtils.eventNoPropagation ~key:(eventKey "dme" tlid idx) "mouseenter" (fun x -> DataMouseEnter (tlid, idx, x))
+    ; ViewUtils.eventNoPropagation ~key:(eventKey "dml" tlid idx) "mouseleave" (fun x -> DataMouseLeave (tlid, idx, x)) ]
   in
   Html.li
     (* TODO: should this be `Vdom.attribute "" "data-content" value`? *)

--- a/client2/src/ViewEntry.ml
+++ b/client2/src/ViewEntry.ml
@@ -79,7 +79,7 @@ let normalEntryHtml (placeholder : string) (ac : autocomplete) : msg Html.html
               [("autocomplete-item", true); ("highlighted", highlighted)]
           ; nothingMouseEvent "mouseup"
           ; nothingMouseEvent "mousedown"
-          ; eventNoPropagation "click" (fun _ -> AutocompleteClick name) ]
+          ; eventNoPropagation ~key:("ac-" ^ name) "click" (fun _ -> AutocompleteClick name) ]
           [ view item []
           ; Html.span [Html.class' "types"]
               [Html.text <| Autocomplete.asTypeString item] ] )

--- a/client2/src/ViewFunction.ml
+++ b/client2/src/ViewFunction.ml
@@ -2,11 +2,12 @@ open Tea
 open! Porting
 module Attrs = Html.Attributes
 open Types
+open Prelude
+module B = Blank
 
 type viewState = ViewUtils.viewState
 type htmlConfig = ViewBlankOr.htmlConfig
 let idConfigs = ViewBlankOr.idConfigs
-let eventNoPropagation = ViewUtils.eventNoPropagation
 let fontAwesome = ViewUtils.fontAwesome
 let viewText = ViewBlankOr.viewText
 let wc = ViewBlankOr.wc
@@ -38,7 +39,10 @@ let viewKillParameterBtn (vs : viewState) (uf : userFunction)
     if allowed then
       Html.div
         [ Html.class' "parameter-btn allowed"
-        ; eventNoPropagation "click" (fun _ ->
+        ; ViewUtils.eventNoPropagation
+            ~key:("dufp-" ^ (showTLID uf.ufTLID) ^ "-" ^ (p.ufpName |> B.toID |> showID))
+            "click"
+            (fun _ ->
               DeleteUserFunctionParameter (uf, p) ) ]
         [fontAwesome "times-circle"]
     else

--- a/client2/src/ViewScaffold.ml
+++ b/client2/src/ViewScaffold.ml
@@ -9,7 +9,7 @@ let viewButtons (m : model) : msg Html.html =
     match m.integrationTestState with
     | IntegrationTestExpectation _ ->
         [ Html.a
-            [ ViewUtils.eventNoPropagation "mouseup" (fun _ -> FinishIntegrationTest)
+            [ ViewUtils.eventNoPropagation ~key:"fit" "mouseup" (fun _ -> FinishIntegrationTest)
             ; Html.src ""
             ; Html.id "finishIntegrationTest"
             ; Html.class' "specialButton" ]
@@ -43,7 +43,7 @@ let viewButtons (m : model) : msg Html.html =
           ; Html.a
               [ Html.class' "link"
               ; Html.href "#"
-              ; ViewUtils.eventNoPropagation "mouseup" (fun _ ->
+              ; ViewUtils.eventNoPropagation ~key:(string_of_bool m.error.showDetails)"mouseup" (fun _ ->
                     ShowErrorDetails (not m.error.showDetails) ) ]
               [ Html.text
                   ( if m.error.showDetails then "hide details"
@@ -60,12 +60,12 @@ let viewButtons (m : model) : msg Html.html =
   in
   Html.div [Html.id "buttons"]
     ( [ Html.a
-          [ ViewUtils.eventNoPropagation "mouseup" (fun _ -> SaveTestButton)
+          [ ViewUtils.eventNoPropagation ~key:"stb" "mouseup" (fun _ -> SaveTestButton)
           ; Html.src ""
           ; Html.class' "specialButton" ]
           [Html.text "SaveTest"]
       ; Html.a
-          [ ViewUtils.eventNoPropagation "mouseup" (fun _ -> ToggleTimers)
+          [ ViewUtils.eventNoPropagation ~key:"tt" "mouseup" (fun _ -> ToggleTimers)
           ; Html.src ""
           ; Html.class' "specialButton" ]
           [ Html.text

--- a/client2/src/ViewUtils.ml
+++ b/client2/src/ViewUtils.ml
@@ -93,20 +93,20 @@ let decodeClickEvent (fn : mouseEvent -> 'a) j : 'a =
     ; button = (JSD.field "button" JSD.int j)
     }
 
-let eventNoPropagation (event : string) (constructor : mouseEvent -> msg) :
+let eventNoPropagation ~(key: string) (event : string) (constructor : mouseEvent -> msg) :
     msg Vdom.property =
-  Html.onWithOptions event
+  Patched_tea_html.onWithOptions ~key event
     {stopPropagation= true; preventDefault= false}
     (Decoders.wrapDecoder (decodeClickEvent constructor))
 
-let eventNoDefault (event : string) (constructor : mouseEvent -> msg) :
+let eventNoDefault ~(key: string) (event : string) (constructor : mouseEvent -> msg) :
     msg Vdom.property =
-  Html.onWithOptions event
+  Patched_tea_html.onWithOptions ~key event
     {stopPropagation= false; preventDefault= true}
     (Decoders.wrapDecoder (decodeClickEvent constructor))
 
 let nothingMouseEvent (name : string) : msg Vdom.property =
-  eventNoPropagation name (fun e -> NothingClick e)
+  eventNoPropagation ~key:"" name (fun e -> NothingClick e)
 
 let placeHtml (m : model) (pos : pos) (html : msg Html.html) : msg Html.html =
   let div class_ subs = Html.div [Html.class' class_] subs in


### PR DESCRIPTION
So! This was a doozy.

This PR is a result of investigating: https://trello.com/c/6fFeAgDv/38-selecting-the-wrong-toplevel-when-we-click-on-it

While investigating a reproducible case for the bug, I stumbled on a bug that if you double clicked a BlankOr after you had just edited it, but before you moved away, the app would crash. Upon adding logging, it was clear that the callback had the _old_ `id` in `BlankOrDoubleClick TLID ID`. 

This did not fit with my understanding of the programming model of the virtual DOM, namely all callbacks from a view are guaranteed to be sent as a `Msg` to the `Model` that rendered them. I initially forked bucklescript-tea to remove all event handler caching, which fixed the bug -- showing that the issue was definitely in the caching behaviour. Upon reading https://github.com/OvermindDL1/bucklescript-tea/issues/5 I got the hint that maybe we weren't correctly passing cache keys. I couldn't actually find anywhere we were passing cache keys, as it turned out the `Tea_html.onWithOptions` function just passed the empty string downstream. This meant that https://github.com/OvermindDL1/bucklescript-tea/blob/master/src-ocaml/vdom.ml#L186-L192 was always executed as `oldName` and `newName` are always `""`. This code doesn't doesn't update the cache, due to the comparison returning equal (presumably because the variants name is the same?, i think relying on the internal structural comparison is the issue here). I didn't quite get to the bottom of this, but regardless we semantically want the second branch here, where the key has changed.

Fix: pass the key down everywhere. I've vendored a changed API for `onWithOptions` that lets us pass a key. Our wrappers in `ViewUtils` have been amended to _require_ a key, to prevent misuse. In the cases where you have no variadic information closed over by the callback, you can simply pass a constant string. This little bit of API pain is worth the misuse prevention I think

I think this also fixes https://trello.com/c/yxrKOOg4/42-cant-unlock-handlers-after-locking-them and presumably a bunch of different bugs.