### PR TITLE
Make the fuzzer a little more normal

### DIFF
--- a/client/test/fuzz_tests.ml
+++ b/client/test/fuzz_tests.ml
@@ -14,33 +14,26 @@ let process_cmdline_args () =
   Tc.Array.iter Sys.argv ~f:(fun str ->
       match (!command, str) with
       | None, "--pattern"
-      | None, "--count"
-      | None, "--only"
       | None, "--size"
-      | None, "--initialSeed"
+      | None, "--seed"
       | None, "--verbosityThreshold" ->
           command := Some str
       | None, "--stopOnFail" ->
-          Fluid_fuzzer.stop_on_fail := true
+          Fluid_fuzzer.stopOnFail := true
+      | None, "--continue" ->
+          Fluid_fuzzer.continue := true
       | None, "--help" ->
           Js.log
-            "Run Dark's client-side fuzzer. Supported arguments:\n  --initialSeed: change the seed\n  --stopOnFail: stop running after the first test fails\n  --only: only run the test number passed in\n  --count: run count number of tests\n  --size: the size of the test cases\n  --verbosityThreshold: once the number of expressions drops below this number, start printing more verbosity\n  --help: Print this message\n  --pattern 'some-regex': Only run tests that contains this regex" ;
+            "Run Dark's client-side fuzzer. Supported arguments:\n  --seed: set the seed (otherwise uses timestamp)\n  --continue: continue running after first test case\n  --stopOnFail: stop on the first failed test case\n  --size: the size of the test cases\n  --verbosityThreshold: once the number of expressions drops below this number, start printing more verbosity\n  --help: Print this message\n  --pattern 'some-regex': Only run tests that contains this regex" ;
           exit 0
       | Some "--pattern", str ->
           Tester.pattern := Some (Js.Re.fromString str) ;
           command := None
-      | Some "--count", str ->
-          Fluid_fuzzer.count := int_of_string str ;
-          command := None
-      | Some "--only", str ->
-          Fluid_fuzzer.only := Some (int_of_string str) ;
-          Fluid_fuzzer.count := max (int_of_string str + 1) !Fluid_fuzzer.count ;
+      | Some "--seed", str ->
+          Fluid_fuzzer.initialSeed := int_of_string str ;
           command := None
       | Some "--size", str ->
           Fluid_fuzzer.size := int_of_string str ;
-          command := None
-      | Some "--initialSeed", str ->
-          Fluid_fuzzer.initialSeed := int_of_string str ;
           command := None
       | Some "--verbosityThreshold", str ->
           Fluid_fuzzer.verbosityThreshold := int_of_string str ;


### PR DESCRIPTION
- it just takes a seed
- it only continues if you specify the --continue flag
- remove --count

Merging this cause I want to use it tomorrow, and this is non-critical code path.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

