### PR TITLE
Revert "Revert "Do not dequeue Maxim's events""

### DIFF
--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -44,6 +44,8 @@ let enqueue
 
 
 let dequeue transaction : t option =
+  (* TODO: The magic UUID here is reify-modification-migrator (ie. maxim)
+   * REMOVE AFTER STRANGELOOP *)
   let fetched =
     Db.fetch_one_option
       ~name:"dequeue_fetch"
@@ -52,6 +54,7 @@ let dequeue transaction : t option =
        JOIN canvases AS c ON e.canvas_id = c.id
        WHERE delay_until < CURRENT_TIMESTAMP
        AND status = 'new'
+       AND e.canvas_id <> '745f5b77-ff32-41b8-b1ee-a7bba72ce606'::uuid
        ORDER BY id DESC, retries ASC
        FOR UPDATE OF e SKIP LOCKED
        LIMIT 1"


### PR DESCRIPTION
Reverts darklang/dark#1404

He's still crashing us.

As discussed /w @IanConnolly , the plan is to:
- normal QWs ignore maxim's events
- we'll spin up one or more special-maxim-only QWs that don't have  healthchecks (so these long-running jobs can finish)
- we've already asked him to do a proper fanout instead of List::map [bigList] fnThatCallsHttp

Note: this is gonna bite us again for sure.