### PR TITLE
Fix fields in autocomplete

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -264,7 +264,18 @@ let () =
       ; fnInfix = true }
     in
     { Defaults.defaultModel with
-      builtInFunctions =
+      analyses =
+        StrDict.singleton (* The default traceID for TLID 7 *)
+          ~key:"94167980-f909-527e-a4af-bc3155f586d3"
+          ~value:
+            { liveValues =
+                StrDict.singleton
+                  ~key:"12"
+                  ~value:
+                    (DObj
+                       (StrDict.fromList [("body", DNull); ("formBody", DNull)]))
+            }
+    ; builtInFunctions =
         [ infixFn "<" TInt TBool
         ; infixFn "+" TInt TInt
         ; infixFn "==" TAny TBool
@@ -1799,6 +1810,11 @@ let () =
         (EPartial (gid (), "Error", blank ()))
         (press K.Enter 5)
         ("Error ___", 6) ;
+      t
+        "autocomplete for field"
+        (EFieldAccess (gid (), EVariable (ID "12", "request"), gid (), "bo"))
+        (press K.Enter 10)
+        ("request.body", 12) ;
       (* test "backspacing on variable reopens autocomplete" (fun () -> *)
       (*     expect (backspace (EVariable (5, "request"))). *)
       (*     gridFor ~pos:116 tokens) |> toEqual {row= 2; col= 2} ) ; *)

--- a/client/src/tc.ml
+++ b/client/src/tc.ml
@@ -133,6 +133,9 @@ module StrDict = struct
 
   let removeMany (dict : 'v t) ~(keys : key list) : 'v t =
     Belt.Map.String.removeMany dict (Belt.List.toArray keys)
+
+
+  let singleton ~(key : key) ~(value : 'v) : 'v t = empty |> insert ~key ~value
 end
 
 module type Key = sig


### PR DESCRIPTION
Fixes completing fluid autocomplete on fields, which crashes because it wasn't implemented. This implements and then wires it up.

https://trello.com/c/P8ZoFUKI/1302-crash-in-field-name
https://trello.com/c/uKYtejK2/1439-when-changing-a-fieldname-in-fluid-it-crashes


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

