### PR TITLE
Revert "make delete button work on infix operators"

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -656,17 +656,7 @@ let () =
         (press K.Backspace 12)
         ("___", 0) ;
       t
-        "pressing delete to clear partial reverts for blank rhs"
-        (EPartial (gid (), "|", EBinOp (gid (), "||", anInt, blank, NoRail)))
-        (press K.Delete 6)
-        ("12345", 5) ;
-      t
-        "pressing delete to clear partial reverts for blank rhs, check lhs pos goes to start"
-        (EPartial (gid (), "|", EBinOp (gid (), "||", newB (), blank, NoRail)))
-        (press K.Delete 10)
-        ("___", 0) ;
-      t
-        "using backspace to remove an infix with a placeholder goes to right place"
+        "deleting an infix with a placeholder goes to right place"
         (EPartial (gid (), "|", EBinOp (gid (), "||", newB (), newB (), NoRail)))
         (press K.Backspace 12)
         ("___", 0) ;
@@ -679,21 +669,6 @@ let () =
         "pressing backspace on single digit binop leaves lhs"
         (EBinOp (gid (), "+", anInt, anInt, NoRail))
         (press K.Backspace 7)
-        ("12345", 5) ;
-      t
-        "using delete to remove an infix with a placeholder goes to right place"
-        (EPartial (gid (), "|", EBinOp (gid (), "||", newB (), newB (), NoRail)))
-        (press K.Delete 10)
-        ("___", 0) ;
-      t
-        "pressing delete to clear rightpartial reverts for blank rhs"
-        (ERightPartial (gid (), "|", blank))
-        (press K.Delete 4)
-        ("___", 0) ;
-      t
-        "pressing delete on single digit binop leaves lhs"
-        (EBinOp (gid (), "+", anInt, anInt, NoRail))
-        (press K.Delete 6)
         ("12345", 5) ;
       t
         "pressing letters and numbers on a partial completes it"
@@ -728,35 +703,7 @@ let () =
           , EInteger (gid (), 5)
           , NoRail )
       in
-      let aPartialBinOp =
-        EPartial
-          ( gid ()
-          , "|"
-          , EBinOp
-              ( gid ()
-              , "||"
-              , EVariable (gid (), "myvar")
-              , EInteger (gid (), 5)
-              , NoRail ) )
-      in
-      tp
-        "backspacing shows ghost partial"
-        aFullBinOp
-        (backspace 8)
-        ("myvar |@ 5", 7) ;
-      tp "deleting shows ghost partial" aFullBinOp (delete 6) ("myvar |@ 5", 6) ;
-      (* TODO backspacing/deleting partial with ghost
-       * should leave a full partial instead of deleting it *)
-      t
-        "backspacing partial with ghost removes it"
-        aPartialBinOp
-        (backspace 7)
-        ("myvar", 5) ;
-      t
-        "deleting partial with ghost removes it"
-        aPartialBinOp
-        (delete 6)
-        ("myvar", 5) ;
+      tp "show ghost partial" aFullBinOp (backspace 8) ("myvar |@ 5", 7) ;
       (* TODO backspace on empty partial does something *)
       (* TODO support delete on all the backspace commands *)
       (* TODO pressing enter at the end of the partialGhost *)

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -2083,6 +2083,10 @@ let doDelete ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TLambdaSep _
   | TPartialGhost _ ->
       (ast, s)
+  | TBinOp (id, _) ->
+      (* TODO this should move to the start of the new blank, but we don't know
+       * where it is at the moment. *)
+      (deleteWithArguments id ast, moveToStart ti s |> left)
   | TConstructorName (id, _) | TFnName (id, _, _) ->
       (deleteWithArguments id ast, moveToStart ti s)
   | TFieldOp id ->
@@ -2108,15 +2112,6 @@ let doDelete ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
       else
         let str = removeCharAt str (offset - 1) in
         (replacePattern mID id ~newPat:(FPString (mID, newID, str)) ast, s)
-  | TBinOp (_, str) when String.length str = 1 ->
-      let ast, targetID = deleteBinOp ti ast in
-      (ast, moveBackTo targetID ast s)
-  | TRightPartial (_, str) when String.length str = 1 ->
-      let ast, targetID = deleteRightPartial ti ast in
-      (ast, moveBackTo targetID ast s)
-  | TPartial (_, str) when String.length str = 1 ->
-      let ast, targetID = deletePartial ti ast in
-      (ast, moveBackTo targetID ast s)
   | TRecordField _
   | TInteger _
   | TPatternInteger _
@@ -2132,7 +2127,6 @@ let doDelete ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TPatternTrue _
   | TPatternFalse _
   | TPatternVariable _
-  | TBinOp _
   | TLambdaVar _ ->
       (replaceStringToken ~f ti.token ast, s)
   | TFloatPoint id ->


### PR DESCRIPTION
Reverts darklang/dark#1073. This seems to be the cause of the test failures on master.