### PR TITLE
Remove 2/3 of stroller msg overhead

### DIFF
--- a/backend/libbackend/analysis.ml
+++ b/backend/libbackend/analysis.ml
@@ -324,9 +324,9 @@ let empty_to_add_op_rpc_result =
   ; deleted_user_tipes = [] }
 
 
-type 'expr_type add_op_stroller_msg =
-  { result : 'expr_type add_op_rpc_result
-  ; params : 'expr_type Api.add_op_rpc_params }
+type add_op_stroller_msg =
+  { result : fluid_expr add_op_rpc_result
+  ; params : fluid_expr Api.add_op_rpc_params }
 [@@deriving to_yojson]
 
 let to_add_op_rpc_result (c : 'expr_type canvas) : 'expr_type add_op_rpc_result


### PR DESCRIPTION
https://trello.com/c/tWzL9O0l/2855-large-handlers-on-canvases-should-have-real-time-typing

Followup to https://github.com/darklang/dark/pull/2208 (only look at the last commit here).

This changes stroller messages from non-fluid expressions to fluid expressions. In my tests the typical overhead went from about 12ms to just over 3ms for medium-large handlers. They're starting to feel very real-time. This also opens some similar speedups for add_op callbacks, and maybe initial load (though not really a part of this project).

I'm going to wait a few days after it goes out to do this, as it changes a client-side API.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

