### PR TITLE
Some foundation for Feature Flag support

### DIFF
--- a/client/src/canvas/View.ml
+++ b/client/src/canvas/View.ml
@@ -10,12 +10,7 @@ let fontAwesome = ViewUtils.fontAwesome
 
 let viewTL_ (m : model) (tl : toplevel) : msg Html.html =
   let tlid = TL.id tl in
-  let tokens =
-    TL.getAST tl
-    |> Option.map ~f:FluidPrinter.toTokens
-    |> Option.withDefault ~default:[]
-  in
-  let vs = ViewUtils.createVS m tl tokens in
+  let vs = ViewUtils.createVS m tl in
   let dragEvents =
     [ ViewUtils.eventNoPropagation
         ~key:("tlmd-" ^ showTLID tlid)
@@ -93,7 +88,7 @@ let viewTL_ (m : model) (tl : toplevel) : msg Html.html =
     |> String.join ~sep:" "
   in
   let id =
-    Fluid.getToken' m.fluidState tokens
+    Fluid.getToken' m.fluidState vs.primaryTokens
     |> Option.map ~f:(fun ti -> FluidToken.tid ti.token)
     |> Option.orElse (idOf m.cursorState)
   in
@@ -437,7 +432,7 @@ let view (m : model) : msg Html.html =
   in
   let fluidStatus =
     if m.editorSettings.showFluidDebugger
-    then [FluidView.viewStatus m ast m.fluidState]
+    then [FluidView.viewStatus m ast]
     else []
   in
   let viewDocs =

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -432,6 +432,12 @@ type astPatternPart =
   | PPBlank
 [@@deriving show {with_path = false}]
 
+type astFlagPart =
+  | FPCond
+  | FPEnabled
+  | FPDisabled
+[@@deriving show {with_path = false}]
+
 (* An astRef represents a reference to a specific part of an AST node,
    such as a specific Record Fieldname rather than just the record.
    Why not use a fluidToken for this purpose?
@@ -471,6 +477,7 @@ type astRef =
   | ARMatch of id * astMatchPart
   | ARLambda of id * astLambdaPart
   | ARPattern of id * astPatternPart
+  | ARFlag of id * astFlagPart
   (* for use if something that should never happen happened *)
   | ARInvalid
 [@@deriving show {with_path = false}]
@@ -1401,6 +1408,9 @@ and fluidToken =
   | TConstructorName of id * string
   | TParenOpen of id
   | TParenClose of id
+  | TFlagCond of id
+  | TFlagEnabled of id
+  | TFlagDefault of id
 
 and fluidTokenInfo =
   { startRow : int

--- a/client/src/fluid/Commands.ml
+++ b/client/src/fluid/Commands.ml
@@ -54,7 +54,10 @@ let commands : command list =
     ; doc = "Put expr in the arm of a match" }
   ; { commandName = "add-feature-flag"
     ; action = FeatureFlags.wrap
-    ; doc = "Clone expression as Case A in a feature flag" }
+    ; doc = "Add a feature flag with the expression as the default case" }
+  ; { commandName = "remove-feature-flag"
+    ; action = FeatureFlags.unwrap
+    ; doc = "Replace the feature flag with the default case" }
   ; putFunctionOnRail
   ; takeFunctionOffRail
   ; { commandName = "create-type"

--- a/client/src/fluid/FluidCommands.ml
+++ b/client/src/fluid/FluidCommands.ml
@@ -9,8 +9,12 @@ let filterInputID : string = "cmd-filter"
 
 let fluidCommands =
   Commands.commands
-  |> List.filter ~f:(fun {commandName; _} ->
-         not (commandName == "add-feature-flag"))
+  |> List.filter ~f:(function
+         | {commandName = "add-feature-flag"; _}
+         | {commandName = "remove-feature-flag"; _} ->
+             false
+         | _ ->
+             true)
 
 
 let reset : fluidCommandState =

--- a/client/src/fluid/FluidToken.ml
+++ b/client/src/fluid/FluidToken.ml
@@ -66,6 +66,9 @@ let tid (t : t) : id =
   | TSep id
   | TParenOpen id
   | TParenClose id
+  | TFlagCond id
+  | TFlagEnabled id
+  | TFlagDefault id
   | TNewline (Some (id, _, _)) ->
       id
   | TNewline None | TIndent _ ->
@@ -157,7 +160,10 @@ let isTextToken t : bool =
   | TPipe _
   | TLambdaArrow _
   | TParenOpen _
-  | TParenClose _ ->
+  | TParenClose _
+  | TFlagCond _
+  | TFlagEnabled _
+  | TFlagDefault _ ->
       false
 
 
@@ -206,7 +212,10 @@ let isKeyword (t : t) =
   | TIfKeyword _
   | TIfThenKeyword _
   | TIfElseKeyword _
-  | TMatchKeyword _ ->
+  | TMatchKeyword _
+  | TFlagCond _
+  | TFlagEnabled _
+  | TFlagDefault _ ->
       true
   | _ ->
       false
@@ -384,6 +393,12 @@ let toText (t : t) : string =
       "("
   | TParenClose _ ->
       ")"
+  | TFlagCond _ ->
+      "when "
+  | TFlagEnabled _ ->
+      "enabled"
+  | TFlagDefault _ ->
+      "default "
 
 
 let toTestText (t : t) : string =
@@ -584,6 +599,12 @@ let toTypeName (t : t) : string =
       "paren-open"
   | TParenClose _ ->
       "paren-close"
+  | TFlagCond _ ->
+      "ff-cond"
+  | TFlagEnabled _ ->
+      "ff-enabled"
+  | TFlagDefault _ ->
+      "ff-default"
 
 
 let toCategoryName (t : t) : string =
@@ -638,6 +659,8 @@ let toCategoryName (t : t) : string =
       "pattern"
   | TParenOpen _ | TParenClose _ ->
       "paren"
+  | TFlagCond _ | TFlagEnabled _ | TFlagDefault _ ->
+      "flag"
 
 
 let toDebugInfo (t : t) : string =

--- a/client/src/fluid/FluidView.ml
+++ b/client/src/fluid/FluidView.ml
@@ -21,10 +21,6 @@ type ast = E.t
 
 type token = T.t
 
-type state = Types.fluidState
-
-let toTokens = Printer.toTokens
-
 let viewAutocomplete (ac : Types.fluidAutocompleteState) : Types.msg Html.html =
   let toList acis class' index =
     List.indexedMap
@@ -182,7 +178,7 @@ let toHtml ~(vs : ViewUtils.viewState) ~tlid ~state (ast : ast) :
           (None, "")
     else (None, "")
   in
-  let currentTokenInfo = Fluid.getToken' state vs.tokens in
+  let currentTokenInfo = Fluid.getToken' state vs.primaryTokens in
   let sourceOfCurrentToken onTi =
     currentTokenInfo
     |> Option.andThen ~f:(fun ti ->
@@ -197,7 +193,7 @@ let toHtml ~(vs : ViewUtils.viewState) ~tlid ~state (ast : ast) :
     match state.cp.location with
     | Some (ltlid, id) when tlid = ltlid ->
         (* Reversing list will get us the last token visually rendered with matching expression ID, so we don't have to keep track of max pos *)
-        vs.tokens
+        vs.primaryTokens
         |> List.reverse
         |> List.getBy ~f:(fun ti -> FluidToken.tid ti.token = id)
     | _ ->
@@ -216,7 +212,7 @@ let toHtml ~(vs : ViewUtils.viewState) ~tlid ~state (ast : ast) :
     let selStart, selEnd = Fluid.getSelectionRange state in
     selStart <= tokenStart && tokenEnd <= selEnd
   in
-  List.map vs.tokens ~f:(fun ti ->
+  List.map vs.primaryTokens ~f:(fun ti ->
       let element nested =
         let tokenId = T.tid ti.token in
         let idStr = deID tokenId in
@@ -366,7 +362,7 @@ let viewLiveValue
     | LoadableError err ->
         [Html.text ("Error loading live value: " ^ err)]
   in
-  Fluid.getToken' state vs.tokens
+  Fluid.getToken' state vs.primaryTokens
   |> Option.andThen ~f:(fun ti ->
          let row = ti.startRow in
          let content =
@@ -420,10 +416,9 @@ let viewReturnValue (vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html
 let viewAST ~(vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html list =
   let ({analysisStore; tlid; _} : ViewUtils.viewState) = vs in
   let state = vs.fluidState in
-  let tokenInfos = vs.tokens in
   let errorRail =
     let indicators =
-      tokenInfos
+      vs.primaryTokens
       |> List.map ~f:(fun ti -> viewErrorIndicator ~analysisStore ~state ti)
     in
     let hasMaybeErrors = List.any ~f:(fun e -> e <> Vdom.noNode) indicators in
@@ -512,8 +507,9 @@ let viewAST ~(vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html list =
   ; errorRail ]
 
 
-let viewStatus (m : model) (ast : ast) (s : state) : Types.msg Html.html =
-  let tokens = toTokens ast in
+let viewStatus (m : model) (ast : ast) : Types.msg Html.html =
+  let s = m.fluidState in
+  let tokens = Printer.toTokens ast in
   let ddText txt = Html.dd [] [Html.text txt] in
   let dtText txt = Html.dt [] [Html.text txt] in
   let posData =

--- a/client/src/util/ViewUtils.ml
+++ b/client/src/util/ViewUtils.ml
@@ -32,9 +32,8 @@ type viewState =
   ; avatarsList : avatar list
   ; permission : permission option
   ; workerStats : workerStats option
-  ; tokens :
-      (* Calculate the tokens once per render only *)
-      FluidToken.tokenInfo list
+  ; primaryTokens : FluidToken.tokenInfo list
+  ; secondaryTokens : FluidToken.tokenInfo list list
   ; menuState : menuState
   ; isExecuting : bool }
 
@@ -45,13 +44,18 @@ type domEvent = msg Vdom.property
 
 type domEventList = domEvent list
 
-let createVS (m : model) (tl : toplevel) (tokens : FluidToken.tokenInfo list) :
-    viewState =
+let createVS (m : model) (tl : toplevel) : viewState =
   let tlid = TL.id tl in
   let hp =
     match tl with TLHandler _ -> TD.get ~tlid m.handlerProps | _ -> None
   in
   let traceID = Analysis.getSelectedTraceID m tlid in
+  let primaryTokens, secondaryTokens =
+    TL.getAST tl
+    |> Option.map ~f:FluidPrinter.toTokensWithSplits
+    |> Option.map ~f:(function [] -> ([], []) | head :: tail -> (head, tail))
+    |> Option.withDefault ~default:([], [])
+  in
   { tl
   ; cursorState = unwrapCursorState m.cursorState
   ; tlid
@@ -126,7 +130,8 @@ let createVS (m : model) (tl : toplevel) (tokens : FluidToken.tokenInfo list) :
            Some {Defaults.defaultWorkerStats with schedule}
        | Some c, Some _ ->
            Some {c with schedule})
-  ; tokens
+  ; primaryTokens
+  ; secondaryTokens
   ; menuState =
       TLIDDict.get ~tlid m.tlMenus
       |> Option.withDefault ~default:Defaults.defaultMenu

--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -190,7 +190,7 @@ $prec-colors: (#301728, #93385f, #4f3466, #9f6b99);
   }
 }
 
-#fluid-editor {
+.fluid-ast {
   /* Colors from tomorrow night:
 https://github.com/chriskempson/tomorrow-theme */
   $black: #1d1f21;

--- a/client/test/view_blankor.ml
+++ b/client/test/view_blankor.ml
@@ -54,7 +54,8 @@ let run () =
             ; avatarsList = []
             ; permission = Some ReadWrite
             ; workerStats = None
-            ; tokens = []
+            ; primaryTokens = []
+            ; secondaryTokens = []
             ; menuState = {isOpen = false}
             ; isExecuting = false }
           in


### PR DESCRIPTION
# What

Miscellaneous beginnings of support for feature flags in fluid. Apart some general groundwork like adding new tokens, the biggest change here is allowing the `FluidPrinter.Bulider` to be "split", which means the result of `toTokens'` is now a tree of Builders, not just a single one. This will be used to render the two cases of a flag in different editors.

**There is no change in visible behavior in this PR. We do tokenize the extra builders, but the results are not currently used.**

# Why

We want to bring back feature flags and this is the result of a bunch of exploration on how to accomplish that. It doesn't actually do anything yet, but I want to get this piece merged in so I don't end up with a super long-lived branch.

https://trello.com/c/uNJ6ffOx/2379-investigate-how-to-render-flag-cases-into-separate-editor-contexts

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

