### PR TITLE
Fix missing nginx.conf space

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -45,7 +45,7 @@ proxy_cache_path /tmp/cache/ levels=1:2 keys_zone=static_cache:100k max_size=100
 log_format honeycomb '$remote_addr - $remote_user [$time_local] $host '
     '"$request" $status $bytes_sent $body_bytes_sent $request_time '
     '"$http_referer" "$http_user_agent" $request_length "$http_authorization" '
-    '"$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name'
+    '"$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name '
     '"$upstream_http_x_darklang_execution_id" "$http_cookie"';
 access_log /var/log/nginx/access.log honeycomb;
 


### PR DESCRIPTION
Missing space between $server_name and "$http_cookie"
