### PR TITLE
Take event timestamps from the DB, thread them to the client, show

### DIFF
--- a/backend/libbackend/stored_event.ml
+++ b/backend/libbackend/stored_event.ml
@@ -104,20 +104,22 @@ let load_events
 
 
 let load_event_for_trace ~(canvas_id : Uuidm.t) (trace_id : Uuidm.t) :
-    (string * RTT.dval) option =
+    (string * RTT.time * RTT.dval) option =
   Db.fetch
-    ~name:"load_events_for_trace"
-    "SELECT path, value FROM stored_events_v2
+    ~name:"load_event_for_trace"
+    "SELECT path, value, timestamp FROM stored_events_v2
     WHERE canvas_id = $1
       AND trace_id = $2
     LIMIT 1"
     ~params:[Uuid canvas_id; Uuid trace_id]
   |> List.hd
   |> Option.map ~f:(function
-         | [request_path; dval] ->
-             (request_path, Dval.of_internal_roundtrippable_v0 dval)
+         | [request_path; dval; timestamp] ->
+             ( request_path
+             , Util.date_of_isostring timestamp
+             , Dval.of_internal_roundtrippable_v0 dval )
          | _ ->
-             Exception.internal "Bad DB format for load_events_for_trace" )
+             Exception.internal "Bad DB format for load_event_for_trace" )
 
 
 let load_event_ids

--- a/backend/libbackend/stored_event.mli
+++ b/backend/libbackend/stored_event.mli
@@ -21,7 +21,9 @@ val store_event :
   -> Types.RuntimeT.time
 
 val load_event_for_trace :
-  canvas_id:Uuidm.t -> Uuidm.t -> (string * Types.RuntimeT.dval) option
+     canvas_id:Uuidm.t
+  -> Uuidm.t
+  -> (string * Types.RuntimeT.time * Types.RuntimeT.dval) option
 
 val load_events :
      canvas_id:Uuidm.t

--- a/backend/libbackend/stored_function_arguments.mli
+++ b/backend/libbackend/stored_function_arguments.mli
@@ -12,6 +12,6 @@ val load_for_analysis :
      canvas_id:Uuidm.t
   -> Types.tlid
   -> Uuidm.t
-  -> Analysis_types.input_vars option
+  -> (Analysis_types.input_vars * Types.RuntimeT.time) option
 
 val load_traceids : canvas_id:Uuidm.t -> Types.tlid -> Uuidm.t list

--- a/backend/libexecution/analysis_types.ml
+++ b/backend/libexecution/analysis_types.ml
@@ -48,6 +48,7 @@ type traceid = uuid [@@deriving show, yojson]
 
 type trace_data =
   { input : input_vars
+  ; timestamp : time
   ; function_results : function_result list }
 [@@deriving eq, show, yojson]
 

--- a/backend/test/test.ml
+++ b/backend/test/test.ml
@@ -2219,6 +2219,7 @@ let t_trace_data_json_format_redacts_passwords () =
   let id = fid () in
   let trace_data : Analysis_types.trace_data =
     { input = [("event", DPassword (PasswordBytes.of_string "redactme1"))]
+    ; timestamp = Time.epoch
     ; function_results =
         [ ( "Password::hash"
           , id
@@ -2227,6 +2228,7 @@ let t_trace_data_json_format_redacts_passwords () =
   in
   let expected : Analysis_types.trace_data =
     { input = [("event", DPassword (PasswordBytes.of_string "Redacted"))]
+    ; timestamp = Time.epoch
     ; function_results =
         [ ( "Password::hash"
           , id

--- a/client/src/Analysis.ml
+++ b/client/src/Analysis.ml
@@ -64,8 +64,9 @@ let replaceFunctionResult
                 ~default:
                   [ ( traceID
                     , Some
-                        {input = StrDict.empty; functionResults = [newResult]}
-                    ) ]
+                        { input = StrDict.empty
+                        ; timestamp = ""
+                        ; functionResults = [newResult] } ) ]
            |> List.map ~f:(fun ((tid, tdata) as t) ->
                   if tid = traceID
                   then

--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -320,6 +320,7 @@ and traces j : traces =
 
 and traceData j : traceData =
   { input = field "input" inputValueDict j
+  ; timestamp = field "timestamp" string j
   ; functionResults = field "function_results" (list functionResult) j }
 
 

--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -571,6 +571,7 @@ and traceID = string
 and traceData (t : Types.traceData) : Js.Json.t =
   object_
     [ ("input", list (tuple2 string dval) (StrDict.toList t.input))
+    ; ("timestamp", string t.timestamp)
     ; ("function_results", list functionResult t.functionResults) ]
 
 

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -390,6 +390,7 @@ and traceID = string
 
 and traceData =
   { input : inputValueDict
+  ; timestamp : string
   ; functionResults : functionResult list }
 
 and trace = traceID * traceData option

--- a/client/src/ViewData.ml
+++ b/client/src/ViewData.ml
@@ -9,6 +9,7 @@ let viewInput
     (tlid : tlid)
     (traceID : traceID)
     (value : string)
+    (timestamp : string)
     (isActive : bool)
     (isHover : bool)
     (tipe : tipe) : msg Html.html =
@@ -29,7 +30,7 @@ let viewInput
           TraceMouseLeave (tlid, traceID, x) ) ]
   in
   Html.li
-    ( [Vdom.attribute "" "data-content" value]
+    ( [Vdom.attribute "" "data-content" (value ^ "\nMade at: " ^ timestamp)]
     @ [classes |> String.join ~sep:" " |> Html.class']
     @ events )
     [Html.text {js|•|js}]
@@ -47,6 +48,10 @@ let viewInputs (vs : ViewUtils.viewState) (ID astID : id) : msg Html.html list
       |> Option.withDefault ~default:"<loading>"
       |> fun s -> if String.length s = 0 then "No input parameters" else s
     in
+    let timestamp =
+      Option.map ~f:(fun (td : traceData) -> td.timestamp) traceData
+      |> Option.withDefault ~default:""
+    in
     (* Note: the isActive and hoverID tlcursors are very different things *)
     let isActive =
       Analysis.cursor' vs.tlCursors vs.traces vs.tl.id = Some traceID
@@ -59,7 +64,7 @@ let viewInputs (vs : ViewUtils.viewState) (ID astID : id) : msg Html.html list
       |> Option.map ~f:Runtime.typeOf
       |> Option.withDefault ~default:TIncomplete
     in
-    viewInput vs.tl.id traceID value isActive isHover astTipe
+    viewInput vs.tl.id traceID value timestamp isActive isHover astTipe
   in
   List.map ~f:traceToHtml vs.traces
 


### PR DESCRIPTION
We store timestamps for traces, but haven't shown them up til now. This isn't the best way to show them, but it's probably enough.

![image](https://user-images.githubusercontent.com/181762/54862042-885aeb80-4cf1-11e9-8d1f-3b3f0986528c.png)

https://trello.com/c/Rfa3Pvop/665-show-timestamp-in-traces-input-values


- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

