### PR TITLE
Add clippy and rustfmt to Rust build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -306,7 +306,7 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
     rustc --version;
 
 # install Rust dev tools
-RUN rustup component add clippy-preview
+RUN rustup component add clippy-preview rustfmt-preview
 
 ############################
 # Remove things that were moved to devDependencies

--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -149,16 +149,19 @@ def backend_test():
           + " 2>&1")
 
 def stroller_build():
-  start = time.time()
   global profile
 
   if os.environ.get("CI"):
-      build_flags = " --release"
-      pass
-  else:
-      build_flags = ""
-      pass
+    start = time.time()
+    result = run_backend(start, "cd stroller && cargo fmt -- --check")
+    if not result:
+      return result
 
+    build_flags = " --release"
+  else:
+    build_flags = ""
+
+  start = time.time()
   build = "cd stroller && unbuffer cargo build" + build_flags
   if profile:
     return run_backend(start, landmarks + build)


### PR DESCRIPTION
As discussed in #420 this adds clippy (style checks) and rustfmt (code formatting check) to the Rust build.

Details:

 * following #477 this checks formatting only in CI, not in dev builds. `cargo fmt` is actually very quick (sub-second on my machine) so it'd be entirely feasible to run it in dev too, but the dev use case is better served by editor integration, and anyway for quick feedback I'd rather see if my code compiles and passes tests before fixing possible formatting errors.
 * this does run clippy checks in dev (after tests), but doesn't fail the build for warnings. In CI, warnings **do** fail the build.
 * for some reason clippy's default behaviour is to style-check every single crate that your code depends on before actually checking the code you wrote. I can't work out how to turn that off. On the plus side I think build caching should mean it only does that occasionally.

N.B. this PR is based on #478 (for the sake of having some non-trivial code to check) - once that merges I'll rebase this branch and change the base of this PR to master.