### PR TITLE
Add DB::generateKey

### DIFF
--- a/backend/libexecution/libdb2.ml
+++ b/backend/libexecution/libdb2.ml
@@ -170,4 +170,18 @@ let fns : Lib.shortfn list =
     ; d = "Returns an `Obj` representing { fieldName: fieldType } in `table`"
     ; f = NotClientAvailable
     ; ps = false
+    ; dep = false }
+  ; { pns = ["DB::generateKey"]
+    ; ins = []
+    ; p = []
+    ; r = TStr
+    ; d = "Returns a random key suitable for use as a DB key"
+    ; f =
+        InProcess
+          (function
+          | _, [] ->
+              Uuidm.v `V4 |> Uuidm.to_string |> Dval.dstr_of_string_exn
+          | args ->
+              fail args)
+    ; ps = false
     ; dep = false } ]


### PR DESCRIPTION
https://trello.com/c/B1xcdQPo/1181-add-a-dbgeneratekey-function

Adds a DB::generateKey which makes a random uuid-like string. This helps us when doing DB::set, cause (UUID::generate |> toString) is a mouthful, and DB::add gives users the wrong idea.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

