### PR TITLE
Having :latest in k8s yaml is risky, let's template instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ translate/.merlin
 translate/_build
 /server/static/bsmain.js
 client2/yarn-error.log
+
+# Templates for these are in scripts/support/*.yaml.template
+builtwithdark.yaml
+queueworker.yaml
+cronchecker.yaml
+tunnel.yaml

--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -98,27 +98,18 @@ gcloud container clusters get-credentials "--zone=${DARK_REGION}" \
 (kubectl create configmap nginx --from-file=scripts/support/nginx.conf -o yaml --dry-run | kubectl replace -f -) \
   ||  kubectl create configmap nginx --from-file=scripts/support/nginx.conf
 
+CHANGE_CAUSE="'circle=${CIRCLE_BUILD_URL} ; orig-time: $(date)'"
+
+sed -e "s/{IMAGE}/${IMAGE}" -e "s/{CHANGE_CAUSE}/${CHANGE_CAUSE}" scripts/support/builtwithdark.yaml.template > builtwithdark.yaml
+sed -e "s/{QW_IMAGE}/${QW_IMAGE}" -e "s/{CHANGE_CAUSE}/${CHANGE_CAUSE}" scripts/support/queueworker.yaml.template > queueworker.yaml
+sed -e "s/{CRON_IMAGE}/${CRON_IMAGE}" -e "s/{CHANGE_CAUSE}/${CHANGE_CAUSE}" scripts/support/cronchecker.yaml.template > cronchecker.yaml
+sed -e "s/{TUNNEL_IMAGE}/${TUNNEL_IMAGE}" -e "s/{CHANGE_CAUSE}/${CHANGE_CAUSE}" scripts/support/tunnel.yaml.template > tunnel.yaml
 
 # make sure deployment matches current understanding
-kubectl apply -f scripts/support/builtwithdark.yaml
-kubectl apply -f scripts/support/queueworker.yaml
-kubectl apply -f scripts/support/cronchecker.yaml
-kubectl apply -f scripts/support/tunnel.yaml
-
-# deploy the image and set the change-cause field
-kubectl set image deployment/bwd-deployment "bwd-ctr=${IMAGE}"
-kubectl annotate deployment/bwd-deployment \
-    kubernetes.io/change-cause="'circle=${CIRCLE_BUILD_URL} ; orig-time: $(date)'"
-
-kubectl set image deployment/qw-deployment "qw-ctr=${QW_IMAGE}"
-kubectl annotate deployment/qw-deployment \
-    kubernetes.io/change-cause="'circle=${CIRCLE_BUILD_URL} ; orig-time: $(date)'"
-
-kubectl set image deployment/cron-deployment "cron-ctr=${CRON_IMAGE}"
-kubectl set image deployment/tunnel-deployment "tunnel-ctr=${TUNNEL_IMAGE}"
-
-kubectl annotate deployment/cron-deployment \
-    kubernetes.io/change-cause="'circle=${CIRCLE_BUILD_URL} ; orig-time: $(date)'"
+kubectl apply -f builtwithdark.yaml
+kubectl apply -f queueworker.yaml
+kubectl apply -f cronchecker.yaml
+kubectl apply -f tunnel.yaml
 
 #########################
 # Tell everyone else what's going on

--- a/scripts/support/builtwithdark.yaml.template
+++ b/scripts/support/builtwithdark.yaml.template
@@ -2,23 +2,26 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: cron-deployment
+  name: bwd-deployment
+  annotations:
+    kubernetes.io/change-cause: {CHANGE_CAUSE}
 spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: cron-checker
-  # there should only be one of these right now, as there's no locking on checking
-  # if we should enqueue or not
-  replicas: 1
+      app: bwd-app
+  replicas: 12
   template:
     metadata:
       labels:
-        app: cron-checker
+        app: bwd-app
     spec:
       containers:
-        - name: cron-ctr
-          image: "gcr.io/balmy-ground-195100/dark-gcp-cron:latest"
+        - name: bwd-ctr
+          image: "gcr.io/balmy-ground-195100/dark-gcp:{IMAGE}"
+          ports:
+            - name: bwd-ctr-port
+              containerPort: 80
           lifecycle:
             preStop:
               httpGet:
