### PR TITLE
Put trace_id in the trace <li> for easier debugging

### DIFF
--- a/client/src/toplevels/ViewData.ml
+++ b/client/src/toplevels/ViewData.ml
@@ -97,7 +97,10 @@ let viewTrace
     else [Html.div [Vdom.noProp] [Html.text {js|•|js}]]
   in
   let viewData = Html.div [Html.class' "data"] [timestampDiv; valueDiv] in
-  Html.li ~key:viewKey (Html.class' classes :: events) (dotHtml @ [viewData])
+  Html.li
+    ~key:viewKey
+    (Html.class' ("traceid-" ^ traceID ^ " " ^ classes) :: events)
+    (dotHtml @ [viewData])
 
 
 let viewTraces (vs : ViewUtils.viewState) (astID : id) : msg Html.html list =


### PR DESCRIPTION
It'd be nice to have a stable way to say "I'm looking at _this_ trace
right now", rather than "it's the third dot from the top".

This provides that.

We could also consider making it more visible - replace "Made [elapsed
time] ago" with "Made [elapsed time] ago\nID: [traceid]", but I did not
do that here.

Before:
![before](https://user-images.githubusercontent.com/172694/72098671-d0c0b580-32d3-11ea-85c8-0e11d5f66410.png)

After:
![after](https://user-images.githubusercontent.com/172694/72098664-cdc5c500-32d3-11ea-8d6e-a7e1c1f04f84.png)

https://trello.com/c/uK75Rb2Q/2208-investigate-marking-trace-dots-with-their-trace-id-for-easier-debugging

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

