### PR TITLE
Use nginx_http_realip module

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -49,6 +49,15 @@ log_format honeycomb '$remote_addr - $remote_user [$time_local] $host '
     '"$upstream_http_x_darklang_execution_id" "$http_cookie"';
 access_log /var/log/nginx/access.log honeycomb;
 
+# 'trust' all ips, rather than the footgun of "oops, changed our incoming ip,
+# forgot to update nginx". We're using this remote_addr value for stats, not
+# auth, so untrusted is ok.
+set_real_ip_from 0.0.0.0/32;
+set_real_ip_from ::/0;
+
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+
 server {
   listen 8000;
   server_name www.darklang.com;


### PR DESCRIPTION
We 'trust' all ips for the reason in the comment - easier to maintain,
and ips are used here for honeycomb, not auth

This gets us a remote_addr field  honeycomb can work with to count unique ips (~"users")

https://trello.com/c/UzNhvX6D/717-preserve-remoteaddr-ip

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

