### PR TITLE
Replace String::sha{256,384} with Crypto::sha{256,384}

### DIFF
--- a/backend/libbackend/libcrypto.ml
+++ b/backend/libbackend/libcrypto.ml
@@ -77,6 +77,40 @@ let fns : Lib.shortfn list =
               fail args)
     ; ps = false
     ; dep = false }
+  ; { pns = ["Crypto::sha256"]
+    ; ins = []
+    ; p = [par "data" TBytes]
+    ; r = TBytes
+    ; d = "Computes the SHA-256 digest of the given `data`."
+    ; f =
+        InProcess
+          (function
+          | _, [DBytes data] ->
+              Cstruct.of_bytes data
+              |> Nocrypto.Hash.SHA256.digest
+              |> digest_to_bytes
+              |> DBytes
+          | args ->
+              fail args)
+    ; ps = false
+    ; dep = false }
+  ; { pns = ["Crypto::sha384"]
+    ; ins = []
+    ; p = [par "data" TBytes]
+    ; r = TBytes
+    ; d = "Computes the SHA-384 digest of the given `data`."
+    ; f =
+        InProcess
+          (function
+          | _, [DBytes data] ->
+              Cstruct.of_bytes data
+              |> Nocrypto.Hash.SHA384.digest
+              |> digest_to_bytes
+              |> DBytes
+          | args ->
+              fail args)
+    ; ps = false
+    ; dep = false }
   ; { pns = ["Crypto::sha256hmac"]
     ; ins = []
     ; p = [par "key" TBytes; par "data" TBytes]

--- a/backend/libexecution/libstring.ml
+++ b/backend/libexecution/libstring.ml
@@ -491,7 +491,8 @@ let fns : Lib.shortfn list =
     ; ins = []
     ; p = [par "s" TStr]
     ; r = TStr
-    ; d = "Take a string and hash it using SHA384."
+    ; d =
+        "Take a string and hash it using SHA384. Please use Crypto::sha384 instead."
     ; f =
         InProcess
           (function
@@ -501,12 +502,13 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["String::sha256"]
     ; ins = []
     ; p = [par "s" TStr]
     ; r = TStr
-    ; d = "Take a string and hash it using SHA256."
+    ; d =
+        "Take a string and hash it using SHA256. Please use Crypto::sha256 instead."
     ; f =
         InProcess
           (function
@@ -516,7 +518,7 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
-    ; dep = false }
+    ; dep = true }
   ; { pns = ["String::random"]
     ; ins = []
     ; p = [par "length" TInt]

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -441,6 +441,20 @@ let t_sha256hmac_for_aws () =
   ()
 
 
+let t_crypto_sha () =
+  check_dval
+    "Crypto::sha256 produces the correct digest"
+    (Dval.dstr_of_string_exn
+       "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855")
+    (exec_ast "(Bytes::hexEncode (Crypto::sha256 (String::toBytes '')))") ;
+  check_dval
+    "Crypto::sha384 produces the correct digest"
+    (Dval.dstr_of_string_exn
+       "38B060A751AC96384CD9327EB1B1E36A21FDB71114BE07434C0CC7BF63F6E1DA274EDEBFE76F65FBD51AD2F14898B95B")
+    (exec_ast "(Bytes::hexEncode (Crypto::sha384 (String::toBytes '')))") ;
+  ()
+
+
 let t_internal_functions () =
   Libbackend.Account.set_admin "test" true ;
   check_dval
@@ -483,4 +497,5 @@ let suite =
   ; ("Date lib works", `Quick, t_date_functions_work)
   ; ("Functions deprecated correctly", `Quick, t_old_functions_deprecated)
   ; ("Internal functions work", `Quick, t_internal_functions)
+  ; ("Crypto::sha digest functions work", `Quick, t_crypto_sha)
   ; ("Crypto::sha256hmac works for AWS", `Quick, t_sha256hmac_for_aws) ]


### PR DESCRIPTION
## What

Adds `Crypto::sha256` and `Crypto::sha384` and deprecates the `String` versions of these functions.

## Why

https://trello.com/c/1y0uXQkr

`Crypto::sha256` is required for implementing AWS Signature v4 signing, which is something Eagon is trying to do. Specifically, being able to get a lowercase hex-encoded version of the output digest is necessary, which is possible now  by using something like  `Crypto::sha256 dataBytes |> Bytes::hexEncode |> String::toLowercase`.

I've deprecated the `String::` versions of these functions because the `String -> String` signature with implicit base64 encoding is just confusing. We have `Bytes::base64Encode` which can encode the output of the `Crypto` versions of these calls if necessary.