### PR TITLE
Separate trace load from initial_load

### DIFF
--- a/backend/libbackend/analysis.ml
+++ b/backend/libbackend/analysis.ml
@@ -326,6 +326,12 @@ let to_add_op_rpc_result (c : canvas) : add_op_rpc_result =
   ; deleted_user_tipes = IDMap.data c.deleted_user_tipes }
 
 
+type all_traces_result = {traces : tlid_traceid list} [@@deriving to_yojson]
+
+let to_all_traces_result (traces : tlid_traceid list) : string =
+  {traces} |> all_traces_result_to_yojson |> Yojson.Safe.to_string ~std:true
+
+
 (* Initial load *)
 type initial_load_rpc_result =
   { toplevels : TL.toplevel list
@@ -334,7 +340,6 @@ type initial_load_rpc_result =
   ; deleted_user_functions : RTT.user_fn list
   ; unlocked_dbs : tlid list
   ; fofs : SE.four_oh_four list
-  ; traces : tlid_traceid list
   ; assets : SA.static_deploy list
   ; user_tipes : RTT.user_tipe list
   ; deleted_user_tipes : RTT.user_tipe list
@@ -349,7 +354,6 @@ let to_initial_load_rpc_result
     (op_ctrs : (string * int) list)
     (permission : Authorization.permission option)
     (fofs : SE.four_oh_four list)
-    (traces : tlid_traceid list)
     (unlocked_dbs : tlid list)
     (assets : SA.static_deploy list)
     (account : Account.user_info)
@@ -362,7 +366,6 @@ let to_initial_load_rpc_result
   ; deleted_user_tipes = IDMap.data c.deleted_user_tipes
   ; unlocked_dbs
   ; fofs
-  ; traces
   ; assets
   ; op_ctrs
   ; permission

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -38,12 +38,7 @@ let ready = ref false
 let server_timing (times : timing_header list) =
   times
   |> List.map ~f:(fun (name, time, desc) ->
-         name
-         ^ ";desc=\""
-         ^ desc
-         ^ "\""
-         ^ ";dur="
-         ^ (time |> Float.to_string_hum ~decimals:3))
+         Printf.sprintf "%s;desc=\"%s\";dur=%0.2f" name desc time)
   |> String.concat ~sep:","
   |> fun x -> [("Server-timing", x)] |> Header.of_list
 
@@ -792,6 +787,46 @@ let admin_add_op_handler
         body
 
 
