### PR TITLE
Make autocomplete show by default in Fluid

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -701,26 +701,6 @@ let () =
         nonEmptyLet
         (press K.Enter 11)
         ("let *** = 6\n5", 12) ;
-      t
-        "end of if-then blank goes up properly"
-        emptyIf
-        (presses ~wrap:false [K.Escape; K.Up] 17)
-        ("if ___\nthen\n  ___\nelse\n  ___", 11) ;
-      t
-        "end of if-then blank goes up properly, twice"
-        emptyIf
-        (presses ~wrap:false [K.Escape; K.Up; K.Up] 17)
-        ("if ___\nthen\n  ___\nelse\n  ___", 5) ;
-      t
-        "end of if-then blank goes down properly"
-        emptyIf
-        (presses ~wrap:false [K.Escape; K.Down] 5)
-        ("if ___\nthen\n  ___\nelse\n  ___", 11) ;
-      t
-        "end of if-then blank goes down properly, twice"
-        emptyIf
-        (presses ~wrap:false [K.Escape; K.Down; K.Down] 5)
-        ("if ___\nthen\n  ___\nelse\n  ___", 17) ;
       (* moving through the autocomplete *)
       test "up goes through the autocomplete" (fun () ->
           expect

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -528,7 +528,6 @@ let initAC (s : state) (m : Types.model) : state = {s with ac = AC.init m}
 let isAutocompleting (ti : tokenInfo) (s : state) : bool =
   Token.isAutocompletable ti.token
   && s.upDownCol = None
-  && s.ac.index <> None
   && s.newPos <= ti.endPos
   && s.newPos >= ti.startPos
 


### PR DESCRIPTION
The autocomplete box would only show when you started typing, instead of once a blank is selected.

Implementation involves changing `Fluid.isAutocompleting` condition to ignore the current autocomplete index. A side effect of this is that hitting up/down on a blank does no longer moves between lines, but toggles autocomplete options (since they're now open by default); which invalidates some tests.

Fixes [this](https://trello.com/c/zU2xrIHh/1069-autcomplete-no-longer-appears-by-default).

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

