### PR TITLE
add take sidebar width away from window start point

### DIFF
--- a/client/src/Url.ml
+++ b/client/src/Url.ml
@@ -169,9 +169,14 @@ let calculatePanOffset (m : model) (tl : toplevel) (page : page) : model =
           {w = Native.Ext.clientWidth e; h = Native.Ext.clientHeight e}
         in
         let windowSize = m.canvasProps.viewportSize in
-        if Viewport.isEnclosed
-             (m.canvasProps.offset, windowSize)
-             (tl.pos, tsize)
+        let sidebarWidth =
+          let sidebar = Native.Ext.querySelector "#sidebar-left" in
+          match sidebar with Some e -> Native.Ext.clientWidth e | None -> 320
+        in
+        let outerOffset =
+          {m.canvasProps.offset with x = m.canvasProps.offset.x + sidebarWidth}
+        in
+        if Viewport.isEnclosed (outerOffset, windowSize) (tl.pos, tsize)
         then m.canvasProps.offset
         else Viewport.centerCanvasOn tl m.canvasProps
     | None ->


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/c/JUFg94uQ)  link
- [x] Describe the goals, problem and solution
We forgot to account for sidebar width when figuring out if a toplevel is within viewport.
Therefore it is considered visible even when its hidden behind sidebar.
Add sidebar width to viewport (outer box) offset when passing to Viewport.isEnclosed function

- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

