### PR TITLE
Split `Entering (cursor)` into `Entering (tlid, id)` and `Omnibox (pos)`

### DIFF
--- a/client/src/app/IntegrationTest.ml
+++ b/client/src/app/IntegrationTest.ml
@@ -69,7 +69,7 @@ let onlyExpr (m : model) : E.t = m |> onlyTL |> TL.getAST |> deOption "onlyast4"
 
 let enter_changes_state (m : model) : testResult =
   match m.cursorState with
-  | Entering (Creating _) ->
+  | Omnibox _ ->
       pass
   | _ ->
       fail ~f:show_cursorState m.cursorState

--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -139,7 +139,7 @@ let processFocus (m : model) (focus : focus) : modification =
         in
         ( match next with
         | Some id ->
-            Enter (Filling (tlid, id))
+            Enter (tlid, id)
         | None ->
           ( match pred with
           | Some id ->
@@ -150,7 +150,7 @@ let processFocus (m : model) (focus : focus) : modification =
     ( match TL.getPD m tlid id with
     | Some pd ->
         if P.isBlank pd || P.toContent pd = ""
-        then Enter (Filling (tlid, id))
+        then Enter (tlid, id)
         else Select (tlid, STID id)
     | _ ->
         NoChange )
@@ -166,7 +166,7 @@ let processFocus (m : model) (focus : focus) : modification =
           Select (tlid, STTopLevelRoot)
       | _ ->
           Deselect )
-    | Entering (Filling (tlid, id)) ->
+    | Entering (tlid, id) ->
       ( match TL.get m tlid with
       | Some tl ->
           if TL.isValidBlankOrID tl id
@@ -518,33 +518,29 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
           let commands = [hashcmd; acCmd; API.sendPresence m avMessage] in
           (m, Cmd.batch commands)
         else (m, Cmd.none)
-    | Enter entry ->
+    | EnterOmnibox pos ->
+        let m, acCmd = processAutocompleteMods m [ACSetTarget None] in
+        let m = {m with cursorState = Omnibox pos} in
+        (m, Cmd.batch [acCmd; Entry.focusEntry m])
+    | Enter (tlid, id) ->
         let cursorState, target =
-          match entry with
-          | Creating _ ->
-              (Entering entry, None)
-          | Filling (tlid, id) ->
-            ( match TL.getPD m tlid id with
-            | Some pd ->
-                (Entering entry, Some (tlid, pd))
-            | None ->
-                (FluidEntering tlid, None) )
+          match TL.getPD m tlid id with
+          | Some pd ->
+              (Entering (tlid, id), Some (tlid, pd))
+          | None ->
+              (FluidEntering tlid, None)
         in
         let m, acCmd = processAutocompleteMods m [ACSetTarget target] in
         let m = {m with cursorState} in
         let m, afCmd = Analysis.analyzeFocused m in
         (m, Cmd.batch [afCmd; acCmd; Entry.focusEntry m])
-    | EnterWithOffset (entry, offset) ->
+    | EnterWithOffset (tlid, id, offset) ->
         let cursorState, target =
-          match entry with
-          | Creating _ ->
-              (Entering entry, None)
-          | Filling (tlid, id) ->
-            ( match TL.getPD m tlid id with
-            | Some pd ->
-                (Entering entry, Some (tlid, pd))
-            | None ->
-                (FluidEntering tlid, None) )
+          match TL.getPD m tlid id with
+          | Some pd ->
+              (Entering (tlid, id), Some (tlid, pd))
+          | None ->
+              (FluidEntering tlid, None)
         in
         let m, acCmd = processAutocompleteMods m [ACSetTarget target] in
         let m = {m with cursorState} in
@@ -1004,10 +1000,10 @@ let update_ (msg : msg) (m : model) : modification =
       NoChange
   | AutocompleteClick index ->
     ( match unwrapCursorState m.cursorState with
-    | Entering cursor ->
+    | Entering (tlid, id) ->
         let newcomplete = {m.complete with index} in
         let newm = {m with complete = newcomplete} in
-        Entry.submit newm cursor Entry.StayHere
+        Entry.submit newm tlid id Entry.StayHere
     | _ ->
         NoChange )
   | FluidMsg (FluidUpdateDropdownIndex index) ->
@@ -1024,9 +1020,9 @@ let update_ (msg : msg) (m : model) : modification =
         (* Clicking on the raw canvas should keep you selected to functions/types in their space *)
         let defaultBehaviour = Select (tlid, STTopLevelRoot) in
         ( match unwrapCursorState m.cursorState with
-        | Entering (Filling _ as cursor) ->
+        | Entering (tlid, id) ->
             (* If we click away from an entry box, commit it before doing the default behaviour *)
-            Many [Entry.commit m cursor; defaultBehaviour]
+            Many [Entry.commit m tlid id; defaultBehaviour]
         | _ ->
             defaultBehaviour )
     | Architecture | FocusedDB _ | FocusedHandler _ | FocusedGroup _ ->
@@ -1038,10 +1034,10 @@ let update_ (msg : msg) (m : model) : modification =
           | Deselected ->
               Many
                 [ AutocompleteMod ACReset
-                ; Enter (Creating (Viewport.toAbsolute m event.mePos)) ]
-          | Entering (Filling _ as cursor) ->
+                ; EnterOmnibox (Viewport.toAbsolute m event.mePos) ]
+          | Entering (tlid, id) ->
               (* If we click away from an entry box, commit it before doing the default behaviour *)
-              Many [Entry.commit m cursor; defaultBehaviour]
+              Many [Entry.commit m tlid id; defaultBehaviour]
           | _ ->
               defaultBehaviour
         else NoChange )
