### PR TITLE
Fix decoder failure for incoming 404s

### DIFF
--- a/client/src/Analysis.ml
+++ b/client/src/Analysis.ml
@@ -267,8 +267,8 @@ module New404Push = struct
   let decode =
     let open Tea.Json.Decoder in
     let open Native.Decoder in
-    let mk404WithTs (space, path, modifier) = {space; path; modifier} in
-    map mk404WithTs (field "detail" (tuple3 string string string))
+    let mk404WithTs (space, path, modifier, _) = {space; path; modifier} in
+    map mk404WithTs (field "detail" (tuple4 string string string string))
 
 
   let listen ~key tagger = Native.registerGlobal "new404Push" key tagger decode


### PR DESCRIPTION
This is actually a 4-tuple, not a triple -- so the decoder is failing
and thus the Msg callback is not firing (and so 404s don't live-update).

The silent failure of the decoder is bad, but I'm unsure where's best to
log/crash for this? @pbiggar: any ideas? These could fire _a lot_ for
say, old clients, so I worry about Rollbar here.

Fixes: https://trello.com/c/I9ey4AfR/678-404s-dont-arrive-until-page-refresh

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [x] Does this add or change product features not discussed in the goals?
- User facing:
  - [x] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [x] Double check any change related to the serialization format.

