### PR TITLE
Remove ability to delete toplevels using backspace

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -872,8 +872,8 @@ let update_ (msg : msg) (m : model) : modification =
             NoChange
       else NoChange
   | ToplevelDelete tlid ->
-    let tl = TL.getTL m tlid in
-    Many [RemoveToplevel tl; RPC ([DeleteTL tl.id], FocusNothing); Deselect]
+      let tl = TL.getTL m tlid in
+      Many [RemoveToplevel tl; RPC ([DeleteTL tl.id], FocusNothing); Deselect]
   | BlankOrClick (targetTLID, targetID, event) ->
       (* TODO: switch to ranges to get actual character offset
      * rather than approximating *)

--- a/client/src/Selection.ml
+++ b/client/src/Selection.ml
@@ -374,13 +374,14 @@ let enterPrevBlank (m : model) (tlid : tlid) (cur : id option) : modification =
   |> Option.map ~f:(fun pd_ -> Enter (Filling (tlid, P.toID pd_)))
   |> Option.withDefault ~default:NoChange
 
+
 (* ------------------------------- *)
 (* misc *)
 (* ------------------------------- *)
 let delete (m : model) (tlid : tlid) (mId : id option) : modification =
   match mId with
   | None ->
-    NoChange
+      NoChange
   | Some id ->
       let newID = gid () in
       let focus = FocusExact (tlid, newID) in

--- a/client/src/Toplevel.ml
+++ b/client/src/Toplevel.ml
@@ -415,7 +415,9 @@ let replace (p : pointerData) (replacement : pointerData) (tl : toplevel) :
       astReplace ()
   | PFnCallName _ ->
       tl
-  (* do nothing for now *)
+
+
+(* do nothing for now *)
 
 let delete (tl : toplevel) (p : pointerData) (newID : id) : toplevel =
   let replacement = P.emptyD_ newID (P.typeOf p) in

--- a/client/src/ViewRoutingTable.ml
+++ b/client/src/ViewRoutingTable.ml
@@ -57,9 +57,7 @@ let httpCategory (_m : model) (tls : toplevel list) : category =
   ; classname = "http"
   ; entries =
       List.map handlers ~f:(fun tl ->
-          let h = tl |> TL.asHandler |> deOption "httpCategory/entry"
-          and minusButton = Some (ToplevelDelete tl.id)
-          in
+          let h = tl |> TL.asHandler |> deOption "httpCategory/entry" in
           Entry
             { name =
                 h.spec.name
@@ -68,7 +66,7 @@ let httpCategory (_m : model) (tls : toplevel list) : category =
             ; uses = None
             ; tlid = h.tlid
             ; destination = Some (Toplevels tl.pos)
-            ; minusButton = minusButton
+            ; minusButton = Some (ToplevelDelete tl.id)
             ; plusButton = None
             ; externalLink = Some h.spec
             ; verb = h.spec.modifier |> Blank.toMaybe } ) }
@@ -82,9 +80,7 @@ let cronCategory (_m : model) (tls : toplevel list) : category =
   ; classname = "cron"
   ; entries =
       List.map handlers ~f:(fun tl ->
-          let h = tl |> TL.asHandler |> deOption "cronCategory/entry"
-          and minusButton = Some (ToplevelDelete tl.id)
-          in
+          let h = tl |> TL.asHandler |> deOption "cronCategory/entry" in
           Entry
             { name =
                 h.spec.name
@@ -93,7 +89,7 @@ let cronCategory (_m : model) (tls : toplevel list) : category =
             ; uses = None
             ; tlid = h.tlid
             ; destination = Some (Toplevels tl.pos)
-            ; minusButton = minusButton
+            ; minusButton = Some (ToplevelDelete tl.id)
             ; plusButton = None
             ; externalLink = None
             ; verb = None } ) }
@@ -118,7 +114,7 @@ let dbCategory (_m : model) (tls : toplevel list) : category =
           ; tlid = db.dbTLID
           ; uses = None
           ; destination = Some (Toplevels pos)
-          ; minusButton = minusButton
+          ; minusButton
           ; externalLink = None
           ; verb = None
           ; plusButton = None } )
@@ -138,9 +134,7 @@ let undefinedCategory (_m : model) (tls : toplevel list) : category =
   ; classname = missingEventSpaceDesc
   ; entries =
       List.map handlers ~f:(fun tl ->
-          let h = tl |> TL.asHandler |> deOption "undefinedCategory/entry"
-          and minusButton = Some (ToplevelDelete tl.id)
-          in
+          let h = tl |> TL.asHandler |> deOption "undefinedCategory/entry" in
           Entry
             { name =
                 h.spec.name
@@ -149,7 +143,7 @@ let undefinedCategory (_m : model) (tls : toplevel list) : category =
             ; uses = None
             ; tlid = h.tlid
             ; destination = Some (Toplevels tl.pos)
-            ; minusButton = minusButton
+            ; minusButton = Some (ToplevelDelete tl.id)
             ; plusButton = None
             ; externalLink = None
             ; verb = None } ) }
@@ -184,9 +178,7 @@ let eventCategories (_m : model) (tls : toplevel list) : category list =
       ; classname = name
       ; entries =
           List.map handlers ~f:(fun tl ->
-              let h = tl |> TL.asHandler |> deOption "eventCategories/entry"
-              and minusButton = Some (ToplevelDelete tl.id)
-              in
+              let h = tl |> TL.asHandler |> deOption "eventCategories/entry" in
               Entry
                 { name =
                     h.spec.name
@@ -195,7 +187,7 @@ let eventCategories (_m : model) (tls : toplevel list) : category list =
                 ; uses = None
                 ; tlid = h.tlid
                 ; destination = Some (Toplevels tl.pos)
-                ; minusButton = minusButton
+                ; minusButton = Some (ToplevelDelete tl.id)
                 ; plusButton = None
                 ; externalLink = None
                 ; verb = None } ) } )


### PR DESCRIPTION
https://trello.com/c/h8YpNSy9
```
Remove ability to delete a handler, database, or function using backspace. Instead, add the ability to delete them using the routing table UI.

Add "-" buttons to all entries in routing table
```

Please, read through the longer commit messages, to understand some if the non-obvious decisions made in the code and UI. I am normally spartian in my messages, so when there's long commit messages there's a reason. Thank you ^__^