### PR TITLE
Ban 'dev' account

### DIFF
--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -46,7 +46,7 @@ let banned_usernames : string list =
   ; "webmaster"
   ; "wpad" ]
   @ (* original to us *)
-    ["billing"]
+    ["billing"; "dev"]
 
 
 type username = string [@@deriving yojson]


### PR DESCRIPTION
- Allows us to use dev.darkstaticassets.com for integration test
  - in case some day we allow <canvas>.darkstaticassets.com
- Recalling the commit where I added this list and took down
www.darklang.com, I checked; there's no dev acc't or canvas, and
dev.builtwithdark.com 404s.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

