### PR TITLE
Propagate DError during DObj creation

### DIFF
--- a/backend/test/test_language.ml
+++ b/backend/test/test_language.ml
@@ -130,6 +130,14 @@ let t_derror_propagation () =
     "ErrorRail in Error results in ErrorRail"
     (DErrorRail (DOption OptNothing))
     (exec_ast "(Error (`List::last_v1 []))") ;
+  check_error
+    "DError as dict value results in DError"
+    (exec_ast "(let v (+ 1 'a') (obj (k v)))")
+    "Dict contains Error value" ;
+  check_dval
+    "ErrorRail in dict value results in ErrorRail"
+    (DErrorRail (DOption OptNothing))
+    (exec_ast "(obj (err (`List::last_v1 [])))") ;
   ()
 
 


### PR DESCRIPTION
## What

Ensure you can't create a `DObj` like `{key: DError}`.

## Why

https://trello.com/c/lpjGyPu6/2014-derror-can-be-put-into-a-dict-as-a-value

I came across this while doing something else and thought I'd fix it because the old behavior seemed error prone to me.

<img width="700" alt="before" src="https://user-images.githubusercontent.com/131/69585356-74b50280-0fad-11ea-98ff-2b984bab7063.png">
<img width="666" alt="after" src="https://user-images.githubusercontent.com/131/69585363-78488980-0fad-11ea-930b-f366e68cda7f.png">
