### PR TITLE
The fact that the client has aborted the UnlockedDBs request, is not interesting

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -382,7 +382,7 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
           | Http.BadPayload _ ->
               true
           | Http.Aborted ->
-              true
+              not ignoreCommon
         in
         let shouldRollbar =
           match e with


### PR DESCRIPTION
Just don't report.

I would say don't rollbar, but that's at least slightly interesting.
