### PR TITLE
Bump qw and cron timeouts

### DIFF
--- a/scripts/support/kubernetes/cronchecker/cron-deployment.yaml.template
+++ b/scripts/support/kubernetes/cronchecker/cron-deployment.yaml.template
@@ -53,7 +53,7 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 10 # every 10 seconds
             timeoutSeconds: 10 # time out after 10 seconds
-            failureThreshold: 3 # kill container after 3 successive time outs
+            failureThreshold: 9 # kill container after 9 successive time outs
           ports:
             - name: cron-ctr-port
               containerPort: 8081

--- a/scripts/support/kubernetes/queueworker/qw-deployment.yaml.template
+++ b/scripts/support/kubernetes/queueworker/qw-deployment.yaml.template
@@ -51,7 +51,7 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 10 # every 10 seconds
             timeoutSeconds: 10 # time out after 10 seconds
-            failureThreshold: 3 # kill container after 3 successive time outs
+            failureThreshold: 9 # kill container after 9 successive time outs
           ports:
             - name: qw-ctr-port
               containerPort: 8081


### PR DESCRIPTION
Long-running jobs might make the worker unresponsive to health checks.

We probs want something better long-term - move healthchecks out of contention with work, change how qws work entirely, something - but this'll help for now.

https://trello.com/c/Wpl2yDqs/1696-bump-qw-and-cron-liveness-timeouts

- [X] Trello link included
- [X] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

