### PR TITLE
Fix findExpr - we should look into matches too

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -1757,6 +1757,15 @@ let () =
         (EFieldAccess (gid (), EVariable (ID "12", "request"), gid (), "bo"))
         (enter 10)
         ("request.body", 12) ;
+      t
+        "autocomplete for field in body"
+        (EMatch
+           ( gid ()
+           , EFieldAccess
+               (gid (), EVariable (ID "12", "request"), gid (), "body")
+           , [] ))
+        (enter 18)
+        ("match request.body", 18) ;
       (* test "backspacing on variable reopens autocomplete" (fun () -> *)
       (*     expect (bs (EVariable (5, "request"))). *)
       (*     gridFor ~pos:116 tokens) |> toEqual {row= 2; col= 2} ) ; *)

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -956,8 +956,13 @@ let rec findExpr (id : id) (expr : fluidExpr) : fluidExpr option =
         fe expr
     | ERecord (_, fields) ->
         fields |> List.map ~f:Tuple3.third |> List.filterMap ~f:fe |> List.head
-    | EMatch (_, _, pairs) ->
-        pairs |> List.map ~f:Tuple2.second |> List.filterMap ~f:fe |> List.head
+    | EMatch (_, expr, pairs) ->
+        fe expr
+        |> Option.orElse
+             ( pairs
+             |> List.map ~f:Tuple2.second
+             |> List.filterMap ~f:fe
+             |> List.head )
     | EFnCall (_, _, exprs, _)
     | EList (_, exprs)
     | EConstructor (_, _, _, exprs)


### PR DESCRIPTION
https://trello.com/c/84jzumDF/1503-completing-a-field-deletes-the-obj-name

In the example, I had typed "request.body" and when I pressed enter on "body", request was removed.

![image](https://user-images.githubusercontent.com/181762/62332307-d5a35280-b473-11e9-9ccb-63834c5235e7.png)

Turns out we didn't look in matches properly.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

