### PR TITLE
If gke-deploy aborts, clean up the deploy lock file

### DIFF
--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -107,6 +107,17 @@ fi
 # Lock before doing a deploy (don't forget to unlock!)
 #############################
 
+cleanup_deploy_lock() {
+  trap '' EXIT # some shells will call EXIT after the INT handler
+  if [[ "${DEPLOY_LOCK_BUCKET}" != "" && "${THIS_DEPLOY_LOCKFILE}" != "" ]];
+  then
+    echo "Removing deploy lock: ${DEPLOY_LOCK_BUCKET}/deploy-lock-${THIS_DEPLOY_LOCKFILE}"
+    gsutil rm "${DEPLOY_LOCK_BUCKET}/deploy-lock-${THIS_DEPLOY_LOCKFILE}"
+  fi
+
+  exit 1
+}
+
 deploy_lock_claimed=""
 
 while [[ "${deploy_lock_claimed}" != "true" ]]; do
@@ -128,6 +139,9 @@ while [[ "${deploy_lock_claimed}" != "true" ]]; do
     if [[ "${max_deploy_lock}" == "" ]]; then
       echo date > "deploy-lock-${THIS_DEPLOY_LOCKFILE}"
       gsutil cp "deploy-lock-${THIS_DEPLOY_LOCKFILE}" "${DEPLOY_LOCK_BUCKET}"
+      # Make sure we remove the lockfile if this script exits early for some reason
+      trap cleanup_deploy_lock INT QUIT TERM
+
       deploy_lock_claimed="true"
     # if the biggest # is greater than ours, then exit instead of deploying
     # NB: "manual-deploy" is greater than any numeric string, so it will always


### PR DESCRIPTION
https://trello.com/c/FdBsw3cX/869-cleanup-deploy-locks

If Circle creates a deploy lockfile, we don't do anything to clean it up, and subsequent attempts to deploy lock until someone manually removes the old lockfile.  Trapping INT/TERM/QUIT should cover that.

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

