### PR TITLE
If PMTF fails a test, it should return a non-zero exit code

### DIFF
--- a/client/__tests__/tester.ml
+++ b/client/__tests__/tester.ml
@@ -200,8 +200,10 @@ let finish () =
   let skipCount = List.length skips |> string_of_int in
   Js.log "\n\n" ;
   if fails = []
-  then Js.log ("Passed " ^ successCount ^ " tests (" ^ skipCount ^ " skipped)")
-  else
+  then (
+    Js.log ("Passed " ^ successCount ^ " tests (" ^ skipCount ^ " skipped)") ;
+    exit 0 )
+  else (
     Js.log
       ( "Failed "
       ^ failCount
@@ -210,4 +212,4 @@ let finish () =
       ^ " passed, "
       ^ skipCount
       ^ " skipped)" ) ;
-  ()
+    exit 1 )


### PR DESCRIPTION
https://trello.com/c/9eAI73cz/2154-failing-client-tests-should-actually-yknow-fail

- [x] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

