### PR TITLE
When backspacing an fncall, don't put the suffix in the partial

### DIFF
--- a/client/src/fluid/FluidPrinter.ml
+++ b/client/src/fluid/FluidPrinter.ml
@@ -311,7 +311,9 @@ let rec toTokens' (e : E.t) (b : Builder.t) : Builder.t =
       |> addMany [TBinOp (id, op); TSep id]
       |> nest ~indent:0 ~placeholderFor:(Some (id, op, 1)) rexpr
   | EPartial (id, newName, EBinOp (_, oldName, lexpr, rexpr, _ster)) ->
-      let ghost = ghostPartial id newName (FluidUtil.partialName oldName) in
+      let ghost =
+        ghostPartial id newName (FluidUtil.ghostPartialName oldName)
+      in
       let start b =
         match lexpr with
         | EPipeTarget _ ->
@@ -343,7 +345,7 @@ let rec toTokens' (e : E.t) (b : Builder.t) : Builder.t =
   | EPartial (id, newName, EFnCall (_, oldName, args, _)) ->
       let partial = TPartial (id, newName) in
       let newText = T.toText partial in
-      let oldText = FluidUtil.partialName oldName in
+      let oldText = FluidUtil.ghostPartialName oldName in
       let ghost = ghostPartial id newText oldText in
       b |> add partial |> addMany ghost |> addArgs oldName id args
   | EConstructor (id, name, exprs) ->

--- a/client/src/fluid/FluidUtil.ml
+++ b/client/src/fluid/FluidUtil.ml
@@ -173,3 +173,6 @@ let versionDisplayName (fnName : string) : string =
 
 
 let partialName = fnDisplayName
+
+let ghostPartialName (fnName : string) =
+  partialName fnName ^ versionDisplayName fnName

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -1556,37 +1556,37 @@ let run () =
         "del on function with version"
         aFnCallWithVersion
         (del 11)
-        "DB::getAll~ ___________________" ;
+        "DB::getAll~@@ ___________________" ;
       t
         ~expectsPartial:true
         "bs on function with version"
         aFnCallWithVersion
         (bs 12)
-        "DB::getAll~ ___________________" ;
+        "DB::getAll~@@ ___________________" ;
       t
         ~expectsPartial:true
         "del on function with version in between the version and function name"
         aFnCallWithVersion
         (del 10)
-        "DB::getAll~ ___________________" ;
+        "DB::getAll~@@ ___________________" ;
       t
         ~expectsPartial:true
         "bs on function with version in between the version and function name"
         aFnCallWithVersion
         (bs 10)
-        "DB::getAl~@ ___________________" ;
+        "DB::getAl~@v@ ___________________" ;
       t
         ~expectsPartial:true
         "del on function with version in function name"
         aFnCallWithVersion
         (del 7)
-        "DB::get~ll@ ___________________" ;
+        "DB::get~ll@v@ ___________________" ;
       t
         ~expectsPartial:true
         "bs on function with version in function name"
         aFnCallWithVersion
         (bs 8)
-        "DB::get~ll@ ___________________" ;
+        "DB::get~ll@v@ ___________________" ;
       t
         "adding function with version goes to the right place"
         b
@@ -1602,19 +1602,19 @@ let run () =
         "DeleteWordBackward in middle of function deletes to beg of function"
         aFnCallWithVersion
         (inputs [DeleteWordBackward] 6)
-        "~tAll@etAl@ ___________________" ;
+        "~tAll@etAllv@ ___________________" ;
       t
         ~expectsPartial:true
         "DeleteWordBackward in end of function version deletes to function"
         aFnCallWithVersion
         (inputs [DeleteWordBackward] 12)
-        "DB::getAll~ ___________________" ;
+        "DB::getAll~@@ ___________________" ;
       t
         ~expectsPartial:true
         "DeleteWordForward in middle of function deletes to beg of function"
         aFnCallWithVersion
         (inputs [DeleteWordForward] 6)
-        "DB::ge~@Al@ ___________________" ;
+        "DB::ge~@Allv@ ___________________" ;
       t
         "DeleteWordForward in end of function version moves cursor to end of blank "
         aFnCallWithVersion
@@ -1640,7 +1640,7 @@ let run () =
         "reflows work for partials too "
         (partial "TEST" (fn "HttpClient::post_v4" [str string160; b; b; b]))
         render
-        "~TEST@lient::pos@\n  \"0123456789abcdefghij0123456789abcdefghij\n  0123456789abcdefghij0123456789abcdefghij\n  0123456789abcdefghij0123456789abcdefghij\n  0123456789abcdefghij0123456789abcdefghij\"\n  ____________\n  ______________\n  ________________" ;
+        "~TEST@lient::postv@\n  \"0123456789abcdefghij0123456789abcdefghij\n  0123456789abcdefghij0123456789abcdefghij\n  0123456789abcdefghij0123456789abcdefghij\n  0123456789abcdefghij0123456789abcdefghij\"\n  ____________\n  ______________\n  ________________" ;
       t
         "reflows happen for functions whose arguments have newlines"
         (fn "HttpClient::post_v4" [emptyStr; emptyRowRecord; b; b])


### PR DESCRIPTION
DB::set|v1 + delete has partial DB::se|
DB::setv1| + delete has partial DB::set|

(Note: the below gifs cover both of the above cases - with the cursor before the version, and with it after - for DB::getAll_v3.)

Before:
![Peek 2020-03-05 11-34](https://user-images.githubusercontent.com/172694/76018672-50828f00-5ed5-11ea-9140-a007432a2386.gif)


After:
![Peek 2020-03-05 11-30](https://user-images.githubusercontent.com/172694/76018437-e5d15380-5ed4-11ea-84f2-5bcc074e1be4.gif)



https://trello.com/c/0yKvcGvb/2438-when-backspacing-an-fncall-from-before-the-suffix-dont-put-the-suffix-in-the-partial

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

