### PR TITLE
`Dict::filter_v1` which correctly propagates errors

### DIFF
--- a/backend/libexecution/libdict.ml
+++ b/backend/libexecution/libdict.ml
@@ -149,6 +149,45 @@ let fns =
           | args ->
               fail args)
     ; ps = true
+    ; dep = true }
+  ; { pns = ["Dict::filter_v1"]
+    ; ins = []
+    ; p = [par "dict" TObj; func ["key"; "value"]]
+    ; r = TObj
+    ; d =
+        "Return only values in `dict` which meet the function's criteria. The function should return true to keep the entry or false to remove it."
+    ; f =
+        InProcess
+          (function
+          | _, [DObj o; DBlock fn] ->
+              let filter_propagating_errors ~key ~data acc =
+                match acc with
+                | Error dv ->
+                    Error dv
+                | Ok m ->
+                  ( match fn [Dval.dstr_of_string_exn key; data] with
+                  | DBool true ->
+                      Ok (Base.Map.set m ~key ~data)
+                  | DBool false ->
+                      Ok m
+                  | (DIncomplete as e) | (DError _ as e) ->
+                      Error e
+                  | other ->
+                      RT.error
+                        "Fn returned incorrect type"
+                        ~expected:"bool"
+                        ~actual:other )
+              in
+              let filtered_result =
+                Base.Map.fold
+                  o
+                  ~init:(Ok DvalMap.empty)
+                  ~f:filter_propagating_errors
+              in
+              (match filtered_result with Ok o -> DObj o | Error dv -> dv)
+          | args ->
+              fail args)
+    ; ps = true
     ; dep = false }
   ; { pns = ["Dict::empty"]
     ; ins = []

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -176,6 +176,7 @@ let t_result_stdlibs_work () =
 
 let t_dict_stdlibs_work () =
   let dstr = Dval.dstr_of_string_exn in
+  let dint i = DInt (Dint.of_int i) in
   check_dval
     "dict keys"
     (exec_ast "(Dict::keys (obj (key1 'val1')))")
@@ -213,13 +214,23 @@ let t_dict_stdlibs_work () =
   check_dval
     "dict filter keeps val"
     (exec_ast
-       "(Dict::filter (obj (key1 'val1') (key2 'val2')) (\\k v -> (== v 'val1')))")
+       "(Dict::filter_v1 (obj (key1 'val1') (key2 'val2')) (\\k v -> (== v 'val1')))")
     (DObj (DvalMap.from_list [("key1", dstr "val1")])) ;
   check_dval
     "dict filter keeps key"
     (exec_ast
-       "(Dict::filter (obj (key1 'val1') (key2 'val2')) (\\k v -> (== k 'key1')))")
+       "(Dict::filter_v1 (obj (key1 'val1') (key2 'val2')) (\\k v -> (== k 'key1')))")
     (DObj (DvalMap.from_list [("key1", dstr "val1")])) ;
+  check_dval
+    "dict filter propagates incomplete from lambda"
+    (exec_ast
+       "(Dict::filter_v1 (obj (key1 'val1') (key2 'val2')) (\\k v -> (== k _)))")
+    DIncomplete ;
+  check_dval
+    "dict filter ignores incomplete from obj"
+    (DObj (DvalMap.from_list [("key1", dint 1); ("key3", dint 3)]))
+    (exec_ast
+       "(Dict::filter_v1 (obj (key1 1) (key2 _) (key3 3)) (\\k v -> (> v 0)))") ;
   ()
 
 


### PR DESCRIPTION
The v0 logic here returns an empty dict if given a lambda that evaluates to Incomplete, which is incorrect (and inconsistent with `List::filter`).

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

