### PR TITLE
Convert partials with quotes around them into strings

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -919,6 +919,21 @@ let () =
         (key K.DeleteNextWord 42)
         ( "\"123456789_abcdefghi,123456789_abcdefghi,\n"
         ^ "~ abcdefghi, 123456789_ abcdefghi,\"" ) ;
+      t
+        "adding a quote at the front turns a partial into a string"
+        (partial "abcdefgh\"" b)
+        (ins '"' 0)
+        "\"~abcdefgh\"" ;
+      t
+        "adding a quote at the back turns a partial into a string"
+        (partial "\"abcdefgh" b)
+        (ins '"' 9)
+        "\"abcdefgh\"~" ;
+      tp
+        "just one quote doesn't turn a partial into a string"
+        (partial "abcdefgh" b)
+        (ins '"' 0)
+        "\"~abcdefgh" ;
       () ) ;
   describe "Integers" (fun () ->
       t "insert 0 at front " anInt (ins '0' 0) "~12345" ;

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -1941,15 +1941,18 @@ let addRecordRowToBack (id : id) (ast : ast) : ast =
 let replaceWithPartial (str : string) (id : id) (ast : ast) : ast =
   updateExpr id ast ~f:(fun e ->
       let str = String.trim str in
-      match e with
-      | EPartial (id, _, oldVal) ->
-          asserT
-            "empty partial, use deletePartial instead"
-            (str <> "")
-            ~debug:str ;
-          EPartial (id, str, oldVal)
-      | oldVal ->
-          if str = "" then newB () else EPartial (gid (), str, oldVal) )
+      if String.startsWith ~prefix:"\"" str && String.endsWith ~suffix:"\"" str
+      then EString (gid (), String.slice ~from:1 ~to_:(-1) str)
+      else
+        match e with
+        | EPartial (id, _, oldVal) ->
+            asserT
+              ~debug:str
+              "empty partial, use deletePartial instead"
+              (str <> "") ;
+            EPartial (id, str, oldVal)
+        | oldVal ->
+            if str = "" then newB () else EPartial (gid (), str, oldVal) )
 
 
 let deletePartial (ti : tokenInfo) (ast : ast) (s : state) : ast * state =


### PR DESCRIPTION
https://trello.com/c/zbPZcuT6/2019-if-users-dont-begin-with-double-quotes-when-typing-a-string-adding-them-after-doesnt-fix-this

Ellen has been asking for this forever so I caved.

If the partial has quotes at both ends, boom, it's a string now.

Before:
![Dec-08-2019 09-43-47](https://user-images.githubusercontent.com/181762/70393484-449f3380-199f-11ea-8ce9-4833a23ea5d0.gif)

After:
![Dec-08-2019 09-43-39](https://user-images.githubusercontent.com/181762/70393483-449f3380-199f-11ea-827d-2834b7ec3de2.gif)


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

