### PR TITLE
Validate honeycomb config in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,6 +349,15 @@ jobs:
             - v6-postgres-honeytail-{{ checksum "rundir/minus3-timestamp" }}
       - run: cd postgres-honeytail && docker build -t dark-gcp-postgres-honeytail .
 
+  validate-honeycomb-config:
+    executor: my-executor
+    steps:
+      - checkout
+      - initialize
+      - run: apk add --update python py-pip && pip install yq
+      - run: pip install yq
+      - run: scripts/support/test-honeycomb-config.sh
+
   build-client:
     executor: my-executor
     steps:
@@ -505,6 +514,7 @@ workflows:
       - build-stroller
       - build-queue-scheduler
       - build-postgres-honeytail
+      - validate-honeycomb-config
 
       # expensive tests
       - integration-tests:
@@ -530,5 +540,6 @@ workflows:
             branches:
               only: master
           requires:
+            - validate-honeycomb-config
             - integration-tests
             - push-to-gcp

--- a/scripts/support/test-honeycomb-config.sh
+++ b/scripts/support/test-honeycomb-config.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eu
+set pipefail
+
+YAML=scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+IMAGE=$(yq -sr '.[4].spec.template.spec.containers[0].image' $YAML)
+
+TMP_CONFIG=tmp_honeycomb_config.yaml
+TMP_DOCKERFILE=tmp_honeycomb_config.Dockerfile
+yq -sr '.[3].data."config.yaml"' $YAML > $TMP_CONFIG
+
+# This is a little silly, but easier than figuring out how to put
+# tmp_honeycomb_config.yaml in a volume for circle
+echo "FROM $IMAGE" > $TMP_DOCKERFILE
+echo "COPY $TMP_CONFIG /etc/honeycomb/config.yaml" >> $TMP_DOCKERFILE
+docker build -t test-honeycomb -f $TMP_DOCKERFILE .
+
+docker run -it test-honeycomb --validate
+
+rm $TMP_CONFIG
+rm $TMP_DOCKERFILE


### PR DESCRIPTION
This would've caught the error in #1519 which was fixed in #1525
(a missing `parser` key in one of the watchers).

https://trello.com/c/qpMOMHC0/1915-check-honeycomb-config-in-ci

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

