### PR TITLE
Log backtrace when an exn bubbles up from the qw

### DIFF
--- a/backend/bin/queue_worker.ml
+++ b/backend/bin/queue_worker.ml
@@ -24,7 +24,8 @@ let queue_worker execution_id =
           ~data:"Unhandled exception bubbled to queue worker"
           ~params:
             [ ("execution_id", Libexecution.Types.string_of_id execution_id)
-            ; ("exn", Libexecution.Exception.exn_to_string e) ] ;
+            ; ("exn", Libexecution.Exception.exn_to_string e)
+            ; ("backtrace", bt |> Libexecution.Exception.backtrace_to_string) ] ;
         Lwt.async (fun () ->
             ( try
                 Libbackend.Rollbar.report_lwt


### PR DESCRIPTION
See: https://rollbar.com/darkops/darklang/items/1640/

"Json Err: Line 1, bytes 0-10:
Invalid token 'mc-vanilla'"

Needs more data to be actionable.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

