### PR TITLE
Enough to decode the CreateDBMigration addOp

### DIFF
--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -219,6 +219,10 @@ and dbColList j : dbColumn list =
   list (tuple2 (blankOr string) (blankOr tipeString)) j
 
 
+and dbmColList j : dbColumn list =
+  list (tuple2 (blankOr string) (blankOr string)) j
+
+
 and dbMigrationState j : dbMigrationState =
   let dv0 = variant0 in
   variants
@@ -420,7 +424,7 @@ and op j : op =
           tlid
           id
           id
-          dbColList )
+          dbmColList )
     ; ( "AddDBColToDBMigration"
       , variant3
           (fun t colnameid coltypeid ->


### PR DESCRIPTION
The decoder that we were using when decoding ops wasn't exactly the same as what's used in other places.

https://trello.com/c/MHFFuDd9/1404-when-tapping-the-db-unlock-button-i-get-this-banner-10-10

This fixes the decoder. It will likely go away in the near future, so just doing enough to make the error stop.

- [x] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

