### PR TITLE
Un-break command palette

### DIFF
--- a/client/src/FluidCommands.ml
+++ b/client/src/FluidCommands.ml
@@ -25,11 +25,11 @@ let commandsFor (tl : toplevel) (id : id) : command list =
   let filterForRail rail =
     Commands.commands
     |> List.filter ~f:(fun c ->
-           if rail = Rail
-           then c.commandName != Commands.putFunctionOnRail.commandName
-           else if rail = NoRail
-           then c.commandName != Commands.takeFunctionOffRail.commandName
-           else true )
+           match rail with
+           | Rail ->
+               c.commandName <> Commands.putFunctionOnRail.commandName
+           | NoRail ->
+               c.commandName <> Commands.takeFunctionOffRail.commandName )
   in
   Toplevel.getAST tl
   |> Option.andThen ~f:(fun x -> AST.find id x)
@@ -41,9 +41,9 @@ let commandsFor (tl : toplevel) (id : id) : command list =
              let cmds =
                Commands.commands
                |> List.filter ~f:(fun c ->
-                      c.commandName != Commands.putFunctionOnRail.commandName
+                      c.commandName <> Commands.putFunctionOnRail.commandName
                       && c.commandName
-                         != Commands.takeFunctionOffRail.commandName )
+                         <> Commands.takeFunctionOffRail.commandName )
              in
              Some cmds )
   |> Option.withDefault ~default:Commands.commands


### PR DESCRIPTION
Make the command palette work again.

Something in the BS 7 upgrade caused these `Command.commands` not to be directly comparable anymore due to them containing fields with functions.

This is the exact code in the BS `caml_equal` function that's throwing:

```js
if (a_type === "function" || b_type === "function") {
  throw [
    Caml_builtin_exceptions.invalid_argument,
    "equal: functional value"
  ];
}
```

Changing these to be compared by name instead (which is unique) seems to work.