### PR TITLE
Give me tlid+trace_id on success, not just failure

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1021,15 +1021,16 @@ let get_trace_data ~(execution_id : Types.id) (host : string) (body : string) :
   in
   let resp_headers = server_timing [t1; t2; t3; t4; t5] in
   let new_log_items =
+    [ ("trace_id", `String (Uuidm.to_string trace_id))
+    ; ("tlid", `String (Types.string_of_id tlid)) ]
+    @
     match result with
     | Ok (Some _) ->
         []
     | Ok None ->
-        [ ("warning", `String "no handler or userfn found")
-        ; ("trace_id", `String (Uuidm.to_string trace_id))
-        ; ("tlid", `String (Types.string_of_id tlid)) ]
+        [("warning", `String "no handler or userfn found")]
     | Error e ->
-        [("error", `String e); ("tlid", `String (Types.string_of_id tlid))]
+        [("error", `String e)]
   in
   Log.add_log_annotations new_log_items (fun _ ->
       match result with


### PR DESCRIPTION
I can quickly cause 200s and 404s in a new canvas, but I want to be sure
what's different between the two.

followup to https://github.com/darklang/dark/pull/1622

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

