### PR TITLE
Add Date::hour_v1, after Date::hour has a big bug

### DIFF
--- a/backend/libexecution/libdate.ml
+++ b/backend/libexecution/libdate.ml
@@ -345,6 +345,25 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
+    ; dep = true }
+  ; { pns = ["Date::hour_v1"]
+    ; ins = []
+    ; p = [par "date" TDate]
+    ; r = TInt
+    ; d = "Returns the hour portion of the Date as an int"
+    ; f =
+        InProcess
+          (function
+          | _, [DDate d] ->
+              d
+              |> Time.to_span_since_epoch
+              |> Time.Span.to_hr
+              |> (fun x -> Float.mod_float x 24.0)
+              |> Dint.of_float
+              |> DInt
+          | args ->
+              fail args)
+    ; ps = true
     ; dep = false }
   ; { pns = ["Date::minute"]
     ; ins = []

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -412,6 +412,11 @@ let t_date_functions_work () =
     "Date::fromSeconds roundtrips"
     (Dval.dint 1095379198)
     (exec_ast "(Date::toSeconds (Date::fromSeconds 1095379198))") ;
+  check_dval
+    "Date::hour works - leif's test case"
+    (DResult (ResOk (Dval.dint 3)))
+    (exec_ast
+       "(Result::map (Date::parse_v1 '2019-12-27T03:27:36Z') (\\d -> (Date::hour_v1 d)))") ;
   ()
 
 


### PR DESCRIPTION
Date::hour had a bug where I'm shocked the test passed. Adds another case that was breaking for Leif.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

