### PR TITLE
Re-add support for passwords to DBs

### DIFF
--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -653,7 +653,7 @@ let generate (m : model) (a : autocomplete) : autocomplete =
           [ACEventSpace "HTTP"; ACEventSpace "CRON"]
       | DBColType ->
           let builtins =
-            ["String"; "Int"; "Boolean"; "Float"; "Title"; "Date"; "UUID"]
+            ["String"; "Int"; "Boolean"; "Float"; "Password"; "Date"; "UUID"]
           in
           let compound = List.map ~f:(fun s -> "[" ^ s ^ "]") builtins in
           List.map ~f:(fun x -> ACDBColType x) (builtins @ compound)


### PR DESCRIPTION
https://trello.com/c/PqXoMqZV/931-password-is-not-allowed-as-a-db-type

Sometime in the past (in PR #805) we removed the ability to add DBs with a password type. I confirmed with Ian that this was an accident (merge conflict).

This readds the ability to add Passwords via autocomplete.

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

