### PR TITLE
Only skip over separators when you press space

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -1692,13 +1692,11 @@ let () =
         (b ())
         (presses [K.Equals; K.Tab] 0)
         ("_________ == _________", 13) ;
-      (* TODO: make autocomplete on space work consistently
       t
         "autocomplete space on bin-op moves to start of first blank"
         (b ())
         (presses [K.Equals; K.Space] 0)
         ("_________ == _________", 0) ;
-      *)
       t
         "variable moves to right place"
         (EPartial (gid (), "req", b ()))
@@ -1744,7 +1742,11 @@ let () =
         (EPartial (gid (), "Nothing", b ()))
         (enter 7)
         ("Nothing", 7) ;
-      (* TODO: autocomplete for nothing at the end of a line, pressing space *)
+      t
+        "autocomplete for Nothing at end of a line"
+        (EIf (gid (), b (), EPartial (gid (), "Nothing", b ()), b ()))
+        (space 21)
+        ("if ___\nthen\n  Nothing\nelse\n  ___", 21) ;
       t
         "autocomplete for Error"
         (EPartial (gid (), "Error", b ()))

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -2124,8 +2124,17 @@ let acMoveBasedOnKey
     | K.Enter ->
         startPos + offset
     | K.Space ->
-        (* if new position is after next blank, stay in next blank *)
-        min nextBlank (startPos + offset + 1)
+        let thisTi =
+          List.find ~f:(fun ti -> ti.startPos = startPos + offset) tokens
+        in
+        ( match thisTi with
+        (* Only move forward to skip over a separator *)
+        (* TODO: are there more separators we should consider here? *)
+        | Some {token} when token = TSep ->
+            min nextBlank (startPos + offset + 1)
+        | _ ->
+            (* if new position is after next blank, stay in next blank *)
+            startPos + offset )
     | _ ->
         s.newPos
   in


### PR DESCRIPTION
https://trello.com/c/1xlr7wzK/1472-pressing-space-at-the-end-of-a-line-goes-to-blank-space-in-next-line

It wasn't really clear what the space did before, except that it was like enter except it went forward 1 place. I think the actual implementation is that it should skip over separators. There may be more separators I haven't considered, but this is enough to make the tests pass.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

