### PR TITLE
One-year max-age for darklang.com Strict Transport Security records

### DIFF
--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -68,7 +68,7 @@ server {
   server_name www.darklang.com;
 
   # tell clients to stop going to http://www.darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
   return 301 https://darklang.com$request_uri;
 }
@@ -84,7 +84,7 @@ server {
   client_max_body_size 100m;
 
   # tell clients to stop going to http://darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
   # These prefixes are handled by the OCaml backend.
   location /a/ {
@@ -112,7 +112,7 @@ server {
   server_name presence.darklang.com;
 
   # tell clients to stop going to http://presence.darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
   location / {
     # redirect http to https.
@@ -130,7 +130,7 @@ server {
   server_name static.darklang.com;
 
   # tell clients to stop going to http://static.darklang.com
-  add_header Strict-Transport-Security "max-age=3600; includeSubDomains; preload" always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
   location / {
     # cache this content on the fs of the nginx container, rather than letting


### PR DESCRIPTION
We've had a one-hour max-age since merging https://github.com/darklang/dark/pull/1190. I haven't heard of any problems; there's nothing in the #users channel and no suspicious rollbars.

I've also poked around on the service with the dev tools network tab open and nothing hits http://.

One year is standard, and is required for the preload list: https://hstspreload.org/

> Serve an HSTS header on the base domain for HTTPS requests:
The max-age must be at least 31536000 seconds (1 year).

Even in the very unlikely case that some route that only exists on http exists and causes an issue, we can fix it by making the route work on https://.