### PR TITLE
Revert "Revert "Make server API use/support fluid""

### DIFF
--- a/backend/libbackend/analysis.ml
+++ b/backend/libbackend/analysis.ml
@@ -9,13 +9,11 @@ module PReq = Parsed_request
 module SE = Stored_event
 module SA = Static_assets
 
-type 'expr_type canvas = 'expr_type Canvas.canvas
-
 (* ------------------------- *)
 (* Non-execution analysis *)
 (* ------------------------- *)
 
-let unlocked (c : 'expr_type canvas) : tlid list =
+let unlocked (c : 'expr_type Canvas.canvas) : tlid list =
   c.dbs
   |> TL.dbs
   |> User_db.unlocked c.id c.owner
@@ -29,7 +27,7 @@ type db_stat =
 
 type db_stat_map = db_stat IDMap.t [@@deriving eq, show, yojson]
 
-let db_stats (c : 'expr_type canvas) (tlids : tlid list) : db_stat_map =
+let db_stats (c : fluid_expr Canvas.canvas) (tlids : tlid list) : db_stat_map =
   List.fold
     ~init:IDMap.empty
     ~f:(fun map tlid ->
@@ -47,7 +45,7 @@ let db_stats (c : 'expr_type canvas) (tlids : tlid list) : db_stat_map =
 
 type worker_stat = {count : int} [@@deriving show, yojson]
 
-let worker_stats (c : 'expr_type canvas) (tlid : tlid) : worker_stat =
+let worker_stats (c : fluid_expr Canvas.canvas) (tlid : tlid) : worker_stat =
   let count =
     Db.fetch_one
       ~name:"count_workers"
@@ -68,8 +66,8 @@ let worker_stats (c : 'expr_type canvas) (tlid : tlid) : worker_stat =
   {count}
 
 
-let get_404s ~(since : RTT.time) (c : 'expr_type canvas) : SE.four_oh_four list
-    =
+let get_404s ~(since : RTT.time) (c : fluid_expr Canvas.canvas) :
+    SE.four_oh_four list =
   let events = SE.list_events ~limit:(`Since since) ~canvas_id:c.id () in
   let handlers =
     Db.fetch
@@ -149,8 +147,8 @@ let saved_input_vars
 
 
 let handler_trace
-    (c : 'expr_type canvas)
-    (h : 'expr_type RTT.HandlerT.handler)
+    (c : fluid_expr Canvas.canvas)
+    (h : Types.fluid_expr RTT.HandlerT.handler)
     (trace_id : traceid) : trace =
   let event = SE.load_event_for_trace ~canvas_id:c.id trace_id in
   let ivs, timestamp =
@@ -167,8 +165,9 @@ let handler_trace
 
 
 let user_fn_trace
-    (c : 'expr_type canvas) (fn : 'expr_type RTT.user_fn) (trace_id : traceid) :
-    trace =
+    (c : fluid_expr Canvas.canvas)
+    (fn : 'expr_type RTT.user_fn)
+    (trace_id : traceid) : trace =
   let event =
     Stored_function_arguments.load_for_analysis ~canvas_id:c.id fn.tlid trace_id
   in
@@ -186,8 +185,8 @@ let user_fn_trace
 
 
 let traceids_for_handler
-    (c : 'expr_type canvas) (h : 'expr_type RTT.HandlerT.handler) : traceid list
-    =
+    (c : fluid_expr Canvas.canvas) (h : 'expr_type RTT.HandlerT.handler) :
+    traceid list =
   match Handler.event_desc_for h with
   | Some ((hmodule, _, _) as desc) ->
       let events = SE.load_event_ids ~canvas_id:c.id desc in
@@ -214,8 +213,9 @@ let traceids_for_handler
       [Uuidm.v5 Uuidm.nil (string_of_id h.tlid)]
 
 
-let traceids_for_user_fn (c : 'expr_type canvas) (fn : 'expr_type RTT.user_fn) :
-    traceid list =
+let traceids_for_user_fn
+    (c : fluid_expr Canvas.canvas) (fn : 'expr_type RTT.user_fn) : traceid list
+    =
   Stored_function_arguments.load_traceids c.id fn.tlid
 
 
@@ -223,8 +223,13 @@ let traceids_for_user_fn (c : 'expr_type canvas) (fn : 'expr_type RTT.user_fn) :
 (* function execution *)
 (* ------------------------- *)
 let execute_function
-    (c : RTT.expr canvas) ~execution_id ~tlid ~trace_id ~caller_id ~args fnname
-    =
+    (c : RTT.expr Canvas.canvas)
+    ~execution_id
+    ~tlid
+    ~trace_id
+    ~caller_id
+    ~args
+    fnname =
   Execution.execute_function
     ~tlid
     ~execution_id
@@ -253,8 +258,8 @@ type fofs = SE.four_oh_four list [@@deriving to_yojson]
 
 type get_trace_data_rpc_result = {trace : trace} [@@deriving to_yojson]
 
-let to_get_trace_data_rpc_result (c : 'expr_type canvas) (trace : trace) :
-    string =
+let to_get_trace_data_rpc_result (c : fluid_expr Canvas.canvas) (trace : trace)
+    : string =
   {trace}
   |> get_trace_data_rpc_result_to_yojson
   |> Yojson.Safe.to_string ~std:true
@@ -264,7 +269,7 @@ type get_unlocked_dbs_rpc_result = {unlocked_dbs : tlid list}
 [@@deriving to_yojson]
 
 let to_get_unlocked_dbs_rpc_result
-    (unlocked_dbs : tlid list) (c : 'expr_type canvas) : string =
+    (unlocked_dbs : tlid list) (c : fluid_expr Canvas.canvas) : string =
   {unlocked_dbs}
   |> get_unlocked_dbs_rpc_result_to_yojson
   |> Yojson.Safe.to_string ~std:true
@@ -304,12 +309,12 @@ let to_worker_schedules_push (ws : Event_queue.Worker_states.t) : string =
  * appearing in toplevels again. *)
 
 (* A subset of responses to be merged in *)
-type 'expr_type add_op_rpc_result =
-  { toplevels : 'expr_type TL.toplevel list (* replace *)
-  ; deleted_toplevels : 'expr_type TL.toplevel list
+type add_op_rpc_result =
+  { toplevels : Types.fluid_expr TL.toplevel list (* replace *)
+  ; deleted_toplevels : Types.fluid_expr TL.toplevel list
         (* replace, see note above *)
-  ; user_functions : 'expr_type RTT.user_fn list (* replace *)
-  ; deleted_user_functions : 'expr_type RTT.user_fn list
+  ; user_functions : Types.fluid_expr RTT.user_fn list (* replace *)
+  ; deleted_user_functions : Types.fluid_expr RTT.user_fn list
   ; user_tipes : RTT.user_tipe list
   ; deleted_user_tipes : RTT.user_tipe list (* replace, see deleted_toplevels *)
   }
@@ -325,12 +330,11 @@ let empty_to_add_op_rpc_result =
 
 
 type add_op_stroller_msg =
-  { result : fluid_expr add_op_rpc_result
+  { result : add_op_rpc_result
   ; params : fluid_expr Api.add_op_rpc_params }
 [@@deriving to_yojson]
 
-let to_add_op_rpc_result (c : 'expr_type canvas) : 'expr_type add_op_rpc_result
-    =
+let to_add_op_rpc_result (c : fluid_expr Canvas.canvas) : add_op_rpc_result =
   { toplevels = IDMap.data c.dbs @ IDMap.data c.handlers
   ; deleted_toplevels = IDMap.data c.deleted_handlers @ IDMap.data c.deleted_dbs
   ; user_functions = IDMap.data c.user_functions
@@ -360,11 +364,11 @@ let time_to_yojson (time : time) : Yojson.Safe.t =
 
 
 (* Initial load *)
-type 'expr_type initial_load_rpc_result =
-  { toplevels : 'expr_type TL.toplevel list
-  ; deleted_toplevels : 'expr_type TL.toplevel list
-  ; user_functions : 'expr_type RTT.user_fn list
-  ; deleted_user_functions : 'expr_type RTT.user_fn list
+type initial_load_rpc_result =
+  { toplevels : Types.fluid_expr TL.toplevel list
+  ; deleted_toplevels : Types.fluid_expr TL.toplevel list
+  ; user_functions : Types.fluid_expr RTT.user_fn list
+  ; deleted_user_functions : Types.fluid_expr RTT.user_fn list
   ; unlocked_dbs : tlid list
   ; fofs : SE.four_oh_four list
   ; assets : SA.static_deploy list
@@ -381,7 +385,7 @@ type 'expr_type initial_load_rpc_result =
 [@@deriving to_yojson]
 
 let to_initial_load_rpc_result
-    (c : RTT.expr canvas)
+    (c : fluid_expr Canvas.canvas)
     (op_ctrs : (string * int) list)
     (permission : Authorization.permission option)
     (fofs : SE.four_oh_four list)
@@ -409,7 +413,7 @@ let to_initial_load_rpc_result
   ; org_canvas_list
   ; worker_schedules
   ; creation_date = c.creation_date }
-  |> initial_load_rpc_result_to_yojson RTT.expr_to_yojson
+  |> initial_load_rpc_result_to_yojson
   |> Yojson.Safe.to_string ~std:true
 
 

--- a/backend/libbackend/api.ml
+++ b/backend/libbackend/api.ml
@@ -31,12 +31,13 @@ type execute_function_rpc_params =
 type 'expr_type upload_function_rpc_params = {fn : 'expr_type RuntimeT.user_fn}
 [@@deriving yojson]
 
-let to_upload_function_rpc_params
-    ~(f : Yojson.Safe.t -> ('expr_type, string) Result.t) (payload : string) :
-    'expr_type upload_function_rpc_params =
-  payload
-  |> Yojson.Safe.from_string
-  |> upload_function_rpc_params_of_yojson f
+let to_upload_function_rpc_params (payload : string) :
+    Types.fluid_expr upload_function_rpc_params =
+  let json = payload |> Yojson.Safe.from_string in
+  json
+  |> upload_function_rpc_params_of_yojson Fluid.expr_json_to_fluid
+  |> Tc.Result.or_else_lazy (fun () ->
+         upload_function_rpc_params_of_yojson Types.fluid_expr_of_yojson json)
   |> Result.ok_or_failwith
 
 
@@ -52,12 +53,13 @@ type route_params =
   ; modifier : string }
 [@@deriving yojson]
 
-let to_add_op_rpc_params
-    ~(f : Yojson.Safe.t -> ('expr_type, string) Result.t) (payload : string) :
-    'expr_type add_op_rpc_params =
-  payload
-  |> Yojson.Safe.from_string
-  |> add_op_rpc_params_of_yojson f
+let to_add_op_rpc_params (payload : string) : Types.fluid_expr add_op_rpc_params
+    =
+  let json = payload |> Yojson.Safe.from_string in
+  json
+  |> add_op_rpc_params_of_yojson Fluid.expr_json_to_fluid
+  |> Tc.Result.or_else_lazy (fun () ->
+         add_op_rpc_params_of_yojson Types.fluid_expr_of_yojson json)
   |> Result.ok_or_failwith
 
 

--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -53,6 +53,10 @@ let to_fluid (c : RTT.expr canvas) : Types.fluid_expr canvas =
   ; deleted_user_tipes = c.deleted_user_tipes }
 
 
+let to_fluid_ref (c : RTT.expr canvas ref) : Types.fluid_expr canvas ref =
+  ref (to_fluid !c)
+
+
 let of_fluid (c : Types.fluid_expr canvas) : RTT.expr canvas =
   { host = c.host
   ; owner = c.owner

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -563,6 +563,7 @@ that's already taken, returns an error."
                       (Unicode_string.to_string host)
                       ~tlids:[Types.id_of_string tlid]
                       []
+                    |> Result.map ~f:Canvas.to_fluid_ref
                     |> Result.map_error ~f:(String.concat ~sep:", ")
                     |> Prelude.Result.ok_or_internal_exception
                          "Canvas load error"

--- a/backend/libexecution/execution.mli
+++ b/backend/libexecution/execution.mli
@@ -7,24 +7,21 @@ val input_vars_for_user_fn :
   Types.RuntimeT.expr Types.RuntimeT.user_fn -> Types.RuntimeT.dval_map
 
 val dbs_as_input_vars :
-     Types.RuntimeT.expr Types.RuntimeT.DbT.db list
-  -> (string * Types.RuntimeT.dval) list
+  'expr_type Types.RuntimeT.DbT.db list -> (string * Types.RuntimeT.dval) list
 
 val http_route_input_vars :
-     Types.RuntimeT.expr Types.RuntimeT.HandlerT.handler
+     'expr_type Types.RuntimeT.HandlerT.handler
   -> string
   -> Types.RuntimeT.input_vars
 
 val sample_route_input_vars :
-     Types.RuntimeT.expr Types.RuntimeT.HandlerT.handler
-  -> Types.RuntimeT.input_vars
+  'expr_type Types.RuntimeT.HandlerT.handler -> Types.RuntimeT.input_vars
 
 val sample_input_vars :
-     Types.RuntimeT.expr Types.RuntimeT.HandlerT.handler
-  -> Types.RuntimeT.input_vars
+  'expr_type Types.RuntimeT.HandlerT.handler -> Types.RuntimeT.input_vars
 
 val sample_function_input_vars :
-  Types.RuntimeT.expr Types.RuntimeT.user_fn -> Types.RuntimeT.input_vars
+  'expr_type Types.RuntimeT.user_fn -> Types.RuntimeT.input_vars
 
 val sample_unknown_handler_input_vars : Types.RuntimeT.input_vars
 

--- a/backend/libexecution/fluid.ml
+++ b/backend/libexecution/fluid.ml
@@ -346,6 +346,11 @@ let rec toFluidExpr ?(inPipe = false) (expr : Types.RuntimeT.expr) :
         ERightPartial (id, str, toFluidExpr ~inPipe oldExpr) )
 
 
+let expr_json_to_fluid (j : Yojson.Safe.t) : (Types.fluid_expr, string) Result.t
+    =
+  j |> Types.RuntimeT.expr_of_yojson |> Result.map ~f:toFluidExpr
+
+
 (* included here as part of killing old exprs, based on
  * FluidExpression.testEqualIgnoringIds *)
 let rec testExprEqualIgnoringIds

--- a/backend/libunshared/tc.ml
+++ b/backend/libunshared/tc.ml
@@ -31,6 +31,14 @@ module Result = struct
     match rb with Error _ -> ra | Ok _ -> rb
 
 
+  let orElseLazy (v : unit -> ('a, 'b) t) (v2 : ('a, 'b) t) : ('a, 'b) t =
+    match v2 with Ok v2 -> Ok v2 | Error _ -> v ()
+
+
+  let or_else = orElse
+
+  let or_else_lazy = orElseLazy
+
   let and_ (ra : ('a, 'b) t) (rb : ('a, 'b) t) : ('a, 'b) t =
     match (ra, rb) with
     | Ok a, Ok _ ->

--- a/backend/test/test_analysis.ml
+++ b/backend/test/test_analysis.ml
@@ -36,8 +36,8 @@ let t_test_filter_slash () =
   let host = "test-test_filter_slash" in
   let route = "/:rest" in
   let oplist = [Op.SetHandler (tlid, pos, http_route_handler ~route ())] in
-  let c = ops2c_exn host oplist in
-  Canvas.serialize_only [tlid] !c ;
+  let c = ops2c_exn host oplist |> C.to_fluid_ref in
+  Canvas.serialize_only [tlid] (C.of_fluid !c) ;
   let t1 = Util.create_uuid () in
   let desc = ("HTTP", "/", "GET") in
   let at_trace_id = AT.of_pp Uuidm.pp_string in

--- a/backend/test/test_framework.ml
+++ b/backend/test/test_framework.ml
@@ -145,8 +145,8 @@ let t_route_variables_work_with_stored_events () =
   clear_test_data () ;
   let host = "test-route_variables_works" in
   let oplist = [Op.SetHandler (tlid, pos, http_route_handler ())] in
-  let c = ops2c_exn host oplist in
-  Canvas.serialize_only [tlid] !c ;
+  let c = ops2c_exn host oplist |> C.to_fluid_ref in
+  Canvas.serialize_only [tlid] (C.of_fluid !c) ;
   let t1 = Util.create_uuid () in
   let desc = ("HTTP", http_request_path, "GET") in
   let route = ("HTTP", http_route, "GET") in


### PR DESCRIPTION
#2216 broke lots of canvases. This is because it uses the fluid decoders for InitialLoad, something which happens very often, decoding the entire canvas.

Sadly, the fluid decoders were broken. It wasn't picked up at the time because they had only been enabled for stroller messages, which meant the error only triggered when someone was editing a match statement with a string literal pattern, which isn't all that common.

I've fixed the decoder in #2233. This means it's now safe to re-enable this during initial load.

To validate this, I've opened a handful of canvases to make sure they load: ops-adduser, listo, tair-snippy.