### PR TITLE
When selecting a function or FnCallName, also show the docs

### DIFF
--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -479,26 +479,6 @@ let withDynamicItems
   withoutDynamic @ new_
 
 
-let paramFor (m : model) (tlid : tlid) (id : id) : parameter option =
-  TL.get m tlid
-  |> Option.andThen ~f:TL.asHandler
-  |> Option.map ~f:(fun x -> x.ast)
-  |> Option.andThen ~f:(fun ast -> AST.getParamIndex ast id)
-  |> Option.andThen ~f:(fun (name, index) ->
-         m.complete.functions
-         |> List.find ~f:(fun f -> name = f.fnName)
-         |> Option.map ~f:(fun x -> x.fnParameters)
-         |> Option.andThen ~f:(List.getAt ~index) )
-
-
-let paramForTarget (m : model) (a : autocomplete) : parameter option =
-  match a.target with
-  | None ->
-      None
-  | Some (tlid, p) ->
-      paramFor m tlid (P.toID p)
-
-
 let fnGotoName (name : string) : string = "Just to function: " ^ name
 
 let tlGotoName (tl : toplevel) : string =


### PR DESCRIPTION
https://trello.com/c/x7cSvHA8/458-docstring-showing-inconsistently

![image](https://user-images.githubusercontent.com/181762/52081437-1b2ba500-254f-11e9-89b7-be1d598244ad.png)

We only showed docstrings when a function was being autocompleted, but we showed docstrings for params. Now also show docstrings when a function is selected.