### PR TITLE
When we have new traces, only analyze the toplevel that was traced.

### DIFF
--- a/client2/src/RPC.ml
+++ b/client2/src/RPC.ml
@@ -68,7 +68,7 @@ let getAnalysisRPC (c : rpcContext) (params : analysisParams) : msg Tea.Cmd.t
   let request =
     postJson Decoders.getAnalysisRPC c.csrfToken url (Encoders.analysisParams params)
   in
-  Tea.Http.send (fun x -> GetAnalysisRPCCallback x) request
+  Tea.Http.send (fun x -> GetAnalysisRPCCallback (params, x)) request
 
 let delete404RPC (c : rpcContext) (param : delete404Param) : msg Tea.Cmd.t =
   let url =

--- a/client2/src/Types.ml
+++ b/client2/src/Types.ml
@@ -490,7 +490,7 @@ and msg =
   | FocusAutocompleteItem of (unit, Dom.errorEvent) Tea.Result.t [@printer opaque "FocusAutocompleteItem"]
   | RPCCallback of focus * rpcParams * (rpcResult, httpError) Tea.Result.t [@printer opaque "RPCCallback"]
   | SaveTestRPCCallback of (string, httpError) Tea.Result.t [@printer opaque "SavetestRPCCallback"]
-  | GetAnalysisRPCCallback of (getAnalysisResult, httpError) Tea.Result.t [@printer opaque "GetAnalysisRPCCallback"]
+  | GetAnalysisRPCCallback of (analysisParams * (getAnalysisResult, httpError) Tea.Result.t) [@printer opaque "GetAnalysisRPCCallback"]
   | GetDelete404RPCCallback of (fourOhFour list, httpError) Tea.Result.t [@printer opaque "GetDelete404RPCCallback"]
   | InitialLoadRPCCallback of
       focus * modification * (initialLoadResult, httpError) Tea.Result.t [@printer opaque "InitialLoadRPCCallback"]


### PR DESCRIPTION
This solves a problem where each request that came back caused every top level
to have an analysis requested for it. It worked fine at small scale since there
were only a few toplevels with traces. But as the canvas stayed open longer,
more toplevels got traces, and so it would grow to running N analyses per
get-analysis call.