### PR TITLE
If sidebar is closed, don't show an empty trash can

### DIFF
--- a/client/src/ViewSidebar.ml
+++ b/client/src/ViewSidebar.ml
@@ -610,13 +610,14 @@ let closedCategory2html (m : model) (c : category) : msg Html.html =
   let icon =
     Html.div
       ( event
-      @ [ Html.classList [("header-icon", true); ("empty", c.count = 0)]
+      @ [ Html.classList [("header-icon", true)]
         ; Vdom.attribute "" "role" "img"
         ; Vdom.attribute "" "alt" c.name ] )
       (categoryIcon c.classname)
   in
   Html.div
-    [Html.class' "collapsed"]
+    [ Html.classList
+        [("collapsed", true); (c.classname, true); ("empty", c.count = 0)] ]
     ([Html.div [Html.class' "collapsed-icon"] (icon :: plusButton)] @ hoverView)
 
 

--- a/client/src/styles/_sidebar.scss
+++ b/client/src/styles/_sidebar.scss
@@ -88,7 +88,10 @@ $prodColor: black;
       padding: 15px 5px;
       color: $grey2;
       width: 100%;
-
+      &.deleted.empty {
+        // Dont show trash can if it's empty
+        display: none;
+      }
       .collapsed-icon {
         display: flex;
         align-items: center;


### PR DESCRIPTION
It's in ellen's way. This was supposed to be this way, but both the CSS and HTML in the sidebar are wastelands, so it's hard to see it. This adds to the problem, sorry!

Before:
![image](https://user-images.githubusercontent.com/181762/64668045-f36bbc00-d410-11e9-8943-6657e292fe9b.png)


After:
![image](https://user-images.githubusercontent.com/181762/64668061-fc5c8d80-d410-11e9-8b00-6b735bf2cc96.png)



- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

