### PR TITLE
Fix download db script

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -20,7 +20,7 @@ do
     ;;
     *)
     echo "Unexpected argument: $i"
-    exit 255
+    exit 1
     ;;
   esac
 done

--- a/scripts/download-gcp-db
+++ b/scripts/download-gcp-db
@@ -16,7 +16,7 @@ do
     ;;
     *)
     echo "Unexpected argument: $i"
-    exit 255
+    exit 1
     ;;
   esac
 done

--- a/scripts/run-in-docker
+++ b/scripts/run-in-docker
@@ -25,7 +25,7 @@ fi
 
 if [[ "$NAME" == "" ]]; then
   echo "No container name. Is the container not running?"
-  exit 255
+  exit 1
 fi
 
 if [ -t 0 ] ;

--- a/scripts/support/runserver
+++ b/scripts/support/runserver
@@ -32,5 +32,5 @@ if [[ -f "${SERVER_EXE}" && -f "${QW_EXE}" && -f "${CRON_EXE}" ]]; then
   "${CRON_EXE}" --no-health-check > "$LOGS/cron.log" 2>&1 &
 else
   echo "Missing binaries"
-  exit 255
+  exit 1
 fi

--- a/scripts/support/runstroller
+++ b/scripts/support/runstroller
@@ -28,5 +28,5 @@ if [[ -f "${STROLLER}" ]]; then
   "${STROLLER}" > "$LOGS/stroller.log" 2>&1 &
 else
   echo "Missing binary"
-  exit 255
+  exit 1
 fi


### PR DESCRIPTION
Our database got big enough that our download-gcp-db script started breaking. This fixes it.

I decided to change how this script works. By default, it will download the latest DB checkout. This avoids both the time and DB CPU overhead of making a new clone. If you pass `--generate`, it will still generate a new one.

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

