### PR TITLE
Move new toplevels to the side a little when the sidebar is open

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1024,11 +1024,18 @@ let toggleTimers (m : model) : model =
 
 
 let findCenter (m : model) : pos =
-  match m.currentPage with
-  | Architecture | FocusedHandler _ | FocusedDB _ | FocusedGroup _ ->
-      Viewport.toCenter m.canvasProps.offset
-  | _ ->
-      Defaults.centerPos
+  let {x; y} =
+    match m.currentPage with
+    | Architecture | FocusedHandler _ | FocusedDB _ | FocusedGroup _ ->
+        Viewport.toCenter m.canvasProps.offset
+    | _ ->
+        Defaults.centerPos
+  in
+  (* if the sidebar is open, the users can't see the livevalues, which
+   * confused new users. Given we can't get z-index to work, moving it to the
+   * side a little seems the best solution for now. *)
+  let xOffset = if m.sidebarOpen then 160 else 0 in
+  {x = x + xOffset; y}
 
 
 let update_ (msg : msg) (m : model) : modification =


### PR DESCRIPTION
https://trello.com/c/jdzJnvPL/2000-if-the-sidebar-is-open-make-the-new-position-for-new-handlers-an-extra-space-to-the-right

New users can't see live values when the sidebar is open, which it is by default. Ideally, we could have solved this with z-indexes, but that's a nightmare of a different sort. So we moved the new toplevels to the right a little.

Before:
![Nov-26-2019 18-18-11](https://user-images.githubusercontent.com/181762/69687841-253c0880-1079-11ea-9796-4c5e710e2888.gif)


After:
![Nov-26-2019 18-16-55](https://user-images.githubusercontent.com/181762/69687778-f6259700-1078-11ea-877b-7879e8af3809.gif)


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

