### PR TITLE
Add tests for the not-deprecated versions of functions

### DIFF
--- a/backend/test/utils.ml
+++ b/backend/test/utils.ml
@@ -84,7 +84,12 @@ let clear_test_data () : unit =
 let at_dval =
   AT.testable
     (fun fmt dv -> Fmt.pf fmt "%s" (Dval.show dv))
-    (fun a b -> compare_dval a b = 0)
+    (fun a b ->
+      match (a, b) with
+      | DIncomplete _, DIncomplete _ ->
+          true
+      | _, _ ->
+          compare_dval a b = 0)
 
 
 let check_dval = AT.check at_dval


### PR DESCRIPTION
We have a bunch of tests for deprecated functions, but we didn't port them when we made newer versions.


- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

