### PR TITLE
Fix extracting a variable when selecting from right to left

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -3941,6 +3941,7 @@ let tokensInRange
 let getTopmostSelectionID
     (ast : FluidAST.t) (s : fluidState) (startPos : int) (endPos : int) :
     ID.t option =
+  let startPos, endPos = orderRangeFromSmallToBig (startPos, endPos) in
   (* TODO: if there's multiple topmost IDs, return parent of those IDs *)
   tokensInRange ast s startPos endPos
   |> List.filter ~f:(fun ti -> not (T.isNewline ti.token))
@@ -3962,7 +3963,6 @@ let getTopmostSelectionID
 
 let getSelectedExprID (ast : FluidAST.t) (s : fluidState) : ID.t option =
   getOptionalSelectionRange s
-  |> Option.map ~f:orderRangeFromSmallToBig
   |> Option.andThen ~f:(getTopmostSelectionID ast s |> Tuple2.uncurry)
 
 


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

### Trello:
https://trello.com/c/NLX2bBCf/2863-extract-variable-works-incorrectly-when-you-do-right-to-left-selection

### What/Why: 
Currently, If you select a value in a record by dragging from right to left, then try to extract the variable through the command palette, it would extract the entire record but this would not happen when selecting from left to right. 
 

### Gifs:
**Before:**
![2020-04-09 14 25 23](https://user-images.githubusercontent.com/32043360/78942177-fba2dd00-7a6d-11ea-80e2-748106dc5d58.gif)

**After:**
![2020-04-09 14 22 11](https://user-images.githubusercontent.com/32043360/78942198-03fb1800-7a6e-11ea-826b-4cbd337e6508.gif)

Note: If you were to select like the example below, it will still extract the entire record, which seems weird to me but this happens when selecting from either direction so I thought it wasn't in scope for this ticket
![Screen Shot 2020-04-09 at 2 27 41 PM](https://user-images.githubusercontent.com/32043360/78942302-46bcf000-7a6e-11ea-86a4-37072df76bdd.png)

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

