### PR TITLE
Don't re-parse params on own add_op response

### DIFF
--- a/client/src/api/API.ml
+++ b/client/src/api/API.ml
@@ -53,11 +53,7 @@ let addOp (m : model) (focus : focus) (params : addOpAPIParams) : msg Tea.Cmd.t
     String.concat ["/api/"; Tea.Http.encodeUri m.canvasName; "/add_op"]
   in
   let request =
-    postJson
-      Decoders.addOpAPIStrollerMsg
-      m.csrfToken
-      url
-      (Encoders.addOpAPIParams params)
+    postJson Decoders.addOpAPI m.csrfToken url (Encoders.addOpAPIParams params)
   in
   Tea.Http.send (fun x -> AddOpsAPICallback (focus, params, x)) request
 

--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -1349,7 +1349,7 @@ let update_ (msg : msg) (m : model) : modification =
         [ TweakModel
             (fun m -> {m with deletedGroups = TD.remove ~tlid m.deletedGroups})
         ]
-  | AddOpsAPICallback (focus, params, Ok r) ->
+  | AddOpsAPICallback (focus, params, Ok (r : addOpAPIResponse)) ->
       let m, newOps, _ = API.filterOpsAndResult m params None in
       let params = {params with ops = newOps} in
       let initialMods =

--- a/client/src/core/Decoders.ml
+++ b/client/src/core/Decoders.ml
@@ -795,6 +795,10 @@ let addOpAPIResult j : addOpAPIResult =
   ; deletedUserTipes = field "deleted_user_tipes" (list userTipe) j }
 
 
+let addOpAPI (j : Js.Json.t) : addOpAPIResponse =
+  {result = field "result" addOpAPIResult j}
+
+
 let addOpAPIParams j : addOpAPIParams =
   { ops = field "ops" (list op) j
   ; opCtr = field "opCtr" int j

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -740,6 +740,8 @@ and addOpAPIResult =
   ; userTipes : userTipe list
   ; deletedUserTipes : userTipe list }
 
+and addOpAPIResponse = {result : addOpAPIResult}
+
 and addOpStrollerMsg =
   { result : addOpAPIResult
   ; params : addOpAPIParams }
@@ -1138,7 +1140,7 @@ and msg =
   | GlobalKeyPress of Keyboard.keyEvent
   | AutocompleteClick of int
   | AddOpsAPICallback of
-      focus * addOpAPIParams * (addOpStrollerMsg, httpError) Tea.Result.t
+      focus * addOpAPIParams * (addOpAPIResponse, httpError) Tea.Result.t
       [@printer opaque "AddOpsAPICallback"]
   | AddOpsStrollerMsg of addOpStrollerMsg
   | SaveTestAPICallback of (saveTestAPIResult, httpError) Tea.Result.t


### PR DESCRIPTION
## What

Somewhat improves performance of typing in large handlers by not re-parsing the data that was just sent to the server.

The `params` field of the response from `/add_op` is never used, so this PR removes the deserialization of it, resulting in a ~50% faster XHR callback function

I didn't investigate removing this from the server payload entirely, but we could. I know it's used in some of the stroller push related code on the client, but it's possible we don't need the data in `add_op` at all.

## Why

Large handlers are very slow to type in, with >100ms between keypress and render. 

https://trello.com/c/j308GE6y/2251-optimize-large-canvases

## Proof

Profiling `listo` on a local prodclone and typing into the same place in one of the large handers looks like this before:
 
<img width="637" alt="before" src="https://user-images.githubusercontent.com/131/73753691-1042bc00-4731-11ea-8b6f-f6c6c06dd4d1.png">

and after:

<img width="607" alt="after" src="https://user-images.githubusercontent.com/131/73753692-1042bc00-4731-11ea-8546-5a19e0a69aef.png">

## Followup

Parsing of the `result` field in the response is still slow, as evidenced by the >100ms XHR function in the _after_ performance graph. This will need to be addressed to make large handlers responsive.

- [X] Trello link included
- [X] Discussed goals, problem and solution
- [X] Information from this description is also in comments
  - [ ] No useful information
- [X] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [X] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [X] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

