### PR TITLE
Disallow some names from being used as account names or auth_domains

### DIFF
--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -3,6 +3,52 @@ open Libexecution
 open Types
 module Hash = Sodium.Password_hash.Bytes
 
+let banned_usernames : string list =
+  (* from https://ldpreload.com/blog/names-to-reserve *)
+  [ "abuse"
+  ; "admin"
+  ; "administrator"
+  ; "autoconfig"
+  ; "broadcasthost"
+  ; "ftp"
+  ; "hostmaster"
+  ; "imap"
+  ; "info"
+  ; "is"
+  ; "isatap"
+  ; "it"
+  ; "localdomain"
+  ; "localhost"
+  ; "mail"
+  ; "mailer-daemon"
+  ; "marketing"
+  ; "mis"
+  ; "news"
+  ; "nobody"
+  ; "noc"
+  ; "noreply"
+  ; "no-reply"
+  ; "pop"
+  ; "pop3"
+  ; "postmaster"
+  ; "root"
+  ; "sales"
+  ; "security"
+  ; "smtp"
+  ; "ssladmin"
+  ; "ssladministrator"
+  ; "sslwebmaster"
+  ; "support"
+  ; "sysadmin"
+  ; "usenet"
+  ; "uucp"
+  ; "webmaster"
+  ; "wpad"
+  ; "www" ]
+  @ (* original to us *)
+    ["billing"]
+
+
 type username = string [@@deriving yojson]
 
 type account =
@@ -188,14 +234,18 @@ let hash_password password =
 
 
 let owner ~(auth_domain : string) : Uuidm.t option =
-  Db.fetch_one_option
-    ~name:"owner"
-    ~subject:auth_domain
-    "SELECT id from accounts
+  let auth_domain = String.lowercase auth_domain in
+  if List.mem banned_usernames auth_domain ~equal:( = )
+  then None
+  else
+    Db.fetch_one_option
+      ~name:"owner"
+      ~subject:auth_domain
+      "SELECT id from accounts
      WHERE accounts.username = $1"
-    ~params:[String (String.lowercase auth_domain)]
-  |> Option.map ~f:List.hd_exn
-  |> Option.bind ~f:Uuidm.of_string
+      ~params:[String auth_domain]
+    |> Option.map ~f:List.hd_exn
+    |> Option.bind ~f:Uuidm.of_string
 
 
 let auth_domain_for host : string =
@@ -335,10 +385,24 @@ let upsert_useful_canvases () : unit =
     ; name = "Korede" }
 
 
+let upsert_banned_accounts () : unit =
+  ignore
+    ( banned_usernames
+    |> List.map ~f:(fun username ->
+           upsert_account
+             { username
+             ; password =
+                 "" (* empty string isn't a valid hash, so can't login *)
+             ; email = "ops@darklang.com"
+             ; name = "Disallowed account" } ) ) ;
+  ()
+
+
 let init () : unit =
   if Config.create_accounts
   then (
     init_testing () ;
+    upsert_banned_accounts () ;
     upsert_admins () ;
     upsert_useful_canvases () ;
     () )


### PR DESCRIPTION
List is from geofft's https://ldpreload.com/blog/names-to-reserve, which
in turn was inspired by a Sandstorm issue:
https://github.com/sandstorm-io/sandcats/issues/43

(Plus "billing")

https://trello.com/c/QdVB0J9z/1171-reserve-some-account-names-as-unusable-by-customers

- [x] Include [Trello](https://trello.com/b/B25On0K9/feb-2019)  link
- [x] Describe the goals, problem and solution ([PR guide](https://docs.google.com/document/d/1IeQdEh7ROhNV6Z2mJdu35E6r8XtFOkOhyhIeAvm8amE/edit))
- [x] Make sure info from this description is also in comments
- [ ] Include before/after screenshots/gif if applicable
- [ ] Add intended followups as trellos
- [ ] If risky, discuss your reversion strategy
- [ ] If this is fixing a regression, add a test

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket
  - [ ] Out-of-scope product changes have been explained
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged
  - [ ] All existing canvases should continue to work
  - [ ] New features are documented in the User Manual or Trello filed
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions)
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

