### PR TITLE
Ismith/nginx logs for monitoring

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -39,6 +39,16 @@ gzip_min_length 1024;
 
 proxy_cache_path /tmp/cache/ levels=1:2 keys_zone=static_cache:100k max_size=100m;
 
+# log_format for honeycomb/honeytail: https://docs.honeycomb.io/getting-data-in/integrations/webservers/nginx/#optional-configuration
+# added: x-darklang-execution-id
+# added: cookie (so we know which user did a thing)
+log_format honeycomb '$remote_addr - $remote_user [$time_local] $host '
+    '"$request" $status $bytes_sent $body_bytes_sent $request_time '
+    '"$http_referer" "$http_user_agent" $request_length "$http_authorization" '
+    '"$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name'
+    '"$upstream_http_x_darklang_execution_id" "$http_cookie"';
+access_log /var/log/nginx/access.log honeycomb;
+
 server {
   listen 8000;
   server_name www.darklang.com;


### PR DESCRIPTION
- [x] https://trello.com/c/9C6Yd5a1/655-add-nginx-conf-to-support-honeytail-for-honeycomb
- [x] We're gonna be ingesting nginx logs into honeycomb; before I hook up honeycomb, I want to be sure this nginx.conf change behaves as expected. (Will deploy, then tail logs)
- [x] Add intended followups: https://trello.com/c/26e5jkBj/656-hook-up-honeytail-honeycomb-to-nginx-logs
