### PR TITLE
Add dismiss button to error bar

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1941,6 +1941,9 @@ let update_ (msg : msg) (m : model) : modification =
             (fun m ->
               {m with canvasProps = {m.canvasProps with minimap = None}} )
         ; MakeCmd (Url.navigateTo Architecture) ]
+  | DismissErrorBar ->
+      TweakModel
+        (fun m -> {m with error = {message = None; showDetails = false}})
 
 
 let rec filter_read_only (m : model) (modification : modification) =

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -1061,6 +1061,7 @@ and msg =
   | CreateGroup
   | HideTopbar
   | LogoutOfDark
+  | DismissErrorBar
 
 (* ----------------------------- *)
 (* AB tests *)

--- a/client/src/ViewScaffold.ml
+++ b/client/src/ViewScaffold.ml
@@ -53,21 +53,31 @@ let viewError (err : darkError) : msg Html.html =
   let viewException (exc : exception_) =
     match exc.result with
     | None ->
-        [Html.text exc.short]
+        [Html.p [] [Html.text exc.short]]
     | Some result ->
-        [Html.text result]
+        [Html.p [] [Html.text result]]
   in
-  Html.div
-    [Html.classList [("error-panel", true); ("show", err.showDetails)]]
-    ( match err.message with
+  let viewErrorMsg =
+    match err.message with
     | None ->
         []
     | Some msg ->
       ( match Json_decode_extended.decodeString Decoders.exception_ msg with
       | Error _ ->
-          [Html.text msg]
+          [Html.p [] [Html.text msg]]
       | Ok exc ->
-          viewException exc ) )
+          viewException exc )
+  in
+  let viewDismissBtn =
+    [ Html.p
+        [ Html.class' "dismissBtn"
+        ; ViewUtils.eventNoPropagation "click" ~key:"dismiss-error" (fun _ ->
+              DismissErrorBar ) ]
+        [Html.text "Dismiss"] ]
+  in
+  Html.div
+    [Html.classList [("error-panel", true); ("show", err.showDetails)]]
+    (viewErrorMsg @ viewDismissBtn)
 
 
 let readOnlyMessage (m : model) : msg Html.html =

--- a/client/src/styles/_footer.scss
+++ b/client/src/styles/_footer.scss
@@ -14,14 +14,22 @@
 
 .error-panel {
   width: 100%;
-  padding: 20px;
   background-color: $red;
   color: $white1;
   position: fixed;
   left: 0;
   bottom: -70px;
-  height: 20px;
+  height: 60px;
   animation-duration: 0.5s;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  p {
+    padding: 0px 20px;
+  }
+  .dismisBtn {
+    cursor: pointer;
+  }
   &.show {
     bottom: 0;
     animation-name: showErrorPanel;


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

We want to add a way to make the error bar go away

Screenshot: 
![Screen Shot 2019-10-22 at 3 47 16 PM](https://user-images.githubusercontent.com/32043360/67340887-58700280-f4e3-11e9-9481-bc28ac97b455.png)


Trello: 
https://trello.com/c/5k5QyQWN/1700-change-error-bar-action-to-just-dismiss-instead-of-toggle-importance-2easy-4

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

