### PR TITLE
deprecate db::add

### DIFF
--- a/backend/libbackend/libdb2.ml
+++ b/backend/libbackend/libdb2.ml
@@ -43,7 +43,7 @@ let fns : shortfn list =
           | args ->
               fail args)
     ; ps = false
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["DB::get_v1"]
     ; ins = []
     ; p = [par "key" TStr; par "table" TDB]


### PR DESCRIPTION
deprecate db::add function

Fixes: https://trello.com/c/eFfHYszD/1424-remove-dbadd-function

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

