### PR TITLE
Sidebar style fixes

### DIFF
--- a/client/src/styles/_sidebar.scss
+++ b/client/src/styles/_sidebar.scss
@@ -1,10 +1,8 @@
-$sidebarClosedWidth: 55px;
-$sidebarFullWidth: 320px;
+$sidebarClosedWidth: 3.5em;
+$sidebarFullWidth: 20em;
 $yellowFilter: invert(0.08) sepia(1) saturate(4) hue-rotate(316.8deg) brightness(0.96);
 $greyFilter: invert(0.06) sepia(0) saturate(1) hue-rotate(0deg) brightness(0.7);
 $sidebard-preview-shadow: 2px 2px 2px 0 $black1;
-
-$countBoxSize: 15px;
 
 $devColor: $blue;
 $prodcloneColor: $magenta;
@@ -85,18 +83,19 @@ $prodColor: black;
       $itemHeight: 30px;
       height: $itemHeight;
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: center;
-      margin: 10px 5px;
+      margin: 15px 5px;
       color: $grey2;
       width: 100%;
+
       .collapsed-icon {
         display: flex;
         align-items: center;
         justify-content: center;
         margin: 10px 0px;
         width: 80%;
-        height: 100%;
+        height: auto;
         .environment {
           height: max-content;
           display: flex;
@@ -130,8 +129,6 @@ $prodColor: black;
 
         .header-icon {
           display: flex;
-          font-size: 34px;
-          color: white;
           position: relative;
 
           &:hover {
@@ -170,6 +167,11 @@ $prodColor: black;
             }
           }
 
+          i.fa {
+            color: white;
+            font-size: 2.16em;
+          }
+
           object,
           i.fa {
             width: 100%;
@@ -197,21 +199,22 @@ $prodColor: black;
 
       &:hover {
         .hover {
-          max-height: 400px;
-          overflow-y: scroll;
           display: flex;
           flex-direction: column;
+
           position: absolute;
+          left: $sidebarClosedWidth;
+
           width: 300px;
+          max-height: 400px;
           padding: 10px;
+          margin-top: 10px;
+
+          overflow-y: scroll;
+
           background-color: darken($canvas-background, 10%);
           box-shadow: $sidebard-preview-shadow;
-          left: $sidebarClosedWidth;
-          -webkit-transform: translate(0%, 40%);
-          -moz-transform: translate(0%, 40%);
-          -ms-transform: translate(0%, 40%);
-          -o-transform: translate(0%, 40%);
-          transform: translate(0%, 40%);
+
           .header-icon {
             display: none;
           }


### PR DESCRIPTION
Work here is a combination of [sidebar hover menu](https://trello.com/c/kyB3Xhsm/1442-the-sidebar-hover-doesnt-allow-me-get-to-the-submenu-1010) and [style fixes](https://trello.com/c/9hypD27x/1499-fix-sidebar-style-bugs).

We want to use relative units instead of fixed units, to be responsive to zoom levels.

<img width="414" alt="Screen Shot 2019-08-02 at 12 00 41 PM" src="https://user-images.githubusercontent.com/244152/62396843-07c2bc00-b529-11e9-9d69-dad0f957dee0.png">


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

