### PR TITLE
When uploading, replace DARK_STATIC_ASSETS_BASE_URL with the deploy url

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -458,6 +458,16 @@ let static_assets_upload_handler
               (Multipart.file_stream file)
               ""
           in
+          (* Replace DARK_STATIC_ASSETS_BASE_URL with the deployed URL. This
+           * will allow users to create SPAs with a sentinel value in them to
+           * converts to the absolute url. In React, you would do this with
+           * PUBLIC_URL. *)
+          let body =
+            String.substr_replace_all
+              body
+              ~pattern:"DARK_STATIC_ASSETS_BASE_URL"
+              ~with_:sa.url
+          in
           Static_assets.upload_to_bucket filename body canvas deploy_hash
         in
         Lwt.return (files |> List.map ~f:processfile)


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [x] Add intended followups as trellos 
- [x] If risky, discuss your reversion strategy
- [x] If this is fixing a regression, add a test

https://trello.com/c/9o9TB5TX/813-replace-darkstaticassetsbaseurl-at-deploy-time-with-the-deploy-url

When deploying a react app, the urls will use absolute URLs, which we don't support. To avoid this, we can use PUBLIC_URL and set that to whatever string we want at `npm build` time. We told users to set PUBLIC_URL to DARK_STATIC_ASSETS_BASE_URL, and to then replace that when index.html is served (they couldn't do it sooner, as they didn't know the deploy url when they built their assets).

This didn't work very well. Although we could get index.html to change, other assets wouldn't change. The correct way to do it is to change the string at deploy time in all files. This does that.

When we have absolute URLs, we may not need this anymore. 

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

