### PR TITLE
User could not start from the beginning of a line and select(shift+click) line above

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -156,6 +156,7 @@ function getFluidSelectionRange() {
     return undefined;
   }
 
+  // We expect the selected node to be either #text or an element with a classList, if not, return null
   function _findFirstNodeWithClassListOrNull(selectedNode) {
     if (selectedNode && selectedNode.classList) {
       return selectedNode;
@@ -184,16 +185,21 @@ function getFluidSelectionRange() {
   // within the text of that node.
   let selBeginIdx = sel.anchorOffset;
   {
-    let nodeWithClasses = _findFirstNodeWithClassList(sel.anchorNode);
-    let node = _parentCrawlToFluidEntryParentOrUndefined(nodeWithClasses);
-    if (!node) {
-      // If this happens, it means that the selection wasn't inside a .fluid-entry node
+    try {
+      let nodeWithClasses = _findFirstNodeWithClassListOrNull(sel.anchorNode);
+      let node = _parentCrawlToFluidEntryParentOrUndefined(nodeWithClasses);
+      if (!node) {
+        // If this happens, it means that the selection wasn't inside a .fluid-entry node
+        throw "Unexpected node selected";
+      }
+      // This only works because we expect .fluid-entry nodes to be siblings with no nesting
+      while (node.previousSibling) {
+        node = node.previousSibling;
+        selBeginIdx += node.textContent.length;
+      }
+    } catch (err) {
+      console.log(`Unexpected error occured: ${err}`);
       return undefined;
-    }
-    // This only works because we expect .fluid-entry nodes to be siblings with no nesting
-    while (node.previousSibling) {
-      node = node.previousSibling;
-      selBeginIdx += node.textContent.length;
     }
   }
   // The 'focusNode' is the node where the selection ended
@@ -201,16 +207,21 @@ function getFluidSelectionRange() {
   // (and where the cursor is now located) within the text of that node.
   let selEndIdx = sel.focusOffset;
   {
-    let nodeWithClasses = _findFirstNodeWithClassList(sel.focusNode);
-    let node = _parentCrawlToFluidEntryParentOrUndefined(nodeWithClasses);
-    if (!node) {
-      // If this happens, it means that the selection wasn't inside a .fluid-entry node
+    try {
+      let nodeWithClasses = _findFirstNodeWithClassListOrNull(sel.focusNode);
+      let node = _parentCrawlToFluidEntryParentOrUndefined(nodeWithClasses);
+      if (!node) {
+        // If this happens, it means that the selection wasn't inside a .fluid-entry node
+        throw "Unexpected node selected";
+      }
+      // This only works because we expect .fluid-entry nodes to be siblings with no nesting
+      while (node.previousSibling) {
+        node = node.previousSibling;
+        selEndIdx += node.textContent.length;
+      }
+    } catch (err) {
+      console.log(`Unexpected error occured: ${err}`);
       return undefined;
-    }
-    // This only works because we expect .fluid-entry nodes to be siblings with no nesting
-    while (node.previousSibling) {
-      node = node.previousSibling;
-      selEndIdx += node.textContent.length;
     }
   }
   return [selBeginIdx, selEndIdx];


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Trello:
https://trello.com/c/THgr1uWk/2329-browser-hangs-when-dragging-up-to-select-text
https://trello.com/c/4zvMgFFa/2392-clicking-repeatedly-in-a-variable-name-freezes-the-canvas

### Follow-up Trello:
https://trello.com/c/xJydhAU1/2394-figure-out-a-way-to-test-selection-on-the-front-end

### Why:
A user reported that they could not select from the start of a line, up, and that it cause the browser to freeze. We want our users to be able to select from the start of a line. 

### Gif:

**Before:**
![2020-02-07 12 07 56](https://user-images.githubusercontent.com/32043360/74062171-8437cb00-49a2-11ea-8640-042025295102.gif)


![2020-02-10 15 12 04](https://user-images.githubusercontent.com/32043360/74198997-bdc53c00-4c17-11ea-8d7b-8d05c3c3eb35.gif)

**After:**
![2020-02-07 12 09 03](https://user-images.githubusercontent.com/32043360/74062232-a7fb1100-49a2-11ea-9208-c650c729cbb1.gif)

![2020-02-10 15 11 19](https://user-images.githubusercontent.com/32043360/74199040-e64d3600-4c17-11ea-821a-9864bcf97918.gif)

Reviewer checklist:
- Product:
  - [x] PR matches stated goal and Trello ticket.
  - [x] Out-of-scope product changes have been explained.
  - [x] I pulled the branch and tested out the feature.
- User facing:
  - [x] Existing stdlib and language semantics are unchanged.
  - [x] Existing granduser HTTP responses are unchanged.
  - [x] All existing canvases should continue to work.
  - [x] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [x] Functions and variables are well-named and self-documenting.
  - [x] Comments have been added for all explanations in PR review comment.
  - [x] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [x] Unneeded code has been removed.
