### PR TITLE
Since {hashReplacements} contains json, doesn't need quotes

### DIFF
--- a/backend/templates/ui.html
+++ b/backend/templates/ui.html
@@ -37,6 +37,7 @@
       const staticUrl = "{STATIC}";
       const hashReplacements = {HASH_REPLACEMENTS};
     </script>
+    <script type="text/javascript" src="//{STATIC}/appsupport.js"></script>
   </head>
   <body onKeyDown="stopKeys(event)" onKeyUp="stopKeys(event)"></body>
 </html>

--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -343,7 +343,7 @@ setTimeout(function () {
   };
 
   async function fetcher(url) {
-    url = "//" + staticUrl + url;
+    url = "//" + staticUrl + (hashReplacements[url] || url);
     return fetch(url)
       .then(resp => {
         if (resp.ok) {


### PR DESCRIPTION
quotes

Otherwise, we get errors b/c it sees the {hashReplacements} string as
ending early.

https://trello.com/c/2oWvxMp2/1068-make-changes-to-appsupportjs-to-load-from-static

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

