### PR TITLE
Commit Partial Field access on enter & on lose focus

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -2454,13 +2454,12 @@ let acEnter (ti : T.tokenInfo) (ast : ast) (s : state) (key : K.key) :
     | TPatternVariable _ ->
         (ast, moveToNextBlank ~pos:s.newPos ast s)
     | TFieldPartial (partialID, _fieldAccessID, anaID, fieldname) ->
-      (* Accept fieldname, even if it's not in the autocomplete *)
-      E.find anaID ast
-      |> Option.map ~f:(fun expr ->
-        let replacement = EFieldAccess (gid (), expr,fieldname) in
-        (E.replace ~replacement partialID ast, s)
-      )
-      |> Option.withDefault ~default:(ast, s)
+        (* Accept fieldname, even if it's not in the autocomplete *)
+        E.find anaID ast
+        |> Option.map ~f:(fun expr ->
+               let replacement = EFieldAccess (gid (), expr, fieldname) in
+               (E.replace ~replacement partialID ast, s))
+        |> Option.withDefault ~default:(ast, s)
     | _ ->
         (ast, s) )
   | Some entry ->
@@ -2478,7 +2477,8 @@ let commitIfValid
   let isInside = newPos >= ti.startPos && newPos <= ti.endPos in
   (* TODO: if we can't move off because it's the start/end etc of the ast, we
    * may want to commit anyway. *)
-  if (not isInside) && Some (T.toText ti.token) = highlightedText
+  if (not isInside)
+     && (Some (T.toText ti.token) = highlightedText || T.isFieldPartial ti.token)
   then
     let newAST, _ = acEnter ti ast s K.Enter in
     newAST

--- a/client/src/fluid/FluidToken.ml
+++ b/client/src/fluid/FluidToken.ml
@@ -250,6 +250,10 @@ let isErrorDisplayable (t : t) : bool =
   isTextToken t && match t with TFnVersion _ -> false | _ -> true
 
 
+let isFieldPartial (t : t) : bool =
+  match t with TFieldPartial _ -> true | _ -> false
+
+
 let toText (t : t) : string =
   let shouldntBeEmpty name =
     if name = ""

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -1386,9 +1386,14 @@ let run () =
         "___.~***" ;
       t
         "commit fieldpartial on enter"
-        (partial "name" (fieldAccess aShortVar ""))
-        (enter 6)
-        "v.name~" ;
+        (partial "u" (fieldAccess aShortVar ""))
+        (enter 3)
+        "v.u~" ;
+      t
+        "commit fieldpartial when cursor moves elsewhere"
+        (partial "u" (fieldAccess aShortVar ""))
+        (keys [K.Left; K.Left] 3)
+        "v~.u" ;
       ()) ;
   describe "Functions" (fun () ->
       t


### PR DESCRIPTION
# Problem

[We just discovered that dot-field access only sometimes works](https://trello.com/c/AlVNCOB8/2243-when-trace-dict-does-not-have-key-you-should-still-be-able-to-type-it-as-a-field-access) (only when the keyname is present in the trace). This makes writing code for more experienced dark developers every difficult, when they know what they want to express, and isn't sending traces just yet to test the code.

This is because commit of field names is based on autocomplete items. Autocomplete gives you suggested fieldnames based on the current trace to help you. This feature is supposed to AID YOU in writing your code, not PREVENT you from code.

You should be able to write the same code, regardless of what your input values are.

The following is valid code (when string is in queryParams)
<img width="739" alt="in-ac" src="https://user-images.githubusercontent.com/244152/72652081-3d722a80-393a-11ea-83cd-f453948ffe93.png">

This should the valid too but it's not, because string is not in queryParams
<img width="739" alt="not-in-ac" src="https://user-images.githubusercontent.com/244152/72652018-27646a00-393a-11ea-9b57-f62060e5a978.png">

When you are creating a function from scratch, this problem because even worst.

# Solution
In our structured editor, we allowed any string to be a valid field, regardless if the fieldname is available in the current trace. We still want to keep the same behavior.

When you hit ENTER, TAB away, SPACE, or place your caret away from the FieldAccessPartial, we will commit the key is in your FieldAccessPartial.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

