### PR TITLE
Click the fncall selector without a filter

### DIFF
--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -755,18 +755,16 @@ test('execute_function_works', async t => {
     .typeText("#entry-box", "Uuid::gen", slow)
     .pressKey("enter")
     .click(Selector('.fa-play'))
-    .click(Selector('.fncall').withText('Uuid::generate'))
+    .click(Selector('.fncall'))
     ;
 
   let v1 = await Selector('.selected[data-live-value]').getAttribute('data-live-value');
-  console.log(v1);
 
   await t
     .click(Selector('.fa-redo'))
     ;
 
   let v2 = await Selector('.selected[data-live-value]').getAttribute('data-live-value');
-  console.log(v2);
 
   let re = /<UUID: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}>/;
   await t.expect(v1).match(re);


### PR DESCRIPTION
The text filter is unnecessary as there's only one fncall
on the canvas -- and on the off chance that we introduce
a bug with more than one, the expectation on the generated
uuid live values more than protects us.

The text filter was flakey as ['Uuid', '::', 'generate'] are
the contents of separate spans in the same div and testcafe
seems to sometimes see them as a whole or sometimes separately.
I couldn't quite figure out why but regardless, it's unneccessary.