### PR TITLE
Fix DError encoding to not break

### DIFF
--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -120,8 +120,10 @@ let rec dval (dv : Types.dval) : Js.Json.t =
   (* user-ish types *)
   | DCharacter c ->
       ev "DCharacter" [string c]
-  | DError (_, msg) ->
-      ev "DError" [string msg]
+  | DError (SourceNone, msg) ->
+      ev "DError" [pair (ev "SourceNone") string ([], msg)]
+  | DError (SourceId i, msg) ->
+      ev "DError" [pair (ev "SourceId") string ([id i], msg)]
   | DResp (h, hdv) ->
       ev "DResp" [tuple2 dhttp dval (h, hdv)]
   | DDB name ->


### PR DESCRIPTION
## What

Fix the client encoding of a `DError` to properly encode the `dval_source`.


## Why

This encoder previously did not match the client decoder, so DError traversing the analysis worker / main thread boundary threw errors. Specifically: https://trello.com/c/R0faYhXn

**Before**:

<img width="629" alt="Screen Shot 2019-11-25 at 3 37 08 PM" src="https://user-images.githubusercontent.com/131/69576030-7aa0e880-0f99-11ea-88b0-627ae60e6a99.png">

**After**:

<img width="682" alt="Screen Shot 2019-11-25 at 3 34 41 PM" src="https://user-images.githubusercontent.com/131/69575863-21d15000-0f99-11ea-9643-3299bf010f62.png">
