### PR TITLE
Add constructors to match patterns

### DIFF
--- a/client/src/AST.ml
+++ b/client/src/AST.ml
@@ -868,6 +868,8 @@ let getValueParent (p : pointerData) (expr : expr) : pointerData option =
       exprs |> List.map ~f:(fun x -> PExpr x) |> Util.listPrevious ~value:p
   | Field, Some (F (_, FieldAccess (obj, _))) ->
       Some (PExpr obj)
+  | Pattern, Some (F (_, Match (cond, _))) ->
+      Some (PExpr cond)
   | _ ->
       None
 

--- a/client/src/Entry.ml
+++ b/client/src/Entry.ml
@@ -588,7 +588,7 @@ let submitACItem
             replace (PParamName (B.newF value))
         | PParamTipe _, ACParamTipe tipe ->
             replace (PParamTipe (B.newF tipe))
-        | PPattern _, ACExtra value ->
+        | PPattern _, ACConstructorName value | PPattern _, ACExtra value ->
           ( match parsePattern value with
           | None ->
               DisplayError "not a pattern"


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Fixes https://trello.com/c/3DGTNiPQ/767-patterns-in-match-dont-autocomplete

Also cleans up some of the hacky `asName` stuff. Should make `match` a little less opaque.

![image](https://user-images.githubusercontent.com/1179074/55264955-6acadc00-5233-11e9-91a4-f19bac695e82.png)

![image](https://user-images.githubusercontent.com/1179074/55264964-75857100-5233-11e9-8774-50bf037771a4.png)

![image](https://user-images.githubusercontent.com/1179074/55264977-80400600-5233-11e9-9bfe-65fd011363ae.png)


Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

