### PR TITLE
ensure client sends repl/workers with correct modifier

### DIFF
--- a/client/src/Entry.ml
+++ b/client/src/Entry.ml
@@ -694,20 +694,29 @@ let submitACItem
           | PEventSpace space, ACEventSpace value, TLHandler h ->
               let new_ = B.newF value in
               let replacement = SpecHeaders.replaceEventSpace id new_ h.spec in
-              let replacement2 =
-                (* Trello ticket for this: https://trello.com/c/xTitDxAs*)
+              let replacedModifier =
                 match (replacement.space, space) with
                 | F (_, newSpace), F (_, oldSpace) when newSpace == oldSpace ->
                     replacement
+                (*
+                 * If becoming a WORKER or REPL, set modifier to "_" as it's invalid otherwise *)
+                | F (_, "REPL"), _ | F (_, "WORKER"), _ ->
+                    SpecHeaders.replaceEventModifier
+                      (B.toID h.spec.modifier)
+                      (B.newF "_")
+                      replacement
+                (*
+                 * Remove modifier when switching between any other types *)
                 | _, _ ->
                     SpecHeaders.replaceEventModifier
                       (B.toID h.spec.modifier)
                       (B.new_ ())
                       replacement
               in
-              let replacement3 =
-                (* Trello ticket with spec for this: https://trello.com/c/AmeAZMgF *)
-                match (replacement2.space, h.spec.name) with
+              let replacedName =
+                match (replacedModifier.space, h.spec.name) with
+                (*
+                 * If from a REPL, drop repl_ prefix and lowercase *)
                 | F (_, newSpace), F (_, name)
                   when newSpace <> "REPL"
                        && String.startsWith
@@ -716,7 +725,9 @@ let submitACItem
                     SpecHeaders.replaceEventName
                       (B.toID h.spec.name)
                       (B.new_ ())
-                      replacement2
+                      replacedModifier
+                (*
+                 * If from an HTTP, strip leading slash and any colons *)
                 | F (_, newSpace), F (_, name)
                   when newSpace <> "HTTP" && String.startsWith ~prefix:"/" name
                   ->
@@ -726,17 +737,19 @@ let submitACItem
                          ( String.dropLeft ~count:1 name
                          |> String.split ~on:":"
                          |> String.join ~sep:"" ))
-                      replacement2
+                      replacedModifier
+                (*
+                 * If becoming an HTTP, add a slash at beginning *)
                 | F (_, "HTTP"), F (_, name)
                   when not (String.startsWith ~prefix:"/" name) ->
                     SpecHeaders.replaceEventName
                       (B.toID h.spec.name)
                       (B.newF ("/" ^ name))
-                      replacement2
+                      replacedModifier
                 | _, _ ->
-                    replacement2
+                    replacedModifier
               in
-              saveH {h with spec = replacement3} (PEventSpace new_)
+              saveH {h with spec = replacedName} (PEventSpace new_)
           | PField _, ACField fieldname, _ ->
               let fieldname =
                 if String.startsWith ~prefix:"." fieldname


### PR DESCRIPTION
This re-applies the `client/` part of https://github.com/darklang/dark/pull/1677 after reverting that entire merge in https://github.com/darklang/dark/pull/1694.

## Explaination

The backend validation of canvases causes canvases with any invalid modifier to break on load. We thought this was fixable by running a SQL query to update the `toplevel_opslist.modifier` of those TLs, but this isn't correct: the canvas validation runs on the opslist computed by applying every op, not on the metadata from the DB row.

Instead, we'll apply the FE, use it to manually append new ops that fix the metadata by switching the type of the affected handlers within the editor, then circle back to apply the backend validation.