### PR TITLE
Correctly serialize cursorState to local storage

### DIFF
--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -648,7 +648,7 @@ and cursorState (cs : Types.cursorState) : Js.Json.t =
   | Deselected ->
       ev "Deselected" []
   | FluidEntering tlid_ ->
-      ev "FluidEntering " [tlid tlid_]
+      ev "FluidEntering" [tlid tlid_]
 
 
 and functionResult (fr : Types.functionResult) : Js.Json.t =


### PR DESCRIPTION
# What

Delete a character and now refreshing the page auto-focuses the handler like it should!

https://trello.com/c/CQIlyGRD/2130-on-refresh-all-handlers-within-a-canvas-are-greyed-out

## How

Because the serialized value was invalid, and the deserializer uses `withDefault`, the deserialized value was being defaulted to `Deselected`, which meant that reloading the page never resulted in the correct handler being automatically focused.

## Commentary

I will say here that this took me a _looong_ time to trace through for a one character fix. The handler focusing code is pretty confusing, and there appears to be a lack of cohesion between `m.cursorState` and `m.currentPage`. In fact this is why the grey overlay still rendered even though the handler wasn't focused — the overly looks at `currentPage` but the handler looks at `cursorState`. Once fluid is the One True Editor, I think it might be worth trying to clean this up a bit for the benefit of future yous and mes.