### PR TITLE
Fix erroneous merge conflict resolution

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -894,7 +894,7 @@ let update_ (msg : msg) (m : model) : modification =
           then NoChange
           else fluidEnterOrSelect m targetTLID targetID )
   | BlankOrDoubleClick (targetTLID, targetID, _) ->
-      Selection.enter m targetTLID targetID
+      Selection.dblclick m targetTLID targetID
   | ToplevelClick (targetTLID, _) ->
     ( match m.cursorState with
     | Dragging (_, _, _, origCursorState) ->


### PR DESCRIPTION
This should be Selection.dblclick as it handles the dispatch based on the fluid input variant. Tests kept passing because they run against non-fluid.

cc: @ismith 