### PR TITLE
Remove add-feature-flag from the command palette in fluid

### DIFF
--- a/client/src/FluidCommands.ml
+++ b/client/src/FluidCommands.ml
@@ -15,15 +15,21 @@ module K = FluidKeyboard
 
 let filterInputID : string = "cmd-filter"
 
+let fluidCommands =
+  Commands.commands
+  |> List.filter ~f:(fun {commandName} ->
+         not (commandName == "add-feature-flag") )
+
+
 let reset : fluidCommandState =
-  {index = 0; commands = Commands.commands; location = None; filter = None}
+  {index = 0; commands = fluidCommands; location = None; filter = None}
 
 
 let commandsFor (tl : toplevel) (id : id) : command list =
   (* NB: do not structurally compare entire Command.command records here, as
    * they contain functions, which BS cannot compare.*)
   let filterForRail rail =
-    Commands.commands
+    fluidCommands
     |> List.filter ~f:(fun c ->
            match rail with
            | Rail ->
@@ -39,14 +45,14 @@ let commandsFor (tl : toplevel) (id : id) : command list =
              Some (filterForRail rail)
          | _ ->
              let cmds =
-               Commands.commands
+               fluidCommands
                |> List.filter ~f:(fun c ->
                       c.commandName <> Commands.putFunctionOnRail.commandName
                       && c.commandName
                          <> Commands.takeFunctionOffRail.commandName )
              in
              Some cmds )
-  |> Option.withDefault ~default:Commands.commands
+  |> Option.withDefault ~default:fluidCommands
 
 
 let show (tl : toplevel) (token : fluidToken) : fluidCommandState =
@@ -135,14 +141,14 @@ let filter (m : model) (query : string) (cp : fluidCommandState) :
             commandsFor tl (FluidToken.tid token) )
         |> recoverOpt "no tl for location" ~default:[]
     | _ ->
-        Commands.commands
+        fluidCommands
   in
   let filter, commands =
     if String.length query > 0
     then
       let isMatched c = String.contains ~substring:query c.commandName in
       (Some query, List.filter ~f:isMatched allCmds)
-    else (None, Commands.commands)
+    else (None, fluidCommands)
   in
   {cp with filter; commands; index = 0}
 


### PR DESCRIPTION
https://trello.com/c/QzOsX2wb/2153-remove-the-feature-flags-option-from-the-altx-menu-in-fluid

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

