### PR TITLE
Don't log qw results, they're huge

### DIFF
--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -135,6 +135,21 @@ let dequeue_and_process execution_id :
                                     ~canvas_id
                                     trace_id
                                     (h.tlid :: touched_tlids) ;
+                                  let result_tipe (r : RTT.dval) =
+                                    match r with
+                                    | DResult (ResOk _) ->
+                                        "ResOk"
+                                    | DResult (ResError _) ->
+                                        "ResError"
+                                    | DOption (OptJust _) ->
+                                        "OptJust"
+                                    | DOption OptNothing ->
+                                        "OptNothing"
+                                    | _ ->
+                                        r
+                                        |> Dval.tipe_of
+                                        |> Dval.tipe_to_string
+                                  in
                                   Log.infO
                                     "queue_worker"
                                     ~data:"Successful execution"
@@ -144,7 +159,7 @@ let dequeue_and_process execution_id :
                                       ; ("event_id", string_of_int event.id)
                                       ; ( "handler_id"
                                         , Types.string_of_id h.tlid )
-                                      ; ("result", Dval.show result) ] ;
+                                      ; ("result_type", result_tipe result) ] ;
                                   Event_queue.finish transaction event ;
                                   Ok (Some result)
                             with e ->


### PR DESCRIPTION
Do log the _type_ of the result, that's at least maybe interesting and
of finite size

https://trello.com/c/bjqmLHlQ/1867-dont-log-the-result-of-qw-cron-executions-the-data-is-large-and-not-useful

We think this might be the reason honeycomb agent crashed a bunch this
past weekend.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

