### PR TITLE
Add netbase to all prod containers

### DIFF
--- a/scripts/support/gcp-cronchecker-Dockerfile
+++ b/scripts/support/gcp-cronchecker-Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
       --no-install-recommends \
       curl \
       apt-transport-https \
-      ca-certificates
+      ca-certificates \
+      netbase
 
 RUN apt-get update \
     && apt-get install \

--- a/scripts/support/gcp-queueworker-Dockerfile
+++ b/scripts/support/gcp-queueworker-Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
       --no-install-recommends \
       curl \
       apt-transport-https \
-      ca-certificates
+      ca-certificates \
+      netbase
 
 RUN apt-get update \
     && apt-get install \

--- a/scripts/support/gcp-server-Dockerfile
+++ b/scripts/support/gcp-server-Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
       --no-install-recommends \
       curl \
       apt-transport-https \
-      ca-certificates
+      ca-certificates \
+      netbase
 
 RUN apt-get update \
     && apt-get install \

--- a/scripts/support/gcp-stroller-Dockerfile
+++ b/scripts/support/gcp-stroller-Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && \
       --no-install-recommends \
       curl \
       apt-transport-https \
-      ca-certificates
+      ca-certificates \
+      netbase
 
 RUN apt-get update \
     && apt-get install \


### PR DESCRIPTION
Fuck me, this was an ordeal.

@ismith I think this might also be your issue with google cloud POSTs in prod? 

Background: We're getting 'unknown scheme' bubbling up from Cohttp's internals, which maps to https://github.com/mirage/ocaml-conduit/blob/a4935d8704e491a3b9155715b8087be709e757e1/lib/resolver.ml#L143-L145 this code. This is a little hard to read, but is a pretty generic way of saying "return this error message if this platform/OS's services database does not have an entry for this application protocol over TCP". The unix implementation of this is here:

https://github.com/mirage/ocaml-conduit/blob/a4935d8704e491a3b9155715b8087be709e757e1/lwt-unix/resolver_lwt_unix.ml#L42-L50

So this syscall isn't finding an entry for http in `/etc/services` on linux (check the documentation for the syscall https://linux.die.net/man/3/getservbyname). Why? Because we don't have one. That's provided by the netbase package on Ubuntu. This PR installs it for all prod containers.

Why is Cohttp looking up the port for the protocol when we've already provided one? Who fucking knows.