### PR TITLE
Improve behavior of pasting into record key slots

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -5301,14 +5301,20 @@ let pasteOverSelection
     | ( ERecord (id, oldKVs)
       , Some (ERecord (_, pastedKVs))
       , Some {astRef = ARRecord (_, RPFieldname index); _} ) ->
-        (* Since keys can't contain exprs, merge pasted record with existing record,
-         * keeping duplicate keys *)
-        let index =
-          index + 1
-          (* adding 1 to ensure pasting after the existing entry *)
+        (* Since fieldnames can't contain exprs, merge pasted record with existing record,
+         * keeping duplicate fieldnames *)
+        let first, last =
+          match List.getAt oldKVs ~index with
+          | Some ("", EBlank _) ->
+              (* not adding 1 to index ensures we don't include this entirely empty entry;
+               * adding 1 ensures we don't include it after the paste either *)
+              ( List.take oldKVs ~count:index
+              , List.drop oldKVs ~count:(index + 1) )
+          | _ ->
+              (* adding 1 to index ensures pasting after the existing entry *)
+              ( List.take oldKVs ~count:(index + 1)
+              , List.drop oldKVs ~count:(index + 1) )
         in
-        let first = List.take oldKVs ~count:index in
-        let last = List.drop oldKVs ~count:index in
         let newKVs = List.concat [first; pastedKVs; last] in
         let replacement = E.ERecord (id, newKVs) in
         List.last pastedKVs

--- a/client/test/fluid_clipboard_test.ml
+++ b/client/test/fluid_clipboard_test.ml
@@ -941,6 +941,12 @@ let run () =
         "myKey"
         "{\n  eximyKey~sting : ___\n}" ;
       testPasteText
+        "pasting json object into existing blank record keys merges and overwrites (middle)"
+        (record [("existing1", b); ("", b); ("existing2", b)])
+        (22, 22)
+        {| { "foo": true } |}
+        "{\n  existing1 : ___\n  foo : true~\n  existing2 : ___\n}" ;
+      testPasteText
         "pasting json object into existing record keys merges (middle)"
         (record [("existing1", b); ("existing2", b)])
         (7, 7)


### PR DESCRIPTION
In [Copying & pasting JSON from outside of Dark into Dark is broken](https://trello.com/c/WoLbgYWw/2854-copying-pasting-json-from-outside-of-dark-into-dark-is-broken), Victoria tried to paste JSON into the `key` slot of a record. Doing this in a standard text editor would create a parse error that would need to be handled manually. Consider this example:

The clipboard contains:

```
{
   "handlesJSONPaste": true
}
```

There is a repl with a record:

```
{
  name : "Dark"
}
```

The caret is placed after "Dark"| and you press enter to insert a new entry:

<img width="414" alt="Screen Shot 2020-04-13 at 1 29 30 PM" src="https://user-images.githubusercontent.com/438112/79158245-d1616000-7d8a-11ea-9809-8d1b359fc344.png">

and you paste:

<img width="402" alt="Screen Shot 2020-04-13 at 1 42 40 PM" src="https://user-images.githubusercontent.com/438112/79159290-a972fc00-7d8c-11ea-8243-832dc6e6d636.png">

Clearly the location where the caret is can only contain valid `keys`, but the clipboard contains a JSON expression that we can interpret as an `ERecord`.

In a standard text editor, pasting there would yield:

```
{
  name : "Dark"
  {
   "handlesJSONPaste": true
}
}
```

which is invalid JSON that would need to be fixed manually. There are two likely interpretations for what you might want:

1) if you paste a JSON object into a key slot, we could merge the key-value pairs of the pasted record with the existing record:
```
{
  name : "Dark"
  handlesJSONPaste: true
}
```

2) if you paste valid JSON into a key slot, we could auto-add a new entry with a blank key:
```
{
  name : "Dark"
  ____ : {
      handlesJSONPaste: true
   }
}
```

Other things we could do:

3) if you try to paste into a key slot, we could block the paste in its entirety if it doesn't conform to the allowed characters allowed in a key
4) if you try to paste into a key slot, we could simulate typing the things you pasted, filling the key with only as much text as is valid, and then moving on to other fields -- this is what we do now, with the consequences shown in the ticket. This will never be perfect unless we change Dark to be fully parseable.

 In the simplified example we're considering here, the `true` in the clipboard becomes a partial that disappears when you click away, and there's an extra blank:
<img width="390" alt="Screen Shot 2020-04-13 at 1 46 43 PM" src="https://user-images.githubusercontent.com/438112/79159623-446bd600-7d8d-11ea-9ffc-a8d6e0e47794.png">
<img width="435" alt="Screen Shot 2020-04-13 at 1 47 20 PM" src="https://user-images.githubusercontent.com/438112/79159643-4f266b00-7d8d-11ea-8d33-4d9b15d39b49.png">

5) we could do one of the above but also visually distinguish key and variable blanks from blanks that allow any expression
6) Given that the user intent is very hard to discern apriori (merge vs new kv pair), we could provide options on paste (possibly with the command palette), so that users can disambiguate their intent.


There was some discussion of that here: https://dark-inc.slack.com/archives/CTR5RRTRD/p1586308646017100 and Paul said:

> I agree that it very much depends on the user intent. From Julian’s suggestions, 1,2,3 and 5 seem reasonable. Having an intuitive use case matters; can you talk us through how you ended up pasting there? For now, I’d lean into 3 (don’t do anything), as we can always add support for it later

In this PR, I implemented 3 as the general case, with a specific exception for records that implements 1. My rationale for this is:

- 1 is what Victoria was trying to do in the original ticket, and is currently not possible to achieve manually without many manual fixup steps
- it is actually possible to achieve 2 manually -- you can paste into the value slot instead of the key slot
- implementing 1 was very straightforward

New behavior for the simplified example:

<img width="452" alt="Screen Shot 2020-04-13 at 2 36 18 PM" src="https://user-images.githubusercontent.com/438112/79163572-2fdf0c00-7d94-11ea-90d4-f2addba2de53.png">

---

Implementation notes:

I modified the match here:

https://github.com/darklang/dark/blob/24c412c5ba9d496572b5bde2e717e04302fe483d/client/src/fluid/Fluid.ml#L5283

to use a caret target instead of a token info. This made it easier to deal with the specifics of the paste target and allowed me to clean up the string paste behavior. In the process of doing that, I discovered a problem in caret target placement on paste before the open quote of a string: https://trello.com/c/j1oq8AbJ/2904-caret-placement-issue-on-paste-before-an-open-quote

There's still a bunch of cases where pasting into a record is less than ideal, for example, pasting around the curly braces of a record, but that seems out of scope. There are also situations where pasting JSON into a record key blocks instead of pasting: consider JSON values that aren't top-level objects, such as arrays. See https://www.json.org/json-en.html for what counts as valid top-level JSON.

---

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

