### PR TITLE
Allow hyphens in record field names

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -48,7 +48,9 @@ let removeCharAt str offset : string =
 
 let isNumber (str : string) = Js.Re.test_ [%re "/[0-9]+/"] str
 
-let isIdentifierChar (str : string) = Js.Re.test_ [%re "/[_a-zA-Z0-9]+/"] str
+let isRecordFieldNameChar (str : string) =
+  Js.Re.test_ [%re "/[_a-zA-Z0-9-]+/"] str
+
 
 let isFnNameChar str =
   Js.Re.test_ [%re "/[_:a-zA-Z0-9]/"] str && String.length str = 1
@@ -3244,7 +3246,7 @@ let doInsert' ~pos (letter : char) (ti : tokenInfo) (ast : ast) (s : state) :
     | TFieldName _
     | TLambdaVar _
     | TRecordFieldname _
-      when not (isIdentifierChar letterStr) ->
+      when not (isRecordFieldNameChar letterStr) ->
         (ast, SamePlace)
     | TVariable _
     | TPatternVariable _


### PR DESCRIPTION
This will allow setting user-agent headers in HttpClient requests

https://trello.com/c/5rI1Y9Zk/2067-obj-keys-must-allow-or-we-cant-use-headers-in-httpclient

This blocks merge-if-ci-complete because https://developer.github.com/v3/#user-agent-required

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

