### PR TITLE
Improve `Result::` docstrings

### DIFF
--- a/backend/libexecution/libresult.ml
+++ b/backend/libexecution/libresult.ml
@@ -9,7 +9,7 @@ let fns : Lib.shortfn list =
     ; p = [par "result" TResult; func ["val"]]
     ; r = TResult
     ; d =
-        "If `result` is `Ok <value>`, returns `Ok <f value>` (the lambda `f` is applied to `value` and the result is wrapped in `Ok`). If `result` is `Error <msg>`, returns `result` unchanged."
+        "If `result` is `Ok value`, returns `Ok (f value)` (the lambda `f` is applied to `value` and the result is wrapped in `Ok`). If `result` is `Error msg`, returns `result` unchanged."
     ; f =
         InProcess
           (function
@@ -29,7 +29,7 @@ let fns : Lib.shortfn list =
     ; p = [par "result" TResult; func ["val"]]
     ; r = TResult
     ; d =
-        "If `result` is `Ok <value>`, returns `Ok <f value>` (the lambda `f` is applied to `value` and the result is wrapped in `Ok`). If `result` is `Error <msg>`, returns `result` unchanged."
+        "If `result` is `Ok value`, returns `Ok (f value)` (the lambda `f` is applied to `value` and the result is wrapped in `Ok`). If `result` is `Error msg`, returns `result` unchanged."
     ; f =
         InProcess
           (function
@@ -49,7 +49,7 @@ let fns : Lib.shortfn list =
     ; p = [par "result" TResult; func ["val"]]
     ; r = TAny
     ; d =
-        "If `result` is `Error <msg>`, returns `Error <f msg>` (the lambda `f` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok <value>`, returns `result` unchanged."
+        "If `result` is `Error msg`, returns `Error (f msg)` (the lambda `f` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok value`, returns `result` unchanged."
     ; f =
         InProcess
           (function
@@ -69,7 +69,7 @@ let fns : Lib.shortfn list =
     ; p = [par "result" TResult; func ["val"]]
     ; r = TAny
     ; d =
-        "If `result` is `Error <msg>`, returns `Error <f msg>` (the lambda `f` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok <value>`, returns `result` unchanged."
+        "If `result` is `Error msg`, returns `Error (f msg)` (the lambda `f` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok value`, returns `result` unchanged."
     ; f =
         InProcess
           (function
@@ -89,7 +89,7 @@ let fns : Lib.shortfn list =
     ; p = [par "result" TResult; par "default" TAny]
     ; r = TAny
     ; d =
-        "If `result` is `Ok <value>`, returns `value`. Returns `default` otherwise."
+        "If `result` is `Ok value`, returns `value`. Returns `default` otherwise."
     ; f =
         InProcess
           (function
@@ -104,7 +104,7 @@ let fns : Lib.shortfn list =
     ; p = [par "option" TOption; par "error" TStr]
     ; r = TResult
     ; d =
-        "Turn an option into a result, using `error` as the error message for Error. Specifically, if `option` is `Just <value>`, returns `Ok <value>`. Returns `Error <error>` otherwise."
+        "Turn an option into a result, using `error` as the error message for Error. Specifically, if `option` is `Just value`, returns `Ok value`. Returns `Error error` otherwise."
     ; f =
         InProcess
           (function
@@ -123,7 +123,7 @@ let fns : Lib.shortfn list =
     ; p = [par "option" TOption; par "error" TStr]
     ; r = TResult
     ; d =
-        "Turn an option into a result, using `error` as the error message for Error. Specifically, if `option` is `Just <value>`, returns `Ok <value>`. Returns `Error <error>` otherwise."
+        "Turn an option into a result, using `error` as the error message for Error. Specifically, if `option` is `Just value`, returns `Ok value`. Returns `Error error` otherwise."
     ; f =
         InProcess
           (function
@@ -183,7 +183,7 @@ let fns : Lib.shortfn list =
     ; p = [par "result" TResult; func ["val"]]
     ; r = TResult
     ; d =
-        "If `result` is `Ok <value>`, returns `f <value>` (the lambda `f` is applied to `value` and must return `Error <msg>` or `Ok <newValue>`). If `result` is `Error <msg>`, returns `result` unchanged."
+        "If `result` is `Ok value`, returns `f value` (the lambda `f` is applied to `value` and must return `Error msg` or `Ok newValue`). If `result` is `Error msg`, returns `result` unchanged."
     ; f =
         InProcess
           (function
@@ -210,7 +210,7 @@ let fns : Lib.shortfn list =
     ; p = [par "result" TResult; func ["val"]]
     ; r = TResult
     ; d =
-        "If `result` is `Ok <value>`, returns `f <value>` (the lambda `f` is applied to `value` and must return `Error <msg>` or `Ok <newValue>`). If `result` is `Error <msg>`, returns `result` unchanged."
+        "If `result` is `Ok value`, returns `f value` (the lambda `f` is applied to `value` and must return `Error msg` or `Ok newValue`). If `result` is `Error msg`, returns `result` unchanged."
     ; f =
         InProcess
           (function


### PR DESCRIPTION
https://trello.com/c/fKWNKATH/2695-fix-docstring-for-resultmap
`Result:map`'s docstring was confusing and grammatically incorrect. While fixing it, I noticed that many other `Result::` functions had the same mistake, so I took a pass at them too.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

