### PR TITLE
Make fluidentry work on single click

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1080,10 +1080,10 @@ let update_ (msg : msg) (m : model) : modification =
       in
       let fluid =
         if VariantTesting.isFluid m.tests
-        then Fluid.update m FluidMouseClick
+        then Fluid.update m (FluidMouseClick targetExnID)
         else NoChange
       in
-      Many [fluid; click]
+      Many [click; fluid]
   | ExecuteFunctionButton (tlid, id, name) ->
       Many
         [ ExecutingFunctionBegan (tlid, id)
@@ -1573,7 +1573,7 @@ let update_ (msg : msg) (m : model) : modification =
            ~context:"TriggerSendPresenceCallback"
            ~importance:IgnorableError
            err)
-  | FluidMouseClick ->
+  | FluidMouseClick _ ->
       impossible "Can never happen"
   | FluidCommandsFilter query ->
       TweakModel

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -892,7 +892,7 @@ and msg =
   | EntrySubmitMsg
   | GlobalKeyPress of Keyboard.keyEvent
   | FluidKeyPress of FluidKeyboard.keyEvent
-  | FluidMouseClick
+  | FluidMouseClick of tlid
   | AutocompleteClick of int
   | AddOpRPCCallback of
       focus * addOpRPCParams * (addOpStrollerMsg, httpError) Tea.Result.t


### PR DESCRIPTION
From a deselected canvas it used to take 2 clicks to go into fluid entering. This was due to a bug where we used the wrong tlid.

Before:
![Jul-26-2019 00-44-44](https://user-images.githubusercontent.com/181762/61935091-968a7400-af3e-11e9-981e-2b7e22d7c247.gif)

After:
![Jul-26-2019 00-31-34](https://user-images.githubusercontent.com/181762/61934842-12d08780-af3e-11e9-9296-ac98c9c575ba.gif)

https://trello.com/c/UIOhzwR6/1455-it-takes-three-clicks-to-add-a-cursor

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

