### PR TITLE
Fix ViewUtils.viewState type-error from pbiggar/fluid merge

### DIFF
--- a/client/__tests__/view_blankor.ml
+++ b/client/__tests__/view_blankor.ml
@@ -65,7 +65,7 @@ let () =
             ; inReferences = []
             ; toReferences = []
             ; usagesOfHoveredReference = []
-            ; fluidState = Defaults.defaultFluidState}
+            ; fluidState = Defaults.defaultFluidState }
           in
           expect (placeHolderFor vs id ParamName) |> toBe "param name" ) ;
       () ) ;


### PR DESCRIPTION
Fixes type error due to new field in merge of [paul/integrate-fluid](https://github.com/darklang/dark/pull/845). New `fluidState` field was added to `ViewUtils.viewState` and it broke unittest setup in [`client/__tests__/view_blankor.ml`](https://github.com/darklang/dark/blob/master/client/__tests__/view_blankor.ml). See failed build [here](https://circleci.com/gh/darklang/dark/10550).

In the future, more robust defaults should be added to [`client/src/Defaults.ml`](https://github.com/darklang/dark/blob/master/client/src/Defaults.ml) to prevent repeated code in unit tests setup. This could not be achieved now due to a number of circular dependency errors.

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

