### PR TITLE
Don't show the topbar if you previously hid it

### DIFF
--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -373,7 +373,10 @@ and serializableEditor (j : Js.Json.t) : serializableEditor =
       withDefault
         Defaults.defaultEditor.sidebarOpen
         (field "sidebarOpen" bool)
-        j }
+        j
+  ; showTopbar =
+      withDefault Defaults.defaultEditor.showTopbar (field "showTopbar" bool) j
+  }
 
 
 and cursorState j =

--- a/client/src/Defaults.ml
+++ b/client/src/Defaults.ml
@@ -28,7 +28,8 @@ let defaultEditor : serializableEditor =
   ; handlerProps = TLIDDict.empty
   ; canvasPos = origin
   ; lastReload = None
-  ; sidebarOpen = true }
+  ; sidebarOpen = true
+  ; showTopbar = true }
 
 
 let defaultFluidState : fluidState =

--- a/client/src/Editor.ml
+++ b/client/src/Editor.ml
@@ -52,7 +52,8 @@ let editor2model (e : serializableEditor) : model =
   ; handlerProps = finalHandlerStates e.handlerProps
   ; canvasProps = {m.canvasProps with offset = e.canvasPos}
   ; lastReload = e.lastReload
-  ; sidebarOpen = e.sidebarOpen }
+  ; sidebarOpen = e.sidebarOpen
+  ; showTopbar = e.showTopbar }
 
 
 let model2editor (m : model) : serializableEditor =
@@ -65,7 +66,8 @@ let model2editor (m : model) : serializableEditor =
   ; handlerProps = m.handlerProps
   ; canvasPos = m.canvasProps.offset
   ; lastReload = m.lastReload
-  ; sidebarOpen = m.sidebarOpen }
+  ; sidebarOpen = m.sidebarOpen
+  ; showTopbar = m.showTopbar }
 
 
 let setHandlerLock (tlid : tlid) (lock : bool) (m : model) : model =

--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -706,7 +706,8 @@ let serializableEditor (se : Types.serializableEditor) : Js.Json.t =
     ; ("canvasPos", pos se.canvasPos)
     ; ( "lastReload"
       , nullable string (Option.map ~f:Js.Date.toString se.lastReload) )
-    ; ("sidebarOpen", bool se.sidebarOpen) ]
+    ; ("sidebarOpen", bool se.sidebarOpen)
+    ; ("showTopbar", bool se.showTopbar) ]
 
 
 let fof (fof : Types.fourOhFour) : Js.Json.t =

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -1464,7 +1464,8 @@ and serializableEditor =
   ; handlerProps : handlerProp TLIDDict.t
   ; canvasPos : pos
   ; lastReload : (Js.Date.t[@opaque]) option
-  ; sidebarOpen : bool }
+  ; sidebarOpen : bool
+  ; showTopbar : bool }
 [@@deriving show {with_path = false}]
 
 and permission =


### PR DESCRIPTION
The topbar in fluid has a "hide" button that doesn't serialize, so the topbar reappears next time you refresh. Since we're just telling them it happened, and the other information is in the docs, maybe we should persist it between refreshes.

This might not be a good idea, or might be a good idea to do in a few days.

Tested by clicking hide and refreshing.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

