### PR TITLE
Make ngrok multiuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,13 +277,24 @@ Note: this only works for paul at the moment, but can be easily extended to more
 Expose your local assets using ngrok:
 
 - Join the company ngrok account by asking Paul
-- install ngrok: `brew cask install ngrok`
-- authorize your ngrok client: `ngrok auth YOURTOKEN`
-- run your tunnel: `ngrok http 8000 -hostname=darklang-paul.ngrok.io`
+- install ngrok: `brew cask install ngrok` on OS X, or follow instructions at
+  https://ngrok.com/download for Linux. (The snap installer is broken.)
+- authorize your ngrok client: `ngrok authtoken YOURTOKEN` (found at
+  https://dashboard.ngrok.com/auth)
+- run your tunnel: `ngrok http 8000 -hostname=darklang-<username>.ngrok.io`
+- You can simplify this to `ngrok start darklang` by adding to your
+  `~/.ngrok2/ngrok.yml`:
+```yaml
+tunnels:
+  darklang:
+    proto: http
+    addr: 8000
+    subdomain: darklang-<username>
+```
 
-Use the queryparam "localhost-assets" to load static assets from darklang-paul.ngrok.io instead of static.darklang.com.
+Use the queryparam "localhost-assets=<username>" to load static assets from darklang-<username>.ngrok.io instead of static.darklang.com.
 
-You can check if it's going through via the ngrok console, and by tailing the server logs: `tail -f rundir/logs/server.log`.
+You can check if it's going through via the ngrok console (which logs requests), and by tailing the server logs: `tail -f rundir/logs/server.log`.
 
 
 ## Debugging ppx stuff

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -918,8 +918,8 @@ let admin_ui_html
   let static_host =
     match local with
     (* TODO: if you want access, we can make this more general *)
-    | Some _ ->
-        "darklang-paul.ngrok.io"
+    | Some username ->
+        "darklang-" ^ username ^ ".ngrok.io"
     | _ ->
         Config.static_host
   in


### PR DESCRIPTION
Now any dev can run an ngrok tunnel to use their local FE against the prod
backend. See README.md for docs.

https://trello.com/c/HRHs76mm/1039-config-to-allow-local-client-to-talk-to-prod-backend

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

