### PR TITLE
When we capture an exn in qw/cron checker, add the current log_annota…

### DIFF
--- a/backend/bin/cron_checker.ml
+++ b/backend/bin/cron_checker.ml
@@ -12,11 +12,12 @@ let cron_checker execution_id =
     match result with
     | Ok _ ->
         if not !shutdown then (cron_checker [@tailcall]) () else exit 0
-    | Error (bt, e) ->
+    | Error (bt, e, log_params) ->
         Libcommon.Log.erroR
           "cron_checker"
           ~data:"Uncaught error"
-          ~params:[("exn", Libexecution.Exception.exn_to_string e)] ;
+          ~params:[("exn", Libexecution.Exception.exn_to_string e)]
+          ~jsonparams:log_params ;
         Lwt.async (fun () ->
             Libbackend.Rollbar.report_lwt
               e

--- a/backend/bin/queue_worker.ml
+++ b/backend/bin/queue_worker.ml
@@ -18,14 +18,15 @@ let queue_worker execution_id =
         else exit 0
     | Ok (Some _) ->
         if not !shutdown then (queue_worker [@tailcall]) () else exit 0
-    | Error (bt, e) ->
+    | Error (bt, e, log_params) ->
         Log.erroR
           "queue_worker"
           ~data:"Unhandled exception bubbled to queue worker"
           ~params:
             [ ("execution_id", Libexecution.Types.string_of_id execution_id)
             ; ("exn", Libexecution.Exception.exn_to_string e)
-            ; ("backtrace", bt |> Libexecution.Exception.backtrace_to_string) ] ;
+            ; ("backtrace", bt |> Libexecution.Exception.backtrace_to_string) ]
+          ~jsonparams:log_params ;
         Lwt.async (fun () ->
             ( try
                 Libbackend.Rollbar.report_lwt

--- a/backend/libbackend/cron.ml
+++ b/backend/libbackend/cron.ml
@@ -233,4 +233,4 @@ let check_all_canvases execution_id : (unit, Exception.captured) Result.t =
         ; ("canvas.errors", `Int !stat_canvas_errors)
         ; ("cron.checked", `Int !stat_crons)
         ; ("cron.queued", `Int !stat_events) ] ;
-    Error (bt, e)
+    Error (bt, e, Log.current_log_annotations ())

--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -17,7 +17,7 @@ let dequeue_and_process execution_id :
           let bt = Exception.get_backtrace () in
           Log.erroR "Exception while dequeueing" ;
           (* execution_id will be in this log *)
-          Error (bt, e)
+          Error (bt, e, [])
       in
       event
       |> Result.bind ~f:(fun event ->
@@ -43,7 +43,7 @@ let dequeue_and_process execution_id :
                        (Event_queue.put_back transaction event ~status:`Err) ;
                      Log.erroR "Exception while loading canvas" ;
                      (* execution_id will be in this log *)
-                     Error (bt, e)
+                     Error (bt, e, [])
                  in
                  c
                  |> Result.bind ~f:(fun c ->
@@ -179,7 +179,8 @@ exception in Event_queue.put_back"
                                       ~data:
                                         (Libexecution.Exception.exn_to_string e)
                                 ) ;
-                              Error (bt, e)))))
+                              let log_params = Log.current_log_annotations () in
+                              Error (bt, e, log_params)))))
 
 
 let run (execution_id : Types.id) :

--- a/backend/libcommon/log.ml
+++ b/backend/libcommon/log.ml
@@ -326,15 +326,16 @@ let fataL = pP ~level:`Fatal
 
 let succesS = pP ~level:`Success
 
+let current_log_annotations () : (string * Yojson.Safe.t) list =
+  match Lwt.get !logkey with None -> [] | Some annotations -> annotations
+
+
 (* Add to the current set of thread-local log annotations. *)
 (* We make no attempt whatsoever to deal with dupe keys, except to put new ones
  * later in the ordering *)
 let add_log_annotations (annotations : (string * Yojson.Safe.t) list) :
     (unit -> 'a) -> 'a =
-  let existing =
-    match Lwt.get !logkey with None -> [] | Some annotations -> annotations
-  in
-  Lwt.with_value !logkey (Some (existing @ annotations))
+  Lwt.with_value !logkey (Some (current_log_annotations () @ annotations))
 
 
 (* ----------------- *)

--- a/backend/libcommon/log.mli
+++ b/backend/libcommon/log.mli
@@ -102,4 +102,6 @@ val succesS :
   -> string
   -> unit
 
+val current_log_annotations : unit -> (string * Yojson.Safe.t) list
+
 val add_log_annotations : (string * Yojson.Safe.t) list -> (unit -> 'a) -> 'a

--- a/backend/libexecution/exception.ml
+++ b/backend/libexecution/exception.ml
@@ -23,7 +23,7 @@ let reraise e =
   Caml.Printexc.raise_with_backtrace e bt
 
 
-type captured = backtrace * exn
+type captured = backtrace * exn * (string * Yojson.Safe.t) list
 
 (* -------------------- *)
 (* Dark exceptions *)


### PR DESCRIPTION
…tions to the error

Prior to this commit, we catch any exceptions, wrap them in an Error (specifically, Exception.captured), and add a backtrace. This commit puts in any log annotations we have handy, which in the case of https://ui.honeycomb.io/dark/datasets/kubernetes-bwd-ocaml/result/qoyFtoQcD7w?tab=raw/https://rollbar.com/darkops/darklang/items/1640/ I'm hoping will include canvas/handler information.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

