### PR TITLE
Absolute minimum to give axel and jessica access to a shared pixelkee…

### DIFF
--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -151,9 +151,20 @@ let valid_user ~(username : username) ~(password : string) : bool =
 
 let can_access_operations ~(username : username) : bool = is_admin ~username
 
+(* This is its own function b/c ocamlformat doesn't want to let me put parens
+ * around these conditions - `x || y || (z && w) || v` loses its parens *)
+(* A join table would be nice for this - "canvas x can be edited by these
+ * accounts" - but this unblocks pixelkeet *)
+let special_cased_can_edit_canvas
+    ~(auth_domain : string) ~(username : username) : bool =
+  String.Caseless.equal "pixelkeet" auth_domain
+  && String.Caseless.equal "laxels" username
+
+
 let can_edit_canvas ~(auth_domain : string) ~(username : username) : bool =
   String.Caseless.equal username auth_domain
   || String.Caseless.equal "sample" auth_domain
+  || special_cased_can_edit_canvas auth_domain username
   || is_admin username
 
 


### PR DESCRIPTION
…t- namespace

https://trello.com/c/mQRDHrRr/903-shared-credentials

Next step would be to use a join table so other canvas-spaces can be
shared, but this unblocks pixelkeet.

Tested locally by hardcoding in ismith and dropping my admin status.

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

