### PR TITLE
Tidy up the error messages generated by the backend

### DIFF
--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -2,7 +2,6 @@ open Tc
 open Json_encode_extended
 
 (* Dark *)
-module RT = Runtime
 
 (* Don't attempt to encode these as integers, because we're not capable
  * of expressing all existing ids as ints because bucklescript is strict


### PR DESCRIPTION
DError error messages used to look like this:

![image](https://user-images.githubusercontent.com/181762/62028403-0a25be80-b195-11e9-9ffc-6261b4c3a155.png)

This is the type of message most commonly generated on a type error, but also in a few other cases.

Now it looks like this:

![image](https://user-images.githubusercontent.com/181762/62028481-30e3f500-b195-11e9-8726-09aaf85a0926.png)

In the more common case of ibcorrect types in fn calls, it looks like this:
![image](https://user-images.githubusercontent.com/181762/62028446-20337f00-b195-11e9-8e80-483610fc71c7.png)

https://trello.com/c/erNis2om/1443-httprespondwithheaders-gives-bad-error-message-when-not-called-with-a-string-8-8

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

