### PR TITLE
Ismith+sydney/fix appsupport loading take 2

### DIFF
--- a/backend/templates/ui.html
+++ b/backend/templates/ui.html
@@ -35,6 +35,7 @@
       const canvasId = "{CANVAS_ID}";
       const csrfToken = "{CSRF_TOKEN}";
       const staticUrl = "{STATIC}";
+      const hashReplacements = "{HASH_REPLACEMENTS}";
 
 
     </script>

--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -343,7 +343,7 @@ setTimeout(function(){
   };
 
   async function fetcher(url) {
-    url = "//" + staticUrl + url;
+    url = "//" + staticUrl + (hashReplacements[url] || url);
     return fetch(url)
       .then(resp => {
         if (resp.ok) {


### PR DESCRIPTION
etags map is string_replace'd into ui.html, and called in fetcher() in
appsupport.js

This allows us to:
- load appsupport.js from CDN, instead of templating it into ui.html
  - which means using ngrok will load local appsupport.js, instead of
    deployed appsupport.js
- replace urls fetched by appsupport.js with CDN hashed urls in prod
- _not_ do this replacemement if we are loading via ngrok (because
  appsupport.js will want to load your local /analysiswrapper.js, etc,
  instead of /analysiswrapper-<some hash>js)

For https://trello.com/c/2oWvxMp2/1068-make-changes-to-appsupportjs-to-load-from-static

First attempt at this was in https://github.com/darklang/dark/pull/956;
that PR was deemed overly complex.

Testing
- this works locally (`not hash_static_files` in webserver.ml)
- if I force hashing in local env, all the js files 404 (because the local files don't have etags hashes)
- if I copy local files from backend/src to their cdn-hashed filenames, local works

Post Deploy:
- confirm that the editor loads as expected, or rollback
- confirm that ngrok loads, _including_ the local appsupport.js AND web workers, or rollback


- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

