### PR TITLE
Don't wrap DError in ErrorRail

### DIFF
--- a/backend/libexecution/ast.ml
+++ b/backend/libexecution/ast.ml
@@ -564,6 +564,8 @@ and call_fn
             v
         | DIncomplete ->
             DIncomplete
+        | DError e ->
+            DError e
         (* There should only be DOptions and DResults here, but hypothetically we got
         * something else, they would go on the error rail too.  *)
         | other ->

--- a/backend/test/test_language.ml
+++ b/backend/test/test_language.ml
@@ -256,6 +256,17 @@ let t_typecheck_any () =
     (Type_checker.check_function_call ~user_tipes fn args |> Result.is_ok)
 
 
+let t_typechecker_error_isnt_wrapped_by_errorail () =
+  check_condition
+    "typechecker_error_dict_get"
+    (exec_ast "(Dict::get_v1 (List::empty) 'hello')")
+    ~f:(function
+      | DError _ ->
+          true
+      | _ ->
+          false )
+
+
 let t_int_functions_works () =
   check_condition
     "Int::random_v1 0 3 returns a number between [0,3]"
@@ -398,6 +409,9 @@ let suite =
     , `Quick
     , t_basic_typecheck_works_unhappy )
   ; ("Type checking supports `Any` in user functions", `Quick, t_typecheck_any)
+  ; ( "Type checking error isn't wrapped by error rail"
+    , `Quick
+    , t_typechecker_error_isnt_wrapped_by_errorail )
   ; ( "Error rail is propagated by functions"
     , `Quick
     , t_error_rail_is_propagated_by_functions )


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Fixes: https://trello.com/c/9f6TljSF/1614-errorrail-shouldnt-wrap-derror

Prevents type checker errors in a Result/Option returning function going on the ErrorRail in an unintended way.


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

