### PR TITLE
Revert "Revert "enable deleting constructors in match patterns""

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -149,6 +149,13 @@ let () =
     EMatch
       (mID, EBlank (gid ()), [(FPInteger (mID, gid (), 3), EBlank (gid ()))])
   in
+  let matchWithConstructorPattern =
+    let mID = gid () in
+    EMatch
+      ( mID
+      , EBlank (gid ())
+      , [(FPConstructor (mID, gid (), "Just", []), EBlank (gid ()))] )
+  in
   let matchWithBinding (bindingName : string) (expr : fluidExpr) =
     let mID = gid () in
     EMatch (mID, blank, [(FPVariable (mID, gid (), bindingName), expr)])
@@ -822,6 +829,16 @@ let () =
         (delete 0)
         ("match ___\n  3 -> ___", 0) ;
       t
+        "delete constructor in match pattern"
+        matchWithConstructorPattern
+        (delete ~wrap:false 12)
+        ("match ___\n  *** -> ___", 12) ;
+      t
+        "backspace constructor in match pattern"
+        matchWithConstructorPattern
+        (backspace ~wrap:false 16)
+        ("match ___\n  *** -> ___", 12) ;
+      t
         "insert changes occurence of non-shadowed var in case"
         (matchWithBinding "binding" (EVariable (gid (), "binding")))
         (insert ~wrap:false 'c' 19)
@@ -867,7 +884,11 @@ let () =
         (backspace 3)
         ("let *** = 6\n5", 3) ;
       t "delete non-empty let" nonEmptyLet (delete 0) ("let *** = 6\n5", 0) ;
-      t "insert space on blank let" emptyLet (press K.Space 4) ("let *** = ___\n5", 4) ;
+      t
+        "insert space on blank let"
+        emptyLet
+        (press K.Space 4)
+        ("let *** = ___\n5", 4) ;
       t "lhs on empty" emptyLet (insert 'c' 4) ("let c = ___\n5", 5) ;
       t "middle of blank" emptyLet (insert 'c' 5) ("let c = ___\n5", 5) ;
       t "backspace letlhs" letWithLhs (backspace 5) ("let *** = 6\n5", 4) ;
@@ -1133,17 +1154,42 @@ let () =
         nestedIf
         (press ~wrap:false K.GoToEndOfLine 12)
         ("if 5\nthen\n  if 5\n  then\n    6\n  else\n    7\nelse\n  7", 16) ;
-      t "try to insert space on blank" emptyIf (press ~wrap:false K.Space 3) ("if ___\nthen\n  ___\nelse\n  ___", 3) ;
-      t "try to insert space on blank indent 2" emptyIf (press ~wrap:false K.Space 14) ("if ___\nthen\n  ___\nelse\n  ___", 14) ;
+      t
+        "try to insert space on blank"
+        emptyIf
+        (press ~wrap:false K.Space 3)
+        ("if ___\nthen\n  ___\nelse\n  ___", 3) ;
+      t
+        "try to insert space on blank indent 2"
+        emptyIf
+        (press ~wrap:false K.Space 14)
+        ("if ___\nthen\n  ___\nelse\n  ___", 14) ;
       () ) ;
   describe "Lists" (fun () ->
       let emptyList = EList (gid (), []) in
       let single = EList (gid (), [fiftySix]) in
       let multi = EList (gid (), [fiftySix; seventyEight]) in
       let withStr = EList (gid (), [EString (gid (), "ab")]) in
-      let longList = EList (gid (), [fiftySix; seventyEight; fiftySix; seventyEight; fiftySix; seventyEight]) in
-      let listWithBlank = EList (gid (), [fiftySix; seventyEight; EBlank (gid ()); fiftySix]) in
-      let multiWithStrs = EList (gid (), [EString (gid (), "ab"); EString (gid (), "cd"); EString (gid (), "ef")]) in
+      let longList =
+        EList
+          ( gid ()
+          , [ fiftySix
+            ; seventyEight
+            ; fiftySix
+            ; seventyEight
+            ; fiftySix
+            ; seventyEight ] )
+      in
+      let listWithBlank =
+        EList (gid (), [fiftySix; seventyEight; EBlank (gid ()); fiftySix])
+      in
+      let multiWithStrs =
+        EList
+          ( gid ()
+          , [ EString (gid (), "ab")
+            ; EString (gid (), "cd")
+            ; EString (gid (), "ef") ] )
+      in
       t "create list" blank (press K.LeftSquareBracket 0) ("[]", 1) ;
       t
         "inserting before the list does nothing"
@@ -1236,7 +1282,7 @@ let () =
         listWithBlank
         (delete 10)
         ("[56,78,___]", 10) ;
-        t
+      t
         "backspace on separator between string items deletes item after separator"
         multiWithStrs
         (backspace 6)

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -498,7 +498,7 @@ let rec toTokens' (s : state) (e : ast) : token list =
   | EList (id, exprs) ->
       let ts =
         exprs
-        |> List.indexedMap ~f:(fun i expr -> [nested expr; TListSep(id, i)])
+        |> List.indexedMap ~f:(fun i expr -> [nested expr; TListSep (id, i)])
         |> List.concat
         (* Remove the extra seperator *)
         |> List.dropRight ~count:1
@@ -1249,7 +1249,8 @@ let replaceWithRightPartial (str : string) (id : id) (ast : ast) : ast =
       | oldVal ->
           ERightPartial (gid (), str, oldVal) )
 
