### PR TITLE
Preserve source ip so nginx' remote_addr in logs is useful in honeycomb

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/bwd-nodeport.yaml
+++ b/scripts/support/kubernetes/builtwithdark/bwd-nodeport.yaml
@@ -4,6 +4,7 @@ metadata:
   name: bwd-nodeport
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   selector:
     app: bwd-app
   ports:

--- a/scripts/support/kubernetes/builtwithdark/darklang-nodeport.yaml
+++ b/scripts/support/kubernetes/builtwithdark/darklang-nodeport.yaml
@@ -4,6 +4,7 @@ metadata:
   name: darklang-nodeport
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   selector:
     app: bwd-app
   ports:


### PR DESCRIPTION
(We want the _user_ IP, not some LB or k8s proxy ip. See
https://trello.com/c/UzNhvX6D/717-nginx-realip-config)

There is a caveat, but this seems acceptable:
https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#caveats-and-limitations-when-preserving-source-ips
```
GCE/AWS load balancers do not provide weights for their target pools. This was not an issue with the old LB kube-proxy rules which would correctly balance across all endpoints.

With the new functionality, the external traffic will not be equally load balanced across pods, but rather equally balanced at the node level (because GCE/AWS and other external LB implementations do not have the ability for specifying the weight per node, they balance equally across all target nodes, disregarding the number of pods on each node).

We can, however, state that for NumServicePods << NumNodes or NumServicePods >> NumNodes, a fairly close-to-equal distribution will be seen, even without weights.
```

(We do have that state - currently 6 nodes and 36+ bwd pods.)

REVERSION STRATEGY:
- once deployed, we'll test by loading both a canvas and a dark endpoint
- if that fails, reversion is just reverting this PR and re-deploying

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [X] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

