### PR TITLE
String::toUppercase + String::toLowercase have the wrong type signature

### DIFF
--- a/backend/libexecution/libstd.ml
+++ b/backend/libexecution/libstd.ml
@@ -795,7 +795,7 @@ let fns : Lib.shortfn list =
   ; { pns = ["String::toUppercase"]
     ; ins = []
     ; p = [par "s" TStr]
-    ; r = TList
+    ; r = TStr
     ; d = "Returns the string, uppercased"
     ; f =
         InProcess
@@ -807,7 +807,7 @@ let fns : Lib.shortfn list =
   ; { pns = ["String::toLowercase"]
     ; ins = []
     ; p = [par "s" TStr]
-    ; r = TList
+    ; r = TStr
     ; d = "Returns the string, lowercased"
     ; f =
         InProcess


### PR DESCRIPTION
Ellen noticed that these weren't appearing in autocompletes she'd expect. The root cause was the type filtering for blanks of function parameters was cutting these out, because their signatures are incorrect!