### PR TITLE
Add `DarkInternal::canvasesFor`

### DIFF
--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -310,6 +310,22 @@ LIKE '%@darklang.com' AND email NOT LIKE '%@example.com'"
             |> DList)
     ; ps = false
     ; dep = false }
+  ; { pns = ["DarkInternal::canvasesFor"]
+    ; ins = []
+    ; p = [par "account" TStr]
+    ; r = TList
+    ; d =
+        "Returns a list of all canvases owned by a particular account (user OR org)"
+    ; f =
+        internal_fn (function
+            | _, [DStr account] ->
+                Serialize.hosts_for (Unicode_string.to_string account)
+                |> List.map ~f:Dval.dstr_of_string_exn
+                |> DList
+            | args ->
+                fail args)
+    ; ps = false
+    ; dep = false }
   ; { pns = ["DarkInternal::schema"]
     ; ins = []
     ; p = [par "host" TStr; par "dbid" TStr]

--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -260,6 +260,18 @@ let current_hosts () : string list =
   |> List.dedup_and_sort ~compare
 
 
+let hosts_for (account_name : string) : string list =
+  Db.fetch
+    ~name:"hosts_for"
+    "SELECT DISTINCT c.name
+     FROM canvases c
+     JOIN accounts acc ON c.account_id = acc.id
+     WHERE acc.username = $1"
+    ~params:[String account_name]
+  |> List.map ~f:List.hd_exn
+  |> List.dedup_and_sort ~compare
+
+
 let tier_one_hosts () : string list =
   [ "ian-httpbin"
   ; "paul-slackermuse"


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Allows: https://trello.com/c/rVesJoDj/1944-create-a-darkinternal-function-to-look-up-all-canvases-a-user-has-access-to

I thought we could do this, but we didn't actually have a way of grabbing canvases for a specific user -- so here it is.

Can easily be combined with existing `DarkInternal::orgsFor` to grab all the canvases a user can access (modulo `sample-` etc.)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

