### PR TITLE
Hide user defined types if a user doesnt already use them

### DIFF
--- a/client/src/ViewSidebar.ml
+++ b/client/src/ViewSidebar.ml
@@ -324,11 +324,11 @@ let standardCategories m hs dbs ufns tipes groups =
     then [groupCategory groups]
     else []
   in
-  (* For the demo video in the launch, we need to hide tipes to
-   * make it fit on ellen's screen. We should be able to remove
-   * this in October 2019 *)
+  (* We want to hide user defined types for users who arent already using them 
+    since there is currently no way to use them other than as a function param.
+    we should show user defined types once the user can use them more *)
   let tipes =
-    if m.username = "ellen" then [] else [userTipeCategory m tipes]
+    if List.length tipes == 0 then [] else [userTipeCategory m tipes]
   in
   let catergories =
     [ httpCategory hs


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [x] Intended followups are trelloed.
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Trello: https://trello.com/c/EALUjhQ3/1853-hide-types-in-sidebar-if-user-doesnt-have-any
Follow up Trello for down the road: https://trello.com/c/FvGi9u5y/1854-users-can-only-use-types-as-function-params

Problem:
Users kept asking how to use their user-defined types in their handlers and currently they can only use them as function param types, which isn't providing much value.

Solution:
We will hide user types if the user has never created one but will show them if a user is already using them so old users don't lose anything.





Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

