### PR TITLE
Store and get the browser id from session storage

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -26,6 +26,17 @@ let createBrowserId : string =
   BsUuid.Uuid.V4.create () |> BsUuid.Uuid.V4.toString
 
 
+let manageBrowserId : string =
+  (* Setting the browser id in session storage so it is stored per tab *)
+  match Dom.Storage.getItem "browserId" Dom.Storage.sessionStorage with
+  | Some browserId ->
+      browserId
+  | None ->
+      let newBrowserId = createBrowserId in
+      Dom.Storage.setItem "browserId" newBrowserId Dom.Storage.sessionStorage ;
+      newBrowserId
+
+
 let init (flagString : string) (location : Web.Location.location) =
   let {Flags.editorState; complete; userContentHost; environment; csrfToken} =
     Flags.fromString flagString
@@ -34,15 +45,6 @@ let init (flagString : string) (location : Web.Location.location) =
   let page =
     Url.parseLocation location
     |> Option.withDefault ~default:Defaults.defaultModel.currentPage
-  in
-  let storedBrowserId =
-    match Dom.Storage.getItem "browserId" Dom.Storage.sessionStorage with
-    | Some browserId ->
-        browserId
-    | None ->
-        let newBrowserId = createBrowserId in
-        Dom.Storage.setItem "browserId" newBrowserId Dom.Storage.sessionStorage ;
-        newBrowserId
   in
   (* these saved values may not be valid yet *)
   let savedCursorState = m.cursorState in
@@ -61,7 +63,7 @@ let init (flagString : string) (location : Web.Location.location) =
     ; origin = location.origin
     ; environment
     ; csrfToken
-    ; browserId = storedBrowserId }
+    ; browserId = manageBrowserId }
   in
   let timeStamp = Js.Date.now () /. 1000.0 in
   let avMessage : avatarModelMessage =


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Fixes: https://trello.com/c/0JSG8HX4/1213-save-browser-id-to-session-storage

Previously we were creating a new browser id every time the page was loaded which created a bug where you would see your old session avatar if you reloaded the page, By saving the browser id to session storage we are able to persist the same browser id for each tab (note: I used session storage instead of local storage because session storage is for each tab) 

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

