### PR TITLE
shift + Cmd arrow / ctrl arrow should select

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -4202,12 +4202,12 @@ let rec updateKey ?(recursing = false) (key : K.key) (ast : ast) (s : state) :
     (* Left/Right movement *)
     | K.GoToEndOfWord maintainSelection, _, R (_, ti)
     | K.GoToEndOfWord maintainSelection, L (_, ti), _ ->
-        if maintainSelection
+        if maintainSelection == K.KeepSelection
         then (ast, updateSelectionRange s (getEndOfWordPos ~pos ast ti))
         else (ast, goToEndOfWord ~pos ast ti s)
     | K.GoToStartOfWord maintainSelection, _, R (_, ti)
     | K.GoToStartOfWord maintainSelection, L (_, ti), _ ->
-        if maintainSelection
+        if maintainSelection == K.KeepSelection
         then (ast, updateSelectionRange s (getStartOfWordPos ~pos ast ti))
         else (ast, goToStartOfWord ~pos ast ti s)
     | K.Left, L (_, ti), _ ->
@@ -4216,11 +4216,11 @@ let rec updateKey ?(recursing = false) (key : K.key) (ast : ast) (s : state) :
         (ast, doRight ~pos ~next:mNext ti s |> acMaybeShow ti)
     | K.GoToStartOfLine maintainSelection, _, R (_, ti)
     | K.GoToStartOfLine maintainSelection, L (_, ti), _ ->
-        if maintainSelection
+        if maintainSelection == K.KeepSelection
         then (ast, updateSelectionRange s (getStartOfLineCaretPos ast ti))
         else (ast, moveToStartOfLine ast ti s)
     | K.GoToEndOfLine maintainSelection, _, R (_, ti) ->
-        if maintainSelection
+        if maintainSelection == K.KeepSelection
         then (ast, updateSelectionRange s (getEndOfLineCaretPos ast ti))
         else (ast, moveToEndOfLine ast ti s)
     | K.DeleteToStartOfLine, _, R (_, ti) | K.DeleteToStartOfLine, L (_, ti), _
@@ -4700,10 +4700,10 @@ let shouldDoDefaultAction (key : K.key) : bool =
 
 let shouldSelect (key : K.key) : bool =
   match key with
-  | K.GoToStartOfWord true
-  | K.GoToEndOfWord true
-  | K.GoToStartOfLine true
-  | K.GoToEndOfLine true
+  | K.GoToStartOfWord K.KeepSelection
+  | K.GoToEndOfWord K.KeepSelection
+  | K.GoToStartOfLine K.KeepSelection
+  | K.GoToEndOfLine K.KeepSelection
   | K.SelectAll ->
       true
   | _ ->

--- a/client/src/fluid/FluidKeyboard.ml
+++ b/client/src/fluid/FluidKeyboard.ml
@@ -116,7 +116,10 @@ and side =
   | RightHand
 [@@deriving show]
 
-and maintainSelection = bool [@@deriving show]
+and maintainSelection =
+  | KeepSelection
+  | DropSelection
+[@@deriving show]
 
 let toString (key : key) : string option =
   match key with
@@ -377,6 +380,7 @@ let fromKeyboardEvent
   let isMac = getBrowserPlatform () = Mac in
   let osCmdKeyHeld = if isMac then meta else ctrl in
   let isMacCmdHeld = isMac && meta in
