### PR TITLE
events needs partial index where status <> done

### DIFF
--- a/backend/migrations/20200110_211251_index-events-on-id-status-where-status-not-done.sql
+++ b/backend/migrations/20200110_211251_index-events-on-id-status-where-status-not-done.sql
@@ -1,0 +1,1 @@
+create index if not exists idx_events_for_dequeue on events (status, id) where status <> 'done'


### PR DESCRIPTION
We don't need the events index to cover events with status = 'done'; not
indexing those keeps the index small enough to fit in cache.

This was responsible for the worker queues outage of 2020-01-09.

Solution: `create index concurrently idx_events_for_dequeue on events
(status, id) where status <> 'done'` in prod, manually; migration to
create index if not exists. (Same index, but not concurrently because
our migration script doesn't handle that well.)

https://trello.com/c/u5UusTxv/2212-partial-index-on-events-queue

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [x] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

