### PR TITLE
CSS bug in presence avatar wrapper.

### DIFF
--- a/client/src/Avatar.ml
+++ b/client/src/Avatar.ml
@@ -72,7 +72,7 @@ let viewAllAvatars (avatars : avatar list) : msg Html.html =
   in
   let avatarView = List.map ~f:avatarDiv avatars in
   Html.div
-    [Html.classList [("all-avatars", List.length avatars > 0)]]
+    [Html.classList [("all-avatars", true); ("hide", List.isEmpty avatars)]]
     [ Html.div [Html.class' "avatars-wrapper"] avatarView
     ; Html.text "Other users" ]
 

--- a/client/src/styles/_avatar.scss
+++ b/client/src/styles/_avatar.scss
@@ -27,13 +27,16 @@
   margin: 0px 5px;
   padding: 5px 10px;
   border-bottom-right-radius: 10px;
-  border-bottom-left-radius: 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
 
   font-size: 10px;
   color: $grey3;
+
+  &.hide {
+    display: none;
+  }
 
   p {
     text-align: center;


### PR DESCRIPTION
[the "other users" label appear even when there's no other users on the canvas](https://trello.com/c/Xpvpzkei/1789-fix-css-on-presence)

<img width="150" alt="Screen Shot 2019-09-24 at 9 42 37 AM" src="https://user-images.githubusercontent.com/244152/65532040-f904df80-deaf-11e9-85af-b5a0e26718f9.png">

Sol: sHide enter presence css block when there's no detectable users on the canvas.

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

