### PR TITLE
Don't send presence messages if origin isn't prod

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -52,6 +52,7 @@ let init (flagString : string) (location : Web.Location.location) =
     ; toplevels = []
     ; canvasName = Url.parseCanvasName location
     ; userContentHost
+    ; origin = location.origin
     ; environment
     ; csrfToken
     ; browserId = createBrowserId }

--- a/client/src/Defaults.ml
+++ b/client/src/Defaults.ml
@@ -104,6 +104,7 @@ let defaultModel : model =
   ; canvasProps = defaultCanvasProps
   ; canvasName = "builtwithdark"
   ; userContentHost = "builtwithdark.com"
+  ; origin = ""
   ; environment = "none"
   ; csrfToken = "UNSET_CSRF"
   ; routingTableOpenDetails = StrSet.empty

--- a/client/src/RPC.ml
+++ b/client/src/RPC.ml
@@ -143,4 +143,13 @@ let sendPresence (m : model) (av : avatarModelMessage) : msg Tea.Cmd.t =
       url
       (Encoders.sendPresenceParams av)
   in
-  Tea.Http.send (fun _ -> TriggerSendPresenceCallback (Ok ())) request
+  (* If origin is https://darklang.com, then we're in prod (or ngrok, running
+   * against prod) and
+   * presence.darklang.com's CORS rules will allow this request. If not, we're
+   * in local, and both CORS and auth (session, canvas_id) will not work against
+   * presence.darklang.com. By putting the conditional here instead of at the
+   * beginning of the function, we still exercise the message and request
+   * generating code locally. *)
+  if m.origin = "https://darklang.com"
+  then Tea.Http.send (fun _ -> TriggerSendPresenceCallback (Ok ())) request
+  else Tea.Cmd.none

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -1132,6 +1132,7 @@ and model =
   ; canvasProps : canvasProps
   ; canvasName : string
   ; userContentHost : string
+  ; origin : string
   ; environment : string
   ; csrfToken : string
   ; routingTableOpenDetails : StrSet.t


### PR DESCRIPTION
- Prod CORS settings want an origin that is https://darklang.com, _AND_
- incoming msgs would need to have prod auth and canvas_id

Neither of which is true for localhost.

We impl this by checking origin so that if you are running local FE
through ngrok against prod backend, presence will work.

https://trello.com/c/mYh69wXh/1126-local-fe-shouldnt-try-to-presence-msg

- [X] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [X] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [X] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

