### PR TITLE
add queue_status 'scheduled' value

### DIFF
--- a/backend/migrations/20191022_154337_add_events_status_scheduled.sql
+++ b/backend/migrations/20191022_154337_add_events_status_scheduled.sql
@@ -1,0 +1,4 @@
+--#[no_tx]
+-- ALTER TYPE .. ADD VALUE cannot be run in a transaction or in multi-line statements.
+-- see https://www.postgresql.org/docs/9.5/sql-altertype.html
+ALTER TYPE queue_status ADD VALUE 'scheduled'


### PR DESCRIPTION
## What

- Adds `scheduled` as a `queue_status` to be used by the `events.status` field.
- To accomplish this, adds support for a special `--#[no_tx]` "pragma" to migration files to skip running them inside a transaction.

## Why

https://trello.com/c/iK4jWUXZ/1889-scheduler-schedule-event-processing-via-scheduler

`scheduled` is the new status that the queue scheduler is going to use to schedule work, so we need that.

Unfortunately, `ALTER TYPE` cannot be run in a transaction or multi-line command. Given we have this problem more than never (we see the same thing with `ADD INDEX CONCURRENTLY`), I figured it was worth supporting it directly in the migrator.

I'm not in love with this solution (_here be dragons_), but it seems to do the job. 

## Checklist

- [X] Trello link included
- [X] Discussed goals, problem and solution
- [X] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [X] Screenshots aren't useful
- [X] Intended followups are trelloed
  - [ ] No followups
- [X] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

