### PR TITLE
Fix string selecting -> entering visual jumpiness

### DIFF
--- a/client/src/ViewEntry.ml
+++ b/client/src/ViewEntry.ml
@@ -32,7 +32,6 @@ let stringEntryHtml (ac : autocomplete) (width : stringEntryWidth) :
     |> List.map visualStringLength
     |> List.foldr max 1
     |> min maxWidthChars
-    |> ( + ) 1
   in
   let rowCount =
     value

--- a/client/src/app.less
+++ b/client/src/app.less
@@ -819,7 +819,6 @@ body #grid * {
 
 .string-style() {
   color: @string-color;
-  font-style: italic;
   max-width: 120ch;
   min-height: 16px;
   white-space: pre-wrap;
@@ -929,7 +928,6 @@ body #grid * {
   .quote {
     .string-style;
     display: none;
-    width: 1.5ch;
     &.quote-start {
       left: 0;
       top: 0;
@@ -1226,8 +1224,8 @@ body #grid * {
   border: 0;
   font-size: @code-font-size;
   margin: 0;
-  padding-left: 1.5ch;
-  padding-right: 1.5ch;
+  padding-left: 1ch;
+  padding-right: 1ch;
   position: relative;
   &::before {
     content: "“";
@@ -1244,8 +1242,7 @@ body #grid * {
     bottom: 0;
     display: inline-block;
     position: absolute;
-    right: 1ch;
-    width: 1.5ch;
+    right: 0ch;
   }
   &.big-string-entry {
     padding-left: 0;


### PR DESCRIPTION
We added a logical extra character width in ViewEntry, multiple half a
character widths in padding, and moved in the right double-quote
1 character. These all seem to be trying to account for each other
in a haphazard way, but we can just remove it all and it works --
even better than before!