### PR TITLE
fix alignment of params on overflowing function call to prevent place…

### DIFF
--- a/client/src/ViewBlankOr.ml
+++ b/client/src/ViewBlankOr.ml
@@ -378,7 +378,9 @@ let viewBlankOr
     div
       vs
       ([WithClass "blank"] @ c @ wID id)
-      [Html.text (placeHolderFor vs id pt)]
+      [ Html.div
+          [Html.class' "blank-entry"]
+          [Html.text (placeHolderFor vs id pt)] ]
   in
   let drawFilled id fill =
     let configs = wID id @ c in

--- a/client/src/app.less
+++ b/client/src/app.less
@@ -290,6 +290,17 @@ body #app * {
     min-width: 8ch;
     .blank-box-style;
     .blank-text-style;
+
+    &.arg-on-new-line{
+      padding-left: 0ch;
+      margin-left: 0px;
+      text-align: start;
+      font-size: @code-font-size;
+      .blank-entry{
+        .blank-text-style;
+        width: 100%;
+      }
+    }
   }
 
   .blankOr.selected {
@@ -1407,11 +1418,19 @@ body #app * {
       box-sizing: border-box;
     }
 
-    .arg-on-new-line > .param-name {
-      width: auto;
-      position: absolute;
-      color: @grey2;
-      font-size: 0.85rem;
+    .arg-on-new-line {
+
+      &.blank > .param-name {
+        font-style: normal;
+      }
+
+      & > .param-name {
+        width: auto;
+        position: absolute;
+        color: @grey2;
+        font-size: 0.85rem;
+      }
+
     }
 
     .tstr {


### PR DESCRIPTION
…holder and param name confusion

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Fixes: https://trello.com/c/Fa4nKAuU/893-fix-parameter-display-in-overflowing-fncalls-47

![Screen Shot 2019-05-07 at 12 43 35 PM](https://user-images.githubusercontent.com/32043360/57328248-c6577780-70c5-11e9-96a5-826f8ee3acd3.png)

We aligned all the overflowing function params to the left to avoid confusion between the param and the placeholder.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

