### PR TITLE
Fix canvas cleanup trim_* and add trim_*_for_canvas

### DIFF
--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -125,6 +125,20 @@ LIKE '%@darklang.com' AND email NOT LIKE '%@example.com'"
                 fail args)
     ; ps = false
     ; dep = false }
+  ; { pns = ["DarkInternal::cleanupOldTracesForCanvas_v1"]
+    ; ins = []
+    ; p = [par "canvas_id" TUuid]
+    ; r = TFloat
+    ; d =
+        "Cleanup the old traces for a specific canvas. Returns elapsed time in ms."
+    ; f =
+        internal_fn (function
+            | state, [DUuid canvas_id] ->
+                DFloat (Canvas.cleanup_old_traces_for_canvas canvas_id)
+            | args ->
+                fail args)
+    ; ps = false
+    ; dep = false }
   ; { pns = ["DarkInternal::checkCanvas"]
     ; ins = []
     ; p = [par "host" TStr]

--- a/backend/libbackend/stored_event.mli
+++ b/backend/libbackend/stored_event.mli
@@ -44,3 +44,5 @@ val clear_all_events : canvas_id:Uuidm.t -> unit -> unit
  * unless listed in keep.
  *)
 val trim_events : unit -> int
+
+val trim_events_for_canvas : Uuidm.t -> int

--- a/backend/libbackend/stored_function_arguments.ml
+++ b/backend/libbackend/stored_function_arguments.ml
@@ -65,21 +65,56 @@ let load_traceids ~(canvas_id : Uuidm.t) (tlid : Types.tlid) : Uuidm.t list =
                "Bad DB format for stored_functions.load_for_analysis")
 
 
-(* This is identical to Stored_function_result.trim_results except for the table
- * name, see that function for comments *)
+(** trim_arguments removes all function_arguments records older than a week,
+ * leaving at minimum 10 records for each tlid on a canvas regardless of age.
+ *
+ * Returns the number of rows deleted.
+ *
+ * CAVEAT: in order to keep our DB from bursting into flames given a large
+ * number of records to cleanup, we cap the maximum number of records deleted
+ * per call to 10_000.
+ *
+ * See also
+ * - Stored_event.trim_events
+ * - Stored_function_result.trim_results
+ * which are nearly identical queries on different tables *)
 let trim_arguments () : int =
   Db.delete
     ~name:"stored_function_argument.trim_arguments"
-    "DELETE FROM function_arguments
-    WHERE trace_id IN (
-      SELECT trace_id FROM (
-        SELECT row_number()
-        OVER (PARTITION BY canvas_id, tlid ORDER BY timestamp
-desc) as rownum, t.trace_id
-        FROM function_arguments t
-        WHERE timestamp < (NOW() - interval '1 week')
-        LIMIT 10000) as u
+    "WITH indexed_arguments AS (
+       SELECT trace_id, row_number() OVER (
+         PARTITION BY canvas_id, tlid
+         ORDER BY timestamp DESC
+       ) AS rownum
+       FROM function_arguments
+       WHERE timestamp < (NOW() - interval '1 week')
+    )
+    DELETE FROM function_arguments WHERE trace_id IN (
+      SELECT trace_id FROM indexed_arguments
       WHERE rownum > 10
       LIMIT 10000
     )"
     ~params:[]
+
+
+(** trim_arguments_for_canvas is like trim_arguments_for_canvas but for a single canvas.
+ *
+ * All the comments and warnings there apply. Please read them. *)
+let trim_arguments_for_canvas (canvas_id : Uuidm.t) : int =
+  Db.delete
+    ~name:"stored_function_argument.trim_arguments_for_canvas"
+    "WITH indexed_arguments AS (
+       SELECT trace_id, row_number() OVER (
+         PARTITION BY canvas_id, tlid
+         ORDER BY timestamp DESC
+       ) AS rownum
+       FROM function_arguments
+       WHERE canvas_id = $1
+       AND timestamp < (NOW() - interval '1 week')
+    )
+    DELETE FROM function_arguments WHERE trace_id IN (
+      SELECT trace_id FROM indexed_arguments
+      WHERE rownum > 10
+      LIMIT 10000
+    )"
+    ~params:[Uuid canvas_id]

--- a/backend/libbackend/stored_function_arguments.mli
+++ b/backend/libbackend/stored_function_arguments.mli
@@ -18,3 +18,5 @@ val load_traceids : canvas_id:Uuidm.t -> Types.tlid -> Uuidm.t list
 
 (* GC old function arguments *)
 val trim_arguments : unit -> int
+
+val trim_arguments_for_canvas : Uuidm.t -> int

--- a/backend/libbackend/stored_function_result.mli
+++ b/backend/libbackend/stored_function_result.mli
@@ -16,3 +16,5 @@ val load :
   -> Analysis_types.function_result list
 
 val trim_results : unit -> int
+
+val trim_results_for_canvas : Uuidm.t -> int


### PR DESCRIPTION
## What

- Fixes trace/fn result/fn args cleanup queries to actually cleanup everything they should
- Adds the ability to cleanup traces/fn results/fn arguments for a specific canvas (not just "everything")
- exposes canvas cleanup as `DarkInternal` fn

## Why

Lots of things are slow because we have millions of rows in the events table.

https://trello.com/c/1IFZCleq/2294-trace-cleanup-isnt-working-leading-to-performance-problems-with-traces

The old trim_* queries had a LIMIT 10000 inside the sub-SELECT, meaning once we hit over 10K events more than a week old we were missing some events on every delete. Now that we have some millions of rows in the events table, it's impossible (read: potentially dangerous?) to try to clean them all up at once.

Instead, I plan to use the new `DarkInternal` fn to cleanup a canvas at a time. Specifically, I plan to enqueue events in `a/ops` into a worker with code as follows. This should allow slowly processing down the backlog of cleanup, 10K at a time.

```
let cid = DarkInternal::canvasIdOfCanvasName event
          |>String::toUUIDv1
let dur = DarkInternal::cleanupOldTracesForCanvasv1 cid
if Float::greaterThan dur 1000.0
then
  let _ = emitv1 event "cleanup-canvas"
  dur
else
  dur
```


- [X] Trello link included
- [X] Discussed goals, problem and solution
- [X] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [X] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [X] No followups
- [ ] Reversion plan exists
  - [X] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

