### PR TITLE
Better casing for autocomplete names

### DIFF
--- a/client/src/forms/Autocomplete.ml
+++ b/client/src/forms/Autocomplete.ml
@@ -43,15 +43,15 @@ let asName (aci : autocompleteItem) : string =
     | NewWorkerHandler maybeName ->
       ( match maybeName with
       | Some name ->
-          "New WORKER handler named " ^ name
+          "New Worker named " ^ name
       | None ->
-          "New WORKER handler" )
+          "New Worker " )
     | NewFunction maybeName ->
       ( match maybeName with
       | Some name ->
-          "New function named " ^ name
+          "New Function named " ^ name
       | None ->
-          "New function" )
+          "New Function" )
     | NewHTTPHandler maybeName ->
       ( match maybeName with
       | Some name ->
@@ -61,21 +61,21 @@ let asName (aci : autocompleteItem) : string =
     | NewCronHandler maybeName ->
       ( match maybeName with
       | Some name ->
-          "New CRON handler named " ^ name
+          "New Cron named " ^ name
       | None ->
-          "New CRON handler" )
+          "New Cron" )
     | NewReplHandler maybeName ->
       ( match maybeName with
       | Some name ->
           "New REPL named " ^ name
       | None ->
-          "New REPL handler" )
+          "New REPL" )
     | NewGroup maybeName ->
       ( match maybeName with
       | Some name ->
-          "New group named " ^ name
+          "New Group named " ^ name
       | None ->
-          "New group" )
+          "New Group" )
     | Goto (_, _, desc, _) ->
         desc )
   | ACHTTPModifier name ->


### PR DESCRIPTION
Supersedes #2131.

This fixes the names of things that are in ALL CAPS but shouldn't be (REPL and HTTP are acronyms).

This also matches the casing in @9ae's PR (#2157).

Before:
![image](https://user-images.githubusercontent.com/181762/77941500-42cbe980-7288-11ea-8570-e440c3c3cee8.png)

After:
![image](https://user-images.githubusercontent.com/181762/77941567-5c6d3100-7288-11ea-864c-7c36b3cbe148.png)


- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

