### PR TITLE
Introduces partial to the old ast, so they can be roundtripped.

### DIFF
--- a/backend/bin/get_functions_and_tlids.ml
+++ b/backend/bin/get_functions_and_tlids.ml
@@ -14,7 +14,7 @@ let flatmap ~(f : 'a -> 'b list) : 'a list -> 'b list =
 
 let rec fnnames_of_expr (expr : RTT.expr) : RTT.fnname list =
   match expr with
-  | Blank _ ->
+  | Partial _ | Blank _ ->
       []
   | Filled (_, nexpr) ->
     ( match nexpr with
@@ -84,7 +84,8 @@ let process_canvas (canvas : Canvas.canvas ref) : fn list =
     let spec = handler.spec in
     String.concat
       ( [spec.module_; spec.name; spec.modifier]
-      |> List.map ~f:(function Filled (_, s) -> s | Blank _ -> "") )
+      |> List.map ~f:(function Filled (_, s) -> s | Partial _ | Blank _ -> "")
+      )
       ~sep:"-"
   in
   let handlers =

--- a/backend/bin/migration_to_deprecate_old_types.ml
+++ b/backend/bin/migration_to_deprecate_old_types.ml
@@ -23,8 +23,8 @@ let transform_op (op : Op.op) : Op.op =
   in
   let transform_string_or_blank (old : string Types.or_blank) =
     match old with
-    | Blank _ as o ->
-        o
+    | Partial _ | Blank _ ->
+        old
     | Filled (id, str) ->
         Filled (id, transform_string str)
   in

--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -192,7 +192,9 @@ let apply_op (is_new : bool) (op : Op.op) (c : canvas ref) : unit =
                 match t with
                 | Filled (id, ts) ->
                     (n, Filled (id, Dval.tipe_of_string ts))
-                | Blank id as b ->
+                | Partial _ as b ->
+                    (n, b)
+                | Blank _ as b ->
                     (n, b) )
           in
           apply_to_db ~f:(User_db.create_migration rbid rfid typed_cols) tlid

--- a/backend/libbackend/libdb.ml
+++ b/backend/libbackend/libdb.ml
@@ -8,7 +8,7 @@ let find_db (dbs : DbT.db list) (name : string) : DbT.db =
   dbs
   |> List.filter ~f:(fun db ->
          match db.name with
-         | Blank _ ->
+         | Partial _ | Blank _ ->
              false
          | Filled (_, dbname) ->
              dbname = name )

--- a/backend/libbackend/user_db.ml
+++ b/backend/libbackend/user_db.ml
@@ -614,7 +614,9 @@ let create2 (name : string) (tlid : tlid) (name_id : id) : db =
 
 
 let rename_db (n : string) (db : db) : db =
-  let id = match db.name with Blank i -> i | Filled (i, _) -> i in
+  let id =
+    match db.name with Partial (i, _) | Blank i -> i | Filled (i, _) -> i
+  in
   {db with name = Filled (id, n)}
 
 

--- a/backend/libexecution/execution.ml
+++ b/backend/libexecution/execution.ml
@@ -21,7 +21,7 @@ let dbs_as_input_vars (dbs : DbT.db list) : (string * dval) list =
       match db.name with
       | Filled (_, name) ->
           Some (name, DDB name)
-      | Blank _ ->
+      | Partial _ | Blank _ ->
           None )
 
 

--- a/backend/libexecution/type_checker.ml
+++ b/backend/libexecution/type_checker.ml
@@ -68,7 +68,7 @@ let user_tipe_list_to_type_env (tipes : user_tipe list) : type_env =
       match t.name with
       | Filled (_, name) ->
           TypeEnv.add_exn map ~key:(name, t.version) ~data:t
-      | Blank _ ->
+      | Partial _ | Blank _ ->
           map )
 
 

--- a/backend/libexecution/types.ml
+++ b/backend/libexecution/types.ml
@@ -92,6 +92,7 @@ module TLIDTable = IDTable
 type 'a or_blank =
   | Blank of id
   | Filled of id * 'a
+  | Partial of id * string
 [@@deriving eq, compare, show, yojson, bin_io]
 
 (* DO NOT CHANGE ABOVE WITHOUT READING docs/oplist-serialization.md *)

