### PR TITLE
fix chmod issues with ~/.cargo vol

### DIFF
--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -166,7 +166,7 @@ def rust_build(name):
     build_flags = ""
 
   start = time.time()
-  build = f"cd {name} && sudo chown dark -R /home/dark/.cargo && unbuffer cargo build{build_flags}"
+  build = f"cd {name} && unbuffer cargo build{build_flags}"
   if profile:
     return run_backend(start, landmarks + build)
   else:


### PR DESCRIPTION
No trello link.

At least on Linux, not sure if it happens on OSX, running scripts/builder after clearing build volumes will fail because ~/.cargo is not owned by the dark user.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

