### PR TITLE
Include the www.hellobirb.com-tls cert in the kubernetes yaml

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/bwd-ingress.yaml
+++ b/scripts/support/kubernetes/builtwithdark/bwd-ingress.yaml
@@ -9,3 +9,4 @@ spec:
   tls:
     - secretName: bwd-tls
     - secretName: darklang-tls
+    - secretName: www.hellobirb.com-tls


### PR DESCRIPTION
I installed this in kubernetes already from the command-line (to unbreak www.hellobirb.com), just following up so the checked-in yaml matches production. 

We serve https://www.hellobirb.com now!

If anyone's curious how this works, here's the document I wrote last year when I did all of this the first time.

https://github.com/darklang/dark/blob/master/docs/tls-2018-08-03.markdown

