### PR TITLE
Make pattern strings purple too

### DIFF
--- a/client/src/styles/_fluid.scss
+++ b/client/src/styles/_fluid.scss
@@ -96,6 +96,7 @@ https://github.com/chriskempson/tomorrow-theme */
     white-space: pre;
   }
 
+  .fluid-pattern-string,
   .fluid-string {
     white-space: pre;
     color: $string-color;


### PR DESCRIPTION
https://trello.com/c/477bhUkx/1504-strings-in-patterns-are-not-highlighted-purple

Before:
![image](https://user-images.githubusercontent.com/181762/62332563-089a1600-b475-11e9-91d9-de94c689064e.png)

After:
![image](https://user-images.githubusercontent.com/181762/62332661-4c8d1b00-b475-11e9-97d3-9e87a8ce8d8d.png)

We missed pattern strings, which should match the stylings of strings.


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

