### PR TITLE
ignore vim swap files from fswatch

### DIFF
--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -351,6 +351,7 @@ def ignore(filename):
             , ".bsbuild"
             , ".sourcedirs.json"
             , ".md"
+            , ".sw"
   ]
   for i in ignores:
     if i in filename:


### PR DESCRIPTION
On my machine (setup + gvim) fairly innocuous actions in vim (e.g. resizing the vim window) trigger a rebuild (and server restart, browser refresh, etc), due to fswatch picking up a change to the vim swap file. This crudely filters out vim swap files.

(Filtering just for `.sw` because vim keeps swap files for unsaved buffers too, and their names get incremented - `.swp`, `.swo`, `.swn` etc. This could be overly broad, although I'm struggling to think of common file extensions we'd care about.)