### PR TITLE
Fix Int::lessThanOrEqualTo and float version in sql compiler

### DIFF
--- a/backend/libbackend/sql_compiler.ml
+++ b/backend/libbackend/sql_compiler.ml
@@ -38,7 +38,7 @@ let binop_to_sql (op : string) : tipe_ * tipe_ * tipe_ * string =
   | "Int::lessThan" ->
       boolOp TInt "<"
   | "Int::lessThanOrEqualTo" ->
-      boolOp TInt "%"
+      boolOp TInt "<="
   | "Float::mod" ->
       allFloats "%"
   | "Float::add" ->
@@ -58,7 +58,7 @@ let binop_to_sql (op : string) : tipe_ * tipe_ * tipe_ * string =
   | "Float::lessThan" ->
       boolOp TFloat "<"
   | "Float::lessThanOrEqualTo" ->
-      boolOp TFloat "%"
+      boolOp TFloat "<="
   | "==" | "equals" ->
       boolOp TAny "="
   | "!=" | "notEquals" ->

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -893,6 +893,20 @@ let t_db_query_works () =
     ( queryv (binop "Float::greaterThan" (field "v" "income") (float' "90" "0"))
     |> execs ) ;
   check_dval
+    "int <="
+    (DList [Dval.dint 10; Dval.dint 65])
+    ( queryv (binop "Int::lessThanOrEqualTo" (field "v" "height") (int 65))
+    |> execs ) ;
+  check_dval
+    "float"
+    (DList [Dval.dint 10; Dval.dint 65])
+    ( queryv
+        (binop
+           "Float::lessThanOrEqualTo"
+           (field "v" "income")
+           (float' "82" "1"))
+    |> execs ) ;
+  check_dval
     "string::tolower"
     (DList [Dval.dint 65])
     ( queryv


### PR DESCRIPTION
Less than functions didn't work in the SQL compiler, for obvious reasons. Includes tests.
https://trello.com/c/SEMUYsw2/2429-fix-floatlessthanorequalto-in-sql-compiler
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

