### PR TITLE
Unify how we log spec fields in various handler types

### DIFF
--- a/backend/libbackend/cron.ml
+++ b/backend/libbackend/cron.ml
@@ -203,7 +203,7 @@ let check_all_canvases execution_id : (unit, Exception.captured) Result.t =
                          [ ("execution_id", Types.string_of_id execution_id)
                          ; ("canvas", endp)
                          ; ("tlid", Types.string_of_id cr.tlid)
-                         ; ("name", name)
+                         ; ("handler_name", name)
                            (* method here to use the spec-handler name for
                             * consistency with http/worker logs *)
                          ; ("method", modifier) ]))

--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -55,12 +55,12 @@ let dequeue_and_process execution_id :
                           [ ("canvas", `String host)
                           ; ("trace_id", `String (Uuidm.to_string trace_id))
                           ; ("canvas_id", `String (Uuidm.to_string canvas_id))
-                            (* name/module/method because those are the names of
-                             * the fields in a handler spec, and we want these
-                             * names to be shared between http logs and
-                             * cron/worker logs *)
+                            (* handler_name/module/method because those are the
+                             * names of the fields in a handler spec, and we
+                             * want these names to be shared between http logs
+                             * and cron/worker logs *)
                           ; ("module", `String event.space)
-                          ; ("name", `String event.name)
+                          ; ("handler_name", `String event.name)
                           ; ("method", `String event.modifier)
                           ; ("retries", `Int event.retries) ]
                           (fun _ ->

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -2115,10 +2115,11 @@ let server () =
     in
     Log.add_log_annotations
       [ ("execution_id", `String (Types.string_of_id execution_id))
-        (* We call this name and not request for a reason - we want to unify
-         * with what other spec-having handlers use, since qw+cron+webserver all
-         * share logs *)
-      ; ("name", `String request_path)
+        (* We call this handler_name and not request for a reason - we want to
+         * unify with what other spec-having handlers use, since
+         * qw+cron+webserver all share logs (and not just "name" because that's
+         * the field we use for a Log call's unlabeled string argument *)
+      ; ("handler_name", `String request_path)
       ; ("module", `String "HTTP")
       ; ("method", `String (Cohttp.Code.string_of_method (CRequest.meth req)))
       ; ("host", `String (Uri.host_with_default ~default:"" (CRequest.uri req)))

--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -78,9 +78,9 @@ data:
         dataset: kubernetes-bwd-ocaml
         parser: json
         processors:
-        # 'request' is what we used to call 'name'; it's in here for the moment
-        # so honeycomb knows how to handle both for the brief period when we
-        # have logs with the old name and logs with the new name.
+        # 'request' is what we now call 'handler_name'; it's in here for the
+        # moment so honeycomb knows how to handle both for the brief period when
+        # we have logs with the old name and logs with the new name.
         - request_shape:
             field: request
             patterns:
@@ -98,7 +98,7 @@ data:
             - /api/:canvas/static_assets
             - /canvas/:canvas/events/:event # stroller - not currently routed through nginx
         - request_shape:
-            field: name
+            field: handler_name
             patterns:
             - /a/:canvas
             - /api/:canvas/save_test


### PR DESCRIPTION
Workers and handlers both use a spec with a module_, name, and modifier.
(This is where I first saw it, but we also have cron+repl handlers)

In logs, we called these different things:

spec: (module, name, modifier)
worker: ("WORKER", event_name, "\_")
http: ("HTTP", route, method/verb)
cron: ("CRON",  name, interval/cron_freq)
repl: ("REPL", name, "\_")

More schema fields is a pain for honeycomb usage - eg, if you are
looking at errors that happen when we execute dark code, now you need to
have fields for each of those. (Eg, I want to know where this exn
happened, I need to group by event_name and route and method and
cron_freq ... instead of just name and method.)

I chose to unify these on (method, handler_name). (handler_name because name is already taken for the unlabeled strng arg to Log calls)

I also had to update the request_shape processor in honeycomb.yaml to
point at the new field (name); this
ensures that honeycomb knows how to normalize web requests to our
endpoints. (I left the old `field: request` parser in for now so we
don't lose logs during the deploy, it can be removed at a later date.)

Likewise, canvas (http) vs host (worker/cron); the latter was arguably a
bug borne of the value being canvas.host. I just changed this to canvas.

Post-deploy: we want the old field names to be hidden from the schema so
they don't show up in autocomplete; this requires manually ticking the
relevant checkboxes in
https://ui.honeycomb.io/dark/datasets/kubernetes-bwd-ocaml/schema; I
think the only ones it's necessary to do this for to avoid confusion
are:
- request
- cron_freq

https://trello.com/c/Zn7LQcz8/2233-unify-handler-spec-names-in-logs-to-simplify-honeycomb-schema

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