-let replaceListSepToken (id : id) (ast : ast) (index : int) :fluidExpr =
+
+let replaceListSepToken (id : id) (ast : ast) (index : int) : fluidExpr =
   let index =
     (* remove expression in front of sep, not behind it *)
     index + 1
@@ -1257,9 +1258,10 @@ let replaceListSepToken (id : id) (ast : ast) (index : int) :fluidExpr =
   wrap id ast ~f:(fun e ->
       match e with
       | EList (id, exprs) ->
-        EList (id, List.removeAt ~index exprs)
+          EList (id, List.removeAt ~index exprs)
       | _ ->
-        e)
+          e )
+
 
 let removeThreadPipe (id : id) (ast : ast) (index : int) : ast =
   let index =
@@ -1966,7 +1968,7 @@ let doBackspace ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TPatternString (mID, id, "") ->
       (replacePattern mID id ~newPat:(FPBlank (mID, newID)) ast, left s)
   | TListSep (id, idx) ->
-      (replaceListSepToken id ast idx, left s)  
+      (replaceListSepToken id ast idx, left s)
   | (TRecordOpen id | TListOpen id) when exprIsEmpty id ast ->
       (replaceExpr id ~newExpr:(EBlank newID) ast, left s)
   | TRecordField (id, i, "") when pos = ti.startPos ->
@@ -1987,7 +1989,6 @@ let doBackspace ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TSep
   | TLambdaSep _
   | TPatternBlank _
-  | TPatternConstructorName _
   | TPartialGhost _ ->
       (ast, left s)
   | TFieldOp id ->
@@ -2040,6 +2041,8 @@ let doBackspace ~(pos : int) (ti : tokenInfo) (ast : ast) (s : state) :
   | TFloatFraction (id, str) ->
       let str = removeCharAt str offset in
       (replaceFloatFraction str id ast, left s)
+  | TPatternConstructorName (mID, id, _) ->
+      (replacePattern ~newPat:(FPBlank (mID, id)) mID id ast, moveToStart ti s)
   | TThreadPipe (id, i) ->
       let s =
         match getTokensAtPosition ~pos:ti.startPos (toTokens s ast) with
@@ -2184,7 +2187,7 @@ let doInsert' ~pos (letter : char) (ti : tokenInfo) (ast : ast) (s : state) :
     when pos = ti.endPos && letter = '.' ->
       (exprToFieldAccess id ast, right)
   (* Dont add space to blanks *)
-  | ti when (FluidToken.isBlank ti) && letterStr == " " ->
+  | ti when FluidToken.isBlank ti && letterStr == " " ->
       (ast, s)
   (* replace blank *)
   | TBlank id | TPlaceholder (_, id) ->
@@ -2363,16 +2366,18 @@ let updateKey (key : K.key) (ast : ast) (s : state) : ast * state =
          * be safely wrapped *)
         true
     | R (token, _) ->
-        (* This almost certainly doesn't catch all cases,
+      (* This almost certainly doesn't catch all cases,
          * if you find a bug please add a case + test *)
-        (match token with
-        | TLetLHS _
-        | TLetAssignment _
-        | TFieldName _
-        | TLambdaSep _
-        | TLambdaArrow _
-        | TLambdaVar _ -> false
-        | _ -> true)
+      ( match token with
+      | TLetLHS _
+      | TLetAssignment _
+      | TFieldName _
+      | TLambdaSep _
+      | TLambdaArrow _
+      | TLambdaVar _ ->
+          false
+      | _ ->
+          true )
   in
   let infixKeys =
     [ K.Plus
@@ -2388,7 +2393,7 @@ let updateKey (key : K.key) (ast : ast) (s : state) : ast * state =
     ; K.Equals
     ; K.Pipe ]
   in
-    (* TODO: When changing TVariable and TFieldName and probably TFnName we
+  (* TODO: When changing TVariable and TFieldName and probably TFnName we
      * should convert them to a partial which retains the old object *)
   let newAST, newState =
     (* This match drives a big chunk of the change operations, but is
@@ -2526,11 +2531,12 @@ let updateKey (key : K.key) (ast : ast) (s : state) : ast * state =
     | key, L (TBinOp _, toTheLeft), _
       when List.member ~value:key infixKeys ->
         doInsert ~pos keyChar toTheLeft ast s
-    | key, _, R (TBlank _, toTheRight)
-      when List.member ~value:key infixKeys ->
+    | key, _, R (TBlank _, toTheRight) when List.member ~value:key infixKeys ->
         doInsert ~pos keyChar toTheRight ast s
-    | key, L (_, toTheLeft), _ when onEdge && List.member ~value:key infixKeys && wrappableInBinop toTheRight
-      ->
+    | key, L (_, toTheLeft), _
+      when onEdge
+           && List.member ~value:key infixKeys
+           && wrappableInBinop toTheRight ->
         ( convertToBinOp keyChar (Token.tid toTheLeft.token) ast
         , s |> moveTo (pos + 2) )
     (* End of line *)


### PR DESCRIPTION
Reverts darklang/dark#1087

It seems it was #1073 that was the cause of the failure on master, so this one can possibly be unconverted.