### PR TITLE
Actually remove partials

### DIFF
--- a/backend/bin/get_functions_and_tlids.ml
+++ b/backend/bin/get_functions_and_tlids.ml
@@ -14,7 +14,7 @@ let flatmap ~(f : 'a -> 'b list) : 'a list -> 'b list =
 
 let rec fnnames_of_expr (expr : RTT.expr) : RTT.fnname list =
   match expr with
-  | Partial _ | Blank _ ->
+  | Blank _ ->
       []
   | Filled (_, nexpr) ->
     ( match nexpr with
@@ -88,8 +88,7 @@ let process_canvas (canvas : Canvas.canvas ref) : fn list =
     let spec = handler.spec in
     String.concat
       ( [spec.module_; spec.name; spec.modifier]
-      |> List.map ~f:(function Filled (_, s) -> s | Partial _ | Blank _ -> "")
-      )
+      |> List.map ~f:(function Filled (_, s) -> s | Blank _ -> "") )
       ~sep:"-"
   in
   let handlers =

--- a/backend/bin/validate_data_loads.ml
+++ b/backend/bin/validate_data_loads.ml
@@ -104,7 +104,7 @@ let () =
           |> List.iter ~f:(fun (db : Libexecution.Types.RuntimeT.DbT.db) ->
                  let dbname =
                    match db.name with
-                   | Filled (id, str) | Partial (id, str) ->
+                   | Filled (id, str) ->
                        str
                    | Blank _ ->
                        "no name"

--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -187,8 +187,6 @@ let apply_op (is_new : bool) (op : Op.op) (c : canvas ref) : unit =
                 match t with
                 | Filled (id, ts) ->
                     (n, Filled (id, Dval.tipe_of_string ts))
-                | Partial _ as b ->
-                    (n, b)
                 | Blank _ as b ->
                     (n, b))
           in
@@ -809,17 +807,11 @@ let check_tier_one_hosts () : unit =
 (* Migrate canvases *)
 (* --------------- *)
 
