### PR TITLE
Deploy linearization:

### DIFF
--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -7,7 +7,7 @@ DARK_REGION="us-west1"
 DARK_PROJECT="balmy-ground-195100"
 DARK_CLUSTER="$(< current-cluster)"
 
-STATIC_ASSETS_BUCKET="gs://darklang-static-assets"
+DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
 
 PREFIX=""
 PREFIX_ARG=""
@@ -91,16 +91,16 @@ while [[ "$deploy_lock_claimed" != "true" ]]; do
   echo "Lock file: ${THIS_DEPLOY_LOCKFILE}"
 
   # If there's a manual lock, loop
-  if ! (gsutil ls ${STATIC_ASSETS_BUCKET}/deploy-lock-manual-deploy); then
+  if ! (gsutil ls ${DEPLOY_LOCK_BUCKET}/deploy-lock-manual-deploy); then
     true # loop
   else
-    max_deploy_lock=$(gsutil ls ${STATIC_ASSETS_BUCKET}/deploy-lock-* | sed
+    max_deploy_lock=$(gsutil ls ${DEPLOY_LOCK_BUCKET}/deploy-lock-* | sed
     's/.-//' | sort -nr | head -n 1)
 
     # if there are no deploy locks, create ours and continue
     if [[ "$max_deploy_lock" == "" ]]; then
       echo date > "deploy-lock-${THIS_DEPLOY_LOCKFILE}"
-      gsutil cp "deploy-lock-${THIS_DEPLOY_LOCKFILE} ${STATIC_ASSETS_BUCKET}"
+      gsutil cp "deploy-lock-${THIS_DEPLOY_LOCKFILE} ${DEPLOY_LOCK_BUCKET}"
       deploy_lock_claimed="true"
     # if the biggest # is greater than ours, then exit instead of deploying
     # NB: "manual-deploy" is greater than any numeric string, so it will always
@@ -169,4 +169,4 @@ echo "Rollbar notified."
 ####################
 # Unlock post-deploy
 ####################
-gsutil rm "${STATIC_ASSETS_BUCKET}/deploy-lock-${THIS_DEPLOY_LOCKFILE}"
+gsutil rm "${DEPLOY_LOCK_BUCKET}/deploy-lock-${THIS_DEPLOY_LOCKFILE}"


### PR DESCRIPTION
- if there is a deploy running, and it is from a build subsequent to
ours, fail fast
- if it is 'prior' to ours, loop until it is done and then do our deploy
- if no deploy, grab a lockfile and deploy

Note: a failed build may result in a lockfile being left behind that
needs to be cleaned up.