### PR TITLE
Disallow '"' in worker event names

### DIFF
--- a/client/src/forms/Autocomplete.ml
+++ b/client/src/forms/Autocomplete.ml
@@ -233,7 +233,7 @@ let nonEventNameSafeCharacters = "[^-a-zA-Z0-9$_@.&!*\"'(),%/:]"
 
 let httpNameValidator = "/[-a-zA-Z0-9$_@.&!*\"'(),%/:]*"
 
-let eventNameValidator = "[-a-zA-Z0-9$_@.&!*\"'(),%/:]+"
+let eventNameValidator = "[-a-zA-Z0-9$_@.&!*\'(),%/:]+"
 
 let varnameValidator = "[a-z_][a-zA-Z0-9_]*"
 

--- a/client/test/autocomplete_test.ml
+++ b/client/test/autocomplete_test.ml
@@ -184,6 +184,20 @@ let run () =
               expect (Entry.validate tl pd value)
               |> toEqual
                    (Some "route variables must match /[a-z_][a-zA-Z0-9_]*/"))) ;
+      describe "validate Worker names" (fun () ->
+          let space = Some "WORKER" in
+          let tl = TLHandler (aHandler ~space ()) in
+          let pd = PEventName (Types.F (ID "0", "foo")) in
+          test "foo is valid" (fun () ->
+              let value = "/foo/bar" in
+              expect (Entry.validate tl pd value) |> toEqual None) ;
+          test
+            "\"foo\" is not valid, no double quotes allowed in worker names"
+            (fun () ->
+              let value = "\"foo\"" in
+              expect (Entry.validate tl pd value)
+              |> toEqual
+                   (Some "event name must match /[-a-zA-Z0-9$_@.&!*'(),%/:]+/"))) ;
       describe "validate CRON intervals" (fun () ->
           let space = Some "CRON" in
           let tl = TLHandler (aHandler ~space ()) in


### PR DESCRIPTION
From trello:
```
It's easy to set a worker's name to "\"foo\"" out of habit
("it's a string when I call it ...") when you mean to set it to "foo".
```

The allowed values in event names are rather long:
/[-a-zA-Z0-9$_@.&!*'(),%/:]+/
and we could likely remove more of that punctuation ... but I decided
just to drop " from the regex, since that's the one that's reported to
be tripping people up.

After:
![image](https://user-images.githubusercontent.com/172694/78724255-ed27ba80-78e1-11ea-93e4-98787ec07e83.png)


https://trello.com/c/QuIoZbIH/2340-worker-names-should-not-allow-quotes

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