-let migrate_or_blank (ob : 'a or_blank) : 'a or_blank =
-  (* Remove Partial: this implementation of partials didn't solve the problem
-   * and so didn't get use. *)
-  match ob with Blank _ -> ob | Partial (id, _) -> Blank id | Filled _ -> ob
-
+let migrate_or_blank (ob : 'a or_blank) : 'a or_blank = ob
 
 let rec migrate_expr (expr : RuntimeT.expr) =
   let f e = migrate_expr e in
   match expr with
-  | Partial (id, _) ->
-      Blank id
   | Blank _ ->
       expr
   | Filled (id, nexpr) ->

--- a/backend/libbackend/user_db.ml
+++ b/backend/libbackend/user_db.ml
@@ -549,9 +549,7 @@ let create2 (name : string) (tlid : tlid) (name_id : id) : db =
 
 
 let rename_db (n : string) (db : db) : db =
-  let id =
-    match db.name with Partial (i, _) | Blank i -> i | Filled (i, _) -> i
-  in
+  let id = match db.name with Blank i -> i | Filled (i, _) -> i in
   {db with name = Filled (id, n)}
 
 

--- a/backend/libexecution/execution.ml
+++ b/backend/libexecution/execution.ml
@@ -21,7 +21,7 @@ let dbs_as_input_vars (dbs : DbT.db list) : (string * dval) list =
       match db.name with
       | Filled (_, name) ->
           Some (name, DDB name)
-      | Partial _ | Blank _ ->
+      | Blank _ ->
           None)
 
 

--- a/backend/libexecution/type_checker.ml
+++ b/backend/libexecution/type_checker.ml
@@ -70,7 +70,7 @@ let user_tipe_list_to_type_env (tipes : user_tipe list) : type_env =
       match t.name with
       | Filled (_, name) ->
           TypeEnv.add_exn map ~key:(name, t.version) ~data:t
-      | Partial _ | Blank _ ->
+      | Blank _ ->
           map)
 
 

--- a/backend/libexecution/types.ml
+++ b/backend/libexecution/types.ml
@@ -74,7 +74,6 @@ module TLIDTable = IDTable
 type 'a or_blank =
   | Blank of id
   | Filled of id * 'a
-  | Partial of id * string
 [@@deriving eq, compare, show {with_path = false}, yojson, bin_io]
 
 (* DO NOT CHANGE ABOVE WITHOUT READING docs/oplist-serialization.md *)

--- a/backend/serialization/81987e55b1296ab4f1af5fba7074efdf
+++ b/backend/serialization/81987e55b1296ab4f1af5fba7074efdf
@@ -1,0 +1,831 @@
+(Exp
+ (Base list
+  ((Exp
+    (Variant
+     ((SetHandler
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp
+         (Record
+          ((tlid (Exp (Base int63 ())))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int63 ()))))
+               (Filled
+                ((Exp (Base int63 ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (FnCallSendToRail
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Match
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp
+                                    (Application
+                                     (Exp
+                                      (Variant
+                                       ((PVariable ((Exp (Base string ()))))
+                                        (PLiteral ((Exp (Base string ()))))
+                                        (PConstructor
+                                         ((Exp (Base string ()))
+                                          (Exp
+                                           (Base list
+                                            ((Exp
+                                              (Variant
+                                               ((Blank
+                                                 ((Exp (Base int63 ()))))
+                                                (Filled
+                                                 ((Exp (Base int63 ()))
+                                                  (Exp (Rec_app 1 ())))))))))))))))
+                                     ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ())))))))))))))))
+                      (Constructor
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FluidPartial
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (FluidRightPartial
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                   ()))))))))
+           (spec
+            (Exp
+             (Record
+              ((module_
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (modifier
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (types
+                (Exp
+                 (Record
+                  ((input
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Base int ()))))))))
+                   (output
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Base int ())))))))))))))))))))))
+      (CreateDB
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp (Base string ()))))
+      (AddDBCol
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (SetDBColName
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (SetDBColType
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (DeleteTL ((Exp (Base int63 ()))))
+      (MoveTL
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))))
+      (SetFunction
+       ((Exp
+         (Record
+          ((tlid (Exp (Base int63 ())))
+           (metadata
+            (Exp
+             (Record
+              ((name
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+               (parameters
+                (Exp
+                 (Base list
+                  ((Exp
+                    (Record
+                     ((name
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+                      (tipe
+                       (Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ()))
+                            (Exp
+                             (Application
+                              (Exp
+                               (Variant
+                                ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                                 (TNull ()) (TDeprecated1 ()) (TStr ())
+                                 (TList ()) (TObj ()) (TIncomplete ())
+                                 (TError ()) (TBlock ()) (TResp ()) (TDB ())
+                                 (TDeprecated6 ()) (TDate ())
+                                 (TDeprecated2 ()) (TDeprecated3 ())
+                                 (TDeprecated4 ((Exp (Base string ()))))
+                                 (TDeprecated5 ((Exp (Base string ()))))
+                                 (TDbList ((Exp (Rec_app 0 ()))))
+                                 (TPassword ()) (TUuid ()) (TOption ())
+                                 (TErrorRail ()) (TCharacter ()) (TResult ())
+                                 (TUserType
+                                  ((Exp (Base string ()))
+                                   (Exp (Base int ()))))
+                                 (TBytes ()))))
+                              ()))))))))
+                      (block_args (Exp (Base list ((Exp (Base string ()))))))
+                      (optional (Exp (Base bool ())))
+                      (description (Exp (Base string ()))))))))))
+               (return_type
+                (Exp
+                 (Variant
+                  ((Blank ((Exp (Base int63 ()))))
+                   (Filled
+                    ((Exp (Base int63 ()))
+                     (Exp
+                      (Application
+                       (Exp
+                        (Variant
+                         ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                          (TNull ()) (TDeprecated1 ()) (TStr ()) (TList ())
+                          (TObj ()) (TIncomplete ()) (TError ()) (TBlock ())
+                          (TResp ()) (TDB ()) (TDeprecated6 ()) (TDate ())
+                          (TDeprecated2 ()) (TDeprecated3 ())
+                          (TDeprecated4 ((Exp (Base string ()))))
+                          (TDeprecated5 ((Exp (Base string ()))))
+                          (TDbList ((Exp (Rec_app 0 ())))) (TPassword ())
+                          (TUuid ()) (TOption ()) (TErrorRail ())
+                          (TCharacter ()) (TResult ())
+                          (TUserType
+                           ((Exp (Base string ())) (Exp (Base int ()))))
+                          (TBytes ()))))
+                       ()))))))))
+               (description (Exp (Base string ())))
+               (infix (Exp (Base bool ())))))))
+           (ast
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int63 ()))))
+               (Filled
+                ((Exp (Base int63 ()))
+                 (Exp
+                  (Application
+                   (Exp
+                    (Variant
+                     ((If
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (Thread
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FnCall
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Variable ((Exp (Base string ()))))
+                      (Let
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (Lambda
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Base string ()))))))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (Value ((Exp (Base string ()))))
+                      (FieldAccess
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                      (ObjectLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Base string ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ())))))))))))))))
+                      (ListLiteral
+                       ((Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FeatureFlag
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (FnCallSendToRail
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (Match
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Tuple
+                             ((Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp
+                                    (Application
+                                     (Exp
+                                      (Variant
+                                       ((PVariable ((Exp (Base string ()))))
+                                        (PLiteral ((Exp (Base string ()))))
+                                        (PConstructor
+                                         ((Exp (Base string ()))
+                                          (Exp
+                                           (Base list
+                                            ((Exp
+                                              (Variant
+                                               ((Blank
+                                                 ((Exp (Base int63 ()))))
+                                                (Filled
+                                                 ((Exp (Base int63 ()))
+                                                  (Exp (Rec_app 1 ())))))))))))))))
+                                     ())))))))
+                              (Exp
+                               (Variant
+                                ((Blank ((Exp (Base int63 ()))))
+                                 (Filled
+                                  ((Exp (Base int63 ()))
+                                   (Exp (Rec_app 0 ())))))))))))))))
+                      (Constructor
+                       ((Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                        (Exp
+                         (Base list
+                          ((Exp
+                            (Variant
+                             ((Blank ((Exp (Base int63 ()))))
+                              (Filled
+                               ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                      (FluidPartial
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                      (FluidRightPartial
+                       ((Exp (Base string ()))
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                   ())))))))))))))
+      (ChangeDBColName
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (ChangeDBColType
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (UndoTL ((Exp (Base int63 ())))) (RedoTL ((Exp (Base int63 ()))))
+      (DeprecatedInitDbm
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))
+        (Exp (Base int63 ())) (Exp (Variant ((DeprecatedMigrationKind ()))))))
+      (SetExpr
+       ((Exp (Base int63 ())) (Exp (Base int63 ()))
+        (Exp
+         (Variant
+          ((Blank ((Exp (Base int63 ()))))
+           (Filled
+            ((Exp (Base int63 ()))
+             (Exp
+              (Application
+               (Exp
+                (Variant
+                 ((If
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                  (Thread
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FnCall
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                  (Variable ((Exp (Base string ()))))
+                  (Let
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                  (Lambda
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Base string ()))))))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                  (Value ((Exp (Base string ()))))
+                  (FieldAccess
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))))
+                  (ObjectLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Tuple
+                         ((Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                          (Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))))))))
+                  (ListLiteral
+                   ((Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FeatureFlag
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                  (FnCallSendToRail
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                  (Match
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Tuple
+                         ((Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ()))
+                               (Exp
+                                (Application
+                                 (Exp
+                                  (Variant
+                                   ((PVariable ((Exp (Base string ()))))
+                                    (PLiteral ((Exp (Base string ()))))
+                                    (PConstructor
+                                     ((Exp (Base string ()))
+                                      (Exp
+                                       (Base list
+                                        ((Exp
+                                          (Variant
+                                           ((Blank ((Exp (Base int63 ()))))
+                                            (Filled
+                                             ((Exp (Base int63 ()))
+                                              (Exp (Rec_app 1 ())))))))))))))))
+                                 ())))))))
+                          (Exp
+                           (Variant
+                            ((Blank ((Exp (Base int63 ()))))
+                             (Filled
+                              ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))))))))
+                  (Constructor
+                   ((Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled
+                        ((Exp (Base int63 ())) (Exp (Base string ())))))))
+                    (Exp
+                     (Base list
+                      ((Exp
+                        (Variant
+                         ((Blank ((Exp (Base int63 ()))))
+                          (Filled
+                           ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+                  (FluidPartial
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ())))))))))
+                  (FluidRightPartial
+                   ((Exp (Base string ()))
+                    (Exp
+                     (Variant
+                      ((Blank ((Exp (Base int63 ()))))
+                       (Filled ((Exp (Base int63 ())) (Exp (Rec_app 0 ()))))))))))))
+               ())))))))))
+      (TLSavepoint ((Exp (Base int63 ()))))
+      (DeleteFunction ((Exp (Base int63 ()))))
+      (CreateDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))
+        (Exp
+         (Base list
+          ((Exp
+            (Tuple
+             ((Exp
+               (Variant
+                ((Blank ((Exp (Base int63 ()))))
+                 (Filled ((Exp (Base int63 ())) (Exp (Base string ())))))))
+              (Exp
+               (Variant
+                ((Blank ((Exp (Base int63 ()))))
+                 (Filled ((Exp (Base int63 ())) (Exp (Base string ())))))))))))))))
+      (AddDBColToDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (SetDBColNameInDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (SetDBColTypeInDBMigration
+       ((Exp (Base int63 ())) (Exp (Base int63 ())) (Exp (Base string ()))))
+      (AbandonDBMigration ((Exp (Base int63 ()))))
+      (DeleteColInDBMigration ((Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (DeleteDBCol ((Exp (Base int63 ())) (Exp (Base int63 ()))))
+      (RenameDBname ((Exp (Base int63 ())) (Exp (Base string ()))))
+      (CreateDBWithBlankOr
+       ((Exp (Base int63 ()))
+        (Exp (Record ((x (Exp (Base int ()))) (y (Exp (Base int ()))))))
+        (Exp (Base int63 ())) (Exp (Base string ()))))
+      (DeleteTLForever ((Exp (Base int63 ()))))
+      (DeleteFunctionForever ((Exp (Base int63 ()))))
+      (SetType
+       ((Exp
+         (Record
+          ((tlid (Exp (Base int63 ())))
+           (name
+            (Exp
+             (Variant
+              ((Blank ((Exp (Base int63 ()))))
+               (Filled ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+           (version (Exp (Base int ())))
+           (definition
+            (Exp
+             (Variant
+              ((UTRecord
+                ((Exp
+                  (Base list
+                   ((Exp
+                     (Record
+                      ((name
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ())) (Exp (Base string ()))))))))
+                       (tipe
+                        (Exp
+                         (Variant
+                          ((Blank ((Exp (Base int63 ()))))
+                           (Filled
+                            ((Exp (Base int63 ()))
+                             (Exp
+                              (Application
+                               (Exp
+                                (Variant
+                                 ((TAny ()) (TInt ()) (TFloat ()) (TBool ())
+                                  (TNull ()) (TDeprecated1 ()) (TStr ())
+                                  (TList ()) (TObj ()) (TIncomplete ())
+                                  (TError ()) (TBlock ()) (TResp ()) 
+                                  (TDB ()) (TDeprecated6 ()) (TDate ())
+                                  (TDeprecated2 ()) (TDeprecated3 ())
+                                  (TDeprecated4 ((Exp (Base string ()))))
+                                  (TDeprecated5 ((Exp (Base string ()))))
+                                  (TDbList ((Exp (Rec_app 0 ()))))
+                                  (TPassword ()) (TUuid ()) (TOption ())
+                                  (TErrorRail ()) (TCharacter ())
+                                  (TResult ())
+                                  (TUserType
+                                   ((Exp (Base string ()))
+                                    (Exp (Base int ()))))
+                                  (TBytes ()))))
+                               ())))))))))))))))))))))))))
+      (DeleteType ((Exp (Base int63 ()))))
+      (DeleteTypeForever ((Exp (Base int63 ()))))))))))

--- a/backend/test/test_canvas_ops.ml
+++ b/backend/test/test_canvas_ops.ml
@@ -191,11 +191,7 @@ let t_db_rename () =
   match List.hd state.dbs with
   | Some db ->
       let newname =
-        match db.name with
-        | Filled (_, name) ->
-            name
-        | Partial _ | Blank _ ->
-            ""
+        match db.name with Filled (_, name) -> name | Blank _ -> ""
       in
       AT.check AT.string "datastore rename success" "BsCode" newname
   | None ->


### PR DESCRIPTION
Followup to #1929, in which we remove partials from oplists. Now we're removing them from the type-system.


Merge order:
- #1929 
- do migration using queues in the ops canvas
- download prodclone again to verify
- merge this

This is branched off #1929, so just look at the last commit.


- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

