### PR TITLE
Don't pctencode the cookie name or value in Http::setCookie

### DIFF
--- a/backend/libexecution/libhttp.ml
+++ b/backend/libexecution/libhttp.ml
@@ -216,4 +216,60 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
+    ; dep = true }
+  ; { pns = ["Http::setCookie_v1"]
+    ; ins = []
+    ; p = [par "name" TStr; par "value" TStr; par "params" TObj]
+    ; r = TObj
+    ; d =
+        "Generate an HTTP Set-Cookie header Object suitable for Http::respondWithHeaders given a cookie name, a string value for it, and an Object of Set-Cookie parameters."
+    ; f =
+        InProcess
+          (function
+          | _, [DStr name; DStr value; DObj o] ->
+              o
+              (* Transform a DOBj into a cookie list of individual cookie params *)
+              |> Map.to_alist
+              |> List.concat_map ~f:(fun (x, y) ->
+                     match (String.lowercase x, y) with
+                     (* Single boolean set-cookie params *)
+                     | "secure", DBool b | "httponly", DBool b ->
+                         if b then [x] else []
+                     (* X=y set-cookie params *)
+                     | "path", DStr str
+                     | "domain", DStr str
+                     | "samesite", DStr str ->
+                         [ Format.sprintf
+                             "%s=%s"
+                             x
+                             (Unicode_string.to_string str) ]
+                     | "max-age", DInt i | "expires", DInt i ->
+                         [Format.sprintf "%s=%s" x (Dint.to_string i)]
+                     (* Throw if there's not a good way to transform the k/v pair *)
+                     | _ ->
+                         y
+                         |> Dval.to_developer_repr_v0
+                         |> Format.sprintf "Unknown set-cookie param: %s: %s" x
+                         |> Exception.code)
+              (* Combine it into a set-cookie header *)
+              |> String.concat ~sep:"; "
+              |> Format.sprintf
+                   "%s=%s; %s"
+                   (* DO NOT ESCAPE THESE VALUES; pctencoding is tempting (see
+                    * the implicit _v0, and
+                    * https://github.com/darklang/dark/pull/1917 for a
+                    * discussion of the bug), but incorrect. By the time it's
+                    * reached Http::setCookie_v1,  you've probably already
+                    * stored the cookie value as-is in a datastore somewhere, so
+                    * any changes will break attempts to look up the session.
+                    *
+                    * If you really want to shield against invalid
+                    * cookie-name/cookie-value strings, go read RFC6265 first. *)
+                   (Unicode_string.to_string name)
+                   (Unicode_string.to_string value)
+              |> Dval.dstr_of_string_exn
+              |> fun x -> Dval.to_dobj_exn [("Set-Cookie", x)]
+          | args ->
+              fail args)
+    ; ps = true
     ; dep = false } ]


### PR DESCRIPTION
Session.to_cookie_hdrs doesn't pctencode, so let's not pctencode in Http::SetCookie

(as tested by generating a bunch of
sessions locally, and seeing that the cookie header was unescaped:
"set-cookie: __session=DLz/MRcJfGehC5DZpnmWETXhWjNP/p+iSPjdH16T;
Max-Age=604800; domain=localhost; path=/; secure; httponly")

This was discovered while testing out ops-login.darklang.com, which uses
Http::setCookie (darklang) instead of Session.to_cookie_hdrs (ocaml).
Specifically, when we generated a session whose key contained url-unsafe
chars, the DB would store the unescaped value but we'd tell the browser to
set the escaped value as its cookie, and so auth would break.

RFC DISCUSSION:
For this, let's not worry about the allowed charset of a cookie-name; it
is not randomly generated, and we can
expect the user to give Http::setCookie an appropriate cookie-name
(like, in our case, `__session`).

So let's discuss cookie values, which actually tickled this bug!
Per
https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02#section-4.2:
```
   cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
   cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
                         ; US-ASCII characters excluding CTLs,
                         ; whitespace DQUOTE, comma, semicolon,
                         ; and backslash
```

I think it is, again, reasonable to expect the user to give
Http::setCookie an appropriate cookie-value.

And in fact, the two places where we use Http::setCookie in ops-login do
this:
- DarkInternal::newSessionForUsername: uses ocaml-session, let's assume
  that DTRT; we saw this bug because ocaml-session gave us a
  forwardslash, which is an acceptable cookie-octet, but not url-safe
  (and so we pctencoded it)
- String::random_v2 (for the __auth cookie): this uses
  Util.random_string, which selects from chars [a-zA-Z0-9], all in the
  safe set

CURRENT USE:
According to get_functions_and_tlids.exe, as of last prodclone, there
were 20 uses in prod of setCookie.

Of these (and ignoring the ones that can't load anyway b/c DuplicateDB
error), the cookie value is:
- a base64-encoded String::random
- empty string ("unset cookie")
- a jwt (one instance, reify-modification-migrator)
- a string literal (one instance, in a REPL, the value "hi")

Making Http::setCookie check its value's validity and
return a result is possible, but out of scope for this change.

https://trello.com/c/fzzt0Dkc/2318-httpsetcookie-bug-should-not-pctencode-cookie-name-and-value

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

