### PR TITLE
Add ctrl-space as new command palette shortcut

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -3482,7 +3482,7 @@ let doDelete ~(pos : int) (ti : T.tokenInfo) (ast : ast) (s : state) :
    * multi-codepoint emoji (the expected behavior of multi-syllable clusters differs from emoji).
    *
    * Note that we do not handle caret affinity properly, but caret affinity should behave the
-   * same for backspace and delete. 
+   * same for backspace and delete.
    *
    * See https://www.notion.so/darklang/Keyboard-and-Input-Handling-44eeedc4953846159e96af1e979004ad.
    *)
@@ -3504,7 +3504,7 @@ let doDelete ~(pos : int) (ti : T.tokenInfo) (ast : ast) (s : state) :
 
 (* [doExplicitInsert [extendedGraphemeCluster] [currCaretTarget] [ast]]
  * produces the (newAST, newPosition) tuple resulting from performing
- * a text insertion at [currCaretTarget] in the [ast]. 
+ * a text insertion at [currCaretTarget] in the [ast].
  * Note that newPosition will be either AtTarget or SamePlace --
  * either the caret stays in the same place, or it ends up at a specific location.
  *
@@ -5579,8 +5579,23 @@ let update (m : Types.model) (msg : Types.fluidMsg) : Types.modification =
       KeyPress.undo_redo m false
   | FluidInputEvent (Keypress {key = K.Redo; _}) ->
       KeyPress.undo_redo m true
-  | FluidInputEvent (Keypress {key = K.CommandPalette; _}) ->
-      maybeOpenCmd m
+  | FluidInputEvent (Keypress {key = K.CommandPalette heritage; _}) ->
+      let maybeOpen = maybeOpenCmd m in
+      let showToast =
+        TweakModel
+          (fun m ->
+            { m with
+              toast =
+                { toastMessage =
+                    Some
+                      "Command Palatte has been moved to Ctrl-Space. Alt-X will be removed soon."
+                ; toastPos = None } })
+      in
+      ( match heritage with
+      | K.LegacyShortcut ->
+          Many [showToast; maybeOpen]
+      | K.CurrentShortcut ->
+          maybeOpen )
   | FluidInputEvent (Keypress {key = K.Omnibox; _}) ->
       KeyPress.openOmnibox m
   | FluidInputEvent (Keypress ke) when FluidCommands.isOpened m.fluidState.cp ->

--- a/client/src/fluid/FluidKeyboard.ml
+++ b/client/src/fluid/FluidKeyboard.ml
@@ -1,5 +1,10 @@
 open Tc
 
+type shortcutHeritage =
+  | LegacyShortcut
+  | CurrentShortcut
+[@@deriving show]
+
 type browserPlatform =
   | Mac
   | Linux
@@ -46,7 +51,7 @@ type key =
   | Undo
   | Redo
   | SelectAll
-  | CommandPalette
+  | CommandPalette of shortcutHeritage
   | Omnibox
   | Unhandled of string
 [@@deriving show]
@@ -102,6 +107,8 @@ let fromKeyboardEvent
       (* Allowing Ctrl on macs because it doesnt override any default mac cursor movements.
        * Default behaivor is desktop switching where the OS swallows the event unless disabled *)
       GoToEndOfWord maintainSelection
+  | " " when ctrl ->
+      CommandPalette CurrentShortcut
   (************
    * Movement *
    ************)
@@ -175,9 +182,9 @@ let fromKeyboardEvent
    * points to the fact that it may be easier to do shortcuts with Cmd/Ctrl
    * instead of Alt. *)
   | "x" when alt ->
-      CommandPalette
+      CommandPalette LegacyShortcut
   | _ when alt && String.length key = 1 ->
-      if key = {js|≈|js} then CommandPalette else Unhandled key
+      if key = {js|≈|js} then CommandPalette LegacyShortcut else Unhandled key
   | _ ->
       Unhandled key
 


### PR DESCRIPTION
## What

Adds ctrl-space as command palette shortcut, with toast for triggering alt-x. My plan is to eventually remove alt-x entirely, but this gives some time for folks to adjust.

## Why

Shortcut handling with option (alt) as the modifier on Mac is kind of a disaster because option is overloaded to type special characters. For example, typing opt-x on my machine gives `≈`. This means to capture this as a shortcut, we have to look for that ≈ character instead of opt+x. See the 20 lines of comments preexisting in FluidKeyboard that explain this craziness.

Even after all that trouble, it still doesn't work for mac users who use a different keyboard layout where opt-x types some other character. Womp. https://trello.com/c/aeEwOuZl/2357-allow-non-us-keyboard-mac-users-to-trigger-command-palette

Instead, let's just not use option for shortcuts anymore. We'll stick to control.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

