### PR TITLE
FF: highlight entire flagged old code

### DIFF
--- a/client/src/prelude/tc.ml
+++ b/client/src/prelude/tc.ml
@@ -342,6 +342,9 @@ module StrSet = struct
 
   let removeMany ~(values : string list) (set : t) : t =
     Belt.Set.String.removeMany set (Array.fromList values)
+
+
+  let eq = Belt.Set.String.eq
 end
 
 module Set (K : Key) = struct
@@ -386,4 +389,6 @@ module Set (K : Key) = struct
   let empty = StrSet.empty
 
   let pp = StrSet.pp
+
+  let eq = StrSet.eq
 end

--- a/libshared/FluidExpression.ml
+++ b/libshared/FluidExpression.ml
@@ -397,6 +397,15 @@ let filter ~(f : t -> bool) (expr : t) : t list =
   filterMap ~f:(fun t -> if f t then Some t else None) expr
 
 
+let decendants (expr : t) : Shared.id list =
+  let res = ref [] in
+  preTraversal expr ~f:(fun e ->
+      res := toID e :: !res ;
+      e)
+  |> ignore ;
+  !res
+
+
 let update ?(failIfMissing = true) ~(f : t -> t) (target : id) (ast : t) : t =
   let found = ref false in
   let rec run e =

--- a/libshared/FluidExpression.mli
+++ b/libshared/FluidExpression.mli
@@ -111,8 +111,14 @@ val blanks : t -> t list
 (** [ids e] returns the id of [e] and all its children *)
 val ids : t -> Shared.id list
 
-(** [children e] returns a list of all the children of [e] *)
+(** [children e] returns a list of all the direct children of [e] *)
 val children : t -> t list
+
+(** [decendants e] returns a list of the IDs of all decendants (children,
+ * grandchildren, etc) of [e] in an unspecified order *)
+val decendants : t -> Shared.id list
+
+val ancestors : Shared.id -> t -> t list
 
 (** [update f target ast] recursively searches [ast] for an expression e
     having an Shared.id of [target].
@@ -131,8 +137,6 @@ val renameVariableUses : oldName:string -> newName:string -> t -> t
 val updateVariableUses : string -> f:(t -> t) -> t -> t
 
 val clone : t -> t
-
-val ancestors : Shared.id -> t -> t list
 
 (** [testEqualIgnoringIds a b] compares the structure and values of two ASTs,
   * ignoring the actual IDs of the expressions.


### PR DESCRIPTION
## What

- actually get the ID of all decendants of the old code expression, not just the direct children
- ensure we highlight all indents within the old code

## Why

https://trello.com/c/9hlGBFAa/2726-fix-ff-highlighting

## Proof

<img width="313" alt="old" src="https://user-images.githubusercontent.com/131/77587987-56113a80-6ebf-11ea-926c-4c934aa1e39e.png">

<img width="305" alt="new" src="https://user-images.githubusercontent.com/131/77587988-56a9d100-6ebf-11ea-81b6-fa6fbabefcf8.png">

## Checklist

- ✔️ Trello link included
- ✔️ Discussed goals, problem and solution
- ✔️ Information from this description is also in comments
- ✔️ Before/after screenshots are included
- ~Intended followups are trelloed~
  - ✔️ No followups
- ~Reversion plan exists~
  - ✔️Standard git revert is fine
- ✔️ Tests are included (required for regressions)
- Specs (docs/trello) are linked in code 
  - ✔️ No spec exists