### PR TITLE
Prevent default ctrl-k behaviour on Linux

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -41,9 +41,11 @@ function stopKeys(event) {
   }
   if (
     event.ctrlKey &&
-    event.keyCode === 75 &&
+    event.keyCode === 75 && // Ctrl-K
     window.navigator.platform.includes("Linux")
   ) {
+    // `Ctrl-K` is meant to open the omnibox on Linux, but without this preventDefault
+    // it will focus the browser's URL bar after creating the omnibox.
     event.preventDefault();
   }
 }


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Fixes: https://trello.com/c/ZB9nkMxs/1538-fix-ctrl-k-on-linux

We use Ctrl-k for omnibox on Linux, which focuses the browser's omnibar in both Chrome+Firefox. This fixes it propagating to the browser.


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

