### PR TITLE
Put the password-reset form onto the login page

### DIFF
--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -38,6 +38,14 @@
         <input type="submit" value="Login" />
       </form>
     </div>
+    <div>
+      Need to reset your password?
+      <form action="https://ops-resetpassword.builtwithdark.com/reset" method="POST">
+        <label for="username">Email address</label>
+        <input type="text" id="email" name="email" />
+        <input type="submit" value="Reset password" />
+      </form>
+    </div>
     <script>
       const urlParams = new URLSearchParams(window.location.search);
       const redirect = urlParams.get("redirect");


### PR DESCRIPTION
This "works" locally, in that it will hit ops-resetpassword and generate
a reset token for your _production_ account.

https://trello.com/c/o90BYnjq/1747-put-reset-password-form-onto-login-page

![image](https://user-images.githubusercontent.com/172694/64659205-52b8d480-d3ef-11e9-8285-63609d986ee7.png)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

