### PR TITLE
Change `let _ = ... in` to `ignore (...)`

### DIFF
--- a/backend/libbackend/static_assets.ml
+++ b/backend/libbackend/static_assets.ml
@@ -18,15 +18,14 @@ type static_asset_error =
 let bucket = "dark-static-assets"
 
 let oauth2_token () : (string, [> static_asset_error]) Lwt_result.t =
-  let _ =
-    match Config.gcloud_application_credentials with
+  ignore
+    ( match Config.gcloud_application_credentials with
     | Some s ->
         Unix.putenv
           Gcloud.Auth.Environment_vars.google_application_credentials
           s
     | None ->
-        ()
-  in
+        () ) ;
   let scopes = ["https://www.googleapis.com/auth/devstorage.read_write"] in
   let r = Gcloud.Auth.get_access_token ~scopes () in
   match%lwt r with

--- a/client/src/IntegrationTest.ml
+++ b/client/src/IntegrationTest.ml
@@ -15,15 +15,14 @@ let fail ?(f : 'a -> string = Js.String.make) (v : 'a) : testResult =
 
 let onlyTL (m : model) : toplevel =
   let len = List.length m.toplevels in
-  let _ =
-    if len = 0
+  ignore
+    ( if len = 0
     then Debug.crash "no toplevels"
     else if len > 1
     then
       Debug.crash
         ("too many toplevels: " ^ show_list ~f:show_toplevel m.toplevels)
-    else "nothing to see here"
-  in
+    else "nothing to see here" ) ;
   m.toplevels |> List.head |> deOption "onlytl1"
 
 

--- a/client/src/Keyboard.ml
+++ b/client/src/Keyboard.ml
@@ -501,9 +501,7 @@ let registerGlobal name key tagger =
     (* TODO: put on window, not document *)
     let elem = Web_node.document_node in
     let cache = Vdom.eventHandler_Register callbacks elem name handler in
-    fun () ->
-      let _ = Vdom.eventHandler_Unregister elem name cache in
-      ()
+    fun () -> ignore (Vdom.eventHandler_Unregister elem name cache)
   in
   Tea_sub.registration key enableCall
 

--- a/client/src/Native.ml
+++ b/client/src/Native.ml
@@ -16,9 +16,7 @@ let registerGlobal name key tagger decoder =
     let handler = EventHandlerCallback (key, fn) in
     let elem = Web_node.document_node in
     let cache = eventHandler_Register callbacks elem name handler in
-    fun () ->
-      let _ = eventHandler_Unregister elem name cache in
-      ()
+    fun () -> ignore (eventHandler_Unregister elem name cache)
   in
   Tea_sub.registration key enableCall
 

--- a/client/src/Prelude.ml
+++ b/client/src/Prelude.ml
@@ -110,7 +110,7 @@ let recoverable (msg : 'a) (val_ : 'b) : 'b =
     ^ Js.String.make val_
   in
   (* TODO: surface the error to the user and in rollbar and continue *)
-  let _ = Debug.crash error in
+  ignore (Debug.crash error) ;
   val_
 
 


### PR DESCRIPTION
I don't think there's any good reason to prefer `let _  = ... in` over `ignore (...)` in any situation, though `ignore` is better when the expression is a function call because the compiler emits a warning/error that the function if the function is partially applied -- which is great if you're changing a function and you add a new parameter.

Because `ignore` is either just-as-good as `let _ =` or better, let's always prefer it. 