### PR TITLE
Don't load functions for redo/undo/SetDBName

### DIFF
--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -271,9 +271,10 @@ let apply_op (is_new : bool) (op : Op.op) (c : canvas ref) : unit =
 (* NOTE: If you add a new verification here, please ensure all places that
  * load canvases/apply ops correctly load the requisite data.
  *
- * eg. The `admin_add_op_handler` in webserver.ml uses `load_with_context` at
- * time of writing. This would not be sufficient if the new verifier required
- * an invariant across eg. all handlers.
+ *
+ * See `Op.required_context` for how we determine which ops need what other
+ * context to be loaded to appropriately verify.
+ *
  * *)
 let verify (c : canvas ref) : (unit, string list) Result.t =
   let duped_db_names =
@@ -465,6 +466,12 @@ let load_all_dbs host (newops : Op.op list) : (canvas ref, string list) Result.t
     =
   let owner = Account.for_host_exn host in
   load_from ~f:Serialize.load_all_dbs host owner newops
+
+
+let load_with_dbs ~tlids host (newops : Op.op list) :
+    (canvas ref, string list) Result.t =
+  let owner = Account.for_host_exn host in
+  load_from ~f:(Serialize.load_with_dbs ~tlids) host owner newops
 
 
 let load_with_context ~tlids host (newops : Op.op list) :

--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -233,6 +233,20 @@ let load_with_context ~host ~(canvas_id : Uuidm.t) ~(tlids : Types.tlid list) ()
   |> strs2tlid_oplists
 
 
+let load_with_dbs ~host ~(canvas_id : Uuidm.t) ~(tlids : Types.tlid list) () :
+    Op.tlid_oplists =
+  let tlid_params = List.map ~f:(fun x -> Db.ID x) tlids in
+  Db.fetch
+    ~name:"load_with_dbs"
+    "SELECT data FROM toplevel_oplists
+      WHERE canvas_id = $1
+        AND (tlid = ANY (string_to_array($2, $3)::bigint[])
+             OR tipe = 'db'::toplevel_type)"
+    ~params:[Db.Uuid canvas_id; Db.List tlid_params; String Db.array_separator]
+    ~result:BinaryResult
+  |> strs2tlid_oplists
+
+
 let load_all_dbs ~host ~(canvas_id : Uuidm.t) () : Op.tlid_oplists =
   Db.fetch
     ~name:"load_all_dbs"

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -713,8 +713,7 @@ let admin_add_op_handler
         | NoContext ->
             C.load_only_tlids ~tlids host ops
         | AllDatastores ->
-            (* This also loads all user functions, but can trim later *)
-            C.load_with_context ~tlids host ops)
+            C.load_with_dbs ~tlids host ops)
   in
   match maybe_c with
   | Ok c ->


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Part one of: https://trello.com/c/7SVzzo6H/2257-loading-time-fast-follows

After my `add_op` changes, we were still unnecessarily loading functions for the `AllDatastore` ops. This should further cut down on loading times for large canvases, especially on undo/redo.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

