### PR TITLE
Fluid - Make autocomplete highlight blue and making refs blue when hovering

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -4638,12 +4638,18 @@ let toHtml
       in
       let element nested =
         let content = Token.toText ti.token in
+        let highlight =
+          if List.member ~value:(Token.tid ti.token) vs.hoveringRefs
+          then ["related-change"]
+          else []
+        in
         let classes = Token.toCssClasses ti.token in
         let idStr = deID (Token.tid ti.token) in
         let idclasses = ["id-" ^ idStr] in
         Html.span
           [ Attrs.class'
-              (["fluid-entry"] @ classes @ idclasses |> String.join ~sep:" ")
+              ( ["fluid-entry"] @ classes @ idclasses @ highlight
+              |> String.join ~sep:" " )
             (* TODO(korede): figure out how to disable default selection while allowing click event *)
           ; ViewUtils.nothingMouseEvent "mousemove"
           ; ViewUtils.eventNeither

--- a/client/src/styles/_fluid.scss
+++ b/client/src/styles/_fluid.scss
@@ -156,7 +156,6 @@ https://github.com/chriskempson/tomorrow-theme */
   .fluid-fn-name,
   .fluid-fn-version {
     color: $white2;
-
     .execution-button {
       position: absolute;
       font-size: 55%;
@@ -197,6 +196,10 @@ https://github.com/chriskempson/tomorrow-theme */
         }
       }
     }
+  }
+
+  .related-change {
+    color: $hover-foreground;
   }
 
   .fluid-partial,


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Trellos: 
https://trello.com/c/qwemmCtk/1761-when-ac-only-has-two-results-its-not-obvious-item-is-selected
https://trello.com/c/DOzvTuHs/1417-when-mousing-over-a-reference-its-variables-should-be-shown-in-blue

A few changes to make fluid match the old editor. I added the blue highlight color for selected autocomplete items and made the reference variables in a handle glow blue when hover on the reference on the side of the handler.

Before:
Note my cursor is hovering on the db ref on the side
![Screen Shot 2019-10-31 at 4 17 17 PM](https://user-images.githubusercontent.com/32043360/67992471-14bf7c00-fbfa-11e9-8d1d-a1e2a06ecbb3.png)
![Screen Shot 2019-10-31 at 4 16 52 PM](https://user-images.githubusercontent.com/32043360/67992472-14bf7c00-fbfa-11e9-93e9-bf2e928e1997.png)

After:
Note my cursor is hovering on the db ref on the side
![Screen Shot 2019-10-31 at 4 18 02 PM](https://user-images.githubusercontent.com/32043360/67992478-1be68a00-fbfa-11e9-93d3-5ed4da1b2b95.png)
![Screen Shot 2019-10-31 at 4 17 53 PM](https://user-images.githubusercontent.com/32043360/67992479-1be68a00-fbfa-11e9-857e-482281f4bae5.png)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

