### PR TITLE
Actually send via rollbar

### DIFF
--- a/backend/bin/cron_checker.ml
+++ b/backend/bin/cron_checker.ml
@@ -18,14 +18,12 @@ let cron_checker execution_id =
           ~data:"Uncaught error"
           ~params:[("exn", Libexecution.Exception.exn_to_string e)] ;
         Lwt.async (fun () ->
-            let _ =
-              Libbackend.Rollbar.report_lwt
-                e
-                bt
-                CronChecker
-                (Libexecution.Types.string_of_id execution_id)
-            in
-            Lwt.return ()) ;
+            Libbackend.Rollbar.report_lwt
+              e
+              bt
+              CronChecker
+              (Libexecution.Types.string_of_id execution_id)
+            >>= fun _ -> Lwt.return ()) ;
         if not !shutdown then (cron_checker [@tailcall]) () else Lwt.return ()
   in
   Lwt_main.run

--- a/backend/bin/queue_worker.ml
+++ b/backend/bin/queue_worker.ml
@@ -26,14 +26,12 @@ let queue_worker execution_id =
             [ ("execution_id", Libexecution.Types.string_of_id execution_id)
             ; ("exn", Libexecution.Exception.exn_to_string e) ] ;
         Lwt.async (fun () ->
-            let _ =
-              Libbackend.Rollbar.report_lwt
-                e
-                bt
-                EventQueue
-                (Libexecution.Types.string_of_id execution_id)
-            in
-            Lwt.return ()) ;
+            Libbackend.Rollbar.report_lwt
+              e
+              bt
+              EventQueue
+              (Libexecution.Types.string_of_id execution_id)
+            >>= fun _ -> Lwt.return ()) ;
         Thread.yield () ;
         if not !shutdown
         then (queue_worker [@tailcall]) ()


### PR DESCRIPTION
I broke this during an upgrade. Before this commit, report_lwt returned a promise that we did not execute, and so the rollbar never got sent. This makes it send the rollbar.

No trello because it was found in a post-review check, thanks @IanConnolly!

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

