### PR TITLE
String::newline

### DIFF
--- a/backend/libexecution/libstd.ml
+++ b/backend/libexecution/libstd.ml
@@ -743,6 +743,14 @@ let fns : Lib.shortfn list =
               fail args)
     ; ps = true
     ; dep = false }
+  ; { pns = ["String::newline"]
+    ; ins = []
+    ; p = []
+    ; r = TStr
+    ; d = "Returns a string containing a single '\n'"
+    ; f = InProcess (function _ -> DStr (Unicode_string.of_string_exn "\n"))
+    ; ps = true
+    ; dep = false }
   ; { pns = ["String::toList"]
     ; ins = []
     ; p = [par "s" TStr]


### PR DESCRIPTION
Because right now we have no way of entering a newline in Dark, and
hotsauce wants a newline so we can construct an RFC2822 email.

(String::base64Encode String::newline) -> "cG"

echo Cg== | base64 -d -> \n

Part of https://trello.com/c/Ai7FSowC/554-welcome-email-for-useradd-canvas-copy-api-integration

Alternatives: I suspect this isn't a permanent solution; I suspect users other than us will also assume "\n" means newline.  But this unblocks the hotsauce project, by allowing us to construct an RFC2822 email for gmail's api.

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

