### PR TITLE
Disable single-click selecting a child node

### DIFF
--- a/client/src/Selection.ml
+++ b/client/src/Selection.ml
@@ -219,7 +219,9 @@ let enterWithOffset (m : model) (tlid : tlid) (id : id) (offset : int) :
         if VariantTesting.variantIsActive m FluidInputModel
         then
           (* AST-wise cursor movements don't make sense in a Fluid world! *)
-          NoChange
+          if tlidOf m.cursorState = Some tlid
+          then NoChange
+          else Select (tlid, None)
         else selectDownLevel m tlid (Some id)
       else
         let enterMod =


### PR DESCRIPTION
In the non-fluid world, if you attempt to `Enter` a node that didn't support an `Entering` cursorState, we'd `Select` its AST-wise child. That's a terrible idea in the fluid world :)