### PR TITLE
Vdom not updating traces

### DIFF
--- a/client/src/ViewData.ml
+++ b/client/src/ViewData.ml
@@ -30,10 +30,10 @@ let viewInput
     ; ViewUtils.eventNoPropagation ~key:(eventKey "dml") "mouseleave" (fun x ->
           TraceMouseLeave (tlid, traceID, x) ) ]
   in
-  let valueDiv =
+  let valueDiv, valueStr =
     match value with
     | None ->
-        ViewUtils.fontAwesome "spinner"
+        (ViewUtils.fontAwesome "spinner", "loading")
     | Some v ->
         let asString = Runtime.inputValueAsString tl v in
         let asString =
@@ -41,7 +41,7 @@ let viewInput
           then "No input parameters"
           else asString
         in
-        Html.div [Vdom.noProp] [Html.text asString]
+        (Html.div [Vdom.noProp] [Html.text asString], "")
   in
   let timestampDiv =
     match timestamp with
@@ -54,13 +54,19 @@ let viewInput
         in
         Html.div [Html.title ts] [Html.text ("Made " ^ human ^ " ago")]
   in
+  (* Fixes: https://trello.com/c/Vv8mMOls/1595-top-request-cursor-is-unselectable-10-6 *)
+  (* viewKey contains the:
+   traceID  - to update with every new traceId,
+   classes  - to update when hover/mouseover, 
+   valueStr - to update from loading to loaded *)
+  let viewKey = traceID ^ classes ^ valueStr in
   let dotHtml =
     if isHover && not isActive
     then [Html.div [Html.class' "empty-dot"] [Vdom.noNode]]
     else [Html.div [Vdom.noProp] [Html.text {js|•|js}]]
   in
   let viewData = Html.div [Html.class' "data"] [timestampDiv; valueDiv] in
-  Html.li (Html.class' classes :: events) (dotHtml @ [viewData])
+  Html.li ~key:viewKey (Html.class' classes :: events) (dotHtml @ [viewData])
 
 
 let viewInputs (vs : ViewUtils.viewState) (ID astID : id) : msg Html.html list


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [x] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Trello: 
https://trello.com/c/Vv8mMOls/1595-top-request-cursor-is-unselectable-10-6

Added a key to the list item that changes with every change ( new trace id, hover/active, and loading/loaded values) 

Also replace empty arrays with Vdom noProp and noNode to fix VDom bug

![2019-08-20 15 03 20](https://user-images.githubusercontent.com/32043360/63388009-db49d500-c35b-11e9-9baf-0c49074696f9.gif)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.
