### PR TITLE
enable deleting pattern constructors

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -932,12 +932,12 @@ let () =
         "delete constructor in match pattern"
         matchWithConstructorPattern
         (delete ~wrap:false 12)
-        ("match ___\n  *** -> ___", 12) ;
+        ("match ___\n  ust -> ___", 12) ;
       t
         "backspace constructor in match pattern"
         matchWithConstructorPattern
         (backspace ~wrap:false 16)
-        ("match ___\n  *** -> ___", 12) ;
+        ("match ___\n  Jus -> ___", 15) ;
       t
         "insert changes occurence of non-shadowed var in case"
         (matchWithBinding "binding" (EVariable (gid (), "binding")))


### PR DESCRIPTION
Enable deleting pattern constructors like regular constructors are currently deleted.

Fixes: https://trello.com/c/fT33Lkte/1247-constructors-in-patterns-cant-be-deleted

New behaviour:
![del0cons](https://user-images.githubusercontent.com/16245199/60615033-0d3eb200-9d83-11e9-8e65-9b25f6a046ee.gif)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

