### PR TITLE
Fix compiler warning

### DIFF
--- a/server/libexecution/libstd.ml
+++ b/server/libexecution/libstd.ml
@@ -903,7 +903,7 @@ let fns : Lib.shortfn list = [
              | e ->
                Exception.user
                  ~actual:s
-                 ~expected:"\d+"
+                 ~expected:"\\d+"
                  "Expected a string with only numbers")
           | args -> fail args)
   ; pr = None


### PR DESCRIPTION
Fixes the following error:

```
File "libexecution/libstd.ml", line 906, characters 28-30:
Warning 14: illegal backslash escape in string.
```