### PR TITLE
Remove assertion

### DIFF
--- a/client/src/core/OldExpr.ml
+++ b/client/src/core/OldExpr.ml
@@ -123,14 +123,7 @@ let rec toFluidExpr' ?(inPipe = false) (expr : expr) : FluidExpression.t =
         ERightPartial (id, str, toFluidExpr' ~inPipe oldExpr) )
 
 
-and toFluidExpr (expr : expr) : FluidExpression.t =
-  asserT
-    "empty functions passed to toFluidExpr'"
-    (!FluidExpression.functions <> []) ;
-  toFluidExpr' expr
-
-
-and toFluidExprNoAssertion (expr : expr) : FluidExpression.t = toFluidExpr' expr
+and toFluidExpr (expr : expr) : FluidExpression.t = toFluidExpr' expr
 
 and fromFluidExpr (expr : FluidExpression.t) : expr =
   let open Types in

--- a/client/src/core/OldExpr.mli
+++ b/client/src/core/OldExpr.mli
@@ -41,9 +41,3 @@ val fromFluidExpr : FluidExpression.t -> expr
 
 (** [toFluid e] recursively converts a corresponding [nExpr Types.blankOr] to [e] *)
 val toFluidExpr : expr -> FluidExpression.t
-
-(** The assertion in toFluidExpr will eventually go away as the server will
-  * also use fluidExprs and so there won't be a need to convert. But we
-  * sometimes need to call this from a place without the functions available,
-  * and we don't want to set off rollbar. *)
-val toFluidExprNoAssertion : expr -> FluidExpression.t


### PR DESCRIPTION
It fires so often it's really not worth it

It has fired 37k times. It fires each time we fetch a trace, so disabling is better for now:

https://rollbar.com/darkops/darklang/items/1595/


- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

