### PR TITLE
Fluid Editor ID/Class Change + OCaml App Support Functions

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -122,110 +122,8 @@ if (pusherConfig.enabled) {
 }
 
 // ---------------------------
-// Fluid
+// Analytics
 // ---------------------------
-// https://stackoverflow.com/a/41034697/104021
-function isChildOfEditor(node) {
-  while (node !== null) {
-    if (node.id === "fluid-editor") {
-      return true;
-    }
-    node = node.parentNode;
-  }
-
-  return false;
-}
-
-// getFluidSelectionRange() returns the [begin, end] indices of the last
-// selection/caret placement within a fluid editor, or undefined if
-// there has been no selection/caret placement, or if the selected nodes are not
-// part of a fluid editor. Begin may be > or < end,
-// depending on the selection direction. If there is no true selection
-// but rather a placement, begin == end.
-// This function assumes there is a flat list of .fluid-entry tokens
-// in the editor, and that any nesting is limited to stylistic nesting within a
-// .fluid-entry node (such as that used for parens).
-function getFluidSelectionRange() {
-  function _parentCrawlToFluidEntryParentOrUndefined(node) {
-    while (node !== null) {
-      if (node.classList.contains("fluid-entry")) {
-        return node;
-      }
-      node = node.parentNode;
-    }
-    return undefined;
-  }
-
-  // We expect the selected node to be either #text or an element with a classList, if not, return null
-  function _findFirstNodeWithClassListOrNull(selectedNode) {
-    if (selectedNode && selectedNode.classList) {
-      return selectedNode;
-    } else if (
-      selectedNode &&
-      selectedNode.parentNode &&
-      selectedNode.parentNode.classList
-    ) {
-      return selectedNode.parentNode;
-    } else {
-      return null;
-    }
-  }
-
-  // OPT(JULIAN): There's likely a more performant way of getting selection
-  // start and end than to walk all prior nodes twice.
-  let sel = window.getSelection();
-  if (
-    sel.focusNode == null ||
-    !isChildOfEditor(sel.focusNode) ||
-    !isChildOfEditor(sel.anchorNode)
-  )
-    return undefined;
-  // The 'anchorNode' is the node where the selection began
-  // and the offset is the relative position where the selection began
-  // within the text of that node.
-  let selBeginIdx = sel.anchorOffset;
-  {
-    try {
-      let nodeWithClasses = _findFirstNodeWithClassListOrNull(sel.anchorNode);
-      let node = _parentCrawlToFluidEntryParentOrUndefined(nodeWithClasses);
-      if (!node) {
-        // If this happens, it means that the selection wasn't inside a .fluid-entry node
-        throw "Unexpected node selected";
-      }
-      // This only works because we expect .fluid-entry nodes to be siblings with no nesting
-      while (node.previousSibling) {
-        node = node.previousSibling;
-        selBeginIdx += node.textContent.length;
-      }
-    } catch (err) {
-      console.log(`Unexpected error occured: ${err}`);
-      return undefined;
-    }
-  }
-  // The 'focusNode' is the node where the selection ended
-  // and the offset is the relative position where the selection ended
-  // (and where the cursor is now located) within the text of that node.
-  let selEndIdx = sel.focusOffset;
-  {
-    try {
-      let nodeWithClasses = _findFirstNodeWithClassListOrNull(sel.focusNode);
-      let node = _parentCrawlToFluidEntryParentOrUndefined(nodeWithClasses);
-      if (!node) {
-        // If this happens, it means that the selection wasn't inside a .fluid-entry node
-        throw "Unexpected node selected";
-      }
-      // This only works because we expect .fluid-entry nodes to be siblings with no nesting
-      while (node.previousSibling) {
-        node = node.previousSibling;
-        selEndIdx += node.textContent.length;
-      }
-    } catch (err) {
-      console.log(`Unexpected error occured: ${err}`);
-      return undefined;
-    }
-  }
-  return [selBeginIdx, selEndIdx];
-}
 
 var Analytics = require("analytics-node");
 var analytics = new Analytics("fVtoR1kNIsfZ484ovfavEybnNubNNVi8");
@@ -248,7 +146,6 @@ function sendSegmentMessage(event) {
   return;
 }
 
-window.getFluidSelectionRange = getFluidSelectionRange;
 window.sendSegmentMessage = sendSegmentMessage;
 
 // ---------------------------

--- a/client/src/canvas/View.ml
+++ b/client/src/canvas/View.ml
@@ -441,7 +441,7 @@ let view (m : model) : msg Html.html =
   let fluidStatus =
     if m.editorSettings.showFluidDebugger
     then [FluidView.viewStatus m ast m.fluidState]
