### PR TITLE
Halve scale (pod count) for bwd and editor deployments

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
+++ b/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: bwd-app
-  replicas: 72
+  replicas: 36
   template:
     metadata:
       labels:

--- a/scripts/support/kubernetes/builtwithdark/editor-deployment.yaml.template
+++ b/scripts/support/kubernetes/builtwithdark/editor-deployment.yaml.template
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: editor-app
-  replicas: 72
+  replicas: 36
   template:
     metadata:
       labels:


### PR DESCRIPTION
72-36

No trello link. For history, see https://dark-inc.slack.com/archives/CTCV12LCC/p1580494188006700

tl;dr: more pods than we need, trying to cut our gcp bill

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

