### PR TITLE
We had to fork ocaml-gcloud and some deps; no longer necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,10 +250,9 @@ RUN opam install -y \
   magic-mime.1.1.1 \
   ezgzip.0.2.1 \
   tablecloth-native.0.0.6 \
-  && opam pin nocrypto -y git+https://github.com/gasche/ocaml-nocrypto.git#master-ocamlbuild-pack \
-  && opam pin -y jwt git+https://github.com/ismith/ocaml-jwt.git#rsa256-verification \
-  && opam pin -y gcloud git+https://github.com/ismith/ocaml-gcloud.git#builds-on-ocaml-4.07.0 \
-  && opam pin -y multipart-form-data git+https://github.com/sgrove/multipart-form-data.git#master
+  && opam pin -y multipart-form-data git+https://github.com/sgrove/multipart-form-data.git#master \
+  && opam pin -y gcloud git+https://github.com/AestheticIntegration/ocaml-gcloud.git#afffedb
+# Note: ocaml-gcloud#afffedb above is just "head of master at the current point in time"
 
 ############################
 # Shellcheck


### PR DESCRIPTION
We forked for compatibility with ocaml 4.07. We're no longer using 4.07,
and ocaml-gcloud upstream should work on 4.06,

Additionally, they just merged my PR:
https://github.com/AestheticIntegration/ocaml-jwt/pull/1, so even if we
later move to ocaml >= 4.07, my forks may unnecessary.

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

