### PR TITLE
Add default link color to sidebar verb links

### DIFF
--- a/client/styles/_sidebar.scss
+++ b/client/styles/_sidebar.scss
@@ -417,14 +417,25 @@ $prodColor: black;
       display: flex;
       align-items: center;
       justify-content: flex-end;
-      // 22% ensures that all of the method "OPTIONS" is visible on HTTP handlers
-      width: 22%;
+      // 25% ensures that all of the method "OPTIONS" is visible on HTTP handlers
+      width: 25%;
       overflow: hidden;
       .verb {
         font-size: 14px;
         text-decoration: none;
         margin-right: 1ch;
       }
+
+      a,
+      a:visited,
+      a:active {
+        color: $white2;
+      }
+
+      a:hover {
+        color: $yellow;
+      }
+
       &.GET a,
       &.GET span {
         color: $http-get;


### PR DESCRIPTION
Real real quick fix, Ellen notice how "OPTIONS" on the sidebar is deep purple (because that is the default visited links color in browsers). She wanted it changed because our themes are too dark to see default blue (unvisited links) and default purple.

This is just a quick fix, we'll have a massive sidebar cleanup coming up coming soon.

Before
<img width="737" alt="Screen Shot 2020-03-10 at 11 55 09 AM" src="https://user-images.githubusercontent.com/244152/76350137-71c5ef80-62c8-11ea-8cfa-2f8e0cd2f4a2.png">

After
<img width="737" alt="Screen Shot 2020-03-10 at 12 04 30 PM" src="https://user-images.githubusercontent.com/244152/76350166-7ee2de80-62c8-11ea-991d-29af08b59d79.png">




- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

