### PR TITLE
Remove the ability to open a DB migration

### DIFF
--- a/client/src/ViewDB.ml
+++ b/client/src/ViewDB.ml
@@ -174,10 +174,13 @@ let viewDB (vs : viewState) (db : db) : msg Html.html list =
     if vs.dbLocked && db.activeMigration = None
     then
       Html.div
-        [ ViewUtils.eventNoPropagation
-            ~key:("sm-" ^ showTLID db.dbTLID)
-            "click"
-            (fun _ -> StartMigration db.dbTLID) ]
+        (* DB migrations dont work yet, and they just confuse users who open
+         * them. *)
+        (* [ ViewUtils.eventNoPropagation *)
+        (*     ~key:("sm-" ^ showTLID db.dbTLID) *)
+        (*     "click" *)
+        (*     (fun _ -> StartMigration db.dbTLID) ] *)
+          []
         [fontAwesome "lock"]
     else fontAwesome "unlock"
   in


### PR DESCRIPTION
We added UI for DB migrations a while back, but haven't managed to ship them. We have enough users now that they come across them and then try to do migrations which fails (and maybe causes a page?!).

This leaves all the code, but just disables the action to bring up the UI.

https://trello.com/c/kNnoE21A/1838-db-migration-ui-confuses-people

Before:
![image](https://user-images.githubusercontent.com/181762/66512095-1aa7be80-ea8d-11e9-8bcd-536da4586738.png)


- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

