### PR TITLE
Remove Content-Length Header from Copied curl Command

### DIFF
--- a/client/src/Curl.ml
+++ b/client/src/Curl.ml
@@ -21,6 +21,10 @@ let objAsHeaderCurl (dv : dval) : string option =
   match dv with
   | DObj o ->
       StrDict.toList o
+      (* curl will add content-length automatically, and having it specified
+       * explicitly causes weird errors if the user, say, changes the body of
+       * the request without changing the value of this header *)
+      |> List.filter ~f:(fun (k, _) -> k != "content-length")
       |> List.map ~f:(fun (k, v) ->
              "-H '" ^ k ^ ":" ^ (RT.toRepr v |> RT.stripQuotes) ^ "'" )
       |> String.join ~sep:" "


### PR DESCRIPTION
## What

Does what it says on the tin.

## Why

https://trello.com/c/fgFkWTTT

There was much confusion during an onboarding over this. The developer attempted to copy-to-curl and then modify the body of the request without changing the Content-Length to be correct. This results in something upstream of OCaml (a LB?) returning a 400 response and forcibly closing the HTTP2 stream, which just looks like a generic curl error:

```curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)```

Neither Ellen nor the developer knew what was going wrong and ended up removing all the header flags (`-H`) from the curl command to fix it.

I believe curl will correctly calculate the Content-Length of the outbound request in every case, so this header should be safe to drop completely. I don't love the idea of making the copy-as-curl  differ from the actual trace request that came in, but I think it's our best option to avoid confusion. 

/cc @JessicaJenkins 