### PR TITLE
In local, we don't want to use tee for log redirection, because that …

### DIFF
--- a/scripts/support/runserver
+++ b/scripts/support/runserver
@@ -42,7 +42,8 @@ fi
 if [[ -f "${SERVER_EXE}" && -f "${QW_EXE}" && -f "${CRON_EXE}" ]]; then
   LOGS="${DARK_CONFIG_RUNDIR}/logs"
   echo "Running server"
-  sudo --preserve-env "${SERVER_EXE}" | tee "$LOGS/server.log" 2>&1 &
+  # shellcheck disable=SC2024
+  sudo --preserve-env "${SERVER_EXE}" > "$LOGS/server.log" 2>&1 &
   "${QW_EXE}" --no-health-check > "$LOGS/queue_worker.log" 2>&1 &
   "${CRON_EXE}" --no-health-check > "$LOGS/cron.log" 2>&1 &
 


### PR DESCRIPTION
…clutters scripts/builder

No trello. Bug was intro'd when making nginx run locally; we now run server.exe on 80 for dev-prod parity, shellcheck complains when you do redirection on a sudo'd process, but tee is incorrect here.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

