### PR TITLE
Fix the rename_function test

### DIFF
--- a/client/src/ViewScaffold.ml
+++ b/client/src/ViewScaffold.ml
@@ -70,7 +70,7 @@ let viewButtons (m : model) : msg Html.html =
     | Fn (_, _) ->
         [ Url.linkFor
             (Toplevels m.canvas.offset)
-            "specialButton default-link"
+            "specialButton default-link return-to-canvas"
             [Html.text "Return to Canvas"] ]
     | _ ->
         []

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -651,9 +651,7 @@ test('feature_flag_in_function', async t => {
     .pressKey("enter")
 
     // Return to main canvas to finish tests
-    .click(".routing-section")
-    .click(".verb-link")
-
+    .click(".return-to-canvas")
 });
 
 test('simple_tab_ordering', async t => {
@@ -744,8 +742,7 @@ test('rename_function', async t => {
     .pressKey('enter')
 
     // Return to main canvas to finish tests
-    .click(".routing-section")
-    .click(".verb-link")
+    .click(".return-to-canvas")
 })
 
 test('rename_pattern_variable', async t => {


### PR DESCRIPTION
Test should click "return to canvas" button instead of navigating through the routing table.

The test clicked on a routing table verb to go back to canvas, but the path to that verb was
damaged by always having the HTTP handler present