### PR TITLE
Store the opCtrs received on InitialLoad

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1414,7 +1414,8 @@ let update_ (msg : msg) (m : model) : modification =
                     Some [trace] ) )
       in
       Many
-        [ SetToplevels (r.handlers, r.dbs, r.groups, true)
+        [ TweakModel (fun m -> {m with opCtrs = r.opCtrs})
+        ; SetToplevels (r.handlers, r.dbs, r.groups, true)
         ; SetDeletedToplevels (r.deletedHandlers, r.deletedDBs)
         ; SetUserFunctions (r.userFunctions, r.deletedUserFunctions, true)
         ; SetTypes (r.userTipes, r.deletedUserTipes, true)


### PR DESCRIPTION
https://trello.com/c/Fzfnmtbg/1645-ops-are-not-reaching-the-server

I discovered this morning that when I went to add ops to the server, that the ops did not stick.

You can replicate this problem in prod with the following:

- create a new canvas
- add some ops
- refresh the page
- add more ops - the ops are not added

The reason the ops aren't added is that the counters are not properly stored in the client on InitialLoad, so the new ops are being thrown away by the server.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

