### PR TITLE
Fix line break problem with long toplevel names

### DIFF
--- a/client/styles/_sidebar.scss
+++ b/client/styles/_sidebar.scss
@@ -24,6 +24,16 @@ $icSize: 1em;
   top: 0;
   left: 0;
   padding: 0;
+
+  ::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+    height: 7px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    border-radius: 7px;
+  }
 }
 
 .viewing-table {
@@ -38,6 +48,9 @@ $icSize: 1em;
   &.detailed {
     width: $sidebarFullWidth;
     overflow-y: scroll;
+    &::-webkit-scrollbar-corner {
+      background-color: transparent;
+    }
   }
 
   &.abridged {
@@ -244,6 +257,7 @@ $icSize: 1em;
   @at-root .abridged > .sidebar-category > & {
     background-color: $sidebarBgColor;
     min-width: $sidebarFullWidth;
+    max-width: 2 * $sidebarFullWidth;
     max-height: 400px;
     padding: $hSpace;
     margin-top: 2 * $hSpace;
@@ -256,6 +270,10 @@ $icSize: 1em;
     position: absolute;
     left: $sidebarClosedWidth;
     top: -1.25em;
+
+    &::-webkit-scrollbar-corner {
+      background-color: transparent;
+    }
 
     .category-name {
       width: 100%;
@@ -326,6 +344,7 @@ $icSize: 1em;
 
     .verb {
       color: $white2;
+      margin-left: 1em;
 
       &.GET {
         color: $http-get;


### PR DESCRIPTION
[The new sidebar styling breaks with  long handler names](https://trello.com/c/8uUUtrFA/2862-the-new-sidebar-styling-breaks-with-long-handler-names). If the name is too long, the name ends up in a new line separated from the cursor dot. We want to keep it together,

Before: 

<img width="331" alt="Screen Shot 2020-04-03 at 10 22 52 AM" src="https://user-images.githubusercontent.com/244152/78388039-2fc15e00-7595-11ea-9e25-35902daf0053.png">
<img width="414" alt="Screen Shot 2020-04-03 at 10 23 20 AM" src="https://user-images.githubusercontent.com/244152/78388609-2684c100-7596-11ea-86e3-a0bef7b7a14b.png">


After:
<img width="307" alt="Screen Shot 2020-04-03 at 10 10 48 AM" src="https://user-images.githubusercontent.com/244152/78387754-b4f84300-7594-11ea-96dd-eec64a2bbaf3.png">
<img width="711" alt="Screen Shot 2020-04-03 at 10 29 05 AM" src="https://user-images.githubusercontent.com/244152/78388505-fb9a6d00-7595-11ea-9ee1-9a983c9a44b3.png">

---
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

