### PR TITLE
DarkInternal::addUser

### DIFF
--- a/backend/libbackend/account.mli
+++ b/backend/libbackend/account.mli
@@ -38,6 +38,14 @@ val upsert_user :
   -> unit
   -> (string, string) Result.t
 
+(* Add a user; return error if we can't b/c username (unique) was taken *)
+val insert_user :
+     username:string
+  -> email:string
+  -> name:string
+  -> unit
+  -> (string, string) Result.t
+
 (* Set whether user is an admin *)
 val set_admin : username:string -> bool -> unit
 

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -163,6 +163,35 @@ LIKE '%@darklang.com' AND email NOT LIKE '%@example.com'"
                 fail args)
     ; ps = false
     ; dep = true }
+  ; { pns = ["DarkInternal::insertUser_v1"]
+    ; ins = []
+    ; p = [par "username" TStr; par "email" TStr; par "name" TStr]
+    ; r = TResult
+    ; d =
+        "Add a user. Returns a result containing the password for the user,
+which was randomly generated. Usernames are unique; if you try to add a username
+that's already taken, returns an error."
+    ; f =
+        internal_fn (function
+            | _, [DStr username; DStr email; DStr name] ->
+                let username = Unicode_string.to_string username in
+                let email = Unicode_string.to_string email in
+                let name = Unicode_string.to_string name in
+                let result =
+                  Account.insert_user ~username ~email ~name ()
+                  |> Result.map ~f:(fun r ->
+                         Stroller.segment_identify_user username ;
+                         r)
+                in
+                ( match result with
+                | Ok password ->
+                    DResult (ResOk (Dval.dstr_of_string_exn password))
+                | Error msg ->
+                    DResult (ResError (Dval.dstr_of_string_exn msg)) )
+            | args ->
+                fail args)
+    ; ps = false
+    ; dep = false }
   ; { pns = ["DarkInternal::upsertUser_v1"]
     ; ins = []
     ; p = [par "username" TStr; par "email" TStr; par "name" TStr]


### PR DESCRIPTION
Unlike the existing ::upsertUser, this will fail if you try to add a
user whose username is already taken.

https://trello.com/c/vJME9WWd/2242-upsertuser-is-useful-but-is-a-security-risk-in-our-adduser-flow

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

