### PR TITLE
New JWT RS256 module.

### DIFF
--- a/backend/libbackend/dune
+++ b/backend/libbackend/dune
@@ -36,6 +36,7 @@
               sodium
               uutf
               yojson
+              x509
               )
 )
 

--- a/backend/libbackend/init.ml
+++ b/backend/libbackend/init.ml
@@ -21,6 +21,7 @@ let init ~run_side_effects =
         @ Libdarkinternal.fns
         @ Libstaticassets.fns
         @ Libtwitter.fns
+        @ Libjwt.fns
       in
       Libexecution.Init.init Config.log_level Config.log_format non_client_fns ;
       (* init the Random module, will be seeded from /dev/urandom on Linux *)

--- a/backend/libbackend/libjwt.ml
+++ b/backend/libbackend/libjwt.ml
@@ -1,0 +1,178 @@
+open Core_kernel
+open Libexecution
+open Runtime
+open Lib
+open Types.RuntimeT
+open Nocrypto
+
+(* Here's how JWT with RS256, and this library, work:
+
+   Users provide a private key, some headers, and a payload.
+
+   We add fields "type" "JWT" and "alg" "RS256" to the header.
+
+   We create the body by base64-encoding the header and the payload,
+   and joining them with a period:
+
+   body = (b64encode header) ^ "." ^ (b64encode payload)
+
+   We use the private key to sign the body:
+
+   signature = sign body
+
+   Then we join the body with the signature with a period.
+
+   token = body ^ "." ^ signature
+
+   We verify by splitting the parts, checking the signature against the body,
+   and then de-base-64-ing the body and parsing the JSON.
+
+   https://jwt.io/ is helpful for validating this!
+ *)
+
+let sign_and_encode
+    ~(key : Rsa.priv)
+    ~(extra_headers : (string * Yojson.Safe.t) list)
+    ~(payload : Yojson.Safe.t) : string =
+  let header =
+    `Assoc ([("alg", `String "RS256"); ("type", `String "JWT")] @ extra_headers)
+    |> Yojson.Safe.to_string
+    |> B64.encode ~alphabet:B64.uri_safe_alphabet ~pad:false
+  in
+  let payload =
+    payload
+    |> Yojson.Safe.to_string
+    |> B64.encode ~alphabet:B64.uri_safe_alphabet ~pad:false
+  in
+  let body = header ^ "." ^ payload in
+  let signature =
+    body
+    |> Cstruct.of_string
+    |> (fun x -> `Message x)
+    |> Rsa.PKCS1.sign ~hash:`SHA256 ~key
+    |> Cstruct.to_string
+    |> B64.encode ~alphabet:B64.uri_safe_alphabet ~pad:false
+  in
+  body ^ "." ^ signature
+
+
+let verify_and_extract ~(key : Rsa.pub) ~(token : string) :
+    (string * string) option =
+  match String.split ~on:'.' token with
+  | [header; payload; signature] ->
+    (* do the minimum of parsing and decoding before verifying signature.
+        c.f. "cryptographic doom principle". *)
+    ( match B64.decode_opt ~alphabet:B64.uri_safe_alphabet signature with
+    | None ->
+        None
+    | Some signature ->
+        if header ^ "." ^ payload
+           |> Cstruct.of_string
+           |> (fun x -> `Message x)
+           |> Rsa.PKCS1.verify
+                ~hashp:(( = ) `SHA256)
+                ~key
+                ~signature:(Cstruct.of_string signature)
+        then
+          match
+            ( B64.decode_opt ~alphabet:B64.uri_safe_alphabet header
+            , B64.decode_opt ~alphabet:B64.uri_safe_alphabet payload )
+          with
+          | Some header, Some payload ->
+              Some (header, payload)
+          | _ ->
+              None
+        else None )
+  | _ ->
+      None
+
+
+let fns =
+  [ { pns = ["JWT::signAndEncode"]
+    ; ins = []
+    ; p = [par "pemPrivKey" TStr; par "payload" TAny]
+    ; r = TStr
+    ; d =
+        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm. Takes an unecnrypted RSA private key in PEM format."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr key; payload] ->
+              let (`RSA key) =
+                key
+                |> Unicode_string.to_string
+                |> Cstruct.of_string
+                |> X509.Encoding.Pem.Private_key.of_pem_cstruct1
+              in
+              let payload = Dval.to_pretty_machine_yojson_v1 payload in
+              sign_and_encode ~key ~extra_headers:[] ~payload
+              |> Dval.dstr_of_string_exn
+          | args ->
+              fail args)
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["JWT::signAndEncodeWithHeaders"]
+    ; ins = []
+    ; p = [par "pemPrivKey" TStr; par "headers" TObj; par "payload" TAny]
+    ; r = TStr
+    ; d =
+        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm, with an extra header map. Takes an unecnrypted RSA private key in PEM format."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr key; DObj headers; payload] ->
+              let (`RSA key) =
+                key
+                |> Unicode_string.to_string
+                |> Cstruct.of_string
+                |> X509.Encoding.Pem.Private_key.of_pem_cstruct1
+              in
+              let json_hdrs =
+                DObj headers
+                |> Dval.to_pretty_machine_yojson_v1
+                |> Yojson.Safe.Util.to_assoc
+              in
+              let payload = Dval.to_pretty_machine_yojson_v1 payload in
+              sign_and_encode ~key ~extra_headers:json_hdrs ~payload
+              |> Dval.dstr_of_string_exn
+          | args ->
+              fail args)
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["JWT::verifyAndExtract"]
+    ; ins = []
+    ; p = [par "pemPubKey" TStr; par "token" TStr]
+    ; r = TOption
+    ; d =
+        "Verify and extra the payload and headers from an rfc751J9 JSON Web Token that uses the RS256 algorithm. Takes an unencrypted RSA public key in PEM format."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr key; DStr token] ->
+            ( match
+                key
+                |> Unicode_string.to_string
+                |> Cstruct.of_string
+                |> X509.Encoding.Pem.Public_key.of_pem_cstruct1
+              with
+            | `EC_pub _ ->
+                DOption OptNothing
+            | `RSA key ->
+              ( match
+                  verify_and_extract
+                    ~key
+                    ~token:(Unicode_string.to_string token)
+                with
+              | Some (headers, payload) ->
+                  [ ("header", Dval.of_unknown_json_v1 headers)
+                  ; ("payload", Dval.of_unknown_json_v1 payload) ]
+                  |> Prelude.StrDict.from_list_exn
+                  |> DObj
+                  |> OptJust
+                  |> DOption
+              | None ->
+                  DOption OptNothing ) )
+          | args ->
+              fail args)
+    ; ps = false
+    ; dep = false } ]

--- a/backend/libexecution/dval.ml
+++ b/backend/libexecution/dval.ml
@@ -843,7 +843,7 @@ let rec to_developer_repr_v0 (dv : dval) : string =
   to_repr_ 0 dv
 
 
-let to_pretty_machine_json_v1 dval =
+let to_pretty_machine_yojson_v1 dval =
   let rec recurse dv =
     match dv with
     (* basic types *)
@@ -893,7 +893,11 @@ let to_pretty_machine_json_v1 dval =
     | DBytes bytes ->
         `String (bytes |> RawBytes.to_string |> B64.encode)
   in
-  recurse dval |> Yojson.Safe.pretty_to_string
+  recurse dval
+
+
+let to_pretty_machine_json_v1 dval =
+  to_pretty_machine_yojson_v1 dval |> Yojson.Safe.pretty_to_string
 
 
 let of_unknown_json_v0 str =

--- a/backend/libexecution/dval.mli
+++ b/backend/libexecution/dval.mli
@@ -83,6 +83,11 @@ val to_enduser_readable_html_v0 : Types.RuntimeT.dval -> string
  * passwords. Customers should not come to rely on this format. *)
 val to_developer_repr_v0 : Types.RuntimeT.dval -> string
 
