### PR TITLE
Revert "When backspacing an fncall, don't put the suffix in the partial"

### DIFF
--- a/client/src/fluid/FluidPrinter.ml
+++ b/client/src/fluid/FluidPrinter.ml
@@ -311,9 +311,7 @@ let rec toTokens' (e : E.t) (b : Builder.t) : Builder.t =
       |> addMany [TBinOp (id, op); TSep id]
       |> nest ~indent:0 ~placeholderFor:(Some (id, op, 1)) rexpr
   | EPartial (id, newName, EBinOp (_, oldName, lexpr, rexpr, _ster)) ->
-      let ghost =
-        ghostPartial id newName (FluidUtil.ghostPartialName oldName)
-      in
+      let ghost = ghostPartial id newName (FluidUtil.partialName oldName) in
       let start b =
         match lexpr with
         | EPipeTarget _ ->
@@ -345,7 +343,7 @@ let rec toTokens' (e : E.t) (b : Builder.t) : Builder.t =
   | EPartial (id, newName, EFnCall (_, oldName, args, _)) ->
       let partial = TPartial (id, newName) in
       let newText = T.toText partial in
-      let oldText = FluidUtil.ghostPartialName oldName in
+      let oldText = FluidUtil.partialName oldName in
       let ghost = ghostPartial id newText oldText in
       b |> add partial |> addMany ghost |> addArgs oldName id args
   | EConstructor (id, name, exprs) ->

--- a/client/src/fluid/FluidUtil.ml
+++ b/client/src/fluid/FluidUtil.ml
@@ -172,7 +172,8 @@ let versionDisplayName (fnName : string) : string =
   if version = "0" then "" else "v" ^ version
 
 
-let partialName = fnDisplayName
-
-let ghostPartialName (fnName : string) =
-  partialName fnName ^ versionDisplayName fnName
+(* Get the function mod, name and version (without underscore) *)
+let partialName (name : string) : string =
+  let version = versionDisplayName name in
+  let name = fnDisplayName name in
+  name ^ version

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -1574,37 +1574,37 @@ let run () =
         "del on function with version"
         aFnCallWithVersion
         (del 11)
-        "DB::getAll~@@ ___________________" ;
+        "DB::getAllv~@ ___________________" ;
       t
         ~expectsPartial:true
         "bs on function with version"
         aFnCallWithVersion
         (bs 12)
-        "DB::getAll~@@ ___________________" ;
+        "DB::getAllv~@ ___________________" ;
       t
         ~expectsPartial:true
         "del on function with version in between the version and function name"
         aFnCallWithVersion
         (del 10)
-        "DB::getAll~@@ ___________________" ;
+        "DB::getAll~1@ ___________________" ;
       t
         ~expectsPartial:true
         "bs on function with version in between the version and function name"
         aFnCallWithVersion
         (bs 10)
-        "DB::getAl~@v@ ___________________" ;
+        "DB::getAl~v1@ ___________________" ;
       t
         ~expectsPartial:true
         "del on function with version in function name"
         aFnCallWithVersion
         (del 7)
-        "DB::get~ll@v@ ___________________" ;
+        "DB::get~llv1@ ___________________" ;
       t
         ~expectsPartial:true
         "bs on function with version in function name"
         aFnCallWithVersion
         (bs 8)
-        "DB::get~ll@v@ ___________________" ;
+        "DB::get~llv1@ ___________________" ;
       t
         "adding function with version goes to the right place"
         b
@@ -1620,7 +1620,7 @@ let run () =
         "DeleteWordBackward in middle of function deletes to beg of function"
         aFnCallWithVersion
         (inputs [DeleteWordBackward] 6)
-        "~tAll@etAllv@ ___________________" ;
+        "~tAllv1@Allv@ ___________________" ;
       t
         ~expectsPartial:true
         "DeleteWordBackward in end of function version deletes to function"
@@ -1632,7 +1632,7 @@ let run () =
         "DeleteWordForward in middle of function deletes to beg of function"
         aFnCallWithVersion
         (inputs [DeleteWordForward] 6)
-        "DB::ge~@Allv@ ___________________" ;
+        "DB::ge~v1@lv@ ___________________" ;
       t
         "DeleteWordForward in end of function version moves cursor to end of blank "
         aFnCallWithVersion


### PR DESCRIPTION
Reverts darklang/dark#2050