### PR TITLE
fix cursor clicking

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1846,7 +1846,11 @@ let update_ (msg : msg) (m : model) : modification =
                   ; oldPos = m.fluidState.newPos
                   ; newPos = s.range |> Tuple2.second } }
           | None ->
-              {m with fluidState = {m.fluidState with selection = None}} )
+              let newPos =
+                Entry.getCursorPosition ()
+                |> Option.withDefault ~default:m.fluidState.newPos
+              in
+              {m with fluidState = {m.fluidState with newPos; selection}} )
   | ResetToast ->
       TweakModel (fun m -> {m with toast = Defaults.defaultToast})
   | UpdateMinimap data ->


### PR DESCRIPTION
previous selecting PR appears to have broken regular cursor clicking, this fixes it

Problem: i'm capturing click event for shift-click but not handling regular click case

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

