### PR TITLE
Reload the page on "Bad CSRF" in the error string

### DIFF
--- a/client/src/Entry.ml
+++ b/client/src/Entry.ml
@@ -374,7 +374,7 @@ let submitACItem
       let pd = TL.findExn tl id in
       let result = validate tl pd stringValue in
       if result <> None
-      then DisplayAndReportError (deOption "checked above" result)
+      then DisplayAndReportError (deOption "checked above" result, None, None)
       else
         let maybeH = TL.asHandler tl in
         let db = TL.asDB tl in
@@ -608,10 +608,12 @@ let submitACItem
             replace (PTypeFieldTipe (B.newF (RT.str2tipe value)))
         | pd, item ->
             DisplayAndReportError
-              ( "Invalid autocomplete option: ("
-              ^ Types.show_pointerData pd
-              ^ ", "
-              ^ Types.show_autocompleteItem item ) )
+              ( "Invalid autocomplete option"
+              , None
+              , Some
+                  ( Types.show_pointerData pd
+                  ^ ", "
+                  ^ Types.show_autocompleteItem item ) ) )
 
 
 let submit (m : model) (cursor : entryCursor) (move : nextMove) : modification

--- a/client/src/Native.ml
+++ b/client/src/Native.ml
@@ -114,6 +114,9 @@ module Location = struct
   external hashString : string = "hash"
     [@@bs.val] [@@bs.scope "window", "location"]
 
+  external reload : bool -> unit = "reload"
+    [@@bs.val] [@@bs.scope "window", "location"]
+
   (* TODO write string query parser *)
 end
 

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -377,7 +377,7 @@ and functionResult =
 (* traces / traceFetcher *)
 and traceFetchResult =
   | TraceFetchSuccess of getTraceDataRPCParams * getTraceDataRPCResult
-  | TraceFetchFailure of getTraceDataRPCParams * string
+  | TraceFetchFailure of getTraceDataRPCParams * string * string
   | TraceFetchMissing of getTraceDataRPCParams
 
 and traceFetchContext =
@@ -680,7 +680,7 @@ and httpError = (string Tea.Http.error[@opaque])
 and modification =
   | DisplayAndReportHttpError of
       string * bool * httpError * (Js.Json.t[@opaque])
-  | DisplayAndReportError of string
+  | DisplayAndReportError of string * string option * string option
   | DisplayError of string
   | ClearError
   | Select of tlid * id option


### PR DESCRIPTION
When we receive a Bad CRSF, there's not much we can do except refresh the page - nothing else will work. This checks for a Bad CSRF from normal RPCs, and also threads the error from TraceFetcher so we can check that too.

https://trello.com/c/Ko2gCINh/654-refresh-client-after-receiving-bad-csrf-response-as-their-session-has-expired

One downside if that if there's an actual server-side problem, we'll endlessly refresh the page. 🤷‍♀️ 

I tested this by tweaking the response in webserver.ml.

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

