### PR TITLE
Suppress "unknown file: Cargo.lock" warning

### DIFF
--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -253,6 +253,7 @@ def mark(should, f):
   # Rust
   elif ("stroller/" in f) \
           and (("Cargo.toml" in f) \
+                  or ("Cargo.lock" in f) \
                   or (".rs" in f)):
     should.stroller_build = True
 


### PR DESCRIPTION
Add `stroller/Cargo.lock` to the known filenames that will trigger a `stroller` build. This is mainly to suppress the "unknown file" warning, but also fixes a case that could in principle happen - if you modify `Cargo.lock` without modifying anything else (e.g. via `cargo update`), that should trigger a rebuild too.