### PR TITLE
Fix toplevel clicks going to wrong TL

### DIFF
--- a/client2/src/View.ml
+++ b/client2/src/View.ml
@@ -106,6 +106,10 @@ let viewCanvas (m : model) : msg Html.html =
     match m.currentPage with
     | Toplevels _ ->
       m.toplevels
+      (* TEA's vdom assumes lists have the same ordering, and diffs incorrectly
+       * if not (though only when using our Util cache). This leads to the
+       * clicks going to the wrong toplevel. Sorting solves it, though I don't
+       * know exactly how. *)
       |> List.sortBy (fun tl -> deTLID (tl.id))
       |> List.map (viewTL m)
     | Fn (tlid, _) -> (


### PR DESCRIPTION
Bug: clicking a toplevel makes selects the wrong toplevel.

Root cause: I had an inkling that the cause here was due to interacting with event handlers directly on the toplevels which are not selected, which are in our own Util cache. I tried deleting our cache, which fixed it -- but made the app unbearably slow so unfortunately it's still necessary. Having read the dependent vdom code, it seems to depend upon an ordering along with some other keys to determine diffing/adding properties/nodes etc. to the DOM. Forcing an ordering via sorting by the TLID _seems_ to fix the clicking problem, but I don't understand exactly why. I think there's some odd interaction between our cached Html/Vdom node and the Vdom differ. The sorting is not required when there is no cache. 

I think we should merge this, regardless of our gap in understanding, as long as someone else verifies that this fixes the clicking issue for them. I'd welcome someone figuring it out further though :)