### PR TITLE
Add Date::parse_v1 function which uses Results

### DIFF
--- a/backend/libexecution/libstd.ml
+++ b/backend/libexecution/libstd.ml
@@ -1828,6 +1828,28 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
+    ; dep = true }
+  ; { pns = ["Date::parse_v1"]
+    ; ins = []
+    ; p = [par "s" TStr]
+    ; r = TResult
+    ; d =
+        "Parses a string representing a date in the ISO format and returns a Date"
+    ; f =
+        InProcess
+          (function
+          | _, [DStr s] ->
+            ( try
+                DResult
+                  (ResOk
+                     (DDate
+                        (Util.date_of_isostring (Unicode_string.to_string s))))
+              with e ->
+                DResult
+                  (ResError (Dval.dstr_of_string_exn "Invalid date format")) )
+          | args ->
+              fail args)
+    ; ps = true
     ; dep = false }
   ; { pns = ["Date::now"]
     ; ins = []

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -272,6 +272,26 @@ MlHbmVv9QMY5UetA9o05uPaAXH4BCCw+SqhEEJqES4V+Y6WEfFWZTmvWv0GV+i/p
     (exec_ast ast)
 
 
+let t_date_functions_work () =
+  check_dval
+    "Valid Date::parse_v0 produces a Date"
+    (DDate (Util.date_of_isostring "2019-07-28T22:42:00Z"))
+    (exec_ast "(Date::parse '2019-07-28T22:42:00Z')") ;
+  check_dval
+    "Invalid Date::parse_v0 produces an error"
+    (DBool true)
+    (exec_ast "(Bool::isError (Date::parse 'asd'))") ;
+  check_dval
+    "Valid Date::parse_v1 produces an Ok Date"
+    (DResult (ResOk (DDate (Util.date_of_isostring "2019-07-28T22:42:00Z"))))
+    (exec_ast "(Date::parse_v1 '2019-07-28T22:42:00Z')") ;
+  check_dval
+    "Invalid Date::parse_v1 produces an Error result"
+    (DResult (ResError (Dval.dstr_of_string_exn "Invalid date format")))
+    (exec_ast "(Date::parse_v1 'asd')") ;
+  ()
+
+
 let suite =
   [ ("Stdlib fns work", `Quick, t_stdlib_works)
   ; ("Option stdlibs work", `Quick, t_option_stdlibs_work)
@@ -280,4 +300,5 @@ let suite =
   ; ( "End-user password hashing and checking works"
     , `Quick
     , t_password_hashing_and_checking_works )
-  ; ("JWT lib works.", `Quick, t_jwt_functions_work) ]
+  ; ("JWT lib works.", `Quick, t_jwt_functions_work)
+  ; ("Date lib works", `Quick, t_date_functions_work) ]


### PR DESCRIPTION
https://trello.com/c/Cxo5ZEgS/1480-add-dateparsev1-using-results

The old Date::parse, when given an invalid format, throws an exception. It should instead use Results. This adds v1 which does that.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

