### PR TITLE
Don't show an avatar for a users current session 

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -794,7 +794,13 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
     | ExpireAvatars ->
         ({m with avatarsList = m.avatarsList |> expireAvatars}, Cmd.none)
     | UpdateAvatarList avatarsList ->
-        ({m with avatarsList = avatarsList |> expireAvatars}, Cmd.none)
+        let updatedAvatars =
+          avatarsList
+          |> List.filter ~f:(fun (avatar : Types.avatar) ->
+                 avatar.browserId != m.browserId )
+          |> expireAvatars
+        in
+        ({m with avatarsList = updatedAvatars}, Cmd.none)
     | AppendStaticDeploy d ->
         ( {m with staticDeploys = DarkStorage.appendDeploy d m.staticDeploys}
         , Cmd.none )

--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -315,7 +315,8 @@ and presenceMsg j : avatar =
   ; username = field "username" string j
   ; serverTime = field "serverTime" serverTime j
   ; email = field "email" string j
-  ; fullname = field "name" (optional string) j }
+  ; fullname = field "name" (optional string) j
+  ; browserId = field "browserId" string j }
 
 
 and inputValueDict j : inputValueDict =

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -1122,7 +1122,8 @@ and avatar =
   ; tlid : string option
   ; username : string
   ; email : string
-  ; fullname : string option }
+  ; fullname : string option
+  ; browserId : string }
 
 and avatarModelMessage =
   { browserId : string


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Fixes: 
https://trello.com/c/hVRqPAsJ/1204-dont-show-the-presence-indicator-for-the-current-session-in-handlers

Adding logic to filter out the current session's avatar by the browser id 

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

