### PR TITLE
DBstats and connected-handlers appeared intermittently in fluid

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1148,7 +1148,7 @@ let update_ (msg : msg) (m : model) : modification =
         | Some (TLHandler _) | Some (TLDB _) | Some (TLGroup _) ->
             Drag (targetTLID, event.mePos, false, m.cursorState)
       else NoChange
-  | TLDragRegionMouseUp (_, event) ->
+  | TLDragRegionMouseUp (tlid, event) ->
       if event.button = Defaults.leftButton
       then
         match m.cursorState with
@@ -1184,11 +1184,13 @@ let update_ (msg : msg) (m : model) : modification =
                             ([MoveTL (draggingTLID, TL.pos tl)], FocusNoChange)
                         ]
                 else SetCursorState origCursorState
-              else SetCursorState origCursorState
+              else
+                Select (draggingTLID, None)
+                (* if we haven't moved, treat this as a single click  and not a attempted drag*)
           | None ->
               SetCursorState origCursorState )
         | _ ->
-            FluidEndClick
+            Many [Select (tlid, None); FluidEndClick]
       else NoChange
   | BlankOrClick (targetExnID, targetID, event) ->
       let select tlid id =

--- a/client/src/ViewDB.ml
+++ b/client/src/ViewDB.ml
@@ -29,7 +29,7 @@ let viewDbCount (stats : dbStats) : msg Html.html =
         [Html.text ("# of Entries: " ^ string_of_int stats.count)] ]
 
 
-let viewDbLatestEnry (stats : dbStats) : msg Html.html =
+let viewDbLatestEntry (stats : dbStats) : msg Html.html =
   let title =
     Html.div
       [Html.class' "title"]
@@ -55,7 +55,7 @@ let viewDbLatestEnry (stats : dbStats) : msg Html.html =
 let viewDBData (vs : viewState) (db : db) : msg Html.html =
   match StrDict.get ~key:(deTLID db.dbTLID) vs.dbStats with
   | Some stats when tlidOf vs.cursorState = Some db.dbTLID ->
-      let liveVal = viewDbLatestEnry stats in
+      let liveVal = viewDbLatestEntry stats in
       let count = viewDbCount stats in
       Html.div [Html.class' "dbdata"] [count; liveVal]
   | _ ->

--- a/client/src/styles/_db.scss
+++ b/client/src/styles/_db.scss
@@ -152,16 +152,21 @@
   }
 
   .dbtitle {
-    background-image: url("/_db.png");
-    background-position: left center;
-    background-repeat: no-repeat;
-    padding-left: 20px;
-    /* Adjust according to image size to push text across. */
     margin-bottom: 10px;
     margin: 0 auto;
 
+    width: 100%;
+    text-align: center;
+    border-bottom: 1px solid #b8b8b8;
+    padding-bottom: $spacing-medium;
+
     /* center the db name */
     &::before {
+      background-image: url("/_db.png");
+      background-position: left center;
+      background-repeat: no-repeat;
+      padding-left: 20px;
+      /* Adjust according to image size to push text across. */
       content: "DB: ";
       font-weight: bold;
       font-size: 110%;

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -893,7 +893,7 @@ test("execute_function_works", async t => {
 
   let v1 = await Selector(".selected .live-value").innerText;
 
-  await t.click(Selector(".fa-redo"));
+  await t.click(Selector(".fa-redo")).click(Selector(".fncall"));
 
   let v2 = await Selector(".selected .live-value").innerText;
 


### PR DESCRIPTION
Problem: Dragging and Clicking are handled separately (TLDragRegionMouseUp and ToplevelClick); prior to this PR, we didn't `Select` the tlid if we didn't drag, we just ... ignored the click entirely. This change says we should Select the tlid if we don't move it. Which is the expected behavior.

We also added a line under DBTitle; this makes it somewhat more visually consistent with TLHandler, etc, though we probably want to redo all of the TLs to make their appearance consistent.

![dbstats](https://user-images.githubusercontent.com/172694/70475901-6f19eb00-1a8a-11ea-8c7b-3e492ac32462.gif)

Now with a horizontal line to differentiate top (draggable) from bottom (clickable): 
![image](https://user-images.githubusercontent.com/172694/70482023-40574100-1a99-11ea-8976-7e91afa29d20.png)


https://trello.com/c/6YvEjT9x/2040-most-recent-db-entry-and-connected-workers-handlers-appear-intermittently-in-fluid

I _think_ this also fixes https://trello.com/c/oUXiZEqk/2050-datastores-with-recent-entries-display-0-entries-when-clicked-on, in that, if not all clicks had an effect, this is what you'd see.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

