### PR TITLE
add x509 certificate lib

### DIFF
--- a/backend/libbackend/init.ml
+++ b/backend/libbackend/init.ml
@@ -22,6 +22,7 @@ let init ~run_side_effects =
         @ Libstaticassets.fns
         @ Libtwitter.fns
         @ Libjwt.fns
+        @ Libx509.fns
       in
       Libexecution.Init.init Config.log_level Config.log_format non_client_fns ;
       (* init the Random module, will be seeded from /dev/urandom on Linux *)

--- a/backend/libbackend/libx509.ml
+++ b/backend/libbackend/libx509.ml
@@ -1,0 +1,33 @@
+open Core_kernel
+open Libexecution
+open Libexecution.Lib
+module U = Libexecution.Unicode_string
+
+let fns =
+  [ { pns = ["X509::pemCertificatePublicKey"]
+    ; ins = []
+    ; p = [par "pemCert" TStr]
+    ; r = TResult
+    ; d =
+        "Extract the public key from a PEM encoded certificate and return the key in PEM format."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr cert] ->
+            ( try
+                cert
+                |> U.to_string
+                |> Cstruct.of_string
+                |> X509.Encoding.Pem.Certificate.of_pem_cstruct1
+                |> X509.public_key
+                |> X509.Encoding.Pem.Public_key.to_pem_cstruct1
+                |> Cstruct.to_string
+                |> Dval.dstr_of_string_exn
+                |> ResOk
+                |> DResult
+              with Invalid_argument msg ->
+                DResult (ResError (Dval.dstr_of_string_exn msg)) )
+          | args ->
+              fail args)
+    ; ps = false
+    ; dep = false } ]


### PR DESCRIPTION
## What

Adds `X509::pemCertificatePublicKey`, which parses a PEM encoded certificate and returns the public key part also PEM encoded.

## Why

https://trello.com/b/B25On0K9/weekly

T. Sattlecker is attempting to do Firebase auth in front of his Dark API, but the public key needed to validate the JWT is a x509 certificate. This allows extraction of the public key from the certificate, suitable for passing into our `JWT::verifyAndExtract` function.

<img width="1259" alt="Screen Shot 2020-01-10 at 12 35 55 PM" src="https://user-images.githubusercontent.com/131/72173652-09c95a80-33a6-11ea-9d67-2bb3895fa780.png">
