### PR TITLE
Add empty HTTP grouping

### DIFF
--- a/client/src/ViewRoutingTable.ml
+++ b/client/src/ViewRoutingTable.ml
@@ -267,8 +267,14 @@ let viewRoutes
     (showLink : showLink)
     (showUndo : showUndo) : msg Html.html list =
   let tls = m.toplevels in
+  let withHTTP entries =
+    if List.any (fun (space, _) -> space = "HTTP") entries
+    then entries
+    else ("HTTP", []) :: entries
+  in
   tls
   |> splitBySpace
+  |> withHTTP
   |> List.sortWith (fun (a, _) (b, _) -> ordering a b)
   |> List.map (Tuple.mapSecond tl2entry)
   |> (fun entries ->


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1179074/49765057-1dc3f980-fc86-11e8-95d8-ea42beb51e36.png)

We now always show HTTP in the routing table, hopefully making it a little more obvious that you can add a handler.