### PR TITLE
Add styling for worker/repl handlers

### DIFF
--- a/client/src/ViewCode.ml
+++ b/client/src/ViewCode.ml
@@ -664,6 +664,10 @@ let viewEventSpec (vs : viewState) (spec : handlerSpec) : msg Html.html =
         baseClass ^ " http-patch"
     | F (_, "CRON"), _ ->
         baseClass ^ " cron"
+    | F (_, "WORKER"), _ ->
+        baseClass ^ " worker"
+    | F (_, "REPL"), _ ->
+        baseClass ^ " repl"
     | _ ->
         baseClass
   in

--- a/client/src/styles/_ast.scss
+++ b/client/src/styles/_ast.scss
@@ -21,11 +21,9 @@ $pipe-color: $blue;
     color: $color;
     border-bottom-color: $color;
 
-    .modifier {
-      .handler-trigger {
-        &:hover {
-          color: lighten($color, 10%);
-        }
+    .handler-trigger {
+      &:hover {
+        color: lighten($color, 10%);
       }
     }
   }
@@ -144,10 +142,10 @@ $toplevel-shadow-front: 1px 2px 4px 2px $black1;
   justify-content: space-between;
   flex-wrap: nowrap;
 
-  color: $queue-color;
+  color: $default-toplevel-color;
   font-size: 8pt;
 
-  border-bottom: 1px solid $queue-color;
+  border-bottom: 1px solid $default-toplevel-color;
   padding-bottom: 4px;
   padding-top: 4px;
   padding-left: $spacing-medium;
@@ -159,11 +157,54 @@ $toplevel-shadow-front: 1px 2px 4px 2px $black1;
   @include handler-type(http-delete, $http-delete);
   @include handler-type(http-patch, $http-patch);
   @include handler-type(cron, $cron-color);
+  @include handler-type(worker, $queue-color);
+  @include handler-type(repl, $repl-color);
 
   .name,
   .modifier,
   .space {
     margin: 0;
+  }
+  .handler-trigger {
+    display: inline;
+    margin-left: 4px;
+    position: relative;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    @include is-executing();
+
+    &.inactive {
+      display: inline;
+      margin-left: 4px;
+      color: $grey2;
+
+      &:hover {
+        cursor: not-allowed;
+      }
+    }
+
+    &.complete {
+      &:before {
+        @extend .font-awesome;
+        content: "\f00c";
+        position: absolute;
+        left: 0;
+        opacity: 1;
+
+        /* duration timing-fn delay fill-mode animation-name */
+        animation: 0.5s linear 2s forwards fadeOut;
+      }
+
+      i.fa.fa-redo {
+        opacity: 0;
+
+        /* duration timing-fn delay fill-mode animation-name */
+        animation: 0.5s linear 2.25s forwards fadeIn;
+      }
+    }
   }
 
   .modifier {
@@ -175,48 +216,6 @@ $toplevel-shadow-front: 1px 2px 4px 2px $black1;
     .external {
       margin-left: 4px;
       color: $green;
-    }
-
-    .handler-trigger {
-      display: inline;
-      margin-left: 4px;
-      position: relative;
-
-      &:hover {
-        cursor: pointer;
-      }
-
-      @include is-executing();
-
-      &.inactive {
-        display: inline;
-        margin-left: 4px;
-        color: $grey2;
-
-        &:hover {
-          cursor: not-allowed;
-        }
-      }
-
-      &.complete {
-        &:before {
-          @extend .font-awesome;
-          content: "\f00c";
-          position: absolute;
-          left: 0;
-          opacity: 1;
-
-          /* duration timing-fn delay fill-mode animation-name */
-          animation: 0.5s linear 2s forwards fadeOut;
-        }
-
-        i.fa.fa-redo {
-          opacity: 0;
-
-          /* duration timing-fn delay fill-mode animation-name */
-          animation: 0.5s linear 2.25s forwards fadeIn;
-        }
-      }
     }
   }
 

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -35,7 +35,9 @@ $http-put: $orange;
 $http-patch: $purple;
 $http-delete: lighten($red, 15%);
 $cron-color: $yellow;
-$queue-color: $grey3;
+$default-toplevel-color: $grey3;
+$queue-color: $cyan;
+$repl-color: $pink;
 $user-functions: saturate($cyan, 10%);
 
 $hover-foreground: darken($blue, 10%);


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Fixes: https://trello.com/c/bIYQorPX/1425-worker-repl-handlers-missing-spec-styling-9-9

Fixes in here:

1) Worker/REPL handlers didn't have CSS classes applied
2) No colors for worker/REPL handlers in the CSS
3) The replay button CSS was under `.modifier` but Worker/REPL handlers don't have modifiers.


![image](https://user-images.githubusercontent.com/1179074/62171672-9abee480-b2e4-11e9-8b72-b09e73db495a.png)



Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

