### PR TITLE
Filter unfilled handlers as they can't match anything

### DIFF
--- a/backend/libexecution/http.ml
+++ b/backend/libexecution/http.ml
@@ -187,5 +187,6 @@ let filter_matching_handlers
     ~(path : string) (pages : RT.HandlerT.handler list) :
     RT.HandlerT.handler list =
   pages
+  |> List.filter ~f:Handler.is_complete
   |> filter_invalid_handler_matches ~path
   |> filter_matching_handlers_by_specificity

--- a/backend/test/test_http.ml
+++ b/backend/test/test_http.ml
@@ -261,6 +261,17 @@ let t_path_gt_route_does_not_crash () =
     bound
 
 
+let t_incomplete_handler_doesnt_throw () =
+  let filled = http_route_handler ~route:"/:foo" () in
+  let empty = handler (ast_for "5") in
+  let ordered = Http.filter_matching_handlers "/a" [filled; empty] in
+  AT.check
+    (AT.list testable_handler)
+    "incomplete handler is filtered out without throwing"
+    [filled]
+    ordered
+
+
 let t_parsed_request_cookies () =
   let with_headers h =
     Parsed_request.from_request (Uri.of_string "test") h [] ""
@@ -345,4 +356,7 @@ let suite =
   ; ( "Query strings behave properly given multiple duplicate keys"
     , `Quick
     , t_query_params_with_duplicate_keys )
-  ; ("Cookies are parsed correctly", `Quick, t_parsed_request_cookies) ]
+  ; ("Cookies are parsed correctly", `Quick, t_parsed_request_cookies)
+  ; ( "Incomplete handler is filtered out safely"
+    , `Quick
+    , t_incomplete_handler_doesnt_throw ) ]


### PR DESCRIPTION
- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Fixes https://rollbar.com/darkops/darklang/items/1061/

Existing uses of the HTTP stack filtering only sent filled handlers thru the filtering, with new code we send all handlers which meant some uses of `event_name_for_exn` were now unsafe.

Fix: filter handlers with unfilled specs because they aren't candidates for matching anyway.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

