### PR TITLE
Modify pipe ligature padding

### DIFF
--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -386,8 +386,7 @@ https://github.com/chriskempson/tomorrow-theme */
   .fluid-pipe-symbol {
     color: $blue;
     font-size: 10px;
-    padding-top: 3px;
-    padding-bottom: 1px;
+    padding: 3px 4px 1px 0px;
   }
 
   /* Will style more later. Cmd palette should look like a smaller version of omnibox


### PR DESCRIPTION
> Before this change, moving the caret up and down between lines with and
without pipes caused the caret to shift left/right by a few pixels
because the ligature is displayed as less than the 2 full character
widths it contains

This doesn't change the caret placement being a little weird inside of the ligature or anything like that, but fixes up/down on the rest of the line.

(Sorry for the key display overlapping the important part in the gifs)

![2020-02-17 13 34 05](https://user-images.githubusercontent.com/131/74679089-d939c500-518a-11ea-8c8a-c6d863c1c6aa.gif)
![2020-02-17 13 34 21](https://user-images.githubusercontent.com/131/74679090-d9d25b80-518a-11ea-831f-2bec7877b5d4.gif)

