### PR TITLE
filter out Cache-Control headers in serve/serveLatest

### DIFF
--- a/backend/libbackend/libstatic_assets.ml
+++ b/backend/libbackend/libstatic_assets.ml
@@ -153,6 +153,11 @@ UTF-8 safe"))
                        (Core_kernel.String.is_substring
                           k
                           ~substring:"Transfer-Encoding") )
+              |> List.filter (fun (k, v) ->
+                     not
+                       (Core_kernel.String.is_substring
+                          k
+                          ~substring:"Cache-Control") )
               |> List.filter (fun (k, v) -> not (String.trim k = ""))
               |> List.filter (fun (k, v) -> not (String.trim v = ""))
             in
@@ -194,6 +199,11 @@ UTF-8 safe"))
                        (Core_kernel.String.is_substring
                           k
                           ~substring:"Transfer-Encoding") )
+              |> List.filter (fun (k, v) ->
+                     not
+                       (Core_kernel.String.is_substring
+                          k
+                          ~substring:"Cache-Control") )
               |> List.filter (fun (k, v) -> not (String.trim k = ""))
               |> List.filter (fun (k, v) -> not (String.trim v = ""))
             in
@@ -231,6 +241,11 @@ UTF-8 safe"))
                        (Core_kernel.String.is_substring
                           k
                           ~substring:"Transfer-Encoding") )
+              |> List.filter (fun (k, v) ->
+                     not
+                       (Core_kernel.String.is_substring
+                          k
+                          ~substring:"Cache-Control") )
               |> List.filter (fun (k, v) -> not (String.trim k = ""))
               |> List.filter (fun (k, v) -> not (String.trim v = ""))
             in
@@ -268,6 +283,11 @@ UTF-8 safe"))
                        (Core_kernel.String.is_substring
                           k
                           ~substring:"Transfer-Encoding") )
+              |> List.filter (fun (k, v) ->
+                     not
+                       (Core_kernel.String.is_substring
+                          k
+                          ~substring:"Cache-Control") )
               |> List.filter (fun (k, v) -> not (String.trim k = ""))
               |> List.filter (fun (k, v) -> not (String.trim v = ""))
             in


### PR DESCRIPTION
As a followup to #936, ignore `Cache-Control` headers when serving via `StaticAssets:{serve, serveLatest}` in Dark. These headers are left on when the bucket URL is hit directly.

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

