### PR TITLE
Nginx redirect hellobirb.com to www.hellobirb.com.

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -135,6 +135,12 @@ server {
 }
 
 server {
+  listen 8000;
+  server_name hellobirb.com;
+  return 301 $http_x_forwarded_proto://www.hellobirb.com$request_uri;
+}
+
+server {
   listen 8000 default_server;
   listen [::]:8000 default_server;
 


### PR DESCRIPTION
This doesn't do anything currently, since `hellobirb.com` points to a server we don't control

However, if we want to serve both `hellobirb.com` and `www.hellobirb.com` with HTTPS, we'll want the pixelkeet folks to point the DNS of hellobirb.com to Dark as well. So, once they do that, this will redirect `hellobirb.com` to `www.hellobirb.com`, which we _do_ currently serve.