+  let maintainSelection = if shift then KeepSelection else DropSelection in
   match key with
   (*************
    * Shortcuts *
@@ -384,11 +388,11 @@ let fromKeyboardEvent
   | "a" when osCmdKeyHeld ->
       SelectAll
   | "a" when ctrl ->
-      GoToStartOfLine shift
+      GoToStartOfLine maintainSelection
   | "d" when ctrl ->
       Delete
   | "e" when ctrl ->
-      GoToEndOfLine shift
+      GoToEndOfLine maintainSelection
   | "y" when (not isMac) && ctrl && not shift ->
       (* CTRL+Y is Windows redo
       but CMD+Y on Mac is the history shortcut in Chrome (since CMD+H is taken for hide)
@@ -407,17 +411,17 @@ let fromKeyboardEvent
   | "Delete" when (isMac && alt) || ((not isMac) && ctrl) ->
       DeleteNextWord
   | "ArrowLeft" when meta ->
-      GoToStartOfLine shift
+      GoToStartOfLine maintainSelection
   | "ArrowLeft" when (isMac && alt) || ctrl ->
       (* Allowing Ctrl on macs because it doesnt override any default mac cursor movements.
        * Default behaivor is desktop switching where the OS swallows the event unless disabled *)
-      GoToStartOfWord shift
+      GoToStartOfWord maintainSelection
   | "ArrowRight" when meta ->
-      GoToEndOfLine shift
+      GoToEndOfLine maintainSelection
   | "ArrowRight" when (isMac && alt) || ctrl ->
       (* Allowing Ctrl on macs because it doesnt override any default mac cursor movements.
        * Default behaivor is desktop switching where the OS swallows the event unless disabled *)
-      GoToEndOfWord shift
+      GoToEndOfWord maintainSelection
   (************
    * Movement *
    ************)
@@ -426,13 +430,13 @@ let fromKeyboardEvent
   | "PageDown" ->
       PageDown
   | "End" when ctrl ->
-      GoToStartOfLine shift
+      GoToStartOfLine maintainSelection
   | "End" ->
-      GoToEndOfLine shift
+      GoToEndOfLine maintainSelection
   | "Home" when ctrl ->
-      GoToEndOfLine shift
+      GoToEndOfLine maintainSelection
   | "Home" ->
-      GoToStartOfLine shift
+      GoToStartOfLine maintainSelection
   | "ArrowUp" ->
       Up
   | "ArrowDown" ->

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -248,11 +248,14 @@ let ctrlLeft
     ?(shiftHeld = false)
     (pos : int)
     (expr : fluidExpr) : testResult =
+  let maintainSelection =
+    if shiftHeld then K.KeepSelection else K.DropSelection
+  in
   process
     ~wrap
     ~clone
     ~debug
-    [ ( K.GoToStartOfWord shiftHeld
+    [ ( K.GoToStartOfWord maintainSelection
       , {shiftKey = shiftHeld; altKey = false; metaKey = false; ctrlKey = false}
       ) ]
     None
@@ -267,11 +270,14 @@ let ctrlRight
     ?(shiftHeld = false)
     (pos : int)
     (expr : fluidExpr) : testResult =
+  let maintainSelection =
+    if shiftHeld then K.KeepSelection else K.DropSelection
+  in
   process
     ~wrap
     ~clone
     ~debug
-    [ ( K.GoToEndOfWord shiftHeld
+    [ ( K.GoToEndOfWord maintainSelection
       , {shiftKey = shiftHeld; altKey = false; metaKey = false; ctrlKey = false}
       ) ]
     None
@@ -2026,22 +2032,26 @@ let run () =
       t
         "ctrl+left twice over lamda from beg moves to beg of first param"
         lambdaWithTwoBindings
-        (keys [K.GoToStartOfWord false; K.GoToStartOfWord false] 1)
+        (keys
+           [K.GoToStartOfWord DropSelection; K.GoToStartOfWord DropSelection]
+           1)
         "~\\x, y -> ___" ;
       t
         "ctrl+right twice over lamda from beg moves to last blank"
         lambdaWithTwoBindings
-        (keys [K.GoToEndOfWord false; K.GoToEndOfWord false] 1)
+        (keys [K.GoToEndOfWord DropSelection; K.GoToEndOfWord DropSelection] 1)
         "\\x, y~ -> ___" ;
       t
         "ctrl+left twice over lamda from end moves to end of second param"
         lambdaWithTwoBindings
-        (keys [K.GoToStartOfWord false; K.GoToStartOfWord false] 12)
+        (keys
+           [K.GoToStartOfWord DropSelection; K.GoToStartOfWord DropSelection]
+           12)
         "\\x, ~y -> ___" ;
       t
         "ctrl+right twice over lamda from end doesnt move"
         lambdaWithTwoBindings
-        (keys [K.GoToEndOfWord false; K.GoToEndOfWord false] 12)
+        (keys [K.GoToEndOfWord DropSelection; K.GoToEndOfWord DropSelection] 12)
         "\\x, y -> ___~" ;
       ()) ;
   describe "Variables" (fun () ->
@@ -2085,22 +2095,22 @@ let run () =
       t
         "move to the front of match"
         emptyMatch
-        (key (K.GoToStartOfLine false) 6)
+        (key (K.GoToStartOfLine DropSelection) 6)
         "~match ___\n  *** -> ___\n" ;
       t
         "move to the end of match"
         emptyMatch
-        (key (K.GoToEndOfLine false) 0)
+        (key (K.GoToEndOfLine DropSelection) 0)
         "match ___~\n  *** -> ___\n" ;
       t
         "move to the front of match on line 2"
         emptyMatch
-        (key (K.GoToStartOfLine false) 15)
+        (key (K.GoToStartOfLine DropSelection) 15)
         "match ___\n  ~*** -> ___\n" ;
       t
         "move to the end of match on line 2"
         emptyMatch
-        (key (K.GoToEndOfLine false) 12)
+        (key (K.GoToEndOfLine DropSelection) 12)
         "match ___\n  *** -> ___~\n" ;
       t
         "move back over match"
@@ -2229,22 +2239,26 @@ let run () =
       t
         "ctrl+left 2 times from end moves to first blank"
         emptyMatch
-        (keys [K.GoToStartOfWord false; K.GoToStartOfWord false] 22)
+        (keys
+           [K.GoToStartOfWord DropSelection; K.GoToStartOfWord DropSelection]
+           22)
         "match ___\n  ~*** -> ___\n" ;
       t
         "ctrl+right 2 times from end doesnt move"
         emptyMatch
-        (keys [K.GoToEndOfWord false; K.GoToEndOfWord false] 22)
+        (keys [K.GoToEndOfWord DropSelection; K.GoToEndOfWord DropSelection] 22)
         "match ___\n  *** -> ___\n~" ;
       t
         "ctrl+left 2 times from beg doesnt move"
         emptyMatch
-        (keys [K.GoToStartOfWord false; K.GoToStartOfWord false] 0)
+        (keys
+           [K.GoToStartOfWord DropSelection; K.GoToStartOfWord DropSelection]
+           0)
         "~match ___\n  *** -> ___\n" ;
       t
         "ctrl+right 2 times from beg moves to last blank"
         emptyMatch
-        (keys [K.GoToEndOfWord false; K.GoToEndOfWord false] 0)
+        (keys [K.GoToEndOfWord DropSelection; K.GoToEndOfWord DropSelection] 0)
         "match ___\n  ***~ -> ___\n" ;
       t
         "ctrl+left from mid moves to previous blank "
@@ -2262,12 +2276,12 @@ let run () =
       t
         "move to the front of let"
         emptyLet
-        (key (K.GoToStartOfLine false) 4)
+        (key (K.GoToStartOfLine DropSelection) 4)
         "~let *** = ___\n5" ;
       t
         "move to the end of let"
         emptyLet
-        (key (K.GoToEndOfLine false) 4)
+        (key (K.GoToEndOfLine DropSelection) 4)
         "let *** = ___~\n5" ;
       t "move back over let" emptyLet (key K.Left 4) "~let *** = ___\n5" ;
       t "move forward over let" emptyLet (key K.Right 0) "let ~*** = ___\n5" ;
@@ -2436,32 +2450,32 @@ let run () =
       t
         "move to the front of pipe on line 1"
         aPipe
-        (key (K.GoToStartOfLine false) 2)
+        (key (K.GoToStartOfLine DropSelection) 2)
         "~[]\n|>List::append [5]\n|>List::append [5]\n" ;
       t
         "move to the end of pipe on line 1"
         aPipe
-        (key (K.GoToEndOfLine false) 0)
+        (key (K.GoToEndOfLine DropSelection) 0)
         "[]~\n|>List::append [5]\n|>List::append [5]\n" ;
       t
         "move to the front of pipe on line 2"
         aPipe
-        (key (K.GoToStartOfLine false) 8)
+        (key (K.GoToStartOfLine DropSelection) 8)
         "[]\n|>~List::append [5]\n|>List::append [5]\n" ;
       t
         "move to the end of pipe on line 2"
         aPipe
-        (key (K.GoToEndOfLine false) 5)
+        (key (K.GoToEndOfLine DropSelection) 5)
         "[]\n|>List::append [5]~\n|>List::append [5]\n" ;
       t
         "move to the front of pipe on line 3"
         aPipe
-        (key (K.GoToStartOfLine false) 40)
+        (key (K.GoToStartOfLine DropSelection) 40)
         "[]\n|>List::append [5]\n|>~List::append [5]\n" ;
       t
         "move to the end of pipe on line 3"
         aPipe
-        (key (K.GoToEndOfLine false) 24)
+        (key (K.GoToEndOfLine DropSelection) 24)
         "[]\n|>List::append [5]\n|>List::append [5]~\n" ;
       t
         "pipes appear on new lines"
@@ -2672,32 +2686,32 @@ let run () =
       t
         "move to front of line 1"
         plainIf
-        (key (K.GoToStartOfLine false) 4)
+        (key (K.GoToStartOfLine DropSelection) 4)
         "~if 5\nthen\n  6\nelse\n  7" ;
       t
         "move to end of line 1"
         plainIf
-        (key (K.GoToEndOfLine false) 0)
+        (key (K.GoToEndOfLine DropSelection) 0)
         "if 5~\nthen\n  6\nelse\n  7" ;
       t
         "move to front of line 3"
         plainIf
-        (key (K.GoToStartOfLine false) 13)
+        (key (K.GoToStartOfLine DropSelection) 13)
         "if 5\nthen\n  ~6\nelse\n  7" ;
       t
         "move to end of line 3"
         plainIf
-        (key (K.GoToEndOfLine false) 12)
+        (key (K.GoToEndOfLine DropSelection) 12)
         "if 5\nthen\n  6~\nelse\n  7" ;
       t
         "move to front of line 5 in nested if"
         nestedIf
-        (key (K.GoToStartOfLine false) 16)
+        (key (K.GoToStartOfLine DropSelection) 16)
         "if 5\nthen\n  ~if 5\n  then\n    6\n  else\n    7\nelse\n  7" ;
       t
         "move to end of line 5 in nested if"
         nestedIf
-        (key (K.GoToEndOfLine false) 12)
+        (key (K.GoToEndOfLine DropSelection) 12)
         "if 5\nthen\n  if 5~\n  then\n    6\n  else\n    7\nelse\n  7" ;
       t
         "try to insert space on blank"
@@ -2901,12 +2915,12 @@ let run () =
       t
         "move to the front of an empty record"
         emptyRowRecord
-        (key (K.GoToStartOfLine false) 13)
+        (key (K.GoToStartOfLine DropSelection) 13)
         "{\n  ~*** : ___\n}" ;
       t
         "move to the end of an empty record"
         emptyRowRecord
-        (key (K.GoToEndOfLine false) 4)
+        (key (K.GoToEndOfLine DropSelection) 4)
         "{\n  *** : ___~\n}" ;
       t
         "cant enter invalid fieldname"
@@ -2956,12 +2970,12 @@ let run () =
       t
         "move to the front of a record with multiRowRecordple values"
         multiRowRecord
-        (key (K.GoToStartOfLine false) 21)
+        (key (K.GoToStartOfLine DropSelection) 21)
         "{\n  f1 : 56\n  ~f2 : 78\n}" ;
       t
         "move to the end of a record with multiRowRecordple values"
         multiRowRecord
-        (key (K.GoToEndOfLine false) 14)
+        (key (K.GoToEndOfLine DropSelection) 14)
         "{\n  f1 : 56\n  f2 : 78~\n}" ;
       t
         "inserting at the end of the key works"
@@ -3558,37 +3572,37 @@ let run () =
       ts
         "K.GoToStartOfWord + shift selects to start of word"
         longLets
-        (key (K.GoToStartOfWord true) 16)
+        (key (K.GoToStartOfWord KeepSelection) 16)
         ( "let firstLetName = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nlet secondLetName = \"0123456789\"\n\"RESULT\""
         , (Some 16, 4) ) ;
       ts
         "K.GoToEndOfWord selects to end of word"
         longLets
-        (key (K.GoToEndOfWord true) 4)
+        (key (K.GoToEndOfWord KeepSelection) 4)
         ( "let firstLetName = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nlet secondLetName = \"0123456789\"\n\"RESULT\""
         , (Some 4, 16) ) ;
       ts
         "K.GoToStartOfLine selects from mid to start of line"
         longLets
-        (key (K.GoToStartOfLine true) 29)
+        (key (K.GoToStartOfLine KeepSelection) 29)
         ( "let firstLetName = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nlet secondLetName = \"0123456789\"\n\"RESULT\""
         , (Some 29, 0) ) ;
       ts
         "K.GoToEndOfLine selects from mid to end of line"
         longLets
-        (key (K.GoToEndOfLine true) 29)
+        (key (K.GoToEndOfLine KeepSelection) 29)
         ( "let firstLetName = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nlet secondLetName = \"0123456789\"\n\"RESULT\""
         , (Some 29, 47) ) ;
       ts
         "K.GoToStartOfLine selects from end to start of line"
         longLets
-        (key (K.GoToStartOfLine true) 47)
+        (key (K.GoToStartOfLine KeepSelection) 47)
         ( "let firstLetName = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nlet secondLetName = \"0123456789\"\n\"RESULT\""
         , (Some 47, 0) ) ;
       ts
         "K.GoToEndOfLine selects to end of line"
         longLets
-        (key (K.GoToEndOfLine true) 0)
+        (key (K.GoToEndOfLine KeepSelection) 0)
         ( "let firstLetName = \"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"\nlet secondLetName = \"0123456789\"\n\"RESULT\""
         , (Some 0, 47) ) ;
       ()) ;


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Trello
https://trello.com/c/QYnh8a4J/2219-holding-shift-with-cmdarrow-doesnt-maintaing-the-key-movement

### Why? 
Users expect to select while holding shift + goToStart/EndOfLine and shift + goToStart/EndOfWord

### Gifs
**Before:**
![2020-01-14 13 42 15](https://user-images.githubusercontent.com/32043360/72385205-cc313e00-36d3-11ea-994a-5c42f43bc11b.gif)

**After:**
![2020-01-14 13 44 41](https://user-images.githubusercontent.com/32043360/72385332-203c2280-36d4-11ea-8d1b-4c0ed7809a91.gif)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

