### PR TITLE
FF: live values

### DIFF
--- a/client/src/fluid/FluidView.ml
+++ b/client/src/fluid/FluidView.ml
@@ -163,8 +163,13 @@ let viewPlayIcon
       Vdom.noNode
 
 
-let toHtml ~(vs : ViewUtils.viewState) ~tokenInfos ~tlid ~state (ast : ast) :
-    Types.msg Html.html list =
+let toHtml
+    ~(vs : ViewUtils.viewState)
+    ~(idx : int)
+    ~tokenInfos
+    ~tlid
+    ~state
+    (ast : ast) : Types.msg Html.html list =
   (* Gets the source of a DIncomplete given an expr id *)
   let sourceOfExprValue id =
     if FluidToken.validID id
@@ -220,7 +225,9 @@ let toHtml ~(vs : ViewUtils.viewState) ~tokenInfos ~tlid ~state (ast : ast) :
   in
   let isSelected tokenStart tokenEnd =
     let selStart, selEnd = Fluid.getSelectionRange state in
-    selStart <= tokenStart && tokenEnd <= selEnd
+    idx = state.activeEditorPanelIdx
+    && selStart <= tokenStart
+    && tokenEnd <= selEnd
   in
   List.map tokenInfos ~f:(fun ti ->
       let element nested =
@@ -566,7 +573,7 @@ let fluidEditorView
       ]
     @ clickHandlers
     @ Tuple3.toList textInputListeners )
-    (toHtml ast ~tokenInfos ~vs ~tlid ~state)
+    (toHtml ast ~idx ~tokenInfos ~vs ~tlid ~state)
 
 
 let viewAST ~(vs : ViewUtils.viewState) (ast : ast) : Types.msg Html.html list =


### PR DESCRIPTION
Fixes live values to work in the FF panel as well as a small bug around highlighting appearing in both the main & flag panels.

There's a bug here that the value of the flag expression in the main editor shows as "This code was not executed", which I'll have to track down separately (see end of gif).

https://trello.com/c/OOplvbe1/2441-fix-live-values-within-ff-panel

![2020-02-21 12 35 36](https://user-images.githubusercontent.com/131/75057422-f6320900-54a6-11ea-87d3-4b21da08f3b8.gif)

- [X] Trello link included
- [X] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [X] No useful information
- [X] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [X] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [X] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [X] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [X] No spec exists