### PR TITLE
Selecting an item in the command palette doesn't work 

### DIFF
--- a/client/src/fluid/FluidCommands.ml
+++ b/client/src/fluid/FluidCommands.ml
@@ -196,8 +196,7 @@ let viewCommandPalette (cp : Types.fluidCommandState) : Types.msg Html.html =
           ; ("valid", true) ]
       ; ViewUtils.nothingMouseEvent "mouseup"
       ; ViewEntry.defaultPasteHandler
-      ; ViewUtils.nothingMouseEvent "mousedown"
-      ; ViewUtils.eventNoPropagation ~key:("cp-" ^ name) "click" (fun _ ->
+      ; ViewUtils.eventNoPropagation ~key:("cp-" ^ name) "mousedown" (fun _ ->
             FluidMsg (FluidCommandsClick item))
       ; ViewUtils.eventBoth ~key:("-mousemove" ^ name) "mousemove" (fun _ ->
             FluidMsg (FluidUpdateDropdownIndex i)) ]


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Trello:
https://trello.com/c/8dgybKWa/2395-command-palette-selection-does-not-work-with-mouse

### Why?
A user complained that they were unable to select an item from the command palette with their mouse.

 This is a bug cause by the "onBlur" event that happens in order to close the command palette when a user clicks outside of the input. "onBlur" prevents bubbling  and swallows the "click" and "mouseUp" event, so by changing the select command palette item event to fire on "mouseDown", both events will fire as they should and not interfere with each other.

### Gifs:
**Before:**
![2020-02-11 14 32 24](https://user-images.githubusercontent.com/32043360/74285863-8a4be580-4cdb-11ea-952c-5e215298bf4e.gif)

**After:**
![2020-02-11 14 33 22](https://user-images.githubusercontent.com/32043360/74285875-8cae3f80-4cdb-11ea-92e3-de66458a2e56.gif)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

