### PR TITLE
Rollbar log stomps on webserver.ml's honeycomb-compatible request value

### DIFF
--- a/backend/libservice/rollbar.ml
+++ b/backend/libservice/rollbar.ml
@@ -183,6 +183,15 @@ let log_rollbar (r : Buffer.t) (payload : Yojson.Safe.json) (e : exn) : unit =
     | _ ->
         [("error", `String "unexpected payload format")]
   in
+  (* rollbar payload includes a request object, but this overwrites the
+     * request path data (key "request") set in webserver.ml, which is in a
+     * format that honeycomb knows how to deal with. So the key for rollbar's
+     * request data to request_obj *)
+  let payload =
+    payload
+    |> List.map ~f:(fun (k, v) ->
+           match k with "request" -> ("request_obj", v) | _ -> (k, v) )
+  in
   let payload =
     match rollbar_link_of_curl_buffer r with
     | None ->


### PR DESCRIPTION
- Rollbar payload includes a request object; this is good, we want that
in rollbar
- We don't want it in the _log_ with that key, though, because that data
is mostly covered by the ("request", request_path) (and method, host,
etc) set in webserver.ml, which honeycomb knows how to parse into
request shapes (and pull out, eg, canvas)
- I considered List.filter'ing it out, but ... decided to just rename it
request_obj so we have both sets of data

https://trello.com/c/89TBo2nU/855-rollbar-shouldnt-stomp-on-request-data-in-honeycomb-logs

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

