### PR TITLE
GC old function arguments

### DIFF
--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -572,14 +572,19 @@ let cleanup_old_traces () : float =
   let function_results_start = Unix.gettimeofday () in
   let trimmed_results = Stored_function_result.trim_results () in
   let function_results_time = runtime_since function_results_start in
+  let function_arguments_start = Unix.gettimeofday () in
+  let trimmed_arguments = Stored_function_arguments.trim_arguments () in
+  let function_arguments_time = runtime_since function_arguments_start in
   let total_time = runtime_since start in
   Log.infO
     "cleanup_old_traces"
     ~jsonparams:
       [ ("trimmed_results", `Int trimmed_results)
       ; ("trimmed_events", `Int trimmed_events)
+      ; ("trimmed_arguments", `Int trimmed_arguments)
       ; ("stored_events_time", `Float stored_events_time)
       ; ("function_results_time", `Float function_results_time)
+      ; ("function_arguments_time", `Float function_arguments_time)
       ; ("total_time", `Float total_time) ] ;
   total_time
 

--- a/backend/libbackend/stored_function_arguments.mli
+++ b/backend/libbackend/stored_function_arguments.mli
@@ -15,3 +15,6 @@ val load_for_analysis :
   -> (Analysis_types.input_vars * Types.RuntimeT.time) option
 
 val load_traceids : canvas_id:Uuidm.t -> Types.tlid -> Uuidm.t list
+
+(* GC old function arguments *)
+val trim_arguments : unit -> int

--- a/backend/libbackend/stored_function_result.mli
+++ b/backend/libbackend/stored_function_result.mli
@@ -15,7 +15,4 @@ val load :
   -> Types.tlid
   -> Analysis_types.function_result list
 
-(* Trim the events for an entire canvas, removing events from before the time,
- * unless listed in keep.
- *)
 val trim_results : unit -> int


### PR DESCRIPTION
Same as stored_events and function_results, we GC anything:
- older than 1 week AND
- not in the latest 10 of that set ("older than 1 week")

Didn't do this in the previous round
(https://trello.com/c/wCDYIAya/765-gc-tooling-for-storedevents-storedfunctionresults)
because low usage of functions means there isn't much accumulated
backlog yet ... but we may as well put this in before it is a problem.

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [x] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [x] If this was a regression, is there a test?
  - [x] Would comments help future understanding somewhere?
  - [x] Double check any change related to the serialization format.

