### PR TITLE
Update the autocomplete index when the mouse moves in autocomplete list

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1101,6 +1101,10 @@ let update_ (msg : msg) (m : model) : modification =
         Entry.submit newm cursor Entry.StayHere
     | _ ->
         NoChange )
+  | FluidMsg (FluidUpdateDropdownIndex index) ->
+      if VariantTesting.isFluid m.tests
+      then Fluid.update m (FluidUpdateDropdownIndex index)
+      else NoChange
   | FluidMsg (FluidAutocompleteClick item) ->
     ( match unwrapCursorState m.cursorState with
     | FluidEntering _ ->

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -5490,6 +5490,12 @@ let update (m : Types.model) (msg : Types.fluidMsg) : Types.modification =
   let s = m.fluidState in
   let s = {s with error = None; oldPos = s.newPos; actions = []} in
   match msg with
+  | FluidUpdateDropdownIndex index when FluidCommands.isOpened m.fluidState.cp
+    ->
+      FluidCommands.cpSetIndex m index s
+  | FluidUpdateDropdownIndex index ->
+      let newState = acSetIndex index s in
+      Types.TweakModel (fun m -> {m with fluidState = newState})
   | FluidKeyPress {key} when key = K.Undo ->
       KeyPress.undo_redo m false
   | FluidKeyPress {key} when key = K.Redo ->
@@ -5641,7 +5647,11 @@ let viewAutocomplete (ac : Types.fluidAutocompleteState) : Types.msg Html.html
           ; ViewEntry.defaultPasteHandler
           ; ViewUtils.nothingMouseEvent "mousedown"
           ; ViewUtils.eventNoPropagation ~key:("ac-" ^ name) "click" (fun _ ->
-                FluidMsg (FluidAutocompleteClick item) ) ]
+                FluidMsg (FluidAutocompleteClick item) )
+          ; ViewUtils.eventBoth
+              ~key:("ac-mousemove" ^ name)
+              "mousemove"
+              (fun _ -> FluidMsg (FluidUpdateDropdownIndex i) ) ]
           [ Html.text fnDisplayName
           ; versionView
           ; Html.span [Html.class' "types"] [Html.text <| AC.asTypeString item]

--- a/client/src/FluidCommands.ml
+++ b/client/src/FluidCommands.ml
@@ -165,7 +165,9 @@ let viewCommandPalette (cp : Types.fluidCommandState) : Types.msg Html.html =
       ; ViewEntry.defaultPasteHandler
       ; ViewUtils.nothingMouseEvent "mousedown"
       ; ViewUtils.eventNoPropagation ~key:("cp-" ^ name) "click" (fun _ ->
-            FluidMsg (FluidCommandsClick item) ) ]
+            FluidMsg (FluidCommandsClick item) )
+      ; ViewUtils.eventBoth ~key:("-mousemove" ^ name) "mousemove" (fun _ ->
+            FluidMsg (FluidUpdateDropdownIndex i) ) ]
       [Html.text name]
   in
   let filterInput =
@@ -182,6 +184,14 @@ let viewCommandPalette (cp : Types.fluidCommandState) : Types.msg Html.html =
       [Html.ul [] (List.indexedMap ~f:viewCommands cp.commands)]
   in
   Html.div [Html.class' "command-palette"] [filterInput; cmdsView]
+
+
+let cpSetIndex (_m : Types.model) (i : int) (s : Types.fluidState) :
+    Types.modification =
+  let newState = {s with cp = {s.cp with index = i}; upDownCol = None} in
+  let cmd = Types.MakeCmd (focusItem i) in
+  let m = Types.TweakModel (fun m -> {m with fluidState = newState}) in
+  Types.Many [m; cmd]
 
 
 let updateCmds (m : Types.model) (keyEvt : K.keyEvent) : Types.modification =

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -1158,10 +1158,11 @@ and fluidMsg =
   | FluidMouseUp of tlid * (int * int) option
   | FluidCommandsFilter of string
   | FluidCommandsClick of command
-  (* Index of the dropdown(autocomplete or command palette) item *)
   | FluidFocusOnToken of id
   | FluidClearErrorDvSrc
   | FluidUpdateAutocomplete
+  (* Index of the dropdown(autocomplete or command palette) item *)
+  | FluidUpdateDropdownIndex of int
 
 and msg =
   | GlobalClick of mouseEvent

--- a/client/src/styles/_fluid.scss
+++ b/client/src/styles/_fluid.scss
@@ -367,9 +367,6 @@ since they are essentially both commands just acting upon different things. */
         list-style-type: none; // remove bullet points
         padding: 0 1ch;
         height: 16px;
-        &:hover {
-          background: lighten($dropdown-selected-background, 5%);
-        }
         .version {
           @extend .fluid-fn-version;
         }


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Trello: https://trello.com/c/AltpBStg/2113-autocomplete-has-conflict-between-mouse-keyboard-and-shows-highlight-over-not-the-item-that-will-be-inserted

Added back an old fix that updates the autocomplete and command palette selection index when you move the mouse over a list item. 

I originally reverted this change because it created a bug where the cursor would overwrite the selection before the mouse had even moved, see gif. 

![2019-12-12 09 54 44](https://user-images.githubusercontent.com/32043360/70736601-85f85180-1cc5-11ea-9e19-025fc57bebf3.gif)

I have now changed to listen to the mouse event `mousemove` instead of `mouseover` so the event does fire if the user does not move the mouse, see gif. 

![2019-12-12 09 57 37](https://user-images.githubusercontent.com/32043360/70736774-e1c2da80-1cc5-11ea-957f-d906e91f4d0b.gif)

Follow up Trello: https://trello.com/c/boTUxvEC/2120-autocomplete-does-not-close-when-you-deselect-a-handler-with-open-autocomplete

In my opinion, this change makes a bug we had previous more apparent. The bug is that when you deselect a handler, it does not close the autocomplete. This makes autocomplete selection not work as expected...Arrow keys scroll around the page instead of the autocomplete items and mousing over the autocomplete items does not update the selection index, see gif of prod and then this branch. 

Prod:
![2019-12-12 10 02 57](https://user-images.githubusercontent.com/32043360/70737133-b2609d80-1cc6-11ea-9446-d1f732c8c534.gif)

Branch:
![2019-12-12 10 03 34](https://user-images.githubusercontent.com/32043360/70737158-be4c5f80-1cc6-11ea-9b54-cf1261455b47.gif)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

