### PR TITLE
Remove updating of autocomplete/command palette index on hover

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1069,10 +1069,6 @@ let update_ (msg : msg) (m : model) : modification =
         Entry.submit newm cursor Entry.StayHere
     | _ ->
         NoChange )
-  | FluidMsg (FluidUpdateDropdownIndex index) ->
-      if VariantTesting.isFluid m.tests
-      then Fluid.update m (FluidUpdateDropdownIndex index)
-      else NoChange
   | FluidMsg (FluidAutocompleteClick item) ->
     ( match unwrapCursorState m.cursorState with
     | FluidEntering _ ->

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -4939,12 +4939,6 @@ let update (m : Types.model) (msg : Types.fluidMsg) : Types.modification =
   let s = m.fluidState in
   let s = {s with error = None; oldPos = s.newPos; actions = []} in
   match msg with
-  | FluidUpdateDropdownIndex index when FluidCommands.isOpened m.fluidState.cp
-    ->
-      FluidCommands.cpSetIndex m index s
-  | FluidUpdateDropdownIndex index ->
-      let newState = acSetIndex index s in
-      Types.TweakModel (fun m -> {m with fluidState = newState})
   | FluidKeyPress {key} when key = K.Undo ->
       KeyPress.undo_redo m false
   | FluidKeyPress {key} when key = K.Redo ->
@@ -5096,11 +5090,7 @@ let viewAutocomplete (ac : Types.fluidAutocompleteState) : Types.msg Html.html
           ; ViewEntry.defaultPasteHandler
           ; ViewUtils.nothingMouseEvent "mousedown"
           ; ViewUtils.eventNoPropagation ~key:("ac-" ^ name) "click" (fun _ ->
-                FluidMsg (FluidAutocompleteClick item) )
-          ; ViewUtils.eventBoth
-              ~key:("ac-mouseover" ^ name)
-              "mouseover"
-              (fun _ -> FluidMsg (FluidUpdateDropdownIndex i) ) ]
+                FluidMsg (FluidAutocompleteClick item) ) ]
           [ Html.text fnDisplayName
           ; versionView
           ; Html.span [Html.class' "types"] [Html.text <| AC.asTypeString item]

--- a/client/src/FluidCommands.ml
+++ b/client/src/FluidCommands.ml
@@ -165,9 +165,7 @@ let viewCommandPalette (cp : Types.fluidCommandState) : Types.msg Html.html =
       ; ViewEntry.defaultPasteHandler
       ; ViewUtils.nothingMouseEvent "mousedown"
       ; ViewUtils.eventNoPropagation ~key:("cp-" ^ name) "click" (fun _ ->
-            FluidMsg (FluidCommandsClick item) )
-      ; ViewUtils.eventBoth ~key:("-mouseover" ^ name) "mouseover" (fun _ ->
-            FluidMsg (FluidUpdateDropdownIndex i) ) ]
+            FluidMsg (FluidCommandsClick item) ) ]
       [Html.text name]
   in
   let filterInput =
@@ -184,14 +182,6 @@ let viewCommandPalette (cp : Types.fluidCommandState) : Types.msg Html.html =
       [Html.ul [] (List.indexedMap ~f:viewCommands cp.commands)]
   in
   Html.div [Html.class' "command-palette"] [filterInput; cmdsView]
-
-
-let cpSetIndex (_m : Types.model) (i : int) (s : Types.fluidState) :
-    Types.modification =
-  let newState = {s with cp = {s.cp with index = i}; upDownCol = None} in
-  let cmd = Types.MakeCmd (focusItem i) in
-  let m = Types.TweakModel (fun m -> {m with fluidState = newState}) in
-  Types.Many [m; cmd]
 
 
 let updateCmds (m : Types.model) (keyEvt : K.keyEvent) : Types.modification =

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -993,7 +993,6 @@ and fluidMsg =
   | FluidCommandsFilter of string
   | FluidCommandsClick of command
   (* Index of the dropdown(autocomplete or command palette) item *)
-  | FluidUpdateDropdownIndex of int
   | FluidFocusOnToken of id
   | FluidClearErrorDvSrc
 

--- a/client/src/styles/_fluid.scss
+++ b/client/src/styles/_fluid.scss
@@ -375,6 +375,16 @@ since they are essentially both commands just acting upon different things. */
         }
       }
     }
+    ul:hover {
+      .fluid-selected,
+      li {
+        background: transparent;
+        &:hover {
+          background-color: $highlight-color;
+          color: darken(white, 5%);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Trello: 
https://trello.com/c/PuThXZPF/2090-dont-change-autocomplete-command-palette-index-on-mouse-hover

Highlight list items when hovering over them, but go back to highlighting the selected item  (determined by autocomplete/command palette index) while not hovering. 

![2019-12-06 10 28 55](https://user-images.githubusercontent.com/32043360/70346997-6f10b580-1814-11ea-9e5b-deaa45ddc516.gif)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

