### PR TITLE
restore testcafe debugger

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -15,8 +15,12 @@ You need testcafe installed on your machine:
 
 ### In debug mode
 
-If you want to use the testcafe debugger, run the tests in debug mode:
+If you want to watch the tests run (without the testcafe bugger), run the tests
+with --debug (this is "not in headless mode"):
  `./integration-tests/run.sh --debug`
+
+If you want to use the testcafe debugger, run the tests in debug mode:
+ `./integration-tests/run.sh --debug-mode`
 
 When Chrome loads, use the buttons at the bottom to step through execution. You can see what step you're on in your terminal. You can run the chrome debugger and inspect, watch what's happening in the console, etc.
 

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 PATTERN=".*"
 DEBUG=false
+DEBUG_MODE_FLAG=""
 
 for i in "$@"
 do
@@ -18,6 +19,10 @@ do
     DEBUG=true
     shift
     ;;
+    --debug-mode)
+    DEBUG_MODE_FLAG="--debug-mode"
+    shift
+    ;;
     *)
     echo "Unexpected argument: $i"
     exit 1
@@ -27,7 +32,7 @@ done
 
 BROWSER='unknown'
 {
-  if [[ "$DEBUG" == "true" ]]; then
+  if [[ "$DEBUG" == "true" || "$DEBUG_MODE_FLAG" == "--debug-mode" ]]; then
     BROWSER='chrome --window-size="1600,1200"'
   else
     BROWSER='chrome:headless --window-size="1600,1200"'
@@ -103,6 +108,7 @@ else
 
   # shellcheck disable=SC2016
   testcafe \
+    $DEBUG_MODE_FLAG \
     --concurrency "$CONCURRENCY" \
     --test-grep "$PATTERN" \
     --video rundir/videos \


### PR DESCRIPTION
We used to have this; Julian and I discovered we no longer do.

There are two flags one might want:
--debug: "run in a real browser, not headless, so I can watch"
--debug-mode: "put the buttons in the UI that let me step through and/or
interact with the browser"

This PR restores the second.

See circled buttons:
![image](https://user-images.githubusercontent.com/172694/74993943-8453b400-5401-11ea-9ea9-b5d59df0e123.png)


https://trello.com/c/m9zUnMBp/2462-put-the-testcafe-debugger-back-into-integration-test-runsh

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

