### PR TITLE
Add scheduling rules, cleanup events indexes

### DIFF
--- a/backend/migrations/20191104_164450_add_event_scheduling_rules.sql
+++ b/backend/migrations/20191104_164450_add_event_scheduling_rules.sql
@@ -1,0 +1,16 @@
+CREATE TYPE scheduling_rule_type AS ENUM ('pause', 'block');
+
+CREATE TABLE IF NOT EXISTS scheduling_rules (
+    id SERIAL PRIMARY KEY,
+    rule_type scheduling_rule_type NOT NULL,
+    canvas_id UUID REFERENCES canvases(id) NOT NULL,
+    handler_name TEXT NOT NULL,
+    event_space TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_uniq_scheduling_rules
+ON scheduling_rules (canvas_id, rule_type, handler_name, event_space);
+
+DROP INDEX idx_dequeue;
+DROP INDEX idx_cleanup


### PR DESCRIPTION
## What

Migration to add scheduling rules. Drops two unused indexes on `events`.

## Why

Ultimately to implement [pause functionality](https://trello.com/c/JgMktfJa/1910-dark-employees-would-like-a-way-to-pause-processing-of-a-worker-handler).

This needs to go in before the actual code that uses it because deploy race condition stuff. Cleaned up the indexes just because I was working on the `events` table queries and noticed they weren't used.

## Details

To understand the rules table, it's probably best to look at the followup branch with the implementation: https://github.com/darklang/dark/compare/dstrelau/scheduler-pause-1...dstrelau/scheduler-pause-2

About those dropped indexes:

Running [this query from the pg wiki](https://wiki.postgresql.org/wiki/Index_Maintenance#Index_size.2Fusage_statistics) to look at index usage, here are the events indexes:

```
 schemaname |      tablename       |                          indexname                           |  num_rows   | table_size | index_size | unique | number_of_scans |  tuples_read  | tuples_fetched
------------+----------------------+--------------------------------------------------------------+-------------+------------+------------+--------+-----------------+---------------+----------------
 public     | events               | events_pkey                                                  | 5.21874e+06 | 867 MB     | 231 MB     | Y      |        78544754 |     129594802 |       78544753
 public     | events               | idx_cleanup                                                  | 5.21874e+06 | 867 MB     | 263 MB     | N      |        39586466 |  139092784811 |    13711332646
 public     | events               | idx_dequeue                                                  | 5.21874e+06 | 867 MB     | 1292 MB    | N      |           16732 |            49 |             25
 public     | events               | index_events_for_stats                                       | 5.21874e+06 | 867 MB     | 213 MB     | N      |        38403486 |    1652474919 |     1120650095
```

I know for a fact that `index_events_for_stats` is actually what's used for the scheduler query, since I've been working on and EXPLAIN-ing that. `idx_dequeue` is just very clearly never used. 

`idx_cleanup` looks like it was used heavily in the past, but I'm fairly certain it's not anymore. That index is `idx_cleanup ON events (dequeued_by, status)` and we hard-code `NULL` as the `dequeued_by` value to all new events. It doesn't appear anywhere else in the codebase. Unless there's some other code lurking somewhere using it, I think it must be a historical artifact.

## Checklist

- [X] Trello link included
- [X] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [X] No useful information
- [ ] Before/after screenshots are included
  - [X] Screenshots aren't useful
- [X] Intended followups are trelloed
  - [ ] No followups
- [X] Reversion plan exists
  - I don't anticipate this migration failing, but if it does, we can manually fix the DB. The worst case here is that the events indexes were actually being used, in which case we can manually add them back (`CONCURRENTLY`).
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

