### PR TITLE
Make segment_identify_user blocking/synchronous

### DIFF
--- a/backend/libbackend/stroller.mli
+++ b/backend/libbackend/stroller.mli
@@ -12,7 +12,7 @@ val segment_track :
   -> event:string
   -> segment_type
   -> Yojson.Safe.t
-  -> unit
+  -> unit Lwt.t
 
 val segment_identify_user : string -> unit
 


### PR DESCRIPTION
We call it in two places:
- bin/segment_identify_users.exe
- in DarkInternal functions for upserting users or setting the admin
flag

Neither of these is an Lwt context! So we want blocking, not async; otherwise, we create a  promise but it never gets run, and so this is effectively a no-op.

Fast-follow for https://trello.com/c/KmXIQZmj/1948-add-identify-functionality-to-ocaml

Also does https://trello.com/c/3pzzfCIz/1967-add-granduser-traffic-events-to-segment

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

