### PR TITLE
Fix non-handler types always being filtered out

### DIFF
--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -296,7 +296,7 @@ let load_only_rendered_tlids
       AND tlid = ANY (string_to_array($2, $3)::bigint[])
       AND deleted IS FALSE
       AND (((tipe = 'handler'::toplevel_type OR tipe = 'db'::toplevel_type) AND pos IS NOT NULL)
-             OR tipe <> 'handler'::toplevel_type)"
+             OR tipe = 'user_function'::toplevel_type OR tipe = 'user_tipe'::toplevel_type)"
     ~params:[Db.Uuid canvas_id; Db.List tlid_params; String Db.array_separator]
     ~result:BinaryResult
   |> strs2rendered_oplist_cache_query_result

--- a/backend/test/test_canvas_ops.ml
+++ b/backend/test/test_canvas_ops.ml
@@ -269,11 +269,7 @@ let t_load_all_dbs_from_cache () =
     |> Result.map_error ~f:(String.concat ~sep:", ")
     |> Prelude.Result.ok_or_internal_exception "Canvas load error"
   in
-  AT.check
-    AT.bool
-    "dbs are loaded from cache"
-    true
-    (!c2.ops = []) ;
+  AT.check AT.bool "dbs are loaded from cache" true (!c2.ops = []) ;
   AT.check
     (AT.list testable_id)
     "Loaded only undeleted dbs"


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Fixes: https://trello.com/c/yFqhCfmB/2741-fix-cache-miss-slow-canvas-loading-for-sean-coleman

`pos` is actually _always_ NULL for functions and tipes, so this `AND pos IS NOT NULL` filter is only valid to apply to handlers and DBs. As a result, we were not loading functions and user types from the cache.

Fixed by narrowing the filter to just handlers and DBs. Needed to fix the `pos` deserializer to handle now being handed empty string/`NULL` `pos` values also. Added an assertion to an existing test that previously just checked we loaded user types at all when loading from cache for HTTP. The assertion now confirms we loaded the user types _from the cache_.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

