### PR TITLE
When clicking (+) next to a 404, remove it from the list

### DIFF
--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -548,6 +548,7 @@ and modification =
   | SetUnlockedDBs of tlid list
   | Set404s of fourOhFour list * string
   | Append404s of fourOhFour list * string
+  | Delete404 of fourOhFour
   | Enter of entryCursor
   | EnterWithOffset of entryCursor * int
   | RPCFull of (rpcParams * focus)


### PR DESCRIPTION
https://trello.com/c/8K6oiIbT/375-creating-a-new-handler-from-a-404-should-remove-the-handler-in-the-404-table

This opened a whole can of worms. The initial goal was the remove the 404 from the list. However, if I remove the 404 because there's now a handler, and then I delete the handler, does it go back? When I refresh the page, what should happen? Really, I should be refreshing from the 404s, but there might be a lot of 404s, and we have a currrently optimization where we only refresh 404s after a timestamp - so now we need to delete the optimization? Ugh.

There is a larger, big picture problem: traces and 404s are both mismatched in their implementation from an intuitive understanding of what they do. I wrote this up to understand this: https://docs.google.com/document/d/1As776y6uPvENr4mNUwj8E-BOW5YitR3gFH4ImfXhNSI/edit#

As a result, I've decided to do the simplest possible thing, and just locally remove the specific 404 from the list. This leaves a long tail of not-great behaviour, that is outside the scope of this ticket.

I also Enter a handler when I create it. Seems like an improvement.