### PR TITLE
Calculate unlocked dbs on demand

### DIFF
--- a/backend/libbackend/analysis.ml
+++ b/backend/libbackend/analysis.ml
@@ -333,11 +333,13 @@ let to_initial_load_rpc_result
 type execute_function_rpc_result =
   { result : RTT.dval
   ; hash : string
-  ; touched_tlids : tlid list }
+  ; touched_tlids : tlid list
+  ; unlocked_dbs : tlid list }
 [@@deriving to_yojson]
 
-let to_execute_function_rpc_result hash touched_tlids dv : string =
-  {result = dv; hash; touched_tlids}
+let to_execute_function_rpc_result hash touched_tlids unlocked_dbs dv : string
+    =
+  {result = dv; hash; touched_tlids; unlocked_dbs}
   |> execute_function_rpc_result_to_yojson
   |> Yojson.Safe.to_string ~std:true
 

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -802,11 +802,15 @@ let execute_function ~(execution_id : Types.id) (host : string) body :
           ~caller_id:params.caller_id
           ~args:params.args )
   in
-  let t4, response =
-    time "4-to-frontend" (fun _ ->
+  let t4, unlocked =
+    time "4-analyze-unlocked-dbs" (fun _ -> Analysis.unlocked !c)
+  in
+  let t5, response =
+    time "5-to-frontend" (fun _ ->
         Analysis.to_execute_function_rpc_result
           (Dval.hash params.args)
           tlids
+          unlocked
           result )
   in
   respond

--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1275,7 +1275,7 @@ let update_ (msg : msg) (m : model) : modification =
         ; InitIntrospect (TD.values allTLs) ]
   | SaveTestRPCCallback (Ok msg_) ->
       DisplayError ("Success! " ^ msg_)
-  | ExecuteFunctionRPCCallback (params, Ok (dval, hash, tlids)) ->
+  | ExecuteFunctionRPCCallback (params, Ok (dval, hash, tlids, unlockedDBs)) ->
       let traces =
         List.map
           ~f:(fun tlid -> (deTLID tlid, [(params.efpTraceID, None)]))
@@ -1290,7 +1290,8 @@ let update_ (msg : msg) (m : model) : modification =
             , hash
             , dval )
         ; ExecutingFunctionComplete [(params.efpTLID, params.efpCallerID)]
-        ; OverrideTraces (StrDict.fromList traces) ]
+        ; OverrideTraces (StrDict.fromList traces)
+        ; SetUnlockedDBs unlockedDBs ]
   | TriggerHandlerRPCCallback (params, Ok tlids) ->
       let traces =
         List.map

--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -533,7 +533,8 @@ and initialLoadRPCResult j : initialLoadRPCResult =
 and executeFunctionRPCResult j : executeFunctionRPCResult =
   ( field "result" dval j
   , field "hash" string j
-  , field "touched_tlids" (list tlid) j )
+  , field "touched_tlids" (list tlid) j
+  , j |> field "unlocked_dbs" (list wireIdentifier) |> StrSet.fromList )
 
 
 and triggerHandlerRPCResult j : triggerHandlerRPCResult =

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -620,7 +620,7 @@ and addOpStrollerMsg =
 
 and dvalArgsHash = string
 
-and executeFunctionRPCResult = dval * dvalArgsHash * tlid list
+and executeFunctionRPCResult = dval * dvalArgsHash * tlid list * unlockedDBs
 
 and triggerHandlerRPCResult = tlid list
 
@@ -1321,7 +1321,7 @@ and model =
       (* tlUsedIn: to answer the question "what TLs is this TL's name used in".  eg
    * if myFunc was called in Repl2, the dict would
    *
-   *   { myfunc.tlid: { repl2.tlid }} 
+   *   { myfunc.tlid: { repl2.tlid }}
    *
    * which you can read as "myfunc is used in repl2".  *)
   ; tlUsedIn : TLIDSet.t TLIDDict.t


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Fixes https://trello.com/c/iIXnUQ01/1341-add-getunlockeddbs-check-to-execute-function

We now calculate the set of unlocked DBs immediately after executing a function on demand, which should improve the UI responsiveness.

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket.
  - [x] Out-of-scope product changes have been explained.
  - [x] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged.
  - [x] All existing canvases should continue to work.
  - [x] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions).
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

