### PR TITLE
Adding a blank let on enter if the cursor is between two different lets

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -169,6 +169,9 @@ let () =
                   (gid (), gid (), "y", EInteger (gid (), "6"), EBlank (gid ()))
               ) ) ] )
   in
+  let nonEmptyLetWithBlankEnd =
+    ELet (gid (), gid (), "", EInteger (gid (), "6"), b ())
+  in
   let nonEmptyLet =
     ELet (gid (), gid (), "", EInteger (gid (), "6"), EInteger (gid (), "5"))
   in
@@ -1685,10 +1688,15 @@ let () =
         (insert '5' 6)
         ("let *** = ___\n5", 6) ;
       t
-        "enter at the end of a line goes to next line"
+        "enter on the end of let goes to blank"
+        nonEmptyLetWithBlankEnd
+        (enter 11)
+        ("let *** = 6\n___", 12) ;
+      t
+        "enter at the end of a line inserts let if no blank is next"
         nonEmptyLet
         (enter 11)
-        ("let *** = 6\n5", 12) ;
+        ("let *** = 6\nlet *** = ___\n5", 16) ;
       t
         "enter at the start of a let creates let above"
         twoLets
@@ -1982,22 +1990,22 @@ let () =
         (enter 4)
         ("if 5\nthen\n  6\nelse\n  7", 5) ;
       t
-        "enter at end of then line does not insert let"
+        "enter at end of then line inserts let if no blank next "
         plainIf
         (enter 9)
-        ("if 5\nthen\n  6\nelse\n  7", 12) ;
+        ("if 5\nthen\n  let *** = ___\n  6\nelse\n  7", 16) ;
       t
         "enter at end of then expr line does nothing"
         plainIf
         (enter 13)
         ("if 5\nthen\n  6\nelse\n  7", 14) ;
       t
-        "enter at end of else line does not insert let"
+        "enter at end of else line does inserts let if no blank next"
         (* TODO: This should probably do nothing, but right now it acts like
          * it's at the front of the line below. *)
         plainIf
         (enter 18)
-        ("if 5\nthen\n  6\nelse\n  7", 21) ;
+        ("if 5\nthen\n  6\nelse\n  let *** = ___\n  7", 25) ;
       t
         "enter at end of else expr line does nothing"
         plainIf

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -2112,11 +2112,11 @@ let addEntryBelow
   let newAST =
     updateExpr id ast ~f:(fun e ->
         match (index, e) with
-        | None, ELet _ ->
-            ELet (gid (), gid (), "", newB (), e)
-        | None, e ->
+        | None, EBlank _ ->
             cursor := `NextToken ;
             e
+        | None, e ->
+            ELet (gid (), gid (), "", newB (), e)
         | Some index, ERecord (id, fields) ->
             ERecord
               (id, List.insertAt fields ~index ~value:(gid (), "", newB ()))


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [x] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Trello: https://trello.com/c/7s0YeB3y/1678-if-you-press-enter-at-the-end-of-a-line-and-theres-a-blank-on-the-next-line-dont-add-a-let

We want to check if the cursor is between two lets on [Enter] to see if we should create a new blank let or just go to the next line.

I created a separate function for getting the first token of each row above/below in case we wanted to use that to check before inserting a blank let above but i can easily add it to the addEntryBelow function

(Note, in gif I pressed enter twice after the 5)
![2019-09-19 14 27 29](https://user-images.githubusercontent.com/32043360/65282390-a7dca080-dae9-11e9-9245-104628cb4da6.gif)




Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

