### PR TITLE
Change selected ast elements to background color instead of border

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -826,7 +826,7 @@ body #grid * {
 
   .blankOr.selected {
     background-color: @darkblue;
-    color: @grey3;
+    color: @white3;
 
     &.tstr {
       color: @string-color;
@@ -1166,7 +1166,6 @@ body #grid * {
 // Strings
 // ---------------------------
 .string-entry {
-  background: @selected-background;
   border: 0;
   font-size: @code-font-size;
   margin: 0;


### PR DESCRIPTION
Using the same blue as autocomplete.

Also changed: string colors, placeholder color
Added comments to color palette usage.

<img width="417" alt="screen shot 2018-11-26 at 3 17 13 pm" src="https://user-images.githubusercontent.com/244152/49048121-842d2000-f18e-11e8-8cd3-17c2243ff125.png">
<img width="481" alt="screen shot 2018-11-26 at 3 17 23 pm" src="https://user-images.githubusercontent.com/244152/49048125-88593d80-f18e-11e8-9cfe-3974cf6949d4.png">
