### PR TITLE
Parse pathshape for more paths

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -89,47 +89,18 @@ data:
             - /api/:canvas/execute_function
             - /api/:canvas/get_trace_data
             - /api/:canvas/get_unlocked_dbs
+            - /api/:canvas/get_worker_stats
+            - /api/:canvas/get_db_stats
             - /api/:canvas/delete_404
             - /api/:canvas/static_assets
             - /canvas/:canvas/events/:event # stroller - not currently routed through nginx
       - labelSelector: "app=cron-checker"
         containerName: cron-ctr
         dataset: kubernetes-bwd-ocaml
-        parser: json
-        processors:
-        - request_shape:
-            field: request
-            patterns:
-            - /a/:canvas
-            - /api/:canvas/save_test
-            - /api/:canvas/rpc
-            - /api/:canvas/add_op
-            - /api/:canvas/initial_load
-            - /api/:canvas/execute_function
-            - /api/:canvas/get_trace_data
-            - /api/:canvas/get_unlocked_dbs
-            - /api/:canvas/delete_404
-            - /api/:canvas/static_assets
-            - /canvas/:canvas/events/:event # stroller - not currently routed through nginx
       - labelSelector: "app=qw-worker"
         containerName: qw-ctr
         dataset: kubernetes-bwd-ocaml
         parser: json
-        processors:
-        - request_shape:
-            field: request
-            patterns:
-            - /a/:canvas
-            - /api/:canvas/save_test
-            - /api/:canvas/rpc
-            - /api/:canvas/add_op
-            - /api/:canvas/initial_load
-            - /api/:canvas/execute_function
-            - /api/:canvas/get_trace_data
-            - /api/:canvas/get_unlocked_dbs
-            - /api/:canvas/delete_404
-            - /api/:canvas/static_assets
-            - /canvas/:canvas/events/:event # stroller - not currently routed through nginx
       - labelSelector: "app=bwd-app"
         containerName: http-proxy
         dataset: kubernetes-bwd-nginx
@@ -151,6 +122,8 @@ data:
             - /api/:canvas/execute_function
             - /api/:canvas/get_trace_data
             - /api/:canvas/get_unlocked_dbs
+            - /api/:canvas/get_worker_stats
+            - /api/:canvas/get_db_stats
             - /api/:canvas/delete_404
             - /api/:canvas/static_assets
             - /canvas/:canvas/events/:event # stroller - not currently routed through nginx


### PR DESCRIPTION
Also remove pathshape parsing for things that don't handle requests.

**It doesn't seem like cron & queue-worker need path shape parsing, so I removed it (keeping this list in sync across ocaml + nginx is hard enough), but please correct me if there's a reason for it being there.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

