### PR TITLE
Set client_max_body_size = 100m

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -51,7 +51,7 @@ server {
   # At least in theory, we could put client_max_body_size under a location {},
   # so we could add a location /api/*/static_assets {}, to leave the default of
   # 1m in place elsewhere.
-  client_max_body_size 100m
+  client_max_body_size 100m;
 
   # These prefixes are handled by the OCaml backend.
   location /a/ {


### PR DESCRIPTION
To allow for >1m static_assets uploads

https://trello.com/c/d2kSGLsY/648-diagnose-resolve-1mb-request-size-limit-on-static-asset-upload

Please read this before making your pull request: https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit
