### PR TITLE
Compile less of cargo-cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,8 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-too
 
 # install Rust dev tools
 RUN rustup component add clippy-preview rustfmt-preview
-RUN cargo install cargo-cache
+RUN cargo install cargo-cache --no-default-features --features ci-autoclean
+
 
 # Once we have cargo and things installed in /usr/local/cargo and that added to PATH,
 # reset CARGO_HOME so that we can use it as a project cache directory like normal.


### PR DESCRIPTION
We only use cargo cache -a (--autoclean). On my laptop, this cuts `cargo
install cargo-cache --force` from 1:22 to 0:02.

See: https://www.reddit.com/r/rust/comments/elkyvo/cargocache_034_faster_cargo_home_caching_on_ci/
```
For those wanting to cache the $CARGO_HOME on continuous integration, I
have added a ci-autoclean feature that skips most dependencies by
stripping away most of the crates functionality that is not needed in
this case.
```

https://trello.com/c/GMWZ5VA8/2193-reduce-container-build-time-by-building-less-of-cargo-cache

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

