### PR TITLE
Set `overflow-y: scroll` for omnibox

### DIFF
--- a/client/src/styles/_dropdown.scss
+++ b/client/src/styles/_dropdown.scss
@@ -155,7 +155,7 @@ $wrapper-background: $black2;
   ul#autocomplete-holder {
     width: 100%;
     background-color: $wrapper-background;
-    overflow-y: visible;
+    overflow-y: scroll;
     list-style-type: none;
     @include border-radius-bottom(6px);
 


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [x] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

The `AC.focusItem` calculation seems off with the style changes. Filing
ticket for Alice for follow-up. This PR gets rid of the nasty visible overflow tho.

https://trello.com/c/5xVXf7r3/1244-style-update-fudged-acfocusitem-calculation-for-omnibox


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

