### PR TITLE
Deleting a partial binop shouldn't delete everything to right

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -1613,6 +1613,8 @@ let replaceWithPartial (str : string) (id : id) (ast : ast) : E.t =
             if str = "" then E.newB () else EPartial (gid (), str, oldVal))
 
 
+(* deleteBinOp' looks at the expr to the left(lhs)andright(rhs)side of a binop to figure out 
+ * what to do when the binop is deleted instead of just deleting the entire rhs *)
 let rec deleteBinOp'
     (lhs : fluidExpr)
     (rhs : fluidExpr)

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -1777,44 +1777,50 @@ let run () =
         "false~ || true" ;
       t
         "pressing bs on ++ binop before blank deletes blank but rest of the lhs"
-        (binop "+" anInt (binop "+" anInt (binop "+" b anInt)))
-        (bs 15)
-        "12345 + 12345~ + 12345" ;
+        (binop "+" (int "10") (binop "*" (int "5") (binop "+" b (int "10"))))
+        (bs 8)
+        "10 + 5~ + 10" ;
       t
         "pressing bs on ++ binop after blank deletes blank but rest of the lhs"
-        (binop "+" anInt (binop "+" anInt (binop "+" b anInt)))
-        (bs 27)
-        "12345 + 12345 + ~12345" ;
+        (binop "+" (int "20") (binop "*" (int "1") (binop "+" b (int "5"))))
+        (bs 20)
+        "20 + 1 * ~5" ;
       t
         "pressing bs on < binop before blank deletes blank but rest of the lhs"
-        (binop "<" anInt (binop "<" b anInt))
-        (bs 7)
-        "12345~ < 12345" ;
+        (binop "<" (int "20") (binop "<" b (int "50")))
+        (bs 4)
+        "20~ < 50" ;
       t
         "pressing bs on < binop after blank deletes blank but rest of the lhs"
-        (binop "<" anInt (binop "<" b anInt))
-        (bs 19)
-        "12345 < ~12345" ;
+        (binop "<" (int "25") (binop "<" b (int "50")))
+        (bs 16)
+        "25 < ~50" ;
       t
         "pressing bs on - binop before blank deletes blank but rest of the lhs"
-        (binop "-" anInt (binop "-" anInt (binop "-" b anInt)))
-        (bs 15)
-        "12345 - 12345~ - 12345" ;
+        (binop "-" (int "200") (binop "-" (int "5") (binop "*" b (int "24"))))
+        (bs 9)
+        "200 - 5~ * 24" ;
       t
         "pressing bs on - binop after blank deletes blank but rest of the lhs"
-        (binop "-" anInt (binop "-" anInt (binop "-" b anInt)))
-        (bs 21)
-        "12345 - 12345 - ~12345" ;
+        (binop "-" (int "200") (binop "-" (int "5") (binop "*" b (int "24"))))
+        (bs 15)
+        "200 - 5 - ~24" ;
       t
         "pressing bs on != binop before blank deletes blank but rest of the lhs"
-        (binop "!=" anInt (binop "!=" anInt (binop "!=" b anInt)))
-        (keys [K.Backspace; K.Backspace] 17)
-        "12345 != 12345~ != 12345" ;
+        (binop
+           "!="
+           (int "54321")
+           (binop "!=" (int "21") (binop "!=" b (int "5"))))
+        (keys [K.Backspace; K.Backspace] 14)
+        "54321 != 21~ != 5" ;
       t
         "pressing bs on != binop after blank deletes blank but rest of the lhs"
-        (binop "!=" anInt (binop "!=" anInt (binop "!=" b anInt)))
-        (keys [K.Backspace; K.Backspace] 24)
-        "12345 != 12345 != ~12345" ;
+        (binop
+           "!="
+           (int "54321")
+           (binop "!=" (int "21") (binop "!=" b (int "5"))))
+        (keys [K.Backspace; K.Backspace] 21)
+        "54321 != 21 != ~5" ;
       t
         "pressing bs on != binop combines lhs and rhs string"
         (binop "!=" (str "One") (binop "!=" (str "Two") (str "Three")))


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### **Trello:**
https://trello.com/c/UQNEd2NZ/2128-developer-had-trouble-deleting-from-middle-of-concatenated-string

### **Spec:**
https://docs.google.com/document/d/1zvG2hueV6VRL1yqW090qXX9ibvzy1IMC6RxmaZEByEQ/edit#

### **Goal:**
- Avoid deleting more code then the user intends/expects 

### **Why?**
A Dark Developer wanted to delete part of a concatenated string and did so by pressing backspace, but ended up losing the entire right part of the string, with this fix, the developer will not lose all the code to the right of the Binop.


### **Gifs:**
**Before:**
![2020-01-09 14 37 43](https://user-images.githubusercontent.com/32043360/72110675-a8de4b80-32ed-11ea-995b-60e1b6585136.gif)
![2020-01-09 14 37 20](https://user-images.githubusercontent.com/32043360/72110676-a976e200-32ed-11ea-8053-e1e02014c9e7.gif)
![2020-01-09 14 37 02](https://user-images.githubusercontent.com/32043360/72110677-a976e200-32ed-11ea-8511-a256aed7c538.gif)
![2020-01-09 14 36 41](https://user-images.githubusercontent.com/32043360/72110678-a976e200-32ed-11ea-8050-2443ba221a01.gif)



**After:**
![2020-01-09 14 15 43](https://user-images.githubusercontent.com/32043360/72109336-931b5700-32ea-11ea-83a0-ee6b5e507b3c.gif)
![2020-01-09 14 15 25](https://user-images.githubusercontent.com/32043360/72109338-931b5700-32ea-11ea-93ae-ae723b54c3e2.gif)
![2020-01-09 14 15 11](https://user-images.githubusercontent.com/32043360/72109340-93b3ed80-32ea-11ea-9df7-a9c6031b6665.gif)
![2020-01-09 14 14 51](https://user-images.githubusercontent.com/32043360/72109341-93b3ed80-32ea-11ea-841c-276d2a3d5fbc.gif)
![2020-01-09 16 09 27](https://user-images.githubusercontent.com/32043360/72115317-7c313080-32fb-11ea-8c21-01a26de1325a.gif)
![2020-01-09 16 09 05](https://user-images.githubusercontent.com/32043360/72115319-7c313080-32fb-11ea-9931-30c8cab4a041.gif)
![2020-01-09 16 17 43](https://user-images.githubusercontent.com/32043360/72115349-99fe9580-32fb-11ea-8aa9-d9597222ec31.gif)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

