### PR TITLE
Re-disable redo

### DIFF
--- a/client/src/FluidKeyboard.ml
+++ b/client/src/FluidKeyboard.ml
@@ -342,8 +342,10 @@ let fromKeyboardEvent
       but CMD+Y on Mac is the history shortcut in Chrome (since CMD+H is taken for hide)
       See https://support.google.com/chrome/answer/157179?hl=en *)
       Redo
-  | ("Z" | "z") when shift && osCmdKeyHeld ->
-      Redo
+  (* Redo appears to be broken: every time we try to redo the server gives
+   * a "Already at latest redo" error. So disable for now. *)
+  (* | ("Z" | "z") when shift && osCmdKeyHeld -> *)
+  (*     Redo *)
   | ("Z" | "z") when (not shift) && osCmdKeyHeld ->
       Undo
   | "Backspace" when isMacCmdHeld ->


### PR DESCRIPTION
I fixed redo earlier, unforunately it now errors in prod in a way in which it does not in dev. So disabling for now.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

