### PR TITLE
Change the default json encoder for http responses

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -261,10 +261,12 @@ let result_to_response
         Header.add_unless_exists headers "Access-Control-Allow-Origin" h
   in
   let json_formatter =
+    (* This was kept in as part of the fallback of the "pretty json" migration.
+     * It can be removed later, if no-one complains. *)
     if Header.get (CRequest.headers req) "x-dark-json-format-version"
-       = Some "1"
-    then Dval.to_pretty_machine_json_v1
-    else Libexecution.Legacy.PrettyResponseJsonV0.to_pretty_response_json_v0
+       = Some "0"
+    then Libexecution.Legacy.PrettyResponseJsonV0.to_pretty_response_json_v0
+    else Dval.to_pretty_machine_json_v1
   in
   match result with
   | RTT.DIncomplete ->


### PR DESCRIPTION
This is second to last part of the "pretty json" migration.

It changes the format for http responses. We don't believe anyone is relying on this, and they've had two warnings. I left in a header to allow them to quickly change back: they should send the HTTP header: "x-dark-json-format-version: 0".

I plan to merge on monday, after alerting people via the #users room.

https://trello.com/c/35AR07ab/687-on-march-25th-follow-through-json-migration-change-and-inform-users

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [x] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

