### PR TITLE
Use an encoding-resistant way to write smart quotes

### DIFF
--- a/client/src/app.less
+++ b/client/src/app.less
@@ -1345,14 +1345,14 @@ body #app * {
       left: 0;
       top: 0;
       &:before {
-        content: "“";
+        content: "\201C";
       }
     }
     &.quote-end {
       bottom: 0;
       right: 0;
       &:before {
-        content: "”";
+        content: "\201D";
       }
     }
   }


### PR DESCRIPTION
We've long had occasional bugs where the smart quotes appear as â€. This is probably an encoding bug, but we're not sure the actual cause. This should avoid it.



- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket
  - [x] Out-of-scope product changes have been explained
  - [x] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged
  - [x] All existing canvases should continue to work
  - [x] New features are documented in the User Manual or Trello filed
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions)
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

