### PR TITLE
Fix usage boxes alignment to be flushed left again.

### DIFF
--- a/client/src/app.less
+++ b/client/src/app.less
@@ -392,6 +392,9 @@ body #app * {
   }
 }
 .use-wrapper{
+  background: transparent;
+  margin-left: 10px;
+  
   &.fade{
     opacity: 0.3;
   }
@@ -399,8 +402,7 @@ body #app * {
   .usages, .used-in  {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    padding-right: 10px;
+    align-items: flex-start;
   }
 }
 
@@ -420,6 +422,11 @@ body #app * {
   color: @white1;
   font-size: @code-font-size;
 
+  &:first-child {
+    margin-top: 0;
+    margin-bottom: 8px;
+  }
+  
   &:hover {
     cursor: pointer;
     color: @yellow;
@@ -1812,9 +1819,9 @@ body #app * {
 //
 
 .sidebar-box {
-  background: @black1;
   position: relative;
   display: flex;
+  align-items: flex-start;
 }
 
 .documentation-box {


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution
Before our usage boxes was on flushed left when it was to the right, we moved things to the right, it looked weird to them flushed either left of right. So we center aligned, but then we end up moving it back to the left again, and forgot to take out the center align.

- [ ] Make sure info from this description is also in comments
- [2] Include before/after screenshots/gif if applicable
Before:
![bug1](https://user-images.githubusercontent.com/244152/57658523-189c0b00-7594-11e9-957c-ea83d088b0c8.png)


After:
<img width="778" alt="Screen Shot 2019-05-13 at 3 27 00 PM" src="https://user-images.githubusercontent.com/244152/57658476-e9859980-7593-11e9-8317-47d7810cbf74.png">

- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

