### PR TITLE
Date::now returns the current time

### DIFF
--- a/backend/libexecution/libdate.ml
+++ b/backend/libexecution/libdate.ml
@@ -60,8 +60,7 @@ let fns : Lib.shortfn list =
     ; ins = []
     ; p = []
     ; r = TDate
-    ; d =
-        "Returns the number of seconds since the epoch (midnight, Jan 1, 1970)"
+    ; d = "Returns the current time."
     ; f =
         InProcess (function _, [] -> DDate (Time.now ()) | args -> fail args)
     ; ps = false


### PR DESCRIPTION
Not seconds since the epoch.

https://trello.com/c/Kk2MMhmB/1732-datenow-does-not-return-the-number-of-seconds-since-the-epoch-it-returns-the-current-time

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

