### PR TITLE
Swallow space key press in blanks

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -1144,7 +1144,7 @@ let () =
         nestedIf
         (press ~wrap:false K.GoToEndOfLine 12)
         ("if 5\nthen\n  if 5\n  then\n    6\n  else\n    7\nelse\n  7", 16) ;
-      t "try to insert space on blank" emptyIf (press ~wrap:false K.Space 2) ("if ___\nthen\n  ___\nelse\n  ___", 2) ;
+      t "try to insert space on blank" emptyIf (press ~wrap:false K.Space 3) ("if ___\nthen\n  ___\nelse\n  ___", 3) ;
       t "try to insert space on blank indent 2" emptyIf (press ~wrap:false K.Space 14) ("if ___\nthen\n  ___\nelse\n  ___", 14) ;
       () ) ;
   describe "Lists" (fun () ->

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -2171,7 +2171,7 @@ let doInsert' ~pos (letter : char) (ti : tokenInfo) (ast : ast) (s : state) :
     when pos = ti.endPos && letter = '.' ->
       (exprToFieldAccess id ast, right)
   (* Dont add space to blanks *)
-  | TBlank _ | TPlaceholder (_, _) | TPatternBlank (_, _) | TRecordField (_,_,_) when letterStr == " " ->
+  | ti when (FluidToken.isBlank ti) && letterStr == " " ->
       (ast, s)
   (* replace blank *)
   | TBlank id | TPlaceholder (_, id) ->


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Fixes: https://trello.com/c/n4M72Ehm/1252-pressing-the-space-bar-on-blanks-causes-them-to-disappear

Problem: When a user would hit [space] in blank, it would insert the space and remove the blank

Solution: The ticket says to either "swallow spacebar on blank, do nothing" or "use spacebar to skip over blanks", I chose to make it do nothing because you don't usually use [space] to move around like you would [tab]. 

Also added a fluid test to test that inserting a space in blank doesn't do anything.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

