### PR TITLE
This fixes the CSS OM/Experimental Web Platform features

### DIFF
--- a/client/src/util/Native.ml
+++ b/client/src/util/Native.ml
@@ -177,7 +177,9 @@ module OnWheel = struct
     let open Tea.Json.Decoder in
     map2
       (* Handle inputs that might be ints or floats, see decodeClickEvent for
-       * details *)
+       * details, and
+       * https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface
+       * for the spec *)
         (fun dX dY -> (dX |> truncate, dY |> truncate))
       (field "deltaX" Tea.Json.Decoder.float)
       (field "deltaY" Tea.Json.Decoder.float)

--- a/client/src/util/ViewUtils.ml
+++ b/client/src/util/ViewUtils.ml
@@ -165,7 +165,9 @@ let decodeClickEvent (fn : mouseEvent -> 'a) j : 'a =
          * then truncate rather than moving to floats everywhere due to concerns
          * about sending data back to browsers whose DOMs don't support float
          * positions - see https://github.com/darklang/dark/pull/2016 for
-         * discussion *)
+         * discussion, and
+         * https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface
+         * for the spec *)
         { vx = field "pageX" Json.Decode.float j |> truncate
         ; vy = field "pageY" Json.Decode.float j |> truncate }
     ; button = field "button" int j


### PR DESCRIPTION
The CSS Object Model View Module spec proposes to change MouseEvent
coordinates to be double instead of int (long). Chrome's "Experimental
Web Plaform features" flag causes this to be active on OS X. (We believe
OS X specific - ismith was unable to repro on Linux, Julian and Victoria both saw it
on OS X.)

Problem is, our decoders assume these coordinates are ints, and so mouse
clicks in browsers with the right config result in "undecodable json"
errors in the dev console, and clicks appear (to users) to be ignored.

Since this is in chrome://flags, it's a bit of an edge case for now, but
we've received 2-3 customer reports. And presumably eventually this will
be a more standard spec and configuration, so we want to fix it now.

We decode these numerics in ViewUtil.ml's decodeClickEvent, so I
started by replacing the int decoder with a float decoder, and then
truncated to get an int.

(This does not break browsers that use int coords, b/c js/json does not
distinguish numerics that are ints vs floats, and so an "int" input can
be decoded into a float.)

https://trello.com/c/fjFvU8JY/2328-fix-the-side-effects-of-upcoming-changes-to-the-css-object-model-which-passes-mouse-positions-as-doubles

(Round 1 was #2016, paul had concerns about breaking browsers whose DOMs
don't support floats)

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

