### PR TITLE
Remove the grey prefix from the start of routes in the routing table

### DIFF
--- a/client/src/app.less
+++ b/client/src/app.less
@@ -449,9 +449,6 @@ body #grid * {
 
       .name {
         color: @white3;
-        .prefix {
-          color: @grey2;
-        }
       }
 
       .external {


### PR DESCRIPTION
https://trello.com/c/j4wm6Cnu/215-remove-the-sharedprefix-greying-of-the-routing-table

Remove the gray prefix - it looks like this now:

![image](https://user-images.githubusercontent.com/181762/49413313-5020a480-f724-11e8-84c5-5571443d292e.png)
