### PR TITLE
Fix CI again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,7 @@ RUN sudo kubectl completion bash | sudo tee /etc/bash_completion.d/kubectl > /de
 # New authentication for docker - not supported via apt
 user root
 RUN curl -sSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.4.3/docker-credential-gcr_linux_amd64-1.4.3.tar.gz" \
-    | tar xz --to-stdout ./docker-credential-gcr > /usr/bin/docker-credential-gcr \
+    | tar xz --to-stdout docker-credential-gcr > /usr/bin/docker-credential-gcr \
     && chmod +x /usr/bin/docker-credential-gcr
 
 RUN docker-credential-gcr config --token-source="gcloud"


### PR DESCRIPTION
Sadly, I didn't test my last changes and broke master even more.

When upgrading docker-credential-gcr, the format of the tarball changed, and I forgot to change it back when downgrading.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

