### PR TITLE
Don't execute userfns if we have a loaded val

### DIFF
--- a/backend/libexecution/ast.ml
+++ b/backend/libexecution/ast.ml
@@ -654,7 +654,7 @@ and exec_fn
           (* Don't execute user functions if it's preview mode and we have a result *)
           ( match (engine.ctx, state.load_fn_result sfr_desc arglist) with
           | Preview, Some (result, _ts) ->
-              result
+              Dval.unwrap_from_errorrail result
           | _ ->
               (* It's okay to execute user functions in both Preview and Real contexts,
                * But in Preview we might not have all the data we need *)


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Fixes: https://trello.com/c/m771vidu/1571-newly-extracted-functions-dont-play

Nothing to do with its new extraction, everything to do with the presence of side-effecting FnCalls inside the called UserFunction. We don't pull the trace data for the user functions into analysis, but try to execute them and then end up returning Incomplete.

This change ensures we don't actually execute UserFunctions if we have a result for them. We'll still attempt to execute them if we don't have a result. Best case: no side-effecting functions, we get a result. Worst case: we get `Incomplete`, which is what we'd return anyway :)
 
Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.



