### PR TITLE
When whole string is selected, delete string turning it into a blank

### DIFF
--- a/client/__tests__/fluid_test.ml
+++ b/client/__tests__/fluid_test.ml
@@ -693,6 +693,11 @@ let () =
         aStr
         (key K.DeleteNextWord 3)
         "\"so~ string\"" ;
+      ts
+        "When the entire string is selected, backspace will delete entire string, returning a blank"
+        aStr
+        (selectionPress K.Backspace 0 13)
+        ("___", (None, 0)) ;
       () ) ;
   describe "Multi-line Strings" (fun () ->
       t

--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -3970,24 +3970,18 @@ let rec updateKey ?(recursing = false) (key : K.key) (ast : ast) (s : state) :
       when pos = ti.startPos + 2 ->
         (ast, moveToNextNonWhitespaceToken ~pos ast s)
     (* Deleting *)
+    | (K.Delete, _, _ | K.Backspace, _, _) when Option.isSome s.selectionStart
+      ->
+        deleteSelection ~state:s ~ast
     | K.Backspace, L (TPatternString _, ti), _
     | K.Backspace, L (TString _, ti), _
       when pos = ti.endPos ->
         (* Backspace should move into a string, not delete it *)
         (ast, moveOneLeft pos s)
-    | K.Backspace, _, R (TRecordFieldname (_, _, _, ""), _)
-      when Option.isSome s.selectionStart ->
-        deleteSelection ~state:s ~ast
     | K.Backspace, _, R (TRecordFieldname (_, _, _, ""), ti) ->
         doBackspace ~pos ti ast s
-    | K.Backspace, _, R (TPatternBlank _, _)
-      when Option.isSome s.selectionStart ->
-        deleteSelection ~state:s ~ast
     | K.Backspace, _, R (TPatternBlank _, ti) ->
         doBackspace ~pos ti ast s
-    | (K.Delete, _, _ | K.Backspace, _, _) when Option.isSome s.selectionStart
-      ->
-        deleteSelection ~state:s ~ast
     | K.Backspace, L (_, ti), _ ->
         doBackspace ~pos ti ast s
     | K.Delete, _, R (_, ti) ->


### PR DESCRIPTION
[Using cmd-a to select text in a function and then delete does not delete the text, instead it places the carat at the end of the line.](https://trello.com/c/hjTOyl2S/2102-using-cmd-a-to-select-text-in-a-function-and-then-delete-does-not-delete-the-text-instead-it-places-the-carat-at-the-end-of-the) was the ticket created, turns out this is not just in functions but for all strings where the whole string is selected (including handlers)

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

