### PR TITLE
Automatically fix DB names to fit the pattern, rather than giving an …

### DIFF
--- a/client/src/Entry.ml
+++ b/client/src/Entry.ml
@@ -412,7 +412,7 @@ let submitACItem
           tl |> TL.replace pd new_ |> fun tl_ -> save tl_ new_
         in
         ( match (pd, item) with
-        | PDBName (F (_, oldName)), ACExtra value ->
+        | PDBName (F (_, oldName)), ACDBName value ->
             if AC.assertValid AC.dbNameValidator value <> value
             then
               DisplayError

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -485,6 +485,7 @@ and autocompleteItem =
   | ACEventName of string
   | ACCronTiming of string
   | ACEventSpace of string
+  | ACDBName of string
   | ACDBColType of string
   | ACParamTipe of string
   | ACExtra of string


### PR DESCRIPTION
…error

https://trello.com/c/cSYUJxLl/468-bad-error-message-for-db-when-not-capital-letter

when you entered an invalid DB name, we'd show you a regex validation error. Now we show:

![image](https://user-images.githubusercontent.com/181762/52154903-eabe3680-2634-11e9-9ddd-c028666e6616.png)