+let fetch_all_traces
+    ~(execution_id : Types.id)
+    ~(username : Account.username)
+    ~(canvas : string)
+    ~(permission : Authorization.permission option)
+    body : (Cohttp.Response.t * Cohttp_lwt__.Body.t) Lwt.t =
+  try
+    let t1, c =
+      time "1-load-canvas" (fun _ ->
+          C.load_all canvas []
+          |> Result.map_error ~f:(String.concat ~sep:", ")
+          |> Prelude.Result.ok_or_internal_exception "Failed to load canvas")
+    in
+    let t2, traces =
+      time "2-load-traces" (fun _ ->
+          let htraces =
+            !c.handlers
+            |> TL.handlers
+            |> List.map ~f:(fun h ->
+                   Analysis.traceids_for_handler !c h
+                   |> List.map ~f:(fun traceid -> (h.tlid, traceid)))
+            |> List.concat
+          in
+          let uftraces =
+            !c.user_functions
+            |> Types.IDMap.data
+            |> List.map ~f:(fun uf ->
+                   Analysis.traceids_for_user_fn !c uf
+                   |> List.map ~f:(fun traceid -> (uf.tlid, traceid)))
+            |> List.concat
+          in
+          htraces @ uftraces)
+    in
+    let t3, result =
+      time "3-to-frontend" (fun _ -> Analysis.to_all_traces_result traces)
+    in
+    respond ~execution_id ~resp_headers:(server_timing [t1; t2; t3]) `OK result
+  with e -> Libexecution.Exception.reraise_as_pageable e
+
+
 let initial_load
     ~(execution_id : Types.id)
     ~(username : Account.username)
@@ -828,49 +863,28 @@ let initial_load
           let latest = Time.sub (Time.now ()) (Time.Span.of_day 7.0) in
           Analysis.get_404s ~since:latest !c)
     in
-    let t4, traces =
-      time "4-traces" (fun _ ->
-          let htraces =
-            !c.handlers
-            |> TL.handlers
-            |> List.map ~f:(fun h ->
-                   Analysis.traceids_for_handler !c h
-                   |> List.map ~f:(fun traceid -> (h.tlid, traceid)))
-            |> List.concat
-          in
-          let uftraces =
-            !c.user_functions
-            |> Types.IDMap.data
-            |> List.map ~f:(fun uf ->
-                   Analysis.traceids_for_user_fn !c uf
-                   |> List.map ~f:(fun traceid -> (uf.tlid, traceid)))
-            |> List.concat
-          in
-          htraces @ uftraces)
+    let t4, assets =
+      time "4-static-assets" (fun _ -> SA.all_deploys_in_canvas !c.id)
     in
-    let t5, assets =
-      time "5-static-assets" (fun _ -> SA.all_deploys_in_canvas !c.id)
-    in
-    let t6, account =
-      time "6-account" (fun _ ->
+    let t5, account =
+      time "5-account" (fun _ ->
           match A.get_user username with
           | Some u ->
               u
           | None ->
               {username; email = ""; name = ""; admin = false})
     in
-    let t7, worker_schedules =
-      time "7-worker-schedules" (fun _ ->
+    let t6, worker_schedules =
+      time "6-worker-schedules" (fun _ ->
           Event_queue.get_worker_schedules_for_canvas !c.id)
     in
-    let t8, result =
-      time "8-to-frontend" (fun _ ->
+    let t7, result =
+      time "7-to-frontend" (fun _ ->
           Analysis.to_initial_load_rpc_result
             !c
             op_ctrs
             permission
             f404s
-            traces
             unlocked
             assets
             account
@@ -878,7 +892,7 @@ let initial_load
     in
     respond
       ~execution_id
-      ~resp_headers:(server_timing [t1; t2; t3; t4; t5; t6; t7; t8])
+      ~resp_headers:(server_timing [t1; t2; t3; t4; t5; t6; t7])
       `OK
       result
   with e -> Libexecution.Exception.reraise_as_pageable e
@@ -1686,6 +1700,10 @@ let admin_api_handler
       when_can_view ~canvas (fun permission ->
           wrap_editor_api_headers
             (initial_load ~execution_id ~username ~canvas ~permission body))
+  | `POST, ["api"; canvas; "all_traces"] ->
+      when_can_view ~canvas (fun permission ->
+          wrap_editor_api_headers
+            (fetch_all_traces ~execution_id ~username ~canvas ~permission body))
   | `POST, ["api"; canvas; "execute_function"] ->
       when_can_edit ~canvas (fun _ ->
           wrap_editor_api_headers (execute_function ~execution_id canvas body))

--- a/client/src/api/API.ml
+++ b/client/src/api/API.ml
@@ -129,6 +129,14 @@ let initialLoad (m : model) (focus : focus) : msg Tea.Cmd.t =
   Tea.Http.send (fun x -> InitialLoadAPICallback (focus, NoChange, x)) request
 
 
+let fetchAllTraces (m : model) : msg Tea.Cmd.t =
+  let url =
+    String.concat ["/api/"; Tea.Http.encodeUri m.canvasName; "/all_traces"]
+  in
+  let request = postEmptyJson Decoders.allTracesResult m.csrfToken url in
+  Tea.Http.send (fun x -> FetchAllTracesAPICallback x) request
+
+
 let logout (m : model) : msg Tea.Cmd.t =
   let url = "/logout" in
   let request = postEmptyString Decoders.saveTestAPIResult m.csrfToken url in

