### PR TITLE
When we have the traceID but no trace for it, request the trace.

### DIFF
--- a/client/src/analysis/Analysis.ml
+++ b/client/src/analysis/Analysis.ml
@@ -414,17 +414,10 @@ let analyzeFocused (m : model) : model * msg Cmd.t =
   match tlidOf m.cursorState with
   | Some tlid ->
       let trace =
-        match getSelectedTraceID m tlid with
-        | Some traceID ->
-            let trace = getTrace m tlid traceID in
-            (* If we failed to get a trace, we don't want to throw away knowledge of the
-             * traceID *)
-            let trace =
-              Option.withDefault ~default:(traceID, Error NoneYet) trace
-            in
-            Some trace
-        | None ->
-            None
+        getSelectedTraceID m tlid
+        |> Option.andThen ~f:(fun traceID ->
+               getTrace m tlid traceID
+               |> Option.orElse (Some (traceID, Error NoneYet)))
       in
       ( match trace with
       | Some (traceID, Error _) ->


### PR DESCRIPTION
https://trello.com/c/ZT10tHXp/2249-investigate-vanishing-traces

Before this, when we selected the traceID, if there was no trace for it, we
would drop the info that we knew the traceID, and not request an analysis.

This seems to have been wrong but stable behaviour that must have gotten
dislodged by a recent change. Perhaps the ordering of things changed, or it took
longer for a worker to run. It's pretty clear it should have been like this all
along though.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

