### PR TITLE
dont center on toplevel when dblclick

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1149,8 +1149,6 @@ let update_ (msg : msg) (m : model) : modification =
             None
       in
       Selection.dblclick m targetExnID targetID offset
-  | ToplevelDoubleClick tlid ->
-      CenterCanvasOn tlid
   | ToplevelClick (targetExnID, _) ->
       let click =
         match m.cursorState with

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -564,7 +564,7 @@ and addOpRPCResult =
 
 and addOpStrollerMsg =
   { result : addOpRPCResult
-  ; params: addOpRPCParams }
+  ; params : addOpRPCParams }
 
 and dvalArgsHash = string
 
@@ -818,7 +818,6 @@ and msg =
   (* but by the time we use it the proper node will be changed *)
   | ToplevelMouseUp of tlid * mouseEvent
   | ToplevelClick of tlid * mouseEvent
-  | ToplevelDoubleClick of tlid
   | ToplevelDelete of tlid
   | ToplevelDeleteForever of tlid
   | DragToplevel of tlid * Tea.Mouse.position [@printer opaque "DragToplevel"]

--- a/client/src/View.ml
+++ b/client/src/View.ml
@@ -55,11 +55,7 @@ let viewTL_ (m : model) (tl : toplevel) : msg Html.html =
     ; ViewUtils.eventNoPropagation
         ~key:("tlc-" ^ showTLID tl.id)
         "click"
-        (fun x -> ToplevelClick (tl.id, x))
-    ; ViewUtils.eventNoPropagation
-        ~key:("tldblc-" ^ showTLID vs.tl.id)
-        "dblclick"
-        (fun _ -> ToplevelDoubleClick vs.tl.id) ]
+        (fun x -> ToplevelClick (tl.id, x)) ]
   in
   let avatars = Avatar.viewAvatars m.avatarsList tl.id in
   let selected = Some tl.id = tlidOf m.cursorState in


### PR DESCRIPTION
When doing focused coding, Alice though it would be a good idea to center on toplevel upon double click. But it turns out to be a bad idea, so killing that code.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

