### PR TITLE
Dont lose autocomplete

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1925,36 +1925,6 @@ let update_ (msg : msg) (m : model) : modification =
       TweakModel (Editor.setHandlerMenu tlid show)
   | FluidMsg (FluidStartSelection targetExnID) ->
       Many [Select (targetExnID, None); StartFluidMouseSelecting targetExnID]
-  | FluidMsg (FluidUpdateSelection (targetExnID, selection)) ->
-      Many
-        [ Select (targetExnID, None)
-        ; TweakModel
-            (fun m ->
-              let selection =
-                Option.orElseLazy
-                  (fun () -> Entry.getFluidSelectionRange ())
-                  selection
-              in
-              match selection with
-              (* if range width is 0, just change pos *)
-              | Some (selBegin, selEnd) when selBegin = selEnd ->
-                  { m with
-                    fluidState =
-                      { m.fluidState with
-                        oldPos = m.fluidState.newPos
-                      ; newPos = selEnd
-                      ; selectionStart = None } }
-              | Some (selBegin, selEnd) ->
-                  { m with
-                    fluidState =
-                      { m.fluidState with
-                        selectionStart = Some selBegin
-                      ; oldPos = m.fluidState.newPos
-                      ; newPos = selEnd } }
-              | None ->
-                  { m with
-                    fluidState = {m.fluidState with selectionStart = None} } )
-        ]
   | FluidMsg msg ->
       (* Handle all other messages *)
       Fluid.update m msg


### PR DESCRIPTION
This fixes two big bugs:

https://trello.com/c/rGPdqtnY/2055-autocomplete-can-make-livevalues-vanish
https://trello.com/c/uTOdowWM/2005-cant-scroll

The first is live values vanishing. This happened when the autocomplete was visible, and then you clicked elsewhere:

Before:
![Dec-05-2019 14-04-31](https://user-images.githubusercontent.com/181762/70277963-33201680-1768-11ea-98a4-377eab007812.gif)

After:
![Dec-05-2019 14-07-20](https://user-images.githubusercontent.com/181762/70278149-95791700-1768-11ea-97aa-ed1bf37caec6.gif)

This happened because the autocomplete state was kept, and so we thought the autocomplete was open. We don't show live values for an open autocomplete (mostly).

You know what else was caused by this? The scrolling bugs! You couldn't scroll because the autocomplete was open, and that doesn't let you scroll. It wasn't open, of course, we just thought it was.

The cause in the code was that we did some Fluid Selection Updates in App.ml, instead of running through the same gauntlet as the other updates. The solution was to integrate it.




 [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

