### PR TITLE
Fix stored_events gc

### DIFF
--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -86,7 +86,7 @@ let dequeue_and_process execution_id : (unit, Exception.captured) Result.t =
                       ; ("host", host)
                       ; ("event", Log.dump desc)
                       ; ("handler_id", Log.dump h.tlid)
-                      ; ("result", Log.dump result) ] ;
+                      ; ("result", Dval.show result) ] ;
                   Event_queue.finish transaction event ;
                   Ok ()
             with e ->


### PR DESCRIPTION
Fixes https://trello.com/c/wCDYIAya/765-gc-tooling-for-storedevents-storedfunctionresults, is a bugfix for Ian's user tipes work.
 
- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))

Problem: gc stopped gc'ing on Friday afternoon, but HTTP handler still worked fine. Clues:
- time of failure (seen in Honecomb) correlated /w 2 deploys, one of which ended up being the salient one
- "result" value in logs (also in Honeycomb) went from looking like `Tag1 (<some float>)` to `<closure>`

Note: when we send result to logs, now we use Dval.show instead of Log.dump, which would've caught this bug.

- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

