### PR TITLE
Less irrititating hover during mouseover

### DIFF
--- a/client/src/ViewBlankOr.ml
+++ b/client/src/ViewBlankOr.ml
@@ -137,8 +137,8 @@ let div
         then ["mouseovered-enterable"]
         else if idOf vs.cursorState = thisID
         then []
-        else ["mouseovered-selectable"]
-      else []
+        else ["mouseovered-selectable-fluid"]
+      else ["mouseovered-selectable"]
     else []
   in
   let idClasses =

--- a/client/src/app.less
+++ b/client/src/app.less
@@ -275,6 +275,11 @@ body #grid * {
     }
   }
 
+  .mouseovered-selectable-fluid:not(.fncall) {
+    outline: 0.5px dotted lighten(@darkblue, 35%);
+    transition-delay: 0.4s;
+  }
+
   .mouseovered-enterable {
     cursor: text;
   }


### PR DESCRIPTION
Make the mouseover less iritiating: it used to be a really annoying blue that when it moved was jarring to the eye. Now it is subtle.

(Note: it does not cause any flicker at all, due to using `outline` instead of `border`.

https://trello.com/c/GGKJ8oim/270-blue-background-on-hover-is-distracting

![image](https://user-images.githubusercontent.com/181762/49964918-91f1dd80-fed0-11e8-8e5c-168248ec3153.png)
