### PR TITLE
Add rudimentary deleting of fns. Not great but good enough for now.

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -151,6 +151,9 @@ let () =
     EBinOp
       (gid (), "==", EVariable (gid (), "myvar"), EInteger (gid (), 5), NoRail)
   in
+  let aConstructor =
+    EConstructor (gid (), gid (), "Just", [EBlank (gid ())])
+  in
   let aField =
     EFieldAccess (gid (), EVariable (gid (), "obj"), gid (), "field")
   in
@@ -470,6 +473,18 @@ let () =
         aFullBinOp
         (press K.Delete 6)
         ("___", 5) ;
+      () ) ;
+  describe "Constructors" (fun () ->
+      t
+        "backspace on a constructor deletes the constructor"
+        aConstructor
+        (press K.Backspace 4)
+        ("___", 0) ;
+      t
+        "delete on a constructor deletes the constructor"
+        aConstructor
+        (press K.Delete 0)
+        ("___", 0) ;
       () ) ;
   describe "Lambdas" (fun () ->
       t "backspace over lambda symbol" aLambda (backspace 1) ("___", 0) ;

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -1243,12 +1243,14 @@ let removeField (id : id) (ast : ast) : ast =
           fail "not a fieldAccess" )
 
 
-let deleteFunction (id : id) (ast : ast) : ast =
+let deleteWithArguments (id : id) (ast : ast) : ast =
   wrap id ast ~f:(fun e ->
       match e with
       | EFnCall (_, _, _, _) ->
           EBlank (gid ())
       | EBinOp (_, _, _, _, _) ->
+          EBlank (gid ())
+      | EConstructor (_, _, _, _) ->
           EBlank (gid ())
       | _ ->
           fail "not a fncall " )
@@ -1773,7 +1775,6 @@ let doBackspace ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TRecordSep _
   | TSep
   | TThreadPipe _
-  | TConstructorName _
   | TLambdaSep _
   | TPatternBlank _
   | TPatternConstructorName _ ->
@@ -1787,9 +1788,9 @@ let doBackspace ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TBinOp (id, _) ->
       (* TODO this should move to the start of the new blank, but we don't know
        * where it is at the moment. *)
-      (deleteFunction id ast, moveToStart ti s |> left)
-  | TFnName (id, _, _) ->
-      (deleteFunction id ast, moveToStart ti s)
+      (deleteWithArguments id ast, moveToStart ti s |> left)
+  | TConstructorName (id, _) | TFnName (id, _, _) ->
+      (deleteWithArguments id ast, moveToStart ti s)
   | TString _
   | TPatternString _
   | TRecordField _
@@ -1857,9 +1858,9 @@ let doDelete ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TBinOp (id, _) ->
       (* TODO this should move to the start of the new blank, but we don't know
        * where it is at the moment. *)
-      (deleteFunction id ast, moveToStart ti s |> left)
-  | TFnName (id, _, _) ->
-      (deleteFunction id ast, moveToStart ti s)
+      (deleteWithArguments id ast, moveToStart ti s |> left)
+  | TConstructorName (id, _) | TFnName (id, _, _) ->
+      (deleteWithArguments id ast, moveToStart ti s)
   | TFieldOp id ->
       (removeField id ast, s)
   | TString (id, str) ->
@@ -1911,8 +1912,6 @@ let doDelete ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
       (replacePatternFloatFraction (f str) mID id ast, s)
   | TPatternFloatWhole (mID, id, str) ->
       (replacePatternFloatWhole (f str) mID id ast, s)
-  | TConstructorName _ ->
-      (ast, s)
   | TPatternBlank _ | TPatternConstructorName _ ->
       (ast, s)
 


### PR DESCRIPTION
This allows us to delete functions and binops and constructors using the backspace and delete keys. This isn't the right design, but this is easy and it gets us closer to feature parity (just giving us the ability to delete) with non-fluid.

- [ ] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [ ] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [ ] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

