### PR TITLE
Fix clicking/double clicking a blankOr getting the wrong id in all circumstances

### DIFF
--- a/client2/src/ViewBlankOr.ml
+++ b/client2/src/ViewBlankOr.ml
@@ -145,7 +145,13 @@ let div (vs : ViewUtils.viewState) (configs : htmlConfig list)
     Html.div [Html.class' "expr-actions"] (featureFlagHtml @ editFnHtml)
   in
   let attrs = liveValueAttr :: classAttr :: events in
-  Html.div attrs (content @ [rightSideHtml])
+  Html.div
+    (* if the id of the blank_or changes, this whole node should be redrawn
+     * without any further diffing. there's no good reason for the Vdom/Dom node
+     * to be re-used for a different blank_or *)
+    ~unique:(thisID |> Option.map showID |> Option.withDefault "")
+    attrs
+    (content @ [rightSideHtml])
 
 
 let text (vs : ViewUtils.viewState) (c : htmlConfig list) (str : string) : msg Html.html


### PR DESCRIPTION
This fixes 3 integration tests. I'm not entirely sure why it's required, because my understanding of the key we pass to the event properties is that they should be updated when their key changes.

I posted an issue to bs-tea asking Overmind/Gabriel if they could explain https://github.com/OvermindDL1/bucklescript-tea/issues/97