### PR TITLE
put cursor in proper position when autocompleting thread

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ RUN pip install -U crcmod
 # Ocaml
 ############################
 USER dark
-ENV FORCE_OCAML_BUILD 6
+ENV FORCE_OCAML_BUILD 5
 RUN curl -sSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh | bash
 ENV OPAMJOBS 4
 # disabling sandboxing as it breaks and isn't necessary cause Docker

--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -1189,18 +1189,6 @@ let () =
         (presses [K.Equals; K.Space] 0)
         ("_________ == _________", 0) ;
       *)
-      (*
-      let emptyThread = EThread (gid (), [EBlank (gid ()); EBlank (gid ())]) in
-      let threadInPlaceholder =
-        EFnCall (gid (), "Http::badRequest", [EBlank (gid ())], NoRail)
-      in
-      let threadInIf = EIf (gid (), newB (), emptyThread, newB ()) in
-      let threadInLambda = ELambda (gid (), [], emptyThread) in
-      let threadInMatch =
-        let mid = gid () in
-        EMatch (mid, EBlank (gid ()), [(FPBlank (mid, gid ()), emptyThread)])
-      in
-      *)
       t
         "variable moves to right place"
         (EPartial (gid (), "req", EBlank (gid ())))


### PR DESCRIPTION
Cursor would usually end up in the wrong place because of hard-coded offset. Instead, determine starting position of blank after the thread pipe token.

This has been corrected and a tests added for that behaviour.

https://trello.com/c/JV1nAF7P/1233-when-creating-a-thread-the-cursor-ends-up-in-the-wrong-place

before & after:
![](https://trello-attachments.s3.amazonaws.com/5bc4c6f5450b4b3ed2856bb5/5d09245d8877e30464a16bc3/ec14dfbf2a141a429a36803ae3c88ada/Jun-18-2019_11-14-38.gif)


![create-thread](https://user-images.githubusercontent.com/16245199/60039364-631ca700-966b-11e9-87e9-59f3b887ce77.gif)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

