### PR TITLE
Need to rename the demo user's username to sample

### DIFF
--- a/server/libbackend/account.ml
+++ b/server/libbackend/account.ml
@@ -495,4 +495,9 @@ let init () : unit =
     ; password = "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkcE9ZT1AwYUpML25xbXBPbWFoRHdBQSR4Q2RlaFZFMEQzeTNOWnRiVEtRUlFwSDUwR1Eydm5MbnZOQ1M0dmJ6VDJRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     ; email = "jeremy@darklang.com"
     ; name = "Jeremy Morony"};
+  upsert_admin
+    { username = "sample"
+    ; password = ""
+    ; email = "nouser@example.com"
+    ; name = "Sample Owner"};
   ()

--- a/server/migrations/20181115_001713_rename-demo-user-to-sample.sql
+++ b/server/migrations/20181115_001713_rename-demo-user-to-sample.sql
@@ -1,0 +1,3 @@
+UPDATE accounts
+SET username = 'sample'
+WHERE username = 'demo'


### PR DESCRIPTION
From slack:
"error in for_host (host: string): "No owner found for host <canvas name>".

tracing back, that uses auth_domain_for_host, which splits on '-' and
then looks up an account by username.  even though presumably it could
go host->canvas->account_id->account."