### PR TITLE
If in the middle of a token, make sure we get the left token right

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -1994,6 +1994,25 @@ let () =
              |> fun (_, s) -> s.ac.index)
           |> toEqual None ) ;
       () ) ;
+  describe "Neighbours" (fun () ->
+      test "with empty AST, have left neighbour" (fun () ->
+          let id = ID "543" in
+          expect
+            (let ast = EString (id, "test") in
+             let tokens = toTokens m.fluidState ast in
+             Fluid.getNeighbours ~pos:3 tokens)
+          |> toEqual
+               (let token = TString (id, "test") in
+                let ti =
+                  { token
+                  ; startRow = 0
+                  ; startCol = 0
+                  ; startPos = 0
+                  ; endPos = 6
+                  ; length = 6 }
+                in
+                (L (token, ti), R (token, ti), None)) ) ;
+      () ) ;
   describe "Tabs" (fun () ->
       t
         "tab goes to first block in a let"

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -828,6 +828,9 @@ let getNeighbours ~(pos : int) (tokens : tokenInfo list) :
     (* The left might be separated by whitespace *)
     | Some prev, Some current when current.startPos >= pos ->
         L (prev.token, prev)
+    | None, Some current when current.startPos < pos ->
+        (* We could be in the middle of a token *)
+        L (current.token, current)
     | None, _ ->
         No
     | _, Some current ->


### PR DESCRIPTION
https://trello.com/c/3fMgXTT1/1466-cant-select-the-0th-token-in-fluid

I broke this code a while back, changing the order of the match. It means that the first token in an expression wasn't found, which prevented any movement/action that used it. Now it will be found, plus a test.

Before: you can see that left is null. (my cursor is position 6, and it won't go any further left even if i press left)
![image](https://user-images.githubusercontent.com/181762/61920296-f9afe280-af0d-11e9-8451-75dfe653cac1.png)

![image](https://user-images.githubusercontent.com/181762/61920329-10eed000-af0e-11e9-8b8c-c312f96c8541.png)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

