### PR TITLE
Add index to events to speed up stats queries.

### DIFF
--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -74,7 +74,7 @@ let log_queue_size
   let dark_queue_size =
     Db.fetch_one
       ~name:"dark queue size"
-      "SELECT count(*) FROM events WHERE status != 'done'"
+      "SELECT count(*) FROM events WHERE status IN ('new','locked','error')"
       ~params:[]
     |> List.hd_exn
     |> int_of_string
@@ -83,7 +83,8 @@ let log_queue_size
     Db.fetch_one
       ~name:"canvas queue size"
       ~subject:canvas_id
-      "SELECT count(*) FROM events WHERE status != 'done' AND canvas_id = $1"
+      "SELECT count(*) FROM events
+      WHERE status IN ('new','locked','error') AND canvas_id = $1"
       ~params:[Uuid (Uuidm.of_string canvas_id |> Option.value_exn)]
     |> List.hd_exn
     |> int_of_string
@@ -92,8 +93,9 @@ let log_queue_size
     Db.fetch_one
       ~name:"canvas queue size"
       ~subject:canvas_id
-      "SELECT count(*) FROM events WHERE status != 'done' AND canvas_id = $1 AND
-space = $2 AND name = $3 AND modifier = $4"
+      "SELECT count(*) FROM events
+      WHERE status IN ('new','locked','error') AND canvas_id = $1
+      AND space = $2 AND name = $3 AND modifier = $4"
       ~params:
         [ Uuid (Uuidm.of_string canvas_id |> Option.value_exn)
         ; String space

--- a/backend/migrations/20191003_155555_index_events.sql
+++ b/backend/migrations/20191003_155555_index_events.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS index_events_for_stats ON events (status, canvas_id)


### PR DESCRIPTION
Problem 1: there was no index on events (status).
Problem 2: even if there were, a != query forces a table scan.

By adding the index and inverting the query (status is an enum, so we
know all the inverse variants), pg should use the index and be much
faster.

https://trello.com/c/G8hQYfDC

- [X] Trello link included
- [X] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [X] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

