### PR TITLE
Bump sleep interval in failed DB Connection

### DIFF
--- a/backend/libservice/dbconnection.ml
+++ b/backend/libservice/dbconnection.ml
@@ -26,6 +26,10 @@ let rec rec_con depth =
       ~params:[("attempt", string_of_int depth)] ;
     if depth < 10
     then (
+      (* It takes the CloudSQL proxy ~30 seconds to go from 'started' to 'ready'
+       * (what could it possibly be doing??). Let's wait max 50 seconds so we're
+       * not crashing twice every time a pod is scheduled. The 20 seconds is
+       * a buffer. Hurry up and wait, private! *)
       Unix.sleep 5 ;
       rec_con (depth + 1) )
     else raise e


### PR DESCRIPTION
All of our monolith containers (across bwd, cron, event queue deployments) crash _twice_ when they are first scheduled because it takes the cloudsql-proxy 30s to go from started to ready, and we manage to fail _twice_ with surprising regularity.

This is just extra busy work for the k8s scheduler so let's sleep for a max of 50s.