### PR TITLE
Remove references to conduit. It's been quite a while

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,12 +310,6 @@ flag to see the commands run. You'll see something that looks like this:
 Run that without the --dump-ast and then look at the .pp.ml file to find
 the preprocessed version.
 
-## Running conduit
-
-- Run `./scripts/run-conduit-frontend.sh`
-- Go to `http://localhost:8001`
-- This will use http://conduit.builtwithdark.localhost:8000 as its server, so use http://darklang.localhost:8000/a/conduit/ to create the UI.
-
 ## Important docs which we believe are up-to-date:
 
 - [docs/add-user.md](docs/add-user.md)

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -277,8 +277,6 @@ let options_handler
      origin, to return Access-Control-Allow-Headers with the requested headers,
      and Access-Control-Allow-Methods for all of the methods we think might
      be useful.
-
-     This makes e.g. conduit from localhost work.
   *)
   let req_headers =
     Cohttp.Header.get (CRequest.headers req) "access-control-request-headers"

--- a/scripts/builder
+++ b/scripts/builder
@@ -36,18 +36,6 @@ if [ -n "$RELOAD_BROWSER" ]; then
 fi
 
 # --------------
-# Conduit
-# --------------
-if [ ! -v CI ]; then
-  if [ ! -d ../conduit-frontend ]; then
-    echo "pulling the conduit frontend"
-    pushd ..
-    git clone git@github.com:darklang/conduit-frontend
-    popd
-  fi
-fi
-
-# --------------
 # Mounts
 # --------------
 
@@ -63,9 +51,6 @@ else
   MOUNTS+=" --mount type=volume,src=dark_client_lib,dst=/home/dark/app/client/lib"
   MOUNTS+=" --mount type=volume,src=dark_stroller_target,dst=/home/dark/app/stroller/target"
 
-  if [[ -e "../conduit-frontend" ]]; then
-    MOUNTS="$MOUNTS --mount type=bind,src=$PWD/../conduit-frontend,dst=/home/dark/conduit-frontend"
-  fi
   if [[ -e "$HOME/.config/gcloud" ]]; then
     MOUNTS="$MOUNTS --mount type=bind,src=$HOME/.config/gcloud,dst=/home/dark/.config/gcloud"
   fi

--- a/scripts/run-conduit-frontend-in-container.sh
+++ b/scripts/run-conduit-frontend-in-container.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-cd ~/conduit-frontend
-elm-live --host=0.0.0.0 --output=elm.js src/Main.elm --pushstate --open --debug

--- a/scripts/run-conduit-frontend.sh
+++ b/scripts/run-conduit-frontend.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-set -x
-
-./scripts/run-in-docker scripts/run-conduit-frontend-in-container.sh


### PR DESCRIPTION
We used to use the conduit project to test Dark. It's been a while since we did that. This removes anything we did to specifically make conduit work.

- [ ] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

