### PR TITLE
if custom domain is not a www, no need to handle the apex case

### DIFF
--- a/scripts/add-custom-domain
+++ b/scripts/add-custom-domain
@@ -26,6 +26,11 @@ CANVAS=$2
 # Apex is "the domain minus /^.*\./". We'll verify below that APEX contains exactly one '.'
 APEX=${DOMAIN#*.}
 
+# There are things we only need to do if the custom domain is a www - the nginx
+# apex redirect, and adding the apex to route_host - so let's add a bool here
+# we can check against
+PREFIX="$(echo "${DOMAIN}" | awk -F"." '{print $1}')"
+
 # shellcheck disable=SC2000
 if [[ "$(echo "${DOMAIN}" | awk -F"." '{print NF-1}')" -ne 2 ]]; then
     echo "We expected DOMAIN to be a domain with 3 parts (www.foo.com), but it was ${DOMAIN}."
@@ -82,7 +87,8 @@ else
 fi
 
 # Nginx apex->www redirect
-cat <<EOF >> scripts/support/nginx.conf
+if [[ "${PREFIX}" == "www" ]]; then
+  cat <<EOF >> scripts/support/nginx.conf
 
 server {
   listen 8000;
@@ -90,6 +96,7 @@ server {
   return 301 \$http_x_forwarded_proto://${DOMAIN}\$request_uri;
 }
 EOF
+fi
 
 # This takes foo.com and www.foo.com and transforms them into
 # '| ["foo"; "com"] | ["www"; "foo"; "com"]`, which we can then put into
@@ -98,7 +105,13 @@ EOF
 new_apex_string="|[\"$(echo "$APEX" | sed -e 's/\./"; "/g')\"]"
 # shellcheck disable=SC2001
 new_domain_string="|[\"$(echo "$DOMAIN" | sed -e 's/\./"; "/g')\"]"
-new_webserver_match="${new_apex_string} ${new_domain_string}"
+
+if [[ "${PREFIX}" == "www" ]]; then
+    new_webserver_match="${new_apex_string} ${new_domain_string}"
+else
+    new_webserver_match="${new_domain_string}"
+fi
+
 
 # Note: perl below b/c I'd initially intended to do multiline matching; I ended
 # up not doing that, but don't care to remember how to translate perl regex back


### PR DESCRIPTION
This script has some assumptions that it'll be given a domain starting in www, and we should handle the apex (for www.food.com, handle food.com too). This is unnecessary if it's not a www domain.

(Tested locally by running
./scripts/add-custom-domain www.food.com foo
and
./scripts/add-custom-domain api.food.com foo
)

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

