### PR TITLE
Process maxim's events in the standard queue worker

### DIFF
--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -141,8 +141,6 @@ let enqueue
 
 
 let dequeue transaction : t option =
-  (* TODO: The magic UUID here is reify-modification-migrator (ie. maxim)
-   * REMOVE AFTER STRANGELOOP *)
   let fetched =
     Db.fetch_one_option
       ~name:"dequeue_fetch"
@@ -152,7 +150,6 @@ let dequeue transaction : t option =
        JOIN canvases AS c ON e.canvas_id = c.id
        WHERE delay_until < CURRENT_TIMESTAMP
        AND status = 'new'
-       AND e.canvas_id <> '745f5b77-ff32-41b8-b1ee-a7bba72ce606'::uuid
        ORDER BY id DESC, retries ASC
        FOR UPDATE OF e SKIP LOCKED
        LIMIT 1"


### PR DESCRIPTION
Now that we've got qw health checks in their own threads, long-running
jobs shouldn't cause qws to crashloopbackoff anymore. (Plus he's using
fanout now.)

Followup: `kubectl delete deployment maxim-qw-deployment`

https://trello.com/c/RMQ08KlD/1769-separate-http-healthchecks-for-queue-and-cron-workers-into-their-own-threads-not-shaerd-with-events

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

