### PR TITLE
Make client send API calls as fluid

### DIFF
--- a/client/src/core/Encoders.ml
+++ b/client/src/core/Encoders.ml
@@ -295,6 +295,13 @@ and handler (h : Types.handler) : Js.Json.t =
     ; ("ast", h.ast |> FluidAST.toExpr |> OldExpr.fromFluidExpr |> expr) ]
 
 
+and fluid_handler (h : Types.handler) : Js.Json.t =
+  object_
+    [ ("tlid", tlid h.hTLID)
+    ; ("spec", spec h.spec)
+    ; ("ast", h.ast |> FluidAST.toExpr |> fluidExpr) ]
+
+
 and dbMigrationKind (k : Types.dbMigrationKind) : Js.Json.t =
   let ev = variant in
   match k with DeprecatedMigrationKind -> ev "DeprecatedMigrationKind" []
@@ -339,7 +346,7 @@ and op (call : Types.op) : Js.Json.t =
   let ev = variant in
   match call with
   | SetHandler (t, p, h) ->
-      ev "SetHandler" [tlid t; pos p; handler h]
+      ev "SetHandler" [tlid t; pos p; fluid_handler h]
   | CreateDB (t, p, name) ->
       ev "CreateDB" [tlid t; pos p; string name]
   | AddDBCol (t, cn, ct) ->
@@ -381,11 +388,11 @@ and op (call : Types.op) : Js.Json.t =
   | MoveTL (t, p) ->
       ev "MoveTL" [tlid t; pos p]
   | SetFunction uf ->
-      ev "SetFunction" [userFunction uf]
+      ev "SetFunction" [fluidUserFunction uf]
   | DeleteFunction t ->
       ev "DeleteFunction" [tlid t]
   | SetExpr (t, i, e) ->
-      ev "SetExpr" [tlid t; id i; e |> OldExpr.fromFluidExpr |> expr]
+      ev "SetExpr" [tlid t; id i; e |> fluidExpr]
   | RenameDBname (t, name) ->
       ev "RenameDBname" [tlid t; string name]
   | CreateDBWithBlankOr (t, p, i, name) ->
@@ -443,7 +450,7 @@ and packageFn (pf : Types.packageFn) : Js.Json.t =
 
 
 and uploadFnAPIParams (params : Types.uploadFnAPIParams) : Js.Json.t =
-  object_ [("fn", userFunction params.uplFn)]
+  object_ [("fn", fluidUserFunction params.uplFn)]
 
 
 and triggerHandlerAPIParams (params : Types.triggerHandlerAPIParams) : Js.Json.t
@@ -528,6 +535,13 @@ and userFunction (uf : Types.userFunction) : Js.Json.t =
     [ ("tlid", tlid uf.ufTLID)
     ; ("metadata", userFunctionMetadata uf.ufMetadata)
     ; ("ast", uf.ufAST |> FluidAST.toExpr |> OldExpr.fromFluidExpr |> expr) ]
+
+
+and fluidUserFunction (uf : Types.userFunction) : Js.Json.t =
+  object_
+    [ ("tlid", tlid uf.ufTLID)
+    ; ("metadata", userFunctionMetadata uf.ufMetadata)
+    ; ("ast", uf.ufAST |> FluidAST.toExpr |> fluidExpr) ]
 
 
 and userFunctionMetadata (f : Types.userFunctionMetadata) : Js.Json.t =


### PR DESCRIPTION
Part of https://trello.com/c/tWzL9O0l/2855-large-handlers-on-canvases-should-have-real-time-typing

Followon to https://github.com/darklang/dark/pull/2216.

Now that the server can safely receive API calls as fluid, this makes the client send them as fluid.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

