### PR TITLE
Fix bug on omnibox deselect

### DIFF
--- a/client/src/app/CursorState.ml
+++ b/client/src/app/CursorState.ml
@@ -83,4 +83,9 @@ let focusEntryWithOffset (m : model) (offset : int) : msg Tea.Cmd.t =
 let setCursorState (cursorState : cursorState) (m : model) :
     model * msg Tea.Cmd.t =
   let m = {m with cursorState} in
+  (* TODO: Move the focusEntry part of this out, to happen
+  * once all modifications have been applied. It's currently
+  * too easy to call this only to have a later modification
+  * change the model in such a way that the resulting view
+  * no longer contains the thing we want to focus. *)
   (m, focusEntry m)

--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -1068,22 +1068,9 @@ let update_ (msg : msg) (m : model) : modification =
           if distSquared viewportStart viewportCurr
              <= maxSquareDistToConsiderAsClick
           then
-            (* Note: the "obvious" thing to do here is to use CursorState.setCursorState
-             * instead of this custom modification. However, setCursorState also
-             * fires a focus command, which might focus something that doesn't
-             * exist in the DOM post-rendering the model (commands are executed post-render).
-             *
-             * An example of where this would break down with setCursorState:
-             * if we have the omnibox open, setting the cursor state while panning would
-             * refocus the omnibox and promptly deselect it, but because rendering
-             * happens before commands, the model with the omnibox deselected would render,
-             * and then the focus command would error due to the omnibox no longer existing.
-             *
-             * The following hack bypasses this issue until we can modify the command generation
-             * for things like setCursorState to happen with the latest version of the model
-             * rather than the way we do it now, where commands may be invalid due to incremental model
-             * changes.
-             *)
+            (* {m with cursorState = prevCursorState} bypasses the focus part of 
+             * CursorState.setCursorState to avoid focusing any elements that
+             * clickBehavior might dismiss (ex closing the omnibox). *)
             Many
               ( ReplaceAllModificationsWithThisOne
                   (fun m ->


### PR DESCRIPTION
This fixes https://trello.com/c/pxqVnLAY/2598-canvas-panning-followupwe-log-an-error-every-time-we-click-on-the-canvas-while-the-omnibox-is-open

Before this fix, closing the omnibox by clicking on the canvas would produce an internal BSTea error: `Attempted to focus a non-existant element of:` `entry-box`.

## General Problem
The reason this happened has to do with the fact that modifications and commands in our central architecture don't compose the way one might expect. Modifications may produce commands, and we frequently compose modifications. However, modifications happen in sequence, followed by rendering, followed by command invocation (thanks to @dstrelau for helping me trace this flow).

Consider the sequence `[(modA, cmdA), (modB, cmdB)]`:
The evaluation order is:

- start with model `model`
- apply `modA` to `model` -> `modelA`; enqueue `cmdA`, which is valid for `modelA`
- apply `modB` to `modelA` -> `modelAB`; enqueue `cmdB`, which is valid for `modelAB`
- render `modelAB`
- invoke `cmdA`
- invoke `cmdB`

A command `cmdA` produced in concert with an early modification such as `modA` may no longer be valid in the context of the model that is rendered (other modifications, such as `modB`, may have changed the model in the meantime).

## Specific Problem
In the context of this bug, on the `WindowMouseUp`/`AppMouseUp` message, when the mouse doesn't move much and we should consider the behavior to be "click", we produced a set of two modifications+commands:

https://github.com/darklang/dark/pull/2061/files#diff-fdd2ae863fbe79997a50148ed34ec7b5L1071-L1074

```
            Many
              ( ReplaceAllModificationsWithThisOne
                  (CursorState.setCursorState prevCursorState)
              :: clickBehavior )
```

one set from `CursorState.setCursorState` and one from `Deselect` (which is what `clickBehavior` returns if the omnibox was open). The former restored the cursor state pre-panning and produced a command to focus on the omnibox:

https://github.com/darklang/dark/blob/06f5e05256d51ae47599ff6f87099261ada7d6ed/client/src/app/CursorState.ml#L86

The latter produced a complicated command batch and modified the model to no longer have an open omnibox: https://github.com/darklang/dark/blob/06f5e05256d51ae47599ff6f87099261ada7d6ed/client/src/app/Main.ml#L496-L516

The command to focus the omnibox was no longer valid at rendertime because the omnibox was closed due to the later modification.

## The Fix
The fix I chose to make is very specific: I bypassed `CursorState.setCursorState` to avoid the command and made a model-only modification instead. This is a special-case workaround. The "proper" fix would likely involve modifying the architecture to prevent commands being prepared in the context of models that might be outdated at render time. I deemed it better in this case to document the problem for the future and punt on solving it more generally.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

