### PR TITLE
Show live values for the rhs even when the lhs is blank

### DIFF
--- a/backend/libexecution/ast.ml
+++ b/backend/libexecution/ast.ml
@@ -200,11 +200,11 @@ let rec exec
         exe st expr
     | Filled (_, Let (lhs, rhs, body)) ->
         let data = exe st rhs in
+        trace_blank lhs data st ;
         ( match data with
         | DErrorRail _ ->
             data
         | _ ->
-            trace_blank lhs data st ;
             let bound =
               match lhs with
               | Filled (_, name) ->


### PR DESCRIPTION
I found some situations, which I can't see to replicate, where when I added a let above I wouldn't see a live value for the rhs of the let unless I added a lhs.

This seems to fix it, and also seems to be correct.


- [ ] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

