### PR TITLE
Disable test

### DIFF
--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -736,7 +736,8 @@ test('rename_function', async t => {
     .pressKey('enter')
 })
 
-test('rename_pattern_variable', async t => {
+// TODO: re-enable when tests no longer run against elm
+test.skip('rename_pattern_variable', async t => {
   await t
     .click(Selector('.letvarname'))
     .pressKey('backspace')


### PR DESCRIPTION
The rename pattern variable integration test fails when run against Elm
because Elm does not support the match statement.

This test should be re-enabled when the Elm codebase is retired (or
isn't the default environment for the master branch).