### PR TITLE
Function autocomplete should have db names

### DIFF
--- a/client/src/Analysis.ml
+++ b/client/src/Analysis.ml
@@ -218,7 +218,7 @@ let getCurrentAvailableVarnames (m : model) (tl : toplevel) (ID id : id) :
         fn.ufMetadata.ufmParameters
         |> List.filterMap ~f:(fun p -> Blank.toMaybe p.ufpName)
       in
-      varsFor fn.ufAST @ params
+      varsFor fn.ufAST @ dbs @ params
   | TLDB _ | TLTipe _ ->
       []
 


### PR DESCRIPTION
We did not include DB names in the autocomplete in a function. Seems to have been an omission.

This also makes the autocomplete test a lot more usable and composable, including names that seem to imply what they actually do.

![image](https://user-images.githubusercontent.com/181762/54861585-d3bccc00-4ce8-11e9-900b-b010979d63df.png)

https://trello.com/c/SczpUN4O/676-in-functions-autocomplete-does-not-include-database-names

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [x] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

