### PR TITLE
Don't show topbar (but keep topbar code around for next time).

### DIFF
--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -377,8 +377,10 @@ and serializableEditor (j : Js.Json.t) : serializableEditor =
         (field "sidebarOpen" bool)
         j
   ; showTopbar =
-      withDefault Defaults.defaultEditor.showTopbar (field "showTopbar" bool) j
-  }
+      withDefault
+        Defaults.defaultEditor.showTopbar
+        (field "showTopbar1" bool)
+        j }
 
 
 and cursorState j =

--- a/client/src/Defaults.ml
+++ b/client/src/Defaults.ml
@@ -29,7 +29,7 @@ let defaultEditor : serializableEditor =
   ; canvasPos = origin
   ; lastReload = None
   ; sidebarOpen = true
-  ; showTopbar = true }
+  ; showTopbar = false }
 
 
 let defaultFluidState : fluidState =

--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -711,7 +711,7 @@ let serializableEditor (se : Types.serializableEditor) : Js.Json.t =
     ; ( "lastReload"
       , nullable string (Option.map ~f:Js.Date.toString se.lastReload) )
     ; ("sidebarOpen", bool se.sidebarOpen)
-    ; ("showTopbar", bool se.showTopbar) ]
+    ; ("showTopbar1", bool se.showTopbar) ]
 
 
 let fof (fof : Types.fourOhFour) : Js.Json.t =

--- a/client/src/ViewTopbar.ml
+++ b/client/src/ViewTopbar.ml
@@ -1,4 +1,3 @@
-open Tc
 open Prelude
 open Types
 
@@ -8,43 +7,29 @@ let msgLink ~(key : string) (content : msg Html.html) (handler : msg) :
   Html.a [event; Html.class' ""] [content]
 
 
-let html (m : model) =
-  if m.showTopbar && VariantTesting.isFluid m.tests
+let html (_m : model) =
+  (* If you need to add a topbar, the steps are:
+    * - set the default in Defaults.ml
+    * - edit the text and links below
+    * - change the name of the key in serializedEditor, in encoders.ml
+    *   and decoders.ml. Otherwise, the user's old "showTopbar" setting
+    *   will be used.
+    *)
+  if false (* m.showTopbar *)
   then
-    let nonFluidUrl =
-      let qp =
-        Url.queryParams
-        |> List.uniqueBy ~f:(fun (k, _) -> k)
-        |> List.filter ~f:(fun (_, v) -> v)
-        |> List.map ~f:(fun (k, _) -> k ^ "=1")
-        |> List.cons "fluid=0"
-        |> String.join ~sep:"&"
-        |> fun s -> "?" ^ s
-      in
+    let url =
+      let qp = "" in
       let loc = {(Tea.Navigation.getLocation ()) with search = qp} in
       loc.protocol ^ "//" ^ loc.host ^ loc.pathname ^ loc.search ^ loc.hash
     in
     [ Html.div
         [Html.styles []; Html.classList [("topbar", true)]]
-        [ Html.text
-            "This is our new \"Fluid\" editor. Typing code should mostly feel just like text. "
-        ; Html.br []
-        ; Html.a
-            [ Html.href nonFluidUrl
+        [ Html.a
+            [ Html.href url
             ; ViewUtils.eventNoPropagation
-                ~key:"toggle-fluid"
+                ~key:"toggle-topbar"
                 "mouseup"
                 (fun _ -> IgnoreMsg ) ]
-            [Html.text "(go to the old editor)"]
-        ; Html.text " "
-        ; Html.a
-            [ Html.href
-                "https://darkcommunity.slack.com/archives/CQWEKP85V/p1574372251002600"
-            ; ViewUtils.eventNoPropagation
-                ~key:"send-feedback"
-                "mouseup"
-                (fun _ -> IgnoreMsg ) ]
-            [Html.text "(send us feedback!)"]
-        ; Html.br []
+            [Html.text "Fill in message here"]
         ; msgLink ~key:"hide-topbar" (Html.text "(hide)") HideTopbar ] ]
   else []


### PR DESCRIPTION
https://trello.com/c/XjE8ViY0/2080-get-rid-of-teal-banner

This removes the topbar. We will likely want it again in the future, so it's worth keeping the code around.

- [x] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

