### PR TITLE
Double-click should Select, not Enter

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -894,7 +894,7 @@ let update_ (msg : msg) (m : model) : modification =
           then NoChange
           else fluidEnterOrSelect m targetTLID targetID )
   | BlankOrDoubleClick (targetTLID, targetID, _) ->
-      Selection.enter m targetTLID targetID
+      Selection.dblclick m targetTLID targetID
   | ToplevelClick (targetTLID, _) ->
     ( match m.cursorState with
     | Dragging (_, _, _, origCursorState) ->

--- a/client/src/Selection.ml
+++ b/client/src/Selection.ml
@@ -232,6 +232,12 @@ let enter (m : model) (tlid : tlid) (id : id) : modification =
   enterWithOffset m tlid id 0
 
 
+let dblclick (m : model) (tlid : tlid) (id : id) : modification =
+  if VariantTesting.variantIsActive m FluidInputModel
+  then Select (tlid, Some id)
+  else enter m tlid id
+
+
 let moveAndEnter
     (m : model)
     (tlid : tlid)


### PR DESCRIPTION
Text-controls double click the word under cursor to 'select', we should too!