### PR TITLE
Fix autocomplete click

### DIFF
--- a/client/src/fluid/FluidView.ml
+++ b/client/src/fluid/FluidView.ml
@@ -39,6 +39,7 @@ let viewAutocomplete (ac : Types.fluidAutocompleteState) : Types.msg Html.html =
           else Vdom.noNode
         in
         Html.li
+          ~unique:name
           [ Attrs.classList
               [ ("autocomplete-item", true)
               ; ("fluid-selected", highlighted)


### PR DESCRIPTION
https://trello.com/c/eeJ0CgSq/2258-when-only-one-item-is-in-autocomplete-user-should-always-get-that-item

Previously, this would pick the wrong item if the length of the list had changed

I understand why this fix is correct, but I don't understand why it had the specific behaviour before. Of well.

Before:
![2020-01-21 18 26 22](https://user-images.githubusercontent.com/181762/72860401-93690a00-3c7b-11ea-9a18-d660e8c0c6b2.gif)

After:
![2020-01-21 18 25 58](https://user-images.githubusercontent.com/181762/72860400-92d07380-3c7b-11ea-97c9-47315710497f.gif)


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

