### PR TITLE
Write + read the `deleted` field from toplevel_oplists

### DIFF
--- a/backend/test/test_canvas_ops.ml
+++ b/backend/test/test_canvas_ops.ml
@@ -97,17 +97,16 @@ let t_http_oplist_roundtrip () =
   in
   (* Can tell it was loaded from the cache, as the canvas object has no
    * oplists *)
-  AT.check AT.bool "handler is loaded from cache" true (!c2.ops = []) ;
+  AT.check AT.bool "handler is loaded from cache #1" true (!c2.ops = []) ;
   AT.check
-    AT.bool
-    "handler is loaded correctly from cache"
-    true
-    ( handler
-    = ( !c2.handlers
-      |> IDMap.data
-      |> List.hd_exn
-      |> Toplevel.as_handler
-      |> Option.value_exn ) )
+    testable_handler
+    "handler is loaded correctly from cache #1"
+    handler
+    ( !c2.handlers
+    |> IDMap.data
+    |> List.hd_exn
+    |> Toplevel.as_handler
+    |> Option.value_exn )
 
 
 let t_http_oplist_loads_user_tipes () =
@@ -130,6 +129,48 @@ let t_http_oplist_loads_user_tipes () =
     "user tipes"
     [tipe]
     (IDMap.data !c2.user_tipes)
+
+
+let t_http_load_ignores_deleted_fns () =
+  clear_test_data () ;
+  let host = "test-http_load_ignores_deleted_fns_and_dbs" in
+  let handler = http_route_handler () in
+  let f = user_fn ~tlid:tlid2 "testfn" [] (ast_for "(+ 5 3)") in
+  let f2 = user_fn ~tlid:tlid3 "testfn" [] (ast_for "(+ 6 4)") in
+  let oplist =
+    [ Op.SetHandler (tlid, pos, handler)
+    ; Op.SetFunction f
+    ; Op.DeleteFunction tlid2
+    ; Op.SetFunction f2 ]
+  in
+  let c1 = ops2c_exn host oplist in
+  Canvas.serialize_only [tlid; tlid2; tlid3] !c1 ;
+  let owner = Account.for_host_exn host in
+  let c2 =
+    Canvas.load_http ~path:http_request_path ~verb:"GET" host owner
+    |> Result.map_error ~f:(String.concat ~sep:", ")
+    |> Prelude.Result.ok_or_internal_exception "Canvas load error"
+  in
+  AT.check AT.bool "handler is loaded from cache #2" true (!c2.ops = []) ;
+  AT.check
+    testable_handler
+    "handler is loaded correctly from cache #2"
+    handler
+    ( !c2.handlers
+    |> IDMap.data
+    |> List.hd_exn
+    |> Toplevel.as_handler
+    |> Option.value_exn ) ;
+  AT.check
+    AT.int
+    "only one function is loaded from cache"
+    1
+    (IDMap.length !c2.user_functions) ;
+  AT.check
+    AT.bool
+    "the most recent function is loaded from the cache"
+    true
+    (f2 = (!c2.user_functions |> IDMap.data |> List.hd_exn))
 
 
 let t_db_create_with_orblank_name () =
@@ -310,4 +351,7 @@ let suite =
     , t_canvas_verification_undo_rename_duped_name )
   ; ( "Loading handler via HTTP router loads user tipes"
     , `Quick
-    , t_http_oplist_loads_user_tipes ) ]
+    , t_http_oplist_loads_user_tipes )
+  ; ( "Loading handler via HTTP router ignores deleted fns"
+    , `Quick
+    , t_http_load_ignores_deleted_fns ) ]

--- a/backend/test/utils.ml
+++ b/backend/test/utils.ml
@@ -274,7 +274,7 @@ let worker name ast : HandlerT.handler =
 
 let hop h = Op.SetHandler (tlid, pos, h)
 
-let user_fn name params ast : user_fn =
+let user_fn ?(tlid = tlid) name params ast : user_fn =
   { tlid
   ; ast
   ; metadata =


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Follow up to #1885. This PR actually writes the `deleted` flag using real data, and utilizes it in the query for the fast http loading.

I don't see any particular safety reason to separate out the read/write PRs like we did for the actual TL cache itself as there's no wild and crazy serialization happening here that might go wrong. A revert will suffice.

We might need an index on `(canvas_id, tlid, deleted)` in prod, but I'm also willing to bet the existing `(canvas_id, tlid)` index will be fine. 

Fixes: https://trello.com/c/hulstXzG/2264-fn-names-cant-be-dupes-including-deleted-fns, mentioned in https://trello.com/c/7SVzzo6H/2257-loading-time-fast-follows

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

