### PR TITLE
Show DError differently from Result Errors

### DIFF
--- a/client/src/Runtime.ml
+++ b/client/src/Runtime.ml
@@ -360,7 +360,7 @@ let rec toRepr_ (oldIndent : int) (dv : dval) : string =
           |> decodeString decoder
           |> Result.toOption
           |> Option.map ~f:(fun e ->
-                 "Error: \n  "
+                 "An error occurred: \n  "
                  ^ e.short
                  ^ maybe "message" e.long
                  ^ maybe "actual value" e.actual


### PR DESCRIPTION
Result Errors display as `Error "value"` while internal errors would display as:

```
Error:
  Message and then
  a: bunch of fields
  on: different lines
```

Maxim spent a while fighting against this, thinking it was an errorrail issue.

This possibly solves it by making it a little clearer what's happening.


https://trello.com/c/40d6zwru/1802-derrors-are-tricky-to-tell-from-result-errors

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket.
  - [x] Out-of-scope product changes have been explained.
  - [x] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged.
  - [x] All existing canvases should continue to work.
  - [x] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [x] Tests are included or unnecessary (required for regressions).
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.