@@ -27,14 +30,14 @@ spec:
                 port: 80
           readinessProbe:
             httpGet:
-              path: /
-              port: 8081
+              path: /ready
+              port: 80
             initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
-              port: 8081
+              port: 80
             # Giving 2 minutes grace here, there's an outstanding k8s issue
             # preventing you from specifying "start checking liveness after an
             # ok from readiness", which is what you'd expect.
@@ -43,9 +46,6 @@ spec:
             periodSeconds: 10 # every 10 seconds
             timeoutSeconds: 10 # time out after 10 seconds
             failureThreshold: 3 # kill container after 3 successive time outs
-          ports:
-            - name: cron-ctr-port
-              containerPort: 8081
           envFrom:
             - configMapRef:
                 name: gke-dark-prod
@@ -76,6 +76,7 @@ spec:
 
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          # https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/128
           command: ["/bin/sh",
                     "-c",
                     "/cloud_sql_proxy -dir=/cloudsql -instances=balmy-ground-195100:us-west1:dark-west=tcp:5432 -credential_file=/secrets/cloudsql/credentials.json"]
@@ -84,23 +85,48 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
 
+        - name: http-proxy
+          image: nginx:1.15.3
+          ports:
+            - name: http-proxy-port
+              containerPort: 8000
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: nginx-conf
       volumes:
         - name: cloudsql-instance-credentials
           secret:
             secretName: cloudsql-instance-credentials
+        - name: nginx-conf
+          configMap:
+            name: nginx
 
 #########################
 # End postgres proxy config
 #########################
 ---
+kind: Service
+apiVersion: v1
+metadata:
+  name: bwd-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: bwd-app
+  ports:
+    - name: bwd-nodeport-port
+      protocol: TCP
+      port: 80
+      targetPort: http-proxy-port
+---
 apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
-  name: cc-network-policy
+  name: bwd-network-policy
 spec:
   podSelector:
     matchLabels:
-      app: cron-checker
+      app: bwd-app
   policyTypes:
   - Egress
   - Ingress
@@ -113,3 +139,44 @@ spec:
         # since there's sensitive data in http://metadata
         - 169.254.0.0/16
   ingress:
+    - ports:
+      - protocol: TCP
+        port: 8000
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bwd-tls-ingress
+spec:
+  backend:
+    serviceName: bwd-nodeport
+    servicePort: 80
+  tls:
+    - secretName: bwd-tls
+---
+# There need to be separate services and ingresses for darklang.com
+# so that we can serve with the correct TLS key
+kind: Service
+apiVersion: v1
+metadata:
+  name: darklang-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: bwd-app
+  ports:
+    - name: darklang-nodeport-port
+      protocol: TCP
+      port: 80
+      targetPort: http-proxy-port
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: darklang-tls-ingress
+spec:
+  backend:
+    serviceName: darklang-nodeport
+    servicePort: 80
+  tls:
+    - secretName: darklang-tls

--- a/scripts/support/cronchecker.yaml.template
+++ b/scripts/support/cronchecker.yaml.template
@@ -2,24 +2,25 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: bwd-deployment
+  name: cron-deployment
+  annotations:
+    kubernetes.io/change-cause: {CHANGE_CAUSE}
 spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: bwd-app
-  replicas: 12
+      app: cron-checker
+  # there should only be one of these right now, as there's no locking on checking
+  # if we should enqueue or not
+  replicas: 1
   template:
     metadata:
       labels:
-        app: bwd-app
+        app: cron-checker
     spec:
       containers:
-        - name: bwd-ctr
-          image: "gcr.io/balmy-ground-195100/dark-gcp:latest"
-          ports:
-            - name: bwd-ctr-port
-              containerPort: 80
+        - name: cron-ctr
+          image: "gcr.io/balmy-ground-195100/dark-gcp-cron:{CRON_IMAGE}"
           lifecycle:
             preStop:
               httpGet:
@@ -28,14 +29,14 @@ spec:
                 port: 80
           readinessProbe:
             httpGet:
-              path: /ready
-              port: 80
+              path: /
+              port: 8081
             initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8081
             # Giving 2 minutes grace here, there's an outstanding k8s issue
             # preventing you from specifying "start checking liveness after an
             # ok from readiness", which is what you'd expect.
