### PR TITLE
Replacing "DB::getMany" with  "DB::getManyWithKeys" + adding "DB::getMany_v2" 

### DIFF
--- a/backend/libbackend/libdb2.ml
+++ b/backend/libbackend/libdb2.ml
@@ -97,7 +97,7 @@ let fns : shortfn list =
     ; p = [par "keys" TList; par "table" TDB]
     ; r = TList
     ; d =
-        "Finds many values in `table` by `keys, returning a [[value]] list of lists"
+        "Finds many values in `table` by `keys, returning a [value] list of values"
     ; f =
         InProcess
           (function
@@ -113,7 +113,7 @@ let fns : shortfn list =
                         ^ (t |> Dval.tipe_of |> Dval.tipe_to_string))
                   keys
               in
-              User_db.get_many ~state db skeys
+              User_db.get_many_v2 ~state db skeys
           | args ->
               fail args)
     ; ps = false
@@ -139,7 +139,7 @@ let fns : shortfn list =
                         ^ (t |> Dval.tipe_of |> Dval.tipe_to_string))
                   keys
               in
-              User_db.getManyWithKeys ~state db skeys
+              User_db.get_many_with_keys ~state db skeys
           | args ->
               fail args)
     ; ps = false

--- a/backend/libbackend/user_db.ml
+++ b/backend/libbackend/user_db.ml
@@ -236,35 +236,6 @@ and get ~state (db : db) (key : string) : dval =
 and get_many ~state (db : db) (keys : string list) : dval =
   Db.fetch
     ~name:"get_many"
-    "SELECT data
-    FROM user_data
-    WHERE table_tlid = $1
-    AND account_id = $2
-    AND canvas_id = $3
-    AND user_version = $4
-    AND dark_version = $5
-    AND key = ANY (string_to_array($6, $7)::text[])"
-    ~params:
-      [ ID db.tlid
-      ; Uuid state.account_id
-      ; Uuid state.canvas_id
-      ; Int db.version
-      ; Int current_dark_version
-      ; List (List.map ~f:(fun s -> String s) keys)
-      ; String Db.array_separator ]
-  |> List.map ~f:(fun return_val ->
-         match return_val with
-         (* TODO(ian): change `to_obj` to just take a string *)
-         | [data] ->
-             to_obj db [data]
-         | _ ->
-             Exception.internal "bad format received in get_many_v2" )
-  |> DList
-
-
-and getManyWithKeys ~state (db : db) (keys : string list) : dval =
-  Db.fetch
-    ~name:"getManyWithKeys"
     "SELECT key, data
      FROM user_data
      WHERE table_tlid = $1
@@ -287,7 +258,65 @@ and getManyWithKeys ~state (db : db) (keys : string list) : dval =
          | [key; data] ->
              DList [Dval.dstr_of_string_exn key; to_obj db [data]]
          | _ ->
-             Exception.internal "bad format received in getManyWithKeys" )
+             Exception.internal "bad format received in get_many" )
+  |> DList
+
+
+and get_many_v2 ~state (db : db) (keys : string list) : dval =
+  Db.fetch
+    ~name:"get_many_v2"
+    "SELECT key, data
+    FROM user_data
+    WHERE table_tlid = $1
+    AND account_id = $2
+    AND canvas_id = $3
+    AND user_version = $4
+    AND dark_version = $5
+    AND key = ANY (string_to_array($6, $7)::text[])"
+    ~params:
+      [ ID db.tlid
+      ; Uuid state.account_id
+      ; Uuid state.canvas_id
+      ; Int db.version
+      ; Int current_dark_version
+      ; List (List.map ~f:(fun s -> String s) keys)
+      ; String Db.array_separator ]
+  |> List.map ~f:(fun return_val ->
+         match return_val with
+         (* TODO(ian): change `to_obj` to just take a string *)
+         | [key; data] ->
+             to_obj db [data]
+         | _ ->
+             Exception.internal "bad format received in get_many_v2" )
+  |> DList
+
+
+and get_many_with_keys ~state (db : db) (keys : string list) : dval =
+  Db.fetch
+    ~name:"get_many_with_keys"
+    "SELECT key, data
+     FROM user_data
+     WHERE table_tlid = $1
+     AND account_id = $2
+     AND canvas_id = $3
+     AND user_version = $4
+     AND dark_version = $5
+     AND key = ANY (string_to_array($6, $7)::text[])"
+    ~params:
+      [ ID db.tlid
+      ; Uuid state.account_id
+      ; Uuid state.canvas_id
+      ; Int db.version
+      ; Int current_dark_version
+      ; List (List.map ~f:(fun s -> String s) keys)
+      ; String Db.array_separator ]
+  |> List.map ~f:(fun return_val ->
+         match return_val with
+         (* TODO(ian): change `to_obj` to just take a string *)
+         | [key; data] ->
+             DList [Dval.dstr_of_string_exn key; to_obj db [data]]
+         | _ ->
+             Exception.internal "bad format received in get_many_with_keys" )
   |> DList
 
 

