### PR TITLE
Stop object keys from jumping around as much

### DIFF
--- a/client/src/ViewCode.ml
+++ b/client/src/ViewCode.ml
@@ -351,7 +351,7 @@ and viewNExpr
       let open_ = a [wc "openbrace"] "{" in
       let close = a [wc "closebrace"] "}" in
       let pexpr (k, v) =
-        n [wc "objectpair"] [viewKey vs [] k; colon; vExpr 0 v]
+        n [wc "objectpair"] [viewKey vs [wc "objectkey"] k; colon; vExpr 0 v]
       in
       n (wc "object" :: mo :: config) ([open_] @ List.map pexpr pairs @ [close])
   | Match (matchExpr, cases) ->

--- a/client/src/app.less
+++ b/client/src/app.less
@@ -967,6 +967,15 @@ body #grid * {
     .indent;
   }
 
+  .objectkey {
+    .entry {
+      // this is awful -- but we need to remove the margin being added to .entry
+      // we should re-organize who adds/removes margins
+      margin-left: 0px;
+      margin-right: 0px;
+    }
+  }
+
   .matchcase {
     .layout-block;
     .indent;


### PR DESCRIPTION
I haven't solved the root cause: which is that it is very hard to understand who adds the margin that we expect from atoms + entries.