### PR TITLE
scripts/builder requires bash 4; exit early with a nice error if we fail

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  # Because we use `-v`
+  echo "We require bash >= 4. Assuming you're on a Mac and have homebrew installed,"
+  echo "upgrade by running \`brew install bash\`."
+  exit 1
+fi
+
 # --------------
 # Build image from clean start
 # --------------


### PR DESCRIPTION
that

Possibly also other scripts, but builder is an entry point of sorts.

https://trello.com/c/GLDqunSW/1756-scripts-builder-requires-bash-4

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

