### PR TITLE
Cmd + arrow should go to frond/end of line

### DIFF
--- a/client/src/FluidKeyboard.ml
+++ b/client/src/FluidKeyboard.ml
@@ -145,11 +145,11 @@ let fromKeyboardCode (shift : bool) (ctrl : bool) (meta : bool) (code : int) :
   | 36 ->
       Home
   | 37 ->
-      Left
+      if osCmdKeyHeld then GoToStartOfLine else Left
   | 38 ->
       Up
   | 39 ->
-      Right
+      if osCmdKeyHeld then GoToEndOfLine else Right
   | 40 ->
       Down
   | 45 ->


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Trello: 
https://trello.com/c/R5HQWedN/1986-keyboard-shortcut-cmd-arrow

We should check if a user is holding down the cmd key while the hit the arrow keys and if so we should move the cursor to the beg/end or left/right of the entire line

![2019-11-19 16 45 40](https://user-images.githubusercontent.com/32043360/69199284-5aca7a00-0aec-11ea-8b72-a49c6a48aa05.gif)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

