### PR TITLE
Remove omnibox autocompletes from command box

### DIFF
--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -832,7 +832,7 @@ let documentationForItem (aci : autocompleteItem) : string option =
   | ACFunction f ->
       if String.length f.fnDescription <> 0
       then Some f.fnDescription
-      else Some "function call with no description"
+      else Some "Function call with no description"
   | ACCommand c ->
       Some (c.doc ^ " (" ^ c.shortcut ^ ")")
   | ACConstructorName "Just" ->
@@ -852,7 +852,7 @@ let documentationForItem (aci : autocompleteItem) : string option =
       then Some ("The database '" ^ var ^ "'")
       else Some ("The variable '" ^ var ^ "'")
   | ACLiteral lit ->
-      Some ("the literal value '" ^ lit ^ "'")
+      Some ("The literal value '" ^ lit ^ "'")
   | ACKeyword KLet ->
       Some "A `let` expression allows you assign a variable to an expression"
   | ACKeyword KIf ->


### PR DESCRIPTION
https://trello.com/c/OE8Onx61/441-disable-default-omnibox-options-when-query-starts-with-to-access-command-palette

Before:
![image](https://user-images.githubusercontent.com/181762/52092200-a9158900-256b-11e9-8390-4012cabec3df.png)

After:
![image](https://user-images.githubusercontent.com/181762/52092180-9e5af400-256b-11e9-9f54-113849d5310c.png)
