### PR TITLE
Trace the blank for keys in records

### DIFF
--- a/backend/libexecution/ast.ml
+++ b/backend/libexecution/ast.ml
@@ -211,14 +211,15 @@ let rec exec
         |> fun l -> find_derrorrail l |> Option.value ~default:(DList l)
     | Filled (_, ObjectLiteral pairs) ->
         pairs
-        |> List.filter_map ~f:(function
-               | Filled (_, k), v ->
+        |> List.filter_map ~f:(fun (k, v) ->
+               match (k, v) with
+               | Filled (_, keyname), v ->
                    let expr = exe st v in
-                   ( match expr with
-                   | DIncomplete ->
-                       None (* ignore unfinished subexpr *)
-                   | _ ->
-                       Some (k, expr) )
+                   trace_blank k expr st ;
+                   if expr = DIncomplete
+                   then (* ignore unfinished subexpr *)
+                     None
+                   else Some (keyname, expr)
                | _, v ->
                    ignore (exe st v) ;
                    None )


### PR DESCRIPTION
https://trello.com/c/P1CEPzNr/888-show-a-livevalue-for-keys-of-objects-68

Keys in records used to show a livevalue of `<loading>`. Now they show the value in question.

Before:
![image](https://user-images.githubusercontent.com/181762/56933472-defbd800-6a9c-11e9-85a8-0316c9524647.png)

After:
![image](https://user-images.githubusercontent.com/181762/56933445-c4c1fa00-6a9c-11e9-9550-7787c04be907.png)

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test



Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

