### PR TITLE
scripts/postprocess-video requires gnu getopt, not bsd getopt

### DIFF
--- a/scripts/postprocess-video
+++ b/scripts/postprocess-video
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+. ./scripts/support/assert-in-container "$0" "$@"
+
 set -euo pipefail
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
- Attempt to detect gnu-getopt, and error if it isn't there
- Set env vars appropriately if brew is present, to put gnu-getopt in PATH

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

