### PR TITLE
Add scripts/gcp-pgcli 'cuz ismith strongly prefers pgcli

### DIFF
--- a/scripts/gcp-pgcli
+++ b/scripts/gcp-pgcli
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+. ./scripts/support/assert-in-container $0 $@
+
+set -euo pipefail
+
+echo "NOTE: you will need to run gcp-psql first, to temporarily whitelist your"
+echo "ip address. We don't do that in this script for you because 'gcloud sql connect'"
+echo "doesn't respect PGPASSWORD, or other script-friendly ways to provide a password."
+
+file="config/${1}"
+
+HOST="$(grep DARK_CONFIG_DB_HOST $file | sed 's/.*=//')"
+DBNAME="$(grep DARK_CONFIG_DB_DBNAME $file | sed 's/.*=//')"
+USER="$(grep DARK_CONFIG_DB_USER $file | sed 's/.*=//')"
+PGPASSWORD="$(grep DARK_CONFIG_DB_PASSWORD $file | sed 's/.*=//')"
+
+# gcp-psql handles whitelisting our IP address for a 5min window.
+# Unfortunately, despite docs saying it respects PGDATABASE, it does not
+# support PGPASSWORD
+# echo "SELECT 1" | PGPASSWORD=${PGPASSWORD} ./scripts/gcp-psql
+
+PGPASSWORD=${PGPASSWORD} pgcli -h ${HOST} -U $USER -d $DBNAME


### PR DESCRIPTION
Note: as the script output documents, you must first run gcp-psql to get
gcloud to whitelist your ip ... and unfortunately I can't figure out how
to run that in the script, because gcloud sql connect won't take a
password as an env var or anything like that, it wants user input.