### PR TITLE
[scheduler] truncate DBs to fix re-running

### DIFF
--- a/queue-scheduler/tests/helpers/mod.rs
+++ b/queue-scheduler/tests/helpers/mod.rs
@@ -27,6 +27,10 @@ pub fn setup_database(log: Arc<slog::Logger>) -> Result<postgres::Connection, Er
 }
 
 pub fn setup_canvas(conn: &postgres::Connection) -> Result<(Uuid, Uuid), Error> {
+    conn.execute("TRUNCATE events", &[])?;
+    conn.execute("TRUNCATE scheduling_rules", &[])?;
+    conn.execute("TRUNCATE accounts CASCADE", &[])?;
+
     conn.execute(
         "INSERT INTO accounts (id, username, name, email, admin, password)
         VALUES (

--- a/queue-scheduler/tests/scheduler.rs
+++ b/queue-scheduler/tests/scheduler.rs
@@ -5,8 +5,8 @@ use helpers::*;
 
 #[test]
 fn schedules_new_events() -> Result<(), Error> {
-    let (conn, mut looper) = helpers::setup()?;
-    let (canvas_id, account_id) = helpers::setup_canvas(&conn)?;
+    let (conn, mut looper) = setup()?;
+    let (canvas_id, account_id) = setup_canvas(&conn)?;
 
     let current_event_id = insert_event(
         &conn,
@@ -43,8 +43,8 @@ fn schedules_new_events() -> Result<(), Error> {
 
 #[test]
 fn does_not_schedule_paused_events() -> Result<(), Error> {
-    let (conn, mut looper) = helpers::setup()?;
-    let (canvas_id, account_id) = helpers::setup_canvas(&conn)?;
+    let (conn, mut looper) = setup()?;
+    let (canvas_id, account_id) = setup_canvas(&conn)?;
 
     insert_pause_rule(&conn, &canvas_id, "worker-2")?;
 


### PR DESCRIPTION
I'm not sure what changed here, but re-running tests in queue-scheduler (such as by saving one of its `.rs` files with `scripts/builder` running) is broken due to a FK constraint on `scheduling_rules` failing. This is because `SELECT canvas_id` returns the same id for each call with the same canvas name.

I honestly don't know how this ever worked, but clearing out the data in the DB seems like the best option for making this foolproof.