### PR TITLE
Adding a ':' between the function params to keep param type layout co…

### DIFF
--- a/client/src/ViewFunction.ml
+++ b/client/src/ViewFunction.ml
@@ -91,9 +91,10 @@ let viewMetadata (vs : viewState) (fn : userFunction) : msg Html.html =
     |> List.map ~f:(fun p ->
            Html.div
              [Html.class' "col"]
-             [ viewParamName vs [wc "name"] p.ufpName
-             ; viewParamTipe vs [wc "type"] p.ufpTipe
-             ; viewKillParameterBtn fn p ] )
+             [ viewKillParameterBtn fn p
+             ; viewParamName vs [wc "name"] p.ufpName
+             ; Html.div [Html.class' "param-divider"] [Html.text ":"]
+             ; viewParamTipe vs [wc "type"] p.ufpTipe ] )
   in
   Html.div [Html.class' "user-fn"] (namediv :: coldivs)
 

--- a/client/src/app.less
+++ b/client/src/app.less
@@ -894,13 +894,13 @@ body #app * {
 .user-fn {
   margin: 10px;
   display: flex;
+  align-items: flex-start;
   flex-direction: column;
   border-bottom: 1px solid @orange;
   padding-bottom: 10px;
 
   .ufn-name {
     padding-bottom: 10px;
-    margin: 0 auto;
     .entry {
       form {
         margin-top: 0;
@@ -918,7 +918,10 @@ body #app * {
     margin-bottom: 4px;
     margin-top: 4px;
     text-align: center;
-
+    .param-divider{
+      font-size: 10px;
+      height: 15px;
+    }
     .name, .type {
       flex: 1;
       font-size: 10px;


### PR DESCRIPTION

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test


Fixes: https://trello.com/c/dyDwz3PZ/892-hard-to-find-params-in-wide-functions-79
When function code is too long horizontally the params and function name are hard to edit because you have to hunt for them since they were aligned center. We moved the params to the left so you don't have to hunt for them. We also moved the delete icon to the other side to better show the different params.
 
![Screen Shot 2019-05-07 at 10 52 26 AM](https://user-images.githubusercontent.com/32043360/57321469-3fe76980-70b6-11e9-8223-5d264805edf4.png)



Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

