### PR TITLE
Get the correct value for the constructor

### DIFF
--- a/client/src/fluid/AST.ml
+++ b/client/src/fluid/AST.ml
@@ -259,8 +259,8 @@ let rec sym_exec ~(trace : E.t -> sym_set -> unit) (st : sym_set) (expr : E.t) :
           | FPBool _
           | FPBlank _ ->
               []
-          | FPVariable (id, _, v) ->
-              [(id, v)]
+          | FPVariable (_, patternID, v) ->
+              [(patternID, v)]
           | FPConstructor (_, _, _, inner) ->
               inner |> List.map ~f:variablesInPattern |> List.concat
         in

--- a/client/test/ast_test.ml
+++ b/client/test/ast_test.ml
@@ -88,6 +88,19 @@ let run () =
             |> StrDict.get ~key:"lastBlankid"
             |> Option.andThen ~f:(fun d -> StrDict.get ~key:"a" d) )
           |> toEqual (Some a2ID)) ;
+      test "variablesIn correctly gets the id of a pattern variable" (fun () ->
+          let id1 = gid () in
+          let targetID = gid () in
+          let b1 = blank () in
+          let target = EBlank targetID in
+          let ast =
+            match' b1 [(pConstructor "Just" [pVar ~id:id1 "myvar"], target)]
+          in
+          expect
+            ( variablesIn ast
+            |> StrDict.get ~key:(ID.toString targetID)
+            |> Option.andThen ~f:(fun d -> StrDict.get ~key:"myvar" d) )
+          |> toEqual (Some id1)) ;
       ()) ;
   describe "removePartials" (fun () ->
       let b () = EBlank (gid ()) in


### PR DESCRIPTION
https://trello.com/c/qAzkHMmD/2756-on-the-rhs-of-a-match-in-a-just-arm-the-variable-pattern-shows-as-incomplete-even-though-it-is-not-and-is-usable

In the image below, we can see that `yy` was incomplete, even though we should have known its value. This was a simple bug - we were looking for the `match` ID, not the pattern id.

Before:
![image](https://user-images.githubusercontent.com/181762/78144311-71b79c00-73fd-11ea-98b2-4cffee6c6833.png)

After:
![image](https://user-images.githubusercontent.com/181762/78144238-58aeeb00-73fd-11ea-812a-15b35f9131fa.png)

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

