### PR TITLE
Push worker schedule changes via stroller

### DIFF
--- a/backend/libbackend/analysis.ml
+++ b/backend/libbackend/analysis.ml
@@ -287,6 +287,10 @@ let to_new_static_deploy_frontend (asset : SA.static_deploy) : string =
   asset |> SA.static_deploy_to_yojson |> Yojson.Safe.to_string ~std:true
 
 
+let to_worker_schedules_push (ws : Event_queue.Worker_states.t) : string =
+  ws |> Event_queue.Worker_states.to_yojson |> Yojson.Safe.to_string ~std:true
+
+
 (* Toplevel deletion:
  * The server announces that a toplevel is deleted by it appearing in
  * deleted_toplevels. The server announces it is no longer deleted by it

--- a/backend/libbackend/stroller.ml
+++ b/backend/libbackend/stroller.ml
@@ -108,3 +108,11 @@ let push_new_event
     ~(event : string)
     (payload : string) =
   push ~execution_id ~canvas_id ~event payload
+
+
+let push_worker_states
+    ~(execution_id : Types.id)
+    ~(canvas_id : Uuidm.t)
+    (ws : Event_queue.Worker_states.t) =
+  let payload = Analysis.to_worker_schedules_push ws in
+  push ~execution_id ~canvas_id ~event:"worker_state" payload

--- a/backend/libbackend/stroller.mli
+++ b/backend/libbackend/stroller.mli
@@ -25,4 +25,10 @@ val push_new_static_deploy :
 val push_new_event :
   execution_id:Types.id -> canvas_id:Uuidm.t -> event:string -> string -> unit
 
+val push_worker_states :
+     execution_id:Types.id
+  -> canvas_id:Uuidm.t
+  -> Event_queue.Worker_states.t
+  -> unit
+
 val status : unit -> [> `Healthy | `Unconfigured | `Unhealthy of string] Lwt.t

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1080,7 +1080,15 @@ let worker_schedule ~(execution_id : Types.id) (host : string) (body : string)
           | _ ->
               Error "unknown action" )
     in
-    let timing = server_timing [t1; t2; t3] in
+    let t4, _ =
+      time "4-push-new-states" (fun _ ->
+          match res with
+          | Ok ws ->
+              Stroller.push_worker_states ~execution_id ~canvas_id:cid ws
+          | _ ->
+              () )
+    in
+    let timing = server_timing [t1; t2; t3; t4] in
     match res with
     | Ok schedules ->
         respond

--- a/client/src/Analysis.ml
+++ b/client/src/Analysis.ml
@@ -278,6 +278,18 @@ module AddOp = struct
   let listen ~key tagger = Native.registerGlobal "addOp" key tagger decode
 end
 
+module WorkerStatePush = struct
+  let decode =
+    let open Tea.Json.Decoder in
+    field
+      "detail"
+      (Decoders.wrapDecoder Decoders.updateWorkerScheduleRPCResult)
+
+
+  let listen ~key tagger =
+    Native.registerGlobal "workerStatePush" key tagger decode
+end
+
 (* Request analysis *)
 module RequestAnalysis = struct
   external send : performAnalysisParams -> unit = "requestAnalysis"

--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1555,6 +1555,8 @@ let update_ (msg : msg) (m : model) : modification =
       UpdateAvatarList avatarsList
   | NewStaticDeployPush asset ->
       AppendStaticDeploy [asset]
+  | WorkerStatePush ws ->
+      UpdateWorkerSchedules ws
   | Delete404RPC f404 ->
       Many
         [ (* This deletion is speculative *)
@@ -2082,7 +2084,9 @@ let subscriptions (m : model) : msg Tea.Sub.t =
           ReceiveFetch s )
     ; Analysis.NewPresencePush.listen ~key:"new_presence_push" (fun s ->
           NewPresencePush s )
-    ; Analysis.AddOp.listen ~key:"add_op" (fun s -> AddOpStrollerMsg s) ]
+    ; Analysis.AddOp.listen ~key:"add_op" (fun s -> AddOpStrollerMsg s)
+    ; Analysis.WorkerStatePush.listen ~key:"worker_state_push" (fun s ->
+          WorkerStatePush s ) ]
   in
   let clipboardSubs =
     [ Native.Clipboard.copyListener ~key:"copy_event" (fun e ->

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -1012,6 +1012,7 @@ and msg =
   | NewTracePush of (traceID * tlid list)
   | New404Push of fourOhFour
   | NewStaticDeployPush of staticDeploy
+  | WorkerStatePush of string StrDict.t
   | Delete404RPCCallback of delete404RPCParams * (unit, httpError) Tea.Result.t
       [@printer opaque "Delete404RPCCallback"]
   | InitialLoadRPCCallback of

--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -550,6 +550,10 @@ setTimeout(function() {
       var event = new CustomEvent("addOp", { detail: data });
       document.dispatchEvent(event);
     });
+    pusherChannel.bind("worker_state", data => {
+      var event = new CustomEvent("workerStatePush", { detail: data });
+      document.dispatchEvent(event);
+    });
   }
 }, 1);
 // ---------------------------


### PR DESCRIPTION
Makes worker states update via push whenever they're changed.

https://trello.com/c/yR1psaxn/1945-worker-scheduling-pause-play-block-should-be-updated-in-realtime

(click to see bigger. shows buttons getting updated across two browser windows for both pause & block.)

![2019-11-14 10 45 59](https://user-images.githubusercontent.com/131/68883102-5a8e4100-06de-11ea-9558-e64c158a35c0.gif)

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

