### PR TITLE
Catch execution errors in Int::random when start > end

### DIFF
--- a/backend/libexecution/libstd.ml
+++ b/backend/libexecution/libstd.ml
@@ -421,19 +421,18 @@ let fns : Lib.shortfn list =
   ; { pns = ["Int::random_v1"]
     ; ins = []
     ; p = [par "start" TInt; par "end" TInt]
-    ; r = TResult
-    ; d =
-        "Returns a random integer between `start` and `end` (inclusive), wrapped in a `Ok`, or `Error <msg>` if the `end` <= `start`."
+    ; r = TInt
+    ; d = "Returns a random integer between `start` and `end` (inclusive)."
     ; f =
         InProcess
           (function
-          (*( +1 as Random.int is exclusive *)
-          | _, [DInt a; DInt b] when a < b ->
-              let open Dint in
-              let res = DInt (a + one + Dint.random (b - a)) in
-              DResult (ResOk res)
           | _, [DInt a; DInt b] ->
-              error_result "invalid range, start < end"
+              let open Dint in
+              (* upper+1 because as Random.int is exclusive *)
+              let lower, upper =
+                if a > b then (b, a + one) else (a, b + one)
+              in
+              DInt (lower + Dint.random (upper - lower))
           | args ->
               fail args)
     ; ps = false

--- a/backend/test/test_language.ml
+++ b/backend/test/test_language.ml
@@ -248,6 +248,27 @@ let t_typecheck_any () =
     (Type_checker.check_function_call ~user_tipes fn args |> Result.is_ok)
 
 
+let t_int_functions_works () =
+  check_condition
+    "Int::random_v1 0 3 returns a number between [0,3]"
+    (exec_ast "(Int::random_v1 0 3)")
+    ~f:(fun dv ->
+      match dv with
+      | DInt i ->
+        (match Dint.to_int i with Some r -> 0 <= r && r <= 3 | None -> false)
+      | _ ->
+          false ) ;
+  check_condition
+    "Int::random_v1 3 0, will swap 3 0 and returns a number between [0,3]"
+    (exec_ast "(Int::random_v1 3 0)")
+    ~f:(fun dv ->
+      match dv with
+      | DInt i ->
+        (match Dint.to_int i with Some r -> 0 <= r && r <= 3 | None -> false)
+      | _ ->
+          false )
+
+
 (* ---------------- *)
 (* Dark internal *)
 (* ---------------- *)

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -90,14 +90,6 @@ let t_result_stdlibs_work () =
     "maperror ok"
     (exec_ast "(Result::mapError (Ok 4) (\\x -> (Int::divide x 2)))")
     (DResult (ResOk (Dval.dint 4))) ;
-  check_result_ok
-    "Int::random_v1 results in Ok"
-    (exec_ast "(Int::random_v1 0 1)")
-    true ;
-  check_result_ok
-    "Int::random_v1 results in Error"
-    (exec_ast "(Int::random_v1 1 0)")
-    false ;
   check_dval
     "maperror error"
     (exec_ast

--- a/backend/test/utils.ml
+++ b/backend/test/utils.ml
@@ -96,18 +96,8 @@ let check_oplist = AT.check (AT.of_pp Op.pp_oplist)
 
 let check_tlid_oplists = AT.check (AT.of_pp Op.pp_tlid_oplists)
 
-let check_result_ok msg dval ok =
-  AT.check
-    AT.bool
-    msg
-    ( match dval with
-    | DResult (ResOk _) ->
-        if ok then true else false
-    | DResult (ResError _) ->
-        if not ok then true else false
-    | _ ->
-        false )
-    true
+let check_condition msg dval ~(f : dval -> bool) =
+  AT.check AT.bool msg (f dval) true
 
 
 let testable_handler = AT.testable HandlerT.pp_handler HandlerT.equal_handler


### PR DESCRIPTION
[Invalid argument Random.int 8,9](https://trello.com/c/iUbyUYt5/1281-invalid-argument-randomint-89)

Problem: When the startInt is more than the endInt Int::random execution throws a huge error and we trigger rollbar, when there's problems with user code

Solution: make new version of the function that is wrapped in result type

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

