### PR TITLE
Remove reference to #users channel in Dark Internal errors

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -2113,7 +2113,7 @@ let callback ~k8s_callback ip req body execution_id =
             if include_internals || Config.show_stacktrace
             then real_err
             else
-              "Dark Internal Error: Dark - the service running this application - encountered an error. This problem is a bug in Dark, we're sorry! Our automated systems have noted this error and we are working to resolve it. The author of this application can post in our Dark Community Slack for more information."
+              "Dark Internal Error: Dark - the service running this application - encountered an error. This problem is a bug in Dark, we're sorry! Our automated systems have noted this error and we are working to resolve it. The author of this application can post in our slack (darkcommunity.slack.com) for more information."
           in
           respond ~execution_id `Internal_server_error body
     with e ->


### PR DESCRIPTION
This wasn't a trello ticket but it took a few seconds to fix.

I noticed this in https://darkcommunity.slack.com/archives/CNTCWD6MP/p1585956109174700?thread_ts=1585953240.170200&cid=CNTCWD6MP