### PR TITLE
Fix inserting an infix in a placeholder

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -4529,7 +4529,8 @@ let rec updateKey ?(recursing = false) (key : K.key) (ast : ast) (s : state) :
     | _, L (TBinOp _, toTheLeft), _
       when keyIsInfix ->
         doInsert ~pos keyStr toTheLeft ast s
-    | _, _, R (TBlank _, toTheRight) when keyIsInfix ->
+    | (_, _, R (TPlaceholder _, toTheRight) | _, _, R (TBlank _, toTheRight))
+      when keyIsInfix ->
         doInsert ~pos keyStr toTheRight ast s
     | _, L (_, toTheLeft), _
       when onEdge && keyIsInfix && wrappableInBinop toTheRight ->

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -1874,6 +1874,11 @@ let run () =
         (* wrap false because else we delete the wrapper *)
         (keys ~wrap:false [K.SelectAll; K.Backspace] 0)
         "~___" ;
+      tp
+        "inserting a binop in a placeholder works"
+        (if' (binop "++" b b) b b)
+        (ins '&' 3)
+        "if &~ ++ ____________\nthen\n  ___\nelse\n  ___" ;
       ()) ;
   describe "Constructors" (fun () ->
       tp "arguments work in constructors" aConstructor (ins 't' 5) "Just t~" ;


### PR DESCRIPTION
https://trello.com/c/ioBaauh1/2277-pressing-ampersand-in-the-wrong-place-puts-an-ampersand-in-the-wrong-place

When inserting an infix operator into a placeholder, it went to a very confusing place. this made it difficult to type something like `if ___ && ___ && ___`

Before:
![2020-01-22 21 48 58](https://user-images.githubusercontent.com/181762/72961391-ba036f80-3d65-11ea-8b4d-e9f4e801db81.gif)

After:
![image](https://user-images.githubusercontent.com/181762/72961384-b5d75200-3d65-11ea-8533-23d95d1fcc2a.png)

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

