### PR TITLE
Don't spin on incompletes/errors in Event queue

### DIFF
--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -77,40 +77,16 @@ let dequeue_and_process execution_id : (unit, Exception.captured) Result.t =
                       ~account_id:!c.owner
                       ~canvas_id
                   in
-                  ( match result with
-                  | RTT.DIncomplete ->
-                      Log.infO
-                        "queue_worker"
-                        ~data:"Got DIncomplete when executing handler"
-                        ~params:
-                          [ ("execution_id", Log.dump execution_id)
-                          ; ("event", Log.dump desc)
-                          ; ("host", host)
-                          ; ("handler_id", Log.dump h.tlid) ] ;
-                      Event_queue.put_back
-                        transaction
-                        event
-                        ~status:`Incomplete
-                  | RTT.DError _ ->
-                      Log.infO
-                        "queue_worker"
-                        ~data:"Got DError when executing handler"
-                        ~params:
-                          [ ("execution_id", Log.dump execution_id)
-                          ; ("event", Log.dump desc)
-                          ; ("host", host)
-                          ; ("handler_id", Log.dump h.tlid) ] ;
-                      Event_queue.put_back transaction event ~status:`Err
-                  | v ->
-                      Log.infO
-                        "queue_worker"
-                        ~data:"Successful execution"
-                        ~params:
-                          [ ("execution_id", Log.dump execution_id)
-                          ; ("host", host)
-                          ; ("event", Log.dump desc)
-                          ; ("handler_id", Log.dump h.tlid) ] ;
-                      Event_queue.finish transaction event ) ;
+                  Log.infO
+                    "queue_worker"
+                    ~data:"Successful execution"
+                    ~params:
+                      [ ("execution_id", Log.dump execution_id)
+                      ; ("host", host)
+                      ; ("event", Log.dump desc)
+                      ; ("handler_id", Log.dump h.tlid)
+                      ; ("result", Log.dump result) ] ;
+                  Event_queue.finish transaction event ;
                   Ok ()
             with e ->
               (* exception occurred when processing an item,


### PR DESCRIPTION
While setting up a kubectl dashboard for myself, noticed that the event queue was spinning a lot on CRON handlers -- specifically CRON handlers that continue to be put back again and again.

I don't think we should be automatically running code more than use -- especially in the presence of side-effects

Consider:

```
let hello = Missiles::launch "San Francisco" in
<blank>
```

which will spin and spin and spin launching missiles.

This PR removes the put_back in the DError and DIncomplete cases, forcing the end-user to replay via the trace interface (just like they would for HTTP handlers)