### PR TITLE
When a function is extracted, don't add DB (or other global-scope vars) to parameters 

### DIFF
--- a/client/src/Analysis.ml
+++ b/client/src/Analysis.ml
@@ -193,7 +193,7 @@ let getCurrentAvailableVarnames (m : model) (tl : toplevel) (ID id : id) :
     |> StrDict.get ~key:id
     |> Option.withDefault ~default:[]
   in
-  let dbs = TL.allDBNames m.toplevels in
+  let glob = TL.allGloballyScopedVarnames m.toplevels in
   match tl.data with
   | TLHandler h ->
       let extras =
@@ -213,13 +213,13 @@ let getCurrentAvailableVarnames (m : model) (tl : toplevel) (ID id : id) :
         | _ ->
             ["request"; "event"]
       in
-      varsFor h.ast @ dbs @ extras
+      varsFor h.ast @ glob @ extras
   | TLFunc fn ->
       let params =
         fn.ufMetadata.ufmParameters
         |> List.filterMap ~f:(fun p -> Blank.toMaybe p.ufpName)
       in
-      varsFor fn.ufAST @ dbs @ params
+      varsFor fn.ufAST @ glob @ params
   | TLDB _ | TLTipe _ ->
       []
 

--- a/client/src/Refactor.ml
+++ b/client/src/Refactor.ml
@@ -151,10 +151,10 @@ let extractFunction (m : model) (tl : toplevel) (p : pointerData) :
     match p with
     | PExpr body ->
         let name = generateFnName () in
-        let dbs = TL.allDBNames m.toplevels in
+        let glob = TL.allGloballyScopedVarnames m.toplevels in
         let freeVars =
           AST.freeVariables body
-          |> List.filter ~f:(fun (_id, v) -> not (List.member ~value:v dbs))
+          |> List.filter ~f:(fun (_id, v) -> not (List.member ~value:v glob))
         in
         let paramExprs =
           List.map ~f:(fun (_, name_) -> F (gid (), Variable name_)) freeVars

--- a/client/src/Toplevel.ml
+++ b/client/src/Toplevel.ml
@@ -524,6 +524,10 @@ let allDBNames (toplevels : toplevel list) : string list =
              None )
 
 
+let allGloballyScopedVarnames (toplevels : toplevel list) : string list =
+  allDBNames toplevels
+
+
 let asPage (tl : toplevel) : page =
   match tl.data with
   | TLHandler _ ->


### PR DESCRIPTION
Prevents extracted function from including DB in parameters of function because DBs always exist in global scope. General function was created for this, especially in the event that more globally scoped types are added.

Involved changing `Refactor.extractFunction` to filter out DBs from the free variables in function bodies that are converted to function params. Also wrapped `TopLevel.allDBNames` with `TopLevel.allGloballyScopedVarnames` to generalize and allow for easy extension in the future.

Fixes [this ticket](https://trello.com/c/EFG0pKwd/796-when-you-extract-a-function-and-the-function-has-a-datastore-param-it-collides-with-db-in-scope-and-breaks-analysis).

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

