### PR TITLE
When there is an exception in js_analysis, pass the error out.

### DIFF
--- a/backend/jsanalysis/jsanalysis.ml
+++ b/backend/jsanalysis/jsanalysis.ml
@@ -160,26 +160,27 @@ let () =
     "darkAnalysis"
     (object%js
        method performHandlerAnalysis
-             (stringified_handler_analysis_param : js_string) : js_string =
+             (stringified_handler_analysis_param : js_string)
+           : js_string Js.js_array Js.t =
          try
            stringified_handler_analysis_param
            |> Js.to_string
            |> perform_handler_analysis
-           |> Js.string
+           |> fun msg -> Js.array [|Js.string "success"; Js.string msg|]
          with e ->
-           print_endline
-             ("Exception in jsanalysis for handler: " ^ Exn.to_string e) ;
-           Exception.reraise e
+           let error = Exception.to_string e in
+           Js.array [|Js.string "failure"; Js.string error|]
 
        method performFunctionAnalysis
-             (stringified_function_analysis_param : js_string) : js_string =
+             (stringified_function_analysis_param : js_string)
+           : js_string Js.js_array Js.t =
          try
            stringified_function_analysis_param
            |> Js.to_string
            |> perform_function_analysis
-           |> Js.string
+           |> fun msg -> Js.array [|Js.string "success"; Js.string msg|]
          with e ->
-           print_endline ("Exception in jsanalysis: " ^ Exn.to_string e) ;
-           Exception.reraise e
+           let error = Exception.to_string e in
+           Js.array [|Js.string "failure"; Js.string error|]
     end) ;
   ()


### PR DESCRIPTION
When an error occurred during client-side analysis, we had no info. Instead, we got this:


![image](https://user-images.githubusercontent.com/181762/54873738-7719e980-4d9a-11e9-9da4-8fa06b1df411.png)

![image](https://user-images.githubusercontent.com/181762/54873737-6f5a4500-4d9a-11e9-876d-80e29a6a5a92.png)


Now we get this:

![image](https://user-images.githubusercontent.com/181762/54873740-839e4200-4d9a-11e9-86a4-7fe464da136c.png)

![image](https://user-images.githubusercontent.com/181762/54873745-8e58d700-4d9a-11e9-9cab-d4667586c70f.png)


- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

