### PR TITLE
Shore up the visual design of the error rail

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1365,10 +1365,6 @@ let update_ (msg : msg) (m : model) : modification =
   | ShowErrorDetails show ->
       let e = m.error in
       TweakModel (fun m -> {m with error= {e with showDetails= show}})
-  | ToggleExprOnRail (tlid, id) ->
-      let tl = TL.getTL m tlid in
-      let pd = TL.findExn tl id in
-      Refactor.toggleOnRail m tl pd
   | _ -> NoChange
 
 let update (m : model) (msg : msg) : model * msg Cmd.t =

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -533,7 +533,6 @@ and msg =
   | StartMigration of tlid
   | AbandonMigration of tlid
   | DeleteColInDB of tlid * id
-  | ToggleExprOnRail of tlid * id
 
 and predecessor = pointerData option
 

--- a/client/src/ViewCode.ml
+++ b/client/src/ViewCode.ml
@@ -242,13 +242,7 @@ and viewNExpr (d : int) (id : id) (vs : viewState) (config : htmlConfig list)
         then []
         else 
           [ Html.div
-            [ Html.class' "error-indicator parameter-btn"
-            ; Html.title "May result in Nothing.\nDouble-click to :toggle-expression-on-rail\nand handle the result in a match statement."
-            ; ViewUtils.eventNoPropagation
-              ~key:("efb-" ^ (showID id) ^ "togglerop")
-              "dblclick"
-              (fun _ -> ToggleExprOnRail (vs.tl.id, id))
-            ]
+            [ Html.class' "error-indicator" ]
             [ Html.div [Html.class' "error-icon"] [] ]
           ]
       in

--- a/client/src/app.less
+++ b/client/src/app.less
@@ -775,23 +775,6 @@ body #grid * {
   .ast .error-indicator {
     position: absolute;
     left: calc(~"100% - 18px");
-
-    &:hover:after {
-        content: attr(title);
-        display: block;
-        position: relative;
-        left: 16px;
-        top: -20px;
-        max-width: 60ch;
-        padding: 2px 4px;
-        overflow: auto;
-        z-index: 100;
-        background-color: @black1;
-        color: lighten(@yellow, 10%);
-        word-wrap: break-word;
-        text-align: left;
-    }
-
   }
 
   .fncall {
@@ -802,18 +785,10 @@ body #grid * {
       border-radius: 50%;
       border: 1px solid lighten(@grey1, 20%);
       background-color: transparent;
-
-      &:hover {
-        border-color: @yellow;
-      }
     }
 
     &[data-live-value="<ErrorRail: Nothing>"] .error-icon {
       background-color: lighten(@grey1, 20%);
-
-      &:hover {
-        background-color: @yellow;
-      }
     }
   }
 }


### PR DESCRIPTION
[Trello tix](https://trello.com/c/Uwd1n7Pw)

Should look like this:
<img width="500" alt="screen shot 2018-12-03 at 4 06 08 pm" src="https://user-images.githubusercontent.com/244152/49409519-e3061280-f715-11e8-913b-be7df872f32a.png">

Originally started with dots:
<img width="513" alt="screen shot 2018-12-03 at 3 24 55 pm" src="https://user-images.githubusercontent.com/244152/49409548-f4e7b580-f715-11e8-9739-430207552ae5.png">
<img width="546" alt="screen shot 2018-12-03 at 3 00 03 pm" src="https://user-images.githubusercontent.com/244152/49409552-f87b3c80-f715-11e8-8021-907989352cda.png">

The initial was too small to see, when I checked with ismith. The second one was more visible, but I felt was too attention grabbing and confusing.

A good implementation of drawing the error rail as a rail (say a diff background, expandable and collapsable) would require code restructuring, and we should probably hold off on that until we dip our feet into the project again.