-    else []
+    else [Vdom.noNode]
   in
   let viewDocs =
     [ Html.a

--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -181,12 +181,6 @@ let getToken (s : fluidState) (ast : ast) : T.tokenInfo option =
 
 
 (* -------------------- *)
-(* Direct canvas interaction *)
-(* -------------------- *)
-
-let editorID = "fluid-editor"
-
-(* -------------------- *)
 (* Update fluid state *)
 (* -------------------- *)
 let tiSentinel : T.tokenInfo =
@@ -3088,7 +3082,7 @@ let doDelete ~(pos : int) (ti : T.tokenInfo) (ast : ast) (s : state) :
    * multi-codepoint emoji (the expected behavior of multi-syllable clusters differs from emoji).
    *
    * Note that we do not handle caret affinity properly, but caret affinity should behave the
-   * same for backspace and delete. 
+   * same for backspace and delete.
    *
    * See https://www.notion.so/darklang/Keyboard-and-Input-Handling-44eeedc4953846159e96af1e979004ad.
    *)
@@ -3110,7 +3104,7 @@ let doDelete ~(pos : int) (ti : T.tokenInfo) (ast : ast) (s : state) :
 
 (* [doExplicitInsert [extendedGraphemeCluster] [currCaretTarget] [ast]]
  * produces the (newAST, newPosition) tuple resulting from performing
- * a text insertion at [currCaretTarget] in the [ast]. 
+ * a text insertion at [currCaretTarget] in the [ast].
  * Note that newPosition will be either AtTarget or SamePlace --
  * either the caret stays in the same place, or it ends up at a specific location.
  *
@@ -5385,7 +5379,7 @@ let renderCallback (m : model) : unit =
         match m.fluidState.selectionStart with
         | Some selStart ->
             (* Updates the browser selection range for 2 in the context of selections *)
-            Entry.setFluidSelectionRange (selStart, m.fluidState.newPos)
+            Entry.setFluidSelectionRange selStart m.fluidState.newPos
         | None ->
             Entry.setFluidCaret m.fluidState.newPos )
   | _ ->

