### PR TITLE
Change the add_op handler to use `load_with_context`

### DIFF
--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -247,6 +247,13 @@ let apply_op (is_new : bool) (op : Op.op) (c : canvas ref) : unit =
     Exception.reraise e
 
 
+(* NOTE: If you add a new verification here, please ensure all places that
+ * load canvases/apply ops correctly load the requisite data.
+ *
+ * eg. The `admin_add_op_handler` in webserver.ml uses `load_with_context` at
+ * time of writing. This would not be sufficient if the new verifier required
+ * an invariant across eg. all handlers.
+ * *)
 let verify (c : canvas ref) : (unit, string list) Result.t =
   let duped_db_names =
     !c.dbs

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -707,7 +707,14 @@ let admin_add_op_handler
   let ops = params.ops in
   let tlids = List.filter_map ~f:Op.tlidOf ops in
   let t2, maybe_c =
-    time "2-load-saved-ops" (fun _ -> C.load_only_tlids ~tlids host ops)
+    (* NOTE: Because we run canvas-wide validation logic, it's important
+     * that we load _at least_ the context (ie. datastores, functions, types etc. )
+     * and not just the tlids in the API payload.
+     *
+     * `load_with_context` is currently sufficient because the only global check is across
+     * DBs, but if it were across all handlers in the future we would need `load_all`
+     * *)
+    time "2-load-saved-ops" (fun _ -> C.load_with_context ~tlids host ops)
   in
   match maybe_c with
   | Ok c ->


### PR DESCRIPTION
- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

I can't find a trello for this, but we had previously (before Thanksgiving?) determined that we wanted to do this and I noticed that we hadn't when chatting with @dstrelau on Slack, so doing it now before I forget again.

The issue here is `Canvas.verify` requires _all_ the datastores to be loaded to correctly check the Datastore name uniqueness variant, but the `admin_add_op_handler` only loaded the tlids present in the RPC payload. This means that if you have a stale client that is unaware of the existence of a datastore of the same name (ie. due to a broken/delayed Pusher pipe) then you can have erroneous RPCs being accepted, which results in the Canvas being unloadable.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

