### PR TITLE
Make queryOne have a play button on the client.

### DIFF
--- a/backend/libexecution/libdb2.ml
+++ b/backend/libexecution/libdb2.ml
@@ -100,7 +100,7 @@ let fns : Lib.shortfn list =
         "Fetch exactly one value from `table` which have the same fields and values that `spec` has. Returns Nothing if none or more than 1 found"
     ; f = NotClientAvailable
     ; pr = None
-    ; ps = true
+    ; ps = false
     ; dep = false }
   ; { pns = ["DB::queryOneWithKey_v1"]
     ; ins = []


### PR DESCRIPTION
It was previewSafe, which meant the webapp didn't show the play
button because it assumed the jsoo analysis could run it, but the jsoo
didn't have a client implementation.

There's no need to bump the version as this is purely a UI fix.