### PR TITLE
Don't ignore the rollbar promise

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -262,12 +262,9 @@ let push
                 Lwt.return ()
           with e ->
             let bt = Exception.get_backtrace () in
-            ignore
-              (Rollbar.report_lwt
-                 e
-                 bt
-                 (Push event)
-                 (Types.show_id execution_id)) ;
+            let%lwt _ =
+              Rollbar.report_lwt e bt (Push event) (Types.show_id execution_id)
+            in
             Lwt.return () )
 
 


### PR DESCRIPTION
This was definitely my bad for missing this in review. This `ignore` should be `let%lwt _` to force the bind.