### PR TITLE
Ismith/silence invalid json rollbar

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1607,11 +1607,15 @@ let callback ~k8s_callback ip req body execution_id =
     try
       let bt = Exception.get_backtrace () in
       let%lwt _ =
-        Rollbar.report_lwt
-          e
-          bt
-          (Remote (request_to_rollbar body req))
-          (Types.show_id execution_id)
+        match e with
+        | Exception.DarkException e when e.tipe = EndUser ->
+            Lwt.return `Disabled
+        | _ ->
+            Rollbar.report_lwt
+              e
+              bt
+              (Remote (request_to_rollbar body req))
+              (Types.show_id execution_id)
       in
       let real_err =
         try


### PR DESCRIPTION
"Invalid json" errors shouldn't rollbar

They 400 and respond with "Invalid json: <original body>", which is
enough.

https://trello.com/c/q00JNeSm/1617-invalid-json-on-incoming-requests-should-not-rollbar

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

