### PR TITLE
Ismith/username response header for honeycomb

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -46,7 +46,7 @@ log_format honeycomb '$remote_addr - $remote_user [$time_local] $host '
     '"$request" $status $bytes_sent $body_bytes_sent $request_time '
     '"$http_referer" "$http_user_agent" $request_length "$http_authorization" '
     '"$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name '
-    '"$upstream_http_x_darklang_execution_id" "$http_cookie"';
+    '"$upstream_http_x_darklang_execution_id" "$http_cookie" "$upstream_http_x_dark_username"';
 access_log /var/log/nginx/access.log honeycomb;
 
 # 'trust' all ips, rather than the footgun of "oops, changed our incoming ip,


### PR DESCRIPTION
From commit msg: "By adding an x-dark-username response header, we can have human usernames in honeycomb"; simple as that.

Note that this is on top of #742, without which we'd have to make the nginx.conf log format change in honeycomb.yaml, too.

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

