### PR TITLE
Change sam password

### DIFF
--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -577,7 +577,7 @@ let init () : unit =
   upsert_account
     { username = "samstokes"
     ; password =
-        "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkZkVCS3d5N1pmS25NUEQxbjZ6OHNxUSRXU1NHR1lTTFhvQloxTjBXb3ZwajBYV004Z2lzcnhTVncxVE96VVUvNkRVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkcVViUzB0USt0ZEE5WDBIUm1MME5BQSQydktjVHV2TG9FMFhNOHg3MHJZelNwQUpLT09YeFpKOVFYb2Y3NU9vMmQ0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     ; email = "me@samstokes.co.uk"
     ; name = "Sam Stokes" } ;
   upsert_admin


### PR DESCRIPTION
I forgot to write down the autogenerated password from `add_user.exe` :man_facepalming: I reran the script with the same username and email and it gave me a new password which I actually saved.

I'm hoping that (given the `upsert_` call) this is sufficient to update my encrypted password to the new one, but let me know if there's anything extra that needs doing.