### PR TITLE
Move varnames to the front of the autocomplete list

### DIFF
--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -467,7 +467,7 @@ let generate (m : model) (a : autocomplete) : autocomplete =
       let keywords =
         List.map (fun x -> ACKeyword x) [KLet; KIf; KLambda; KMatch]
       in
-      constructors @ keywords @ varnames @ functions
+      varnames @ constructors @ keywords @ functions
     else []
   in
   let regular = List.map (fun x -> ACExtra x) extras @ exprs @ fields in


### PR DESCRIPTION
https://trello.com/c/wIvs6HS4/359-move-variables-to-the-top-of-autocomplete-sort

![image](https://user-images.githubusercontent.com/181762/51135381-ba7e3780-17ee-11e9-86fe-4f5142c465af.png)
