### PR TITLE
Provide a preview for All DB::query functions

### DIFF
--- a/backend/libexecution/ast.ml
+++ b/backend/libexecution/ast.ml
@@ -533,11 +533,14 @@ and call_fn
         | None ->
             let sfr_desc = (state.tlid, name, id) in
             let fn_result = state.load_fn_result sfr_desc argvals in
-            (* In the case of DB::query, we want to backfill the
-             * lambda's livevalues, as the lambda was never actually
-             * executed. We hack this is here as we have no idea what
-             * this abstraction might look like in the future. *)
-            ( if state.context = Preview && name = "DB::query_v4"
+            (* In the case of DB::query (and friends), we want to backfill
+             * the lambda's livevalues, as the lambda was never actually
+             * executed. We hack this is here as we have no idea what this
+             * abstraction might look like in the future. *)
+            ( if state.context = Preview
+                 (* The prefix might match too much but that's fixed by the
+                  * match which is very specific *)
+                 && Prelude.String.startsWith ~prefix:"DB::query" name
             then
               match argvals with
               | [DDB dbname; DBlock b] ->

--- a/backend/libexecution/libs.ml
+++ b/backend/libexecution/libs.ml
@@ -57,6 +57,23 @@ let get_fn_exn ~(user_fns : RuntimeT.user_fn list) (name : string) : RuntimeT.fn
       Exception.client ("No function named '" ^ name ^ "' exists")
 
 
+(* We sometimes want to test execution similar to how it's run in the
+ * frontend, which do not have any preview_execution_safe functions available
+ * (it's more complicated than that, it's really backend-only tests that
+ * they're missing, but we dont have a way to tell easily so this will have
+ * to do. *)
+let filter_out_non_preview_safe_functions_for_tests ~(f : unit -> unit) () :
+    unit =
+  let old_fns = !static_fns in
+  let new_fns =
+    Prelude.StrDict.filter ~f:(fun fn -> fn.preview_execution_safe) old_fns
+  in
+  static_fns := new_fns ;
+  f () ;
+  static_fns := old_fns ;
+  ()
+
+
 let init (libs : shortfn list) : unit =
   List.iter ~f:add_short_fn libs ;
   ()

--- a/backend/test/utils.ml
+++ b/backend/test/utils.ml
@@ -410,14 +410,15 @@ let exec_handler ?(ops = []) (prog : string) : dval =
   |> fun h -> execute_ops (ops @ [h])
 
 
-let exec_ast ?(canvas_name = "test") (prog : string) : dval =
-  let c, state, input_vars = test_execution_data ~canvas_name [] in
+let exec_ast ?(ops = []) ?(canvas_name = "test") (prog : string) : dval =
+  let c, state, input_vars = test_execution_data ~canvas_name ops in
   let result = Ast.execute_ast ~input_vars ~state (ast_for prog) in
   result
 
 
-let exec_ast' ?(canvas_name = "test") (prog : Fluid.fluidExpr) : dval =
-  let c, state, input_vars = test_execution_data ~canvas_name [] in
+let exec_ast' ?(ops = []) ?(canvas_name = "test") (prog : Fluid.fluidExpr) :
+    dval =
+  let c, state, input_vars = test_execution_data ~canvas_name ops in
   let result = Ast.execute_ast ~input_vars ~state (Fluid.fromFluidExpr prog) in
   result
 
@@ -430,9 +431,9 @@ let exec_userfn (prog : string) : dval =
   Ast.execute_fn ~state name execution_id []
 
 
-let exec_save_dvals ?(canvas_name = "test") (ast : expr) :
+let exec_save_dvals ?(ops = []) ?(canvas_name = "test") (ast : expr) :
     Analysis_types.dval_store =
-  let c, state, input_vars = test_execution_data ~canvas_name [] in
+  let c, state, input_vars = test_execution_data ~canvas_name ops in
   let { tlid
       ; execution_id
       ; dbs


### PR DESCRIPTION
https://trello.com/c/VQEEbHgR/2248-provide-a-preview-for-all-dbquery-functions

A user complained that DB::queryOne was not working. Indeed, they couldn't commit `value.fieldname`, and that was because there was no preview built-in. That was because the preview was only run on DB::query, not DB::queryOne. This makes the preview code run on anything starting with DB::query.

Note that the substring match will match more DB::query functions than intended, such as DB::queryExactFields. However, if the fn doesn't have the exact signature it won't run, so there should be no downside. I thought about other ways to solve this, and nothing seemed to be much better, so I went with this. Happy to take an alternate approach if someone has a good suggestion.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

