### PR TITLE
Fix docstrings in liboption

### DIFF
--- a/backend/libexecution/liboption.ml
+++ b/backend/libexecution/liboption.ml
@@ -23,7 +23,7 @@ let fns : Lib.shortfn list =
     ; p = [par "option" TOption; func ["val"]]
     ; r = TOption
     ; d =
-        "Transform an Option using `f`, only if the Option is a Just. If Nothing, doesn't nothing."
+        "Transform an Option using `f`, only if the Option is a Just. If Nothing, does nothing."
     ; f =
         InProcess
           (function
@@ -42,7 +42,7 @@ let fns : Lib.shortfn list =
     ; p = [par "option" TOption; func ["val"]]
     ; r = TOption
     ; d =
-        "Transform an Option using `f`, only if the Option is a Just. If Nothing, doesn't nothing."
+        "Transform an Option using `f`, only if the Option is a Just. If Nothing, does nothing."
     ; f =
         InProcess
           (function
@@ -61,7 +61,7 @@ let fns : Lib.shortfn list =
     ; p = [par "option" TOption; func ["val"]]
     ; r = TOption
     ; d =
-        "Transform an Option using `f`, only if the Option is a Just. If Nothing, doesn't nothing. Combines the result into a single option, where if both the caller and the result are Just, the result is a single Just"
+        "Transform an Option using `f`, only if the Option is a Just. If Nothing, does nothing. Combines the result into a single option, where if both the caller and the result are Just, the result is a single Just"
     ; f =
         InProcess
           (function


### PR DESCRIPTION
- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Fixes: https://trello.com/c/Lg09xJD7/1927-fix-optionmap-optionandthen-docstrings

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

