### PR TITLE
Fix Fluid autocomplete width CSS

### DIFF
--- a/client/src/app.less
+++ b/client/src/app.less
@@ -394,7 +394,7 @@ body #app * {
 .use-wrapper{
   background: transparent;
   margin-left: 10px;
-  
+
   &.fade{
     opacity: 0.3;
   }
@@ -426,7 +426,7 @@ body #app * {
     margin-top: 0;
     margin-bottom: 8px;
   }
-  
+
   &:hover {
     cursor: pointer;
     color: @yellow;
@@ -1186,9 +1186,13 @@ body #app * {
     // removing position realtive. Removing background color. Something with z-index; Opacity too. Inline-block seems to work.
   }
   #fluid-dropdown {
+    background-color: @dropdown-background;
+    color: @dropdown-foreground;
+    z-index: 1000;
     position: absolute;
     left: -1ch;
     box-shadow: 1px 1px 1px black;
+    width: max-content;
     ul {
       margin: 0;
       padding-inline-start: 0;
@@ -1197,27 +1201,17 @@ body #app * {
         background-color: @dropdown-selected-background;
         color: darken(white, 5%);
       }
-    }
-  }
-  // </ Position autocomplete as a dropdown>
-
-  #fluid-dropdown {
-    // Don't show text under it.
-    background-color: @dropdown-background;
-    color: @dropdown-foreground;
-    z-index: 1000;
-    ul {
       li {
         list-style-type: none; // remove bullet points
         padding: 0 1ch;
 
         .types {
           float: right;
+          margin-left: 4ch;
           text-transform: lowercase;
           font-family: monospace;
-          font-size: 80%;
+          color: darken(@dropdown-foreground, 15%);
         }
-
       }
     }
   }


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test


Makes the width of the Autocomplete the same as its largest item. Ensures some margin between the type and the main content:

![image](https://user-images.githubusercontent.com/1179074/57810666-3183f800-771d-11e9-8549-13e6c988c887.png)

![image](https://user-images.githubusercontent.com/1179074/57810691-41034100-771d-11e9-814a-e10bf8423854.png)

Remove the `font-size: 80%` on the `types` section as it had no effect on width but caused issues with the text baseline. if we want to shrink that text we should do that differently in future.

Fixes: https://trello.com/c/QTsy6Q4L/983-autocomplete-displays-badly-when-lines-are-too-long

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

