### PR TITLE
Remove exempted users

### DIFF
--- a/client/src/VariantTesting.ml
+++ b/client/src/VariantTesting.ml
@@ -22,26 +22,7 @@ let libtwitterAvailable (vts : variantTest list) : bool =
 (* To turn off fluid, add the ?fluidv2=0 or ?fluidv2=false *)
 let forceFluid (_isAdmin : bool) (username : string) (vts : variantTest list) :
     variantTest list =
-  let shouldForceFluid =
-    let exemptUsers =
-      [ "cordeliamurphy"
-      ; "eagon"
-      ; "geoffrey"
-      ; "hkgumbs"
-      ; "jgaskins"
-      ; "listo"
-      ; "maximfilimonov"
-      ; "pmmck"
-      ; "renee"
-      ; "rockspot"
-      ; "stevehind"
-      ; "trown"
-        (* XXX(JULIAN): The `test` user is here as a hack while we 
-         fix integration tests to run in fluid *)
-      ; "test" ]
-    in
-    not (List.member ~value:username exemptUsers)
-  in
+  let shouldForceFluid = username <> "test" in
   if shouldForceFluid
   then
     (* Checking to see if fluid is set to false *)


### PR DESCRIPTION
We decided when we shipped fluid that a number of users should not be automatically put onto fluid. Now that all new users are on fluid, and the fluid experience is good, it is time to remove the non-fluid editor, and so we need to move all users to the new one.

We looked at who was using it, and of those, who were using features currently unsupported by fluid:

Thanks Victoria for the data here:
cordeliamurphy - has not been active since we switched to Heap (early November), no recent grand users
eagon - last canvas edits were 12/4, amatorium canvas had 835 grand users last week
geoffrey - has not been active since we switched to Heap (early November)
hkgumbs - last canvas edits were 11/21, I don’t think there were any grand users recently
jgaskins - last canvas edits were 11/25, no grand users since thin
listo - last canvas edits were 11/21, 181 grand users last week
maximfilimonov, last canvas edits 11/29, no grand users last week
pmmck - has not been active since we switched to Heap (early November)
renee - has not been active since we switched to Heap (early November)
rockspot - canvas edits 12/4, no grand users recently
stevehind - canvas edits 11/16, 33 grand users last week
trown - has not been active since we switched to Heap (early November), no recent grand users

I checked to see if listo, maxim, eagon, and stevehind were using the features in question.

I checked all the canvases, looks like the only ones with feature flags are reify-training and amatorium-vall. The former is for training I believe, and in the latter, the handler last had an event a month ago.

Listo has a significant amount of string escaping, all of it for quotes in html or email. Given @ismith is working on that (planning to ship on Thursday), and given chase hasn’t been around in a month and this only breaks editing, not grand users, that’s fine. 

amatorium-vall is in a similar situation - it has a few newlines which are not the end of the world. Eagon has not been around in 2 weeks so it's fine.

So now I'm removing all exempted users.


- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

