### PR TITLE
Add deleted flag to toplevel_oplists

### DIFF
--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -654,6 +654,7 @@ let serialize_only (tlids : tlid list) (c : canvas) : unit =
             ~name
             ~module_
             ~modifier
+            ~deleted:None
             ~tipe
         else ())
   with e -> Libexecution.Exception.reraise_as_pageable e

--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -298,6 +298,7 @@ let save_toplevel_oplist
     ~(canvas_id : Uuidm.t)
     ~(account_id : Uuidm.t)
     ~tipe
+    ~(deleted : bool option)
     ~(name : string option)
     ~(module_ : string option)
     ~(modifier : string option)
@@ -308,12 +309,15 @@ let save_toplevel_oplist
   let binary_option o =
     match o with Some bin -> Db.Binary bin | None -> Db.Null
   in
+  let bool_option o =
+    match o with Some boolean -> Db.Bool boolean | None -> Db.Null
+  in
   let tipe_str = Toplevel.tl_tipe_to_string tipe in
   Db.run
     ~name:"save per tlid oplist"
     "INSERT INTO toplevel_oplists
-    (canvas_id, account_id, tlid, digest, tipe, name, module, modifier, data, rendered_oplist_cache)
-    VALUES ($1, $2, $3, $4, $5::toplevel_type, $6, $7, $8, $9, $10)
+    (canvas_id, account_id, tlid, digest, tipe, name, module, modifier, data, rendered_oplist_cache, deleted)
+    VALUES ($1, $2, $3, $4, $5::toplevel_type, $6, $7, $8, $9, $10, $11)
     ON CONFLICT (canvas_id, tlid) DO UPDATE
     SET account_id = $2,
         digest = $4,
@@ -322,7 +326,9 @@ let save_toplevel_oplist
         module = $7,
         modifier = $8,
         data = $9,
-        rendered_oplist_cache = $10;"
+        rendered_oplist_cache = $10,
+        deleted = $11;
+        "
     ~params:
       [ Uuid canvas_id
       ; Uuid account_id
@@ -333,7 +339,8 @@ let save_toplevel_oplist
       ; string_option module_
       ; string_option modifier
       ; Binary (Op.oplist_to_string ops)
-      ; binary_option binary_repr ]
+      ; binary_option binary_repr
+      ; bool_option deleted ]
 
 
 (* ------------------------- *)

--- a/backend/migrations/20200122_231606_add-deleted-to-toplevel-oplists.sql
+++ b/backend/migrations/20200122_231606_add-deleted-to-toplevel-oplists.sql
@@ -1,0 +1,2 @@
+ALTER TABLE toplevel_oplists ADD COLUMN deleted BOOLEAN
+

--- a/backend/test/test_canvas_ops.ml
+++ b/backend/test/test_canvas_ops.ml
@@ -71,6 +71,7 @@ let t_db_oplist_roundtrip () =
     oplist
     ~binary_repr:None
     ~tlid
+    ~deleted:None
     ~canvas_id
     ~account_id:owner
     ~tipe:TL.TLHandler


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Currently writes `NULL` in all cases, logic to follow in the next PR. Designed to fix the issue of the `rendered_oplist_cache` not knowing whether or not a toplevel is deleted, and unconditionally putting toplevels loaded via the cache as if they were undeleted.

Fixes: https://trello.com/c/hulstXzG/2264-fn-names-cant-be-dupes-including-deleted-fns, mentioned in https://trello.com/c/7SVzzo6H/2257-loading-time-fast-follows

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

