### PR TITLE
FF XI: correctly set & unset activeEditor

### DIFF
--- a/client/test/feature_flag_test.ml
+++ b/client/test/feature_flag_test.ml
@@ -1,3 +1,4 @@
+open Tc
 open Tester
 open FluidShortcuts
 module FF = FeatureFlags
@@ -40,12 +41,12 @@ let testUnwrap
   let id = Shared.gid () in
   let ast = FluidAST.ofExpr (exprFn id) in
   test (name ^ "- KeepOld") (fun () ->
-      let actualOld, _ = FF.unwrap FF.KeepOld ast id in
+      let actualOld = FF.unwrap FF.KeepOld ast id |> Option.valueExn in
       expect (FluidAST.toExpr actualOld)
       |> withEquality FluidExpression.testEqualIgnoringIds
       |> toEqual keepOld) ;
   test (name ^ "- KeepNew") (fun () ->
-      let actualNew, _ = FF.unwrap FF.KeepNew ast id in
+      let actualNew = FF.unwrap FF.KeepNew ast id |> Option.valueExn in
       expect (FluidAST.toExpr actualNew)
       |> withEquality FluidExpression.testEqualIgnoringIds
       |> toEqual keepNew)


### PR DESCRIPTION
## What

- When creating a feature flag, automatically move the caret to the blank after `when`.
- Bonus: fix a bunch of errors that happened when you removed a flag from within the panel (caused by not resetting `activeEditor` to the `MainEditor`)

I'm not super happy with this, but I'm not sure what I could do. The reaching into `fluidState` is particularly bad, but other than maybe extract a helper function or two, I'm not sure what I can do. The dependency cycle is real.

## Why

https://trello.com/c/6K2lJ3B3/2806-auto-focus-ff-panel-when-adding-a-new-ff

## Checklist

- ☑️ Trello link included
- ☑️ Discussed goals, problem and solution
- ~Information from this description is also in comments~
  - ☑️ No useful information
- ☑️ Before/after screenshots are included
- ~Intended followups are trelloed~
  - ☑️ No followups
- ~Reversion plan exists~
  - ☑️ Standard git revert is fine
- 🚫 Tests are included (required for regressions)
  - 💭 I don't really know how to write a good test for this. Ideally we could unit test the model state, but it's all tied up in modifications, which aren't easy to test.
- ~Specs (docs/trello) are linked in code~
  - ☑️ No spec exists