### PR TITLE
Sanitize slashes in paths

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -183,7 +183,7 @@ let user_page_handler
   let query = req |> CRequest.uri |> Uri.query in
   (* sanitize both repeated '/' and final '/'.
      "/foo//bar/" -> "/foo/bar"*)
-  let sanitize_uri_path path :string =
+  let sanitize_uri_path path : string =
     path
     |> (fun str -> Re2.replace_exn (Re2.create_exn "/+") str ~f:(fun _ -> "/"))
     |> Util.maybe_chop_suffix "/"

--- a/backend/libexecution/util.ml
+++ b/backend/libexecution/util.ml
@@ -74,6 +74,7 @@ let int_sum (l : int list) : int = List.fold_left ~f:( + ) ~init:0 l
 let maybe_chop_prefix ~prefix msg =
   String.chop_prefix ~prefix msg |> Option.value ~default:msg
 
+
 let maybe_chop_suffix ~suffix msg =
   String.chop_suffix ~suffix msg |> Option.value ~default:msg
 


### PR DESCRIPTION
- Remove any repeated slashes ("//foo//bar" -> "/foo/bar")
- Remove any final slash ("/foo/" -> "/foo")

Does not prevent users from creating a handler for "/foo/", "/foo//bar",
etc.

https://trello.com/c/uE4pT28Y/351-hello-and-hello-should-be-the-same-route