### PR TITLE
Add dark_queue_scheduler_target to clear-builder-volumes

### DIFF
--- a/scripts/clear-builder-volumes
+++ b/scripts/clear-builder-volumes
@@ -10,4 +10,5 @@ docker volume rm \
   dark_client_node_modules \
   dark_client_lib \
   dark_stroller_target \
-  dark_rust_cargo
+  dark_rust_cargo \
+  dark_queue_scheduler_target


### PR DESCRIPTION
One of the volumes was missing from `scripts/clear-builder-volumes`.

Find all of the volumes with `docker volume ls`:
```
local               dark_backend_build
local               dark_backend_dotesy
local               dark_backend_esy
local               dark_backend_node_modules
local               dark_client_lib
local               dark_client_node_modules
local               dark_queue_scheduler_target
local               dark_rust_cargo
local               dark_stroller_target
```
