### PR TITLE
Reduce runtime from ~20s to ~8s by only launching 1 process per forma…

### DIFF
--- a/scripts/format
+++ b/scripts/format
@@ -129,15 +129,15 @@ check_ocamlformat() {
 }
 
 check_prettier () {
-  xargs -0L1 client/node_modules/.bin/prettier --list-different
+  xargs -0 client/node_modules/.bin/prettier --list-different
 }
 
 format_ocamlformat() {
-  xargs -0L1 ocamlformat --inplace 
+  xargs -0 ocamlformat --inplace 
 }
 
 format_prettier() {
-  xargs -0L1 client/node_modules/.bin/prettier --write
+  xargs -0 client/node_modules/.bin/prettier --write
 }
 
 do_ocamlformat() {


### PR DESCRIPTION
…tter, not per file

No need to do xargs -L1, prettier and ocamlformat both know how to
accept variadic file args.

- [ ] Trello link included (No trello)
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

