### PR TITLE
Rename JSON::read to JSON::parse, which is more expected

### DIFF
--- a/backend/libexecution/libjson.ml
+++ b/backend/libexecution/libjson.ml
@@ -34,4 +34,19 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
+    ; dep = true }
+  ; { pns = ["JSON::parse_v0"]
+    ; ins = []
+    ; p = [par "json" TStr]
+    ; r = TAny
+    ; d =
+        "Parses a json string and returns its value. HTTPClient functions, and our request handler, automatically parse JSON into the `body` and `jsonbody` fields, so you probably won't need this. However, if you need to consume bad JSON, you can use string functions to fix the JSON and then use this function to parse it."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr json] ->
+              Dval.of_unknown_json_v1 (Unicode_string.to_string json)
+          | args ->
+              fail args)
+    ; ps = true
     ; dep = false } ]


### PR DESCRIPTION
This came up in an onboarding call. I don't remember why we called it JSON::read, but JSON::parse seems better.

https://trello.com/c/6br3Qimf/2099-rename-jsonread-to-jsonparse

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

