### PR TITLE
I should be able to upsert a user without overwriting their admin bit.

### DIFF
--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -107,7 +107,6 @@ let upsert_account ?(validate : bool = true) (account : account) :
     ON CONFLICT (username)
     DO UPDATE SET name = EXCLUDED.name,
                   email = EXCLUDED.email,
-                  admin = false,
                   password = EXCLUDED.password"
         ~params:
           [ Uuid (Util.create_uuid ())


### PR DESCRIPTION
W/o this commit, calling DarkInternal::upsertUser on an admin will
remove their admin bit.

https://trello.com/c/GoskcnMJ/1681-ability-for-user-to-reset-their-password

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

