### PR TITLE
Tiny fix

### DIFF
--- a/backend/libbackend/stored_event.ml
+++ b/backend/libbackend/stored_event.ml
@@ -71,11 +71,7 @@ let load_events ~(canvas_id : Uuidm.t) ((module_, path, modifier) : event_desc)
     ~params:[Uuid canvas_id; String module_; String path; String modifier]
   |> List.map ~f:(function
          | [dval; _ts; trace_id] ->
-             let trace_id =
-               if trace_id = ""
-               then Util.create_uuid ()
-               else Util.uuid_of_string trace_id
-             in
+             let trace_id = Util.uuid_of_string trace_id in
              (trace_id, Dval.unsafe_dval_of_json_string dval)
          | _ ->
              Exception.internal "Bad DB format for stored_events" )


### PR DESCRIPTION
The schema has a `not null` uuid, so it's not possible to get an empty string anymore.