### PR TITLE
Don't ever add a Content-Type if there's already one.

### DIFF
--- a/server/libbackend/server.ml
+++ b/server/libbackend/server.ml
@@ -231,7 +231,7 @@ let user_page_handler ~(execution_id: Types.id) ~(canvas: string) ~(ip: string) 
                     ~store_fn_result:(Stored_function_result.store ~canvas_id ~trace_id)
      in
      let maybe_infer_headers resp_headers value =
-       if List.Assoc.mem resp_headers ~equal:(=) "Content-Type"
+       if List.Assoc.mem resp_headers ~equal:(String.Caseless.equal) "Content-Type"
        then
          resp_headers
        else


### PR DESCRIPTION
I was having trouble getting `Http::respondWithHeaders` to output a text/html document and this is why: somewhere between `Http::respondWithHeaders` and this code path (`maybe_infer_headers`), `Content-type` gets lowercased. Then the current code adds a `Content-Type:  text/plain; utf-8`, because there's not a `Content-Type` (with that casing).

This uses `String.Caseless.equal` for that check, so either one will work.