### PR TITLE
Add docs to fluid tests

### DIFF
--- a/client/__tests__/fluid_pattern_test.ml
+++ b/client/__tests__/fluid_pattern_test.ml
@@ -6,6 +6,10 @@ open Prelude
 open Fluid
 module K = FluidKeyboard
 
+(* These tests should be synced with the subset of tests in fluid_test.ml that
+ * makes sense for patterns. See the extensive docs there for how this all
+ * works. *)
+
 let tl ast =
   { id = TLID "7"
   ; pos = {x = 0; y = 0}

--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -7,6 +7,53 @@ open Fluid
 module B = Blank
 module K = FluidKeyboard
 
+(*
+ * These tests are all written in a common style: t "delete end of whole"
+ * aFloat (delete 2) ("12.456", 2) ;
+ *
+ * This is a test that takes the fluidExpr called aFloat, and does a delete on
+ * it in position 2. The stringified result is "12.456" and the cursor should
+ * be in position 2.
+ *
+ * There are a handful of functions you can call, including press, presses,
+ * insert, backspace, delete, tab, shiftTab, and render.
+ *
+ * There are a few different ways of running a test:
+ *  - t vs tp:
+ *    - a test case is created by calling t. This also asserts that the result
+ *      does not include a partial.
+ *    - you can also call tp, which asserts that the result _does_ include a
+ *      partial.
+ *  - wrap:
+ *      When I started writing these tests, I discovered that they kept passing
+ *      despite there being a bug. Whenever the cursor went over the end, it
+ *      would stay in the last place, giving a false positive. To avoid this,
+ *      I wrapped all test cases:
+ *         ```
+ *         let request = expression-I-actually-want-to-test
+ *         request
+ *         ```
+ *      There is a downside to this though: the indentation gets screwed up.
+ *      This affects match, if, records - basically anything that applies it's
+ *      own indent. The outcome is that the final position is wrong if it's not
+ *      on the same line. The solution to this is to set ~wrap:false on the
+ *      test.
+ *  - debug:
+ *      When you need more information about a single test, set the ~debug:true
+ *      flag.
+ * There are also certain conventions in the display of text in the output:
+ *  - TBlanks are displayed as `___`
+ *  - TPlaceHolders are displayed as normal but with underscores: for example
+ *    `_a_:_Int_`
+ *  - TPartials are displayed as text - to detect their presence,
+ *    see "t vs tp" above.
+ *  - TGhostPartials are displayed as multiple @ signs
+ *  - Other blanks (see FluidToken.isBlank) are displayed as `***` This is
+ *    controlled by FluidToken.toTestText
+ *
+ *  There are more tests in fluid_pattern_tests for match patterns.
+ *)
+
 let complexExpr =
   EIf
     ( gid ()


### PR DESCRIPTION
People get confused by the tests, so they're now documented.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

