### PR TITLE
Enable faded not-executed code for admins

### DIFF
--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -73,7 +73,11 @@ let init (encodedParamString : string) (location : Web.Location.location) =
   let variants = VariantTesting.enabledVariantTests () in
   let variants =
     (* TODO(alice) take out when we remove the variant *)
+    (* Check user didn't manually disable this variant *)
     if isAdmin
+       && not
+            ( Url.queryParams ()
+            |> List.any ~f:(fun (prop, on) -> prop = "exe" && on = false) )
     then ExeCodeVariant :: variants
     else variants
   in


### PR DESCRIPTION
a quickie enables the code merged in PR #2168 for admins without them having to put ?exe=1 in the url param.