### PR TITLE
Reveal fluid-toggle-topbar to customers

### DIFF
--- a/client/src/VariantTesting.ml
+++ b/client/src/VariantTesting.ml
@@ -14,12 +14,6 @@ let isFluidV2 (vts : variantTest list) : bool =
   List.member ~value:FluidVariant vts
 
 
-(* This is fluid as Dark employees see it, with the status box *)
-let isFluidWithStatus (vts : variantTest list) : bool =
-  List.member ~value:FluidVariant vts
-  && not (List.member ~value:FluidWithoutStatusVariant vts)
-
-
 let isFluid (vts : variantTest list) : bool =
   List.member ~value:FluidVariant vts
   || List.member ~value:FluidWithoutStatusVariant vts

--- a/client/src/View.ml
+++ b/client/src/View.ml
@@ -398,7 +398,7 @@ let view (m : model) : msg Html.html =
   let activeAvatars = Avatar.viewAllAvatars m.avatarsList in
   let ast = TL.selectedAST m |> Option.withDefault ~default:(Blank.new_ ()) in
   let fluidStatus =
-    if VariantTesting.isFluidWithStatus m.tests
+    if VariantTesting.isFluidV2 m.tests
     then [Fluid.viewStatus (Fluid.fromExpr m.fluidState ast) m.fluidState]
     else []
   in

--- a/client/src/ViewTopbar.ml
+++ b/client/src/ViewTopbar.ml
@@ -11,8 +11,7 @@ let msgLink ~(key : string) (content : msg Html.html) (handler : msg) :
 let html (m : model) =
   if m.showTopbar = false
   then []
-  else if VariantTesting.isFluidV2 m.tests
-  then
+  else
     let fluid = VariantTesting.isFluidForCustomers m.tests in
     let fluidUrl =
       let qp =
@@ -46,4 +45,3 @@ let html (m : model) =
                 else "Try our new editor!" ) ]
         ; Html.text " "
         ; msgLink ~key:"hide-topbar" (Html.text "(hide)") HideTopbar ] ]
-  else []


### PR DESCRIPTION
(It's no longer hidden behind ?fluidv2=1, though fluidv2=1 will still
turn on the fluid status box.)

Also: we used to _only_ allow the status box if fluid was off
(fluidv2=1&fluid=0 or fluid not present). Now, we allow the status box
if fluidv2=1&fluid=1

https://trello.com/c/OGxbsRP8/1659-ship-fluid-to-customers

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

