### PR TITLE
Merge new traces with old traces

### DIFF
--- a/client2/src/Main.ml
+++ b/client2/src/Main.ml
@@ -502,7 +502,19 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         let m2 = {m with analyses= Analysis.record m.analyses id analysis} in
         processAutocompleteMods m2 [ACRegenerate]
     | UpdateTraces traces ->
-        let m2 = {m with traces} in
+        let newTraces =
+          GMap.String.merge
+            m.traces
+            traces
+            (fun _ maybeOld maybeNew ->
+               (match maybeOld, maybeNew with
+                | None, None -> None
+                | Some o, None -> Some o
+                | None, Some n -> Some n
+                | Some _, Some n -> Some n)
+            )
+        in
+        let m2 = {m with traces = newTraces} in
         processAutocompleteMods m2 [ACRegenerate]
     | UpdateTraceFunctionResult (tlid, traceID, callerID, fnName, hash, dval)
       ->


### PR DESCRIPTION
Model.traces is a map of `tlid -> [trace]`, UpdateTraces
is also a map of `tlid -> [trace]` -- but it might not contain the full
set of tlids that we have previously seen in this session because we
only received a subset from the server. We should merge our old set
with the new set, preserving traces for toplevels not in the latest
batch but overwriting all traces for toplevels in the new batch.

This should ensure we have available variables and data for a toplevel
when we click away and come back. This seems to work in Elm without
this patch, but it seems to me like that is accidental and that this
patch correctly expresses our intent.

Warning: I've observed that this brings back our Aw, Snap! behaviour
on linux -- but I think that's because we are now requesting analysis
for all toplevels we have traces for -- as opposed to just the one
we just received back. This extra compute seems to mean the web
workers get created faster than they complete and are GC'd