### PR TITLE
Don't show errors the user doesn't care about

### DIFF
--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -591,7 +591,7 @@ and canvasProps =
 and httpError = (string Tea.Http.error[@opaque])
 
 and modification =
-  | DisplayAndReportHttpError of string * httpError
+  | DisplayAndReportHttpError of string * bool * httpError
   | DisplayAndReportError of string
   | DisplayError of string
   | ClearError


### PR DESCRIPTION
We run GetUnlockedDBs every second, and a failure isn't valuable information and
isn't actionable, so don't bother reporting it.

Still rollbar them.

