### PR TITLE
Updated all Http::respond* to Http::response*

### DIFF
--- a/backend/libexecution/libhttp.ml
+++ b/backend/libexecution/libhttp.ml
@@ -17,12 +17,43 @@ let fns : Types.RuntimeT.fn list =
           | args ->
               fail args)
     ; preview_safety = Safe
+    ; deprecated = true }
+  ; { prefix_names = ["Http::response"]
+    ; infix_names = []
+    ; parameters = [par "response" TAny; par "code" TInt]
+    ; return_type = TResp
+    ; description =
+        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body."
+    ; func =
+        InProcess
+          (function
+          | _, [dv; DInt code] ->
+              DResp (Response (Dint.to_int_exn code, []), dv)
+          | args ->
+              fail args)
+    ; preview_safety = Safe
     ; deprecated = false }
-  ; (* TODO(ian): merge Http::respond with Http::respond_with_headers
+    (* TODO(ian): merge Http::respond with Http::respond_with_headers
    * -- need to figure out how to deprecate functions w/o breaking
    * user code
    *)
-    { prefix_names = ["Http::respondWithHeaders"]
+  ; { prefix_names = ["Http::respondWithHeaders"]
+    ; infix_names = []
+    ; parameters = [par "response" TAny; par "headers" TObj; par "code" TInt]
+    ; return_type = TResp
+    ; description =
+        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code`, `response` body, and `headers`."
+    ; func =
+        InProcess
+          (function
+          | _, [dv; (DObj _ as obj); DInt code] ->
+              let pairs = Dval.to_string_pairs_exn obj in
+              DResp (Response (Dint.to_int_exn code, pairs), dv)
+          | args ->
+              fail args)
+    ; preview_safety = Safe
+    ; deprecated = true }
+  ; { prefix_names = ["Http::responseWithHeaders"]
     ; infix_names = []
     ; parameters = [par "response" TAny; par "headers" TObj; par "code" TInt]
     ; return_type = TResp
@@ -67,6 +98,24 @@ let fns : Types.RuntimeT.fn list =
           | args ->
               fail args)
     ; preview_safety = Safe
+    ; deprecated = true }
+  ; { prefix_names = ["Http::responseWithHtml"]
+    ; infix_names = []
+    ; parameters = [par "response" TAny; par "code" TInt]
+    ; return_type = TResp
+    ; description =
+        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"text/html\"."
+    ; func =
+        InProcess
+          (function
+          | _, [dv; DInt code] ->
+              DResp
+                ( Response
+                    (Dint.to_int_exn code, [("Content-Type", "text/html")])
+                , dv )
+          | args ->
+              fail args)
+    ; preview_safety = Safe
     ; deprecated = false }
   ; { prefix_names = ["Http::respondWithText"]
     ; infix_names = []
@@ -85,8 +134,45 @@ let fns : Types.RuntimeT.fn list =
           | args ->
               fail args)
     ; preview_safety = Safe
+    ; deprecated = true }
+  ; { prefix_names = ["Http::responseWithText"]
+    ; infix_names = []
+    ; parameters = [par "response" TAny; par "code" TInt]
+    ; return_type = TResp
+    ; description =
+        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"text/plain\"."
+    ; func =
+        InProcess
+          (function
+          | _, [dv; DInt code] ->
+              DResp
+                ( Response
+                    (Dint.to_int_exn code, [("Content-Type", "text/plain")])
+                , dv )
+          | args ->
+              fail args)
+    ; preview_safety = Safe
     ; deprecated = false }
   ; { prefix_names = ["Http::respondWithJson"]
+    ; infix_names = []
+    ; parameters = [par "response" TAny; par "code" TInt]
+    ; return_type = TResp
+    ; description =
+        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"application/json\""
+    ; func =
+        InProcess
+          (function
+          | _, [dv; DInt code] ->
+              DResp
+                ( Response
+                    ( Dint.to_int_exn code
+                    , [("Content-Type", "application/json")] )
+                , dv )
+          | args ->
+              fail args)
+    ; preview_safety = Safe
+    ; deprecated = true }
+  ; { prefix_names = ["Http::responseWithJson"]
     ; infix_names = []
     ; parameters = [par "response" TAny; par "code" TInt]
     ; return_type = TResp
@@ -176,7 +262,7 @@ let fns : Types.RuntimeT.fn list =
     ; parameters = [par "name" TStr; par "value" TStr; par "params" TObj]
     ; return_type = TObj
     ; description =
-        "Generate an HTTP Set-Cookie header Object suitable for Http::respondWithHeaders given a cookie name, a string value for it, and an Object of Set-Cookie parameters."
+        "Generate an HTTP Set-Cookie header Object suitable for Http::responseWithHeaders given a cookie name, a string value for it, and an Object of Set-Cookie parameters."
     ; func =
         InProcess
           (function
@@ -222,7 +308,7 @@ let fns : Types.RuntimeT.fn list =
     ; parameters = [par "name" TStr; par "value" TStr; par "params" TObj]
     ; return_type = TObj
     ; description =
-        "Generate an HTTP Set-Cookie header Object suitable for Http::respondWithHeaders given a cookie name, a string value for it, and an Object of Set-Cookie parameters."
+        "Generate an HTTP Set-Cookie header Object suitable for Http::responseWithHeaders given a cookie name, a string value for it, and an Object of Set-Cookie parameters."
     ; func =
         InProcess
           (function

--- a/docs/tls-2018-08-03.markdown
+++ b/docs/tls-2018-08-03.markdown
@@ -62,7 +62,7 @@ this:
 
 ```
 /.well-known/pki-validation/3DDCB20FE60956090A312AA36B1A9E0E.txt HTTP GET
-Http::respondWithHtml
+Http::responseWithHtml
 "82EF68C568D5B84C00FE816EFED8F86A371CB21C79ED340AFC0C6144F06E55A8
 comodoca.com"
 200


### PR DESCRIPTION
Also updated two docstrings referring to Http::respondWithHeaders

https://trello.com/c/N6S13I0R/2761-change-all-instances-of-httprespond-to-httpresponse

- [x] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

