### PR TITLE
DarkInternal::newSessionForUsername_v1, now returns both sessionKey a…

### DIFF
--- a/backend/libbackend/auth.ml
+++ b/backend/libbackend/auth.ml
@@ -46,6 +46,21 @@ module SessionSync = struct
 
   let new_for_username username =
     Backend.generate backend ~value:(session_data username)
+
+
+  type session_key_and_csrf_token =
+    { sessionKey : string
+    ; csrfToken : string }
+
+  let new_for_username_with_csrf_token username =
+    let session_data = session_data username in
+    let csrfToken =
+      session_data
+      |> Yojson.Basic.from_string
+      |> Yojson.Basic.Util.member "csrf_token"
+      |> Yojson.Basic.Util.to_string
+    in
+    {sessionKey = Backend.generate backend ~value:session_data; csrfToken}
 end
 
 module SessionLwt = struct

--- a/backend/libbackend/auth.mli
+++ b/backend/libbackend/auth.mli
@@ -31,5 +31,12 @@ module SessionSync : sig
 
   val new_for_username : Account.username -> string
 
+  type session_key_and_csrf_token =
+    { sessionKey : string
+    ; csrfToken : string }
+
+  val new_for_username_with_csrf_token :
+    Account.username -> session_key_and_csrf_token
+
   val username_of_key : string -> string option
 end


### PR DESCRIPTION
…nd csrfToken

We need the csrfToken to pass back to dark-cli; right now it gets that
when it logs in to the ocaml handler, but we'll be making it do auth via
login.darklang.com as part of our migration to auth0, so
login.darklang.com needs to  have both a sessionKey and a csrfToken to
respond with.

Part of https://trello.com/c/MXRVhUAl/2346-update-dark-cli-to-work-with-auth0

Two remaining pieces:
- ops-login/login.darklang.com implements the password grant flow
- dark-cli gets cookie & token from login.darklang.com

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [x] Intended followups are trelloed (intended followup is the same trello)
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

