### PR TITLE
Switch msgs from taking userfunctions to tlids

### DIFF
--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -944,9 +944,9 @@ and msg =
   | StartFeatureFlag
   | EndFeatureFlag of id * pick
   | ToggleFeatureFlag of id * bool
-  | DeleteUserFunctionParameter of userFunction * userFunctionParameter
-  | AddUserFunctionParameter of userFunction
-  | DeleteUserTypeField of userTipe * userRecordField
+  | DeleteUserFunctionParameter of tlid * userFunctionParameter
+  | AddUserFunctionParameter of tlid
+  | DeleteUserTypeField of tlid * userRecordField
   | BlankOrClick of tlid * id * mouseEvent
   | BlankOrDoubleClick of tlid * id * mouseEvent
   | BlankOrMouseEnter of tlid * id * mouseEvent

--- a/client/src/ViewFunction.ml
+++ b/client/src/ViewFunction.ml
@@ -64,7 +64,7 @@ let viewKillParameterBtn (uf : userFunction) (p : userFunctionParameter) :
               ^ "-"
               ^ (p.ufpName |> B.toID |> showID) )
             "click"
-            (fun _ -> DeleteUserFunctionParameter (uf, p)) ]
+            (fun _ -> DeleteUserFunctionParameter (uf.ufTLID, p)) ]
         [fontAwesome "times-circle"]
     else
       Html.div
@@ -89,7 +89,7 @@ let viewMetadata (vs : viewState) (fn : userFunction) : msg Html.html =
           ; ViewUtils.eventNoPropagation
               ~key:("aufp-" ^ showTLID fn.ufTLID)
               "click"
-              (fun _ -> AddUserFunctionParameter fn) ]
+              (fun _ -> AddUserFunctionParameter fn.ufTLID) ]
           [fontAwesome "plus-circle"]
       ; Html.span [Html.class' "btn-label"] [Html.text "add new parameter"] ]
   in

--- a/client/src/ViewUserType.ml
+++ b/client/src/ViewUserType.ml
@@ -47,7 +47,7 @@ let viewKillFieldBtn (t : userTipe) (field : userRecordField) : msg Html.html =
           ^ "-"
           ^ (field.urfName |> B.toID |> showID) )
         "click"
-        (fun _ -> DeleteUserTypeField (t, field)) ]
+        (fun _ -> DeleteUserTypeField (t.utTLID, field)) ]
     [fontAwesome "times-circle"]
 
 


### PR DESCRIPTION
https://trello.com/c/9HaLn0Ua/1403-clicking-add-param-to-get-the-first-param-renames-the-function-to-a-default-1010

When we were rendering userFunctions (and the same is true of userTipes), the handlers closed over the entire userfunction. Then, when the userfunction changed because it was renamed, the handler still refered to the old data. It should just have referred to the tlid instead.

![Jul-26-2019 22-01-34](https://user-images.githubusercontent.com/181762/61990211-f8a3b180-aff0-11e9-8492-0b5b85472cf0.gif)

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

