### PR TITLE
Give a better error when canvas name is too long

### DIFF
--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -271,10 +271,16 @@ let tier_one_hosts () : string list =
 
 (* https://stackoverflow.com/questions/15939902/is-select-or-insert-in-a-function-prone-to-race-conditions/15950324#15950324 *)
 let fetch_canvas_id (owner : Uuidm.t) (host : string) : Uuidm.t =
-  Db.fetch_one
-    ~name:"fetch_canvas_id"
-    "SELECT canvas_id($1, $2, $3)"
-    ~params:[Uuid (Util.create_uuid ()); Uuid owner; String host]
-  |> List.hd_exn
-  |> Uuidm.of_string
-  |> Option.value_exn
+  let host_length = String.length host in
+  if host_length > 64
+  then
+    Exception.internal
+      (Printf.sprintf "Canvas name was %i chars, must be <= 64." host_length)
+  else
+    Db.fetch_one
+      ~name:"fetch_canvas_id"
+      "SELECT canvas_id($1, $2, $3)"
+      ~params:[Uuid (Util.create_uuid ()); Uuid owner; String host]
+    |> List.hd_exn
+    |> Uuidm.of_string
+    |> Option.value_exn


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/172694/68715118-424be400-056f-11ea-86a6-ebba5a0879d2.png)

After:
![image](https://user-images.githubusercontent.com/172694/68715139-4bd54c00-056f-11ea-9904-1c5a663b6092.png)

https://trello.com/c/YUADvYE6/1936-we-leak-sql-errors-when-using-a-canvas-name-that-is-too-long

Note: this does mean that if we update canvases.name to loosen this constraint, we'll want to change the error separately - but that's acceptable.

Alternative fix for https://github.com/darklang/dark/pull/1553, since just making the varchar columns be unconstrained text was disliked.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

