### PR TITLE
A slightly better curl command for empty non-GET routes

### DIFF
--- a/client/__tests__/curl_test.ml
+++ b/client/__tests__/curl_test.ml
@@ -62,13 +62,11 @@ let () =
       in
       test "returns command for /test GET" (fun () ->
           expect (curlFromSpec m defaultTLID)
-          |> toEqual
-               (Some "curl -X GET http://test-curl.builtwithdark.com/test") ) ;
+          |> toEqual (Some "curl http://test-curl.builtwithdark.com/test") ) ;
       test "returns command in https if env=prod" (fun () ->
           let m1 = {m with environment = "production"} in
           expect (curlFromSpec m1 defaultTLID)
-          |> toEqual
-               (Some "curl -X GET https://test-curl.builtwithdark.com/test") ) ;
+          |> toEqual (Some "curl https://test-curl.builtwithdark.com/test") ) ;
       test "returns None if tlid not found" (fun () ->
           expect (curlFromSpec m (TLID "1")) |> toEqual None ) ;
       test "returns None for non-HTTP handlers" (fun () ->

--- a/client/src/Curl.ml
+++ b/client/src/Curl.ml
@@ -42,7 +42,15 @@ let curlFromSpec (m : model) (tlid : tlid) : string option =
              let route =
                proto ^ "://" ^ m.canvasName ^ "." ^ m.userContentHost ^ path
              in
-             Some ("curl -X " ^ meth ^ " " ^ route)
+             ( match meth with
+             | "GET" ->
+                 Some ("curl " ^ route)
+             | _ ->
+                 Some
+                   ( "curl -X "
+                   ^ meth
+                   ^ " -H 'Content-Type: application/json' "
+                   ^ route ) )
          | _ ->
              None )
 


### PR DESCRIPTION
https://trello.com/c/qRT6zts8

Ellen requested a better copy-to-curl. Not much, but this at least adds the right `Content-Type`. We discussed adding `-d '{}'` as well to indicate that you should probably add some JSON data, but it seemed a bit weird to add it as empty (and we can't properly fill it out with, eg, required JSON fields yet), so we'll just leave it off instead.

- [X] Trello link included
- [X] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [X] No useful information
- [ ] Before/after screenshots are included
  - [X] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [X] No followups
- [ ] Reversion plan exists
  - [X] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

