### PR TITLE
Bug: deleting db name causes app crash

### DIFF
--- a/client/src/Selection.ml
+++ b/client/src/Selection.ml
@@ -387,7 +387,7 @@ let delete (m : model) (tlid : tlid) (mId : id option) : modification =
               RPC ([SetFunction f], focus)
           | TLTipe _ | TLDB _ ->
               impossible ("pointer type mismatch", newTL.data, pd) )
-      | FnName | TypeName ->
+      | DBName | FnName | TypeName ->
           Many [Enter (Filling (tlid, id)); AutocompleteMod (ACSetQuery "")]
       | _ ->
           let newTL = TL.delete tl pd newID in


### PR DESCRIPTION
DBName should behave same as FnName and TypeName here - "we just put the
cursorState to Entering and set the autocomplete content to """

https://trello.com/c/ptazgpUX/768-deleting-db-name-causes-crash-97

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

