### PR TITLE
Clean up deploy lock

### DIFF
--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -195,7 +195,7 @@ gcloud container clusters get-credentials "--zone=${DARK_REGION}" \
 (kubectl create configmap nginx --from-file=scripts/support/nginx.conf -o yaml --dry-run | kubectl replace -f -) \
   ||  kubectl create configmap nginx --from-file=scripts/support/nginx.conf
 
-CHANGE_CAUSE="'circle=${CIRCLE_BUILD_URL} ; orig-time: $(date); git-commit: $(git rev-parse --short HEAD)';"
+CHANGE_CAUSE="'circle=${CIRCLE_BUILD_URL} ; orig-time: $(date); git-commit: $(git rev-parse --short HEAD)'"
 
 sed -e "s!{IMAGE}!${SERVER_IMAGE_ID}!" \
   -e "s!{CHANGE_CAUSE}!${CHANGE_CAUSE}!" \


### PR DESCRIPTION
Master is broken when trying to deploy, so trying to unbreak it (and fix some root causes).

The actual cause of the error was an extra semicolon in CHANGE_CAUSE, which gets included in a yaml file. This was introduced in https://github.com/darklang/dark/pull/1475. Fix is in 85e274bdc75bb0f2aa675163368ddc7343146654. (master was broken when this was merged, so it wasn't detected immediately).

A secondary issue is that deploys were locked. We intend to clear all deploy locks when a deploy finishes. However, the trap didn't fire for ERR signals - unclear why. So when kubectl failed, it didn't clean up. This caused some builds to run forever.

Another secondary issue is that manual deploys didn't work due to an error in the `-gt` logic. I don't understand what was happening, but this seems to fix it. I also don't understand why the if/elif logic was written this way, but I went with the intention indicated by the comment (that was no longer necessary after the change). This could do with some scrutiny.

I'm going to merge this once it's green and watch it go out. I would appreciate post-commit review, esp of the `-gt` thing which I'm suspicious of.


- [ ] Trello link included
- [x] Discussed goals, problem and solution.
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed.
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Unnecessary
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual or Trello filed.
- Engineering:
  - [ ] Tests are included or unnecessary (required for regressions).
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

