### PR TITLE
Don't destroy selection when a user hits alt

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -4908,8 +4908,8 @@ let updateMsg m tlid (ast : ast) (msg : Types.fluidMsg) (s : fluidState) :
           if key = K.Left then left else right
         in
         (ast, {s with lastKey = key; newPos; selectionStart = None})
-    | FluidKeyPress {key; metaKey; ctrlKey}
-      when (metaKey || ctrlKey) && shouldDoDefaultAction key ->
+    | FluidKeyPress {key; altKey; metaKey; ctrlKey}
+      when (altKey || metaKey || ctrlKey) && shouldDoDefaultAction key ->
         (* To make sure no letters are entered if user is doing a browser default action *)
         (ast, s)
     | FluidKeyPress {key; shiftKey} ->


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Trello: 
https://trello.com/c/Q6tObBAz/2062-pressing-alt-destroys-the-existing-editor-selection-which-makes-it-impossible-to-use-the-command-palette-on-selected-stuff

Follow up Trello for Alt-X :
https://trello.com/c/On5Qt3g7/2091-alt-x-on-a-selection-doesnt-work-consistently

We don't want to change the ast or state when a user hits just `alt`, now we will no longer delete the current selection.

Before: 
![2019-12-06 11 29 09](https://user-images.githubusercontent.com/32043360/70350460-a5056800-181b-11ea-9ac0-27ffab20dde7.gif)

After: 
![alt doesn't destroy selection](https://user-images.githubusercontent.com/32043360/70350481-ae8ed000-181b-11ea-9cca-2d16078d799f.gif)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

