### PR TITLE
Bump merlin version to fix CI dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -232,7 +232,7 @@ RUN opam install -y \
   js_of_ocaml-lwt.3.2.0 \
   sodium.0.6.0 \
   utop \
-  ocamlformat \
+  ocamlformat.0.8 \
   uuseg.11.0.0 \
   uunf.11.0.0 \
   multipart-form-data.0.1.0 \


### PR DESCRIPTION
```
The following dependencies couldn't be met:
  - merlin → ocaml < 4.07
      base of this switch (use `--unlock-base' to force)
```
in
https://circleci.com/gh/darklang/dark/9367

No PR - fixing a CI issue.

Slack discussion at https://dark-inc.slack.com/archives/CC3R87UCW/p1555101402000600

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

