### PR TITLE
Omnibox should show all options without having to scroll

### DIFF
--- a/client/src/styles/_dropdown.scss
+++ b/client/src/styles/_dropdown.scss
@@ -154,6 +154,7 @@ $wrapper-background: $black2;
 
   ul#autocomplete-holder {
     width: 100%;
+    max-height: unset;
     background-color: $wrapper-background;
     overflow-y: visible;
     list-style-type: none;


### PR DESCRIPTION
[trello](https://trello.com/c/5xVXf7r3/1244-style-update-fudged-acfocusitem-calculation-for-omnibox)

Alice accidentally fudged up omnibox in her css refractor. Omnibox unlike autocomplete, and command palette does not appear inside code bits, or db fields, with things around it . When visible it is front and center, it has no siblings or parents. Therefore it can take precedence and not have to worry about other stuff and keeping its size clamped.
Essentially omnibox should show all the options, and because omnibox was sharing some autocomplete styles things got messed up in the refactor.

Before
<img width="537" alt="Screen Shot 2019-06-20 at 2 50 59 PM" src="https://user-images.githubusercontent.com/244152/59884193-657db900-936c-11e9-9b0e-5a4931252301.png">

After
<img width="537" alt="Screen Shot 2019-06-20 at 2 47 02 PM" src="https://user-images.githubusercontent.com/244152/59884198-6c0c3080-936c-11e9-8e8c-256e6bfed73b.png">


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

