### PR TITLE
Don't log analysis results as errors if no error

### DIFF
--- a/client/workers/AnalysisWrapper.ml
+++ b/client/workers/AnalysisWrapper.ml
@@ -32,24 +32,24 @@ let () =
               Js.Json.stringify (Encoders.performHandlerAnalysisParams hParams)
             in
             let success, msg = darkAnalysis##performHandlerAnalysis encoded in
-            Js.logMany [|"An execution failure occurred in a handler"; msg|] ;
             if success = "success"
             then Belt.Result.Ok msg
-            else
+            else (
+              Js.logMany [|"An execution failure occurred in a handler"; msg|] ;
               Belt.Result.Error
-                (Types.AnalysisExecutionError (event##data, msg))
+                (Types.AnalysisExecutionError (event##data, msg)) )
         | AnalyzeFunction fParams ->
             let encoded =
               Js.Json.stringify
                 (Encoders.performFunctionAnalysisParams fParams)
             in
             let success, msg = darkAnalysis##performFunctionAnalysis encoded in
-            Js.logMany [|"An execution failure occurred in a function"; msg|] ;
             if success = "success"
             then Belt.Result.Ok msg
-            else
+            else (
+              Js.logMany [|"An execution failure occurred in a function"; msg|] ;
               Belt.Result.Error
-                (Types.AnalysisExecutionError (event##data, msg))
+                (Types.AnalysisExecutionError (event##data, msg)) )
       in
       let decoded =
         Tc.Result.andThen


### PR DESCRIPTION
No trello for this - relates to https://github.com/darklang/dark/pull/760

That PR introduced better logging for analysis errors - and then logged all analysis results, success or failure. Very confusing. This fixes that by only logging if there was an error

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

