### PR TITLE
Dont alert when using ngrok

### DIFF
--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -339,12 +339,7 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         in
         let ignore =
           (* Ignore when using Ngrok *)
-          let usingNgrok =
-            Url.queryParams ()
-            |> List.findMap ~f:(fun (str, _) ->
-                   if str = "localhost-assets" then Some str else None)
-            |> Option.isSome
-          in
+          let usingNgrok = VariantTesting.variantIsActive m NgrokVariant in
           (* This message is deep in the server code and hard to pull
               * out, so just ignore for now *)
           Js.log "Already at latest redo - ignoring server error" ;

--- a/client/src/app/VariantTesting.ml
+++ b/client/src/app/VariantTesting.ml
@@ -16,6 +16,8 @@ let toVariantTest (s : string * bool) : variantTest option =
         Some GroupVariant
     | "ff" ->
         Some FeatureFlagVariant
+    | "localhost-assets" ->
+        Some NgrokVariant
     | _ ->
         None )
 
@@ -29,6 +31,8 @@ let toCSSClass (vt : variantTest) : string =
         "grouping"
     | FeatureFlagVariant ->
         "ff"
+    | NgrokVariant ->
+        "ngrok"
   in
   test ^ "-variant"
 

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -1306,6 +1306,7 @@ and variantTest =
       StubVariant
   | GroupVariant
   | FeatureFlagVariant
+  | NgrokVariant
 
 (* ----------------------------- *)
 (* FeatureFlags *)


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Relavent link
https://dark-inc.slack.com/archives/CHS2R7CDU/p1583864135013600 
https://trello.com/c/NKITj4aB/2701-dont-alert-rollbar-when-using-ngrok

### Why
We want to prevent any rollbars from happening when dark employees are using ngrok

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