@@ -44,6 +45,9 @@ spec:
             periodSeconds: 10 # every 10 seconds
             timeoutSeconds: 10 # time out after 10 seconds
             failureThreshold: 3 # kill container after 3 successive time outs
+          ports:
+            - name: cron-ctr-port
+              containerPort: 8081
           envFrom:
             - configMapRef:
                 name: gke-dark-prod
@@ -74,7 +78,6 @@ spec:
 
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.11
-          # https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/128
           command: ["/bin/sh",
                     "-c",
                     "/cloud_sql_proxy -dir=/cloudsql -instances=balmy-ground-195100:us-west1:dark-west=tcp:5432 -credential_file=/secrets/cloudsql/credentials.json"]
@@ -83,48 +86,23 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
 
-        - name: http-proxy
-          image: nginx:1.15.3
-          ports:
-            - name: http-proxy-port
-              containerPort: 8000
-          volumeMounts:
-            - mountPath: /etc/nginx/conf.d
-              name: nginx-conf
       volumes:
         - name: cloudsql-instance-credentials
           secret:
             secretName: cloudsql-instance-credentials
-        - name: nginx-conf
-          configMap:
-            name: nginx
 
 #########################
 # End postgres proxy config
 #########################
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: bwd-nodeport
-spec:
-  type: NodePort
-  selector:
-    app: bwd-app
-  ports:
-    - name: bwd-nodeport-port
-      protocol: TCP
-      port: 80
-      targetPort: http-proxy-port
----
 apiVersion: extensions/v1beta1
 kind: NetworkPolicy
 metadata:
-  name: bwd-network-policy
+  name: cc-network-policy
 spec:
   podSelector:
     matchLabels:
-      app: bwd-app
+      app: cron-checker
   policyTypes:
   - Egress
   - Ingress
@@ -137,44 +115,3 @@ spec:
         # since there's sensitive data in http://metadata
         - 169.254.0.0/16
   ingress:
-    - ports:
-      - protocol: TCP
-        port: 8000
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: bwd-tls-ingress
-spec:
-  backend:
-    serviceName: bwd-nodeport
-    servicePort: 80
-  tls:
-    - secretName: bwd-tls
----
-# There need to be separate services and ingresses for darklang.com
-# so that we can serve with the correct TLS key
-kind: Service
-apiVersion: v1
-metadata:
-  name: darklang-nodeport
-spec:
-  type: NodePort
-  selector:
-    app: bwd-app
-  ports:
-    - name: darklang-nodeport-port
-      protocol: TCP
-      port: 80
-      targetPort: http-proxy-port
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: darklang-tls-ingress
-spec:
-  backend:
-    serviceName: darklang-nodeport
-    servicePort: 80
-  tls:
-    - secretName: darklang-tls

--- a/scripts/support/queueworker.yaml.template
+++ b/scripts/support/queueworker.yaml.template
@@ -3,6 +3,8 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: qw-deployment
+  annotations:
+    kubernetes.io/change-cause: {CHANGE_CAUSE}
 spec:
   revisionHistoryLimit: 10
   selector:
@@ -16,7 +18,7 @@ spec:
     spec:
       containers:
         - name: qw-ctr
-          image: "gcr.io/balmy-ground-195100/dark-gcp-qw:latest"
+          image: "gcr.io/balmy-ground-195100/dark-gcp-qw:{QW_IMAGE}"
           lifecycle:
             preStop:
               httpGet:

--- a/scripts/support/tunnel.yaml.template
+++ b/scripts/support/tunnel.yaml.template
@@ -2,6 +2,8 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: tunnel-deployment
+  annotations:
+    kubernetes.io/change-cause: {CHANGE_CAUSE}
 spec:
   selector:
     matchLabels:
@@ -14,7 +16,7 @@ spec:
     spec:
       containers:
       - name: tunnel-ctr
-        image: gcr.io/balmy-ground-195100/tunnel:latest
+        image: gcr.io/balmy-ground-195100/tunnel:{TUNNEL_IMAGE}
         ports:
           - name: tunnel-port
             containerPort: 1080


### PR DESCRIPTION
Also, this should let us (will need to confirm post-merge) do
change-cause annotations on deployments more reliably than we're doing
now.