### PR TITLE
Dont force fluid on Jessica

### DIFF
--- a/client/src/VariantTesting.ml
+++ b/client/src/VariantTesting.ml
@@ -23,11 +23,13 @@ let libtwitterAvailable (vts : variantTest list) : bool =
   List.member ~value:LibtwitterVariant vts
 
 
-(* This is temporary to force Darklings(minus ellen) to use fluid. *)
+(* This is temporary to force Darklings(minus ellen, and jessica) to use fluid. *)
 (* To turn off fluid, add the ?fluidv2=0 or ?fluidv2=false *)
 let forceFluid (isAdmin : bool) (username : string) (vts : variantTest list) :
     variantTest list =
-  let shouldForceFluid = isAdmin && username != "ellen" in
+  let shouldForceFluid =
+    isAdmin && username != "ellen" && username != "jessicajenkins"
+  in
   if shouldForceFluid
   then
     (* Checking to see if fluid is set to false *)


### PR DESCRIPTION
- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Making it so fluid is not forced on Jessica

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

