### PR TITLE
Show all deploys not just most recent

### DIFF
--- a/client/src/ViewRoutingTable.ml
+++ b/client/src/ViewRoutingTable.ml
@@ -602,13 +602,12 @@ let closedDeployStats2html (m : model) : msg Html.html =
               [Html.class' "count-box"]
               [Html.p [] [Html.text (count |> string_of_int)]] ] ]
   in
-  let deployLatest =
-    if count <> 0
-    then entries |> List.take ~count:1 |> List.map ~f:deploy2html
-    else []
-  in
   let hoverView =
-    if count = 0 then [] else [Html.div [Html.class' "hover"] deployLatest]
+    if count > 0
+    then
+      let deploys = List.map ~f:deploy2html entries in
+      [Html.div [Html.class' "hover"] deploys]
+    else [Vdom.noNode]
   in
   let icon =
     Html.div


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Fixes: https://trello.com/c/jU05rkc8/1225-sidebar-hover-only-shows-one-deploy-even-though-there-are-4

Alice said:

> Alice Wong [2:26 PM]
>  in the collapsed state, we should just show all


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

