### PR TITLE
make delete button work on infix operators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ RUN pip install -U crcmod
 # Ocaml
 ############################
 USER dark
-ENV FORCE_OCAML_BUILD 6
+ENV FORCE_OCAML_BUILD 5
 RUN curl -sSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh | bash
 ENV OPAMJOBS 4
 # disabling sandboxing as it breaks and isn't necessary cause Docker

--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -659,7 +659,17 @@ let () =
         (press K.Backspace 11)
         ("___", 0) ;
       t
-        "deleting an infix with a placeholder goes to right place"
+        "pressing delete to clear partial reverts for blank rhs"
+        (EPartial (gid (), "|", EBinOp (gid (), "||", anInt, blank, NoRail)))
+        (press K.Delete 6)
+        ("12345", 5) ;
+      t
+        "pressing delete to clear partial reverts for blank rhs, check lhs pos goes to start"
+        (EPartial (gid (), "|", EBinOp (gid (), "||", newB (), blank, NoRail)))
+        (press K.Delete 10)
+        ("___", 0) ;
+      t
+        "using backspace to remove an infix with a placeholder goes to right place"
         (EPartial (gid (), "|", EBinOp (gid (), "||", newB (), newB (), NoRail)))
         (press K.Backspace 11)
         ("___", 0) ;
@@ -672,6 +682,21 @@ let () =
         "pressing backspace on single digit binop leaves lhs"
         (EBinOp (gid (), "+", anInt, anInt, NoRail))
         (press K.Backspace 7)
+        ("12345", 5) ;
+      t
+        "using delete to remove an infix with a placeholder goes to right place"
+        (EPartial (gid (), "|", EBinOp (gid (), "||", newB (), newB (), NoRail)))
+        (press K.Delete 10)
+        ("___", 0) ;
+      t
+        "pressing delete to clear rightpartial reverts for blank rhs"
+        (ERightPartial (gid (), "|", blank))
+        (press K.Delete 4)
+        ("___", 0) ;
+      t
+        "pressing delete on single digit binop leaves lhs"
+        (EBinOp (gid (), "+", anInt, anInt, NoRail))
+        (press K.Delete 6)
         ("12345", 5) ;
       t
         "pressing letters and numbers on a partial completes it"
@@ -717,12 +742,14 @@ let () =
         aFullBinOp
         (backspace 8)
         ("myvar |@ 5", 7) ;
+      tp "deleting shows ghost partial" aFullBinOp (delete 6) ("myvar |@ 5", 6) ;
+      (* TODO backspacing/deleting partial with ghost
+       * should leave a full partial instead of deleting it *)
       t
         "backspacing partial with ghost removes it"
         aPartialBinOp
         (backspace 7)
         ("myvar", 5) ;
-      tp "deleting shows ghost partial" aFullBinOp (delete 6) ("myvar |@ 5", 6) ;
       t
         "deleting partial with ghost removes it"
         aPartialBinOp


### PR DESCRIPTION
Formerly, delete button would remove the entire infix operator. This PR brings that opreation ot parity with the backspace button, which replaces a multi-character infix operator with a "partial ghost" on one of the character that was deleted.

Fixes: https://trello.com/c/C57SUp3d/1228-delete-button-should-work-on-infix-and-partials-like-the-backspace-button-does.

before & after
![infix-delete-old](https://user-images.githubusercontent.com/16245199/60056640-72651a00-9696-11e9-8416-77e5d912ba96.gif)

![infix-delete](https://user-images.githubusercontent.com/16245199/60056571-2fa34200-9696-11e9-88b3-059018bdb1a4.gif)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

