### PR TITLE
Merge the execution engine and state in backend execution

### DIFF
--- a/backend/bin/validate_data_loads.ml
+++ b/backend/bin/validate_data_loads.ml
@@ -116,6 +116,9 @@ let () =
                    ; user_fns = []
                    ; user_tipes = []
                    ; dbs
+                   ; context = Real
+                   ; trace = (fun _ _ -> ())
+                   ; trace_tlid = (fun _ -> ())
                    ; execution_id = Types.id_of_int 0
                    ; fail_fn = None
                    ; load_fn_result = (fun _ _ -> None)

--- a/backend/libexecution/ast.mli
+++ b/backend/libexecution/ast.mli
@@ -27,15 +27,15 @@ val execute_ast :
   -> Types.RuntimeT.expr
   -> Types.RuntimeT.dval * Types.tlid list
 
-val execute_saving_intermediates :
-     input_vars:Types.RuntimeT.input_vars
-  -> Types.RuntimeT.exec_state
+val execute_ast :
+     state:Types.RuntimeT.exec_state
+  -> input_vars:Types.RuntimeT.input_vars
   -> Types.RuntimeT.expr
-  -> Types.RuntimeT.dval * Analysis_types.dval_store * Types.tlid list
+  -> Types.RuntimeT.dval
 
 val execute_fn :
-     Types.RuntimeT.exec_state
+     state:Types.RuntimeT.exec_state
   -> string
   -> Types.id
   -> Types.RuntimeT.dval list
-  -> Types.RuntimeT.dval * Types.tlid list
+  -> Types.RuntimeT.dval

--- a/backend/libexecution/execution.ml
+++ b/backend/libexecution/execution.ml
@@ -100,7 +100,9 @@ let execute_handler
     ?(store_fn_result = store_no_results)
     ?(store_fn_arguments = store_no_arguments)
     (h : HandlerT.handler) : dval * tlid list =
-  let vars = dbs_as_input_vars dbs @ input_vars in
+  let input_vars = dbs_as_input_vars dbs @ input_vars in
+  let tlid_store = TLIDTable.create () in
+  let trace_tlid tlid = Hashtbl.set tlid_store ~key:tlid ~data:true in
   let state : exec_state =
     { tlid
     ; account_id
@@ -108,6 +110,9 @@ let execute_handler
     ; user_fns
     ; user_tipes
     ; dbs
+    ; trace = (fun _ _ -> ())
+    ; trace_tlid
+    ; context = Real
     ; execution_id
     ; fail_fn = None
     ; load_fn_result
@@ -115,7 +120,8 @@ let execute_handler
     ; store_fn_result
     ; store_fn_arguments }
   in
-  let result, tlids = Ast.execute_ast vars state h.ast in
+  let result = Ast.execute_ast ~state ~input_vars h.ast in
+  let tlids = TLIDTable.keys tlid_store in
   match result with
   | DErrorRail (DOption OptNothing) | DErrorRail (DResult (ResError _)) ->
       (DResp (Response (404, []), Dval.dstr_of_string_exn "Not found"), tlids)
@@ -142,6 +148,8 @@ let execute_function
     ?(store_fn_result = store_no_results)
     ?(store_fn_arguments = store_no_arguments)
     fnname =
+  let tlid_store = TLIDTable.create () in
+  let trace_tlid tlid = Hashtbl.set tlid_store ~key:tlid ~data:true in
   let state : exec_state =
     { tlid
     ; account_id
@@ -149,6 +157,9 @@ let execute_function
     ; user_fns
     ; user_tipes
     ; dbs
+    ; trace = (fun _ _ -> ())
+    ; trace_tlid
+    ; context = Real
     ; execution_id
     ; fail_fn = None
     ; load_fn_result = load_no_results
@@ -156,7 +167,7 @@ let execute_function
     ; store_fn_result
     ; store_fn_arguments }
   in
-  Ast.execute_fn state fnname caller_id args
+  (Ast.execute_fn state fnname caller_id args, TLIDTable.keys tlid_store)
 
 
 (* -------------------- *)
@@ -174,6 +185,8 @@ let analyse_ast
     ?(load_fn_result = load_no_results)
     ?(load_fn_arguments = load_no_arguments)
     (ast : expr) : analysis =
