### PR TITLE
Canvases don't share editor state.

### DIFF
--- a/client2/src/Main.ml
+++ b/client2/src/Main.ml
@@ -1352,7 +1352,7 @@ let update (m : model) (msg : msg) : model * msg Cmd.t =
   let mods = update_ msg m in
   let newm, newc = updateMod mods (m, Cmd.none) in
   let state = m |> Editor.model2editor |> Editor.toString in
-  Dom.Storage.setItem "editorState" state Dom.Storage.localStorage;
+  Dom.Storage.setItem ("editorState-" ++ m.canvasName) state Dom.Storage.localStorage;
   ( {newm with lastMsg= msg; lastMod= mods}
   , newc)
 

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -265,10 +265,10 @@ function addWheelListener(elem){
 }
 
 setTimeout(function(){
-
+  const canvasName = new URL(window.location).pathname.split("/")[2];
   const params = JSON.stringify(
     {
-      editorState: window.localStorage.getItem('editorState'),
+      editorState: window.localStorage.getItem('editorState-' + canvasName),
       complete: complete,
       userContentHost: userContentHost,
       environment: environmentName,


### PR DESCRIPTION
Prior to this, editor state was stored in local storage with the key "editorState".

In the before times, this worked just fine because each canvas lived under a separate subdomain. With all canvases living under the same subdomain (darklang) this doesn't work. "editorState" holds information about the last canvas that was open. If a developer switches canvases, this state is meaningless; the application may behave strangely.

Now, key the editor state in local storage using the canvas name.

This solution is possibly too janky.  :)