### PR TITLE
Remove extra url if there is no other hash state

### DIFF
--- a/client/src/Url.ml
+++ b/client/src/Url.ml
@@ -7,7 +7,11 @@ module TL = Toplevel
 
 let hashUrlParams (params : (string * string) list) : string =
   let merged = List.map ~f:(fun (k, v) -> k ^ "=" ^ v) params in
-  "#" ^ String.join ~sep:"&" merged
+  if merged = []
+  then
+    (* the space here is important - https://stackoverflow.com/a/49373716/104021 *)
+    " "
+  else "#" ^ String.join ~sep:"&" merged
 
 
 let urlFor (page : page) : string =


### PR DESCRIPTION
This solves what is clearly our most important issue: https://trello.com/c/MCJkp0Lv/857-remove-the-from-the-url-1010

We previously would show a `#` EVEN WHEN THERE WAS NO STATE IN THE URL! Madness! This fixes it so that there is no hash unless there's something after it.

![image](https://user-images.githubusercontent.com/181762/56920660-ab0ebb80-6a78-11e9-9d41-0d3b22b4779a.png)


- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

