### PR TITLE
Always allow panning in grid

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1978,7 +1978,12 @@ let subscriptions (m : model) : msg Tea.Sub.t =
           else PageVisibilityChange Hidden ) ]
   in
   let mousewheelSubs =
-    if m.canvasProps.enablePan && not (isACOpened m)
+    if m.canvasProps.enablePan
+       && (not (isACOpened m))
+       (* TODO: disabled this cause it was buggy and it completely fucked up
+        * ellen's demo. We need to make sure targets are always set perfectly
+        * for this to never get stuck, which feels optimistic. *)
+       && not (VariantTesting.variantIsActive m GridLayout)
     then
       [ Native.OnWheel.listen ~key:"on_wheel" (fun (dx, dy) ->
             MouseWheel (dx, dy) ) ]


### PR DESCRIPTION
There are bugs in the conditions for panning, and unfortunately it constantly breaks ellen's demo. Disable it under grid mode.

Low risk so merging.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

