### PR TITLE
Ismith/dont call init twice in cronchecker

### DIFF
--- a/backend/bin/cron_checker.ml
+++ b/backend/bin/cron_checker.ml
@@ -6,30 +6,35 @@ open Libbackend.Worker_util
 let shutdown = ref false
 
 let cron_checker execution_id =
-  let rec cron_checker () =
-    let%lwt () = Lwt_unix.sleep 1.0 in
-    let result = Libbackend.Cron.check_all_canvases execution_id in
-    match result with
-    | Ok _ ->
-        if not !shutdown then (cron_checker [@tailcall]) () else Lwt.return ()
-    | Error (bt, e) ->
-        Libcommon.Log.erroR
-          "cron_checker"
-          ~data:"Uncaught error"
-          ~params:[("exn", Libexecution.Exception.exn_to_string e)] ;
-        Lwt.async (fun () ->
-            Libbackend.Rollbar.report_lwt
-              e
-              bt
-              CronChecker
-              (Libexecution.Types.string_of_id execution_id) ) ;
-        if not !shutdown then (cron_checker [@tailcall]) () else Lwt.return ()
-  in
-  Lwt_main.run
-    (Log.add_log_annotations
-       [ ( "execution_id"
-         , `String (Libexecution.Types.string_of_id execution_id) ) ]
-       (fun _ -> Nocrypto_entropy_lwt.initialize () >>= cron_checker))
+  Thread.create (fun _ ->
+      let rec cron_checker () =
+        let%lwt () = Lwt_unix.sleep 1.0 in
+        let result = Libbackend.Cron.check_all_canvases execution_id in
+        match result with
+        | Ok _ ->
+            if not !shutdown
+            then (cron_checker [@tailcall]) ()
+            else Lwt.return ()
+        | Error (bt, e) ->
+            Libcommon.Log.erroR
+              "cron_checker"
+              ~data:"Uncaught error"
+              ~params:[("exn", Libexecution.Exception.exn_to_string e)] ;
+            Lwt.async (fun () ->
+                Libbackend.Rollbar.report_lwt
+                  e
+                  bt
+                  CronChecker
+                  (Libexecution.Types.string_of_id execution_id) ) ;
+            if not !shutdown
+            then (cron_checker [@tailcall]) ()
+            else Lwt.return ()
+      in
+      Lwt_main.run
+        (Log.add_log_annotations
+           [ ( "execution_id"
+             , `String (Libexecution.Types.string_of_id execution_id) ) ]
+           (fun _ -> Nocrypto_entropy_lwt.initialize () >>= cron_checker)) )
 
 
 let () =


### PR DESCRIPTION
Orig bug was just that cron_checker died b/c:
```
duplicate library function: Bool::not
```
(https://rollbar.com/darkops/darklang/items/1186/)

Second commit is to avoid:
```
dark@dark-dev:~/app$ ./scripts/support/gcp-run-cronchecker
[...]
cron_checker.exe: ev.c:3541: ev_run: Assertion `("libev: ev_loop recursion during release detected", ((loop)->loop_done) != 0x80)' failed.
./scripts/support/gcp-run-cronchecker: line 15: 15165 Aborted                 sudo --preserve-env ./bin/cron_checker.exe
dark@dark-dev:~/app$
```

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

