### PR TITLE
We don't want duplicate avatar entries

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -795,7 +795,14 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         in
         ({m with avatarsList = presentAvatars}, Cmd.none)
     | UpdateAvatarList avatarsList ->
-        let newAvatarList = avatarsList @ m.avatarsList in
+        let newAvatarList =
+          avatarsList @ m.avatarsList
+          |> List.sort_by ~f:(fun a -> a.serverTime)
+          |> List.reverse
+          (* sort in desc time *)
+          |> List.unique_by ~f:(fun (a : Types.avatar) ->
+                 Option.withDefault ~default:"" a.tlid ^ a.username )
+        in
         ({m with avatarsList = newAvatarList}, Cmd.none)
     | AppendStaticDeploy d ->
         ( {m with staticDeploys = DarkStorage.appendDeploy d m.staticDeploys}


### PR DESCRIPTION
Fast follow for https://trello.com/c/Wc0RW6On/901-we-dont-know-where-other-users-are-on-the-canvas

Without this, the tlid avatar view accumulates lots of dupes.

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

