### PR TITLE
use stakater/Reloader to auto-reload honeycomb daemonset when configm…

### DIFF
--- a/scripts/gke-deploy
+++ b/scripts/gke-deploy
@@ -257,6 +257,7 @@ kubectl apply -f scripts/support/kubernetes/tunnel/tunnel-deployment.yaml
 kubectl apply -f scripts/support/kubernetes/tunnel/isolate-tunnel.yaml
 kubectl apply -f scripts/support/kubernetes/tunnel/tunnel-service.yaml
 kubectl apply -f scripts/support/kubernetes/postgres-honeytail-deployment.yaml
+kubectl apply -f scripts/support/kubernetes/reloader.yaml
 
 #########################
 # Tell everyone else what's going on

--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -144,6 +144,8 @@ metadata:
     version: v1.1
   name: honeycomb-agent-v1.1
   namespace: default
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -155,6 +157,8 @@ spec:
         k8s-app: honeycomb-agent
         kubernetes.io/cluster-service: 'true'
         version: v1.1
+      annotations:
+        reloader.stakater.com/auto: "true"
     spec:
       tolerations:
         - operator: Exists

--- a/scripts/support/kubernetes/reloader.yaml
+++ b/scripts/support/kubernetes/reloader.yaml
@@ -1,0 +1,131 @@
+# From https://github.com/stakater/Reloader
+---
+# Source: reloader/templates/role.yaml
+
+
+---
+# Source: reloader/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.49"
+    release: "reloader"
+    heritage: "Tiller"
+    group: com.stakater.platform
+    provider: stakater
+    version: v0.0.49
+    
+  name: reloader-reloader
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: reloader-reloader
+      release: "reloader"
+  template:
+    metadata:
+      labels:
+        app: reloader-reloader
+        chart: "reloader-v0.0.49"
+        release: "reloader"
+        heritage: "Tiller"
+        group: com.stakater.platform
+        provider: stakater
+        version: v0.0.49
+        
+    spec:
+      containers:
+      - env:
+        image: "stakater/reloader:v0.0.49"
+        imagePullPolicy: IfNotPresent
+        name: reloader-reloader
+        args:
+      serviceAccountName: reloader-reloader
+
+---
+# Source: reloader/templates/clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.49"
+    release: "reloader"
+    heritage: "Tiller"
+  name: reloader-reloader-role
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - list
+      - get
+      - update
+      - patch
+
+---
+# Source: reloader/templates/rolebinding.yaml
+
+
+---
+# Source: reloader/templates/clusterrolebinding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.49"
+    release: "reloader"
+    heritage: "Tiller"
+  name: reloader-reloader-role-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: reloader-reloader-role
+subjects:
+  - kind: ServiceAccount
+    name: reloader-reloader
+    namespace: default
+
+---
+# Source: reloader/templates/serviceaccount.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: reloader-reloader
+    chart: "reloader-v0.0.49"
+    release: "reloader"
+    heritage: "Tiller"
+  name: reloader-reloader
+


### PR DESCRIPTION
…ap changes

Without this, any time you edit the honeycomb configuration - to add a new service, say, or add routes to the path normalizer in the nginx processor, you have to manually delete the honeycomb agent pods so they restart and pick up the new config. 

Reloaded automates that step - deploying a configmap triggers a rolling upgrade. 

https://trello.com/c/Mw15lbxn/1933-use-stakater-reloader-to-cause-honeycomb-to-pick-up-config-changes-with-fewer-manual-steps

I recommend manual testing before merge
- deploying honeycomb.yaml
- deploying reloader.yaml
- making a change to the honeycomb configmap, and
- verifying that the last ste triggered a rolling upgrade:
  `kubectl rollout status ds/honeycomb-agent-v1.1`

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

