### PR TITLE
TFnVersion should not get error styling

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -4928,7 +4928,7 @@ let toHtml ~(vs : ViewUtils.viewState) ~tlid ~state (ast : ast) :
           let sourceId, errorType = sourceOfExprValue analysisId in
           let isError =
             (* Only apply to text tokens (not TSep, TNewlines, etc.) *)
-            Token.isErrorable ti.token
+            Token.isErrorDisplayable ti.token
             && (* This expression is the source of its own incompleteness. We only draw underlines under sources of incompletes, not all propagated occurrences. *)
                sourceId |> Option.isSomeEqualTo ~value:analysisId
           in

--- a/client/src/FluidToken.ml
+++ b/client/src/FluidToken.ml
@@ -229,7 +229,8 @@ let isAutocompletable (t : token) : bool =
       false
 
 
-let isErrorable (t : token) : bool =
+(* Is this token something we can highlight as DError or DIncomplete? *)
+let isErrorDisplayable (t : token) : bool =
   isTextToken t && match t with TFnVersion _ -> false | _ -> true
 
 


### PR DESCRIPTION
One thing I noticed when setting up for demo is that function version although are text tokens, are styled differently and should technically behave like be belong in the fnname part.

The underlining of them is a bit off:
<img width="416" alt="Screen Shot 2019-11-22 at 2 48 37 PM" src="https://user-images.githubusercontent.com/244152/69465875-45955b80-0d37-11ea-806c-b381b4b882d5.png">

And when a fncall is evaluates to error, if the fn name has the cursor on, the version blinks. Which is an awkward behavior.
<img width="838" alt="Screen Shot 2019-11-22 at 2 27 50 PM" src="https://user-images.githubusercontent.com/244152/69465907-6a89ce80-0d37-11ea-9afd-a3009d391cc4.png">

I want to change it so, we don't mark the version token with a error class, so it gets neither the underline or will potentially blink.
<img width="838" alt="Screen Shot 2019-11-22 at 2 35 09 PM" src="https://user-images.githubusercontent.com/244152/69465947-8a20f700-0d37-11ea-8e98-b3d9e13a6446.png">


- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

