### PR TITLE
Update docstring for  Date::parse

### DIFF
--- a/backend/libexecution/libdate.ml
+++ b/backend/libexecution/libdate.ml
@@ -25,7 +25,7 @@ let fns : Lib.shortfn list =
     ; p = [par "s" TStr]
     ; r = TResult
     ; d =
-        "Parses a string representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns a Date"
+        "Parses a string representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns the Date wrapped in a Result."
     ; f =
         InProcess
           (function
@@ -47,7 +47,7 @@ let fns : Lib.shortfn list =
     ; p = [par "s" TStr]
     ; r = TResult
     ; d =
-        "Parses a string representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns a Date"
+        "Parses a string representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns the Date wrapped in a Result."
     ; f =
         InProcess
           (function


### PR DESCRIPTION
[The documentation for Date::parse says that it returns a Date, but it actually returns a Result](https://trello.com/c/A1pOh9xS/2393-the-documentation-for-dateparse-says-that-it-returns-a-date-but-it-actually-returns-a-result)

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

