### PR TITLE
Fix curl receiving gzip/deflate responses

### DIFF
--- a/backend/libbackend/httpclient.ml
+++ b/backend/libbackend/httpclient.ml
@@ -143,6 +143,14 @@ let http_call_with_code
       C.set_writefunction c responsefn ;
       C.set_httpheader c headers ;
       C.set_headerfunction c headerfn ;
+      (* This tells CURL to send an Accept-Encoding header including all
+       * of the encodings it supports *and* tells it to automagically decode
+       * responses in those encodings. This works even if someone manually specifies
+       * the encoding in the header, as libcurl will still appropriately decode it
+       *
+       * https://curl.haxx.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html
+       * *)
+      C.set_encoding c C.CURL_ENCODING_ANY ;
       (* Don't let users curl to e.g. file://; just HTTP and HTTPs. *)
       C.set_protocols c [C.CURLPROTO_HTTP; C.CURLPROTO_HTTPS] ;
       (* Seems like redirects can be used to get around the above list... *)


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Fixes: https://trello.com/c/47A9VkTV/1363-fix-httpclient-decompression-of-gzip-deflate-encoded-responses

Even though the user was providing the `Accept-Encoding` header (and we were sending it), there's actually a magical flag you have to set in libcurl to enable automatic decompression of `Content-Encoding` encoded data. We set it to any, which tells curl to always ask for all supported encoding and magically decompress. This works even if the user also provides the `Accept-Encoding` header.

We have terrible (read: none) test coverage here, and no obvious way of adding it. So I'm relying on manual testing for this one.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

