### PR TITLE
Remove error mods

### DIFF
--- a/client/src/app/Rollbar.ml
+++ b/client/src/app/Rollbar.ml
@@ -19,9 +19,8 @@ let sendAPIError (m : model) (e : apiError) : unit =
 let displayAndReportError m message url custom : model * msg Tea.Cmd.t =
   let url = match url with Some url -> " (" ^ url ^ ")" | None -> "" in
   let custom = match custom with Some c -> ": " ^ c | None -> "" in
-  let error = message ^ url ^ custom in
+  let msg = message ^ url ^ custom in
   (* Reload on bad csrf *)
-  if String.contains error ~substring:"Bad CSRF"
-  then Native.Location.reload true ;
-  ( {m with error = Some error}
-  , Tea.Cmd.call (fun _ -> send error None Js.Json.null) )
+  if String.contains msg ~substring:"Bad CSRF" then Native.Location.reload true ;
+  (m, Tea.Cmd.call (fun _ -> send msg None Js.Json.null))
+  |> Model.updateError (Error.set msg)

--- a/client/src/canvas/ViewScaffold.ml
+++ b/client/src/canvas/ViewScaffold.ml
@@ -53,7 +53,8 @@ let viewIntegrationTestButton (testState : integrationTestState) : msg Html.html
   Html.div [Html.id "buttons"] integrationTestButton
 
 
-let viewError (message : string option) : msg Html.html =
+let viewError (message : Error.t) : msg Html.html =
+  let message = Error.asOption message in
   let viewErrorMsg =
     match message with
     | None ->

--- a/client/src/canvas/ViewSidebar.ml
+++ b/client/src/canvas/ViewSidebar.ml
@@ -821,7 +821,7 @@ let viewSidebar_ (m : model) : msg Html.html =
         deployStats2html
   in
   let status =
-    match m.error with
+    match Error.asOption m.error with
     | Some _ when m.isAdmin ->
         Html.div
           [Html.classList [("error-status error", true); ("opened", true)]]

--- a/client/src/components/Error.ml
+++ b/client/src/components/Error.ml
@@ -1,0 +1,9 @@
+type t = string option [@@deriving show]
+
+let clear _ = None
+
+let default = None
+
+let set str _ = Some str
+
+let asOption t = t

--- a/client/src/components/Error.mli
+++ b/client/src/components/Error.mli
@@ -1,0 +1,9 @@
+type t [@@deriving show]
+
+val clear : t -> t
+
+val default : t
+
+val set : string -> t -> t
+
+val asOption : t -> string option

--- a/client/src/components/model.ml
+++ b/client/src/components/model.ml
@@ -1,0 +1,8 @@
+open Types
+
+let updateError (fn : Error.t -> Error.t) ((m, cmd) : model * msg Tea.Cmd.t) =
+  ({m with error = fn m.error}, cmd)
+
+
+let updateErrorMod (fn : Error.t -> Error.t) : modification =
+  ReplaceAllModificationsWithThisOne (fun m -> updateError fn (m, Tea.Cmd.none))

--- a/client/src/core/Defaults.ml
+++ b/client/src/core/Defaults.ml
@@ -82,7 +82,7 @@ let defaultFnSpace : fnProps =
 
 
 let defaultModel : model =
-  { error = None
+  { error = Error.default
   ; lastMsg = IgnoreMsg
   ; lastMods = []
   ; opCtrs = StrDict.empty

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -1049,8 +1049,6 @@ and modification =
   | TriggerHandlerAPICall of TLID.t
   | UpdateDBStatsAPICall of TLID.t
   (* End API Calls *)
-  | DisplayError of string
-  | ClearError
   | Select of TLID.t * tlidSelectTarget
   | SetHover of TLID.t * ID.t
   | ClearHover of TLID.t * ID.t
@@ -1570,7 +1568,7 @@ and avatarModelMessage =
   ; timestamp : float }
 
 and model =
-  { error : string option
+  { error : Error.t
   ; lastMsg : msg
   ; lastMods : string list
   ; tests : variantTest list

--- a/client/src/fluid/Commands.ml
+++ b/client/src/fluid/Commands.ml
@@ -74,7 +74,7 @@ let commands : command list =
               let nameId = BlankOr.toID tipe.utName in
               AddOps ([SetType tipe], FocusNext (tipe.utTLID, Some nameId))
           | Error s ->
-              DisplayError ("Can't create-type: " ^ s))
+              Model.updateErrorMod (Error.set ("Can't create-type: " ^ s)))
     ; doc = "Create a type from a live value" }
   ; { commandName = "copy-request-as-curl"
     ; action =

--- a/client/src/forms/KeyPress.ml
+++ b/client/src/forms/KeyPress.ml
@@ -31,7 +31,7 @@ let undo_redo (m : model) (redo : bool) : modification =
                  load from disk/db once, but still check server side.
               *)
           if DB.isLocked m tlid
-          then DisplayError "Cannot undo/redo in locked DBs"
+          then Model.updateErrorMod (Error.set "Cannot undo/redo in locked DBs")
           else undo
       | None ->
           undo )


### PR DESCRIPTION
This is an experiment in removing `modifications` and replacing them with components. I extracted the "Error" component (`m.error`), and removed the two mods (`DisplayError of str | ClearError`).

To support this I added `Model.updateError` (for when we are piping `m * cmd`) and `Model.updateErrorMod` for when we are returning a `modification`. I tried to find a way to put `Model.updateError fn m` as `Error.update fn m`, but I couldn't find a way to do that.

I think the experiment worked so merging is probably the next step if people agree with the direction here.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

