### PR TITLE
Close analysisWorker when it's done

### DIFF
--- a/server/templates/ui.html
+++ b/server/templates/ui.html
@@ -67,6 +67,8 @@
           result.error = darkExe.handleAnalysisErrors(error)
         }
         postMessage(result);
+
+        close();
       }
     </script>
     <script type="text/javascript">


### PR DESCRIPTION
We create an analysisWorker when requestAnalysis is called; in theory,
we could send an analysisWorker thread more than one message, but in
practice we don't - so close the worker after it has sent its response.