### PR TITLE
Import tablecloth on the client and use it in a file

### DIFF
--- a/client/bsconfig.json
+++ b/client/bsconfig.json
@@ -22,7 +22,8 @@
   "bs-dependencies": [
     "bucklescript-tea",
     "@glennsl/bs-json",
-    "bs-webapi"
+    "bs-webapi",
+    "tablecloth-bucklescript"
   ],
   "bs-dev-dependencies": [
     "@glennsl/bs-jest"

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "mouse-wheel": "^1.2.0",
     "pusher-js": "^4.3.1",
     "rollbar": "^2.4.2",
-    "sha2": "^1.0.2"
+    "sha2": "^1.0.2",
+    "tablecloth-bucklescript": "0.0.2"
   },
   "scripts": {
     "clean": "bsb -clean-world",

--- a/client/src/Keyboard.ml
+++ b/client/src/Keyboard.ml
@@ -393,8 +393,9 @@ let code (key : key) : int option =
   | Z ->
       Some 90
   | Ambiguous choices ->
-      if Porting.List.all
-           (fun a -> Porting.List.member a [Windows; Command; ChromeSearch])
+      if Tablecloth.List.all
+           ~f:(fun value ->
+             Tablecloth.List.member ~value [Windows; Command; ChromeSearch] )
            choices
       then Some 91
       else None

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5673,6 +5673,11 @@ table-parser@^0.1.3:
   dependencies:
     connected-domain "^1.0.0"
 
+tablecloth-bucklescript@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/tablecloth-bucklescript/-/tablecloth-bucklescript-0.0.2.tgz#f86089cb57eca57b82a17d59ff8fa4586dfe8e69"
+  integrity sha512-iK566kOp59iViWNY5jtRdSGt1Wumu5hoZKT3HkjI2MCLfXrIpOUuR1KQvH0bHUZMdhUNNhK9IGVLZ9C608r/qg==
+
 tar@^4:
   version "4.4.8"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"


### PR DESCRIPTION
https://trello.com/c/9DyCqtB2/1353-start-a-standard-library-shared-between-the-frontend-and-the-backend

This adds [tablecloth](https://github.com/darklang/tablecloth], a library I built over the weekend by pulling out the main modules from porting.ml, and reimplementing them using Base.

This is just to add it to the repo and use it in one place. This unblocks a number of further tech debt improvements:
- remove many modules from porting and break it apart
- use the same functions on the backend and the frontend
- use the same types on the backend and frontend
- use snake_case on the frontend

I plan to move files over piecemeal, and we can all do this. Any time you want to move a file over, change `open! Porting` to `open Tablecloth` and fix up any functions. The main differences are that Tablecloth functions use labels for all-but-one parameter, mostly `~f`, like Core does.

My plan is to merge this and a similar backend one (as soon as it gets published to opam: https://github.com/ocaml/opam-repository/pull/13300), and then do a big update later.