### PR TITLE
Debugger is no wider than 50% of the container.

### DIFF
--- a/server/static/base.less
+++ b/server/static/base.less
@@ -1638,4 +1638,25 @@ body #grid * {
   max-height: 500px;
   max-width: 500px;
   overflow: scroll;
+
+  nav {
+     max-width: 50%;
+
+    .history {
+      span {
+        &.details {
+          width: 25px;
+        }
+
+        &.message {
+          width: calc(~"100% - 75px");
+        }
+
+        &.index {
+          width: 30px;
+          clear: both;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Plus, actually fix the history container css to behave the way the author intended.

<img width="610" alt="screen shot 2018-11-28 at 2 43 03 pm" src="https://user-images.githubusercontent.com/525343/49187310-f8e19500-f31b-11e8-8d22-a3de010c567a.png">
