### PR TITLE
Select the FnCall when you click the expression

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1099,7 +1099,8 @@ let update_ (msg : msg) (m : model) : modification =
   | ExecuteFunctionButton (tlid, id, name) ->
       Many
         [ ExecutingFunctionBegan (tlid, id)
-        ; ExecutingFunctionRPC (tlid, id, name) ]
+        ; ExecutingFunctionRPC (tlid, id, name)
+        ; Select (tlid, Some id) ]
   | TraceClick (tlid, traceID, _) ->
     ( match m.cursorState with
     | Dragging (_, _, _, origCursorState) ->


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Fixes: https://trello.com/c/YoWkFd1Z/1597-select-the-fncall-expression-when-the-execute-function-button-is-clicked

Very simple, works great! 

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket.
  - [x] Out-of-scope product changes have been explained.
  - [x] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged.
  - [x] All existing canvases should continue to work.
  - [x] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions).
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

