### PR TITLE
List all failures at the end of the test

### DIFF
--- a/client/__tests__/tester.ml
+++ b/client/__tests__/tester.ml
@@ -204,6 +204,11 @@ let finish () =
     Js.log ("Passed " ^ successCount ^ " tests (" ^ skipCount ^ " skipped)") ;
     exit 0 )
   else (
+    Js.log "Failures:" ;
+    fails
+    |> List.iter ~f:(fun {name} ->
+           Js.log @@ testIndent () ^ {j|❌|j} ^ " " ^ name ) ;
+    Js.log "" ;
     Js.log
       ( "Failed "
       ^ failCount


### PR DESCRIPTION
I find it convenient to have a list at the end of all test failures, so I don't have to go digging through the list. (Though an in-order is nice too for "did our failures cluster somewhere?")

Now the bottom of the test output looks like this (the original failure output is still up above in the Fluid_test -> String escaping section, too):
![image](https://user-images.githubusercontent.com/172694/71220707-5f668780-227e-11ea-8b4d-1b054caf189f.png)


- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

