### PR TITLE
Make integration tests passing a requirement

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -118,12 +118,5 @@ RESULT=$?
 # Fix xunit output for CircleCI flaky-tests stats
 sed -i 's/ (screenshots: .*)"/"/' ${TEST_RESULTS_XML}
 
-# TODO(bucklescript): remove after ship
-# Intent: make integration tests report legitimate result when running elm tests
-# and return 0 for bucklescript
-if [[ "${CIRCLE_BRANCH:+$CIRCLE_BRANCH}" == "master" ]]; then
-  exit $RESULT
-else
-  exit 0
-fi
+exit $RESULT
 


### PR DESCRIPTION
This PR makes integration tests passing a requirement for all builds, to ensure no regressions in the integration test suite as we continue to iterate on bucklescript.

The suite still runs integration tests against Elm on master CI, and bucklescript in all other builds.