### PR TITLE
Pass s.ac.functions directly instead of passing state around

### DIFF
--- a/client/__tests__/autocomplete_test.ml
+++ b/client/__tests__/autocomplete_test.ml
@@ -804,7 +804,7 @@ let () =
               ~cursorState
               ()
           in
-          let exprToStr ast = Fluid.exprToStr m.fluidState ast in
+          let exprToStr ast = Fluid.exprToStr sampleFunctions ast in
           let searchCache =
             m.searchCache
             |> TLIDDict.insert ~tlid:http.hTLID ~value:(exprToStr http.ast)

--- a/client/__tests__/fluid_ac_test.ml
+++ b/client/__tests__/fluid_ac_test.ml
@@ -84,8 +84,8 @@ let defaultFullQuery ?(tl = defaultToplevel) (m : model) (query : string) :
     match tl with
     | TLHandler {ast; _} | TLFunc {ufAST = ast; _} ->
         ast
-        |> fromExpr m.fluidState
-        |> toTokens m.fluidState
+        |> fromExpr m.fluidState.ac.functions
+        |> toTokens m.fluidState.ac.functions
         |> List.head
         |> Option.withDefault ~default:defaultTokenInfo
     | _ ->
@@ -216,7 +216,7 @@ let acFor ?(tlid = defaultTLID) ?(pos = 0) (m : model) : AC.autocomplete =
     match TL.get m tlid with
     | Some (TLHandler {ast; _}) | Some (TLFunc {ufAST = ast; _}) ->
         ast
-        |> fromExpr m.fluidState
+        |> fromExpr m.fluidState.ac.functions
         |> Fluid.getToken {m.fluidState with newPos = pos}
         |> Option.withDefault ~default:defaultTokenInfo
     | _ ->

--- a/client/__tests__/fluid_pattern_test.ml
+++ b/client/__tests__/fluid_pattern_test.ml
@@ -58,7 +58,7 @@ let () =
     if debug
     then (
       Js.log2 "state before " (Fluid_utils.debugState s) ;
-      Js.log2 "pattern before" (eToStructure s ast) ) ;
+      Js.log2 "pattern before" (eToStructure s.ac.functions ast) ) ;
     let newAST, newState =
       let h = h ast in
       let m = {m with handlers = Handlers.fromList [h]} in
@@ -80,12 +80,12 @@ let () =
       | EMatch (_, _, [(pat, _)]) ->
           pat
       | _ ->
-          failwith ("can't match: " ^ eToString s newAST)
+          failwith ("can't match: " ^ eToString s.ac.functions newAST)
     in
     if debug
     then (
       Js.log2 "state after" (Fluid_utils.debugState newState) ;
-      Js.log2 "pattern after" (eToStructure newState newAST) ) ;
+      Js.log2 "pattern after" (eToStructure s.ac.functions newAST) ) ;
     (pToString result, max 0 (newState.newPos - extra))
   in
   let del ?(debug = false) (pos : int) (pat : fluidPattern) : string * int =

--- a/client/__tests__/refactor_test.ml
+++ b/client/__tests__/refactor_test.ml
@@ -269,8 +269,8 @@ let () =
       let exprToString expr : string =
         expr
         |> Tuple2.first
-        |> Fluid.fromExpr Defaults.defaultFluidState
-        |> Fluid.eToString Defaults.defaultFluidState
+        |> Fluid.fromExpr builtInFunctions
+        |> Fluid.eToString builtInFunctions
       in
       test "with sole expression" (fun () ->
           let expr = B.newF (Value "4") in

--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1034,7 +1034,7 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         in
         ({m with searchCache}, Cmd.none)
     | InitASTCache (handlers, userFunctions) ->
-        let exprToString ast = Fluid.exprToStr m.fluidState ast in
+        let exprToString ast = Fluid.exprToStr m.fluidState.ac.functions ast in
         let hcache =
           handlers
           |> List.foldl ~init:m.searchCache ~f:(fun h cache ->

--- a/client/src/Clipboard.ml
+++ b/client/src/Clipboard.ml
@@ -13,7 +13,7 @@ let getCurrentPointer (m : model) : (toplevel * pointerData) option =
         let s = m.fluidState in
         TL.get m tlid
         |> Option.andThen ~f:TL.getAST
-        |> Option.map ~f:(Fluid.fromExpr s)
+        |> Option.map ~f:(Fluid.fromExpr s.ac.functions)
         |> Option.andThen ~f:(Fluid.getToken s)
         |> Option.map ~f:(fun ti -> FluidToken.tid ti.token)
     | _ ->

--- a/client/src/View.ml
+++ b/client/src/View.ml
@@ -125,7 +125,7 @@ let viewTL_ (m : model) (tl : toplevel) : msg Html.html =
     if VariantTesting.isFluid m.tests
     then
       TL.getAST tl
-      |> Option.map ~f:(Fluid.fromExpr m.fluidState)
+      |> Option.map ~f:(Fluid.fromExpr m.fluidState.ac.functions)
       |> Option.andThen ~f:(Fluid.getToken m.fluidState)
       |> Option.map ~f:(fun ti -> FluidToken.tid ti.token)
       |> Option.orElse (idOf m.cursorState)
@@ -461,7 +461,10 @@ let view (m : model) : msg Html.html =
   let ast = TL.selectedAST m |> Option.withDefault ~default:(Blank.new_ ()) in
   let fluidStatus =
     if m.editorSettings.showFluidDebugger
-    then [Fluid.viewStatus (Fluid.fromExpr m.fluidState ast) m.fluidState]
+    then
+      [ Fluid.viewStatus
+          (Fluid.fromExpr m.fluidState.ac.functions ast)
+          m.fluidState ]
     else []
   in
   let viewDocs =

--- a/client/src/ViewCode.ml
+++ b/client/src/ViewCode.ml
@@ -463,7 +463,7 @@ let view (vs : viewState) (e : expr) =
   then
     [ Html.div
         [Html.class' "fluid-ast"]
-        (Fluid.viewAST ~vs (Fluid.fromExpr vs.fluidState e)) ]
+        (Fluid.viewAST ~vs (Fluid.fromExpr vs.fns e)) ]
   else
     let showRail = AST.usesRail e in
     let errorRail =


### PR DESCRIPTION
Infix functions used to accidentally be displayed in prefix form, such as `+ 1 2`. This was because `Fluid.toTokens` looked up whether a function was infix by looking at the list of functions in state.ac, and in some places, someone passed `Defaults.defaultFluidState` instead of state.

This attempts to prevent the problem from returning by explicitly passing a list of functions. However, I'm not sure if it really solves the problem, or if it's worth the extra complexity.

Opinions welcome.

https://trello.com/c/ULk0rFCZ/2020-fluid-sometimes-displays-prefix-notation-instead-of-infix-notation

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