--- a/client/src/core/Decoders.ml
+++ b/client/src/core/Decoders.ml
@@ -839,7 +839,6 @@ let initialLoadAPIResult j : initialLoadAPIResult =
       j |> field "unlocked_dbs" (list wireIdentifier) |> StrSet.fromList
   ; fofs = field "fofs" (list fof) j
   ; staticDeploys = field "assets" (list sDeploy) j
-  ; traces = field "traces" (list (pair tlid traceID)) j
   ; userTipes = field "user_tipes" (list userTipe) j
   ; deletedUserTipes = field "deleted_user_tipes" (list userTipe) j
   ; opCtrs =
@@ -851,6 +850,10 @@ let initialLoadAPIResult j : initialLoadAPIResult =
   ; deletedGroups = List.filterMap ~f:TL.asGroup tls
   ; account = field "account" account j
   ; worker_schedules = field "worker_schedules" (strDict string) j }
+
+
+let allTracesResult j : allTracesAPIResult =
+  {traces = field "traces" (list (pair tlid traceID)) j}
 
 
 let executeFunctionAPIResult j : executeFunctionAPIResult =

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -836,6 +836,8 @@ and dbStatsAPIResult = dbStatsStore
 
 and workerStatsAPIResult = workerStats
 
+and allTracesAPIResult = {traces : (tlid * traceID) list}
+
 and initialLoadAPIResult =
   { handlers : handler list
   ; deletedHandlers : handler list
@@ -846,7 +848,6 @@ and initialLoadAPIResult =
   ; unlockedDBs : unlockedDBs
   ; fofs : fourOhFour list
   ; staticDeploys : staticDeploy list
-  ; traces : (tlid * traceID) list
   ; userTipes : userTipe list
   ; deletedUserTipes : userTipe list
   ; permission : permission option
@@ -1205,6 +1206,8 @@ and msg =
   | InitialLoadAPICallback of
       focus * modification * (initialLoadAPIResult, httpError) Tea.Result.t
       [@printer opaque "InitialLoadAPICallback"]
+  | FetchAllTracesAPICallback of (allTracesAPIResult, httpError) Tea.Result.t
+      [@printer opaque "FetchAllTracesAPICallback"]
   | ExecuteFunctionAPICallback of
       executeFunctionAPIParams
       * (executeFunctionAPIResult, httpError) Tea.Result.t


### PR DESCRIPTION
## What

Separates the load of the last 10 trace ids for each handler from `initial_load` into it's own API call.

## Why

https://trello.com/c/ZDgRdZcv/2250-chases-canvas-listo-wont-load-502-during-initial-load

`listo` is frequently throwing 502 errors on initial load. Profiling seems to indicate that both the ops load and the trace load are slow. We should fix each of those to be fast, but in the meantime this buys us some breathing room with little downside. 

## How

Pretty straight-forward extraction into a separate API call with corresponding changes on the front-end.

I wanted to load the traces in parallel with calling `initial_load`, but that seems to block a bunch of other asset requests from going through, resulting in weird rendering things that I didn't want to fix.

## Followups

We could add a loading indicator to the trace UI (currently you see the "empty" trace until all traces load). We could do much more fancy things around only loading traces for handlers that are on-screen or other magic. I don't think either of these are really necessary.

## Proof

Loading `a/listo` locally on a prodclone:

Before you can see `initial_load` taking a long time and blocking other requests:
<img width="1116" alt="before" src="https://user-images.githubusercontent.com/131/72913532-46cd0f80-3d0b-11ea-9d29-be4644edc14e.png">

After, `initial_load` is fast(er) and `all_traces` is called later in the process:
<img width="1114" alt="after" src="https://user-images.githubusercontent.com/131/72913533-46cd0f80-3d0b-11ea-82d7-8f0ae44b63ba.png">
