### PR TITLE
Add cache headers for serving static assets

### DIFF
--- a/backend/libbackend/static_assets.ml
+++ b/backend/libbackend/static_assets.ml
@@ -131,6 +131,11 @@ let upload_to_bucket
   in
   let ct = Magic_mime.lookup filename in
   let cl = String.length body |> string_of_int in
+  (*
+   * Correctly send object metadata using a multi-part upload with both the raw asset and the metadata in JSON.
+   * Multipart uploads: https://cloud.google.com/storage/docs/json_api/v1/how-tos/multipart-upload
+   * Metadata schema:   https://cloud.google.com/storage/docs/json_api/v1/objects#resource
+   * *)
   let body_string = body |> Ezgzip.compress in
   let boundary = "metadata_boundary" in
   let body =


### PR DESCRIPTION
Previously, static assets were sent to GCP without correct metadata for HTTP headers when they are served. This PR correctly sends the [object metadata](https://cloud.google.com/storage/docs/json_api/v1/objects#resource) using a multi-part upload with both the raw asset and the metadata in JSON (per [this guide](https://cloud.google.com/storage/docs/json_api/v1/how-tos/multipart-upload)).

Fixes [this ticket](https://trello.com/c/4Fz92H22/861-add-cache-headers-for-static-assets).

`StaticAssets::serveLatest_v1` with proper `Cache-Control` headers set on response:

<img width="736" alt="Screen Shot 2019-05-17 at 2 26 51 PM" src="https://user-images.githubusercontent.com/16245199/57957075-f1a14a00-78af-11e9-8cf9-f4861ce23b06.png">


- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

