### PR TITLE
Roundtrip ids

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -519,9 +519,12 @@ let () =
       () ) ;
   describe "Record" (fun () ->
       let emptyRecord = ERecord (gid (), []) in
-      let emptyRow = ERecord (gid (), [("", blank)]) in
-      let single = ERecord (gid (), [("f1", fiftySix)]) in
-      let multi = ERecord (gid (), [("f1", fiftySix); ("f2", seventyEight)]) in
+      let emptyRow = ERecord (gid (), [(gid (), "", blank)]) in
+      let single = ERecord (gid (), [(gid (), "f1", fiftySix)]) in
+      let multi =
+        ERecord
+          (gid (), [(gid (), "f1", fiftySix); (gid (), "f2", seventyEight)])
+      in
       (* let withStr = EList (gid (), [EString (gid (), "ab")]) in *)
       t "create record" blank (press K.LeftCurlyBrace 0) ("{}", 1) ;
       t

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -957,7 +957,8 @@ and fluidExpr =
   | EFnCall of id * fluidName * fluidExpr list * sendToRail
   | EPartial of id * string
   | EList of id * fluidExpr list
-  | ERecord of id * (fluidName * fluidExpr) list
+  (* The ID in the list is extra for the fieldname *)
+  | ERecord of id * (id * fluidName * fluidExpr) list
   | EThread of id * fluidExpr list
   (* The 2nd ID is extra for the name *)
   | EConstructor of id * id * fluidName * fluidExpr list


### PR DESCRIPTION
This was an attempt to fix https://trello.com/c/TBeHyFdA/967-using-short-variable-name-ie-i-messes-up-autocomplete-vs-abcd, and also avoid general weirdness.

In fluid, there are fewer IDs. Therefore to roundtrip back to non-fluid, I created new IDs. I speculated that the IDs changing damaged some of the results of analysis, which might have causes the varname problem in the trello. But it didnt fix it (it did seem to make it more deterministic, but hard to tell just yet).

There are probably other problems that come from not roundtripping, so better be safe than sorry.


- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

