### PR TITLE
Use getToken to pick the live value

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -3584,10 +3584,9 @@ let toHtml
   |> List.flatten
 
 
-let viewLiveValue ~tlid ~currentResults ~state (tis : tokenInfo list) :
-    Types.msg Html.html =
+let viewLiveValue ~tlid ~ast ~currentResults ~state : Types.msg Html.html =
   let liveValues, show, offset =
-    getLeftTokenAt state.newPos tis
+    getToken state ast
     |> Option.andThen ~f:(fun ti ->
            let id = Token.tid ti.token in
            if FluidToken.validID id
@@ -3643,7 +3642,7 @@ let viewAST ~(vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html list
   in
   let liveValue =
     if tlidOf vs.cursorState = Some tlid
-    then viewLiveValue ~tlid ~currentResults ~state tokenInfos
+    then viewLiveValue ~tlid ~ast ~currentResults ~state
     else Vdom.noNode
   in
   [ liveValue


### PR DESCRIPTION
https://trello.com/c/8pM0Gsmb/1056-chose-better-live-value-in-lets

We previously always used the token on the left; now we use getToken which chooses which a better heuristic (which is also improved in #1272).

Before:
![image](https://user-images.githubusercontent.com/181762/62884923-7d2e4980-bcec-11e9-8741-5430bf236125.png)


After: 
![image](https://user-images.githubusercontent.com/181762/62884874-65ef5c00-bcec-11e9-85a6-44f74eb30734.png)


From the ticket:
Before:
![image](https://user-images.githubusercontent.com/181762/62885032-b797e680-bcec-11e9-8acd-10b206486272.png)

After:
![image](https://user-images.githubusercontent.com/181762/62885056-c383a880-bcec-11e9-9d57-072c78f4afc3.png)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

