### PR TITLE
Redirect birb https

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -141,8 +141,11 @@ let should_use_https uri =
     uri |> Uri.host |> Option.value ~default:"" |> fun h -> String.split h '.'
   in
   match parts with
-  | ["darklang"; "com"] | ["builtwithdark"; "com"] | [_; "builtwithdark"; "com"]
-    ->
+  | ["darklang"; "com"]
+  | ["builtwithdark"; "com"]
+  | [_; "builtwithdark"; "com"]
+  | ["hellobirb"; "com"]
+  | ["www"; "hellobirb"; "com"] ->
       true
   | _ ->
       false


### PR DESCRIPTION
Birb is not redirecting to https. It seems to be because we don't tell it to.



Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

