### PR TITLE
Reuse the same ID when changing a blankOr

### DIFF
--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -507,7 +507,7 @@ let submitACItem
           | PEventName _, ACCronName value, _
           | PEventName _, ACReplName value, _
           | PEventName _, ACWorkerName value, _ ->
-              replace (PEventName (B.newF value))
+              replace (PEventName (F (id, value)))
           | PEventName _, ACHTTPRoute value, TLHandler h ->
               (* Check if the ACHTTPRoute value is a 404 path *)
               let f404s =
@@ -530,15 +530,15 @@ let submitACItem
                     [ saveH {h with spec = specInfo} (PEventName new_)
                     ; Delete404 f404 ]
               | None ->
-                  replace (PEventName (B.newF value)) )
+                  replace (PEventName (F (id, value))) )
           (* allow arbitrary HTTP modifiers *)
           | PEventModifier _, ACHTTPModifier value, _
           | PEventModifier _, ACCronTiming value, _
           | PEventModifier _, ACEventModifier value, _ ->
-              replace (PEventModifier (B.newF value))
+              replace (PEventModifier (F (id, value)))
           (* allow arbitrary eventspaces *)
           | PEventSpace space, ACEventSpace value, TLHandler h ->
-              let new_ = B.newF value in
+              let new_ = F (id, value) in
               let replacement = SpecHeaders.replaceEventSpace id new_ h.spec in
               let replacedModifier =
                 match (replacement.space, space) with
@@ -606,33 +606,34 @@ let submitACItem
                 Model.updateErrorMod
                   (Error.set ("There is already a Function named " ^ value))
               else
-                let newPD = PFnName (B.newF value) in
+                let newPD = PFnName (F (id, value)) in
                 let new_ =
                   { old with
-                    ufMetadata = {old.ufMetadata with ufmName = B.newF value} }
+                    ufMetadata = {old.ufMetadata with ufmName = F (id, value)}
+                  }
                 in
                 let changedNames = Refactor.renameFunction m old value in
                 wrapNew (SetFunction new_ :: changedNames) newPD
           | PParamName _, ACParamName value, _ ->
-              replace (PParamName (B.newF value))
+              replace (PParamName (F (id, value)))
           | PParamTipe _, ACParamTipe tipe, _ ->
-              replace (PParamTipe (B.newF tipe))
+              replace (PParamTipe (F (id, tipe)))
           | PTypeName _, ACTypeName value, TLTipe old ->
               if List.member ~value (UserTypes.allNames m.userTipes)
               then
                 Model.updateErrorMod
                   (Error.set ("There is already a Type named " ^ value))
               else
-                let newPD = PTypeName (B.newF value) in
+                let newPD = PTypeName (F (id, value)) in
                 let new_ = UserTypes.replace pd newPD old in
                 let changedNames = Refactor.renameUserTipe m old new_ in
                 wrapNew (SetType new_ :: changedNames) newPD
           | PTypeFieldName _, ACTypeFieldName value, _ ->
-              replace (PTypeFieldName (B.newF value))
+              replace (PTypeFieldName (F (id, value)))
           | PTypeFieldTipe _, ACTypeFieldTipe tipe, _ ->
-              replace (PTypeFieldTipe (B.newF tipe))
+              replace (PTypeFieldTipe (F (id, tipe)))
           | PGroupName _, ACGroupName name, _ ->
-              replace (PGroupName (B.newF name))
+              replace (PGroupName (F (id, name)))
           | pd, item, _ ->
               ReplaceAllModificationsWithThisOne
                 (fun m ->


### PR DESCRIPTION
Subsection of 
https://trello.com/c/Jtn7OH7D/2469-all-fields-at-the-top-of-handlers-that-can-be-edited-should-be-selectable-with-double-click

(trello for just this bit: https://trello.com/c/HrmqiK8a/2823-dont-lose-selection-when-double-clicking-in-the-spec-headers)

This fixes part of the ticket. It doesn't make the double-click behaviour perfect, but it keeps the caret in the place you expect it to be. My plan is to 

Before:
![2020-03-27 16 09 43](https://user-images.githubusercontent.com/181762/77796316-6b17d600-7045-11ea-8713-f070d7b5164e.gif)

After:
![2020-03-27 16 09 32](https://user-images.githubusercontent.com/181762/77796314-6a7f3f80-7045-11ea-8697-8d97f9d7b309.gif)

The problem was that when doubleclicking a blankOr, the single click behaviour happens twice, then the doubleclick happens. The single clicks submit, changing the ID of the entry, and then the doubleclick handler doesn't run because its for an ID which doesnt exist.


TODO: integration test

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

