### PR TITLE
Make the timestamp of input data be relative

### DIFF
--- a/client/src/Util.ml
+++ b/client/src/Util.ml
@@ -34,6 +34,56 @@ let removeQuotes (s : string) : string =
   else s
 
 
+let humanReadableTimeElapsed (time : float) : string =
+  let msPerMinute = 60.0 *. 1000.0 in
+  let msPerHour = msPerMinute *. 60.0 in
+  let msPerDay = msPerHour *. 24.0 in
+  let msPerMonth = msPerDay *. 30.0 in
+  let msPerYear = msPerDay *. 365.0 in
+  let rec f time =
+    if time /. msPerYear > 1.0
+    then
+      let suffix = if time /. msPerYear > 2.0 then "years" else "year" in
+      ( (time /. msPerYear |> int_of_float |> string_of_int)
+      ^ " "
+      ^ suffix
+      ^ ", " )
+      ^ f (mod_float time msPerYear)
+    else if time /. msPerMonth > 1.0
+    then
+      let suffix = if time /. msPerMonth > 2.0 then "months" else "month" in
+      ( (time /. msPerMonth |> int_of_float |> string_of_int)
+      ^ " "
+      ^ suffix
+      ^ ", " )
+      ^ f (mod_float time msPerMonth)
+    else if time /. msPerDay > 1.0
+    then
+      let suffix = if time /. msPerDay > 2.0 then "days" else "day" in
+      ( (time /. msPerDay |> int_of_float |> string_of_int)
+      ^ " "
+      ^ suffix
+      ^ ", " )
+      ^ f (mod_float time msPerDay)
+    else if time /. msPerHour > 1.0
+    then
+      let suffix = if time /. msPerHour > 2.0 then "hours" else "hour" in
+      ( (time /. msPerHour |> int_of_float |> string_of_int)
+      ^ " "
+      ^ suffix
+      ^ ", " )
+      ^ f (mod_float time msPerHour)
+    else if time /. msPerMinute > 1.0
+    then
+      let suffix = if time /. msPerMinute > 2.0 then "minutes" else "minute" in
+      ((time /. msPerMinute |> int_of_float |> string_of_int) ^ " " ^ suffix)
+      ^ f (mod_float time msPerMinute)
+    else ""
+  in
+  let diff = f time in
+  if diff = "" then "less than a minute" else diff
+
+
 module Regex = struct
   type t = Js.Re.t
 

--- a/client/src/ViewData.ml
+++ b/client/src/ViewData.ml
@@ -54,8 +54,8 @@ let viewInputs (vs : ViewUtils.viewState) (ID astID : id) : msg Html.html list
     let timestamp =
       Option.map ~f:(fun (td : traceData) -> td.timestamp) traceData
       |> Option.map ~f:(fun tstr ->
-             Js.Date.now () -. Js.Date.parseAsFloat tstr |> Util.timeDifference
-         )
+             Js.Date.now () -. Js.Date.parseAsFloat tstr
+             |> Util.humanReadableTimeElapsed )
       |> Option.withDefault ~default:""
     in
     (* Note: the isActive and hoverID tlcursors are very different things *)


### PR DESCRIPTION
The timestamp of input data is formatted as absolute time. This replaces that with a human-friendly relative time "X minutes ago".

Fixes [this ticket](https://trello.com/c/M0FQo8zK/858-the-timestamp-of-input-values-should-be-relative-4-seconds-ago).

Before and after:
 
<img width="582" alt="Screen Shot 2019-05-29 at 2 55 05 PM" src="https://user-images.githubusercontent.com/16245199/58594210-d3c5d480-8221-11e9-8651-a61a084803bb.png">

<img width="376" alt="Screen Shot 2019-05-29 at 2 50 05 PM" src="https://user-images.githubusercontent.com/16245199/58594207-d3c5d480-8221-11e9-9e71-fd7475fa1165.png">


- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

