### PR TITLE
Stop splitting valid and invalid types

### DIFF
--- a/client/src/fluid/FluidAutocomplete.ml
+++ b/client/src/fluid/FluidAutocomplete.ml
@@ -289,14 +289,11 @@ let findExpectedType
 let typeCheck
     (pipedType : tipe option)
     (expectedReturnType : TypeInformation.t)
-    (item : item) : (data, data) Either.t =
-  let open Either in
-  let valid = Left {item; validity = FACItemValid} in
-  let invalidFirstArg tipe =
-    Right {item; validity = FACItemInvalidPipedArg tipe}
-  in
+    (item : item) : data =
+  let valid = {item; validity = FACItemValid} in
+  let invalidFirstArg tipe = {item; validity = FACItemInvalidPipedArg tipe} in
   let invalidReturnType =
-    Right {item; validity = FACItemInvalidReturnType expectedReturnType}
+    {item; validity = FACItemInvalidReturnType expectedReturnType}
   in
   let expectedReturnType = expectedReturnType.returnType in
   match item with
@@ -495,10 +492,7 @@ let filter
   (* Now split list by type validity *)
   let pipedType = Option.map ~f:RT.typeOf query.pipedDval in
   let expectedTypeInfo = findExpectedType functions query.tl query.ti in
-  let valid, invalid =
-    List.partitionMap allMatches ~f:(typeCheck pipedType expectedTypeInfo)
-  in
-  valid @ invalid
+  List.map allMatches ~f:(typeCheck pipedType expectedTypeInfo)
 
 
 let refilter (query : fullQuery) (old : t) (items : item list) : t =

--- a/client/test/fluid_ac_test.ml
+++ b/client/test/fluid_ac_test.ml
@@ -495,20 +495,6 @@ let run () =
                 |> List.map ~f:AC.asName
                 |> List.filter ~f:(( = ) "String::newline") )
               |> toEqual ["String::newline"]) ;
-          test "valid come before invalid in the autocomplete" (fun () ->
-              let id = gid () in
-              let expr = pipe (str ~id "asd") [partial "append" b] in
-              let m =
-                defaultModel
-                  ~analyses:[(id, DStr "asd")]
-                  ~handlers:[aHandler ~expr ()]
-                  ()
-              in
-              let ac = acFor m ~pos:14 in
-              let valid = filterValid ac in
-              let invalid = filterInvalid ac in
-              expect (List.map ~f:AC.item ac.completions)
-              |> toEqual (valid @ invalid)) ;
           test "Pattern expressions are available in pattern blank" (fun () ->
               let tlid = TLID.fromString "789" in
               let mID = ID.fromString "1234" in


### PR DESCRIPTION
https://trello.com/c/GeEfbLIy/2812-instead-of-splitting-out-autocomplete-entries-where-the-type-doesnt-match-and-putting-them-at-the-bottom-leave-them-in-their-ori

The issue is that when users type a function name that they expect, they might not get it if they type doesn't match. Then they're confused.

Sometimes they will press enter without checking, and get frustrated.

We decided to solve this by keeping things in the same position if they're invalid, but still providing the visual cues about the bad types.

Before:
![image](https://user-images.githubusercontent.com/181762/78069455-269f7980-7368-11ea-824c-357c6ac3be2e.png)


after:
![image](https://user-images.githubusercontent.com/181762/78069447-22735c00-7368-11ea-9eed-4c806d2d2656.png)


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

