### PR TITLE
Revert "Parse pathshape for more paths"

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -89,18 +89,47 @@ data:
             - /api/:canvas/execute_function
             - /api/:canvas/get_trace_data
             - /api/:canvas/get_unlocked_dbs
-            - /api/:canvas/get_worker_stats
-            - /api/:canvas/get_db_stats
             - /api/:canvas/delete_404
             - /api/:canvas/static_assets
             - /canvas/:canvas/events/:event # stroller - not currently routed through nginx
       - labelSelector: "app=cron-checker"
         containerName: cron-ctr
         dataset: kubernetes-bwd-ocaml
+        parser: json
+        processors:
+        - request_shape:
+            field: request
+            patterns:
+            - /a/:canvas
+            - /api/:canvas/save_test
+            - /api/:canvas/rpc
+            - /api/:canvas/add_op
+            - /api/:canvas/initial_load
+            - /api/:canvas/execute_function
+            - /api/:canvas/get_trace_data
+            - /api/:canvas/get_unlocked_dbs
+            - /api/:canvas/delete_404
+            - /api/:canvas/static_assets
+            - /canvas/:canvas/events/:event # stroller - not currently routed through nginx
       - labelSelector: "app=qw-worker"
         containerName: qw-ctr
         dataset: kubernetes-bwd-ocaml
         parser: json
+        processors:
+        - request_shape:
+            field: request
+            patterns:
+            - /a/:canvas
+            - /api/:canvas/save_test
+            - /api/:canvas/rpc
+            - /api/:canvas/add_op
+            - /api/:canvas/initial_load
+            - /api/:canvas/execute_function
+            - /api/:canvas/get_trace_data
+            - /api/:canvas/get_unlocked_dbs
+            - /api/:canvas/delete_404
+            - /api/:canvas/static_assets
+            - /canvas/:canvas/events/:event # stroller - not currently routed through nginx
       - labelSelector: "app=bwd-app"
         containerName: http-proxy
         dataset: kubernetes-bwd-nginx
@@ -122,8 +151,6 @@ data:
             - /api/:canvas/execute_function
             - /api/:canvas/get_trace_data
             - /api/:canvas/get_unlocked_dbs
-            - /api/:canvas/get_worker_stats
-            - /api/:canvas/get_db_stats
             - /api/:canvas/delete_404
             - /api/:canvas/static_assets
             - /canvas/:canvas/events/:event # stroller - not currently routed through nginx


### PR DESCRIPTION
Reverts darklang/dark#1519

```
dark@dark-dev:~/app$ kubectl logs honeycomb-agent-v1.1-72xqn
time="2019-10-29T04:03:26Z" level=info msg="Initializing agent" version=1.3.3 
Error in watcher configuration:
No parser specified
```