### PR TITLE
Fix click in Autocomplete box for structured/typed entries

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -850,8 +850,7 @@ let update_ (msg : msg) (m : model) : modification =
   | AutocompleteClick value ->
     ( match unwrapCursorState m.cursorState with
     | Entering cursor ->
-        let complete = m.complete in
-        let newcomplete = {complete with value} in
+        let newcomplete = AC.setQuery m value m.complete in
         let newm = {m with complete = newcomplete} in
         Entry.submit newm cursor Entry.StayHere
     | _ ->


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [x] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

This would submit the clicked value as an ACExtra via the fall-thru
in Entry.submit because there's no `highlighted` value in the
autocomplete. This means that pointer types that don't support ACExtra
(which should be all of them!) would break.

Root cause: Bypassing the Autocomplete module's well defined interface.

Fixes https://trello.com/c/DpoGyJgo/777-clicking-in-the-autocomplete-for-db-schema-options-does-not-save-typing-string-and-hitting-enter-does

Unsure if this worth an integration test as I'll be killing this UI in the next few weeks with DBs-with-record-types?


Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