@@ -1135,15 +1131,15 @@ let update_ (msg : msg) (m : model) : modification =
                 (* if we haven't moved, treat this as a single click and not a attempted drag *)
                 let defaultBehaviour = Select (draggingTLID, STTopLevelRoot) in
                 ( match origCursorState with
-                | Entering (Filling _ as cursor) ->
-                    Many [Entry.commit m cursor; defaultBehaviour]
+                | Entering (tlid, id) ->
+                    Many [Entry.commit m tlid id; defaultBehaviour]
                 | _ ->
                     defaultBehaviour )
           | None ->
               SetCursorState origCursorState )
-        | Entering (Filling _ as cursor) ->
+        | Entering (tlid, id) ->
             Many
-              [ Entry.commit m cursor
+              [ Entry.commit m tlid id
               ; Select (tlid, STTopLevelRoot)
               ; FluidEndClick ]
         | _ ->
@@ -1163,17 +1159,15 @@ let update_ (msg : msg) (m : model) : modification =
           select targetID
       | Dragging (_, _, _, origCursorState) ->
           SetCursorState origCursorState
-      | Entering cursor ->
-          let defaultBehaviour = select targetID in
-          ( match cursor with
-          | Filling (_, fillingID) ->
-              if fillingID = targetID
-              then
-                NoChange
-                (* If we click away from an entry box, commit it before doing the default behaviour *)
-              else Many [Entry.commit m cursor; defaultBehaviour]
-          | _ ->
-              defaultBehaviour )
+      | Omnibox _ ->
+          select targetID
+      | Entering (tlid, id) ->
+          if id = targetID
+          then
+            (* If we click away from an entry box, commit it before doing
+             * the default behaviour *)
+            NoChange
+          else Many [Entry.commit m tlid id; select targetID]
       | Selecting (_, _) ->
           select targetID
       | FluidEntering _ ->
@@ -1190,8 +1184,8 @@ let update_ (msg : msg) (m : model) : modification =
       in
       ( match m.cursorState with
       (* If we click away from an entry box, commit it before doing the default behaviour *)
-      | Entering (Filling _ as cursor) ->
-          Many (Entry.commit m cursor :: defaultBehaviour)
+      | Entering (tlid, id) ->
+          Many (Entry.commit m tlid id :: defaultBehaviour)
       | _ ->
           Many defaultBehaviour )
   | ExecuteFunctionButton (tlid, id, name) ->
@@ -1872,10 +1866,10 @@ let update_ (msg : msg) (m : model) : modification =
         [FluidStartClick; Select (targetExnID, STTopLevelRoot)]
       in
       ( match m.cursorState with
-      | Entering (Filling _ as cursor) ->
+      | Entering (tlid, id) ->
           Many
             (* If we click away from an entry box, commit it before doing the default behaviour *)
-            (Entry.commit m cursor :: defaultBehaviour)
+            (Entry.commit m tlid id :: defaultBehaviour)
       | _ ->
           Many defaultBehaviour )
   | FluidMsg (FluidMouseUp (targetExnID, _) as msg) ->

--- a/client/src/canvas/View.ml
+++ b/client/src/canvas/View.ml
@@ -301,11 +301,7 @@ let viewCanvas (m : model) : msg Html.html =
       | FocusedHandler _ | FocusedDB _ ->
           true
       | Architecture ->
-        ( match unwrapCursorState m.cursorState with
-        | Entering (Creating _) ->
-            true
-        | _ ->
-            false )
+        (match m.cursorState with Omnibox _ -> true | _ -> false)
       | _ ->
           false
     in

--- a/client/src/core/Decoders.ml
+++ b/client/src/core/Decoders.ml
@@ -392,9 +392,14 @@ and cursorState j =
   let dv4 = variant4 in
   variants
     [ ("Selecting", dv2 (fun a b -> Selecting (a, b)) tlid (optional id))
-    ; ("Entering", dv1 (fun a -> Entering a) entering)
+    ; ( "Entering"
+      , oneOf
+          (* Support the old serialized form for now *)
+          [dv1 identity oldEntering; dv2 (fun a b -> Entering (a, b)) tlid id]
+      )
     ; ( "Dragging"
       , dv4 (fun a b c d -> Dragging (a, b, c, d)) tlid vPos bool cursorState )
+    ; ("Omnibox", dv1 (fun x -> Omnibox x) pos)
     ; ("Deselected", dv0 Deselected) (* Old value *)
     ; ("SelectingCommand", dv2 (fun a b -> Selecting (a, Some b)) tlid id)
     ; ("FluidEntering", dv1 (fun a -> FluidEntering a) tlid)
@@ -402,12 +407,12 @@ and cursorState j =
     j
 
 
-and entering j =
+and oldEntering j =
   let dv1 = variant1 in
   let dv2 = variant2 in
   variants
-    [ ("Creating", dv1 (fun x -> Creating x) pos)
-    ; ("Filling", dv2 (fun a b -> Filling (a, b)) tlid id) ]
+    [ ("Creating", dv1 (fun x -> Omnibox x) pos)
+    ; ("Filling", dv2 (fun a b -> Entering (a, b)) tlid id) ]
     j
 
 

--- a/client/src/core/Encoders.ml
+++ b/client/src/core/Encoders.ml
@@ -626,10 +626,10 @@ and cursorState (cs : Types.cursorState) : Js.Json.t =
   match cs with
   | Selecting (tlid_, mId) ->
       ev "Selecting" [tlid tlid_; nullable id mId]
-  | Entering (Creating pos_) ->
-      ev "Entering" [ev "Creating" [pos pos_]]
-  | Entering (Filling (tlid_, id_)) ->
-      ev "Entering" [ev "Filling" [tlid tlid_; id id_]]
+  | Omnibox pos_ ->
+      ev "Omnibox" [pos pos_]
+  | Entering (tlid_, id_) ->
+      ev "Entering" [tlid tlid_; id id_]
   | Dragging (tlid_, vpos_, hasMoved, cursor) ->
       ev "Dragging" [tlid tlid_; vPos vpos_; bool hasMoved; cursorState cursor]
   | Deselected ->

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -558,15 +558,12 @@ and isLeftButton = bool
 (* ----------------------------- *)
 (* CursorState *)
 (* ----------------------------- *)
-and entryCursor =
-  | Creating of pos
-  | Filling of tlid * id
-
 and hasMoved = bool
 
 and cursorState =
   | Selecting of tlid * id option
-  | Entering of entryCursor
+  | Omnibox of pos
+  | Entering of tlid * id
   | FluidEntering of tlid
   | Dragging of tlid * vPos * hasMoved * cursorState
   | Deselected
@@ -1060,8 +1057,9 @@ and modification =
   | AppendUnlockedDBs of unlockedDBs
   | Append404s of fourOhFour list
   | Delete404 of fourOhFour
-  | Enter of entryCursor
-  | EnterWithOffset of entryCursor * int
+  | Enter of tlid * id
+  | EnterWithOffset of tlid * id * int
+  | EnterOmnibox of pos
   | UpdateWorkerStats of tlid * workerStats
   | UpdateWorkerSchedules of string StrDict.t
   | NoChange

--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -4773,7 +4773,7 @@ let update (m : Types.model) (msg : Types.fluidMsg) : Types.modification =
                * entering, as some keypresses fire in both editors. *)
               match m.cursorState with FluidEntering _ -> true | _ -> false
             in
-            let enter id = Enter (Filling (tlid, id)) in
+            let enter id = Enter (tlid, id) in
             (* if tab is wrapping... *)
             if isFluidEntering
                && newState.lastKey = K.Tab

--- a/client/src/forms/KeyPress.ml
+++ b/client/src/forms/KeyPress.ml
@@ -129,7 +129,7 @@ let defaultHandler (event : Keyboard.keyEvent) (m : model) : modification =
           if osCmdKeyHeld then openOmnibox m else NoChange
       | _ ->
           NoChange )
