### PR TITLE
Wrap Httpclient::* so it returns Results

### DIFF
--- a/backend/libexecution/libhttpclient.ml
+++ b/backend/libexecution/libhttpclient.ml
@@ -75,7 +75,7 @@ let fns : Lib.shortfn list =
     ; d = "Make blocking HTTP POST call to `uri`"
     ; f = NotClientAvailable
     ; ps = false
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["HttpClient::put_v1"]
     ; ins = []
     ; p = params
@@ -83,7 +83,7 @@ let fns : Lib.shortfn list =
     ; d = "Make blocking HTTP PUT call to `uri`"
     ; f = NotClientAvailable
     ; ps = false
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["HttpClient::get_v1"]
     ; ins = []
     ; p = params_no_body
@@ -91,18 +91,18 @@ let fns : Lib.shortfn list =
     ; d = "Make blocking HTTP GET call to `uri`"
     ; f = NotClientAvailable
     ; ps = false
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["HttpClient::delete_v1"]
     ; ins =
         []
-        (* https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE 
+        (* https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
          * the spec says it may have a body *)
     ; p = params_no_body
     ; r = TObj
     ; d = "Make blocking HTTP DELETE call to `uri`"
     ; f = NotClientAvailable
     ; ps = false
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["HttpClient::options_v1"]
     ; ins = []
     ; p = params_no_body
@@ -110,7 +110,7 @@ let fns : Lib.shortfn list =
     ; d = "Make blocking HTTP OPTIONS call to `uri`"
     ; f = NotClientAvailable
     ; ps = false
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["HttpClient::head_v1"]
     ; ins = []
     ; p = params_no_body
@@ -118,12 +118,78 @@ let fns : Lib.shortfn list =
     ; d = "Make blocking HTTP HEAD call to `uri`"
     ; f = NotClientAvailable
     ; ps = false
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["HttpClient::patch_v1"]
     ; ins = []
     ; p = params
     ; r = TObj
     ; d = "Make blocking HTTP PATCH call to `uri`"
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = true }
+  ; { pns = ["HttpClient::post_v2"]
+    ; ins = []
+    ; p = params
+    ; r = TObj
+    ; d =
+        "Make blocking HTTP POST call to `uri`. Returns a `Result` where `Ok` is a response Obj if successful and `Error` is an error message if not successful"
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["HttpClient::put_v2"]
+    ; ins = []
+    ; p = params
+    ; r = TObj
+    ; d =
+        "Make blocking HTTP PUT call to `uri`. Returns a `Result` where `Ok` is a response Obj if successful and `Error` is an error message if not successful"
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["HttpClient::get_v2"]
+    ; ins = []
+    ; p = params_no_body
+    ; r = TResult
+    ; d =
+        "Make blocking HTTP GET call to `uri`. Returns a `Result` where `Ok` is a response Obj if successful and `Error` is an error message if not successful"
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["HttpClient::delete_v2"]
+    ; ins =
+        []
+        (* https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
+         * the spec says it may have a body *)
+    ; p = params_no_body
+    ; r = TObj
+    ; d =
+        "Make blocking HTTP DELETE call to `uri`. Returns a `Result` where `Ok` is a response Obj if successful and `Error` is an error message if not successful"
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["HttpClient::options_v2"]
+    ; ins = []
+    ; p = params_no_body
+    ; r = TObj
+    ; d =
+        "Make blocking HTTP OPTIONS call to `uri`. Returns a `Result` where `Ok` is a response Obj if successful and `Error` is an error message if not successful"
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["HttpClient::head_v2"]
+    ; ins = []
+    ; p = params_no_body
+    ; r = TObj
+    ; d =
+        "Make blocking HTTP HEAD call to `uri`. Returns a `Result` where `Ok` is a response Obj if successful and `Error` is an error message if not successful"
+    ; f = NotClientAvailable
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["HttpClient::patch_v2"]
+    ; ins = []
+    ; p = params
+    ; r = TObj
+    ; d =
+        "Make blocking HTTP PATCH call to `uri`. Returns a `Result` where `Ok` is a response Obj if successful and `Error` is an error message if not successful"
     ; f = NotClientAvailable
     ; ps = false
     ; dep = false }


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Fixes https://trello.com/c/fAZYfVFB/776-httpclient-functions-should-return-result-not-derror

Ellen ran into this issue in her demo this morning, which was super annoying for a user. Users can't do anything with DErrors so it's sort of a dead-end from a demo/live-value POV. We probably don't want to use `Result` here at all, instead just putting everything into a response object with a good API -- but that requires some thought and the conversion from DError -> Result is an easy incremental win.

![image](https://user-images.githubusercontent.com/1179074/55253292-31ce3f80-5212-11e9-98ba-1aca9510fa0b.png)

![image](https://user-images.githubusercontent.com/1179074/55253380-693cec00-5212-11e9-9f2c-e4c3f65e5ea7.png)



Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [x] Does this add or change product features not discussed in the goals?
- User facing:
  - [x] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [x] If this was a regression, is there a test?
  - [x] Would comments help future understanding somewhere?
  - [x] Double check any change related to the serialization format.

