### PR TITLE
Improved canvas validation error

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1631,7 +1631,7 @@ let admin_ui_handler
       respond
         ~execution_id
         `Bad_request
-        "Your canvas name must:\n - Start and end with an alphanumeric character\n - May contain a dash or understore only if it is between two alpahnumeric charcters"
+        "Your canvas name must:\n - Consist of lowercase alphanumeric characters, '-', and '_'\n - Start and end with an alphanumeric character (no initial/final '-' or '_')"
   | _ ->
       respond ~execution_id `Not_found "Not found"
 


### PR DESCRIPTION
Made it both more correct (lowercase alphanumeric, `-`, `_`) and more
clear (no initial/final `-`, `_`)

The old string also had some typos.

Follow up for https://trello.com/c/53r3IqWZ/2435-canvas-names-may-not-include-this-causes-canvasbuiltwithdarkcom-and-similar-for-darksacom-to-have-two-levels-of-subdomain-which

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

