### PR TITLE
Close command palette when focused handler is changed

### DIFF
--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -254,6 +254,14 @@ let isACOpened (m : model) : bool =
   else AC.isOpened m.complete
 
 
+let updateDropdownVisabilty (m : model) : model =
+  if FluidAutocomplete.isOpened m.fluidState.ac
+  then FluidAutocomplete.updateAutocompleteVisability m
+  else if FluidCommands.isOpened m.fluidState.cp
+  then FluidCommands.updateCommandPaletteVisability m
+  else m
+
+
 let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
     model * msg Cmd.t =
   if m.integrationTestState <> NoIntegrationTest
@@ -1055,7 +1063,7 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
     | Many mods ->
         List.foldl ~f:updateMod ~init:(m, Cmd.none) mods
   in
-  let newm = FluidAutocomplete.updateAutocompleteVisability newm in
+  let newm = updateDropdownVisabilty newm in
   (newm, Cmd.batch [cmd; newcmd])
 
 

--- a/client/src/FluidCommands.ml
+++ b/client/src/FluidCommands.ml
@@ -228,3 +228,18 @@ let updateCmds (m : Types.model) (keyEvt : K.keyEvent) : Types.modification =
 
 
 let isOpened (cp : fluidCommandState) : bool = cp.location <> None
+
+let updateCommandPaletteVisability (m : model) : model =
+  let oldTlid =
+    match m.fluidState.cp.location with
+    | Some (tlid, _) ->
+        Some tlid
+    | None ->
+        tlidOf m.cursorState
+  in
+  let newTlid = tlidOf m.cursorState in
+  if isOpened m.fluidState.cp && oldTlid <> newTlid
+  then
+    let newCp = reset in
+    {m with fluidState = {m.fluidState with cp = newCp}}
+  else m


### PR DESCRIPTION
- [x] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

**Trello**
https://trello.com/c/NKoLcN1D/2111-after-using-option-x-to-open-the-command-palette-clicking-away-doesnt-always-remove-it

**Problem**
The command palette would stay open if you focused on any different top level and this caused multiple weird bugs like: 

- Typing in another handler wouldn't work if command palette was opened on another handler
- Opening multiple command palettes on different handlers then hovering over a command palette list item caused weird scrolling in other open command palettes.


**Solution**
Changed `updateAutocompleteVisability` to call `updateDropdownVisabilty` so we now check if either the autocomplete or the command palette is open, then close the opened dropdown if the tlid of the cursor state no longer matches the tlid from the dropdown search. Previously we had this functionality for autocomplete, so I was able to use the same logic for the command palette .

With this approach, I believe that we will no longer leave the command palette or the autocomplete open if a user changes the focused top level, and we will avoid having to add code to reset the command palette  or the autocomplete to each modification that changes the cursor state.

**Before**
![2019-12-18 11 27 53](https://user-images.githubusercontent.com/32043360/71116776-960ea600-2189-11ea-90d3-69aeba424ffd.gif)

![2019-12-18 11 33 58](https://user-images.githubusercontent.com/32043360/71117151-7035d100-218a-11ea-83d9-0b88979e5219.gif)

**After**
![2019-12-18 11 28 41](https://user-images.githubusercontent.com/32043360/71116793-9d35b400-2189-11ea-8cb4-ed7237826762.gif)

![2019-12-18 11 35 46](https://user-images.githubusercontent.com/32043360/71117230-95c2da80-218a-11ea-8b07-4ac4a39da66b.gif)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

