### PR TITLE
Originally, is_pageable was true or null

### DIFF
--- a/backend/libservice/rollbar.ml
+++ b/backend/libservice/rollbar.ml
@@ -191,11 +191,10 @@ let log_rollbar (r : Buffer.t) (payload : Yojson.Safe.json) (e : exn) : unit =
         ("rollbar", `String link) :: payload
   in
   let payload =
-    match e with
-    | Pageable.PageableExn _ ->
-        ("is_pageable", `Bool true) :: payload
-    | _ ->
-        payload
+    let is_pageable =
+      match e with Pageable.PageableExn _ -> true | _ -> false
+    in
+    ("is_pageable", `Bool is_pageable) :: payload
   in
   Log.erroR "rollbar" ~jsonparams:payload
 


### PR DESCRIPTION
Followup for #800 

But we can't construct a query including a field honeycomb has never
seen, so ... we can't create a trigger/alert for is_pageable=true until
we get a pagable exn. Oops.

By defaulting to false, we get this field added to the schema as soon Fas
rollbar goes off at all, which means we can put an alert on it quickly.

https://trello.com/c/zPJBbq4O/808-pagerduty-alert-if-canvas-cant-save

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] Does this match the goal of the PR or trello?
  - [x] Does this add or change product features not discussed in the goals?
- User facing:
  - [x] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [x] Is there consistent naming of new user concepts?
- Engineering: 
  - [x] If this was a regression, is there a test?
  - [x] Would comments help future understanding somewhere?
  - [x] Double check any change related to the serialization format.