+(* For passing to Dark functions that operate on JSON, such as the JWT fns.
+ * This turns Option and Result into plain values, or null/error. String-like
+ * values are rendered as string. Redacts passwords.  *)
+val to_pretty_machine_yojson_v1 : Types.RuntimeT.dval -> Yojson.Safe.t
+
 (* When sending json back to the user, or via a HTTP API, attempt to convert
  * everything into reasonable json, in the absence of a schema. This turns
  * Option and Result into plain values, or null/error. String-like values are

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -200,6 +200,78 @@ let t_password_hashing_and_checking_works () =
     (DBool true)
 
 
+let t_jwt_functions_work () =
+  let privatekey =
+    "-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAvxW2wuTTK2d0ob5mu/ASJ9vYDc/SXy06QAIepF9x9eoVZZVZ
+d8ksxvk3JGp/L0+KHuVyXoZFRzE9rU4skIqLn9/0Ag9ua4ml/ft7COprfEYA7klN
+c+xp2lwnGsxL70KHyHvHo5tDK1OWT81ivOGWCV7+3DF2RvDV2okk3x1ZKyBy2Rw2
+uUjl0EzWLycYQjhRrby3gjVtUVanUgStsgTwMlHbmVv9QMY5UetA9o05uPaAXH4B
+CCw+SqhEEJqES4V+Y6WEfFWZTmvWv0GV+i/p4Ur22mtma+6ree45gsdnzlj1OASW
+DQx/7vj7Ickt+eTwrVqyRWb9iNZPXj3ZrkJ44wIDAQABAoIBAQC+0olj0a3MT5Fa
+oNDpZ9JJubLmAB8e6wSbvUIqdiJRKUXa3y2sgNtVjLTzieKfNXhCaHIxUTdH5DWq
+p0G7yo+qxbRghlaHz7tTitsQSUGzphjx3YQaewIujQ6EJXbDZZZBsNLqYHfQgbW+
+1eV/qGvzyckLzd1G9OUrSv/mS+GrPQ00kpIJIX+EInFOPQ04DheppGNdlxoAUwQQ
+XUUhE1LifY4DyyK71mNlUoYyCs+0ozLzbxQwr9n8PKnLKdukL6X0g3tlKEbqQWPv
+vz2J8QZeSyhnZM9AjtYdVqTO6qs4l9dyWjdpDRIV9WylasOsIbb8XP8bv2NpH2Ua
+6a54L/RJAoGBAPVWwU1jU6e86WrnocJf3miydkhF5VV1tporiuAi391N84zCG509
+rWZWa0xsD2tq2+yNDry1qdqMGmvBXKoTJAx3cjpvK/uK7Tkd+tnislDLw8Wq/fCz
+NBdSidGIuASXdh4Bo9OK8iYMBgfpUGXRKAs4rO45mwrS/+b0YYZSiX/1AoGBAMdj
+amEa5SzXw7tSqtp4Vr4pp4H52YULKI84UKvEDQOROfazQrZMHxbtaSMXG69x7SBr
+r48MuRYWd8KZ3iUkYjQLhr4n4zw5DS4AVJqgrLootVWHgt6Ey29Xa1g+B4pZOre5
+PJcrxNsG0OjIAEUsTb+yeURSphVjYe+xlXlYD0Z3AoGACdxExKF7WUCEeSF6JN/J
+hpe1nU4B259xiVy6piuAp9pcMYoTpgw2jehnQ5kMPZr739QDhZ4fh4MeBLquyL8g
+McgTNToGoIOC6UrFLECqPgkSgz1OG4B4VX+hvmQqUTTtMGOMfBIXjWPqUiMUciMn
+4tuSR7jU/GhilJu517Y1hIkCgYEAiZ5ypEdd+s+Jx1dNmbEJngM+HJYIrq1+9ytV
+ctjEarvoGACugQiVRMvkj1W5xCSMGJ568+9CKJ6lVmnBTD2KkoWKIOGDE+QE1sVf
+n8Jatbq3PitkBpX9nAHok2Vs6u6feoOd8HFDVDGmK6Uvmo7zsuZKkP/CpmyMAla9
+5p0DHg0CgYEAg0Wwqo3sDFSyKii25/Sffjr6tf1ab+3gFMpahRslkUvyFE/ZweKb
+T/YWcgYPzBA6q8LBfGRdh80kveFKRluUERb0PuK+jiHXz42SJ4zEIaToWeK1TQ6I
+FW78LEsgtnna+JpWEr+ugcGN/FH8e9PLJDK7Z/HSLPtV8E6V/ls3VDM=
+-----END RSA PRIVATE KEY-----"
+    |> String.substr_replace_all ~pattern:"\n" ~with_:"\\n"
+  in
+  let publickey =
+    "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvxW2wuTTK2d0ob5mu/AS
+J9vYDc/SXy06QAIepF9x9eoVZZVZd8ksxvk3JGp/L0+KHuVyXoZFRzE9rU4skIqL
+n9/0Ag9ua4ml/ft7COprfEYA7klNc+xp2lwnGsxL70KHyHvHo5tDK1OWT81ivOGW
+CV7+3DF2RvDV2okk3x1ZKyBy2Rw2uUjl0EzWLycYQjhRrby3gjVtUVanUgStsgTw
+MlHbmVv9QMY5UetA9o05uPaAXH4BCCw+SqhEEJqES4V+Y6WEfFWZTmvWv0GV+i/p
+4Ur22mtma+6ree45gsdnzlj1OASWDQx/7vj7Ickt+eTwrVqyRWb9iNZPXj3ZrkJ4
+4wIDAQAB
+-----END PUBLIC KEY-----"
+    |> String.substr_replace_all ~pattern:"\n" ~with_:"\\n"
+  in
+  let ast =
+    Printf.sprintf
+      "(let privatekey '%s'
+                 (let publickey '%s'
+                   (let payload (obj (abc 'def'))
+                     (let extraHeaders (obj (ghi 'jkl'))
+                       (JWT::verifyAndExtract publickey
+                         (JWT::signAndEncodeWithHeaders
+                           privatekey
+                           extraHeaders
+                           payload))))))"
+      privatekey
+      publickey
+  in
+  check_dval
+    "JWT::verifyAndExtract works on output of JWT::signAndEncodeWithheaders"
+    ( [ ( "payload"
+        , DObj (DvalMap.from_list [("abc", Dval.dstr_of_string_exn "def")]) )
+      ; ( "header"
+        , DObj
+            (DvalMap.from_list
+               [ ("type", Dval.dstr_of_string_exn "JWT")
+               ; ("alg", Dval.dstr_of_string_exn "RS256")
+               ; ("ghi", Dval.dstr_of_string_exn "jkl") ]) ) ]
+    |> DvalMap.from_list
+    |> fun x -> DOption (OptJust (DObj x)) )
+    (exec_ast ast)
+
+
 let suite =
   [ ("Stdlib fns work", `Quick, t_stdlib_works)
   ; ("Option stdlibs work", `Quick, t_option_stdlibs_work)
@@ -207,4 +279,5 @@ let suite =
   ; ("Dict stdlibs work", `Quick, t_dict_stdlibs_work)
   ; ( "End-user password hashing and checking works"
     , `Quick
-    , t_password_hashing_and_checking_works ) ]
+    , t_password_hashing_and_checking_works )
+  ; ("JWT lib works.", `Quick, t_jwt_functions_work) ]


### PR DESCRIPTION
Hello!

Felipe asked us to provice RSA PKCS1.5 signatures with SHA256, so that he can use the Google Play API from Dark. I went ahead and wrote this small library instead, which I believe solves Felipe's issue.

https://trello.com/c/nukGDOGY/1449-felipe-milani-needs-sha256withrsa

Why not just expose the cryptographic primitives?
---

A few reasons:

One: it's not significantly easier. Most of the complexity here is parsing arguments, parsing RSA keys formatted as PEM, and shaping the data into the format that the Nocrypto API expects. JWT is not really a complicated protocol (on the face of it; it has some emergent complexity security-wise) and it's not a lot of code.

Two: exposing crytpographic primitives, like PKCS1.5, is not really a good way to build a user-facing cryptography API. When we do this, we ought to make it as misuse-resistant; I'd recommend something like l[ibsodium's API, for which most users would only use `sign` and `open` functions,](https://libsodium.gitbook.io/doc/public-key_cryptography/public-key_signatures) and with no configuration when it comes to cryptographic building blocks. This means that stuff like this ought to be treated as interoperation with already-existing systems, not as a general-purpose cryptographic API.

Third: even though JWT is not very complicated, it's tricky to get right because of how abstract and configurable it is. Dark ought to be a real language with the ability to write these kinds of things if users need to, but that doesn't mean we should have every user implement a given cryptographic protocol when they need it.

Why not use a JWT library?
--

OCaml libraries are kind of a mess. I evaluated these two:

+ https://github.com/besport/ocaml-jwt
+ https://github.com/sporto/jwto

The first one has not had a release in a while. The released version uses cryptokit, not Nocrypto, and crypytokit doesn't provide a PEM-parsing function, so using it would generate some extra complexity on our end. It would be possible to use the unreleased `master` somehow, but I'm not sure that it's intended to be ready for release. Tests are commented out, there are assertions that I don't think are meant to be part of the final API, and there are open issues like "add unit tests". I think this small piece of code that I wrote for this PR has better test coverage than this library.

The second one doesn't support RS256 (which Felipe needs) or general-purpose JSON (it takes lists of strings).

Why only RS256?
---

This is not technically a conforming JWT implementation: it only creates and accepts RS256 tokens. However, that's all Felipe needs right now, and adding configurability for cryptographic building blocks has some pitfalls. It's also one of the better options in JWT (though probably not the one we would recommend for new systems that accept JWT tokens).

However, JWT is not really a good way to build new systems (happy to expand on this if there's value), and we can always add other protocols, including "none", if and when there's demand for them.

How do I use this API?
---

Here's an example, generating a JWT token and then verifying it:

![dark_jwt](https://user-images.githubusercontent.com/490421/61751378-fd503780-ad5c-11e9-8011-296641faa317.png)



---

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

