### PR TITLE
Enable Home and End to go the start and end of a line

### DIFF
--- a/client/src/FluidKeyboard.ml
+++ b/client/src/FluidKeyboard.ml
@@ -78,8 +78,6 @@ type key =
   | Delete
   | PageUp
   | PageDown
-  | End
-  | Home
   | Insert
   | PrintScreen
   | PauseBreak
@@ -206,8 +204,6 @@ let toChar key : char option =
   | Delete
   | PageUp
   | PageDown
-  | End
-  | Home
   | Insert
   | PrintScreen
   | PauseBreak


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists


**Trello:**
https://trello.com/c/EszBsu7r/2074-recognize-end-and-home-for-gotostartofline-gotoendofline-keyboard-shortcuts

Currently, in the fluid editor, a developer is unable to use their `Home` and/or `End` key to move their cursor. With this fix, whenever the `End` key is pressed the cursor will go to the end of the line and if the `Home` key is pressed the cursor will go to the start of a line and holding Ctrl + `End` or `Home` will do the opposite. 

![2019-12-18 10 04 35](https://user-images.githubusercontent.com/32043360/71111632-b9802380-217e-11ea-870c-d8b4330713d6.gif)

NOTE: If you are on Mac os, the `End` key is fn + right arrow and `Home` is fn + left arrow

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

