### PR TITLE
Reenable feature flag test

### DIFF
--- a/client/src/IntegrationTest.ml
+++ b/client/src/IntegrationTest.ml
@@ -484,7 +484,7 @@ let feature_flag_works (m : model) : testResult =
                       ( _
                       , FnCall
                           ( "Int::greaterThan"
-                          , [F (_, Value "10"); F (_, Variable "a")]
+                          , [F (_, Variable "a"); F (_, Value "10")]
                           , _ ) )
                   , F (_, Value "\"A\"")
                   , F (_, Value "\"B\"") ) ) ) ) ->

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -583,7 +583,7 @@ test('nochange_for_failed_paste', async t => {
     .pressKey("ctrl+v")
 });
 
-test.skip('feature_flag_works', async t => {
+test('feature_flag_works', async t => {
   await t
     // Create an empty let
     .pressKey("enter")


### PR DESCRIPTION
The "feature_flag_works" integration test was disabled a long time ago
because it crashed the browser.

This commit re-enables it and adjusts the order of items in the FnCall
list to make the test pass.