### PR TITLE
Use fluidExpr in handlers

### DIFF
--- a/client/__tests__/autocomplete_test.ml
+++ b/client/__tests__/autocomplete_test.ml
@@ -61,7 +61,7 @@ let defaultModel
 
 let aHandler
     ?(tlid = defaultTLID)
-    ?(expr = defaultExpr)
+    ?(expr = defaultFluidExpr)
     ?(space : string option = None)
     ?(name : string option = None)
     ?(modifier : string option = None)
@@ -524,9 +524,8 @@ let run () =
               ~name:(Some "/hello")
               ~modifier:(Some "GET")
               ~expr:
-                (B.newF
-                   (FieldAccess
-                      (B.newF (Variable "request"), B.newF "queryParams")))
+                (EFieldAccess
+                   (gid (), EVariable (gid (), "request"), gid (), "queryParams"))
               ()
           in
           let repl =
@@ -535,7 +534,7 @@ let run () =
               ~space:(Some "REPL")
               ~name:(Some "findingDori")
               ~modifier:(Some "_")
-              ~expr:(B.newF (FnCall (B.newF "Int::add", [], NoRail)))
+              ~expr:(EFnCall (gid (), "Int::add", [], NoRail))
               ()
           in
           let fn =
@@ -559,13 +558,14 @@ let run () =
               ~cursorState
               ()
           in
-          let exprToStr ast =
-            ast |> FluidExpression.fromNExpr |> FluidPrinter.eToString
-          in
           let searchCache =
             m.searchCache
-            |> TLIDDict.insert ~tlid:http.hTLID ~value:(exprToStr http.ast)
-            |> TLIDDict.insert ~tlid:repl.hTLID ~value:(exprToStr repl.ast)
+            |> TLIDDict.insert
+                 ~tlid:http.hTLID
+                 ~value:(FluidPrinter.eToString http.ast)
+            |> TLIDDict.insert
+                 ~tlid:repl.hTLID
+                 ~value:(FluidPrinter.eToString repl.ast)
             |> TLIDDict.insert
                  ~tlid:fn.ufTLID
                  ~value:(FluidPrinter.eToString fn.ufAST)

--- a/client/__tests__/curl_test.ml
+++ b/client/__tests__/curl_test.ml
@@ -1,13 +1,14 @@
 open Tester
 open! Tc
 open Types
+open Prelude
 open Curl
 module B = Blank
 
 let defaultTLID = TLID "7"
 
 let http ~(path : string) ?(meth = "GET") () : handler =
