### PR TITLE
When we run the container in the background, we can timeout. Fix it.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,9 @@ commands:
   run-background-container:
     steps:
       - run:
+          name: Build container if necessary
+          command: scripts/builder
+      - run:
           name: Run background container
           command: scripts/builder --ci-serve
           background: true


### PR DESCRIPTION
For example, in https://circleci.com/gh/darklang/dark/3328#tests/containers/3,
there was no prebuilt container available, so it built the container on
demand. Because this was done in the background, the "wait-for-container" script
timedout after 5m, failing the build.

The correct thing to do is run the build in full and then run it in the background.