### PR TITLE
Close autocomplete when a handler is deselected

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -1054,9 +1054,6 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
     | Many mods ->
         List.foldl ~f:updateMod ~init:(m, Cmd.none) mods
   in
-  (* Instead of finding each case where the user can change the focused toplevel or focus on the canvas,
-   * check if the focused toplevel tlid(via the cursorstate) still matches the fluid autocomplete query tlid
-   * after the model has been updated *)
   let newm = FluidAutocomplete.updateAutocompleteVisability newm in
   (newm, Cmd.batch [cmd; newcmd])
 

--- a/client/src/FluidAutocomplete.ml
+++ b/client/src/FluidAutocomplete.ml
@@ -655,6 +655,6 @@ let updateAutocompleteVisability (m : model) : model =
   let newTlid = tlidOf m.cursorState in
   if isOpened m.fluidState.ac && oldTlid <> newTlid
   then
-    let newAc = init m in
+    let newAc = reset m in
     {m with fluidState = {m.fluidState with ac = newAc}}
   else m


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists


**Trello:**
https://trello.com/c/boTUxvEC/2120-autocomplete-does-not-close-when-you-deselect-a-handler-with-open-autocomplete

**Follow up Trello:**
https://trello.com/c/33DK7109/2139-the-mini-map-on-the-function-page-shows-autocomplete-open-on-canvas


**Problem**
The autocomplete would stay open if you focused on any different top level and it created many weird bugs like: 
- It looked like you could select an autocomplete item, but you couldn't actually select anything
- If you created a new top level while the autocomplete was still open on another top level, it would open the autocomplete on both

**Solution**

At first, I thought that I would create a new fluidMsg `FluidCloseAutocomplete` and use it to call fluid.update in every case that the cursor state would change but I realized that there are many cases, that I didn't know of, where the user could change the cursor state.

After realizing this, I decided to write the function "updateAutocompleteVisability" to check if the cursor state tlid still matched the tild that last queried an autocomplete after the model has been completely updated. 

With this approach, I believe that we will no longer leave the autocomplete open if a user changes the focused top level, and we will avoid having to add code to reset the autocomplete to each modification that changes the cursor state. 


**Before:**

![2019-12-16 15 10 25](https://user-images.githubusercontent.com/32043360/70951962-adc71c80-2019-11ea-8804-48c290e9c6e5.gif)
![2019-12-16 15 11 02](https://user-images.githubusercontent.com/32043360/70951976-b61f5780-2019-11ea-849b-b70709bc1074.gif)


**After:**
![2019-12-16 15 11 34](https://user-images.githubusercontent.com/32043360/70951931-9720c580-2019-11ea-84de-5f4ad64c2b33.gif)

![2019-12-16 15 12 43](https://user-images.githubusercontent.com/32043360/70951861-6c367180-2019-11ea-91a9-25aa60746289.gif)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.
