### PR TITLE
Add honeycomb-heapster for k8s cluster events + metrics

### DIFF
--- a/scripts/gke-create-cluster
+++ b/scripts/gke-create-cluster
@@ -341,6 +341,21 @@ kubectl create -f - <<EOF
 }
 EOF
 
+# Honeycomb write key for honeycomb-heapster
+kubectl create --namespace=kube-system -f - <<EOF
+{
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "type": "Opaque",
+  "data": {
+    "key": "$DARK_CLUSTER_HONEYCOMB_WRITE_KEY"
+  },
+  "metadata": {
+    "name": "honeycomb-writekey"
+  }
+}
+EOF
+
 kubectl create -f - <<EOF
 {
   "apiVersion": "v1",

--- a/scripts/support/kubernetes/honeycomb-heapster.yaml
+++ b/scripts/support/kubernetes/honeycomb-heapster.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster-honeycomb
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: heapster
+    spec:
+      serviceAccountName: honeycomb-heapster
+      containers:
+      - name: heapster
+        image: gcr.io/google_containers/heapster-amd64:v1.5.1
+        imagePullPolicy: Always
+        command:
+        - /heapster
+        args:
+        - --source=kubernetes:https://kubernetes.default
+        - --sink=honeycomb:?dataset=kubernetes-resource-metrics
+        env:
+        - name: HONEYCOMB_WRITEKEY
+          valueFrom:
+            secretKeyRef:
+              key: key
+              name: honeycomb-writekey
+      - name: eventer
+        image: gcr.io/google_containers/heapster-amd64:v1.5.1
+        imagePullPolicy: Always
+        command:
+        - /eventer
+        args:
+        - --source=kubernetes:https://kubernetes.default
+        - --sink=honeycomb:?dataset=kubernetes-cluster-events
+        env:
+        - name: HONEYCOMB_WRITEKEY
+          valueFrom:
+            secretKeyRef:
+              key: key
+              name: honeycomb-writekey
+---
+kind: ClusterRoleBinding
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: honeycomb-heapster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:heapster
+subjects:
+- kind: ServiceAccount
+  name: honeycomb-heapster
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: honeycomb-heapster
+  namespace: kube-system
+...


### PR DESCRIPTION
https://trello.com/c/HgHlo3gv/729-get-cluster-event-resource-metrics-from-heapster-into-honeycomb

This is already deployed in the cluster, as of this morning. Not sure what all is in these metrics, but deploying it is easy (honeycomb gave us yaml to deploy, no real config needed), and might be nice to see, eg, failed readiness checks, etc.

- [X]  Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

