### PR TITLE
convert fluid colors back to prev color scheme

### DIFF
--- a/client/src/styles/app.scss
+++ b/client/src/styles/app.scss
@@ -1265,18 +1265,11 @@ https://github.com/chriskempson/tomorrow-theme */
     $black: #1d1f21;
     $background: transparent;
     $selected-background: #2d2d2d;
-    $blanks: lighten($selected-background, 8%);
-    $currentline: #282a2e;
-    $selection: #373b41;
-    $foreground: #c5c8c6;
-    $comment: #969896;
-    $red: #cc6666;
-    $orange: #de935f;
-    $yellow: #f0c674;
-    $green: #b5bd68;
-    $aqua: #8abeb7;
-    $blue: #81a2be;
-    $purple: #b294bb;
+    $blanks: lighten($black1, 8%);
+    $currentline: $grey1;
+    $selection: $grey3;
+    $foreground: $white2;
+    $comment: $grey3;
 
     $dropdown-background: lighten($selected-background, 10%);
     $dropdown-selected-background: lighten($selected-background, 20%);
@@ -1313,7 +1306,7 @@ https://github.com/chriskempson/tomorrow-theme */
 
     .fluid-string {
         white-space: pre;
-        color: $green;
+        color: $string-color;
     }
 
     .fluid-sep,
@@ -1333,6 +1326,12 @@ https://github.com/chriskempson/tomorrow-theme */
         margin-right: 0.11px;
     }
 
+    .fluid-lambda-symbol,
+    .fluid-lambda-var,
+    .fluid-lambda-arrow {
+        color: $orange;
+    }
+
     .fluid-blank {
         background-color: $blanks;
     }
@@ -1343,16 +1342,16 @@ https://github.com/chriskempson/tomorrow-theme */
     }
 
     .fluid-empty {
-        color: green;
+        color: $green;
         background-color: $blanks;
     }
 
     .fluid-keyword {
-        color: $purple;
+        color: $green;
     }
 
     .fluid-fn-name {
-        color: $orange;
+        color: $white2;
     }
 
     .fluid-partial {
@@ -1363,6 +1362,11 @@ https://github.com/chriskempson/tomorrow-theme */
     .fluid-entry {
         position: relative;
         // removing position realtive. Removing background color. Something with z-index; Opacity too. Inline-block seems to work.
+    }
+
+    .fluid-thread-pipe {
+        color: $blue;
+        font-size: 10px;
     }
 
     /* Will style more later. Cmd palette should look like a smaller version of omnibox


### PR DESCRIPTION
- [x] Include [Trello](https://trello.com/c/vcg0XCS1/1096-convert-fluid-to-old-colorscheme)  link
- [x] Describe the goals, problem and solution
Just revert fluid colors back to old color scheme.
- [ ] Make sure info from this description is also in comments
- [x] Include before/after screenshots/gif if applicable
Old Colors:
<img width="968" alt="Screen Shot 2019-05-29 at 2 55 31 PM" src="https://user-images.githubusercontent.com/244152/58594427-70887200-8222-11e9-9dd6-8cd4f727d4da.png">

Update Fluid colors to old colors:
<img width="1114" alt="Screen Shot 2019-05-29 at 2 54 46 PM" src="https://user-images.githubusercontent.com/244152/58594455-86963280-8222-11e9-9f62-580a3b4570c1.png">

- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

