### PR TITLE
Add fetchBytes, fetchLatestBytes and serve_v1 functions using new Bytes type

### DIFF
--- a/backend/libbackend/libstatic_assets.ml
+++ b/backend/libbackend/libstatic_assets.ml
@@ -209,12 +209,11 @@ UTF-8 safe"))
         (function
         | state, [DStr file] ->
             let url =
-              "https://avatars1.githubusercontent.com/u/32852373?s=280&v=4"
-              (*url_for
+              url_for
                 state.canvas_id
                 (latest_deploy_hash state.canvas_id)
                 `Short
-                (Unicode_string.to_string file)*)
+                (Unicode_string.to_string file)
             in
             let body, code, headers, _error =
               Httpclient.http_call_with_code url [] Httpclient.GET [] ""
@@ -235,15 +234,11 @@ UTF-8 safe"))
               |> List.filter (fun (k, v) -> not (String.trim k = ""))
               |> List.filter (fun (k, v) -> not (String.trim v = ""))
             in
-            DResult (ResOk (DResp (Response (code, headers), DBytes body)))
-            (*( match body with
-            | Some dv ->
-                DResult (ResOk (DResp (Response (code, headers), dv)))
-            | None ->
-                DResult
-                  (ResError
-                     (Dval.dstr_of_string_exn "Response was not UTF-8 safe"))
-            )*)
+            DResult
+              (ResOk
+                 (DResp
+                    ( Response (code, headers)
+                    , DBytes (body |> RawBytes.of_string) )))
         | args ->
             Libexecution.Lib.fail args) )
   ; ( "StaticAssets::serveLatest_v1"

--- a/backend/libexecution/dval.ml
+++ b/backend/libexecution/dval.ml
@@ -367,8 +367,6 @@ let rec unsafe_dval_of_yojson (json : Yojson.Safe.json) : dval =
       DOption (OptJust (unsafe_dval_of_yojson dv))
   | `Assoc [("type", `String "errorrail"); ("value", dv)] ->
       DErrorRail (unsafe_dval_of_yojson dv)
-  | `Assoc [("type", `String "bytes"); ("value", dv)] ->
-      DBytes (dv |> Yojson.Safe.to_string |> B64.decode)
   | `Assoc _ ->
       DObj (unsafe_dvalmap_of_yojson json)
 


### PR DESCRIPTION
Using the `Bytes` type introduced in [`korede+ian/binary-type`](https://github.com/darklang/dark/pull/862), adds new `fetchBytes` and `fetchLatestBytes` functions, similar with `fetch` and `fetchLatest` but returning byte strings (which night not be UTF-8 safe). Also adds a new version of `serve_v1` that functions in the same fashion.

Fixes [this PR](https://trello.com/c/ne8O5V9U/928-add-fetchbytes-fetchlatestbytes-functions-like-fetch-fetchlatest-but-returning-a-dbytes-instead-of-a-dstring).

<img width="485" alt="Screen Shot 2019-05-10 at 12 17 52 PM" src="https://user-images.githubusercontent.com/16245199/57551441-ed0feb00-731d-11e9-91d8-693e9f828d61.png">
<img width="481" alt="Screen Shot 2019-05-10 at 12 18 37 PM" src="https://user-images.githubusercontent.com/16245199/57551442-ed0feb00-731d-11e9-9ab7-d25f2d944547.png">
<img width="634" alt="Screen Shot 2019-05-10 at 12 19 10 PM" src="https://user-images.githubusercontent.com/16245199/57551443-ed0feb00-731d-11e9-931b-b09d51d3c605.png">

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