--- a/backend/libbackend/user_db.mli
+++ b/backend/libbackend/user_db.mli
@@ -14,7 +14,9 @@ val get : state:exec_state -> DbT.db -> string -> dval
 
 val get_many : state:exec_state -> DbT.db -> string list -> dval
 
-val getManyWithKeys : state:exec_state -> DbT.db -> string list -> dval
+val get_many_v2 : state:exec_state -> DbT.db -> string list -> dval
+
+val get_many_with_keys : state:exec_state -> DbT.db -> string list -> dval
 
 val get_all : state:exec_state -> DbT.db -> dval
 

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -105,7 +105,7 @@ let t_db_get_many_v2_works () =
   let ast =
     "(let one (DB::set_v1 (obj (x 'foo')) 'first' MyDB)
                 (let two (DB::set_v1 (obj (x 'bar')) 'second' MyDB)
-                 (let fetched (DB::getMany_v2 ('first' 'second') MyDB)
+                  (let fetched (DB::getMany_v2 ('first' 'second') MyDB)
                   fetched)))"
   in
   check_dval
@@ -114,6 +114,23 @@ let t_db_get_many_v2_works () =
        [ DObj (DvalMap.singleton "x" (Dval.dstr_of_string_exn "foo"))
        ; DObj (DvalMap.singleton "x" (Dval.dstr_of_string_exn "bar")) ])
     (exec_handler ~ops ast)
+
+
+let t_db_get_many_v1_works () =
+  clear_test_data () ;
+  let ops =
+    [ Op.CreateDB (dbid, pos, "MyDB")
+    ; Op.AddDBCol (dbid, colnameid, coltypeid)
+    ; Op.SetDBColName (dbid, colnameid, "x")
+    ; Op.SetDBColType (dbid, coltypeid, "Str") ]
+  in
+  let ast =
+    "(let one (DB::set_v1 (obj (x 'foo')) 'first' MyDB)
+              (let two (DB::set_v1 (obj (x 'bar')) 'second' MyDB)
+                (let fetched (DB::getManyWithKeys ('first' 'second') MyDB)
+                (== (('first' one) ('second' two)) fetched))))"
+  in
+  check_dval "equal_after_roundtrip" (DBool true) (exec_handler ~ops ast)
 
 
 let t_db_queryWithKey_works_with_many () =
@@ -296,6 +313,7 @@ let suite =
   ; ("DB::set_v1 upserts", `Quick, t_db_set_does_upsert)
   ; ("DB::getAllWithKeys_v1 works", `Quick, t_db_get_all_with_keys_works)
   ; ("DB::getManyWithKeys works", `Quick, t_db_get_many_with_keys_works)
+  ; ("DB::getMany_v1 works", `Quick, t_db_get_many_v1_works)
   ; ("DB::getMany_v2 works", `Quick, t_db_get_many_v2_works)
   ; ( "DB::queryWithKey_v1 works with many items"
     , `Quick


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Fixes: https://trello.com/c/uUFOkujo/1358-dbgetmany-should-not-return-a-key-value-list

- Deprecated  "DB::getMany" and renamed it "DB::getManyWithKeys" 
 
- Added "DB::getMany_v2" to return [value]

- Added tests for both  

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

