### PR TITLE
Only keep 10 traces per TLID in model

### DIFF
--- a/client/src/analysis/Analysis.ml
+++ b/client/src/analysis/Analysis.ml
@@ -338,19 +338,20 @@ let mergeTraces ~(onConflict : trace -> trace -> trace) oldTraces newTraces :
           (* merge the lists, updating the trace in the same position
               * if present, and adding it to the front otherwise. *)
           Some
-            (List.foldl n ~init:o ~f:(fun ((newID, newData) as new_) acc ->
-                 let found = ref false in
-                 let updated =
-                   List.map acc ~f:(fun ((oldID, oldData) as old) ->
-                       if oldID = newID
-                       then (
-                         found := true ;
-                         onConflict old new_ )
-                       else (oldID, oldData))
-                 in
-                 if !found (* deref, not "not" *)
-                 then updated
-                 else (newID, newData) :: acc)))
+            ( List.foldl n ~init:o ~f:(fun ((newID, newData) as new_) acc ->
+                  let found = ref false in
+                  let updated =
+                    List.map acc ~f:(fun ((oldID, oldData) as old) ->
+                        if oldID = newID
+                        then (
+                          found := true ;
+                          onConflict old new_ )
+                        else (oldID, oldData))
+                  in
+                  if !found (* deref, not "not" *)
+                  then updated
+                  else (newID, newData) :: acc)
+            |> List.take ~count:10 ))
 
 
 let requestTrace ?(force = false) m tlid traceID : model * msg Cmd.t =


### PR DESCRIPTION
We only load 10 from the server (with no way to fetch more currently), but live events are pushed in, which can result in an unbounded list if the editor is kept open.

Like this:

<img width="235" alt="Screen Shot 2020-01-28 at 4 48 52 PM" src="https://user-images.githubusercontent.com/131/73308489-67570700-41ee-11ea-8618-67806c2dd083.png">


- [ ] Trello link included
  - No, I just ran into this and it was an easy fix
- [X] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [X] No useful information
- [X] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [X] No followups
- [ ] Reversion plan exists
  - [X] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

