### PR TITLE
When an incomplete is on the errorrail, it should remain as an incomplete

### DIFF
--- a/backend/libexecution/ast.ml
+++ b/backend/libexecution/ast.ml
@@ -497,6 +497,8 @@ and call_fn
             v
         | DResult (ResOk v) ->
             v
+        | DIncomplete ->
+            DIncomplete
         (* There should only be DOptions and DResults here, but hypothetically we got
         * something else, they would go on the error rail too.  *)
         | other ->


### PR DESCRIPTION
Not be wrapped in an errorrail.

This fixes the case where the execute-function button is already "pressed"
because it has a non-incomplete answer.

Before:
![image](https://user-images.githubusercontent.com/181762/53211569-802a6600-35f6-11e9-904c-148cab5f1749.png)

After:
![image](https://user-images.githubusercontent.com/181762/53211584-8a4c6480-35f6-11e9-90c2-0c81761d65f5.png)