--- a/client/src/fluid/FluidView.ml
+++ b/client/src/fluid/FluidView.ml
@@ -438,7 +438,7 @@ let viewAST ~(vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html list =
   in
   let returnValue = viewReturnValue vs ast in
   let textInputListeners =
-    (* the command palette is inside div#fluid-editor but has it's own input
+    (* the command palette is inside div.fluid-editor but has it's own input
      * handling, so don't do normal fluid input stuff if it's open *)
     if FluidCommands.isOpened vs.fluidState.cp
     then (Html.noProp, Html.noProp, Html.noProp)
@@ -497,8 +497,14 @@ let viewAST ~(vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html list =
           then FluidMsg FluidClearErrorDvSrc
           else IgnoreMsg) ]
   in
+  let idAttr =
+    if tlidOf vs.cursorState = Some vs.tlid
+    then Attrs.id "active-editor"
+    else Attrs.noProp
+  in
   [ Html.div
-      ( [ Attrs.id Fluid.editorID
+      ( [ Attrs.class' "fluid-editor"
+        ; idAttr
         ; Vdom.prop "contentEditable" "true"
         ; Attrs.autofocus true
         ; Vdom.attribute "" "spellcheck" "false"

--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -190,7 +190,7 @@ $prec-colors: (#301728, #93385f, #4f3466, #9f6b99);
   }
 }
 
-#fluid-editor {
+.fluid-editor {
   /* Colors from tomorrow night:
 https://github.com/chriskempson/tomorrow-theme */
   $black: #1d1f21;

--- a/integration-tests/prep.sh
+++ b/integration-tests/prep.sh
@@ -31,7 +31,7 @@ rm -f "${TEST_LOGS_DIR}"/*
 DBLOG="${DARK_CONFIG_RUNDIR}/integration_db.log"
 echo "Clearing old DB data (logs in ${DBLOG})"
 DB="${DARK_CONFIG_DB_DBNAME}"
-function run_sql { psql -d "$DB" -c "$@" >> "$DBLOG" 2>&1; }
+function run_sql { psql -d "$DB" -c "$@" >> "$DBLOG" ; }
 
 function fetch_sql { psql -d "$DB" -t -c "$@"; }
 
@@ -39,6 +39,7 @@ CANVASES=$(fetch_sql "SELECT id FROM canvases WHERE substring(name, 0, 6)
 = 'test-';")
 SCRIPT=""
 for cid in $CANVASES; do
+  SCRIPT+="DELETE FROM scheduling_rules WHERE canvas_id = '$cid';";
   SCRIPT+="DELETE FROM events WHERE canvas_id = '$cid';";
   SCRIPT+="DELETE FROM function_results_v2 WHERE canvas_id = '$cid';";
   SCRIPT+="DELETE FROM stored_events_v2 WHERE canvas_id = '$cid';";

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -103,7 +103,7 @@ else
 
   # Check the version (matters when running outside the container)
   version=$(testcafe --version)
-  expected_version=$(grep testcafe client/package.json | sed 's/[[:space:]]*"testcafe": "//' | sed 's/",[[:space:]]*//')
+  expected_version=$(grep testcafe package.json | sed 's/[[:space:]]*"testcafe": "//' | sed 's/",[[:space:]]*//')
   if [[ "$version" != "$expected_version" ]]
   then
     echo "Incorrect version of testcafe: $version (expected $expected_version)"

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -134,7 +134,7 @@ async function createRepl(t) {
 }
 
 async function gotoAST(t) {
-  await t.click("#fluid-editor");
+  await t.click("#active-editor");
 }
 
 function user_content_url(t, endpoint) {
@@ -244,10 +244,10 @@ test("field_access_closes", async t => {
   await createHTTPHandler(t);
   await gotoAST(t);
   await t
-    .typeText("#fluid-editor", "req")
+    .typeText("#active-editor", "req")
     .expect(fluidAcHighlightedText("requestdict"))
     .ok()
-    .typeText("#fluid-editor", ".bo")
+    .typeText("#active-editor", ".bo")
     .expect(fluidAcHighlightedText("bodyfield"))
     .ok()
     .pressKey("enter");
@@ -257,10 +257,10 @@ test("field_access_pipes", async t => {
   await createHTTPHandler(t);
   await gotoAST(t);
   await t
-    .typeText("#fluid-editor", "req")
+    .typeText("#active-editor", "req")
     .expect(fluidAcHighlightedText())
     .contains("request")
-    .typeText("#fluid-editor", ".bo")
+    .typeText("#active-editor", ".bo")
     .expect(fluidAcHighlightedText())
     .eql("bodyfield")
     .pressKey("shift+enter");
@@ -270,16 +270,16 @@ test("tabbing_works", async t => {
   await createRepl(t);
   // Fill in "then" box in if stmt
   await t
-    .typeText("#fluid-editor", "if")
+    .typeText("#active-editor", "if")
     .pressKey("space tab")
-    .typeText("#fluid-editor", "5");
+    .typeText("#active-editor", "5");
 });
 
 test("autocomplete_highlights_on_partial_match", async t => {
   await createRepl(t);
   await gotoAST(t);
   await t
-    .typeText("#fluid-editor", "nt::add")
+    .typeText("#active-editor", "nt::add")
     .expect(fluidAcHighlightedText("Int::add"))
     .ok()
     .pressKey("enter");
@@ -289,7 +289,7 @@ test("no_request_global_in_non_http_space", async t => {
   await createWorkerHandler(t);
   await gotoAST(t);
   await t
-    .typeText("#fluid-editor", "request")
+    .typeText("#active-editor", "request")
     .expect(fluidAcHighlightedText("Http::badRequest"))
     .ok()
     .pressKey("enter");
@@ -307,7 +307,7 @@ test("ellen_hello_world_demo", async t => {
     .pressKey("enter")
 
     // string
-    .typeText("#fluid-editor", '"Hello world!"');
+    .typeText("#active-editor", '"Hello world!"');
 });
 
 test("editing_headers", async t => {
@@ -364,19 +364,19 @@ test("tabbing_through_let", async t => {
   await createRepl(t);
   await gotoAST(t);
   await t
-    .typeText("#fluid-editor", "let")
+    .typeText("#active-editor", "let")
     .pressKey("enter")
     // round trip through the let blanks once
     .pressKey("tab tab tab")
     // go to the body and fill it in
     .pressKey("tab tab")
-    .typeText("#fluid-editor", "5")
+    .typeText("#active-editor", "5")
     // go to the rhs and fill it in
     .pressKey("tab tab")
-    .typeText("#fluid-editor", "5")
+    .typeText("#active-editor", "5")
     // fill in the var
     .pressKey("tab")
-    .typeText("#fluid-editor", "myvar");
+    .typeText("#active-editor", "myvar");
 });
 
 test("rename_db_fields", async t => {
@@ -543,7 +543,7 @@ test("rename_function", async t => {
 test("execute_function_works", async t => {
   await createRepl(t);
   await t
-    .typeText("#fluid-editor", "Uuid::gen")
+    .typeText("#active-editor", "Uuid::gen")
     .pressKey("enter")
     .click(Selector(".execution-button-needed"));
 
@@ -561,7 +561,7 @@ test("execute_function_works", async t => {
 
 test("correct_field_livevalue", async t => {
   await t
-    .click(Selector("#fluid-editor"))
+    .click(Selector(".fluid-editor")) // this click required to activate the editor
     .click(Selector(".fluid-field-name").withExactText("gth"));
 
   let v1 = await Selector(".selected .live-value").innerText;
@@ -572,7 +572,7 @@ test("correct_field_livevalue", async t => {
 test("function_version_renders", async t => {
   await createRepl(t);
   await t
-    .typeText("#fluid-editor", "DB::del")
+    .typeText("#active-editor", "DB::del")
     .expect(Selector(".autocomplete-item.fluid-selected .version").withText("v1"))
     .ok();
 });
@@ -637,7 +637,7 @@ test("function_analysis_works", async t => {
     .navigateTo("#fn=1039370895")
     .expect(available(".user-fn-toplevel"))
     .ok({ timeout: 1000 })
-    .click(Selector(".user-fn-toplevel #fluid-editor .fluid-binop"))
+    .click(Selector(".user-fn-toplevel #active-editor .fluid-binop"))
     .expect(Selector(".selected .live-value").textContent)
     .eql("10", { timeout: 5000 });
 });
@@ -689,7 +689,7 @@ test("load_with_unnamed_function", async t => {
 });
 
 test("extract_from_function", async t => {
-  const exprElem = Selector(".user-fn-toplevel #fluid-editor > span");
+  const exprElem = Selector(".user-fn-toplevel #active-editor > span");
 
   await t
     .navigateTo("#fn=123")
@@ -753,7 +753,7 @@ test("fluid_double_click_selects_token", async t => {
     .navigateTo("#handler=123")
     .expect(available(".tl-123"))
     .ok()
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .doubleClick(Selector(".fluid-match-keyword"), { caretPos: 3 });
 });
@@ -763,7 +763,7 @@ test("fluid_double_click_with_alt_selects_expression", async t => {
     .navigateTo("#handler=123")
     .expect(available(".tl-123"))
     .ok()
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .doubleClick(Selector(".fluid-match-keyword"), {
       caretPos: 3,
@@ -776,7 +776,7 @@ test("fluid_shift_right_selects_chars_in_front", async t => {
     .navigateTo("#handler=123")
     .expect(available(".tl-123"))
     .ok()
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .click(Selector(".fluid-category-string"), { caretPos: 2 })
     .pressKey("shift+right shift+down shift+right");
@@ -787,7 +787,7 @@ test("fluid_shift_left_selects_chars_at_back", async t => {
     .navigateTo("#handler=123")
     .expect(available(".tl-123"))
     .ok()
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .click(Selector(".fluid-category-string"), { caretPos: 2 })
     .pressKey("down shift+left shift+up");
@@ -798,7 +798,7 @@ test("fluid_undo_redo_happen_exactly_once", async t => {
     .expect(available(".tl-608699171"))
     .ok()
     .click(Selector(".id-68470584.fluid-category-string"))
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .expect(Selector(".fluid-category-string").textContent)
     .eql('"12345"')
@@ -815,7 +815,7 @@ test("fluid_ctrl_left_on_string", async t => {
     .navigateTo("#handler=428972234")
     .expect(available(".tl-428972234"))
     .ok()
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .click(Selector(".fluid-string"), { caretPos: 10 })
     .pressKey("ctrl+left");
@@ -826,7 +826,7 @@ test("fluid_ctrl_right_on_string", async t => {
     .navigateTo("#handler=428972234")
     .expect(available(".tl-428972234"))
     .ok()
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .click(Selector(".fluid-string"), { caretPos: 10 })
     .pressKey("ctrl+right");
@@ -837,7 +837,7 @@ test("fluid_ctrl_left_on_empty_match", async t => {
     .navigateTo("#handler=281413634")
     .expect(available(".tl-281413634"))
     .ok()
-    .expect(available(".selected #fluid-editor"))
+    .expect(available(".selected #active-editor"))
     .ok()
     .click(Selector(".fluid-category-pattern.id-63381027"), { caretPos: 0 })
     .pressKey("ctrl+left");


### PR DESCRIPTION
## What

Change `#fluid-editor` to `.fluid-editor` and mark active editor with `#active-editor` instead. I need to support multiple editors for feature flags, and this is a step in that direction.

As an experiment, I also converted the `(get|set)FluidSelectionRange` functions to OCaml. I'm curious what folks think of this. It's a net increase in lines, but having the type system around to help makes me feel much better.

The `get` function features an improved algorithm, searching once from the beginning of the editor tokens for both the start and end indexes instead of searching backwards once for each index.

- [ ] Trello link included
  - partial work of [feature flag exploration](https://trello.com/c/uNJ6ffOx/2379-investigate-how-to-render-flag-cases-into-separate-editor-contexts)
- [X] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [X] No useful information
- [ ] Before/after screenshots are included
  - [X] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [X] No followups
- [ ] Reversion plan exists
  - [X] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists