### PR TITLE
Add Bytes::length

### DIFF
--- a/backend/libexecution/libbytes.ml
+++ b/backend/libexecution/libbytes.ml
@@ -45,4 +45,18 @@ let fns : Lib.shortfn list =
           | args ->
               fail args)
     ; ps = true
+    ; dep = false }
+  ; { pns = ["Bytes::length"]
+    ; ins = []
+    ; p = [par "bytes" TBytes]
+    ; r = TInt
+    ; d = "Length of encoded byte string"
+    ; f =
+        InProcess
+          (function
+          | _, [DBytes bytes] ->
+              Dval.dint (Bytes.length bytes)
+          | args ->
+              fail args)
+    ; ps = true
     ; dep = false } ]

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -521,6 +521,14 @@ let t_crypto_sha () =
   ()
 
 
+let t_libbytes () =
+  check_dval
+    "Length is right"
+    (Dval.dint 6)
+    (exec_ast' (fn "Bytes::length" [fn "String::toBytes" [str "abcdef"]])) ;
+  ()
+
+
 let t_internal_functions () =
   Libbackend.Account.set_admin "test" true ;
   check_dval
@@ -662,5 +670,6 @@ let suite =
   ; ("Crypto::sha256hmac works for AWS", `Quick, t_sha256hmac_for_aws)
   ; ("URL percent encoding", `Quick, t_url_encode)
   ; ("Float stdlibs work", `Quick, t_float_stdlibs)
+  ; ("Bytes stdlibs work", `Quick, t_libbytes)
   ; ("List::sortByComparator works", `Quick, t_liblist_sort_by_comparator_works)
   ]


### PR DESCRIPTION
A urer asked to figure out the length of bytes. This seems like a sensible thing so I added it. https://darkcommunity.slack.com/archives/CNTCWD6MP/p1581047445419500

https://trello.com/c/hoD3E1ot/2375-add-byteslength

Is it sensible? I don't know. Pls review. 

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

