### PR TITLE
Don't rollbar if the client aborts a request

### DIFF
--- a/client/src/ApiError.ml
+++ b/client/src/ApiError.ml
@@ -50,7 +50,8 @@ let shouldRollbar (e : apiError) : bool =
       (* Don't rollbar if you aren't logged in *)
       response.status.code <> 401
   | Http.Aborted ->
-      e.importance = ImportantError
+      (* Don't rollbar if the client aborted the request *)
+      false
 
 
 let parseResponse (body : Http.responseBody) : string =


### PR DESCRIPTION
Someone hitting the `Stop` button in their browser shouldn't
wake anyone up ever.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

