### PR TITLE
Initialize Nocrypto in cron and queue workers

### DIFF
--- a/backend/bin/cron_checker.ml
+++ b/backend/bin/cron_checker.ml
@@ -60,4 +60,4 @@ let () =
     (Log.add_log_annotations
        [ ( "execution_id"
          , `String (Libexecution.Types.string_of_id execution_id) ) ]
-       (fun _ -> cron_checker ()))
+       (fun _ -> Nocrypto_entropy_lwt.initialize () >>= cron_checker))

--- a/backend/bin/queue_worker.ml
+++ b/backend/bin/queue_worker.ml
@@ -67,4 +67,4 @@ let () =
     (Log.add_log_annotations
        [ ( "execution_id"
          , `String (Libexecution.Types.string_of_id execution_id) ) ]
-       (fun _ -> queue_worker ()))
+       (fun _ -> Nocrypto_entropy_lwt.initialize () >>= queue_worker))


### PR DESCRIPTION
https://trello.com/c/90X2PGg5/1646-initialize-nocrypto-in-workers

Fixes Nocrypto.Uncommon.Boot.Unseeded_generator problems from https://rollbar.com/darkops/darklang/items/1142/

These problems came up in rollbar. It looks like a user was using libjwt stuff but we hadn't initialized nocrypto (nocrypto has a weird way to be initialized so it doesn't fit nicely in Libbackend.Init like the other initializations).

I copied the fix from webserver.ml where it seems to be working fine.

I tested this by disabling the initialization call from webserver and checking that it caused the same error. It did.

This is low risk, so I'm going to merge it now.

- [x] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

