### PR TITLE
Fix crash when dragging a DB

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -1756,45 +1756,45 @@ let update (m : Types.model) (msg : Types.msg) : Types.modification =
     | None ->
         Types.NoChange
     | Some tl ->
-        let ast =
-          TL.rootExpr tl
-          |> deOption "Fluid.update"
-          |> fromExpr m.builtInFunctions
-        in
-        let newAST, newState, cmd =
-          let s =
-            {m.fluidState with ac = {m.fluidState.ac with targetTL = Some tl}}
+      ( match TL.rootExpr tl with
+      | None ->
+          NoChange
+      | Some ast ->
+          let ast = ast |> fromExpr m.builtInFunctions in
+          let newAST, newState, cmd =
+            let s =
+              {m.fluidState with ac = {m.fluidState.ac with targetTL = Some tl}}
+            in
+            let s = {s with error = None; oldPos = s.newPos} in
+            match msg with
+            | FluidMouseClick ->
+              ( match getCursorPosition () with
+              | Some newPos ->
+                  (ast, setPosition s newPos, Cmd.none)
+              | None ->
+                  (ast, {s with error = Some "found no pos"}, Cmd.none) )
+            | FluidKeyPress {key} ->
+                let s = {s with lastKey = key; actions = []} in
+                let newAST, newState = updateKey m key ast s in
+                (* These might be the same token *)
+                let cmd =
+                  if newAST <> ast || newState.oldPos <> newState.newPos
+                  then setBrowserPos newState.newPos
+                  else Cmd.none
+                in
+                (newAST, newState, cmd)
+            | _ ->
+                (ast, s, Cmd.none)
           in
-          let s = {s with error = None; oldPos = s.newPos} in
-          match msg with
-          | FluidMouseClick ->
-            ( match getCursorPosition () with
-            | Some newPos ->
-                (ast, setPosition s newPos, Cmd.none)
-            | None ->
-                (ast, {s with error = Some "found no pos"}, Cmd.none) )
-          | FluidKeyPress {key} ->
-              let s = {s with lastKey = key; actions = []} in
-              let newAST, newState = updateKey m key ast s in
-              (* These might be the same token *)
-              let cmd =
-                if newAST <> ast || newState.oldPos <> newState.newPos
-                then setBrowserPos newState.newPos
-                else Cmd.none
-              in
-              (newAST, newState, cmd)
-          | _ ->
-              (ast, s, Cmd.none)
-        in
-        let astMod =
-          if ast <> newAST
-          then Toplevel.setSelectedAST m (toExpr newAST)
-          else Types.NoChange
-        in
-        Types.Many
-          [ Types.TweakModel (fun m -> {m with fluidState = newState})
-          ; astMod
-          ; Types.MakeCmd cmd ] )
+          let astMod =
+            if ast <> newAST
+            then Toplevel.setSelectedAST m (toExpr newAST)
+            else Types.NoChange
+          in
+          Types.Many
+            [ Types.TweakModel (fun m -> {m with fluidState = newState})
+            ; astMod
+            ; Types.MakeCmd cmd ] ) )
 
 
 (* -------------------- *)


### PR DESCRIPTION
https://trello.com/c/9qsjRcU2/989-exception-in-fluidupdate

This was a real bug - it crashed when dragging a TL without an ast (db or type).

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

