### PR TITLE
Fix most of the copy/paste in fluid

### DIFF
--- a/client/__tests__/fluid_clipboard_test.ml
+++ b/client/__tests__/fluid_clipboard_test.ml
@@ -987,14 +987,17 @@ let () =
   describe "Feature Flags" (fun () ->
       (* TODO: test feature flags, not yet in fluid *) () ) ;
   describe "Copy/paste roundtrip" (fun () ->
+      let longString =
+        EString
+          ( gid ()
+          , "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
+          )
+      in
       roundtrip (EBlank (gid ())) ;
       roundtrip (EInteger (gid (), "6")) ;
       roundtrip aThread ;
       roundtrip
         (EFnCall (gid (), "HttpClient::post_v4", [EString (gid (), "")], NoRail)) ;
-      roundtrip
-        (EString
-           ( gid ()
-           , "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
-           )) ;
+      roundtrip longString ;
+      roundtrip (ELet (gid (), gid (), "myVariable", longString, newB ())) ;
       () )

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -3837,7 +3837,8 @@ let reconstructExprFromRange ~state ~ast (range : int * int) : fluidExpr option
     | EString (eID, _), tokens ->
         let merged =
           tokens
-          |> List.filter ~f:(fun (_, _, type_) -> type_ <> "newline")
+          |> List.filter ~f:(fun (_, _, type_) ->
+                 type_ <> "newline" && type_ <> "indent" )
           |> List.map ~f:Tuple3.second
           |> String.join ~sep:""
         in


### PR DESCRIPTION
This solves a number of copy/paste bugs in fluid. They were all edge-case-type bugs, and not flaws with the framework.

## Pasting into multiline strings puts the text in the wrong place:
https://trello.com/c/fJLEvMbB/1976-pasting-into-a-string-that-reflows-puts-the-cursor-in-the-wrong-position

The copy/paste framework didn't account for multi-line strings when pasting, and so it used the wrong offset.

Before:
![Nov-19-2019 11-19-00](https://user-images.githubusercontent.com/181762/69178435-6e5eec00-0abe-11ea-832f-c911fbb75e09.gif)


After:
![Nov-19-2019 09-15-52](https://user-images.githubusercontent.com/181762/69169436-34d1b500-0aad-11ea-8962-907400a205c4.gif)

## Pasting a multiline string adds newlines
https://trello.com/c/wcFASq4A/1971-copy-pasting-long-text-inserts-newlines

This didn't account for multilines when copying, and so it included the newlines and the indents.

Before:
![Nov-19-2019 11-21-13](https://user-images.githubusercontent.com/181762/69178559-ba119580-0abe-11ea-9d42-bcbdaf24d598.gif)


After:
![Nov-19-2019 09-19-25](https://user-images.githubusercontent.com/181762/69169737-b6294780-0aad-11ea-80ab-6e53f53623c2.gif)

## Copy/pasting functions with versions created partials

https://trello.com/c/gS51xKJf/1981-copy-paste-considers-function-colors-functions-as-invalid

When copying a function, we didn't account for the version name. As a result, the fn name was different than the expected name, which we used as a signal to turn it into a partial.

Before:
![Nov-19-2019 11-22-20](https://user-images.githubusercontent.com/181762/69178674-e9c09d80-0abe-11ea-8801-da1ea124df33.gif)


After:
![Nov-19-2019 11-17-19](https://user-images.githubusercontent.com/181762/69178293-2d66d780-0abe-11ea-9310-11a6e50f6f03.gif)


## Copy/pasting threads went very wrong

https://trello.com/c/LhGPo8TH/1980-copy-paste-of-a-thread-adds-a-partial

When copying threads, we didn't account for the EThreadMarker when copying. 

Before:
![Nov-19-2019 11-23-36](https://user-images.githubusercontent.com/181762/69178745-0ceb4d00-0abf-11ea-9724-904ad8f0aa46.gif)

After:
![Nov-19-2019 11-16-10](https://user-images.githubusercontent.com/181762/69178233-0c9e8200-0abe-11ea-9e99-3ec488e54a42.gif)


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

