### PR TITLE
Local login needs to redirect to :8000

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1307,11 +1307,18 @@ let handle_login_page ~execution_id req body =
                    session
             in
             let redirect_to =
-              match redirect with
+              ( match redirect with
               | None | Some "" ->
                   "/a/" ^ Uri.pct_encode username
               | Some redir ->
-                  Uri.pct_decode redir
+                  Uri.pct_decode redir )
+              |> Uri.of_string
+              |> Uri.path_and_query
+              (* Strip the host; that also means we'll use
+                                       the port of the incoming request, solving
+                                       the local login bug where we redirect to
+                                       darklang.localhost:80/something when we
+                                       want to hit :8000 *)
             in
             over_headers_promise
               ~f:(fun h -> Header.add_list h headers)


### PR DESCRIPTION
Problem: local login page got query param telling it to redirect to
darklang.localhost/some_path; we actually want
darklang.localhost:8000/some_path.

The solution here is to parse the redirect query param to get only the
path + query params, _not_ the host; thus we will redirect to
/some_path, and the browser will keep the host+port it was using.
(Locally, darklang.localhost:8000; in prod, darklang.com[:80])

https://trello.com/c/bFEzTmPE/1921-fix-login-redirect-in-local-its-missing-the-port

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

