### PR TITLE
Validate function params start with [a-z]

### DIFF
--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -351,6 +351,10 @@ let keynameValidator = ".+"
 
 let fnNameValidator = "[a-z][a-zA-Z0-9_]*"
 
+(* NB: disallowing inital-capitals also defends against having a collision
+ * between a function param name and a db name *)
+let paramNameValidator = "[a-z][a-zA-Z0-9_]*"
+
 let typeNameValidator = dbNameValidator
 
 let paramTypeValidator = "[A-Za-z0-9_]*"

--- a/client/src/Entry.ml
+++ b/client/src/Entry.ml
@@ -302,7 +302,7 @@ let validate (tl : toplevel) (pd : pointerData) (value : string) :
   | PConstructorName _ ->
       v AC.constructorNameValidator "constructor name"
   | PParamName _ ->
-      None
+      v AC.paramNameValidator "param name"
   | PParamTipe _ ->
       v AC.paramTypeValidator "param type"
   | PTypeName _ ->


### PR DESCRIPTION
https://trello.com/c/M68ABPPM/833-if-you-add-a-parameter-to-a-function-with-the-same-name-as-a-global-variable-analysis-crashes-99

Avoids crash when function param name collides with a db name, since db
names must start with [A-Z]

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

