### PR TITLE
End-users should actually _get the bytes_

### DIFF
--- a/backend/libexecution/dval.ml
+++ b/backend/libexecution/dval.ml
@@ -578,7 +578,7 @@ let rec to_enduser_readable_text_v0 dval =
     | DOption OptNothing ->
         "Nothing"
     | DBytes bytes ->
-        "<Bytes: length=" ^ string_of_int (RawBytes.length bytes) ^ ">"
+        Bytes.to_string bytes
   in
   reprfn dval
 


### PR DESCRIPTION
- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Currently we get 
![image](https://user-images.githubusercontent.com/1179074/57713429-50a05e00-7627-11e9-8b77-eabb60f23071.png) in the body.

The end-user repr seems wrong, it should actually send the bytes down.

Currently untested.


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

