### PR TITLE
Roundtrip and display feature flag, showing only case a

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -201,8 +201,9 @@ let rec fromExpr ?(inThread = false) (s : state) (expr : Types.expr) :
         in
         let pairs = List.map pairs ~f:(fun (p, e) -> (fromPattern p, f e)) in
         EMatch (id, f mexpr, pairs)
-    | FeatureFlag _ ->
-        EOldExpr expr
+    | FeatureFlag (msg, cond, casea, caseb) ->
+        EFeatureFlag
+          (id, varToName msg, Blank.toID msg, f cond, f casea, f caseb)
     | FluidPartial (str, oldExpr) ->
         EPartial (id, str, f oldExpr)
     | FluidRightPartial (str, oldExpr) ->
@@ -333,6 +334,11 @@ let rec toExpr ?(inThread = false) (expr : fluidExpr) : Types.expr =
       F (id, Match (toExpr mexpr, pairs))
   | EThreadTarget _ ->
       fail "Cant convert threadtargets back to exprs"
+  | EFeatureFlag (id, name, nameID, cond, caseA, caseB) ->
+      F
+        ( id
+        , FeatureFlag
+            (F (nameID, name), toExpr cond, toExpr caseA, toExpr caseB) )
   | EOldExpr expr ->
       expr
 
@@ -361,6 +367,7 @@ let eid expr : id =
   | EThreadTarget id
   | EBinOp (id, _, _, _, _)
   | EConstructor (id, _, _, _)
+  | EFeatureFlag (id, _, _, _, _, _)
   | EMatch (id, _, _) ->
       id
 
@@ -636,6 +643,8 @@ let rec toTokens' (s : state) (e : ast) : token list =
       [TPartial (id, str)]
   | ERightPartial (id, newOp, expr) ->
       [nested expr; TSep; TRightPartial (id, newOp)]
+  | EFeatureFlag (_id, _msg, _msgid, _cond, casea, _caseb) ->
+      [nested casea]
 
 
 (* TODO: we need some sort of reflow thing that handles line length. *)
@@ -946,6 +955,8 @@ let rec findExpr (id : id) (expr : fluidExpr) : fluidExpr option =
         None
     | EPartial (_, _, oldExpr) | ERightPartial (_, _, oldExpr) ->
         fe oldExpr
+    | EFeatureFlag (_, _, _, cond, casea, caseb) ->
+        fe cond |> Option.orElse (fe casea) |> Option.orElse (fe caseb)
 
 
 let isEmpty (e : fluidExpr) : bool =
@@ -1015,6 +1026,8 @@ let findParent (id : id) (ast : ast) : fluidExpr option =
           fp expr
       | ERightPartial (_, _, expr) ->
           fp expr
+      | EFeatureFlag (_, _, _, cond, casea, caseb) ->
+          fp cond |> Option.orElse (fp casea) |> Option.orElse (fp caseb)
   in
   findParent' ~parent:None id ast
 
@@ -1064,6 +1077,8 @@ let recurse ~(f : fluidExpr -> fluidExpr) (expr : fluidExpr) : fluidExpr =
       EPartial (id, str, f oldExpr)
   | ERightPartial (id, str, oldExpr) ->
       ERightPartial (id, str, f oldExpr)
+  | EFeatureFlag (id, msg, msgid, cond, casea, caseb) ->
+      EFeatureFlag (id, msg, msgid, f cond, f casea, f caseb)
 
 
 (* Slightly modified version of `AST.uses` (pre-fluid code) *)

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -1092,6 +1092,8 @@ and fluidExpr =
   (* Placeholder that indicates the target of the Thread. May be movable at
    * some point *)
   | EThreadTarget of id
+  (* The 2nd id is for the name *)
+  | EFeatureFlag of id * string * id * fluidExpr * fluidExpr * fluidExpr
   | EOldExpr of expr
 
 and placeholder = string * string


### PR DESCRIPTION
This implements just enough feature flag to get fluid to testing. Making a good feature flag experience in fluid is a bigger challenge, but this should be enough to show it to users.

https://trello.com/c/ApLtfFD2/1463-just-enough-fluid-feature-flag

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