-    | Entering cursor ->
+    | Omnibox pos ->
         if event.ctrlKey
         then
           match event.keyCode with
@@ -141,39 +141,56 @@ let defaultHandler (event : Keyboard.keyEvent) (m : model) : modification =
               NoChange
         else (
           match event.keyCode with
-          | Key.Spacebar ->
-            ( match cursor with
-            | Creating _ ->
-                if AC.isOmnibox m.complete
-                then AutocompleteMod (ACSetQuery (m.complete.value ^ " "))
-                else NoChange
-            | _ ->
-                NoChange )
           | Key.Enter ->
-              Entry.submit m cursor Entry.StayHere
-          | Key.Tab ->
-            ( match cursor with
-            | Filling (tlid, id) ->
-                let content = AC.getValue m.complete in
-                let hasContent = content <> "" in
-                if event.shiftKey
-                then
-                  if hasContent
-                  then NoChange
-                  else Selection.enterPrevBlank m tlid id
-                else if hasContent
-                then Entry.submit m cursor Entry.GotoNext
-                else Selection.enterNextBlank m tlid id
-            | Creating _ ->
+            ( match AC.highlighted m.complete with
+            | Some (ACOmniAction act) ->
+                Entry.submitOmniAction m pos act
+            | Some _ ->
+                NoChange
+            (* If empty, create an empty handler *)
+            | None when m.complete.value = "" ->
+                Entry.submitOmniAction m pos (NewReplHandler None)
+            | None ->
                 NoChange )
+          | Key.Spacebar ->
+              AutocompleteMod (ACSetQuery (m.complete.value ^ " "))
+          | Key.Escape ->
+              Many [Deselect; AutocompleteMod ACReset]
+          | Key.Up ->
+              AutocompleteMod ACSelectUp (* NB: see `stopKeys` in ui.html *)
+          | Key.Down ->
+              AutocompleteMod ACSelectDown (* NB: see `stopKeys` in ui.html *)
+          | _ ->
+              AutocompleteMod (ACSetVisible true) )
+    | Entering (tlid, id) ->
+        if event.ctrlKey
+        then
+          match event.keyCode with
+          | Key.P ->
+              AutocompleteMod ACSelectUp
+          | Key.N ->
+              AutocompleteMod ACSelectDown
+          | _ ->
+              NoChange
+        else (
+          match event.keyCode with
+          | Key.Enter ->
+              Entry.submit m tlid id Entry.StayHere
+          | Key.Tab ->
+              let content = AC.getValue m.complete in
+              let hasContent = content <> "" in
+              if event.shiftKey
+              then
+                if hasContent
+                then NoChange
+                else Selection.enterPrevBlank m tlid id
+              else if hasContent
+              then Entry.submit m tlid id Entry.GotoNext
+              else Selection.enterNextBlank m tlid id
           | Key.Unknown _ ->
               NoChange
           | Key.Escape ->
-            ( match cursor with
-            | Creating _ ->
-                Many [Deselect; AutocompleteMod ACReset]
-            | Filling (tlid, p) ->
-                Many [Select (tlid, STID p); AutocompleteMod ACReset] )
+              Many [Select (tlid, STID id); AutocompleteMod ACReset]
           | Key.Up ->
               AutocompleteMod ACSelectUp (* NB: see `stopKeys` in ui.html *)
           | Key.Down ->

--- a/client/src/forms/Selection.ml
+++ b/client/src/forms/Selection.ml
@@ -49,7 +49,7 @@ let enterDB (m : model) (db : db) (tl : toplevel) (id : id) : modification =
   let pd = TL.find tl id in
   let enterField =
     Many
-      [ Enter (Filling (tlid, id))
+      [ Enter (tlid, id)
       ; AutocompleteMod
           (ACSetQuery
              (pd |> Option.map ~f:P.toContent |> Option.withDefault ~default:""))
@@ -78,9 +78,9 @@ let enterWithOffset (m : model) (tlid : tlid) (id : id) (offset : int option) :
         let enterMod =
           match offset with
           | None ->
-              Enter (Filling (tlid, id))
+              Enter (tlid, id)
           | Some offset ->
-              EnterWithOffset (Filling (tlid, id), offset)
+              EnterWithOffset (tlid, id, offset)
         in
         Many [enterMod; AutocompleteMod (ACSetQuery (P.toContent pd))]
     | None ->
@@ -131,7 +131,7 @@ let enterNextBlank (m : model) (tlid : tlid) (cur : id) : modification =
       let nextBlank = TL.getNextBlank tl cur in
       let target =
         nextBlank
-        |> Option.map ~f:(fun id -> Enter (Filling (tlid, id)))
+        |> Option.map ~f:(fun id -> Enter (tlid, id))
         |> Option.withDefault ~default:(fluidEnteringMod tlid)
       in
       maybeEnterFluid ~nonFluidCursorMod:target tl nextBlank
@@ -145,7 +145,7 @@ let enterPrevBlank (m : model) (tlid : tlid) (cur : id) : modification =
       let prevBlank = TL.getPrevBlank tl cur in
       let target =
         prevBlank
-        |> Option.map ~f:(fun id -> Enter (Filling (tlid, id)))
+        |> Option.map ~f:(fun id -> Enter (tlid, id))
         |> Option.withDefault ~default:(fluidEnteringMod tlid)
       in
       maybeEnterFluid ~nonFluidCursorMod:target tl prevBlank

--- a/client/src/forms/ViewBlankOr.ml
+++ b/client/src/forms/ViewBlankOr.ml
@@ -210,7 +210,7 @@ let viewBlankOr
         drawBlank id
   in
   match vs.cursorState with
-  | Entering (Filling (_, thisID)) ->
+  | Entering (_, thisID) ->
       let id = B.toID bo in
       if id = thisID
       then

--- a/client/src/forms/ViewEntry.ml
+++ b/client/src/forms/ViewEntry.ml
@@ -102,7 +102,7 @@ let normalEntryHtml (placeholder : string) (ac : autocomplete) : msg Html.html =
 
 let viewEntry (m : model) : msg Html.html =
   match unwrapCursorState m.cursorState with
-  | Entering (Creating pos) ->
+  | Omnibox pos ->
       let styleProp =
         let offset = m.canvasProps.offset in
         let loc = Viewport.subPos pos offset in

--- a/client/src/prelude/Prelude.ml
+++ b/client/src/prelude/Prelude.ml
@@ -66,33 +66,19 @@ let rec unwrapCursorState (s : cursorState) : cursorState =
 
 let tlidOf (s : cursorState) : tlid option =
   match unwrapCursorState s with
-  | Selecting (tlid, _) ->
+  | Selecting (tlid, _) | Entering (tlid, _) | FluidEntering tlid ->
       Some tlid
-  | Entering entryCursor ->
-    ( match entryCursor with
-    | Creating _ ->
-        None
-    | Filling (tlid, _) ->
-        Some tlid )
-  | Deselected ->
+  | Omnibox _ | Deselected | Dragging _ ->
       None
-  | Dragging (_, _, _, _) ->
-      None
-  | FluidEntering tlid ->
-      Some tlid
 
 
 let idOf (s : cursorState) : id option =
   match unwrapCursorState s with
   | Selecting (_, id) ->
       id
-  | Entering entryCursor ->
-    (match entryCursor with Creating _ -> None | Filling (_, id) -> Some id)
-  | Deselected ->
-      None
-  | Dragging (_, _, _, _) ->
-      None
-  | FluidEntering _ ->
+  | Entering (_, id) ->
+      Some id
+  | Deselected | Dragging _ | Omnibox _ | FluidEntering _ ->
       None
 
 

--- a/client/test/autocomplete_test.ml
+++ b/client/test/autocomplete_test.ml
@@ -31,10 +31,10 @@ let defaultBlankOr = Blank defaultID
 let defaultExpr = EBlank defaultID
 
 let fillingCS ?(tlid = defaultTLID) ?(id = defaultID) () : cursorState =
-  Entering (Filling (tlid, id))
+  Entering (tlid, id)
 
 
-let creatingCS : cursorState = Entering (Creating {x = 0; y = 0})
+let creatingCS : cursorState = Omnibox {x = 0; y = 0}
 
 (* Sets the model with the appropriate toplevels *)
 let defaultModel
@@ -151,7 +151,7 @@ let enteringEventNameHandler ?(space : string option = None) () : model =
 
 let creatingOmni : model =
   { Defaults.defaultModel with
-    cursorState = Entering (Creating {x = 0; y = 0})
+    cursorState = Omnibox {x = 0; y = 0}
   ; builtInFunctions = sampleFunctions }
 
 
@@ -159,10 +159,8 @@ let creatingOmni : model =
 let acFor ?(target = Some (defaultTLID, PDBColType defaultBlankOr)) (m : model)
     : autocomplete =
   match m.cursorState with
-  | Entering (Creating _) ->
+  | Omnibox _ ->
       init m |> setTarget m None
-  | Entering (Filling _) ->
-      init m |> setTarget m target
   | _ ->
       init m |> setTarget m target
 


### PR DESCRIPTION
Once upon a time, the omnibox and the entering box were one and the same, but over the last two years this has ceased to be the case. This makes the types recognize this truth.

This is a refactor, no change in behaviour.


- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

