### PR TITLE
Push the pixels in the omnibox

### DIFF
--- a/client/src/styles/_dropdown.scss
+++ b/client/src/styles/_dropdown.scss
@@ -170,7 +170,6 @@ $wrapper-background: $black2;
     @include border-radius-bottom(6px);
 
     li.autocomplete-item {
-      letter-spacing: 0.05rem;
       font-size: 1rem;
       padding: 2px $left-margin;
     }


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists


Fixes: https://trello.com/c/1I6c0aJF/1515-fonts-are-awkward-in-omnibox-the-ac-and-the-input-are-different-front-and-they-dont-line-up-10-8

Old: 
![image](https://user-images.githubusercontent.com/1179074/62898476-7282ad00-bd0a-11e9-8426-566eca5189eb.png)


New:
![image](https://user-images.githubusercontent.com/1179074/62898456-5e3eb000-bd0a-11e9-8fc6-087168b715bb.png)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

