### PR TITLE
Move minimap to bottom right

### DIFF
--- a/client/src/styles/_canvas.scss
+++ b/client/src/styles/_canvas.scss
@@ -188,7 +188,7 @@ body #app * {
 .minimap {
   position: fixed;
   bottom: 10px;
-  left: 50px;
+  right: 20px;
 
   border: $cyan 2px solid;
   width: 200px;


### PR DESCRIPTION
One of those "changes happened at once" problems. When I was developing this I was testing with canvas that had the sidebar already collapsed. But in explained sidebar, when it has alot of stuff, the minimap blocks the bottom content. Since bottom right is unused real estate I moved it there.

Merging ASAP before our big customers notice 🤫

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

