### PR TITLE
Make docker reap orphan processes in scripts/builder

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -135,6 +135,12 @@ fi
 # --------------
 echo "Run the build"
 
+# --init here keeps orphaned processes (`<defunct>`, in ps) from
+# hanging around forever; see https://tech.fpcomplete.com/rust/pid1
+# (above the fold) for a description of the process 1 problem in
+# docker, and
+# https://docs.docker.com/engine/reference/run/#specify-an-init-process
+# for documentation of --init.
 $FSWATCH | docker run \
              --init \
              --rm \


### PR DESCRIPTION
tl;dr: pid 1 is responsible for reaping orphans, docker breaks this if
you have a multiprocess container. Which is why, in our local
scripts/builder container, we end up with lots of <defunct> processes.

Not a functional problem, but a minor annoyance if one is running ps to
check up on one's dev env. Solved by using docker's --init flag. Only
affects the local env, because this is in scripts/builder.

(See https://tech.fpcomplete.com/rust/pid1 for more about pid 1 and
various solutions to this problem; it's how I discovered docker --init,
which is doc'd at
https://docs.docker.com/engine/reference/run/#specify-an-init-process)

https://trello.com/c/Uh2vEqMh/2076-use-docker-init-to-avoid-orphan-processes-in-dev-container

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

