### PR TITLE
Set Strict-Transport-Security for darklang.com and subdomains.

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -68,7 +68,7 @@ server {
   server_name www.darklang.com;
 
   # tell clients to stop going to http://www.darklang.com
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
 
   return 301 https://darklang.com$request_uri;
 }
@@ -84,7 +84,7 @@ server {
   client_max_body_size 100m;
 
   # tell clients to stop going to http://darklang.com
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
 
   # These prefixes are handled by the OCaml backend.
   location /a/ {
@@ -112,7 +112,7 @@ server {
   server_name presence.darklang.com;
 
   # tell clients to stop going to http://presence.darklang.com
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
 
   location / {
     # redirect http to https.
@@ -130,7 +130,7 @@ server {
   server_name static.darklang.com;
 
   # tell clients to stop going to http://static.darklang.com
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
 
   location / {
     # cache this content on the fs of the nginx container, rather than letting


### PR DESCRIPTION
This tells clients to never visit `http://...` (and to visit `https://...` instead) for `darklang.com`. They shouldn't be visiting `http://` anyway, and they'll get redirected, but this removes the small window of unencrypted traffic for clients who have visited before.

This prevents ["sslstrip"](https://moxie.org/software/sslstrip/) style attacks and also prevents ISPs, cafes, etc from injecting ads or trackers in any Dark traffic for established users.

This sets the `max-age` for this setting to one year; this means that clients will cache this information for up to a year. This can be a little operationally risky for some systems, since it means that `http://`-only behavior will no longer work at all, but I'm pretty confident that there's nothing served at http://darklang.com, and if there is I'm sure we can quickly move it to `https://`.

This also includes `preload`, which makes us eligible for the[ HSTS preload list](https://hstspreload.org/). I think we should submit darklang.com to this as well; this will remove the small window of unencrypted traffic for all browser clients, including those who have never visited before.

---

I think nginx is the best place to do this if we want to handle every darklang.com subdomain -- some of the darklang.com subdomains (for example, `presence.`, and the root domain which leads to the splash page) don't exist in the backend at all. This makes it easy to see that this header applies to every route for these domains

It's possible (likely?) that we will eventually add some backend work for `builtwithdark.com` URLs. However, some thought needs to be done about things like:
+ How will custom domains with dark work?
+ Should Dark users be able to override and specify their own HSTS setting?
+ Should Dark users be able to serve on HTTP at all? (maybe for legacy or embedded systems or something niche like that...)

I'm inclined to punt on this question entirely and just apply it to `darklang.com` for now.

---

https://trello.com/c/1HnKIkQj/1414-investigate-hsts-hsts-preload-and-weird-https-issues-that-come-out-of-letting-users-set-headers