### PR TITLE
Fix w/ test for path > / (old handler stored_events)

### DIFF
--- a/backend/libexecution/http.ml
+++ b/backend/libexecution/http.ml
@@ -67,17 +67,6 @@ let bind_route_variables ~(route : string) (request_path : string) :
       (* If the route is shorter than the path, AND the last segment of the route is
        * wild then we'll munge the path's extra segments into a single string such that
        * the lengths match and we can do a zip binding *)
-      Log.infO
-        "ROUTE"
-        ~params:
-          [ ("split_path", Log.dump split_path)
-          ; ("path", request_path)
-          ; ("route", route)
-          ; ("empty list", Log.dump [])
-          ; ("split_route", Log.dump split_route) ] ;
-      (* route '/' has split_route [], so we need List.last here, not
-      * List.last_exn *)
-      (* saw this bug with route '/', path '/favicon.ico' *)
       let last_route_segment = List.last split_route in
       if Option.is_some (last_route_segment |> Option.bind ~f:route_variable)
          || Option.value ~default:"" last_route_segment = "%"

--- a/backend/test/test.ml
+++ b/backend/test/test.ml
@@ -2519,6 +2519,13 @@ let t_route_non_prefix_colon_does_not_denote_variable () =
   AT.check AT.bool "binding fails due to concrete mismatch" true (None = bound)
 
 
+let t_path_gt_route_does_not_crash () =
+  let route = "/" in
+  let path = "/a/b/c/d" in
+  let bound = Http.bind_route_variables ~route path in
+  AT.check AT.bool "binding fails without crash" true (None = bound)
+
+
 (* ------------------- *)
 (* Test setup *)
 (* ------------------- *)
@@ -2746,7 +2753,10 @@ let suite =
     , t_route_eq_path_match_concrete )
   ; ( "apparent route variable that's not a prefix does not match"
     , `Quick
-    , t_route_non_prefix_colon_does_not_denote_variable ) ]
+    , t_route_non_prefix_colon_does_not_denote_variable )
+  ; ( "path > route with root handler does not crash"
+    , `Quick
+    , t_path_gt_route_does_not_crash ) ]
 
 
 let () =


### PR DESCRIPTION
- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

This bug is causing issues on loads for handlers/stored_event pairs where there is a `/` handler and some data for that handler like `/foo`.

Test fails without the fix.

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

