### PR TITLE
Disable creating more than one FF per TL

### DIFF
--- a/client/src/fluid/FeatureFlags.ml
+++ b/client/src/fluid/FeatureFlags.ml
@@ -59,8 +59,8 @@ let wrapCmd (_ : model) (tl : toplevel) (id : ID.t) : modification =
     | Some ast ->
         ast
         |> FluidAST.filter ~f:(function E.EFeatureFlag _ -> true | _ -> false)
-        |> List.length
-        |> ( <> ) 0
+        |> List.isEmpty
+        |> not
     | None ->
         false
   in


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [x] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Implements: https://trello.com/c/BOhkbhOH/2725-dont-allow-more-than-1-ff-per-handler

Filtering the command out of the command palette would be pretty big code change because the information isn't there to filter. But this'll work as an incision for now to get FFs out and iterate.

Toast looks like: 
![image](https://user-images.githubusercontent.com/1179074/77119183-2f509100-69f3-11ea-93a2-34dfb08fed00.png)


Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

