### PR TITLE
stroller healthcheck

### DIFF
--- a/backend/libbackend/stroller.mli
+++ b/backend/libbackend/stroller.mli
@@ -11,3 +11,5 @@ val push_new_404 :
   -> canvas_id:Uuidm.t
   -> Stored_event.four_oh_four
   -> unit
+
+val status : unit -> [> `Healthy | `Unconfigured | `Unhealthy of string] Lwt.t


### PR DESCRIPTION
Note: QW healthcheck does fewer things - it's DB-only, no check for stroller. Can't just check Stroller.status from backend/libservice/health_check.ml:
```
module Stroller = Libbackend.Stroller # Unbound module Libbackend
```