### PR TITLE
Don't show timeouts for UnlockedDBs call

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -369,7 +369,7 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
           | Http.BadUrl _ ->
               true
           | Http.Timeout ->
-              true
+              not ignoreCommon
           | Http.NetworkError ->
               not ignoreCommon
           | Http.BadStatus response ->


### PR DESCRIPTION
https://trello.com/c/mvrx7UeO/718-dont-give-an-error-on-timeout-for-unlockeddbs

We show too many errors that are unactionable to the user. One of them is when the UnlockedDBs RPC fails because of a timeout. So let's not show that error. (We continue to report it on rollbar though).

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

