### PR TITLE
Remove libtwitter fns that have { in them

### DIFF
--- a/backend/libbackend/libtwitter.ml
+++ b/backend/libbackend/libtwitter.ml
@@ -115,6 +115,13 @@ let auth_param : param =
 
 let fns =
   schema.apis
+  |> List.filter ~f:(fun (api : Swagger.api) ->
+         (* There are a bunch of apis that have "{id}" or "{format}" in their
+          * names. We don't support filling in those paramters at the moment so
+          * they can't actually be called correctly, and the presence of "{"
+          * made it impossible to create objects in the autocomplete, so we
+          * disabled them for now *)
+         not (String.contains ~substring:"{" api.path) )
   |> List.filter_map ~f:(fun (api : Swagger.api) ->
          api.operations
          |> List.head


### PR DESCRIPTION
No trello.

In https://dark-inc.slack.com/archives/CAJPMCGQL/p1564341968100800, Dieterick was using the libtwitter flag and couldn't enter objects cause the autocomplete didn't allow it. I didn't want to fix the actual autocomplete, so I removed these functions, which were not valid anyway.

It's possible that users are using these functions and will no longer be able to. However, these functions currently don't do anything useful (as we don't fill in the variables in their urls). Also, this is behind a flag so there's an implicit understanding that this is beta.

- [ ] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

