### PR TITLE
Reduce resource limits for postgres-honeycomb pod

### DIFF
--- a/scripts/support/kubernetes/postgres-honeytail-deployment.yaml.template
+++ b/scripts/support/kubernetes/postgres-honeytail-deployment.yaml.template
@@ -18,7 +18,7 @@ spec:
       containers:
         - image: "gcr.io/balmy-ground-195100/dark-gcp-postgres-honeytail:{POSTGRES_HONEYTAIL_IMAGE}"
           name: postgres-honeytail-ctr
-          # This pod is a 'Burstable, ref:
+          # This pod is a 'Burstable' pod, ref:
           #  https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6
           resources:
             requests:


### PR DESCRIPTION
https://trello.com/c/j2sYovbi/825-post-postgres-honeytail-deploy-check-actual-cpu-mem-usage-and-adjust-k8s-spec-accordingly

https://ui.honeycomb.io/dark/datasets/kubernetes-resource-metrics/result/nZdThdN4FLv

Honeycomb shows a brief spike when this deploy first went out - likely
due to having a backlog of messages to catch up to - and subsequently,
CPU usage has been stable at ~35, and mem at 63M.

We also don't need these to be "guaranteed"; burstable seems fine: https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6

Giving them 2x observed usage for requests, and 4x for limit, gets us
75m/150m cpu, and 128Mi/256Mi ram.

If this turns out to be insufficient (or if postgres usage, and thus
logging, increases), we'll know when this pod restarts frequently.
(Filed as
https://trello.com/c/jFG6ziub/838-alert-graph-something-for-pod-restarts)

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [x] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

