### PR TITLE
Failed migrations should fail CI.

### DIFF
--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -127,6 +127,7 @@ def server_build():
                   , "bin/cron_checker.exe"
                   , "bin/add_user.exe"
                   , "bin/cleanup_traces.exe"
+                  , "bin/migration_runner.exe"
                   , "bin/darkjs.bc.js"
                   , "@darkjs"
                   ])
@@ -158,16 +159,28 @@ def server_test():
   password = "DARK_CONFIG_DB_PASSWORD=eapnsdc"
   env = "DARK_CONFIG_ENV_DISPLAY_NAME=test"
   dbenv = host + " " + dbname + " " + user + " " + password
-  return run_test(start,
-          "unbuffer dune build --root server test/test.exe"
-          + " && dropdb --if-exists testdb"
-          + " && createdb testdb"
-          + " && cd " + rundir
-          + " && " + dbenv
-          + " unbuffer ../server/_build/default/test/test.exe"
-          + " --show-errors "
-          + ci
-          + " 2>&1")
+  return (
+    run_test(start,
+      "unbuffer dune build --root server bin/migration_runner.exe"
+      + " && dropdb --if-exists testdb"
+      + " && createdb testdb"
+      + " && cd " + rundir
+      + " && " + dbenv
+      + " unbuffer ../server/_build/default/bin/migration_runner.exe"
+      + " --show-errors "
+      + ci
+      + " 2>&1")
+  and
+    run_test(start,
+      "unbuffer dune build --root server test/test.exe"
+      + " && dropdb --if-exists testdb"
+      + " && createdb testdb"
+      + " && cd " + rundir
+      + " && " + dbenv
+      + " unbuffer ../server/_build/default/test/test.exe"
+      + " --show-errors "
+      + ci
+      + " 2>&1"))
 
 def reload_server():
   start = time.time()

--- a/server/bin/dune
+++ b/server/bin/dune
@@ -76,3 +76,12 @@
   (preprocess (pps lwt.ppx))
   (package dark)
 )
+
+(executable
+  (name migration_runner)
+  (public_name migration_runner)
+  (modules migration_runner)
+  (flags (-warn-error +A))
+  (libraries libbackend)
+  (package dark)
+)

--- a/server/bin/migration_runner.ml
+++ b/server/bin/migration_runner.ml
@@ -1,0 +1,4 @@
+let () =
+    print_endline "Running migrations";
+    Libbackend.Migrations.init ();
+    print_endline "Done running migrations"


### PR DESCRIPTION
This does that by:
- adding a migration_runner.exe that
- gets called when we run scripts/builder --compile --test
- Also puts migration loglines into the scripts/builder output, which
  means they'll be more visible in CI