### PR TITLE
migrations files should end in .sql; if your vim leaves behind a .swp…

### DIFF
--- a/backend/libbackend/migrations.ml
+++ b/backend/libbackend/migrations.ml
@@ -62,7 +62,13 @@ let run_system_migration (name : string) (sql : string) : unit =
            done_sql)
 
 
-let names () = File.lsdir ~root:Migrations "" |> List.sort ~compare
+let names () =
+  File.lsdir ~root:Migrations ""
+  (* endsWith sql filters out, say, the .swp files vim sometimes leaves behind
+   * *)
+  |> List.filter ~f:(Tc.String.endsWith ~suffix:".sql")
+  |> List.sort ~compare
+
 
 let run () : unit =
   if not (is_initialized ()) then initialize_migrations_table () ;


### PR DESCRIPTION
…, ignore it

If you accidentally get a vim .swp file in backend/migrations, the error is really opaque.

https://trello.com/c/6y3KV1hk/2418-migrations-files-should-all-end-with-sql

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

