### PR TITLE
Ismith/handle presence.darklang.com

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -97,6 +97,21 @@ server {
 
 server {
   listen 8000;
+  server_name presence.darklang.com;
+
+  location / {
+    # redirect http to https.
+    if ($http_x_forwarded_proto = "http") {
+      rewrite ^(.*)$ https://$server_name$1 permanent;
+    }
+
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_pass https://sydney-presence.builtwithdark.com;
+  }
+}
+
+server {
+  listen 8000;
   server_name static.darklang.com;
 
   location / {


### PR DESCRIPTION
Route presence.darklang.com -> sydney-presence.builtwithdark.com

This should allow us to share cookies between the editor and the
presence service.

Other steps to be taken:
- CNAME presence.darklang.com -> darklang.com (requires 2FA, I believe Paul has this)

To test, post-merge (and post-dns-setup):
- I've got a / handler up on sydney-presence; hitting presence.darklang.com/ should result in a trace
with my cookie in the headers.
- traces in both sydney-presence and ellen-staticdarklang have X-Forwarded-Host headers

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

