### PR TITLE
Include Strict-Transport-Security even on HTTP errors and redirects.

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -68,7 +68,7 @@ server {
   server_name www.darklang.com;
 
   # tell clients to stop going to http://www.darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
 
   return 301 https://darklang.com$request_uri;
 }
@@ -84,7 +84,7 @@ server {
   client_max_body_size 100m;
 
   # tell clients to stop going to http://darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
 
   # These prefixes are handled by the OCaml backend.
   location /a/ {
@@ -112,7 +112,7 @@ server {
   server_name presence.darklang.com;
 
   # tell clients to stop going to http://presence.darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
 
   location / {
     # redirect http to https.
@@ -130,7 +130,7 @@ server {
   server_name static.darklang.com;
 
   # tell clients to stop going to http://static.darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload";
+  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
 
   location / {
     # cache this content on the fs of the nginx container, rather than letting


### PR DESCRIPTION
I didn't realize nginx filters out `add_header` on non-`200`s. 

Using `always` is how nginx recommends doing HSTS:

https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/
```
add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
```