### PR TITLE
Show pause button on newly created workers

### DIFF
--- a/client/src/ViewData.ml
+++ b/client/src/ViewData.ml
@@ -9,8 +9,26 @@ module TL = Toplevel
 let pauseWorkerButton (vs : ViewUtils.viewState) (name : string) :
     msg Html.html =
   let strTLID = showTLID vs.tlid in
-  match vs.workerStats with
-  | Some ws when ws.schedule = Some "run" ->
+  let schedule =
+    vs.workerStats
+    |> Option.andThen ~f:(fun (ws : Types.workerStats) -> ws.schedule)
+    |> Option.withDefault ~default:"run"
+  in
+  match schedule with
+  | "pause" ->
+      Html.div
+        [ ViewUtils.eventNoPropagation ~key:("run-" ^ strTLID) "click" (fun _ ->
+              RunWorker name )
+        ; Html.class' "restart-worker"
+        ; Html.title "Run worker" ]
+        [ViewUtils.fontAwesome "play-circle"]
+  | "block" ->
+      Html.div
+        [ Html.class' "blocked-worker"
+        ; Html.title
+            "Worker disabled by Dark. Please get in touch to discuss why." ]
+        [ViewUtils.fontAwesome "ban"]
+  | "run" ->
       Html.div
         [ ViewUtils.eventNoPropagation
             ~key:("pause-" ^ strTLID)
@@ -19,19 +37,6 @@ let pauseWorkerButton (vs : ViewUtils.viewState) (name : string) :
         ; Html.class' "pause-worker"
         ; Html.title "Pause worker" ]
         [ViewUtils.fontAwesome "pause-circle"]
-  | Some ws when ws.schedule = Some "pause" ->
-      Html.div
-        [ ViewUtils.eventNoPropagation ~key:("run-" ^ strTLID) "click" (fun _ ->
-              RunWorker name )
-        ; Html.class' "restart-worker"
-        ; Html.title "Run worker" ]
-        [ViewUtils.fontAwesome "play-circle"]
-  | Some ws when ws.schedule = Some "block" ->
-      Html.div
-        [ Html.class' "blocked-worker"
-        ; Html.title
-            "Worker disabled by Dark. Please get in touch to discuss why." ]
-        [ViewUtils.fontAwesome "ban"]
   | _ ->
       Vdom.noNode
 


### PR DESCRIPTION
## What

**Before**: (note it takes a page reload for the button to show up)
![2019-11-21 11 18 33](https://user-images.githubusercontent.com/131/69370161-64c6b700-0c6b-11ea-9478-2140dc93e2ac.gif)

**After**:
![2019-11-21 14 28 30](https://user-images.githubusercontent.com/131/69370166-67c1a780-0c6b-11ea-8326-1524aa010ca2.gif)

# Why

It was broken. https://trello.com/c/rSW16TE6/1965-bug-newly-created-workers-do-not-render-pause-button

# How

Quoting from the PR description:
> The problem here is that the `workerStats` state
> does not include the newly created worker, so it was getting rendered
> without the button.

⚠️ **Important** ⚠️ 

> Note that this is only correct so long as the server creates workers in
> the "run" state and if the server starts creating the handler paused,
> this will need to change.

I think this is okay for this low-effort fix. If we change server behavior in the future, we will need to think about a better solution.