### PR TITLE
Fix types due to earlier PR

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1220,12 +1220,12 @@ let update_ (msg : msg) (m : model) : modification =
                         ]
                 else SetCursorState origCursorState
               else
-                Select (draggingTLID, None)
-                (* if we haven't moved, treat this as a single click  and not a attempted drag*)
+                (* if we haven't moved, treat this as a single click and not a attempted drag *)
+                Select (draggingTLID, STTopLevelRoot)
           | None ->
               SetCursorState origCursorState )
         | _ ->
-            Many [Select (tlid, None); FluidEndClick]
+            Many [Select (tlid, STTopLevelRoot); FluidEndClick]
       else NoChange
   | BlankOrClick (targetExnID, targetID, event) ->
       let select tlid id =


### PR DESCRIPTION
When https://github.com/darklang/dark/pull/1645 merged into master, it introduced a type conflict with code that had merged slightly earlier. This makes the client compile again.