-  { ast = B.new_ ()
+  { ast = EBlank (gid ())
   ; hTLID = defaultTLID
   ; pos = {x = 0; y = 0}
   ; spec =
@@ -68,7 +69,7 @@ let run () =
       test "returns None for non-HTTP handlers" (fun () ->
           let cronTLID = TLID "2" in
           let cron =
-            { ast = B.new_ ()
+            { ast = EBlank (gid ())
             ; hTLID = cronTLID
             ; pos = {x = 0; y = 0}
             ; spec =

--- a/client/__tests__/fluid_ac_test.ml
+++ b/client/__tests__/fluid_ac_test.ml
@@ -59,7 +59,7 @@ let defaultExpr = EBlank defaultID
 
 let defaultToplevel =
   TLHandler
-    { ast = E.toNExpr defaultExpr
+    { ast = defaultExpr
     ; spec =
         { space = Blank (gid ())
         ; name = Blank (gid ())
@@ -83,13 +83,7 @@ let defaultFullQuery ?(tl = defaultToplevel) (m : model) (query : string) :
     AC.fullQuery =
   let ti =
     match tl with
-    | TLHandler {ast; _} ->
-        ast
-        |> E.fromNExpr
-        |> toTokens
-        |> List.head
-        |> Option.withDefault ~default:defaultTokenInfo
-    | TLFunc {ufAST = ast; _} ->
+    | TLHandler {ast; _} | TLFunc {ufAST = ast; _} ->
         ast
         |> toTokens
         |> List.head
@@ -144,7 +138,7 @@ let aHandler
     () : handler =
   let space = match space with None -> B.new_ () | Some name -> B.newF name in
   let spec = {space; name = B.new_ (); modifier = B.new_ ()} in
-  {ast = E.toNExpr expr; spec; hTLID = tlid; pos = {x = 0; y = 0}}
+  {ast = expr; spec; hTLID = tlid; pos = {x = 0; y = 0}}
 
 
 let aFunction ?(tlid = defaultTLID) ?(expr = defaultExpr) () : userFunction =
@@ -217,12 +211,7 @@ let enteringHandler ?(space : string option = None) ?(expr = defaultExpr) () :
 let acFor ?(tlid = defaultTLID) ?(pos = 0) (m : model) : AC.autocomplete =
   let ti =
     match TL.get m tlid with
-    | Some (TLHandler {ast; _}) ->
-        ast
-        |> E.fromNExpr
-        |> Fluid.getToken {m.fluidState with newPos = pos}
-        |> Option.withDefault ~default:defaultTokenInfo
-    | Some (TLFunc {ufAST = ast; _}) ->
+    | Some (TLHandler {ast; _}) | Some (TLFunc {ufAST = ast; _}) ->
         ast
         |> Fluid.getToken {m.fluidState with newPos = pos}
         |> Option.withDefault ~default:defaultTokenInfo

--- a/client/__tests__/fluid_pattern_test.ml
+++ b/client/__tests__/fluid_pattern_test.ml
@@ -17,7 +17,7 @@ let eToString = Printer.eToString
 let pToString = Printer.pToString
 
 let h ast =
-  { ast = E.toNExpr ast
+  { ast
   ; hTLID = TLID "7"
   ; spec =
       { space = Blank.newF "HTTP"

--- a/client/__tests__/fluid_utils.ml
+++ b/client/__tests__/fluid_utils.ml
@@ -1,5 +1,4 @@
 open Types
-open Fluid
 module B = Blank
 module K = FluidKeyboard
 
@@ -16,7 +15,7 @@ let debugState s =
 
 
 let h ast : handler =
-  { ast = E.toNExpr ast
+  { ast
   ; hTLID = TLID "7"
   ; pos = {x = 0; y = 0}
   ; spec =

--- a/client/__tests__/introspect_test.ml
+++ b/client/__tests__/introspect_test.ml
@@ -10,7 +10,7 @@ let run () =
   describe "Introspect" (fun () ->
       let h1tlid = gtlid () in
       let h1data =
-        { ast = B.new_ ()
+        { ast = EBlank (gid ())
         ; spec =
             { space = B.newF "JOB"
             ; name = B.newF "processOrder"
@@ -22,11 +22,11 @@ let run () =
       let dbRefID = gid () in
       let h2data =
         { ast =
-            B.newF
-              (FnCall
-                 ( B.newF "DB::deleteAll_v1"
-                 , [F (dbRefID, Variable "Books")]
-                 , NoRail ))
+            EFnCall
+              ( gid ()
+              , "DB::deleteAll_v1"
+              , [EVariable (dbRefID, "Books")]
+              , NoRail )
         ; spec =
             { space = B.newF "HTTP"
             ; name = B.newF "/hello"
@@ -62,7 +62,12 @@ let run () =
           let functions = StrDict.empty in
           let usages =
             match
-              findUsagesInAST h2tlid datastores handlers functions h2data.ast
+              findUsagesInAST
+                h2tlid
+                datastores
+                handlers
+                functions
+                (FluidExpression.toNExpr h2data.ast)
             with
             | [{refersTo; usedIn; id}] ->
                 refersTo = h2tlid && usedIn = dbtlid && id == dbRefID

--- a/client/__tests__/page_test.ml
+++ b/client/__tests__/page_test.ml
@@ -9,11 +9,13 @@ let defaultTLID = gtlid ()
 
 let defaultExpr = B.new_ ()
 
+let defaultFluidExpr = EBlank (gid ())
+
 let defaultPos = {x = 0; y = 0}
 
 let aHandler
     ?(tlid = defaultTLID)
-    ?(expr = defaultExpr)
+    ?(expr = defaultFluidExpr)
     ?(pos = defaultPos)
     ?(space : string option = None)
     () : toplevel =

--- a/client/src/Analysis.ml
+++ b/client/src/Analysis.ml
@@ -175,7 +175,7 @@ let getAvailableVarnames
   in
   match tl with
   | TLHandler h ->
-      varsFor h.ast @ glob @ inputVariables
+      varsFor (FluidExpression.toNExpr h.ast) @ glob @ inputVariables
   | TLFunc fn ->
       varsFor (FluidExpression.toNExpr fn.ufAST) @ glob @ inputVariables
   | TLDB _ | TLTipe _ | TLGroup _ ->

--- a/client/src/App.ml
+++ b/client/src/App.ml
@@ -953,11 +953,10 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         in
         ({m with searchCache}, Cmd.none)
     | InitASTCache (handlers, userFunctions) ->
-        let exprToString ast = FluidPrinter.nexprToString ast in
         let hcache =
           handlers
           |> List.foldl ~init:m.searchCache ~f:(fun h cache ->
-                 let value = exprToString h.ast in
+                 let value = FluidPrinter.eToString h.ast in
                  cache |> TLIDDict.insert ~tlid:h.hTLID ~value)
         in
         let searchCache =
@@ -1705,7 +1704,7 @@ let update_ (msg : msg) (m : model) : modification =
         else gtlid ()
       in
       let pos = center in
-      let ast = B.new_ () in
+      let ast = EBlank (gid ()) in
       let aHandler =
         { ast
         ; spec =
@@ -1744,7 +1743,8 @@ let update_ (msg : msg) (m : model) : modification =
       Many
         ( traceMods
         @ [ RPC
-              ([SetHandler (tlid, pos, aHandler)], FocusExact (tlid, B.toID ast))
+              ( [SetHandler (tlid, pos, aHandler)]
+              , FocusExact (tlid, FluidExpression.id ast) )
           ; Delete404 fof ] )
   | MarkRoutingTableOpen (shouldOpen, key) ->
       TweakModel

--- a/client/src/Decoders.ml
+++ b/client/src/Decoders.ml
@@ -433,7 +433,7 @@ let handlerSpec j : handlerSpec =
 
 
 let handler pos j : handler =
-  { ast = field "ast" expr j
+  { ast = field "ast" expr j |> FluidExpression.fromNExpr
   ; spec = field "spec" handlerSpec j
   ; hTLID = field "tlid" tlid j
   ; pos }

--- a/client/src/Encoders.ml
+++ b/client/src/Encoders.ml
@@ -297,7 +297,10 @@ and spec (spec : Types.handlerSpec) : Js.Json.t =
 
 
 and handler (h : Types.handler) : Js.Json.t =
-  object_ [("tlid", tlid h.hTLID); ("spec", spec h.spec); ("ast", expr h.ast)]
+  object_
+    [ ("tlid", tlid h.hTLID)
+    ; ("spec", spec h.spec)
+    ; ("ast", expr (FluidExpression.toNExpr h.ast)) ]
 
 
 and dbMigrationKind (k : Types.dbMigrationKind) : Js.Json.t =

--- a/client/src/Entry.ml
+++ b/client/src/Entry.ml
@@ -136,7 +136,7 @@ let newHandler m space name modifier pos =
   in
   let spaceid = gid () in
   let handler =
-    { ast = B.new_ ()
+    { ast = EBlank (gid ())
     ; spec =
         { space = F (spaceid, space)
         ; name = B.ofOption name
@@ -151,13 +151,13 @@ let newHandler m space name modifier pos =
     (* Fallback to ast if spec has no blanks *)
     handler.spec
     |> SpecHeaders.firstBlank
-    |> Option.withDefault ~default:(handler.ast |> Blank.toID)
+    |> Option.withDefault ~default:(handler.ast |> FluidExpression.id)
   in
   let fluidMods =
     let s = m.fluidState in
     let newS = {s with newPos = 0} in
     let cursorState =
-      if idToEnter = (handler.ast |> Blank.toID)
+      if idToEnter = (handler.ast |> FluidExpression.id)
       then FluidEntering tlid
       else Entering (Filling (tlid, idToEnter))
     in

--- a/client/src/Introspect.ml
+++ b/client/src/Introspect.ml
@@ -148,7 +148,12 @@ let getUsageFor
     (functions : tlid StrDict.t) : usage list =
   match tl with
   | TLHandler h ->
-      findUsagesInAST h.hTLID datastores handlers functions h.ast
+      findUsagesInAST
+        h.hTLID
+        datastores
+        handlers
+        functions
+        (FluidExpression.toNExpr h.ast)
   | TLDB _ ->
       []
   | TLFunc f ->

--- a/client/src/Types.ml
+++ b/client/src/Types.ml
@@ -344,7 +344,7 @@ and handlerSpace =
   | HSDeprecatedOther
 
 and handler =
-  { ast : expr
+  { ast : fluidExpr
   ; spec : handlerSpec
   ; hTLID : tlid
   ; pos : pos }

--- a/client/src/View.ml
+++ b/client/src/View.ml
@@ -29,8 +29,7 @@ let viewTL_ (m : model) (tl : toplevel) : msg Html.html =
     | TLDB db ->
         (ViewDB.viewDB vs db dragEvents, [])
     | TLFunc f ->
-        ( [ViewFunction.viewFunction vs f]
-        , ViewData.viewData vs (FluidExpression.toNExpr f.ufAST) )
+        ([ViewFunction.viewFunction vs f], ViewData.viewData vs f.ufAST)
     | TLTipe t ->
         ([ViewUserType.viewUserTipe vs t], [])
     | TLGroup g ->

--- a/client/src/ViewCode.ml
+++ b/client/src/ViewCode.ml
@@ -53,7 +53,7 @@ let handlerIsExeFail (vs : viewState) : bool =
     let outermostId =
       match vs.tl with
       | TLHandler handler ->
-          Some (Blank.toID handler.ast)
+          Some (FluidExpression.id handler.ast)
       | _ ->
           None
     in
@@ -300,6 +300,6 @@ let handlerAttrs (tlid : tlid) (state : handlerState) : msg Vdom.property list =
 let viewHandler (vs : viewState) (h : handler) (dragEvents : domEventList) :
     msg Html.html list =
   let attrs = handlerAttrs vs.tlid (ViewUtils.getHandlerState vs) in
-  let ast = Html.div attrs (view vs (FluidExpression.fromNExpr h.ast)) in
+  let ast = Html.div attrs (view vs h.ast) in
   let header = viewEventSpec vs h.spec dragEvents in
   [header; ast]

--- a/client/src/ViewData.ml
+++ b/client/src/ViewData.ml
@@ -122,8 +122,8 @@ let viewInputs (vs : ViewUtils.viewState) (astID : id) : msg Html.html list =
   List.map ~f:traceToHtml vs.traces
 
 
-let viewData (vs : ViewUtils.viewState) (ast : expr) : msg Html.html list =
-  let astID = B.toID ast in
+let viewData (vs : ViewUtils.viewState) (ast : fluidExpr) : msg Html.html list =
+  let astID = FluidExpression.id ast in
   let requestEls = viewInputs vs astID in
   let tlSelected =
     match tlidOf vs.cursorState with


### PR DESCRIPTION
Use a fluidExpr in a handler.

This reduces a significant amount of copying back and forth between exprs and fluidExprs. Tair-snippy is much less slow, but not yet fast. (render is 160ms, where it was 400ms).

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

