### PR TITLE
Put error bar in front of _everything_

### DIFF
--- a/client/styles/_zindex.scss
+++ b/client/styles/_zindex.scss
@@ -14,7 +14,7 @@
 }
 
 .error-panel {
-  z-index: 60;
+  z-index: 260;
 }
 
 .message-panel {


### PR DESCRIPTION
Previously, error bar would be behind the minimap in function view,
which hid the [dismiss] button.

This still doesn't address minimap covering the docs link, but maybe
it's a useful improvement?

Before:
![screenshot_1](https://user-images.githubusercontent.com/172694/72023564-fbedcb00-3227-11ea-894a-7577c5f9ea49.png)

After:
![screenshot](https://user-images.githubusercontent.com/172694/72023571-ff815200-3227-11ea-8df3-90db7fb76031.png)


- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

