### PR TITLE
Apply CORs settings to DErrors and DIncompletes.

### DIFF
--- a/backend/test/test_json.ml
+++ b/backend/test/test_json.ml
@@ -181,6 +181,24 @@ let t_result_to_response_works () =
                "without any other settings, we get Access-Control-Allow-Origin: *."
                (Some "*")
                (Header.get (Resp.headers r) "Access-Control-Allow-Origin") )
+       ; ( DError "oh no :("
+         , req
+         , None
+         , fun r ->
+             AT.check
+               (AT.option AT.string)
+               "we get Access-Control-Allow-Origin: * even for errors."
+               (Some "*")
+               (Header.get (Resp.headers r) "Access-Control-Allow-Origin") )
+       ; ( DIncomplete
+         , req
+         , None
+         , fun r ->
+             AT.check
+               (AT.option AT.string)
+               "we get Access-Control-Allow-Origin: * even for incompletes."
+               (Some "*")
+               (Header.get (Resp.headers r) "Access-Control-Allow-Origin") )
        ; ( exec_ast "1"
          , req
          , Some Canvas.AllOrigins


### PR DESCRIPTION
A user was confused recently by CORs errors when actually the problem was that the Dark routes in question were returning DINcompletes.

This sets `Access-Control-Allow-Origin` on all output from a Dark route, including DError and DIncomplete.

https://trello.com/b/B25On0K9/weekly

---

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket.
  - [x] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [x] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions).
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

