### PR TITLE
Keys to move between selecting and entering.

### DIFF
--- a/client/src/KeyPressExperiments.ml
+++ b/client/src/KeyPressExperiments.ml
@@ -65,20 +65,32 @@ let arrowMoveHandler (event : Keyboard.keyEvent) (m : model) :
       None
   | true ->
     ( match m.cursorState with
-    | Entering (Filling (tlid, mId)) ->
+    | Entering (Filling (tlid, id)) ->
       ( match event.keyCode with
       | Key.Up ->
           if m.complete.visible
           then Some (AutocompleteMod ACSelectUp)
-          else Some (arrowMoveUp m tlid (Some mId))
+          else Some (arrowMoveUp m tlid (Some id))
       | Key.Down ->
           if m.complete.visible
           then Some (AutocompleteMod ACSelectDown)
-          else Some (arrowMoveDown m tlid (Some mId))
+          else Some (arrowMoveDown m tlid (Some id))
       | Key.Right ->
-          Some (arrowMoveRight m tlid (Some mId))
+          if event.metaKey && event.shiftKey
+          then Some (Select (tlid, Some id))
+          else Some (arrowMoveRight m tlid (Some id))
       | Key.Left ->
-          Some (arrowMoveLeft m tlid (Some mId))
+          if event.metaKey && event.shiftKey
+          then Some (Select (tlid, Some id))
+          else Some (arrowMoveLeft m tlid (Some id))
+      | Key.Escape ->
+          Some NoChange
+      | _ ->
+          None )
+    | Selecting (tlid, Some id) ->
+      ( match event.keyCode with
+      | Key.Escape ->
+          Some (Enter (Filling (tlid, id)))
       | _ ->
           None )
     | _ ->


### PR DESCRIPTION
Keys are based on OSX keyboard movements in editors:
- Cmd-shift-left and Cmd-shift-right select the full blank
- Escape from selecting drops down to a cursor again
- Escape with a cursor does nothing

All changes only in fluidInputMode.