### PR TITLE
Don't submit the omnibox when the user presses <spacebar>

### DIFF
--- a/client/src/KeyPress.ml
+++ b/client/src/KeyPress.ml
@@ -403,9 +403,13 @@ let defaultHandler (event : Keyboard.keyEvent) (m : model) : modification =
         else (
           match event.keyCode with
           | Key.Spacebar ->
-              if m.complete.value = "=" || AC.isStringEntry m.complete
-              then NoChange
-              else Entry.submit m cursor Entry.GotoNext
+            ( match cursor with
+            | Creating _ ->
+                NoChange
+            | _ ->
+                if m.complete.value = "=" || AC.isStringEntry m.complete
+                then NoChange
+                else Entry.submit m cursor Entry.GotoNext )
           | Key.Enter ->
               if AC.isLargeStringEntry m.complete
               then AutocompleteMod (ACSetQuery m.complete.value)


### PR DESCRIPTION
https://trello.com/c/x0lTpmNg/356-do-not-submit-omnibox-for-space-and-tab

We shouldn't submit the omnibox for space and tab. We already didn't submit on tab, so this just removes space.