### PR TITLE
swallow spaces in blankOrs

### DIFF
--- a/client/src/KeyPress.ml
+++ b/client/src/KeyPress.ml
@@ -384,9 +384,7 @@ let defaultHandler (event : Keyboard.keyEvent) (m : model) : modification =
                 then AutocompleteMod (ACSetQuery (m.complete.value ^ " "))
                 else NoChange
             | _ ->
-                if m.complete.value = "=" || AC.isStringEntry m.complete
-                then NoChange
-                else Entry.submit m cursor Entry.GotoNext )
+                NoChange )
           | Key.Enter ->
               if AC.isLargeStringEntry m.complete
               then AutocompleteMod (ACSetQuery m.complete.value)


### PR DESCRIPTION
## What

Swallow presses of the spacebar while editing blankOr fields.

## Why

https://trello.com/c/eJtsuxQh/2129-adding-spaces-in-fields-that-dont-support-them-places-caret-in-next-field

In Fluid, these are only in the handler headers and hitting space to go between these fields is confusing.