### PR TITLE
Error Indicator disappeared from Fluid

### DIFF
--- a/client/src/styles/_ast.scss
+++ b/client/src/styles/_ast.scss
@@ -284,6 +284,52 @@ $toplevel-shadow-front: 1px 2px 4px 2px $black1;
   margin-top: $spacing-medium;
 }
 
+.error-indicator {
+  position: absolute;
+  left: calc(100% - 2ch);
+  width: 12px;
+  height: 12px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  opacity: 0.5;
+
+  &:hover {
+    opacity: 1;
+    cursor: pointer;
+  }
+
+  &:hover:after {
+    @extend .tooltip;
+
+    content: "Handle errors that arise from this function yourself";
+
+    position: absolute;
+    left: 25px;
+    top: -2px;
+  }
+
+  &.Option {
+    background-image: url("/icons/option_just.svg");
+
+    &.ErrorRail {
+      background-image: url("/icons/option_nothing.svg");
+    }
+  }
+
+  &.Result {
+    background-image: url("/icons/result_ok.svg");
+
+    &.ErrorRail {
+      background-image: url("/icons/result_error.svg");
+    }
+  }
+
+  &.Result.EvalFail,
+  &.Option.EvalFail {
+    background-image: none;
+  }
+}
+
 .ast {
   font-size: 10pt;
   padding-right: $spacing-medium;
@@ -294,52 +340,6 @@ $toplevel-shadow-front: 1px 2px 4px 2px $black1;
   width: max-content;
   display: inline-block;
   vertical-align: top;
-
-  .error-indicator {
-    position: absolute;
-    left: calc(100% - 2ch);
-    width: 12px;
-    height: 12px;
-    background-size: contain;
-    background-repeat: no-repeat;
-    opacity: 0.5;
-
-    &:hover {
-      opacity: 1;
-      cursor: pointer;
-    }
-
-    &:hover:after {
-      @extend .tooltip;
-
-      content: "Handle errors that arise from this function yourself";
-
-      position: absolute;
-      left: 25px;
-      top: -2px;
-    }
-
-    &.Option {
-      background-image: url("/icons/option_just.svg");
-
-      &.ErrorRail {
-        background-image: url("/icons/option_nothing.svg");
-      }
-    }
-
-    &.Result {
-      background-image: url("/icons/result_ok.svg");
-
-      &.ErrorRail {
-        background-image: url("/icons/result_error.svg");
-      }
-    }
-
-    &.Result.EvalFail,
-    &.Option.EvalFail {
-      background-image: none;
-    }
-  }
 
   div {
     display: inline-block;

--- a/client/src/styles/_fluid.scss
+++ b/client/src/styles/_fluid.scss
@@ -319,6 +319,7 @@ since they are essentially both commands just acting upon different things. */
   }
 
   .error-indicator {
+    position: absolute;
     left: 6px;
   }
 }


### PR DESCRIPTION
One day [error indicator in ErrorRail disappeared from fluid](https://trello.com/c/EMbKSdMN/1697-error-indicators-in-errorrail-disappear-in-fluid). It was scoped in .ast, but not .fluid-ast.. probably due to rebase resolution mistakes.

The error rail class and wrapper didn't need to be in that scope anyway so I moved it out.

<img width="423" alt="Screen Shot 2019-09-19 at 12 15 07 PM" src="https://user-images.githubusercontent.com/244152/65273994-398ee280-dad7-11e9-8f7b-612f8d748ba0.png">

*** Unfortunately we don't really have a good system of testing regressions like this.... when we scale up in engineering team, maybe we can make pixel matching divs? Another suggestion is parse through the css selectors and assert under certain conditions they are selectable in the dom.
Neither unit tests nor integration tests could have caught this particular regression =/

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions) ***
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

