### PR TITLE
Specificity - ligatures in pipes

### DIFF
--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -190,7 +190,7 @@ $prec-colors: (#301728, #93385f, #4f3466, #9f6b99);
   }
 }
 
-.fluid-editor {
+#app .fluid-editor {
   /* Colors from tomorrow night:
 https://github.com/chriskempson/tomorrow-theme */
   $black: #1d1f21;


### PR DESCRIPTION
We stopped showing ligatures for pipes and infix operators. This was because the specificity of FireMono beat out FiraCode. Fixed it with a dirty hack.

After:
![image](https://user-images.githubusercontent.com/181762/74574405-78b34980-4f38-11ea-9ca0-a7ae9b2e14d3.png)


- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

