### PR TITLE
Implement "commit on click away" for DB drag region

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1221,9 +1221,19 @@ let update_ (msg : msg) (m : model) : modification =
                 else SetCursorState origCursorState
               else
                 (* if we haven't moved, treat this as a single click and not a attempted drag *)
-                Select (draggingTLID, STTopLevelRoot)
+                let defaultBehaviour = Select (draggingTLID, STTopLevelRoot) in
+                ( match origCursorState with
+                | Entering (Filling _ as cursor) ->
+                    Many [Entry.commit m cursor; defaultBehaviour]
+                | _ ->
+                    defaultBehaviour )
           | None ->
               SetCursorState origCursorState )
+        | Entering (Filling _ as cursor) ->
+            Many
+              [ Entry.commit m cursor
+              ; Select (tlid, STTopLevelRoot)
+              ; FluidEndClick ]
         | _ ->
             Many [Select (tlid, STTopLevelRoot); FluidEndClick]
       else NoChange


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Fixes: https://trello.com/c/Zh86gCPn/2121-clicking-away-from-a-blank-doesnt-work-if-you-click-in-a-db

This still experiences the flicker the name does, but should mostly solve the issue.

I can't figure out how to attach the fixed gif here, so it's the 'after' attached to the above ticket.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

