### PR TITLE
Make serve/serveLatest pass along gzipped content without expanding & re-compressing

### DIFF
--- a/backend/test/dune
+++ b/backend/test/dune
@@ -2,5 +2,5 @@
   (name test)
   (flags (-warn-error +A))
   (preprocess (pps lwt.ppx))
-  (libraries libbackend libcommon alcotest junit junit_alcotest)
+  (libraries libbackend libcommon alcotest junit junit_alcotest tablecloth-native)
 )

--- a/config/dev
+++ b/config/dev
@@ -62,7 +62,7 @@ DARK_CONFIG_PUSHER_CLUSTER=us2
 DARK_CONFIG_BROWSER_RELOAD_ENABLED=y
 DARK_CONFIG_HASH_STATIC_FILENAMES=n
 DARK_GCLOUD_APPLICATION_CREDENTIALS=balmy-ground-195100-d9b0f3de3013.json
-DARK_STATIC_ASSETS_BUCKET=dark-static-assets-dev
+DARK_STATIC_ASSETS_BUCKET=dark-static-assets
 
 ######################################
 # XXX: Changes won't take effect until you restart script/builder


### PR DESCRIPTION
Add a `Curl.CURL_ENCODING_NONE` flag to the request setup within `Httpclient.http_call_with_code` to stop serve and serveLatest from expanding and re-compressing content before passing it along.

Fixes [this ticket](https://trello.com/c/cMHztUVf/927-serve-servelatest-should-pass-along-gzipped-content-untouched-instead-of-expandingrecompressing).

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

