### PR TITLE
Fix missing honeycomb parser

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -97,6 +97,7 @@ data:
       - labelSelector: "app=cron-checker"
         containerName: cron-ctr
         dataset: kubernetes-bwd-ocaml
+        parser: json
       - labelSelector: "app=qw-worker"
         containerName: qw-ctr
         dataset: kubernetes-bwd-ocaml


### PR DESCRIPTION
```
dark@dark-dev:~/app$ kubectl logs honeycomb-agent-v1.1-72xqn
time="2019-10-29T04:03:26Z" level=info msg="Initializing agent" version=1.3.3
Error in watcher configuration:
No parser specified
```

Caused crashloopbackoff after #1519

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [x] Intended followups are trelloed: https://trello.com/c/qpMOMHC0/1915-check-honeycomb-config-in-ci
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

