### PR TITLE
Fix error re: DB list types

### DIFF
--- a/backend/libexecution/dval.ml
+++ b/backend/libexecution/dval.ml
@@ -178,11 +178,11 @@ and parse_list_tipe (list_tipe : string) : tipe =
   | "datastore" ->
       Exception.internal "todo"
   | "date" ->
-      Exception.internal "todo"
+      TDbList TDate
   | "title" ->
-      Exception.internal "todo"
+      TDbList TTitle
   | "url" ->
-      Exception.internal "todo"
+      TDbList TUrl
   | table ->
       THasMany list_tipe
 

--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -631,15 +631,7 @@ let generate (m : model) (a : autocomplete) : autocomplete =
           [ACEventSpace "HTTP"; ACEventSpace "CRON"]
       | DBColType ->
           let builtins =
-            [ "String"
-            ; "Int"
-            ; "Boolean"
-            ; "Float"
-            ; "Title"
-            ; "Url"
-            ; "Date"
-            ; "Password"
-            ; "UUID" ]
+            ["String"; "Int"; "Boolean"; "Float"; "Title"; "Date"; "UUID"]
           in
           let compound = List.map ~f:(fun s -> "[" ^ s ^ "]") builtins in
           List.map ~f:(fun x -> ACDBColType x) (builtins @ compound)


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos 
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Fixes: https://trello.com/c/ntoHygUx/820-todo-type-date-triggered-an-alert

We are throwing exceptions on types we let the user select in the
Autocomplete. This moves forward some of the URL/Title removal to
prevent any DBs being added with those fields, and fully supports
them + Date in the DB parser.

Reviewer checklist:
- Product:
  - [ ] Does this match the goal of the PR or trello?
  - [ ] Does this add or change product features not discussed in the goals?
- User facing:
  - [ ] Could this cause a silent change in behaviour of user programs, eg an output format or function behaviour?
  - [ ] Is there consistent naming of new user concepts?
- Engineering: 
  - [ ] If this was a regression, is there a test?
  - [ ] Would comments help future understanding somewhere?
  - [ ] Double check any change related to the serialization format.

