### PR TITLE
Deprecate `Date::sub` and replace with `Date::subtract`

### DIFF
--- a/backend/libexecution/libdate.ml
+++ b/backend/libexecution/libdate.ml
@@ -140,6 +140,20 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
+    ; dep = true }
+  ; { pns = ["Date::subtract"]
+    ; ins = []
+    ; p = [par "d" TDate; par "seconds" TInt]
+    ; r = TDate
+    ; d = "Returns a new Date `seconds` seconds before `d`"
+    ; f =
+        InProcess
+          (function
+          | _, [DDate d; DInt s] ->
+              DDate (Time.sub d (Time.Span.of_int_sec (Dint.to_int_exn s)))
+          | args ->
+              fail args)
+    ; ps = true
     ; dep = false }
   ; { pns = ["Date::greaterThan"]
     ; ins = ["Date::>"]


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

**Trello:**  
https://trello.com/c/qPguIhA9/2185-deprecate-datesub-add-datesubtract

**Goal:**
Deprecate "date::sub" and create new function called "date::subtract"

**Screenshot**
![2020-01-06 10 44 30](https://user-images.githubusercontent.com/32043360/71840154-96f07480-3071-11ea-93dd-f1be8c0af66d.gif)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

