### PR TITLE
DBlock takes one arg now, somewhere pre-merge it took none

### DIFF
--- a/client/src/toplevels/CurlCommand.ml
+++ b/client/src/toplevels/CurlCommand.ml
@@ -9,7 +9,7 @@ module TL = Toplevel
  * _), DOption (OptNothing) - moved to the None case *)
 let rec to_url_string (dv : dval) : string option =
   match dv with
-  | DBlock
+  | DBlock _
   | DIncomplete _
   | DPassword _
   | DObj _


### PR DESCRIPTION
NO trello, fixes merge failure

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

