### PR TITLE
Improve readiness checks

### DIFF
--- a/backend/libbackend/init.ml
+++ b/backend/libbackend/init.ml
@@ -34,6 +34,7 @@ let init ~run_side_effects =
         Migrations.init () ;
         Account.init () ;
         Serialize.write_shape_data () ) ;
+      if Config.check_tier_one_hosts then Canvas.check_tier_one_hosts () ;
       Libcommon.Log.infO "Libbackend" ~data:"Initialization Complete" ;
       has_inited := true )
   with e ->

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1124,8 +1124,6 @@ let k8s_handler req ~execution_id ~stopper =
           if !ready
           then respond ~execution_id `OK "Hello internal overlord"
           else (
-            (* exception here caught by handle_error *)
-            if Config.check_tier_one_hosts then Canvas.check_tier_one_hosts () ;
             Log.infO "Service ready" ;
             ready := true ;
             respond ~execution_id `OK "Hello internal overlord" )


### PR DESCRIPTION
We're doing a _bunch_ of work on every pod every few seconds due to not understanding the lifecycle properly. This improves it.