### PR TITLE
Add functions to fetch/validate canvases

### DIFF
--- a/server/libbackend/libdarkinternal.ml
+++ b/server/libbackend/libdarkinternal.ml
@@ -43,9 +43,7 @@ let replacements =
     , (fun _ -> DNull)
 
     ; "DarkInternal::checkAllCanvases"
-    , (fun _ ->
-      Canvas.check_all_hosts ();
-      DNull)
+    , (fun _ -> DNull)
 
     ; "DarkInternal::migrateAllCanvases"
     , (fun _ ->
@@ -56,4 +54,20 @@ let replacements =
     , (fun _ ->
       Canvas.cleanup_old_traces ();
       DNull)
+
+    ; "DarkInternal::checkCanvas"
+    , (function
+        | (state, [DStr host]) ->
+          (try
+            Canvas.validate_host host;
+            DBool true
+           with
+           | _ -> DBool false)
+        | args -> fail args)
+
+    ; "DarkInternal::getAllCanvases"
+    , (fun _ ->
+         Serialize.current_hosts ()
+         |> List.map ~f:(fun s -> DStr s)
+         |> DList)
   ]

--- a/server/libexecution/libdarkinternal.ml
+++ b/server/libexecution/libdarkinternal.ml
@@ -24,7 +24,7 @@ let fns : Lib.shortfn list = [
   ; f = NotClientAvailable
   ; pr = None
   ; ps = false
-  ; dep = false
+  ; dep = true
   }
   ;
 
@@ -44,6 +44,30 @@ let fns : Lib.shortfn list = [
   ; ins = []
   ; p = []
   ; r = TNull
+  ; d = "TODO"
+  ; f = NotClientAvailable
+  ; pr = None
+  ; ps = false
+  ; dep = false
+  }
+  ;
+
+  { pns = ["DarkInternal::checkCanvas"]
+  ; ins = []
+  ; p = [par "host" TStr]
+  ; r = TBool
+  ; d = "TODO"
+  ; f = NotClientAvailable
+  ; pr = None
+  ; ps = false
+  ; dep = false
+  }
+  ;
+
+  { pns = ["DarkInternal::getAllCanvases"]
+  ; ins = []
+  ; p = []
+  ; r = TList
   ; d = "TODO"
   ; f = NotClientAvailable
   ; pr = None


### PR DESCRIPTION
This lets admins do a nice `filter getAllCanvases |> checkCanvas` in Dark to see if it can serialize/deserialize.