### PR TITLE
Dont toggle routing for plus

### DIFF
--- a/client/src/ViewRoutingTable.ml
+++ b/client/src/ViewRoutingTable.ml
@@ -36,7 +36,7 @@ and item =
 
 let buttonLink ~(key : string) (content : msg Html.html) (handler : msg) :
     msg Html.html =
-  let event = ViewUtils.eventNoDefault ~key "click" (fun _ -> handler) in
+  let event = ViewUtils.eventNeither ~key "click" (fun _ -> handler) in
   Html.a [event; Html.class' "button-link"] [content]
 
 

--- a/client/src/ViewUtils.ml
+++ b/client/src/ViewUtils.ml
@@ -123,6 +123,16 @@ let decodeTransEvent (fn : string -> 'a) j : 'a =
   fn (JSD.field "propertyName" JSD.string j)
 
 
+let eventNeither
+    ~(key : string) (event : string) (constructor : mouseEvent -> msg) :
+    msg Vdom.property =
+  Patched_tea_html.onWithOptions
+    ~key
+    event
+    {stopPropagation = true; preventDefault = true}
+    (Decoders.wrapDecoder (decodeClickEvent constructor))
+
+
 let eventNoPropagation
     ~(key : string) (event : string) (constructor : mouseEvent -> msg) :
     msg Vdom.property =


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

https://trello.com/c/wTLgt8Rl/788-bug-clicking-in-routing-table-next-to-a-header-eg-http-both-creates-a-handler-and-toggles-expand-collapse-of-that-section-of-the

When we press (+), the routing table opens and closes. This adds ViewUtils.eventNeither, which neither propagates nor does the default. I tried both eventNoDefault and eventNoPropagate, and the old behaviour stayed for both. With eventNeither, it stopped.

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [x] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

