### PR TITLE
Seemingly fix the positioning bug

### DIFF
--- a/client/styles/_canvas.scss
+++ b/client/styles/_canvas.scss
@@ -110,6 +110,7 @@ body {
   height: 100%;
   // Adding this in hopes of fixing the chrome scroll back bug
   overscroll-behavior-x: none;
+  overflow: hidden;
 }
 
 #app {
@@ -117,7 +118,6 @@ body {
   width: 100%;
   height: 100vh;
   overflow: hidden;
-  position: absolute;
   top: 0;
   left: 0;
 


### PR DESCRIPTION
# What

I managed to reproduce the positioning bug (creating a new repl taking me to a random place) on one of my prod canvases, pretty reliably. With these small css changes, I was no longer able to reproduce the positioning bug.

# How

Unfortunately, I don't know exactly why this fixes the problem, but I can't think of any reason for 
`#app` to be `position: absolute;` in the first place, so it doesn't seem like removing that is a bad change in general.

Simply removing `position: absolute;` is insufficient because it produces scrollbars (since the canvas extends beyond the bounds of the window). Adding `overflow: hidden;` to the `body` removes the scrollbars.

# Additional Context

Note that 

> If the position property is absolute, the containing block is formed by the edge of the padding box of the nearest ancestor element that has a position value other than static (fixed, absolute, relative, or sticky).

https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_Block

which is (I think) why the docs button sometimes showed up in the wrong place.