### PR TITLE
Move building the production containers until just before we use them.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,6 @@ commands:
 
 
 # TODO:
-# split the integration tests by test time
 # optimize workflow
 
 jobs:
@@ -163,7 +162,6 @@ jobs:
       - run: scripts/builder --compile --test
       - run-background-container
       - wait-for-container
-      - run: scripts/run-in-docker scripts/gcp-build-containers
       - copy-out-of-container
       - save-caches
       - persist_to_workspace:
@@ -212,6 +210,7 @@ jobs:
       - copy-into-container
       - run-background-container
       - wait-for-container
+      - run: scripts/run-in-docker scripts/gcp-build-containers
       - run: scripts/deploy-from-circle
 
 


### PR DESCRIPTION
We can't guarantee the containers are present cause that's not how CircleCI
works.

If you want something to persist between steps, put it in a workspace.