### PR TITLE
Ismith/accept encoding in curl

### DIFF
--- a/backend/libbackend/httpclient.ml
+++ b/backend/libbackend/httpclient.ml
@@ -85,6 +85,7 @@ let recode_latin1 (src : string) =
 
 
 let http_call_with_code
+    ?(raw_bytes = false)
     (url : string)
     (query_params : (string * string list) list)
     (verb : verb)
@@ -150,7 +151,7 @@ let http_call_with_code
        *
        * https://curl.haxx.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html
        * *)
-      C.set_encoding c C.CURL_ENCODING_ANY ;
+      if not raw_bytes then C.set_encoding c C.CURL_ENCODING_ANY ;
       (* Don't let users curl to e.g. file://; just HTTP and HTTPs. *)
       C.set_protocols c [C.CURLPROTO_HTTP; C.CURLPROTO_HTTPS] ;
       (* Seems like redirects can be used to get around the above list... *)
@@ -214,15 +215,41 @@ let http_call_with_code
 
 
 let http_call
+    ?(raw_bytes = false)
     (url : string)
     (query_params : (string * string list) list)
     (verb : verb)
     (headers : (string * string) list)
     (body : string) : string * (string * string) list * int =
-  let resp_body, code, resp_headers, _ =
-    http_call_with_code url query_params verb headers body
+  let resp_body, code, resp_headers, error =
+    http_call_with_code ~raw_bytes url query_params verb headers body
   in
-  (resp_body, resp_headers, code)
+  if code < 200 || code > 299
+  then
+    let info =
+      [ ("url", url)
+      ; ("code", string_of_int code)
+      ; ("error", error)
+      ; ("response", resp_body) ]
+    in
+    Exception.code
+      ~info
+      ("Bad HTTP response (" ^ string_of_int code ^ ") in call to " ^ url)
+  else (resp_body, resp_headers, code)
+
+
+let call
+    ?(raw_bytes = false)
+    (url : string)
+    (verb : verb)
+    (headers : (string * string) list)
+    (body : string) : string =
+  Log.debuG
+    "HTTP"
+    ~params:[("verb", show_verb verb); ("url", url)]
+    ~jsonparams:[("body", `Int (body |> String.length))] ;
+  let results, _, _ = http_call ~raw_bytes url [] verb headers body in
+  results
 
 
 let init () : unit = C.global_init C.CURLINIT_GLOBALALL

--- a/backend/libbackend/libstaticassets.ml
+++ b/backend/libbackend/libstaticassets.ml
@@ -126,7 +126,7 @@ UTF-8 safe"))
                   (Unicode_string.to_string file)
               in
               let response =
-                Legacy.HttpclientV0.call url Httpclient.GET [] ""
+                Httpclient.call ~raw_bytes:true url Httpclient.GET [] ""
               in
               DResult (ResOk (DBytes (response |> RawBytes.of_string)))
           | args ->
@@ -184,7 +184,7 @@ UTF-8 safe"))
                   (Unicode_string.to_string file)
               in
               let response =
-                Legacy.HttpclientV0.call url Httpclient.GET [] ""
+                Httpclient.call ~raw_bytes:true url Httpclient.GET [] ""
               in
               DResult (ResOk (DBytes (response |> RawBytes.of_string)))
           | args ->
@@ -262,7 +262,13 @@ UTF-8 safe"))
                   (Unicode_string.to_string file)
               in
               let body, code, headers, _error =
-                Httpclient.http_call_with_code url [] Httpclient.GET [] ""
+                Httpclient.http_call_with_code
+                  ~raw_bytes:true
+                  url
+                  []
+                  Httpclient.GET
+                  []
+                  ""
               in
               let headers =
                 headers
@@ -312,7 +318,13 @@ UTF-8 safe"))
                   (Unicode_string.to_string file)
               in
               let body, code, headers, _error =
-                Httpclient.http_call_with_code url [] Httpclient.GET [] ""
+                Httpclient.http_call_with_code
+                  ~raw_bytes:true
+                  url
+                  []
+                  Httpclient.GET
+                  []
+                  ""
               in
               let headers =
                 headers
@@ -361,7 +373,13 @@ UTF-8 safe"))
                   (Unicode_string.to_string file)
               in
               let body, code, headers, _error =
-                Httpclient.http_call_with_code url [] Httpclient.GET [] ""
+                Httpclient.http_call_with_code
+                  ~raw_bytes:true
+                  url
+                  []
+                  Httpclient.GET
+                  []
+                  ""
               in
               let headers =
                 headers


### PR DESCRIPTION
https://trello.com/c/kCR94BQg/1785-accept-encoding-gzip-causes-httpclientget-to-fail

This has been hanging around for months. I tested it against a local version of ops-corpsite since that bit in a periovious iteration broke, it works fine now.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

