### PR TITLE
Add Date::fromSeconds

### DIFF
--- a/backend/libexecution/dint.ml
+++ b/backend/libexecution/dint.ml
@@ -6,6 +6,10 @@ let of_int = Int63.of_int
 
 let to_int = Int63.to_int
 
+let to_int63 t = t
+
+let of_int63 t = t
+
 let to_int_exn = Int63.to_int_exn
 
 let of_string_exn = Int63.of_string

--- a/backend/libexecution/dint.mli
+++ b/backend/libexecution/dint.mli
@@ -4,6 +4,10 @@ val of_int : int -> t
 
 val to_int : t -> int option
 
+val to_int63 : t -> Core_kernel.Int63.t
+
+val of_int63 : Core_kernel.Int63.t -> t
+
 val to_int_exn : t -> int
 
 val of_float : float -> t

--- a/backend/libexecution/libdate.ml
+++ b/backend/libexecution/libdate.ml
@@ -140,6 +140,25 @@ let fns : Lib.shortfn list =
               fail args)
     ; ps = true
     ; dep = false }
+  ; { pns = ["Date::fromSeconds"]
+    ; ins = []
+    ; p = [par "seconds" TInt]
+    ; r = TDate
+    ; d =
+        "Converts an integer representing seconds since the Unix epoch into a Date"
+    ; f =
+        InProcess
+          (function
+          | _, [DInt s] ->
+              s
+              |> Dint.to_int63
+              |> Time.Span.of_int63_seconds
+              |> Time.of_span_since_epoch
+              |> DDate
+          | args ->
+              fail args)
+    ; ps = true
+    ; dep = false }
   ; { pns = ["Date::toHumanReadable"]
     ; ins = []
     ; p = [par "date" TDate]

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -375,6 +375,15 @@ let t_date_functions_work () =
     (DResult (ResOk (Dval.dint 45)))
     (exec_ast
        "(Result::map (Date::parse_v1 '2019-07-28T22:42:45Z') (\\d -> (Date::second d)))") ;
+  check_dval
+    "Date::toSeconds roundtrips"
+    (DResult (ResOk (Dval.dstr_of_string_exn "2019-07-28T22:42:45Z")))
+    (exec_ast
+       "(Result::map (Date::parse_v1 '2019-07-28T22:42:45Z') (\\d -> (toString (Date::fromSeconds (Date::toSeconds d)))))") ;
+  check_dval
+    "Date::fromSeconds roundtrips"
+    (Dval.dint 1095379198)
+    (exec_ast "(Date::toSeconds (Date::fromSeconds 1095379198))") ;
   ()
 
 


### PR DESCRIPTION
Support turning seconds into Dates.

After testing, I found that it's possible to create dates that couldn't be printed, but that appears to be a bug in the pretty-printer.

https://trello.com/c/NaPOcbwW/1804-function-to-translate-between-ints-and-dates

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

