### PR TITLE
Hide fluid-specific constructs in non-fluid.

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -636,7 +636,7 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         let handlers =
           if VariantTesting.isFluid m.tests
           then handlers
-          else Fluid.stripHandlerConstructs handlers
+          else Fluid.stripFluidConstructsFromHandlers handlers
         in
         let m =
           { m with
@@ -772,7 +772,11 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         (m, Cmd.batch [afCmd; acCmd; reExeCmd])
     | SetUserFunctions (userFuncs, deletedUserFuncs, updateCurrent) ->
         (* TODO: note: this updates existing, despite not being called update *)
-        let userFuncs = Fluid.stripFunctionConstructs userFuncs in
+        let userFuncs =
+          if VariantTesting.isFluid m.tests
+          then userFuncs
+          else Fluid.stripFluidConstructsFromFunctions userFuncs
+        in
         let m =
           { m with
             userFunctions =

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -4940,9 +4940,10 @@ let stripConstructs (ast : expr) : expr =
   f ast
 
 
-let stripFunctionConstructs (ufs : userFunction list) : userFunction list =
+let stripFluidConstructsFromFunctions (ufs : userFunction list) :
+    userFunction list =
   List.map ufs ~f:(fun uf -> {uf with ufAST = stripConstructs uf.ufAST})
 
 
-let stripHandlerConstructs (hs : handler list) : handler list =
+let stripFluidConstructsFromHandlers (hs : handler list) : handler list =
   List.map hs ~f:(fun h -> {h with ast = stripConstructs h.ast})


### PR DESCRIPTION
As a transitional step between fluid and non-fluid, usrs may try fluid, get confused, and then switch back to non-fluid. However, if they choose a fluid-specific construct while doing so (including by accident), their code will break in non-fluid. This unwraps the fluid constructs, so that if you make a change in non-fluid, it will overwrite the old fluid construct.

https://trello.com/c/RQ49TKfg/1713-when-not-using-the-fluid-editor-unwrap-the-fluid-editor-stuff-partials-as-it-breaks-the-non-fluid-editor

- [x] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Before:

![image](https://user-images.githubusercontent.com/181762/66710456-8314cb00-ed2d-11e9-835b-3c8213f88a1c.png)

After:

![image](https://user-images.githubusercontent.com/181762/66710458-90ca5080-ed2d-11e9-9ac0-2605d0173a15.png)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

