### PR TITLE
This causes Libbackend.init to fail (fatally) if an exc is raised

### DIFF
--- a/server/libbackend/init.ml
+++ b/server/libbackend/init.ml
@@ -42,8 +42,4 @@ let init ~run_side_effects =
   with e ->
     let bt = Libexecution.Exception.get_backtrace () in
     Rollbar.last_ditch e ~bt "backend initialization" "no execution id" ;
-
-    (* If we've gotten here, die - this is not a recoverable error (for example,
-     * failing to run migrations should fail hard *)
-    Caml.print_endline (Libexecution.Exception.to_string e);
-    exit 1
+    raise e


### PR DESCRIPTION
Solves the immediate need of making bad migrations fail in CI; also
means deploys with migrations that fail should fail. (Which we want.)