### PR TITLE
Ismith/queue worker should handle all exns

### DIFF
--- a/backend/bin/queue_worker.ml
+++ b/backend/bin/queue_worker.ml
@@ -33,7 +33,9 @@ let queue_worker execution_id =
                   EventQueue
                   (Libexecution.Types.string_of_id execution_id)
               with e ->
-                Log.erroR "Error in Rollbar.report_lwt in queue worker" ;
+                Log.erroR
+                  "Error in Rollbar.report_lwt in queue worker"
+                  ~data:(Libexecution.Exception.exn_to_string e) ;
                 Lwt.return (`Failure : Libbackend.Rollbar.result) )
             >>= fun _ -> Lwt.return ()) ;
         Thread.yield () ;


### PR DESCRIPTION
We're getting a DarkException; make sure we log it more verbosely

```
Thread 2 killed on uncaught exception Libexecution__Exception.DarkException(_)
Raised at file "src/core/lwt.ml", line 3027, characters 20-29
Called from file "src/unix/lwt_main.ml", line 27, characters 10-20
Called from file "src/unix/lwt_main.ml", line 114, characters 8-13
Re-raised at file "src/unix/lwt_main.ml", line 120, characters 4-13
Called from file "thread.ml", line 39, characters 8-14
```

This commit doesn't address "if thread 2 dies, thread 1 should
terminate", but it addresses one possible source of the above
DarkException.

No trello, we'll retro this later.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

