### PR TITLE
Handle json.load errors in postgres-honeytail

### DIFF
--- a/postgres-honeytail/logs.py
+++ b/postgres-honeytail/logs.py
@@ -5,7 +5,6 @@ import json
 import re
 import sys
 import os
-from future.utils import raise_from
 
 LOG_LINE_PREFIX_RE = re.compile(
     "^\\[[0-9]*\\]: \\[[0-9]*-1\\] db=[^,]*,user=[^ ]* ")
@@ -25,7 +24,7 @@ def process_message(data):
         j = json.loads(data)
     except json.decoder.JSONDecodeError as e:
         msg = "Error, could not load json from message: '{}'".format(data)
-        raise_from(msg, e)
+        raise msg from e
         return ""
 
     # log_line_prefix can't be changed in CloudSQL, so we're going to add our


### PR DESCRIPTION
https://trello.com/c/ZvIGFiQV/839-handle-json-errors-in-postgres-honeytail

See: https://console.cloud.google.com/errors/CKKJ15jyg6j6qwE?time=P30D&project=balmy-ground-195100&authuser=0

"json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)"

No trello; for now this is just better error logging so we know what messages are getting dropped.

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

