### PR TITLE
Correctly set cursor/page on TL deletion

### DIFF
--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -1281,9 +1281,10 @@ let update_ (msg : msg) (m : model) : modification =
     | None ->
         NoChange )
   | ToplevelDelete tlid ->
-      let tl = TL.get m tlid in
-      Option.map tl ~f:(fun tl ->
-          Many [RemoveToplevel tl; AddOps ([DeleteTL (TL.id tl)], FocusSame)])
+      TL.get m tlid
+      |> Option.map ~f:(fun tl ->
+             Many
+               [RemoveToplevel tl; AddOps ([DeleteTL (TL.id tl)], FocusNothing)])
       |> Option.withDefault ~default:NoChange
   | ToplevelDeleteForever tlid ->
       Many

--- a/client/src/toplevels/Toplevel.ml
+++ b/client/src/toplevels/Toplevel.ml
@@ -68,6 +68,7 @@ let pos tl =
 
 
 let remove (m : model) (tl : toplevel) : model =
+  let m = {m with cursorState = Deselected; currentPage = Architecture} in
   match tl with
   | TLHandler h ->
       Handlers.remove m h


### PR DESCRIPTION
Fixes a rollbar about `failed to find #fluid-editor` when deleting a toplevel. Turns out this also fixes behavior where we stay in "selected" state and all the handlers are grayed out until you click somewhere.

![old](https://user-images.githubusercontent.com/131/74687197-b1a22700-51a1-11ea-9d8c-2232b587893b.gif)

![new](https://user-images.githubusercontent.com/131/74687194-afd86380-51a1-11ea-9d36-7e42272511f1.gif)

## Checklist

- [ ] Trello link included
- none, just cleaning up some rollbars
- [X] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [X] No useful information
- [X] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [X] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists