### PR TITLE
Make param button row the same height as a param row

### DIFF
--- a/client/src/ViewFunction.ml
+++ b/client/src/ViewFunction.ml
@@ -83,14 +83,15 @@ let viewKillParameterBtn (uf : userFunction) (p : userFunctionParameter) :
 let viewMetadata (vs : viewState) (fn : userFunction) : msg Html.html =
   let addParamBtn =
     Html.div
-      [ Html.class' "parameter-btn allowed add"
-      ; ViewUtils.eventNoPropagation
-          ~key:("aufp-" ^ showTLID fn.ufTLID)
-          "click"
-          (fun _ -> AddUserFunctionParameter fn) ]
-      [ fontAwesome "plus-circle"
-      ; Html.span [Html.class' "helper-text"] [Html.text "add new parameter"]
-      ]
+      [Html.class' "col new-parameter"]
+      [ Html.div
+          [ Html.class' "parameter-btn allowed add"
+          ; ViewUtils.eventNoPropagation
+              ~key:("aufp-" ^ showTLID fn.ufTLID)
+              "click"
+              (fun _ -> AddUserFunctionParameter fn) ]
+          [fontAwesome "plus-circle"]
+      ; Html.span [Html.class' "btn-label"] [Html.text "add new parameter"] ]
   in
   let namediv =
     Html.div

--- a/client/src/styles/_function.scss
+++ b/client/src/styles/_function.scss
@@ -21,24 +21,6 @@
     }
   }
 
-  .parameter-btn.add {
-    &:hover {
-      .helper-text {
-        color: $grey3;
-      }
-    }
-
-    i {
-      margin-right: 6px;
-    }
-
-    .helper-text {
-      color: $grey2;
-      font-style: italic;
-      font-size: 0.7 * $code-font-size;
-    }
-  }
-
   .col {
     display: flex;
     flex-direction: row;
@@ -83,6 +65,24 @@
           margin-top: 0;
           position: relative;
         }
+      }
+    }
+  }
+
+  .col.new-parameter {
+    .parameter-btn.add i {
+      margin-right: 8px;
+    }
+
+    .btn-label {
+      color: $grey2;
+      font-style: italic;
+      font-size: 0.7 * $code-font-size;
+    }
+
+    &:hover {
+      .btn-label {
+        color: $grey3;
       }
     }
   }


### PR DESCRIPTION
Was focused on getting it working, and missed out on the height difference between the param rows.

Master:
<img width="430" alt="Screen Shot 2019-07-16 at 10 58 39 AM" src="https://user-images.githubusercontent.com/244152/61318855-dae97780-a7ba-11e9-85ca-a9a2d3e329bc.png">

Fixed:
<img width="423" alt="Screen Shot 2019-07-16 at 11 10 12 AM" src="https://user-images.githubusercontent.com/244152/61318861-df159500-a7ba-11e9-934a-87214da212cd.png">



- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

