### PR TITLE
String::mustContainSubstring and String::mustNotContainSubstring

### DIFF
--- a/backend/libexecution/libstd.ml
+++ b/backend/libexecution/libstd.ml
@@ -668,7 +668,49 @@ let fns : Lib.shortfn list =
   ; (* ====================================== *)
     (* String *)
     (* ====================================== *)
-    { pns = ["String::foreach"]
+    { pns = ["String::mustContainSubstring"]
+    ; ins = []
+    ; p = [par "s" TStr; par "substr" TStr]
+    ; r = TNull
+    ; d = "If input string does not contain substring, fail."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr s; DStr substr] ->
+              if Unicode_string.is_substring ~substring:substr s
+              then DNull
+              else
+                DError
+                  (Printf.sprintf
+                     "Expected '%s' to be a substr of '%s"
+                     (Unicode_string.to_string substr)
+                     (Unicode_string.to_string s))
+          | args ->
+              fail args)
+    ; ps = true
+    ; dep = false }
+  ; { pns = ["String::mustNotContainSubstring"]
+    ; ins = []
+    ; p = [par "s" TStr; par "substr" TStr]
+    ; r = TNull
+    ; d = "If input string contains substring, fail."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr s; DStr substr] ->
+              if not (Unicode_string.is_substring ~substring:substr s)
+              then DNull
+              else
+                DError
+                  (Printf.sprintf
+                     "Expected '%s' to be a substr of '%s"
+                     (Unicode_string.to_string substr)
+                     (Unicode_string.to_string s))
+          | args ->
+              fail args)
+    ; ps = true
+    ; dep = false }
+  ; { pns = ["String::foreach"]
     ; ins = []
     ; p = [par "s" TStr; func ["char"]]
     ; r = TStr


### PR DESCRIPTION
Consider this a strawman; instead of making this return a boolean, we
treat these as asserts.

Intended use: string is a rendered template, substring is '{{'; if
string contains any instances of '{{', we error, because that means we
failed to interpolate all {{variables}}.

Related to: https://trello.com/c/Ai7FSowC/554-welcome-email-for-useradd-canvas-copy-api-integration

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

