### PR TITLE
Renaming "Database" to "Datastore"

### DIFF
--- a/backend/libbackend/authorization.ml
+++ b/backend/libbackend/authorization.ml
@@ -5,7 +5,7 @@ open Util
 open Types
 
 (* Permission levels, scoped to a single auth_domain.
-   These are stored in the database for granted access,
+   These are stored in the datastore for granted access,
    or returned by the functions in this namespace to indicate a
    particular user's permissions for a particular auth_domain.
 

--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -282,7 +282,7 @@ let add_ops (c : canvas ref) (oldops : Op.op list) (newops : Op.op list) : unit
 let fetch_cors_setting (id : Uuidm.t) : cors_setting option =
   let cors_setting_of_db_string (string_from_db : string) : cors_setting option
       =
-    (* none if null from database *)
+    (* none if null from datastore *)
     (if string_from_db = "" then None else Some string_from_db)
     (* parse json, handle if it's not valid... *)
     |> Option.map ~f:Yojson.Safe.from_string

--- a/backend/libbackend/user_db.ml
+++ b/backend/libbackend/user_db.ml
@@ -85,7 +85,7 @@ and (* PG returns lists of strings. This converts them to types using the
         match Dval.of_internal_queryable_v1 obj with
         | DObj o ->
             (* <HACK>: some legacy objects were allowed to be saved with `id` keys _in_ the
-         * data object itself. they got in the database on the `update` of
+         * data object itself. they got in the datastore on the `update` of
          * an already present object as `update` did not remove the magic `id` field
          * which had been injected on fetch. we need to remove magic `id` if we fetch them
          * otherwise they will not type check on the way out any more and will not work.

--- a/backend/test/test_canvas_ops.ml
+++ b/backend/test/test_canvas_ops.ml
@@ -125,7 +125,7 @@ let t_db_create_with_orblank_name () =
     ; Op.AddDBCol (dbid, colnameid, coltypeid) ]
   in
   let _, state, _ = test_execution_data ops in
-  AT.check AT.bool "database is created" true (state.dbs <> [])
+  AT.check AT.bool "datastore is created" true (state.dbs <> [])
 
 
 let t_db_rename () =
@@ -145,9 +145,9 @@ let t_db_rename () =
         | Partial _ | Blank _ ->
             ""
       in
-      AT.check AT.string "database rename success" "BsCode" newname
+      AT.check AT.string "datastore rename success" "BsCode" newname
   | None ->
-      AT.check AT.bool "fail to rename database" true false
+      AT.check AT.bool "fail to rename datastore" true false
 
 
 let t_set_after_delete () =

--- a/backend/test/test_user_db.ml
+++ b/backend/test/test_user_db.ml
@@ -125,7 +125,7 @@ let t_password_hash_db_roundtrip () =
   in
   AT.check
     AT.int
-    "A Password::hash'd string can get stored in and retrieved from a user database."
+    "A Password::hash'd string can get stored in and retrieved from a user datastore."
     0
     ( match exec_handler ~ops ast with
     | DList [p1; p2] ->

--- a/client/__tests__/introspect_test.ml
+++ b/client/__tests__/introspect_test.ml
@@ -60,11 +60,11 @@ let () =
           expect v |> toEqual (Some h1tlid) ) ;
       test "findUsagesInAST" (fun () ->
           let handlers = handlersByName handlers in
-          let databases = dbsByName dbs in
+          let datastores = dbsByName dbs in
           let functions = StrDict.empty in
           let usages =
             match
-              findUsagesInAST h2tlid databases handlers functions h2data.ast
+              findUsagesInAST h2tlid datastores handlers functions h2data.ast
             with
             | [{refersTo; usedIn; id}] ->
                 refersTo = h2tlid && usedIn = dbtlid && id == dbRefID

--- a/client/__tests__/refactor_test.ml
+++ b/client/__tests__/refactor_test.ml
@@ -92,7 +92,7 @@ let () =
         ; activeMigration = None
         ; pos = {x = 0; y = 0} }
       in
-      test "database renamed, handler updates variable" (fun () ->
+      test "datastore renamed, handler updates variable" (fun () ->
           let h =
             { ast = F (ID "ast1", Variable "ElmCode")
             ; spec =
@@ -131,7 +131,7 @@ let () =
                 false
           in
           expect res |> toEqual true ) ;
-      test "database renamed, handler does not change" (fun () ->
+      test "datastore renamed, handler does not change" (fun () ->
           let h =
             { ast = F (ID "ast1", Variable "request")
             ; spec =

--- a/client/src/Autocomplete.ml
+++ b/client/src/Autocomplete.ml
@@ -1003,7 +1003,7 @@ let documentationForItem (aci : autocompleteItem) : string option =
       Some ("The '" ^ fieldname ^ "' field of the object")
   | ACVariable var ->
       if String.isCapitalized var
-      then Some ("The database '" ^ var ^ "'")
+      then Some ("The datastore '" ^ var ^ "'")
       else Some ("The variable '" ^ var ^ "'")
   | ACLiteral lit ->
       Some ("The literal value '" ^ lit ^ "'")

--- a/client/src/FluidAutocomplete.ml
+++ b/client/src/FluidAutocomplete.ml
@@ -579,7 +579,7 @@ let rec documentationForItem (aci : autocompleteItem) : string option =
       Some ("The '" ^ fieldname ^ "' field of the object")
   | FACVariable var ->
       if String.isCapitalized var
-      then Some ("The database '" ^ var ^ "'")
+      then Some ("The datastore '" ^ var ^ "'")
       else Some ("The variable '" ^ var ^ "'")
   | FACLiteral lit ->
       Some ("The literal value '" ^ lit ^ "'")

--- a/client/src/Introspect.ml
+++ b/client/src/Introspect.ml
@@ -104,7 +104,7 @@ let allUsedIn (tlid : tlid) (m : model) : toplevel list =
 
 let findUsagesInAST
     (tlid : tlid)
-    (databases : tlid StrDict.t)
+    (datastores : tlid StrDict.t)
     (handlers : tlid StrDict.t)
     (functions : tlid StrDict.t)
     (ast : expr) : usage list =
@@ -112,7 +112,7 @@ let findUsagesInAST
   |> List.filterMap ~f:(fun pd ->
          match pd with
          | PExpr (F (id, Variable name)) ->
-             StrDict.get ~key:name databases
+             StrDict.get ~key:name datastores
              |> Option.map ~f:(fun dbTLID -> (dbTLID, id))
          | PExpr
              (F
@@ -143,22 +143,22 @@ let findUsagesInAST
 
 let getUsageFor
     (tl : toplevel)
-    (databases : tlid StrDict.t)
+    (datastores : tlid StrDict.t)
     (handlers : tlid StrDict.t)
     (functions : tlid StrDict.t) : usage list =
   match tl with
   | TLHandler h ->
-      findUsagesInAST h.hTLID databases handlers functions h.ast
+      findUsagesInAST h.hTLID datastores handlers functions h.ast
   | TLDB _ ->
       []
   | TLFunc f ->
-      findUsagesInAST f.ufTLID databases handlers functions f.ufAST
+      findUsagesInAST f.ufTLID datastores handlers functions f.ufAST
   | TLTipe _ ->
       []
 
 
 let refreshUsages (m : model) (tlids : tlid list) : model =
-  let databases = dbsByName m.dbs in
+  let datastores = dbsByName m.dbs in
   let handlers = handlersByName m.handlers in
   let functions = functionsByName m.userFunctions in
   (* We need to overwrite the already-stored results for the passed-in TLIDs.
@@ -173,7 +173,7 @@ let refreshUsages (m : model) (tlids : tlid list) : model =
     tlids
     |> List.map ~f:(fun tlid ->
            let tl = TL.getExn m tlid in
-           getUsageFor tl databases handlers functions )
+           getUsageFor tl datastores handlers functions )
     |> List.concat
     |> List.foldl
          ~init:(tlUsedInDict, tlRefersToDict)

--- a/client/src/Toplevels/Toplevel.ml
+++ b/client/src/Toplevels/Toplevel.ml
@@ -159,7 +159,7 @@ let toOp (tl : toplevel) : op list =
   | TLTipe t ->
       [SetType t]
   | TLDB _ ->
-      impossible "This isn't how database ops work"
+      impossible "This isn't how datastore ops work"
 
 
 let customEventSpaceNames (handlers : handler TD.t) : string list =

--- a/client/src/ViewSidebar.ml
+++ b/client/src/ViewSidebar.ml
@@ -151,7 +151,7 @@ let dbCategory (m : model) (dbs : db list) : category =
           ; plusButton = None } )
   in
   { count = List.length dbs
-  ; name = "Databases"
+  ; name = "Datastores"
   ; classname = "dbs"
   ; plusButton = Some CreateDBTable
   ; entries }


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

**Trello:** 
https://trello.com/c/9VM5PS8Y/1422-rename-database-to-datastore-and-use-this-consistently

Changed all "database" references to "datastore"

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

