### PR TITLE
Sort avatars before uniquifying for canvas-level view

### DIFF
--- a/client/src/Avatar.ml
+++ b/client/src/Avatar.ml
@@ -60,7 +60,14 @@ let viewAvatars (avatars : avatar list) (tlid : tlid) : msg Html.html =
 
 
 let viewAllAvatars (avatars : avatar list) : msg Html.html =
-  let avatars = avatars |> List.uniqueBy ~f:(fun avatar -> avatar.username) in
+  (* Sort by serverTime desc, then unique by avatar - gets us the most recent
+   * avatar for a given username *)
+  let avatars =
+    avatars
+    |> List.sortBy ~f:(fun avatar -> avatar.serverTime)
+    |> List.reverse
+    |> List.uniqueBy ~f:(fun avatar -> avatar.username)
+  in
   let avatarView = List.map ~f:avatarDiv avatars in
   Html.div
     [Html.class' "all-avatars"]


### PR DESCRIPTION
This ensures that the avatar being displayed is the most recent for that
user - which makes a difference, if we have an older inactive one, and a
newer active one.

https://trello.com/c/ZTAVO9Ql/1122-all-present-avatars-are-shown-on-top-level

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

