### PR TITLE
Fix gsutil condition.

### DIFF
--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -91,7 +91,7 @@ while [[ "$deploy_lock_claimed" != "true" ]]; do
   echo "Lock file: ${THIS_DEPLOY_LOCKFILE}"
 
   # If there's a manual lock, loop
-  if ! (gsutil ls ${DEPLOY_LOCK_BUCKET}/deploy-lock-manual-deploy); then
+  if (gsutil ls ${DEPLOY_LOCK_BUCKET}/deploy-lock-manual-deploy); then
     true # loop
   else
     max_deploy_lock=$(gsutil ls ${DEPLOY_LOCK_BUCKET}/deploy-lock-* | sed


### PR DESCRIPTION
Bash ifs return true when the command succeeds. gsutil ls fails if there are no
objects matched. So this command will fail if deploy-lock-is-missing. So it
doesn't need to be inverted.