### PR TITLE
Temporarily disable taking off error rail via clicking

### DIFF
--- a/client/src/Fluid.ml
+++ b/client/src/Fluid.ml
@@ -5702,7 +5702,7 @@ let viewCopyButton tlid value : msg Html.html =
     [ViewUtils.fontAwesome "copy"]
 
 
-let viewErrorIndicator ~tlid ~analysisStore ~state ti : Types.msg Html.html =
+let viewErrorIndicator ~analysisStore ~state ti : Types.msg Html.html =
   let returnTipe name =
     let fn = Functions.findByNameInList name state.ac.functions in
     Runtime.tipe2str fn.fnReturnTipe
@@ -5722,13 +5722,18 @@ let viewErrorIndicator ~tlid ~analysisStore ~state ti : Types.msg Html.html =
   | TFnName (id, _, _, fnName, Rail) ->
       let offset = string_of_int ti.startRow ^ "rem" in
       let cls = ["error-indicator"; returnTipe fnName; sentToRail id] in
+      let event =
+        Vdom.noProp
+        (* TEMPORARY DISABLE
+          ViewUtils.eventNoPropagation	
+            ~key:("er-" ^ show_id id)	
+            "click"	
+            (fun _ -> TakeOffErrorRail (tlid, id)) *)
+      in
       Html.div
         [ Html.class' (String.join ~sep:" " cls)
         ; Html.styles [("top", offset)]
-        ; ViewUtils.eventNoPropagation
-            ~key:("er-" ^ show_id id)
-            "click"
-            (fun _ -> TakeOffErrorRail (tlid, id)) ]
+        ; event ]
         []
   | _ ->
       Vdom.noNode
@@ -6041,8 +6046,7 @@ let viewAST ~(vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html list
   let errorRail =
     let indicators =
       tokenInfos
-      |> List.map ~f:(fun ti ->
-             viewErrorIndicator ~tlid ~analysisStore ~state ti )
+      |> List.map ~f:(fun ti -> viewErrorIndicator ~analysisStore ~state ti)
     in
     let hasMaybeErrors = List.any ~f:(fun e -> e <> Vdom.noNode) indicators in
     Html.div


### PR DESCRIPTION
[Temporarily disable taking off error rail via clicking](https://trello.com/c/C8aLwZSl/2127-temporarily-disable-taking-off-error-rail-via-clicking)
Users do it and then have no idea. We'll come back to it later, but for now just remove.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

