### PR TITLE
Add DB::count, to count the elements in a DB

### DIFF
--- a/backend/libbackend/libdb2.ml
+++ b/backend/libbackend/libdb2.ml
@@ -190,6 +190,14 @@ let replacements =
             User_db.get_all ~state ~magic:false db
         | args ->
             fail args) )
+  ; ( "DB::count"
+    , InProcess
+        (function
+        | state, [DDB dbname] ->
+            let db = find_db state.dbs dbname in
+            User_db.count ~state db |> DInt
+        | args ->
+            fail args) )
   ; (* previously called `DB::keys` *)
     ( "DB::schemaFields_v1"
     , InProcess

--- a/backend/libbackend/user_db.ml
+++ b/backend/libbackend/user_db.ml
@@ -506,6 +506,27 @@ let get_all ~state ~magic (db : db) : dval =
   |> DList
 
 
+let count ~state (db : db) : int =
+  Db.fetch
+    ~name:"count"
+    "SELECT count(*)
+     FROM user_data
+     WHERE table_tlid = $1
+     AND account_id = $2
+     AND canvas_id = $3
+     AND user_version = $4
+     AND dark_version = $5"
+    ~params:
+      [ ID db.tlid
+      ; Uuid state.account_id
+      ; Uuid state.canvas_id
+      ; Int db.version
+      ; Int current_dark_version ]
+  |> List.hd_exn
+  |> List.hd_exn
+  |> int_of_string
+
+
 let delete ~state (db : db) (key : string) =
   (* covered by composite PK index *)
   Db.run

--- a/backend/libbackend/user_db.mli
+++ b/backend/libbackend/user_db.mli
@@ -27,6 +27,8 @@ val query : state:exec_state -> magic:bool -> DbT.db -> dval -> dval
 val query_by_one :
   state:exec_state -> magic:bool -> DbT.db -> string -> dval -> dval
 
+val count : state:exec_state -> DbT.db -> int
+
 val delete : state:exec_state -> DbT.db -> string -> unit
 
 val delete_all : state:exec_state -> DbT.db -> unit

--- a/backend/libexecution/libdb2.ml
+++ b/backend/libexecution/libdb2.ml
@@ -129,6 +129,14 @@ let fns : Lib.shortfn list =
     ; f = NotClientAvailable
     ; ps = false
     ; dep = false }
+  ; { pns = ["DB::count"]
+    ; ins = []
+    ; p = [par "table" TDB]
+    ; r = TInt
+    ; d = "Return the number of items stored in `table`."
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = false }
   ; (* previously called `DB::keys` *)
     { pns = ["DB::schemaFields_v1"]
     ; ins = []


### PR DESCRIPTION
Julius's canvas had a trace that was too large to load and so was causing a stack overflow. He was only adding this so that he could call List::length on it. https://trello.com/c/Kw8KEtZF/723-add-dbcount

This adds DB::count so we can replace uses of DB::get_all on his canvas with something efficient that doesn't try to load the entire DB into memory.

The ideal way to solve this would be to add optimizations for DB access/queries/etc. When we add that, we can deprecate this.

Followup to update Julius's canvas once this is merged: https://trello.com/c/G4tADGHb/724-replace-calls-to-dbgetall-with-dbcount-on-the-stats-handler-in-julius-canvas


- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [x] Add intended followups as trellos 
- [x] If risky, discuss your reversion strategy
- [x] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