--- a/backend/serialization/36687aac2efa3d33acc96f8655048023
+++ b/backend/serialization/36687aac2efa3d33acc96f8655048023
@@ -1,0 +1,978 @@
+(Exp
+ (Base list
+  ((Exp
+    (Variant
+     ((SetHandler
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp
+         (Record
+          ((tlid (Exp (Base int63 ())))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int63 ()))))
+               (Filled
+                ((Exp (Base int63 ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (FnCallSendToRail
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (Match
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp
+                                    (Application
+                                     (Exp
+                                      (Variant
+                                       ((PVariable ((Exp (Base string ()))))
+                                        (PLiteral ((Exp (Base string ()))))
+                                        (PConstructor
+                                         ((Exp (Base string ()))
+                                          (Exp
+                                           (Base list
+                                            ((Exp
+                                              (Variant
+                                               ((Blank
+                                                 ((Exp (Base int63 ()))))
+                                                (Filled
+                                                 ((Exp (Base int63 ()))
+                                                  (Exp (Rec_app 1 ()))))
+                                                (Partial
+                                                 ((Exp (Base int63 ()))
+                                                  (Exp (Base string ())))))))))))))))
+                                     ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))))))))))
+                      (Constructor
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))
+                   ()))))
+               (Partial ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+           (spec
+            (Exp
+             (Record
+              ((module_
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))
+                   (Partial ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))
+                   (Partial ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (modifier
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))
+                   (Partial ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (types
+                (Exp
+                 (Record
+                  ((input
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Base int ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+                   (output
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Base int ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))))))))
+      (CreateDB
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp (Base string ()))))
+      (AddDBCol
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (SetDBColName
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (SetDBColType
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (DeleteTL ((Exp (Base int63 ()))))
+      (MoveTL
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))))
+      (SetFunction
+       ((Exp
+         (Record
+          ((tlid (Exp (Base int63 ())))
+           (metadata
+            (Exp
+             (Record
+              ((name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))
+                   (Partial ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (parameters
+                (Exp
+                 (Base list
+                  ((Exp
+                    (Record
+                     ((name
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+                      (tipe
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ()))
+                            (Exp
+                             (Application
+                              (Exp
+                               (Variant
+                                ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                                 (TNull ()) (TDeprecated1 ()) (TStr ())
+                                 (TList ()) (TObj ()) (TIncomplete ())
+                                 (TError ()) (TBlock ()) (TResp ()) (TDB ())
+                                 (TID ()) (TDate ()) (TDeprecated2 ())
+                                 (TDeprecated3 ())
+                                 (TBelongsTo ((Exp (Base string ()))))
+                                 (THasMany ((Exp (Base string ()))))
+                                 (TDbList ((Exp (Rec_app 0 ()))))
+                                 (TPassword ()) (TUuid ()) (TOption ())
+                                 (TErrorRail ()) (TCharacter ()) (TResult ())
+                                 (TUserType
+                                  ((Exp (Base string ()))
+                                   (Exp (Base int ())))))))
+                              ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+                      (block_args (Exp (Base list ((Exp (Base string ()))))))
+                      (optional (Exp (Base bool ())))
+                      (description (Exp (Base string ()))))))))))
+               (return_type
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled
+                    ((Exp (Base int63 ()))
+                     (Exp
+                      (Application
+                       (Exp
+                        (Variant
+                         ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                          (TNull ()) (TDeprecated1 ()) (TStr ()) (TList ())
+                          (TObj ()) (TIncomplete ()) (TError ()) (TBlock ())
+                          (TResp ()) (TDB ()) (TID ()) (TDate ())
+                          (TDeprecated2 ()) (TDeprecated3 ())
+                          (TBelongsTo ((Exp (Base string ()))))
+                          (THasMany ((Exp (Base string ()))))
+                          (TDbList ((Exp (Rec_app 0 ())))) (TPassword ())
+                          (TUuid ()) (TOption ()) (TErrorRail ())
+                          (TCharacter ()) (TResult ())
+                          (TUserType
+                           ((Exp (Base string ())) (Exp (Base int ())))))))
+                       ()))))
+                   (Partial ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (description (Exp (Base string ())))
+               (infix (Exp (Base bool ())))))))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int63 ()))))
+               (Filled
+                ((Exp (Base int63 ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (FnCallSendToRail
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                      (Match
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp
+                                    (Application
+                                     (Exp
+                                      (Variant
+                                       ((PVariable ((Exp (Base string ()))))
+                                        (PLiteral ((Exp (Base string ()))))
+                                        (PConstructor
+                                         ((Exp (Base string ()))
+                                          (Exp
+                                           (Base list
+                                            ((Exp
+                                              (Variant
+                                               ((Blank
+                                                 ((Exp (Base int63 ()))))
+                                                (Filled
+                                                 ((Exp (Base int63 ()))
+                                                  (Exp (Rec_app 1 ()))))
+                                                (Partial
+                                                 ((Exp (Base int63 ()))
+                                                  (Exp (Base string ())))))))))))))))
+                                     ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ()))))
+                                 (Partial
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))))))))))
+                      (Constructor
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                              (Partial
+                               ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))
+                   ()))))
+               (Partial ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))
+      (ChangeDBColName
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (ChangeDBColType
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (UndoTL ((Exp (Base int63 ())))) (RedoTL ((Exp (Base int63 ()))))
+      (DeprecatedInitDbm
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))
+        (Exp (Base int63 ())) (Exp (Variant ((DeprecatedMigrationKind ()))))))
+      (SetExpr
+       ((Exp (Base int63 ())) (Exp (Base int63 ()))
+        (Exp
+         (Variant
+          ((Blank ((Exp (Base int63 ()))))
+           (Filled
+            ((Exp (Base int63 ()))
+             (Exp
+              (Application
+               (Exp
+                (Variant
+                 ((If
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                  (Thread
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                  (FnCall
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                  (Variable ((Exp (Base string ()))))
+                  (Let
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                  (Lambda
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                  (Value ((Exp (Base string ()))))
+                  (FieldAccess
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                  (ObjectLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Tuple
+                         ((Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ())) (Exp (Base string ()))))
+                             (Partial
+                              ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                          (Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                             (Partial
+                              ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))
+                  (ListLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                  (FeatureFlag
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                  (FnCallSendToRail
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))))))
+                  (Match
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Tuple
+                         ((Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ()))
+                               (Exp
+                                (Application
+                                 (Exp
+                                  (Variant
+                                   ((PVariable ((Exp (Base string ()))))
+                                    (PLiteral ((Exp (Base string ()))))
+                                    (PConstructor
+                                     ((Exp (Base string ()))
+                                      (Exp
+                                       (Base list
+                                        ((Exp
+                                          (Variant
+                                           ((Blank ((Exp (Base int63 ()))))
+                                            (Filled
+                                             ((Exp (Base int63 ()))
+                                              (Exp (Rec_app 1 ()))))
+                                            (Partial
+                                             ((Exp (Base int63 ()))
+                                              (Exp (Base string ())))))))))))))))
+                                 ()))))
+                             (Partial
+                              ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                          (Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                             (Partial
+                              ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))
+                  (Constructor
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ()))))
+                       (Partial
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))
+                          (Partial
+                           ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))
+               ()))))
+           (Partial ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+      (TLSavepoint ((Exp (Base int63 ()))))
+      (DeleteFunction ((Exp (Base int63 ()))))
+      (CreateDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))
+        (Exp
+         (Base list
+          ((Exp
+            (Tuple
+             ((Exp
+               (Variant
+                ((Blank ((Exp (Base int63 ()))))
+                 (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))
+                 (Partial ((Exp (Base int63 ())) (Exp (Base string ())))))))
+              (Exp
+               (Variant
+                ((Blank ((Exp (Base int63 ()))))
+                 (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))
+                 (Partial ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))
+      (AddDBColToDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (SetDBColNameInDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (SetDBColTypeInDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (AbandonDBMigration ((Exp (Base int63 ()))))
+      (DeleteColInDBMigration ((Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (DeleteDBCol ((Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (RenameDBname ((Exp (Base int63 ())) (Exp (Base string ()))))
+      (CreateDBWithBlankOr
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp (Base int63 ())) (Exp (Base string ()))))
+      (DeleteTLForever ((Exp (Base int63 ()))))
+      (DeleteFunctionForever ((Exp (Base int63 ()))))
+      (SetType
+       ((Exp
+         (Record
+          ((tlid (Exp (Base int63 ())))
+           (name
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int63 ()))))
+               (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))
+               (Partial ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+           (version (Exp (Base int ())))
+           (definition
+            (Exp
+             (Variant
+              ((UTRecord
+                ((Exp
+                  (Base list
+                   ((Exp
+                     (Record
+                      ((name
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+                       (tipe
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ()))
+                             (Exp
+                              (Application
+                               (Exp
+                                (Variant
+                                 ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                                  (TNull ()) (TDeprecated1 ()) (TStr ())
+                                  (TList ()) (TObj ()) (TIncomplete ())
+                                  (TError ()) (TBlock ()) (TResp ()) 
+                                  (TDB ()) (TID ()) (TDate ())
+                                  (TDeprecated2 ()) (TDeprecated3 ())
+                                  (TBelongsTo ((Exp (Base string ()))))
+                                  (THasMany ((Exp (Base string ()))))
+                                  (TDbList ((Exp (Rec_app 0 ()))))
+                                  (TPassword ()) (TUuid ()) (TOption ())
+                                  (TErrorRail ()) (TCharacter ())
+                                  (TResult ())
+                                  (TUserType
+                                   ((Exp (Base string ()))
+                                    (Exp (Base int ())))))))
+                               ()))))
+                           (Partial
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))))))))))))
+      (DeleteType ((Exp (Base int63 ()))))
+      (DeleteTypeForever ((Exp (Base int63 ()))))))))))

--- a/backend/test/test.ml
+++ b/backend/test/test.ml
@@ -1854,7 +1854,11 @@ let t_db_rename () =
   match List.hd state.dbs with
   | Some db ->
       let newname =
-        match db.name with Filled (_, name) -> name | Blank _ -> ""
+        match db.name with
+        | Filled (_, name) ->
+            name
+        | Partial _ | Blank _ ->
+            ""
       in
       AT.check AT.string "database rename success" "BsCode" newname
   | None ->

--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -555,7 +555,7 @@ let tlDestinations (m : model) : autocompleteItem list =
     List.filterMap
       ~f:(fun fn ->
         match fn.ufMetadata.ufmName with
-        | Blank _ ->
+        | Partial _ | Blank _ ->
             None
         | F (_, name) ->
             Some (Goto (FocusedFn fn.ufTLID, fn.ufTLID, fnGotoName name)) )

--- a/client/src/Blank.ml
+++ b/client/src/Blank.ml
@@ -2,7 +2,7 @@ open Prelude
 open Types
 
 let toID (b : 'a blankOr) : id =
-  match b with Blank id -> id | F (id, _) -> id
+  match b with Partial (id, _) | Blank id -> id | F (id, _) -> id
 
 
 let new_ (() : unit) : 'a blankOr = Blank (gid ())
@@ -10,25 +10,31 @@ let new_ (() : unit) : 'a blankOr = Blank (gid ())
 let newF (a : 'a) : 'a blankOr = F (gid (), a)
 
 let clone (fn : 'a -> 'a) (b : 'a blankOr) : 'a blankOr =
-  match b with Blank _ -> Blank (gid ()) | F (_, val_) -> F (gid (), fn val_)
+  match b with
+  | Partial (_, data) ->
+      Partial (gid (), data)
+  | Blank _ ->
+      Blank (gid ())
+  | F (_, val_) ->
+      F (gid (), fn val_)
 
 
 let isBlank (b : 'a blankOr) : bool =
-  match b with Blank _ -> true | F (_, _) -> false
+  match b with Partial _ | Blank _ -> true | F (_, _) -> false
 
 
 let isF (b : 'a blankOr) : bool = not (isBlank b)
 
 let asF (b : 'a blankOr) : 'a option =
-  match b with F (_, v) -> Some v | Blank _ -> None
+  match b with F (_, v) -> Some v | Partial _ | Blank _ -> None
 
 
 let valueWithDefault (a : 'a) (b : 'a blankOr) : 'a =
-  match b with F (_, v) -> v | Blank _ -> a
+  match b with F (_, v) -> v | Partial _ | Blank _ -> a
 
 
 let toMaybe (b : 'a blankOr) : 'a option =
-  match b with F (_, v) -> Some v | Blank _ -> None
+  match b with F (_, v) -> Some v | Partial _ | Blank _ -> None
 
 
 let ofOption (o : 'a option) : 'a blankOr =
@@ -44,5 +50,5 @@ let deBlank (msg : string) (x : 'a blankOr) : 'a =
   match x with
   | F (_, y) ->
       y
-  | Blank _ ->
+  | Partial _ | Blank _ ->
       impossible ("got Blank but expected Flagged: " ^ msg)

--- a/client/src/DB.ml
+++ b/client/src/DB.ml
@@ -35,7 +35,11 @@ let allData (db : dB) : pointerData list =
 let hasCol (db : dB) (name : string) : bool =
   db.cols
   |> List.any ~f:(fun (colname, _) ->
-         match colname with Blank _ -> false | F (_, n) -> name = n )
+         match colname with
+         | Partial _ | Blank _ ->
+             false
+         | F (_, n) ->
+             name = n )
 
 
 let isLocked (m : model) (TLID tlid : tlid) : bool =

--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -23,7 +23,8 @@ let vPos j : vPos = {vx = field "vx" int j; vy = field "vy" int j}
 let blankOr d =
   variants
     [ ("Filled", variant2 (fun id v -> F (id, v)) id d)
-    ; ("Blank", variant1 (fun id -> Blank id) id) ]
+    ; ("Blank", variant1 (fun id -> Blank id) id)
+    ; ("Partial", variant2 (fun id v -> Partial (id, v)) id string) ]
 
 
 let rec pointerData j : pointerData =

--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -20,6 +20,8 @@ let blankOr (encoder : 'a -> Js.Json.t) (v : 'a Types.blankOr) =
   match v with
   | F (i, s) ->
       variant "Filled" [id i; encoder s]
+  | Partial (i, str) ->
+      variant "Partial" [id i; string str]
   | Blank i ->
       variant "Blank" [id i]
 
@@ -500,7 +502,7 @@ and nExpr (nexpr : Types.nExpr) : Js.Json.t =
       if r = Rail
       then ev "FnCallSendToRail" [string n; list e exprs]
       else ev "FnCall" [string n; list e exprs]
-  | FnCall (Blank _, _, _) ->
+  | FnCall (Partial _, _, _) | FnCall (Blank _, _, _) ->
       Debug.crash "fnCall hack used"
   | Let (lhs, rhs, body) ->
       ev "Let" [blankOr string lhs; e rhs; e body]

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -98,10 +98,14 @@ let gid () = string_of_int (Random.int (4096 * 1024) |> abs)
 
 let rec fromExpr (expr : Types.expr) : expr =
   let open Types in
-  let varToName var = match var with Blank _ -> "" | F (_, name) -> name in
+  let varToName var =
+    match var with Blank _ -> "" | Partial (_, name) | F (_, name) -> name
+  in
   match expr with
   | Blank (ID id) ->
       EBlank id
+  | Partial (ID id, v) ->
+      EPartial (id, v)
   | F (ID id, nExpr) ->
     ( match nExpr with
     | Let (name, rhs, body) ->
@@ -187,8 +191,8 @@ let rec toExpr (expr : expr) : Types.expr =
       F (ID id, Let (F (ID (gid ()), lhs), toExpr rhs, toExpr body))
   | EIf (id, cond, thenExpr, elseExpr) ->
       F (ID id, If (toExpr cond, toExpr thenExpr, toExpr elseExpr))
-  | EPartial (id, _) ->
-      Blank (ID id)
+  | EPartial (id, str) ->
+      Partial (ID id, str)
   | EList (id, exprs) ->
       F (ID id, ListLiteral (List.map ~f:toExpr exprs))
   | ERecord (id, pairs) ->

--- a/client/src/Introspect.ml
+++ b/client/src/Introspect.ml
@@ -5,8 +5,8 @@ module B = Blank
 
 let keyForHandlerSpec (space : string blankOr) (name : string blankOr) : string
     =
-  let space_ = match space with F (_, s) -> s | Blank _ -> "_" in
-  let name_ = match name with F (_, n) -> n | Blank _ -> "_" in
+  let space_ = match space with F (_, s) -> s | Partial _ | Blank _ -> "_" in
+  let name_ = match name with F (_, n) -> n | Partial _ | Blank _ -> "_" in
   space_ ^ ":" ^ name_
 
 
@@ -18,7 +18,7 @@ let dbsByName (toplevels : toplevel list) : tlid StrDict.t =
         ( match db.dbName with
         | F (_, name) ->
             StrDict.insert ~key:name ~value:tl.id res
-        | Blank _ ->
+        | Partial _ | Blank _ ->
             res )
       | _ ->
           res )
@@ -270,14 +270,14 @@ let updateMeta (tl : toplevel) (meta : tlMeta StrDict.t) : tlMeta StrDict.t =
     | F (_, dbname) ->
         let value = DBMeta (dbname, dB.cols) in
         StrDict.insert ~key ~value meta
-    | Blank _ ->
+    | Partial _ | Blank _ ->
         meta )
   | TLFunc f ->
     ( match f.ufMetadata.ufmName with
     | F (_, name) ->
         let value = FunctionMeta (name, f.ufMetadata.ufmParameters) in
         StrDict.insert ~key ~value meta
-    | Blank _ ->
+    | Partial _ | Blank _ ->
         meta )
   | TLTipe _ ->
       meta

--- a/client/src/Pattern.ml
+++ b/client/src/Pattern.ml
@@ -8,7 +8,7 @@ module P = Pointer
 
 let rec allData (p : pattern) : pointerData list =
   match p with
-  | Blank _ ->
+  | Partial _ | Blank _ ->
       [PPattern p]
   | F (_, PLiteral _) ->
       [PPattern p]
@@ -49,7 +49,7 @@ let rec hasVariableNamed (name : varName) (p : pattern) : bool =
 
 let rec variableNames (p : pattern) : varName list =
   match p with
-  | Blank _ | F (_, PLiteral _) ->
+  | Partial _ | Blank _ | F (_, PLiteral _) ->
       []
   | F (_, PVariable name) ->
       [name]

--- a/client/src/Pointer.ml
+++ b/client/src/Pointer.ml
@@ -189,7 +189,7 @@ let isBlank (pd : pointerData) : bool =
 let strMap (pd : pointerData) ~(f : string -> string) : pointerData =
   let bf s =
     match s with
-    | Blank _ ->
+    | Blank _ | Partial _ ->
       (match f "" with "" -> s | other -> Blank.newF other)
     | F (id, str) ->
         F (id, f str)

--- a/client/src/Refactor.ml
+++ b/client/src/Refactor.ml
@@ -222,13 +222,17 @@ let renameFunction (m : model) (old : userFunction) (new_ : userFunction) :
     in
     let origName, calls =
       match old_.ufMetadata.ufmName with
-      | Blank _ ->
+      | Partial _ | Blank _ ->
           (None, [])
       | F (_, n) ->
           (Some n, AST.allCallsToFn n ast |> List.map ~f:(fun x -> PExpr x))
     in
     let newName =
-      match new_.ufMetadata.ufmName with Blank _ -> None | F (_, n) -> Some n
+      match new_.ufMetadata.ufmName with
+      | Partial _ | Blank _ ->
+          None
+      | F (_, n) ->
+          Some n
     in
     match (origName, newName) with
     | Some _, Some r ->
@@ -273,7 +277,7 @@ let rec isFunctionInExpr (fnName : string) (expr : expr) : bool =
         if name = fnName
         then true
         else List.any ~f:(isFunctionInExpr fnName) list
-    | FnCall (Blank _, _, _) ->
+    | FnCall (Blank _, _, _) | FnCall (Partial _, _, _) ->
         Debug.crash "blank in fncall"
     | Constructor (_, args) ->
         List.any ~f:(isFunctionInExpr fnName) args
@@ -318,13 +322,17 @@ let renameUserTipe (m : model) (old : userTipe) (new_ : userTipe) : op list =
     in
     let origName, uses =
       match oldTipe.utName with
-      | Blank _ ->
+      | Partial _ | Blank _ ->
           (None, [])
       | F (_, n) ->
           (Some n, Functions.usesOfTipe n oldTipe.utVersion fn)
     in
     let newName =
-      match newTipe.utName with Blank _ -> None | F (_, n) -> Some n
+      match newTipe.utName with
+      | Partial _ | Blank _ ->
+          None
+      | F (_, n) ->
+          Some n
     in
     match (origName, newName) with
     | Some _, Some newName ->
@@ -425,7 +433,7 @@ let transformFnCalls (m : model) (uf : userFunction) (f : nExpr -> nExpr) :
     in
     let origName, calls =
       match old.ufMetadata.ufmName with
-      | Blank _ ->
+      | Partial _ | Blank _ ->
           (None, [])
       | F (_, n) ->
           (Some n, AST.allCallsToFn n ast |> List.map ~f:(fun x -> PExpr x))

--- a/client/src/SpecHeaders.ml
+++ b/client/src/SpecHeaders.ml
@@ -10,7 +10,11 @@ let spaceOf (hs : handlerSpec) : handlerSpace =
     let lwr = String.toLower s in
     if lwr = "http" then HSHTTP else if lwr = "cron" then HSCron else HSOther
   in
-  match hs.module_ with Blank _ -> HSEmpty | F (_, s) -> spaceOfStr s
+  match hs.module_ with
+  | Partial _ | Blank _ ->
+      HSEmpty
+  | F (_, s) ->
+      spaceOfStr s
 
 
 let visibleModifier (hs : handlerSpec) : bool =

--- a/client/src/Toplevel.ml
+++ b/client/src/Toplevel.ml
@@ -524,7 +524,11 @@ let allDBNames (toplevels : toplevel list) : string list =
   |> List.filterMap ~f:(fun tl ->
          match tl.data with
          | TLDB db ->
-           (match db.dbName with F (_, name) -> Some name | Blank _ -> None)
+           ( match db.dbName with
+           | F (_, name) ->
+               Some name
+           | Partial _ | Blank _ ->
+               None )
          | _ ->
              None )
 

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -38,6 +38,8 @@ and id = ID of string
 
 and 'a blankOr =
   | Blank of id
+  (* A partial is only used by Fluid *)
+  | Partial of id * string
   | F of id * 'a
 
 (* There are two coordinate systems. Pos is an absolute position in the *)

--- a/client/src/ViewBlankOr.ml
+++ b/client/src/ViewBlankOr.ml
@@ -388,7 +388,7 @@ let viewBlankOr
     match bo with
     | F (id, fill) ->
         drawFilled id fill
-    | Blank id ->
+    | Partial (id, _) | Blank id ->
         drawBlank id
   in
   match vs.cursorState with

--- a/client/src/ViewCode.ml
+++ b/client/src/ViewCode.ml
@@ -186,7 +186,7 @@ and viewNExpr
         ; n [wc "ifbody"] [vExpr 0 ifbody]
         ; kw [] "else"
         ; n [wc "elsebody"] [vExpr 0 elsebody] ]
-  | FnCall (Blank _, _, _) ->
+  | FnCall (Partial _, _, _) | FnCall (Blank _, _, _) ->
       Debug.crash "fn with blank"
   | FnCall ((F (_, name) as nameBo), exprs, sendToRail) ->
       let width = ViewUtils.approxNWidth e in

--- a/client/src/ViewIntrospect.ml
+++ b/client/src/ViewIntrospect.ml
@@ -92,7 +92,7 @@ let fnView (tlid : tlid) (name : string) (params : userFunctionParameter list)
             ( match p.ufpTipe with
             | F (_, v) ->
                 Runtime.tipe2str v
-            | Blank _ ->
+            | Partial _ | Blank _ ->
                 "no type" ) ]
     in
     Html.div [Html.class' "fnparam"] [name; Html.text ":"; ptype]

--- a/client/src/ViewRoutingTable.ml
+++ b/client/src/ViewRoutingTable.ml
@@ -99,7 +99,7 @@ let dbCategory (m : model) (tls : toplevel list) : category =
     List.map dbs ~f:(fun (db, _) ->
         let uses =
           match db.dbName with
-          | Blank _ ->
+          | Partial _ | Blank _ ->
               0
           | F (_, name) ->
               Refactor.dbUseCount m name

--- a/client/src/ViewUtils.ml
+++ b/client/src/ViewUtils.ml
@@ -218,7 +218,7 @@ let inCh (w : int) : string = w |> string_of_int |> fun s -> s ^ "ch"
 let widthInCh (w : int) : msg Vdom.property = w |> inCh |> Html.style "width"
 
 let blankOrLength ~(f : 'a -> int) (b : 'a blankOr) : int =
-  match b with Blank _ -> 6 | F (_, value) -> f value
+  match b with Partial _ | Blank _ -> 6 | F (_, value) -> f value
 
 
 let strBlankOrLength (b : string blankOr) : int =
@@ -233,7 +233,7 @@ let visualStringLength (string : string) : int =
 
 
 let rec approxWidth (e : expr) : int =
-  match e with Blank _ -> 6 | F (_, ne) -> approxNWidth ne
+  match e with Partial _ | Blank _ -> 6 | F (_, ne) -> approxNWidth ne
 
 
 and approxNWidth (ne : nExpr) : int =


### PR DESCRIPTION
In all cases they work exactly like Blanks, they just roundtrip to fluid differently.

This makes partials work in the fluid editor, which is needed for just about everything.

I'm really unsure about this change, but it's simple and mechanical, vs other options that touched things like SetTopLevel which I'm honestly afraid of.

I started by adding partials to Exprs, and not roundtripping them. This let me add letters, but then it would be overwritten by the RPC returning.

Thoughts appreciated.

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

