### PR TITLE
re-org queue-scheduler to produce library

### DIFF
--- a/queue-scheduler/Cargo.lock
+++ b/queue-scheduler/Cargo.lock
@@ -217,21 +217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dark-queue-scheduler"
-version = "0.1.0"
-dependencies = [
- "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rollbar 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "digest"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +228,26 @@ dependencies = [
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "failure"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "fake-simd"
@@ -770,6 +775,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "queue-scheduler"
+version = "0.1.0"
+dependencies = [
+ "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rollbar 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,6 +1569,8 @@ dependencies = [
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1647,6 +1681,7 @@ dependencies = [
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/queue-scheduler/Cargo.toml
+++ b/queue-scheduler/Cargo.toml
@@ -1,14 +1,23 @@
 [package]
-name = "dark-queue-scheduler"
+name = "queue-scheduler"
 version = "0.1.0"
 authors = ["Dark Inc <ops@darklang.com>"]
 edition = "2018"
+
+[lib]
+name = "scheduler"
+path = "src/lib.rs"
+
+[[bin]]
+name = "dark-queue-scheduler"
+path = "src/main.rs"
 
 [dependencies]
 backoff = "0.1.5"
 backtrace = "0.3"
 chrono = "0.4"
 config = "0.9"
+failure = "0.1.6"
 postgres = "0.15"
 rand = "0.7.2"
 rollbar = "0.6.0"

--- a/queue-scheduler/src/config.rs
+++ b/queue-scheduler/src/config.rs
@@ -1,5 +1,5 @@
-pub use config::ConfigError;
 use config::{Config, Environment};
+use failure::Error;
 
 #[derive(Debug)]
 pub struct Database {
@@ -23,28 +23,36 @@ pub struct AppConfig {
     pub rollbar: Rollbar,
 }
 
-pub fn load() -> Result<AppConfig, ConfigError> {
+pub fn load_database(cfg: &Config) -> Result<Database, Error> {
+    Ok(Database {
+        user: cfg.get_str("DB_USER")?,
+        password: cfg.get_str("DB_PASSWORD")?,
+        host: cfg.get_str("DB_HOST")?,
+        dbname: cfg.get_str("DB_DBNAME")?,
+        url: format!(
+            "postgres://{}:{}@{}/{}",
+            cfg.get_str("DB_USER")?,
+            cfg.get_str("DB_PASSWORD")?,
+            cfg.get_str("DB_HOST")?,
+            cfg.get_str("DB_DBNAME")?,
+        ),
+    })
+}
+
+pub fn load_rollbar(cfg: &Config) -> Result<Rollbar, Error> {
+    Ok(Rollbar {
+        enabled: cfg.get_str("ROLLBAR_ENABLED").map(|s| s == "y")?,
+        environment: cfg.get_str("ROLLBAR_ENVIRONMENT")?,
+        token: cfg.get_str("ROLLBAR_POST_SERVER_ITEM")?,
+    })
+}
+
+pub fn load() -> Result<AppConfig, Error> {
     let mut cfg = Config::new();
     cfg.merge(Environment::with_prefix("DARK_CONFIG"))?;
 
     Ok(AppConfig {
-        rollbar: Rollbar {
-            enabled: cfg.get_str("ROLLBAR_ENABLED").map(|s| s == "y")?,
-            environment: cfg.get_str("ROLLBAR_ENVIRONMENT")?,
-            token: cfg.get_str("ROLLBAR_POST_SERVER_ITEM")?,
-        },
-        database: Database {
-            user: cfg.get_str("DB_USER")?,
-            password: cfg.get_str("DB_PASSWORD")?,
-            host: cfg.get_str("DB_HOST")?,
-            dbname: cfg.get_str("DB_DBNAME")?,
-            url: format!(
-                "postgres://{}:{}@{}/{}",
-                cfg.get_str("DB_USER")?,
-                cfg.get_str("DB_PASSWORD")?,
-                cfg.get_str("DB_HOST")?,
-                cfg.get_str("DB_DBNAME")?,
-            ),
-        },
+        rollbar: load_rollbar(&cfg)?,
+        database: load_database(&cfg)?,
     })
 }

--- a/queue-scheduler/src/lib.rs
+++ b/queue-scheduler/src/lib.rs
@@ -1,0 +1,54 @@
+pub mod config;
+pub mod errors;
+pub mod pg;
+mod stats;
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use failure::Error;
+use slog::info; // macro
+
+pub struct Looper {
+    conn: postgres::Connection,
+    log: Arc<slog::Logger>,
+}
+
+impl Looper {
+    pub fn new(conn: postgres::Connection, log: Arc<slog::Logger>) -> Looper {
+        Looper { conn, log }
+    }
+
+    pub fn every(&mut self, d: Duration) -> Result<(), Error> {
+        loop {
+            thread::sleep(d);
+            self.tick()?;
+        }
+    }
+
+    fn tick(&mut self) -> Result<(), Error> {
+        let t_start = Instant::now();
+
+        let newly_scheduled = schedule_events(&self.conn)?;
+        let stats = stats::fetch(&self.conn)?;
+
+        info!(*self.log, "tick" ;
+        "duration" => t_start.elapsed().as_secs_f64() * 1000.0,
+        "events.newly_scheduled" => newly_scheduled,
+        "events.new_count" => stats.new,
+        "events.scheduled_count" => stats.scheduled,
+        );
+
+        Ok(())
+    }
+}
+
+fn schedule_events(conn: &postgres::Connection) -> Result<u64, Error> {
+    conn.execute(
+        "UPDATE events SET status = 'scheduled' \
+         WHERE status = 'new' AND delay_until < CURRENT_TIMESTAMP",
+        &[],
+    )
+    .map_err(|e| Error::from_boxed_compat(Box::new(e)))
+}

--- a/queue-scheduler/src/pg.rs
+++ b/queue-scheduler/src/pg.rs
@@ -1,35 +1,33 @@
-// use std::io;
 use std::sync::Arc;
-use std::time;
+use std::time::Duration;
 
-use backoff::Operation;
-use slog::debug; // macros
+use backoff::Error::{Permanent, Transient};
+use backoff::Operation; // trait for retry_notify
+use failure::Error;
+use slog::debug;
 
-use crate::errors;
-
-pub fn connect(
-    log: Arc<slog::Logger>,
-    dburl: &str,
-) -> Result<postgres::Connection, errors::FatalError> {
-    let notifier = |e: postgres::Error, d: time::Duration| {
-        debug!(log, "postgres.connect.error"; "error.msg" => format!("{}", e), "retry_in" => d.as_millis());
+pub fn connect(log: Arc<slog::Logger>, dburl: &str) -> Result<postgres::Connection, Error> {
+    let notifier = |e: postgres::Error, d: Duration| {
+        debug!(log, "postgres.connect.error";
+        "error.msg" => e.to_string(),
+        "retry_in" => d.as_millis()
+        );
     };
     let mut boff = backoff::ExponentialBackoff {
-        initial_interval: time::Duration::from_millis(500),
-        max_interval: time::Duration::from_secs(1),
-        max_elapsed_time: Some(time::Duration::from_secs(10)),
+        initial_interval: Duration::from_millis(500),
+        max_interval: Duration::from_secs(1),
+        max_elapsed_time: Some(Duration::from_secs(10)),
         ..Default::default()
     };
 
     let mut connect = || {
-        postgres::Connection::connect(dburl, postgres::TlsMode::None)
-            .map_err(backoff::Error::Transient) // TODO(ds): do we want to label some as Permanent?
+        // TODO(ds): do we want to label some as Permanent?
+        postgres::Connection::connect(dburl, postgres::TlsMode::None).map_err(Transient)
     };
 
     connect
         .retry_notify(&mut boff, notifier)
         .map_err(|e| match e {
-            backoff::Error::Permanent(e) => errors::FatalError::PostgresConnectError(e),
-            backoff::Error::Transient(e) => errors::FatalError::PostgresConnectError(e),
+            Permanent(e) | Transient(e) => Error::from_boxed_compat(Box::new(e)),
         })
 }

--- a/queue-scheduler/src/scheduler.rs
+++ b/queue-scheduler/src/scheduler.rs
@@ -1,7 +1,0 @@
-pub fn schedule_events(conn: &postgres::Connection) -> Result<u64, postgres::Error> {
-    conn.execute(
-        "UPDATE events SET status = 'scheduled' \
-         WHERE status = 'new' AND delay_until < CURRENT_TIMESTAMP",
-        &[],
-    )
-}

--- a/scripts/support/run-rust
+++ b/scripts/support/run-rust
@@ -16,7 +16,6 @@ else
 fi
 
 BIN="$NAME/target/$TARGET/dark-$NAME"
-echo $BIN
 
 # Stop existing process (note that this makes the old process a zombie.
 # Doesn't matter though, as this only runs in dev).
@@ -30,9 +29,11 @@ do
   fi
 done
 
+echo "Running ${BIN}"
+export RUST_BACKTRACE=1
+
 if [[ -f "${BIN}" ]]; then
   LOGS="${DARK_CONFIG_RUNDIR}/logs"
-  echo "Running ${BIN}"
   "${BIN}" > "$LOGS/$NAME.log" 2>&1 &
 else
   echo "Missing binary"


### PR DESCRIPTION
## What

* Reorganizes things a bit so we can create a binary and library.
* Use failure::Error instead of custom error stuff.

## Why

We're attempting to add tests ([trello](https://trello.com/c/kPUUsMZl/1919-tests-for-scheduler-logic)), but we need a library in order to write integration tests, which are treated as a separate crate that must use the library's public API.

The failure::Error stuff just came along for the ride (sorry). It makes error handling much much nicer, as pretty much anything can be cast into an `Error`, which carries a backtrace along with it and is just generally a much nicer API to work with. I haven't quite fixed the Rollbar reporting yet, but this should enable doing that more easily.

## Checklist

- [X] Trello link included
- [X] Discussed goals, problem and solution
- [X] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [X] Screenshots aren't useful
- [X] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [X] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

