### PR TITLE
Fix transparent background in toplevels bug

### DIFF
--- a/client/src/app.less
+++ b/client/src/app.less
@@ -241,6 +241,7 @@ body #app * {
   min-width: @toplevel-min-width;
   padding: 4px;
   border: @top-border;
+  background: @black1;
 
   &.selected {
     background-color: @selected-toplevel-background;


### PR DESCRIPTION
Bug right now
<img width="535" alt="1bug" src="https://user-images.githubusercontent.com/244152/57818860-b92c2f80-773a-11e9-8892-1a0b65469d5e.png">

How we got there. We set the sidebar-box transparent because it was making a weird background in reference boxes that was outside
<img width="693" alt="1origproblem" src="https://user-images.githubusercontent.com/244152/57818902-dd880c00-773a-11e9-90cf-2107d94000c0.png">

The solution, and a more logical place to be setting the background would be in div.toplevel and not div.sidebar-box because that's were our actual content lies.
<img width="693" alt="1solution" src="https://user-images.githubusercontent.com/244152/57818955-10320480-773b-11e9-9222-385601ef6d5f.png">

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

