### PR TITLE
Delete function_arguments with a null trace, and add the index.

### DIFF
--- a/backend/migrations/20190221_231739_remove-null-traces-from-function_arguments.sql
+++ b/backend/migrations/20190221_231739_remove-null-traces-from-function_arguments.sql
@@ -1,0 +1,3 @@
+DELETE FROM function_arguments WHERE trace_id IS NULL;
+
+ALTER TABLE function_arguments ALTER COLUMN trace_id SET NOT NULL


### PR DESCRIPTION
The index is syncronous, but we tested on prodclone and it only takes a moment

