### PR TITLE
Fix `"keepalive_timeout" directive is duplicate`

### DIFF
--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -189,6 +189,9 @@ gcloud container clusters get-credentials "--zone=${DARK_REGION}" \
 (kubectl create configmap gke-dark-prod --from-env-file ${DARK_CLUSTER_CONFIGMAP_FILE}  -o yaml --dry-run | kubectl replace -f -) \
   ||  kubectl create configmap gke-dark-prod --from-env-file ${DARK_CLUSTER_CONFIGMAP_FILE}
 
+(kubectl create configmap base-nginx --from-file=scripts/support/base-nginx.conf -o yaml --dry-run | kubectl replace -f -) \
+  ||  kubectl create configmap base-nginx --from-file=scripts/support/base-nginx.conf
+
 (kubectl create configmap nginx --from-file=scripts/support/nginx.conf -o yaml --dry-run | kubectl replace -f -) \
   ||  kubectl create configmap nginx --from-file=scripts/support/nginx.conf
 

--- a/scripts/support/base-nginx.conf
+++ b/scripts/support/base-nginx.conf
@@ -1,0 +1,33 @@
+# This is the base nginx.conf from Debian stretch, _minus_ keepalive_timeout so
+# we can set that in "our" nginx.conf
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+

--- a/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
+++ b/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
@@ -157,6 +157,8 @@ spec:
             - name: http-proxy-port
               containerPort: 8000
           volumeMounts:
+            - mountPath: /etc/nginx/nginx.conf
+              name: base-nginx-conf
             - mountPath: /etc/nginx/conf.d
               name: nginx-conf
           lifecycle:
@@ -169,6 +171,9 @@ spec:
         - name: cloudsql-instance-credentials
           secret:
             secretName: cloudsql-instance-credentials
+        - name: base-nginx-conf
+          configMap:
+            name: base-nginx
         - name: nginx-conf
           configMap:
             name: nginx


### PR DESCRIPTION
We introduced keepalive_timeout in our nginx.conf to solve
https://trello.com/c/6tpmZ7KW/1030-reduce-502s-by-bumping-nginx-timeouts.
Unfortunately, the default nginx.conf in debian (which loads our
nginx.conf) already had this directive.

To fix:
- we have added a new base-nginx.conf file, copied from the default
debian nginx.conf but minus the duped directive
- which gets mounted at /etc/nginx/nginx.conf

Followup:
- Make sure the CI load of nginx.conf actually replicates what we have
in prod, which it did not before. Trello:
https://trello.com/c/1Mco5ZDr/1034-improve-testing-of-nginxconf-in-ci

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

