### PR TITLE
Add `rendered_oplist_cache` column to `toplevel_oplists`

### DIFF
--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -197,8 +197,8 @@ let save_toplevel_oplist
   Db.run
     ~name:"save per tlid oplist"
     "INSERT INTO toplevel_oplists
-    (canvas_id, account_id, tlid, digest, tipe, name, module, modifier, data)
-    VALUES ($1, $2, $3, $4, $5::toplevel_type, $6, $7, $8, $9)
+    (canvas_id, account_id, tlid, digest, tipe, name, module, modifier, data, rendered_oplist_cache)
+    VALUES ($1, $2, $3, $4, $5::toplevel_type, $6, $7, $8, $9, NULL)
     ON CONFLICT (canvas_id, tlid) DO UPDATE
     SET account_id = $2,
         digest = $4,

--- a/backend/migrations/20200117_233054_add-rendered-oplist-cache-to-toplevel-oplists.sql
+++ b/backend/migrations/20200117_233054_add-rendered-oplist-cache-to-toplevel-oplists.sql
@@ -1,0 +1,1 @@
+ALTER TABLE toplevel_oplists ADD COLUMN rendered_oplist_cache BYTEA


### PR DESCRIPTION
Explicitly setting it to NULL in the save

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

