### PR TITLE
Better error for non-json request w content-type: application-json

### DIFF
--- a/backend/libexecution/parsed_request.ml
+++ b/backend/libexecution/parsed_request.ml
@@ -29,7 +29,8 @@ let body_parser_type headers =
 let parser_fn p (str : string) : dval =
   match p with
   | Json ->
-      Dval.of_unknown_json_v0 str
+    ( try Dval.of_unknown_json_v0 str with e ->
+        Exception.enduser ~actual:str ("Invalid json: " ^ str) )
   | Form ->
       Dval.of_form_encoding str
   | Unknown ->


### PR DESCRIPTION
Before:
```
[ismith:~] $ curl -i -X POST -H 'Content-type: application/json'  ismith-foo.builtwithdark.localhost:8000/intsize -d '{"foo":}'
HTTP/1.1 500 Internal Server Error
content-length: 291
x-darklang-execution-id: 2608031104071982420

{
  "short":
    "Invalid json: (\"Yojson.Json_error(\\\"Line 1, bytes 7-8:\\\\nInvalid token '}'\\\")\")",
  "long": null,
  "tipe": "userCode",
  "actual": "{\"foo\":}",
  "actual_tipe": null,
  "expected": null,
  "result": null,
  "result_tipe": null,
  "info": {},
  "workarounds": []
}
```
After:
```
[ismith:~] $ curl -i -X POST -H 'Content-type: application/json'  ismith-foo.builtwithdark.localhost:8000/intsize -d '{"foo":}'
HTTP/1.1 400 Bad Request
content-length: 22
x-darklang-execution-id: 536101589386316267

Invalid json: {"foo":}
```

https://trello.com/c/5dfMycPd/926-better-error-for-non-json-request-95

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

