### PR TITLE
Only specify nginx log format in one place

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -76,7 +76,8 @@ data:
           name: nginx
           dataset: kubernetes-bwd-nginx
           options:
-            log_format: '$remote_addr - $remote_user [$time_local] $host "$request" $status $bytes_sent $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $request_length "$http_authorization" "$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name "$upstream_http_x_darklang_execution_id" "$http_cookie"'
+            config_file: /etc/nginx/conf.d/nginx.conf
+            log_format_name: honeycomb
         processors:
         - request_shape:
             field: request


### PR DESCRIPTION
Per
https://docs.honeycomb.io/getting-data-in/integrations/webservers/nginx,
header "Identify log locations and formats", if we specify ConfigFile
and LogFormatName, honeytail can discover this value itself - no need to
keep nginx.conf and honeycomb.yaml in sync anymore.

Not directly required by https://trello.com/c/qGpTop75/727-put-username-in-response-headers-for-honeycomb-consumption, but simplifies it.

Testing strategy:
- manually deploy configmap and run `nginx -s reload` on a single pod to verify that it parses
- merge, wait for CI deploy, confirm that new (post-merge) data in honeycomb is still there (should look like the old data, no visible change)

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

