### PR TITLE
change handler name when switching to/from 'HTTP' or from default 'REPL' space

### DIFF
--- a/client/src/Entry.ml
+++ b/client/src/Entry.ml
@@ -571,6 +571,7 @@ let submitACItem
                   replacement
             in
             let replacement3 =
+              (* Trello ticket with spec for this: https://trello.com/c/AmeAZMgF *)
               match (replacement2.space, h.spec.name) with
               | F (_, newSpace), F (_, name)
                 when newSpace <> "REPL"
@@ -585,7 +586,10 @@ let submitACItem
                 ->
                   SpecHeaders.replaceEventName
                     (B.toID h.spec.name)
-                    (B.newF (String.dropLeft ~count:1 name))
+                    (B.newF
+                       ( String.dropLeft ~count:1 name
+                       |> String.split ~on:":"
+                       |> String.join ~sep:"" ))
                     replacement2
               | F (_, "HTTP"), F (_, name)
                 when not (String.startsWith ~prefix:"/" name) ->

--- a/client/src/IntegrationTest.ml
+++ b/client/src/IntegrationTest.ml
@@ -233,10 +233,28 @@ let editing_headers (m : model) : testResult =
       fail other
 
 
-let switching_from_http_space_removes_slash (m : model) : testResult =
+let switching_from_http_space_removes_leading_slash (m : model) : testResult =
   let spec = onlyTL m |> TL.asHandler |> deOption "hw2" |> fun x -> x.spec in
   match (spec.space, spec.name, spec.modifier) with
   | F (_, newSpace), F (_, "spec_name"), _ when newSpace != "HTTP" ->
+      pass
+  | other ->
+      fail other
+
+
+let switching_from_http_to_cron_space_removes_leading_slash =
+  switching_from_http_space_removes_leading_slash
+
+
+let switching_from_http_to_repl_space_removes_leading_slash =
+  switching_from_http_space_removes_leading_slash
+
+
+let switching_from_http_space_removes_variable_colons (m : model) : testResult
+    =
+  let spec = onlyTL m |> TL.asHandler |> deOption "hw2" |> fun x -> x.spec in
+  match (spec.space, spec.name, spec.modifier) with
+  | F (_, newSpace), F (_, "spec_name/variable"), _ when newSpace != "HTTP" ->
       pass
   | other ->
       fail other
@@ -818,8 +836,12 @@ let trigger (test_name : string) : integrationTestState =
         editing_does_not_deselect
     | "editing_headers" ->
         editing_headers
-    | "switching_from_http_space_removes_slash" ->
-        switching_from_http_space_removes_slash
+    | "switching_from_http_to_cron_space_removes_leading_slash" ->
+        switching_from_http_to_cron_space_removes_leading_slash
+    | "switching_from_http_to_repl_space_removes_leading_slash" ->
+        switching_from_http_to_repl_space_removes_leading_slash
+    | "switching_from_http_space_removes_variable_colons" ->
+        switching_from_http_space_removes_variable_colons
     | "switching_to_http_space_adds_slash" ->
         switching_to_http_space_adds_slash
     | "switching_from_default_repl_space_removes_name" ->

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -189,6 +189,63 @@ const scrollBy = ClientFunction((id, dx, dy) => {
 // Tests below here. Don't forget to update client/src/IntegrationTest.ml
 // ------------------------
 
+test("switching_from_http_to_cron_space_removes_leading_slash", async t => {
+  await createHTTPHandler(t);
+  await t
+    // add headers
+    .typeText("#entry-box", "/spec_name")
+    .pressKey("enter")
+
+    .typeText("#entry-box", "PO")
+    .expect(acHighlightedText("POST"))
+    .ok()
+    .pressKey("enter")
+
+    // edit space
+    .click(".spec-header > .space")
+    .pressKey("backspace")
+    .typeText("#entry-box", "CRON")
+    .pressKey("enter");
+});
+
+test("switching_from_http_to_repl_space_removes_leading_slash", async t => {
+  await createHTTPHandler(t);
+  await t
+    // add headers
+    .typeText("#entry-box", "/spec_name")
+    .pressKey("enter")
+
+    .typeText("#entry-box", "PO")
+    .expect(acHighlightedText("POST"))
+    .ok()
+    .pressKey("enter")
+
+    // edit space
+    .click(".spec-header > .space")
+    .pressKey("backspace")
+    .typeText("#entry-box", "REPL")
+    .pressKey("enter");
+});
+
+test("switching_from_http_space_removes_variable_colons", async t => {
+  await createHTTPHandler(t);
+  await t
+    // add headers
+    .typeText("#entry-box", "/spec_name/:variable")
+    .pressKey("enter")
+
+    .typeText("#entry-box", "PO")
+    .expect(acHighlightedText("POST"))
+    .ok()
+    .pressKey("enter")
+
+    // edit space
+    .click(".spec-header > .space")
+    .pressKey("backspace")
+    .typeText("#entry-box", "REPL")
+    .pressKey("enter");
+});
+
 test("enter_changes_state", async t => {
   await t
     .pressKey("enter")
@@ -429,25 +486,6 @@ test("editing_headers", async t => {
     .click(".spec-header > .modifier")
     .pressKey("delete")
     .typeText("#entry-box", "GET")
-    .pressKey("enter");
-});
-
-test("switching_from_http_space_removes_slash", async t => {
-  await createHTTPHandler(t);
-  await t
-    // add headers
-    .typeText("#entry-box", "/spec_name")
-    .pressKey("enter")
-
-    .typeText("#entry-box", "PO")
-    .expect(acHighlightedText("POST"))
-    .ok()
-    .pressKey("enter")
-
-    // edit space
-    .click(".spec-header > .space")
-    .pressKey("backspace")
-    .typeText("#entry-box", "CRON")
     .pressKey("enter");
 });
 


### PR DESCRIPTION
when switching handler spaces, rename the handler accordingly:
- HTTP -> Any: Remove leading "/"
- Any -> HTTP: Add leading "/"
- REPL -> Any: If using default "REPL_XXX" name, revert to blank

this prevents from having invalid names like "/route" on a CRON or "REPL_1234" on a handler.

https://trello.com/c/AmeAZMgF/1428-when-transitioning-between-event-spaces-update-name-modifier-appropriately

New behavior looks like:
![transition_spaces](https://user-images.githubusercontent.com/16245199/62811474-aebdcf80-bab6-11e9-96bf-7b830e474b76.gif)

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

