### PR TITLE
Comment out scripts/gcp-build-containers step in build-backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,9 +200,9 @@ jobs:
       - run: touch backend/static/appsupport.js
       - copy-into-container
       - run: scripts/builder --compile-backend --test
-      - run-background-container
-      - wait-for-container
-      - run: scripts/gcp-build-containers --skip-stroller
+    # - run-background-container
+    # - wait-for-container
+    # - run: scripts/gcp-build-containers --skip-stroller
       - run:
           name: Copy out generated files and caches
           command: |


### PR DESCRIPTION
- This keeps failing non-deterministically (sometimes works, sometimes
doesn't) with the error `^@^@cp: cannot stat 'backend/_build/default/bin/server.exe': No such file or directory`
- Example failure: https://circleci.com/gh/darklang/dark/12293
- Leaving this step in build-stroller because we haven't seen it fail
there yet

The intent of this step was that if our ldd check fails (wrong dylibs
available in prod containers, relative to what we compile with), we'd
know pre-merge. With this commit, we'll still be protected against bad
deploys (because the post-merge gcp-build-containers step will fail),
but we will have a broken master branch. These failures (ldd check) are
less common than the missing-exe error that we're seeing in
build-backend, so that's acceptable.

Trello'd investigation/fix/uncommenting of this step at
https://trello.com/c/1GmycHBK/1024-fix-pre-merge-gcp-build-containers-step

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X} Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

