### PR TITLE
No ligatures in strings

### DIFF
--- a/client/src/styles/_fluid.scss
+++ b/client/src/styles/_fluid.scss
@@ -97,6 +97,11 @@ https://github.com/chriskempson/tomorrow-theme */
   }
 
   .fluid-category-string {
+    // I don't know why this works inside &:not(.fa) and not a level up ... but
+    // I tried it, since that's how we do it in _canvas.scss
+    //
+    // The intent here is that chars in strings should not have ligatures (see
+    // https://github.com/darklang/dark/pull/1412 for screenshots).
     &:not(.fa) {
       font-family: "Fira Mono", monospace;
     }


### PR DESCRIPTION
By using Fira Mono instead of Fira Code.

https://trello.com/c/7orU1WrH/1693-has-a-nice-ligature-for-threads-but-maybe-we-dont-want-that-in-strings

Before:
![image](https://user-images.githubusercontent.com/172694/65213860-a913bc00-da5c-11e9-9c8b-9ddde2e66670.png)

After:
![image](https://user-images.githubusercontent.com/172694/65213916-d7919700-da5c-11e9-8393-36dbd3e21c50.png)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

