### PR TITLE
Improve error messages for 404/500

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -203,14 +203,19 @@ let user_page_handler
            ~canvas_id
            ("HTTP", Uri.path uri, verb) ;
       let resp_headers = Cohttp.Header.of_list [cors] in
-      respond ~resp_headers ~execution_id `Not_found "404: No page matches"
+      respond
+        ~resp_headers
+        ~execution_id
+        `Not_found
+        "404 Not Found: No route matches"
   | a :: b :: _ ->
       let resp_headers = Cohttp.Header.of_list [cors] in
       respond
         `Internal_server_error
         ~resp_headers
         ~execution_id
-        "500: More than one page matches"
+        ( "500 Internal Server Error: More than one handler for route: "
+        ^ Uri.path uri )
   | [page] ->
       let input = PReq.from_request headers query body in
       ( match (Handler.module_for page, Handler.modifier_for page) with


### PR DESCRIPTION
https://trello.com/c/9hGh8W8V/256-500-more-than-one-page-matches-should-be-500-route-matches-more-than-one-handler 

Jim found these confusing due to the reference to 'page' -- which is a legacy concept from Graph-y Dark (!!!), this changes the message to reference 'routes' and 'handlers' which are more general concepts.