### PR TITLE
Ismith/install compiled crcmod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       kubectl \
       python3-pip \
       python3-setuptools \
+      python3-dev \
       libsodium-dev \
       gcc \
       pgcli \
@@ -217,8 +218,22 @@ RUN curl -sSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/rele
 
 RUN docker-credential-gcr config --token-source="gcloud"
 
-# crcmod for gsutil
-RUN pip3 install -U --no-cache-dir -U crcmod
+# crcmod for gsutil; this gets us the compiled (faster), not pure Python
+# (slower) crcmod, as described in `gsutil help crcmod`
+#
+# It requires that python3-pip, python3-dev, python3-setuptools, and gcc be
+# installed. You'll also need CLOUDSDK_PYTHON=python3 to be set when you use
+# gsutil. (Which the ENV line handles.)
+#
+# The last line greps to confirm that gsutil has a compiled crcmod.
+# Possible failure modes; missing deps above (-pip, -dev, -setuptools, gcc); a
+# pre-installed crcmod that needs to be uninstalled first.  Added that because
+# this install is a bit brittle, and it's easy to invisibly install the pure
+# Python crcmod.
+ENV CLOUDSDK_PYTHON=python3
+RUN pip3 install -U --no-cache-dir -U crcmod \
+  && ((gsutil version -l | grep compiled.crcmod:.True) \
+      || (echo "Compiled crcmod not installed." && false))
 
 ############################
 # Pip packages


### PR DESCRIPTION
compiled crcmod speeds up download-gcp-db

When running download-gcp-db, we get a warning:

```
==> NOTE: You are downloading one or more large file(s), which would
run significantly faster if you enabled sliced object downloads. This
feature is enabled by default but requires that compiled crcmod be
installed (see "gsutil help crcmod").
```

`gsutil help crcmod` tells us that we can check if we have the pure
Python (slow) or natively compiled (faster) crcmod installed by running
`gsutil version -l | grep compiled.crcmod`; `run-in-docker [that]` says
we don't.

This Dockerfile change fixes that.

Note: can't use pip3 for this, because gsutil/google-cloud-sdk is python
2.

https://trello.com/c/4Cfhc99G/2204-compiled-crcmod-will-speed-download-gcp-db
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

