### PR TITLE
Add just enough to get autocompletemods showing properly in console.log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -277,6 +277,14 @@ ENV TERM=xterm-256color
 # Quick hacks here, to avoid massive recompiles
 ######################
 
+# To use PPXes in bucklescript, we need to install them from opam
+RUN opam switch create 4.02.3
+RUN eval $(opam env) \
+  && opam install -y \
+    ppx_deriving_yojson \
+    ppx_deriving
+RUN opam switch 4.07.0
+
 ############################
 # Finish
 ############################

--- a/client2/bsconfig.json
+++ b/client2/bsconfig.json
@@ -15,6 +15,9 @@
     "module": "commonjs",
     "in-source": false
   },
+  "ppx-flags": [
+    "./run-ppxes"
+  ],
   "suffix": ".bs.js",
   "bs-dependencies": [
     "bucklescript-tea",

--- a/client2/run-ppxes
+++ b/client2/run-ppxes
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+eval $(opam env --switch=4.02.3 --set-switch)
+
+dir=$(ocamlfind query ppx_deriving)
+
+"$dir"/ppx_deriving \
+  "$dir"/ppx_deriving_show.cma \
+  $@

--- a/client2/src/GMap.ml
+++ b/client2/src/GMap.ml
@@ -1,0 +1,24 @@
+(* We don't have an internal standard library, but should. This file it
+ * potentially the start of one. I named it GMap because it needs some prefix
+ * (not D!), and G is a letter. *)
+
+module String = struct
+  include Belt.Map.String
+  let pp
+      (f: Format.formatter -> 'value -> unit)
+      (fmt: Format.formatter)
+      (v: 'value t)
+    =
+    ()
+end
+
+module Int = struct
+  include Belt.Map.Int
+  let pp
+      (f: Format.formatter -> 'value -> unit)
+      (fmt: Format.formatter)
+      (v: 'value t)
+    =
+    ()
+end
+

--- a/client2/src/Main.ml
+++ b/client2/src/Main.ml
@@ -155,11 +155,8 @@ let processFocus (m : model) (focus : focus) : modification =
 
 let processAutocompleteMods (m : model) (mods : autocompleteMod list) :
     model * msg Cmd.t =
-  let _ =
-    if m.integrationTestState <> NoIntegrationTest then
-      Debug.log "autocompletemod update" mods
-    else mods
-  in
+  if m.integrationTestState <> NoIntegrationTest then
+    Debug.loG "autocompletemod update" (show_list show_autocompleteMod mods);
   let complete =
     List.foldl
       (fun mod_ complete_ -> AC.update m mod_ complete_)
@@ -184,11 +181,9 @@ let processAutocompleteMods (m : model) (mods : autocompleteMod list) :
 
 let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
     model * msg Cmd.t =
-  let _ =
-    if m.integrationTestState <> NoIntegrationTest then
-      Debug.log "mod update" mod_
-    else mod_
-  in
+  if m.integrationTestState <> NoIntegrationTest then
+    Debug.loG "mod update" (show_modification mod_);
+
   let closeBlanks newM =
     m.cursorState |> tlidOf
     |> Option.andThen (TL.get m)
@@ -607,11 +602,8 @@ let findCenter (m : model) : pos =
   | _ -> Defaults.centerPos
 
 let update_ (msg : msg) (m : model) : modification =
-  let _ =
-    if m.integrationTestState <> NoIntegrationTest then
-      Debug.log "msg update" msg
-    else msg
-  in
+  if m.integrationTestState <> NoIntegrationTest then
+    Debug.loG "msg update" (show_msg msg);
   match msg with
   | GlobalKeyPress event -> (
       if (event.metaKey || event.ctrlKey) && event.keyCode = Key.Z then
@@ -1029,7 +1021,7 @@ let update_ (msg : msg) (m : model) : modification =
           | Deselected ->
               Many
                 [ AutocompleteMod ACReset
-                ; Enter (Creating (Viewport.toAbsolute m event.pos)) ]
+                ; Enter (Creating (Viewport.toAbsolute m event.mePos)) ]
           | _ -> Deselect
         else NoChange
     | _ -> NoChange )
@@ -1058,7 +1050,7 @@ let update_ (msg : msg) (m : model) : modification =
         let tl = TL.getTL m targetTLID in
         match tl.data with
         | TLFunc _ -> NoChange
-        | _ -> Drag (targetTLID, event.pos, false, m.cursorState)
+        | _ -> Drag (targetTLID, event.mePos, false, m.cursorState)
       else NoChange
   | ToplevelMouseUp (targetTLID, event) ->
       if event.button = Defaults.leftButton then
@@ -1318,7 +1310,7 @@ let subscriptions (m : model) : msg Sub.t =
           Tea.Time.second
           (fun f -> TimerFire (RefreshAnalysis, f))
         ]
-      ) @ 
+      ) @
       [ Patched_tea_time.every
         ~key: "check_url_hash_position"
         Time.second

--- a/client2/src/Porting.ml
+++ b/client2/src/Porting.ml
@@ -20,6 +20,7 @@ let registerGlobal name key tagger decoder =
 
 module PageVisibility = struct
   type visibility = Hidden | Visible
+  [@@deriving show]
 end
 
 let (<|) a b = a b
@@ -244,8 +245,17 @@ module Result = struct
     match r with
     | Ok v -> Some v
     | _ -> None
+  let pp
+    (ferr: Format.formatter -> 'err -> unit)
+    (fok: Format.formatter -> 'ok -> unit)
+    (fmt: Format.formatter)
+    (v: ('err, 'ok) t)
+  = ()
+
+
 end
 type ('err, 'ok) result = ('err, 'ok) Result.t
+[@@deriving show]
 
 module Base64 = struct
   let encode (str: string) : string =

--- a/client2/src/Ppx_deriving_runtime.ml
+++ b/client2/src/Ppx_deriving_runtime.ml
@@ -1,0 +1,59 @@
+module Predef = struct
+  type _int = int
+  type _char = char
+  type _string = string
+  type _float = float
+  type _bool = bool
+  type _unit = unit
+  type _exn = exn
+  type 'a _array = 'a array
+  type 'a _list = 'a list
+  type 'a _option = 'a option = None | Some of 'a
+  type _nativeint = nativeint
+  type _int32 = int32
+  type _int64 = int64
+  type 'a _lazy_t = 'a lazy_t
+  type _bytes = bytes
+end
+
+type int = Predef._int
+type char = Predef._char
+type string = Predef._string
+type float = Predef._float
+type bool = Predef._bool
+type unit = Predef._unit
+type exn = Predef._exn
+type 'a array = 'a Predef._array
+type 'a list = 'a Predef._list
+type 'a option = 'a Predef._option = None | Some of 'a
+type nativeint = Predef._nativeint
+type int32 = Predef._int32
+type int64 = Predef._int64
+type 'a lazy_t = 'a Predef._lazy_t
+type bytes = Predef._bytes
+
+module Pervasives = Pervasives
+module Char = Char
+module String = String
+module Printexc = Printexc
+module Array = Array
+module List = List
+module Nativeint = Nativeint
+module Int32 = Int32
+module Int64 = Int64
+module Lazy = Lazy
+module Bytes = Bytes
+
+module Hashtbl = Hashtbl
+module Queue = Queue
+module Stack = Stack
+module Set = Set
+module Map = Map
+module Weak = Weak
+
+module Printf = Printf
+module Format = Format
+module Buffer = Buffer
+module Result = Result
+
+include Pervasives

--- a/client2/src/Types.ml
+++ b/client2/src/Types.ml
@@ -1,3 +1,10 @@
+let show_list (f: 'a -> string) (x: 'a list) : string =
+  "[" ^ String.concat "," (List.map f x) ^ "]"
+
+let opaque msg fmt _ =
+  Format.pp_print_string fmt ("<opaque:" ^ msg ^ ">");
+  ()
+
 type exception_ =
   { short: string
   ; long: string option
@@ -7,9 +14,23 @@ type exception_ =
   ; result: string option
   ; resultType: string option
   ; expected: string option
-  ; info: string Belt.Map.String.t
+  ; info: string GMap.String.t
   ; workarounds: string list }
 
+(* ---------------------- *)
+(* Basic types *)
+(* ---------------------- *)
+
+and tlid = TLID of int
+and id = ID of int
+and 'a blankOr = Blank of id
+               | F of id * 'a
+
+and pos = {x: int; y: int}
+and vPos = {vx: int; vy: int}
+(* ---------------------- *)
+(* Types *)
+(* ---------------------- *)
 and tipe =
   | TInt
   | TStr
@@ -37,280 +58,20 @@ and tipe =
   | THasMany of string
   | TDbList of tipe
 
-and dhttp = Redirect of string | Response of int * (string * string) list
-
-and optionT = OptJust of dval | OptNothing
-
-and dval =
-  | DInt of int
-  | DFloat of float
-  | DBool of bool
-  | DNull
-  | DChar of char
-  | DStr of string
-  | DList of dval list
-  | DObj of dval Belt.Map.String.t
-  | DIncomplete
-  | DError of string
-  | DBlock
-  | DErrorRail of dval
-  | DResp of dhttp * dval
-  | DDB of string
-  | DID of string
-  | DDate of string
-  | DTitle of string
-  | DUrl of string
-  | DPassword of string
-  | DUuid of string
-  | DOption of optionT
-
-and pos = {x: int; y: int}
-
-and vPos = {vx: int; vy: int}
-
-and mouseEvent = {pos: vPos; button: int}
-
-and isLeftButton = bool
-
-and tlid = TLID of int
-
-and id = ID of int
-
-and entryCursor = Creating of pos | Filling of tlid * id
-
-and hasMoved = bool
-
-and cursorState =
-  | Selecting of tlid * id option
-  | Entering of entryCursor
-  | Dragging of tlid * vPos * hasMoved * cursorState
-  | SelectingCommand of tlid * id
-  | Deselected
-
-and timerAction = RefreshAnalysis | CheckUrlHashPosition
-
-and globalVariable = string
-
-and rpcResult =
-  toplevel list
-  * toplevel list
-  * traces
-  * globalVariable list
-  * userFunction list
-  * tlid list
-
-and dvalArgsHash = string
-
-and executeFunctionRPCResult = dval * dvalArgsHash
-
-and getAnalysisResult =
-  traces * globalVariable list * fourOhFour list * tlid list
-
-and initialLoadResult = rpcResult
-
-and msg =
-  | GlobalClick of mouseEvent
-  | NothingClick of mouseEvent
-  | ToplevelMouseDown of tlid * mouseEvent
-  | ToplevelMouseUp of tlid * mouseEvent
-  | ToplevelClick of tlid * mouseEvent
-  | DragToplevel of tlid * Tea.Mouse.position
-  | EntryInputMsg of string
-  | EntrySubmitMsg
-  | GlobalKeyPress of Keyboard.keyEvent
-  | AutocompleteClick of string
-  | FocusEntry of (unit, Dom.errorEvent) Tea.Result.t
-  | FocusAutocompleteItem of (unit, Dom.errorEvent) Tea.Result.t
-  | RPCCallback of focus * rpcParams * (rpcResult, string Tea.Http.error) Tea.Result.t
-  | SaveTestRPCCallback of (string, string Tea.Http.error) Tea.Result.t
-  | GetAnalysisRPCCallback of (getAnalysisResult, string Tea.Http.error) Tea.Result.t
-  | GetDelete404RPCCallback of (fourOhFour list, string Tea.Http.error) Tea.Result.t
-  | InitialLoadRPCCallback of
-      focus * modification * (initialLoadResult, string Tea.Http.error) Tea.Result.t
-  | LocationChange of Web.Location.location
-  | AddRandom
-  | FinishIntegrationTest
-  | SaveTestButton
-  | ToggleTimers
-  | ExecuteFunctionRPCCallback of
-      executeFunctionRPCParams
-      * (executeFunctionRPCResult, string Tea.Http.error) Tea.Result.t
-  | ExecuteFunctionButton of tlid * id * string
-  | ExecuteFunctionCancel of tlid * id
-  | Initialization
-  | CreateHandlerFrom404 of fourOhFour
-  | Delete404 of fourOhFour
-  | WindowResize of int * int
-  | TimerFire of timerAction * Tea.Time.t
-  | JSError of string
-  | PageVisibilityChange of Porting.PageVisibility.visibility
-  | StartFeatureFlag
-  | EndFeatureFlag of id * pick
-  | ToggleFeatureFlag of id * bool
-  | DeleteUserFunctionParameter of userFunction * userFunctionParameter
-  | BlankOrClick of tlid * id * mouseEvent
-  | BlankOrDoubleClick of tlid * id * mouseEvent
-  | BlankOrMouseEnter of tlid * id * mouseEvent
-  | BlankOrMouseLeave of tlid * id * mouseEvent
-  | MouseWheel of int * int
-  | DataClick of tlid * int * mouseEvent
-  | DataMouseEnter of tlid * int * mouseEvent
-  | DataMouseLeave of tlid * int * mouseEvent
-  | CreateRouteHandler
-  | CreateDBTable
-  | CreateFunction
-  | ExtractFunction
-  | DeleteUserFunction of tlid
-  | RestoreToplevel of tlid
-  | LockHandler of tlid * bool
-  | ReceiveAnalysis of string
-  | EnablePanning of bool
-  | ShowErrorDetails of bool
-  | StartMigration of tlid
-  | AbandonMigration of tlid
-  | DeleteColInDB of tlid * id
-  [@@bs.deriving {accessors}]
-
-and predecessor = pointerData option
-
-and successor = pointerData option
-
-and focus =
-  | FocusNothing
-  | FocusExact of tlid * id
-  | FocusNext of tlid * id option
-  | FocusPageAndCursor of page * cursorState
-  | FocusSame
-  | FocusNoChange
-
-and rollbackID = id
-
-and rollforwardID = id
-
-and op =
-  | SetHandler of tlid * pos * handler
-  | CreateDB of tlid * pos * dBName
-  | AddDBCol of tlid * id * id
-  | SetDBColName of tlid * id * dBColName
-  | SetDBColType of tlid * id * dBColType
-  | DeleteTL of tlid
-  | MoveTL of tlid * pos
-  | TLSavepoint of tlid
-  | UndoTL of tlid
-  | RedoTL of tlid
-  | SetFunction of userFunction
-  | DeleteFunction of tlid
-  | ChangeDBColName of tlid * id * dBColName
-  | ChangeDBColType of tlid * id * dBColType
-  | DeprecatedInitDbm of
-      tlid * id * rollbackID * rollforwardID * dBMigrationKind
-  | SetExpr of tlid * id * expr
-  | CreateDBMigration of tlid * rollbackID * rollforwardID * dBColumn list
-  | AddDBColToDBMigration of tlid * id * id
-  | SetDBColNameInDBMigration of tlid * id * dBColName
-  | SetDBColTypeInDBMigration of tlid * id * dBColType
-  | DeleteColInDBMigration of tlid * id
-  | AbandonDBMigration of tlid
-
-and rpcParams = {ops: op list}
-
-and executeFunctionRPCParams =
-  { efpTLID: tlid
-  ; efpTraceID: traceID
-  ; efpCallerID: id
-  ; efpArgs: dval list
-  ; efpFnName: string }
-
-and analysisParams = tlid list
-
-and delete404Param = fourOhFour
-
-and autocomplete =
-  { functions: function_ list
-  ; admin: bool
-  ; completions: autocompleteItem list list
-  ; allCompletions: autocompleteItem list
-  ; index: int
-  ; value: string
-  ; prevValue: string
-  ; target: (tlid * pointerData) option
-  ; acTipe: tipe option
-  ; isCommandMode: bool }
-
-and stringEntryPermission = StringEntryAllowed | StringEntryNotAllowed
-
-and stringEntryWidth = StringEntryNormalWidth | StringEntryShortWidth
-
-and literal = string
-
-and omniAction =
-  | NewDB of dBName
-  | NewHandler
-  | NewFunction of string option
-  | NewHTTPHandler
-  | NewHTTPRoute of string
-  | NewEventSpace of string
-
-and keyword = KLet | KIf | KLambda
-
-and command =
-  { commandName: string
-  ; action: model -> toplevel -> pointerData -> modification
-  ; doc: string
-  ; shortcut: string }
-
-and autocompleteItem =
-  | ACFunction of function_
-  | ACField of string
-  | ACVariable of varName
-  | ACExtra of string
-  | ACLiteral of literal
-  | ACOmniAction of omniAction
-  | ACKeyword of keyword
-  | ACCommand of command
-
-and target = tlid * pointerData
-
-and autocompleteMod =
-  | ACSetQuery of string
-  | ACAppendQuery of string
-  | ACReset
-  | ACSelectDown
-  | ACSelectUp
-  | ACSetTarget of target option
-  | ACRegenerate
-  | ACEnableCommandMode
-
-and variantTest = StubVariant
-
-and class_ = string
-
-and pick = PickA | PickB
-
-and ffIsExpanded = bool
-
-and flagsVS = ffIsExpanded Belt.Map.Int.t
+(* ---------------------- *)
+(* Exprs and AST types *)
+(* ---------------------- *)
 
 and varName = string
-
 and fnName = string
-
 and fieldName = string
-
 and keyName = string
-
 and varBind = varName blankOr
-
 and field = fieldName blankOr
-
 and key = keyName blankOr
-
 and lambdaParameter = varName blankOr
-
-and expr = nExpr blankOr
-
 and sendToRail = Rail | NoRail
-
+and expr = nExpr blankOr
 and nExpr =
   | If of expr * expr * expr
   | FnCall of fnName * expr list * sendToRail
@@ -354,10 +115,14 @@ and pointerType =
   | ParamName
   | ParamTipe
 
-and 'a blankOr = Blank of id | F of id * 'a
-
 and pointerOwner = POSpecHeader | POAst | PODb
 
+
+(* ---------------------- *)
+(* Toplevels *)
+(* ---------------------- *)
+
+(* handlers *)
 and handlerSpec =
   {module_: string blankOr; name: string blankOr; modifier: string blankOr}
 
@@ -365,17 +130,14 @@ and handlerSpace = HSHTTP | HSCron | HSOther | HSEmpty
 
 and handler = {ast: expr; spec: handlerSpec; tlid: tlid}
 
+(* dbs *)
 and dBName = string
-
 and dBColName = string
-
 and dBColType = string
-
 and dBColumn = dBColName blankOr * dBColType blankOr
-
 and dBMigrationKind = DeprecatedMigrationKind
-
-and dBMigrationState = DBMigrationAbandoned | DBMigrationInitialized
+and dBMigrationState = DBMigrationAbandoned
+                      | DBMigrationInitialized
 
 and dBMigration =
   { startingVersion: int
@@ -393,47 +155,404 @@ and dB =
   ; oldMigrations: dBMigration list
   ; activeMigration: dBMigration option }
 
-and tLData = TLHandler of handler | TLDB of dB | TLFunc of userFunction
+(* userFunctions *)
+and userFunctionParameter =
+  { ufpName: string blankOr
+  ; ufpTipe: tipe blankOr
+  ; ufpBlock_args: string list
+  ; ufpOptional: bool
+  ; ufpDescription: string }
+
+and userFunctionMetadata =
+  { ufmName: string blankOr
+  ; ufmParameters: userFunctionParameter list
+  ; ufmDescription: string
+  ; ufmReturnTipe: tipe blankOr
+  ; ufmInfix: bool }
+
+and userFunction = {ufTLID: tlid; ufMetadata: userFunctionMetadata; ufAST: expr}
+
+(* toplevels *)
+and tLData = TLHandler of handler
+            | TLDB of dB
+            | TLFunc of userFunction
 
 and toplevel = {id: tlid; pos: pos; data: tLData}
 
-and lvDict = dval Belt.Map.Int.t
 
-and avDict = varName list Belt.Map.Int.t
 
+and dhttp = Redirect of string | Response of int * (string * string) list
+
+and optionT = OptJust of dval | OptNothing
+
+and dval =
+  | DInt of int
+  | DFloat of float
+  | DBool of bool
+  | DNull
+  | DChar of char
+  | DStr of string
+  | DList of dval list
+  | DObj of dval GMap.String.t
+  | DIncomplete
+  | DError of string
+  | DBlock
+  | DErrorRail of dval
+  | DResp of dhttp * dval
+  | DDB of string
+  | DID of string
+  | DDate of string
+  | DTitle of string
+  | DUrl of string
+  | DPassword of string
+  | DUuid of string
+  | DOption of optionT
+
+and mouseEvent = {mePos: vPos; button: int}
+
+and isLeftButton = bool
+
+and entryCursor = Creating of pos | Filling of tlid * id
+
+and hasMoved = bool
+
+and cursorState =
+  | Selecting of tlid * id option
+  | Entering of entryCursor
+  | Dragging of tlid * vPos * hasMoved * cursorState
+  | SelectingCommand of tlid * id
+  | Deselected
+
+and timerAction = RefreshAnalysis | CheckUrlHashPosition
+
+(* ------------------- *)
+(* Analysis *)
+(* ------------------- *)
+and globalVariable = string
+and traceID = string
+and lvDict = dval GMap.Int.t
+and avDict = varName list GMap.Int.t
+and inputValueDict = dval GMap.String.t
 and analysisResults = {liveValues: lvDict; availableVarnames: avDict}
 
-and analyses = analysisResults Belt.Map.String.t
-
-and inputValueDict = dval Belt.Map.String.t
-
+and analyses = analysisResults GMap.String.t
 and functionResult =
   {fnName: string; callerID: id; argHash: string; value: dval}
 
-and traceID = string
 
 and trace =
   { traceID: traceID
   ; input: inputValueDict
-  ; functionResults: functionResult list }
-
-and traces = trace list Belt.Map.Int.t
+  ; functionResults: functionResult list
+  }
+and traces = trace list GMap.Int.t
 
 and fourOhFour = {space: string; path: string; modifier: string}
 
-and name = string
+(* ------------------- *)
+(* ops *)
+(* ------------------- *)
+and rollbackID = id
+and rollforwardID = id
+and op =
+  | SetHandler of tlid * pos * handler
+  | CreateDB of tlid * pos * dBName
+  | AddDBCol of tlid * id * id
+  | SetDBColName of tlid * id * dBColName
+  | SetDBColType of tlid * id * dBColType
+  | DeleteTL of tlid
+  | MoveTL of tlid * pos
+  | TLSavepoint of tlid
+  | UndoTL of tlid
+  | RedoTL of tlid
+  | SetFunction of userFunction
+  | DeleteFunction of tlid
+  | ChangeDBColName of tlid * id * dBColName
+  | ChangeDBColType of tlid * id * dBColType
+  | DeprecatedInitDbm of
+      tlid * id * rollbackID * rollforwardID * dBMigrationKind
+  | SetExpr of tlid * id * expr
+  | CreateDBMigration of tlid * rollbackID * rollforwardID * dBColumn list
+  | AddDBColToDBMigration of tlid * id * id
+  | SetDBColNameInDBMigration of tlid * id * dBColName
+  | SetDBColTypeInDBMigration of tlid * id * dBColType
+  | DeleteColInDBMigration of tlid * id
+  | AbandonDBMigration of tlid
 
-and page = Toplevels of pos | Fn of tlid * pos
+(* ------------------- *)
+(* RPCs *)
+(* ------------------- *)
+(* params *)
+and rpcParams = {ops: op list}
+
+and executeFunctionRPCParams =
+  { efpTLID: tlid
+  ; efpTraceID: traceID
+  ; efpCallerID: id
+  ; efpArgs: dval list
+  ; efpFnName: string }
+
+and analysisParams = tlid list
+
+and delete404Param = fourOhFour
+
+(* results *)
+and rpcResult =
+  toplevel list
+  * toplevel list
+  * traces
+  * globalVariable list
+  * userFunction list
+  * tlid list
+
+and dvalArgsHash = string
+
+and executeFunctionRPCResult = dval * dvalArgsHash
+
+and getAnalysisResult =
+  traces * globalVariable list * fourOhFour list * tlid list
+
+and initialLoadResult = rpcResult
+
+(* ------------------- *)
+(* Autocomplete *)
+(* ------------------- *)
+(* functions *)
+and parameter =
+  { paramName: string
+  ; paramTipe: tipe
+  ; paramBlock_args: string list
+  ; paramOptional: bool
+  ; paramDescription: string }
+
+and function_ =
+  { fnName: string
+  ; fnParameters: parameter list
+  ; fnDescription: string
+  ; fnReturnTipe: tipe
+  ; fnPreviewExecutionSafe: bool
+  ; fnDeprecated: bool
+  ; fnInfix: bool }
+
+(* autocomplete items *)
+and literal = string
+and keyword = KLet | KIf | KLambda
+and command =
+  { commandName: string
+  ; action: model -> toplevel -> pointerData -> modification
+  ; doc: string
+  ; shortcut: string }
+
+and omniAction =
+  | NewDB of dBName
+  | NewHandler
+  | NewFunction of string option
+  | NewHTTPHandler
+  | NewHTTPRoute of string
+  | NewEventSpace of string
+
+and autocompleteItem =
+  | ACFunction of function_
+  | ACField of string
+  | ACVariable of varName
+  | ACExtra of string
+  | ACLiteral of literal
+  | ACOmniAction of omniAction
+  | ACKeyword of keyword
+  | ACCommand of command
+
+and target = tlid * pointerData
+and autocomplete =
+  { functions: function_ list
+  ; admin: bool
+  ; completions: autocompleteItem list list
+  ; allCompletions: autocompleteItem list
+  ; index: int
+  ; value: string
+  ; prevValue: string
+  ; target: (tlid * pointerData) option
+  ; acTipe: tipe option
+  ; isCommandMode: bool }
+
+and autocompleteMod =
+  | ACSetQuery of string
+  | ACAppendQuery of string
+  | ACReset
+  | ACSelectDown
+  | ACSelectUp
+  | ACSetTarget of target option
+  | ACRegenerate
+  | ACEnableCommandMode
+
+(* ------------------- *)
+(* Modifications *)
+(* ------------------- *)
+and page = Toplevels of pos
+          | Fn of tlid * pos
+
+and focus =
+  | FocusNothing
+  | FocusExact of tlid * id
+  | FocusNext of tlid * id option
+  | FocusPageAndCursor of page * cursorState
+  | FocusSame
+  | FocusNoChange
 
 and clipboard = pointerData option
+and canvasProps = {offset: pos; fnOffset: pos; enablePan: bool}
+
+and pick = PickA | PickB
+
+and httpError = string Tea.Http.error [@opaque]
+
+and modification =
+  | DisplayAndReportHttpError of string * httpError
+  | DisplayAndReportError of string
+  | DisplayError of string
+  | ClearError
+  | Select of tlid * id option
+  | SelectCommand of tlid * id
+  | SetHover of id
+  | ClearHover of id
+  | Deselect
+  | RemoveToplevel of toplevel
+  | SetToplevels of toplevel list * bool
+  | UpdateToplevels of toplevel list * bool
+  | SetDeletedToplevels of toplevel list
+  | UpdateDeletedToplevels of toplevel list
+  | UpdateAnalysis of traceID * analysisResults
+  | RequestAnalysis of toplevel list
+  | SetGlobalVariables of globalVariable list
+  | SetUserFunctions of userFunction list * bool
+  | SetUnlockedDBs of tlid list
+  | Set404s of fourOhFour list
+  | Enter of entryCursor
+  | RPCFull of (rpcParams * focus)
+  | RPC of (op list * focus)
+  | GetAnalysisRPC
+  | NoChange
+  | MakeCmd of msg Tea.Cmd.t [@printer opaque "MakeCmd"]
+  | AutocompleteMod of autocompleteMod
+  | Many of modification list
+  | Drag of tlid * vPos * hasMoved * cursorState
+  | TriggerIntegrationTest of string
+  | EndIntegrationTest
+  | SetCursorState of cursorState
+  | SetPage of page
+  | SetCenter of pos
+  | CopyToClipboard of clipboard
+  | SetCursor of tlid * int
+  | ExecutingFunctionBegan of tlid * id
+  | ExecutingFunctionRPC of tlid * id * string
+  | ExecutingFunctionComplete of (tlid * id) list
+  | SetLockedHandlers of tlid list
+  | MoveCanvasTo of canvasProps * page * pos
+  | UpdateTraces of traces
+  | UpdateTraceFunctionResult of
+      tlid * traceID * id * fnName * dvalArgsHash * dval
+  | TweakModel of (model -> model)
+
+(* ------------------- *)
+(* Msgs *)
+(* ------------------- *)
+and msg =
+  | GlobalClick of mouseEvent
+  | NothingClick of mouseEvent
+  | ToplevelMouseDown of tlid * mouseEvent
+  | ToplevelMouseUp of tlid * mouseEvent
+  | ToplevelClick of tlid * mouseEvent
+  | DragToplevel of tlid * Tea.Mouse.position [@printer opaque "DragToplevel"]
+  | EntryInputMsg of string
+  | EntrySubmitMsg
+  | GlobalKeyPress of Keyboard.keyEvent [@printer opaque "GlobalKeyPress"]
+  | AutocompleteClick of string
+  | FocusEntry of (unit, Dom.errorEvent) Tea.Result.t [@printer opaque "FocusEntry"]
+  | FocusAutocompleteItem of (unit, Dom.errorEvent) Tea.Result.t [@printer opaque "FocusAutocompleteItem"]
+  | RPCCallback of focus * rpcParams * (rpcResult, httpError) Tea.Result.t [@printer opaque "RPCCallback"]
+  | SaveTestRPCCallback of (string, httpError) Tea.Result.t [@printer opaque "SavetestRPCCallback"]
+  | GetAnalysisRPCCallback of (getAnalysisResult, httpError) Tea.Result.t [@printer opaque "GetAnalysisRPCCallback"]
+  | GetDelete404RPCCallback of (fourOhFour list, httpError) Tea.Result.t [@printer opaque "GetDelete404RPCCallback"]
+  | InitialLoadRPCCallback of
+      focus * modification * (initialLoadResult, httpError) Tea.Result.t [@printer opaque "InitialLoadRPCCallback"]
+  | LocationChange of Web.Location.location [@printer opaque "LocationChange"]
+  | AddRandom
+  | FinishIntegrationTest
+  | SaveTestButton
+  | ToggleTimers
+  | ExecuteFunctionRPCCallback of
+      executeFunctionRPCParams
+      * (executeFunctionRPCResult, httpError) Tea.Result.t [@printer opaque "ExecuteFunctionRPCCallback"]
+  | ExecuteFunctionButton of tlid * id * string
+  | ExecuteFunctionCancel of tlid * id
+  | Initialization
+  | CreateHandlerFrom404 of fourOhFour
+  | Delete404 of fourOhFour
+  | WindowResize of int * int
+  | TimerFire of timerAction * Tea.Time.t [@printer opaque "TimerFire"]
+  | JSError of string
+  | PageVisibilityChange of Porting.PageVisibility.visibility
+  | StartFeatureFlag
+  | EndFeatureFlag of id * pick
+  | ToggleFeatureFlag of id * bool
+  | DeleteUserFunctionParameter of userFunction * userFunctionParameter
+  | BlankOrClick of tlid * id * mouseEvent
+  | BlankOrDoubleClick of tlid * id * mouseEvent
+  | BlankOrMouseEnter of tlid * id * mouseEvent
+  | BlankOrMouseLeave of tlid * id * mouseEvent
+  | MouseWheel of int * int
+  | DataClick of tlid * int * mouseEvent
+  | DataMouseEnter of tlid * int * mouseEvent
+  | DataMouseLeave of tlid * int * mouseEvent
+  | CreateRouteHandler
+  | CreateDBTable
+  | CreateFunction
+  | ExtractFunction
+  | DeleteUserFunction of tlid
+  | RestoreToplevel of tlid
+  | LockHandler of tlid * bool
+  | ReceiveAnalysis of string
+  | EnablePanning of bool
+  | ShowErrorDetails of bool
+  | StartMigration of tlid
+  | AbandonMigration of tlid
+  | DeleteColInDB of tlid * id
+  [@@bs.deriving {accessors}]
+
+and predecessor = pointerData option
+
+and successor = pointerData option
+and stringEntryPermission = StringEntryAllowed | StringEntryNotAllowed
+
+and stringEntryWidth = StringEntryNormalWidth | StringEntryShortWidth
+
+and variantTest = StubVariant
+
+and class_ = string
+
+and ffIsExpanded = bool
+
+and flagsVS = ffIsExpanded GMap.Int.t
 
 and syncState = {inFlight: bool; ticks: int}
 
 and urlState = {lastPos: pos}
 
-and tLCursors = int Belt.Map.Int.t
+and tLCursors = int GMap.Int.t
 
-and canvasProps = {offset: pos; fnOffset: pos; enablePan: bool}
+and serializableEditor =
+  { clipboard: pointerData option
+  ; timersEnabled: bool
+  ; cursorState: cursorState
+  ; lockedHandlers: tlid list }
+
+and darkError = {message: string option; showDetails: bool}
+
+and testResult = (string, unit) Porting.Result.t
+
+and integrationTestState =
+  | IntegrationTestExpectation of (model -> testResult)
+  | IntegrationTestFinished of testResult
+  | NoIntegrationTest
 
 and model =
   { error: darkError
@@ -468,101 +587,7 @@ and model =
   ; userContentHost: string
   ; environment: string
   ; csrfToken: string}
-
-and serializableEditor =
-  { clipboard: pointerData option
-  ; timersEnabled: bool
-  ; cursorState: cursorState
-  ; lockedHandlers: tlid list }
-
-and darkError = {message: string option; showDetails: bool}
-
-and testResult = (string, unit) Porting.Result.t
-
-and integrationTestState =
-  | IntegrationTestExpectation of (model -> testResult)
-  | IntegrationTestFinished of testResult
-  | NoIntegrationTest
-
-[@bs.deriving accessors]
-and modification =
-  | DisplayAndReportHttpError of string * string Tea.Http.error
-  | DisplayAndReportError of string
-  | DisplayError of string
-  | ClearError
-  | Select of tlid * id option
-  | SelectCommand of tlid * id
-  | SetHover of id
-  | ClearHover of id
-  | Deselect
-  | RemoveToplevel of toplevel
-  | SetToplevels of toplevel list * bool
-  | UpdateToplevels of toplevel list * bool
-  | SetDeletedToplevels of toplevel list
-  | UpdateDeletedToplevels of toplevel list
-  | UpdateAnalysis of traceID * analysisResults
-  | RequestAnalysis of toplevel list
-  | SetGlobalVariables of globalVariable list
-  | SetUserFunctions of userFunction list * bool
-  | SetUnlockedDBs of tlid list
-  | Set404s of fourOhFour list
-  | Enter of entryCursor
-  | RPCFull of (rpcParams * focus)
-  | RPC of (op list * focus)
-  | GetAnalysisRPC
-  | NoChange
-  | MakeCmd of msg Tea.Cmd.t
-  | AutocompleteMod of autocompleteMod
-  | Many of modification list
-  | Drag of tlid * vPos * hasMoved * cursorState
-  | TriggerIntegrationTest of string
-  | EndIntegrationTest
-  | SetCursorState of cursorState
-  | SetPage of page
-  | SetCenter of pos
-  | CopyToClipboard of clipboard
-  | SetCursor of tlid * int
-  | ExecutingFunctionBegan of tlid * id
-  | ExecutingFunctionRPC of tlid * id * string
-  | ExecutingFunctionComplete of (tlid * id) list
-  | SetLockedHandlers of tlid list
-  | MoveCanvasTo of canvasProps * page * pos
-  | UpdateTraces of traces
-  | UpdateTraceFunctionResult of
-      tlid * traceID * id * fnName * dvalArgsHash * dval
-  | TweakModel of (model -> model)
-
-and parameter =
-  { paramName: string
-  ; paramTipe: tipe
-  ; paramBlock_args: string list
-  ; paramOptional: bool
-  ; paramDescription: string }
-
-and function_ =
-  { fnName: string
-  ; fnParameters: parameter list
-  ; fnDescription: string
-  ; fnReturnTipe: tipe
-  ; fnPreviewExecutionSafe: bool
-  ; fnDeprecated: bool
-  ; fnInfix: bool }
-
-and userFunctionParameter =
-  { ufpName: string blankOr
-  ; ufpTipe: tipe blankOr
-  ; ufpBlock_args: string list
-  ; ufpOptional: bool
-  ; ufpDescription: string }
-
-and userFunctionMetadata =
-  { ufmName: string blankOr
-  ; ufmParameters: userFunctionParameter list
-  ; ufmDescription: string
-  ; ufmReturnTipe: tipe blankOr
-  ; ufmInfix: bool }
-
-and userFunction = {ufTLID: tlid; ufMetadata: userFunctionMetadata; ufAST: expr}
+[@@deriving show]
 
 and rpcContext = { canvasName : string; csrfToken : string }
 

--- a/client2/src/ViewUtils.ml
+++ b/client2/src/ViewUtils.ml
@@ -87,9 +87,9 @@ let fontAwesome (name : string) : msg Html.html =
 let decodeClickEvent (fn : mouseEvent -> 'a) j : 'a =
   let module JSD = Json_decode_extended in
   fn
-    { pos = { vx = JSD.field "pageX" JSD.int j
-            ; vy = JSD.field "pageY" JSD.int j
-            }
+    { mePos = { vx = JSD.field "pageX" JSD.int j
+              ; vy = JSD.field "pageY" JSD.int j
+              }
     ; button = (JSD.field "button" JSD.int j)
     }
 


### PR DESCRIPTION
I want to use ppx_deriving show to make it easier to read logs in integration tests. This is the first step to enabling that, by adding `[@@deriving show]` types.ml (I also reorganized the file as an attempt to break apart the giant `and` chain, but I couldn't get there).

The user of the deriver is in main.ml.

We need to use 4.02.3 ppx as that's the version bucklescript is on.

I think I should rename myMap (suggestions helpful) but otherwise I think this is ready to merge.