### PR TITLE
Remove invite variant

### DIFF
--- a/client/src/app/VariantTesting.ml
+++ b/client/src/app/VariantTesting.ml
@@ -16,8 +16,6 @@ let toVariantTest (s : string * bool) : variantTest option =
         Some GroupVariant
     | "ff" ->
         Some FeatureFlagVariant
-    | "invite" ->
-        Some InviteVariant
     | _ ->
         None )
 
@@ -31,8 +29,6 @@ let toCSSClass (vt : variantTest) : string =
         "grouping"
     | FeatureFlagVariant ->
         "ff"
-    | InviteVariant ->
-        "invite"
   in
   test ^ "-variant"
 

--- a/client/src/canvas/View.ml
+++ b/client/src/canvas/View.ml
@@ -409,18 +409,13 @@ let accountView (m : model) : msg Html.html =
       [Html.text "Account"]
   in
   let share =
-    (* Remove with variant *)
-    if VariantTesting.variantIsActive m InviteVariant
-    then
-      Html.p
-        [ Html.class' "account-action-btn invite"
-        ; ViewUtils.eventNoPropagation ~key:"open-invite" "click" (fun _ ->
-              SettingsViewMsg
-                (ToggleSettingsView
-                   (true, Some (InviteUser SettingsView.defaultInviteFields))))
-        ]
-        [Html.text "Share Dark"]
-    else Vdom.noNode
+    Html.p
+      [ Html.class' "account-action-btn invite"
+      ; ViewUtils.eventNoPropagation ~key:"open-invite" "click" (fun _ ->
+            SettingsViewMsg
+              (ToggleSettingsView
+                 (true, Some (InviteUser SettingsView.defaultInviteFields)))) ]
+      [Html.text "Share Dark"]
   in
   Html.div
     [ Html.class' "my-account"

--- a/client/src/components/SettingsView.ml
+++ b/client/src/components/SettingsView.ml
@@ -192,7 +192,7 @@ let settingsTabToHtml (svs : settingsViewState) : Types.msg Html.html list =
       viewInviteUserToDark svs
 
 
-let tabTitleView (tab : settingsTab) (showInvite : bool) : Types.msg Html.html =
+let tabTitleView (tab : settingsTab) : Types.msg Html.html =
   let tabTitle (t : settingsTab) =
     let isSameTab =
       match (tab, t) with
@@ -209,8 +209,6 @@ let tabTitleView (tab : settingsTab) (showInvite : bool) : Types.msg Html.html =
           (fun _ -> Types.SettingsViewMsg (SwitchSettingsTabs t)) ]
       [Html.text (settingsTabToText t)]
   in
-  (* Remove "allTabs" with variant *)
-  let allTabs = if showInvite then allTabs else [UserSettings] in
   Html.div [Html.class' "settings-tab-titles"] (List.map allTabs ~f:tabTitle)
 
 
@@ -224,13 +222,11 @@ let onKeydown (evt : Web.Node.event) : Types.msg option =
              None)
 
 
-let settingViewWrapper (acc : settingsViewState) (showInvite : bool) :
-    Types.msg Html.html =
+let settingViewWrapper (acc : settingsViewState) : Types.msg Html.html =
   let tabView = settingsTabToHtml acc in
   Html.div
     [Html.class' "settings-tab-wrapper"]
-    ( [Html.h1 [] [Html.text "Account"]; tabTitleView acc.tab showInvite]
-    @ tabView )
+    ([Html.h1 [] [Html.text "Account"]; tabTitleView acc.tab] @ tabView)
 
 
 let html (m : Types.model) : Types.msg Html.html =
@@ -243,8 +239,6 @@ let html (m : Types.model) : Types.msg Html.html =
           (fun _ -> Types.SettingsViewMsg (ToggleSettingsView (false, None))) ]
       [fontAwesome "times"]
   in
-  (* Remove with variant test *)
-  let showInvite = VariantTesting.variantIsActive m InviteVariant in
   Html.div
     [ Html.class' "settings modal-overlay"
     ; ViewUtils.nothingMouseEvent "mousedown"
@@ -259,4 +253,4 @@ let html (m : Types.model) : Types.msg Html.html =
         ; ViewUtils.eventNoPropagation ~key:"epf" "mouseleave" (fun _ ->
               EnablePanning true)
         ; Html.onCB "keydown" "keydown" onKeydown ]
-        [settingViewWrapper m.settingsView showInvite; closingBtn] ]
+        [settingViewWrapper m.settingsView; closingBtn] ]

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -1346,7 +1346,6 @@ and variantTest =
       StubVariant
   | GroupVariant
   | FeatureFlagVariant
-  | InviteVariant
 
 (* ----------------------------- *)
 (* FeatureFlags *)


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Trello: 
https://trello.com/c/jSW7hlkr/2672-remove-variant-from-invite-flow

### Why? 
To release the invite form to users 

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

