### PR TITLE
create clusterrolebinding is only needed once per cluster

### DIFF
--- a/scripts/gke-create-cluster
+++ b/scripts/gke-create-cluster
@@ -355,6 +355,10 @@ kubectl create -f - <<EOF
 }
 EOF
 
+kubectl create clusterrolebinding circleci-admin-binding \
+--clusterrole=cluster-admin \
+--user=circleci-deployer@${DARK_CLUSTER_PROJECT}.iam.gserviceaccount.com
+
 print_step "deploying code and containers"
 
 ./scripts/gke-deploy \

--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -204,11 +204,7 @@ kubectl apply -f scripts/support/kubernetes/builtwithdark/bwd-nodeport.yaml
 kubectl apply -f scripts/support/kubernetes/builtwithdark/bwd-network-policy.yaml
 kubectl apply -f scripts/support/kubernetes/builtwithdark/darklang-nodeport.yaml
 kubectl apply -f scripts/support/kubernetes/builtwithdark/darklang-ingress.yaml
-
-# TODO make this better?
-kubectl create clusterrolebinding circleci-admin-binding --clusterrole=cluster-admin --user=circleci-deployer@balmy-ground-195100.iam.gserviceaccount.com
 kubectl apply -f scripts/support/kubernetes/builtwithdark/honeycomb.yaml
-
 kubectl apply -f scripts/support/kubernetes/queueworker/qw-deployment.yaml
 kubectl apply -f scripts/support/kubernetes/queueworker/qw-network-policy.yaml
 kubectl apply -f scripts/support/kubernetes/tunnel/tunnel-deployment.yaml


### PR DESCRIPTION
I'm not sure if this'll do the right thing if you're running gke-create-cluster as a user other than the circleci-deployer, but I guess we'll find out.