### PR TITLE
Don't highlight source of incomplete when the caret is in a blank or on the same line

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -4925,10 +4925,10 @@ let toHtml ~(vs : ViewUtils.viewState) ~tlid ~state (ast : ast) :
     else (None, "")
   in
   let currentTokenInfo = getToken state ast in
-  let sourceOfCurrentToken =
+  let sourceOfCurrentToken onTi =
     currentTokenInfo
     |> Option.andThen ~f:(fun ti ->
-           if Token.isBlank ti.token
+           if Token.isBlank ti.token || onTi.startRow = ti.startRow
            then None
            else
              let someId, _ = Token.analysisID ti.token |> sourceOfExprValue in
@@ -4969,8 +4969,8 @@ let toHtml ~(vs : ViewUtils.viewState) ~tlid ~state (ast : ast) :
           ; (errorType, errorType <> "")
           ; (* This expression is the source of an incomplete propogated into another   expression, where the cursor is currently on *)
             ( "is-origin"
-            , sourceOfCurrentToken |> Option.isSomeEqualTo ~value:analysisId )
-          ]
+            , sourceOfCurrentToken ti |> Option.isSomeEqualTo ~value:analysisId
+            ) ]
         in
         Html.span
           [ Html.classList (cls @ conditionalClasses)


### PR DESCRIPTION
![dontflash mov](https://user-images.githubusercontent.com/244152/69585477-abcaea00-0f94-11ea-930f-b3bb50b7fc48.gif)
When you are on the same line and in another blank, don't flash the incomplete source

<img width="426" alt="doflash" src="https://user-images.githubusercontent.com/244152/69585521-c8ffb880-0f94-11ea-9c57-aa30063a3b5d.png">
We still want to flash the incomplete source if it is on a different line.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

