### PR TITLE
[DO NOT MERGE] Should we be using canvas_id?

### DIFF
--- a/backend/libbackend/op.ml
+++ b/backend/libbackend/op.ml
@@ -150,7 +150,7 @@ let is_latest_op_request browser_id op_ctr canvas_id : bool =
              * that it also handles the initial case where there is no
              * browser_id record yet *)
     "INSERT INTO op_ctrs(browser_id,ctr,canvas_id) VALUES($1, $2, $3)
-             ON CONFLICT (browser_id)
+             ON CONFLICT (browser_id,canvas_id)
              DO UPDATE SET ctr = EXCLUDED.ctr, timestamp = NOW()
                        WHERE op_ctrs.ctr < EXCLUDED.ctr"
     ~params:
@@ -159,10 +159,11 @@ let is_latest_op_request browser_id op_ctr canvas_id : bool =
       ; Db.Uuid canvas_id ] ;
   Db.exists
     ~name:"check-if-op_ctr-is-latest"
-    "SELECT 1 FROM op_ctrs WHERE browser_id = $1 AND ctr = $2"
+    "SELECT 1 FROM op_ctrs WHERE browser_id = $1 AND ctr = $2 AND canvas_id = $3"
     ~params:
       [ Db.Uuid (browser_id |> Uuidm.of_string |> Option.value_exn)
-      ; Db.Int op_ctr ]
+      ; Db.Int op_ctr
+      ; Db.Uuid canvas_id ]
 
 
 (* filter down to only those ops which can be applied out of order


### PR DESCRIPTION
When I was looking around this code I wondered if we should be using canvas_id here?

cc @ismith 

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

