### PR TITLE
Add 'organization' to segment events

### DIFF
--- a/backend/libbackend/stroller.ml
+++ b/backend/libbackend/stroller.ml
@@ -251,15 +251,11 @@ let segment_identify_user (username : string) : unit =
            |> Authorization.orgs_for
            (* A user's orgs for this purpose do not include orgs it has
             * read-only access to *)
-           |> List.filter ~f:(function
-                  | _, Read ->
-                      false
-                  | _, ReadWrite ->
-                      true)
+           |> List.filter ~f:(function _, rw -> rw = ReadWrite)
            (* If you have one org, that's your org! If you have no orgs, or
-            * more than one, then we just use your username. *)
-           |> fun orgs ->
-           match orgs with [(org_name, _)] -> org_name | _ -> p.username)
+            * more than one, then we just use your username. This is because
+            * Heap's properties/traits don't support lists. *)
+           |> function [(org_name, _)] -> org_name | _ -> p.username)
   in
   Option.map2 organization payload ~f:(fun organization payload ->
       { username = payload.username


### PR DESCRIPTION
 Heap doesn't (we think) allow list-type properties (eagon belongs to
 both 'eagon' and 'amatorium' groups), so we're limiting to just one org
 per user.                                                               


- In the case of a user (an identify message), its organization is:
  - the organization's username, if the user belongs to exactly 1 org,
or
  - the username

(Note: readonly orgs don't count, we only care about ones you have
readwrite access to.)

- In the case of an event (editing a canvas, traffic to bwd), the
organization is the auth_domain of the canvas. ('ismith' is one
possibility; 'amatorium' is another)

Since traits (Identify msgs) and properties (Event msgs) are just the
json body, this requires no changes to stroller, just changes to ocaml.

Post-merge, Ian will re-run segment_identify_users.exe to update existing users' traits.

https://trello.com/c/cKddUA2r/2187-usernames-and-canvases-should-be-linked-in-heap

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

