### PR TITLE
Fix integration test screenshots path to not include "path=" in the directory name

### DIFF
--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -90,7 +90,7 @@ else
     --app-init-delay 0 \
     --pageload-timeout 200 \
     --screenshots takeOnFails=true \
-    --screenshots path=rundir/screenshots/ \
+    --screenshots rundir/screenshots/ \
     --concurrency "$CONCURRENCY" \
     --reporter=spec \
     $debugcmd \


### PR DESCRIPTION
@IanConnolly noticed that I had a bunch of screenshots being generated in 
`dark/path=rundir/screenshots/*`

This fixes that so they get saved in `dark/rundir/screenshots/*` instead.