### PR TITLE
Mostly a revert of #742, but also an update of log_format to match x-…

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -77,7 +77,7 @@ data:
           dataset: kubernetes-bwd-nginx
           options:
             config_file: /etc/nginx/conf.d/nginx.conf
-            log_format_name: honeycomb
+            log_format: '$remote_addr - $remote_user [$time_local] $host "$request" $status $bytes_sent $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $request_length "$http_authorization" "$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name "$upstream_http_x_darklang_execution_id" "$http_cookie" "$upstream_http_x_dark_username"'
         processors:
         - request_shape:
             field: request


### PR DESCRIPTION
…dark-username (#743)

Related: https://trello.com/c/qGpTop75/727-put-username-in-response-headers-for-honeycomb-consumption

Turns out, log_format is _only_ for putting the actual log_format string
in, and _can't_ be used to pull in an nginx.conf and get it from that.
(In contrast to running the honeytail cli, which has flags for this.)
Honeycomb has opened a ticket to ... either fix this discrepancy or
document how to use it.

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

