### PR TITLE
Better error msg when get_trace_data response is too big

### DIFF
--- a/client/workers/Fetcher.ml
+++ b/client/workers/Fetcher.ml
@@ -65,8 +65,19 @@ let fetch_
              Fetch.Response.text resp
              |> then_ (fun body -> resolve (postMessage self (on_failure body)))
          | _ ->
-             reportError "fetch error" (url, err) ;
-             resolve (postMessage self (on_failure (Obj.magic err)##message)))
+             let message = (Obj.magic err)##message in
+             let message =
+               if String.endsWith
+                    ~suffix:"Maximum call stack size exceeded"
+                    message
+               then
+                 "Selected trace too large for the editor to load, maybe try another?"
+               else message
+             in
+             (* data here is jsonified params; ex: for a get_trace_data failure,
+              * it contains a tlid and a trace id *)
+             reportError "fetch error" (url, err, data) ;
+             resolve (postMessage self (on_failure message)))
 
 
 let fetch (context : Types.fetchContext) (request : Types.fetchRequest) =


### PR DESCRIPTION
Old error: "Error fetching trace (<...>/get_trace_data): Maximum call
stack size exceeded" is opaque and not actionable.

New error: "Error fetching trace (<...>/get_trace_data): Selected trace
too large for editor to load, maybe try another?" suggests an action.

 We also - on any error in fetch_, not just max call stack size errors -
 put the params (to the fetch_ call) into the msg sent to rollbar.

Note:
I want to look at if we can mark these traces as unloadable somehow -
diff color, tooltip - but leaving that for a separate PR. Related trellos: https://trello.com/c/uK75Rb2Q/2208-investigate-marking-trace-dots-with-their-trace-id-for-easier-debugging , https://trello.com/c/SlDAWunV/2207-if-we-cant-fetch-data-for-a-trace-can-we-mark-that-trace-in-the-dom

(This is not the error eagon ran into, mentioned in the trello, but
occured when I was trying to investigate that error.)
https://trello.com/c/386sLpUc/2200-investigate-the-uncaughttype-error-eagon-ran-into

Before:
![before](https://user-images.githubusercontent.com/172694/72097017-4591f080-32d0-11ea-89cd-1931985fda1a.png)


After:
![after](https://user-images.githubusercontent.com/172694/72097004-3f037900-32d0-11ea-8aba-2cb082af05ab.png)


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

g