+  let value_store = IDTable.create () in
+  let trace id dval = Hashtbl.set value_store ~key:id ~data:dval in
   let input_vars = dbs_as_input_vars dbs @ input_vars in
   let state : exec_state =
     { tlid
@@ -182,6 +195,9 @@ let analyse_ast
     ; user_fns
     ; user_tipes
     ; dbs
+    ; trace
+    ; trace_tlid = (fun _ -> ())
+    ; context = Preview
     ; execution_id
     ; fail_fn = None
     ; load_fn_result
@@ -189,7 +205,6 @@ let analyse_ast
     ; store_fn_result = store_no_results
     ; store_fn_arguments = store_no_arguments }
   in
-  let _, traced_values, _ =
-    Ast.execute_saving_intermediates state ~input_vars ast
-  in
-  traced_values
+  Libcommon.Log.infO "Executing for intermediates" ;
+  let _ = Ast.execute_ast ~state ~input_vars ast in
+  value_store

--- a/backend/libexecution/types.ml
+++ b/backend/libexecution/types.ml
@@ -504,6 +504,13 @@ module RuntimeT = struct
 
   type fail_fn_type = (?msg:string -> unit -> dval) option
 
+  (* this is _why_ we're executing the AST, to allow us to not
+   * emit certain side-effects (eg. DB writes) when showing previews *)
+  type context =
+    | Preview
+    | Real
+  [@@deriving eq, show, yojson]
+
   type exec_state =
     { tlid : tlid
     ; canvas_id : Uuidm.t
@@ -511,6 +518,9 @@ module RuntimeT = struct
     ; user_fns : user_fn list
     ; user_tipes : user_tipe list
     ; dbs : DbT.db list
+    ; trace : id -> dval -> unit
+    ; trace_tlid : tlid -> unit
+    ; context : context
     ; execution_id : id
     ; load_fn_result : load_fn_result_type
     ; store_fn_result : store_fn_result_type

--- a/backend/test/utils.ml
+++ b/backend/test/utils.ml
@@ -349,6 +349,9 @@ let test_execution_data
     ; fail_fn = None
     ; dbs = TL.dbs !c.dbs
     ; execution_id
+    ; trace = (fun _ _ -> ())
+    ; trace_tlid = (fun _ -> ())
+    ; context = Real
     ; load_fn_result = load_test_fn_results
     ; store_fn_result =
         Stored_function_result.store ~canvas_id ~trace_id
@@ -371,6 +374,9 @@ let execute_ops
         ; store_fn_arguments
         ; execution_id
         ; dbs
+        ; trace
+        ; trace_tlid
+        ; context
         ; user_fns
         ; user_tipes
         ; account_id
@@ -412,7 +418,7 @@ let exec_handler ?(ops = []) (prog : string) : dval =
 
 let exec_ast ?(canvas_name = "test") (prog : string) : dval =
   let c, state, input_vars = test_execution_data ~canvas_name [] in
-  let result, _ = Ast.execute_ast input_vars state (ast_for prog) in
+  let result = Ast.execute_ast ~input_vars ~state (ast_for prog) in
   result
 
 
@@ -421,15 +427,36 @@ let exec_userfn (prog : string) : dval =
   let ast = ast_for prog in
   let fn = user_fn name [] ast in
   let c, state, _ = test_execution_data [SetFunction fn] in
-  let result, _ = Ast.execute_fn state name execution_id [] in
-  result
+  Ast.execute_fn ~state name execution_id []
 
 
 let exec_save_dvals ?(canvas_name = "test") (ast : expr) :
     Analysis_types.dval_store =
   let c, state, input_vars = test_execution_data ~canvas_name [] in
-  let _, dvstore, _ = Ast.execute_saving_intermediates input_vars state ast in
-  dvstore
+  let { tlid
+      ; execution_id
+      ; dbs
+      ; user_fns
+      ; user_tipes
+      ; account_id
+      ; canvas_id
+      ; load_fn_result
+      ; load_fn_arguments
+      ; _ } =
+    state
+  in
+  Execution.analyse_ast
+    ~tlid
+    ~execution_id
+    ~input_vars
+    ~dbs
+    ~user_fns
+    ~user_tipes
+    ~account_id
+    ~canvas_id
+    ~load_fn_result
+    ~load_fn_arguments
+    ast
 
 
 (* Sample values *)


### PR DESCRIPTION
I needed to thread the execution engine a little lower, to places where there is already state. Given that the state/engine split is confusing anyway, its easier to merge them (given they now that they are needed in the same paces).

Needed for: https://trello.com/c/omNlanMN/2188-ship-query-sql-compiler

Also simplifies traces a little bit.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

