### PR TITLE
Add the steps to compile bs-tea locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,21 @@ Use the queryparam "localhost-assets=<username>" to load static assets from dark
 
 You can check if it's going through via the ngrok console (which logs requests), and by tailing the server logs: `tail -f rundir/logs/server.log`.
 
+## Editing other BS libraries
+
+We sometimes have to edit other bs libraries in tandem with our codebase, which
+is a little challenging. Here are the steps to make it work:
+
+In client/package.json
+```
+-    "bucklescript-tea": "darklang/bucklescript-tea#master",
++    "bucklescript-tea": "file:../../bucklescript-tea",
+```
+
+In scripts/builder:
++  MOUNTS="$MOUNTS --mount type=bind,src=$PWD/../bucklescript-tea,dst=/home/dark/bucklescript-tea"
+
+
 
 ## Debugging ppx stuff
 

--- a/scripts/compile-local-bs-tea
+++ b/scripts/compile-local-bs-tea
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# It can be hard to recompile bucklescript-tea when you're editing a checkout
+# of it. I'm not sure if this is true for all bs libraries, but if so this
+# could probably be extended to handling them.
+
+cd client \
+  && rm -Rf node_modules/* node_modules/.* node_modules/.bin/ \
+  && rm -Rf node_modules/bucklescript-tea/lib/ lib/* \
+  && yarn install \
+  && yarn run-s build:bsb build:js build:fetcher build:analysiswrapper


### PR DESCRIPTION
If we're editing bs-tea, we need to do a bit of a dance. This adds scripts and README to explain the dance.

- [ ] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

