### PR TITLE
custom domain accounts.darklang.com -> ops-adduser

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -144,6 +144,7 @@ let should_use_https uri =
   | [_; "builtwithdark"; "com"]
   (* Customers - do not remove the marker below *)
   (* ACD-should_use_https-MARKER *)
+  | ["accounts"; "darklang"; "com"]
   | ["dark"; "mackenzieclark"; "codes"]
   | ["hellobirb"; "com"]
   | ["www"; "hellobirb"; "com"]
@@ -1830,6 +1831,8 @@ let route_host req =
       Some (Canvas "darksingleinstance")
   (* Customers - do not remove the marker below *)
   (* ACD-route_host-MARKER *)
+  | ["accounts"; "darklang"; "com"] ->
+      Some (Canvas "ops-adduser")
   | ["dark"; "mackenzieclark"; "codes"] ->
       Some (Canvas "xmclark")
   | [a; "dabblefox"; "com"] ->

--- a/scripts/support/kubernetes/builtwithdark/bwd-ingress.yaml
+++ b/scripts/support/kubernetes/builtwithdark/bwd-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     # This can be a comma-separated list of managed certificates
     # NOTE: max certs per ingress = 15, that includes both managed certs and the
     # tls secrets mentioned below in spec.tls.
-    networking.gke.io/managed-certificates: www.kiksht.com-cert,food.placeofthin.gs-cert,rest.sankhe.com-cert,login.darklang.com-cert,dark.mackenzieclark.codes-cert
+    networking.gke.io/managed-certificates: www.kiksht.com-cert,food.placeofthin.gs-cert,rest.sankhe.com-cert,login.darklang.com-cert,dark.mackenzieclark.codes-cert,accounts.darklang.com-cert
     kubernetes.io/ingress.global-static-ip-name: bwd-tls-ip
 spec:
   backend:

--- a/scripts/support/kubernetes/certs/accounts.darklang.com-cert.yaml
+++ b/scripts/support/kubernetes/certs/accounts.darklang.com-cert.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: accounts.darklang.com-cert
+spec:
+  domains:
+    # NB: Per https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs,
+    # domains can _only_ have one entry, we cannot have both www and
+    # the apex, nor can we have wildcards
+    - accounts.darklang.com


### PR DESCRIPTION
Since we can't send cookies cross-domain, and we need to make a
cookie-auth'd-request for /send-invite as part of Sydney's
add-collaborators project

https://trello.com/c/XWMavGqz/2668-custom-domain-accountsdarklangcom-ops-adduser

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

