### PR TITLE
Add copy button to return value on bottom of handler 

### DIFF
--- a/client/src/fluid/FluidView.ml
+++ b/client/src/fluid/FluidView.ml
@@ -185,15 +185,13 @@ let viewReturnValue (vs : ViewUtils.viewState) : Types.msg Html.html =
           then Html.br []
           else Vdom.noNode
         in
+        let viewDval = viewDval vs.tlid dval ~canCopy:true in
         Html.div
           [ Html.classList
               [ ("return-value", true)
               ; ("refreshed", isRefreshed)
               ; ("incomplete", isIncomplete) ] ]
-          [ Html.text "This trace returns: "
-          ; newLine
-          ; Html.text dvalString
-          ; auxText ]
+          ([Html.text "This trace returns: "; newLine] @ viewDval @ [auxText])
     | _ ->
         Vdom.noNode
   else Vdom.noNode


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Trello:
https://trello.com/c/fAhimQAW/2840-put-copy-button-back-on-return-value

### Why: 
When adding "This trace returns:" we accidentally removed the copy button. 

### What: 
We now have the copy button there. Note, it copies the value, not the "This trace returns:"

### Gif: 
![2020-04-02 17 05 16](https://user-images.githubusercontent.com/32043360/78310918-381d8880-7504-11ea-94d3-2dde8c564ca4.gif)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

