### PR TITLE
Errors happened because if the field is null, (CURRENT_TIMESTAMP - fi…

### DIFF
--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -170,6 +170,10 @@ let dequeue transaction : t option =
       ; modifier
       ; queue_delay_ms ] ->
       log_queue_size Dequeue ~host canvas_id space name modifier ;
+      let queue_delay =
+        try [("queue_delay_ms", `Float (queue_delay_ms |> float_of_string))]
+        with e -> []
+      in
       Log.infO
         "queue_delay"
         ~params:
@@ -178,8 +182,7 @@ let dequeue transaction : t option =
           ; ("space", space)
           ; ("name", name)
           ; ("modifier", modifier) ]
-        ~jsonparams:
-          [("queue_delay_ms", `Float (queue_delay_ms |> float_of_string))] ;
+        ~jsonparams:queue_delay ;
       Some
         { id = int_of_string id
         ; value = Dval.of_internal_roundtrippable_v0 value


### PR DESCRIPTION
…eld) is null

And we can't float_of_string that. So, try/with, and if it isn't there, don't put it in the log.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

