### PR TITLE
fix failing test from #1147 due to merge of #1133

### DIFF
--- a/client/__tests__/refactor_test.ml
+++ b/client/__tests__/refactor_test.ml
@@ -321,5 +321,5 @@ let () =
           let m, tl = modelAndTl ast in
           expect (R.extractVarInAst m tl expr ast "var" |> exprToString)
           |> toEqual
-               "let id = Uuid::generate\nlet var = DB::set_v1 request.body toString id ___\nvar\n|>assoc \"id\" id"
+               "let id = Uuid::generate\nlet var = DB::setv1 request.body toString id ___\nvar\n|>assoc \"id\" id"
       ) )


### PR DESCRIPTION
fix failing test from #1147 (extract variable) due to merge of #1133 (function version)

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

