### PR TITLE
Show user function params

### DIFF
--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -708,6 +708,7 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
               |> TD.removeMany ~tlids:(List.map ~f:UserFunctions.toID userFuncs)
           }
         in
+        (* Update the functions variable for use in FluidPrinter for fn params *)
         OldExpr.functions := FluidAutocomplete.allFunctions m ;
         (* Bring back the TL being edited, so we don't lose work done since the
            API call *)


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Trello: 
https://trello.com/c/EE9Y31Xo/2274-user-functions-do-not-show-parameters-in-fluid-blanks

### Why?
When a user selects a built in function it shows blanks with placeholders describing the param, but the param placeholders were not showing when a user select a function that they created. Now the params should show no matter if a user select a built in or user defined function. 

### Gifs
**Before:**
![2020-01-29 10 36 16](https://user-images.githubusercontent.com/32043360/73386157-3aa0ff00-4283-11ea-8ee2-19d126b42388.gif)

**After:**
![2020-01-29 10 35 28](https://user-images.githubusercontent.com/32043360/73386146-3674e180-4283-11ea-807b-d5e4df405ceb.gif)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

