### PR TITLE
Type check `Any` correctly in function calls

### DIFF
--- a/backend/libexecution/type_checker.ml
+++ b/backend/libexecution/type_checker.ml
@@ -77,6 +77,13 @@ let error err = Error [err]
 let rec unify ~(type_env : type_env) (expected : tipe) (value : dval) :
     (unit, Error.t list) Result.t =
   match (expected, value) with
+  (* Any should be removed, but we currently allow it as a param tipe
+   * in user functions, so we should allow it here.
+   *
+   * Potentially needs to be removed before we use this type checker for DBs?
+   *   - Could always have a type checking context that allows/disallows any *)
+  | TAny, _ ->
+      Ok ()
   | TInt, DInt _ ->
       Ok ()
   | TFloat, DFloat _ ->

--- a/backend/test/test.ml
+++ b/backend/test/test.ml
@@ -2276,6 +2276,17 @@ let t_basic_typecheck_works_unhappy () =
     (Type_checker.check_function_call ~user_tipes fn args |> Result.is_error)
 
 
+let t_typecheck_any () =
+  let args = DvalMap.of_alist_exn [("v", DInt 5)] in
+  let fn = Libs.get_fn_exn ~user_fns:[] "toString" in
+  let user_tipes = [] in
+  AT.check
+    AT.bool
+    "Typechecking 'Any' succeeds"
+    true
+    (Type_checker.check_function_call ~user_tipes fn args |> Result.is_ok)
+
+
 (* ------------------- *)
 (* Test setup *)
 (* ------------------- *)
@@ -2470,7 +2481,9 @@ let suite =
     , t_basic_typecheck_works_happy )
   ; ( "Basic typechecking works in unhappy case"
     , `Quick
-    , t_basic_typecheck_works_unhappy ) ]
+    , t_basic_typecheck_works_unhappy )
+  ; ("Type checking supports `Any` in user functions", `Quick, t_typecheck_any)
+  ]
 
 
 let () =


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [x] If this is fixing a regression, add a test

Fixes https://trello.com/c/2q3f2cOc/794-the-any-type-does-not-unify-with-everything-as-it-should

Fairly self-explanatory, test will fail without patch, succeeds with patch. (Note: `toString` takes a `TAny` as a parameter)

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [x] Does this add or change product features not discussed in the goals?
- User facing:
  - [x] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [x] If this was a regression, is there a test?
  - [x] Would comments help future understanding somewhere?
  - [x] Double check any change related to the serialization format.

