### PR TITLE
Don't show wrong documentation

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -2322,9 +2322,11 @@ let acClear (s : state) : state =
   {s with ac = {s.ac with index = None}}
 
 
-let acShow (s : state) : state =
+let acMaybeShow (ti : tokenInfo) (s : state) : state =
   let s = recordAction "acShow" s in
-  if s.ac.index = None then {s with ac = {s.ac with index = Some 0}} else s
+  if isAutocompleting ti s && s.ac.index = None
+  then {s with ac = {s.ac with index = Some 0}}
+  else s
 
 
 let acMoveUp (s : state) : state =
@@ -3154,13 +3156,13 @@ let rec updateKey ?(recursing = false) (key : K.key) (ast : ast) (s : state) :
     (* TODO: press colon when in a record field *)
     (* Left/Right movement *)
     | K.Left, L (_, ti), _ ->
-        (ast, doLeft ~pos ti s |> acShow)
+        (ast, doLeft ~pos ti s |> acMaybeShow ti)
     | K.Right, _, R (_, ti) ->
-        (ast, doRight ~pos ~next:mNext ti s |> acShow)
+        (ast, doRight ~pos ~next:mNext ti s |> acMaybeShow ti)
     | K.GoToStartOfLine, _, R (_, ti) | K.GoToStartOfLine, L (_, ti), _ ->
         (ast, moveToStartOfLine ast ti s)
     | K.GoToEndOfLine, _, R (_, ti) ->
-        (ast, moveToEndOfLine ast ti s |> acShow)
+        (ast, moveToEndOfLine ast ti s)
     | K.Up, _, _ ->
         (ast, doUp ~pos ast s)
     | K.Down, _, _ ->


### PR DESCRIPTION
https://trello.com/c/WqGxtc9S/1664-always-shows-wrong-doc-info

Moving Left or Right would set autocomplete to position 0, even if we weren't autocompleting, which caused the docstring in fluid to display something, almost always something wrong. Now it won't display unless we're actually autocompleting.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

