### PR TITLE
Remove <return> tag type from rich-text spec

### DIFF
--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -64,7 +64,7 @@ let fns : fn list =
     ; parameters = []
     ; return_type = TList
     ; description =
-        "<return Return> a <type list> of all user email addresses for non-admins and not in @darklang.com or @example.com"
+        "Return a <type list> of all user email addresses for non-admins and not in @darklang.com or @example.com"
     ; func =
         internal_fn (function
             | _, [] ->
@@ -551,7 +551,7 @@ that's already taken, returns an error."
     ; parameters = [par "host" TStr; par "tlid" TStr]
     ; return_type = TBool
     ; description =
-        "Takes a <var host> and a <var tlid> and <return returns> {{true}} iff we can load and parse traces for the handler identified by <var tlid>, and {{false}} otherwise."
+        "Takes a <var host> and a <var tlid> and returns {{true}} iff we can load and parse traces for the handler identified by <var tlid>, and {{false}} otherwise."
     ; func =
         internal_fn (function
             | _, [DStr host; DStr tlid] ->
@@ -758,7 +758,7 @@ that's already taken, returns an error."
     ; parameters = [par "host" TStr; par "tlid" TStr]
     ; return_type = TOption
     ; description =
-        "<return Returns> {{Just <var events>}}, where <var events> is the most recent stored events for the <param tlid> if it is a handler or {{Nothing}} if it is not."
+        "Returns {{Just <var events>}}, where <var events> is the most recent stored events for the <param tlid> if it is a handler or {{Nothing}} if it is not."
     ; func =
         internal_fn (function
             | _, [DStr host; DStr tlid_str] ->

--- a/client/src/util/PrettyDocs.ml
+++ b/client/src/util/PrettyDocs.ml
@@ -11,7 +11,7 @@ let nestedTag = Regex.regex "\\<\\w+\\s[^>]*<\\w+\\s[^<]*\\>.*\\>"
 
 let nestedCodeBlock = Regex.regex "\\{\\{.*\\{\\{.*\\}\\}.*\\}\\}"
 
-let validTags = ["param"; "fn"; "var"; "type"; "return"; "err"; "cmd"]
+let validTags = ["param"; "fn"; "var"; "type"; "err"; "cmd"]
 
 type parseResult =
   | ParseSuccess of msg Html.html list

--- a/client/styles/_doc.scss
+++ b/client/styles/_doc.scss
@@ -28,9 +28,7 @@
   .type {
     color: $green;
   }
-  .return {
-    color: lighten($orange, 15%);
-  }
+
   .err {
     color: lighten(saturate($red, 25%), 30%);
   }

--- a/client/test/prettydocs_test.ml
+++ b/client/test/prettydocs_test.ml
@@ -43,10 +43,9 @@ let run () =
       test "converts string with multiple tags and a constructor" (fun () ->
           expect
             (convert
-               "<return Returns> an <type Result>. If it is {{Error <var message>}}, then it will go to error rail")
+               "Returns an <type Result>. If it is {{Error <var message>}}, then it will go to error rail")
           |> toEqual
-               [ tag "return" [txt "Returns"]
-               ; txt " an "
+               [ txt "Returns an "
                ; tag "type" [txt "Result"]
                ; txt ". If it is "
                ; tag "code" [txt "Error "; tag "var" [txt "message"]]

--- a/docs/writing-docstrings.md
+++ b/docs/writing-docstrings.md
@@ -18,7 +18,6 @@ Currently valid tag types are:
 | fn      | `<fn String::split>`        |
 | var     | `<var val>`                 |
 | type    | `<type String>`             |
-| return  | `<return Returns>`          |
 | err     | `<err Type Error>`          |
 | cmd     | `<cmd take-off-error-rail>` |
 


### PR DESCRIPTION
Paul doesn't like return being highlighting because it's not a language element.
Alice thinks it's important because it's the main thing developers look for when reading docs, and it's ok to violate taxonomy if it makes the product easier to learn.

> Alice :  When a developer looks a function description, they are primarily looking for one of the following things: Details on acceptable input arguments. What the function will do to the input. And if the function returns an output, what should they expect. The return-sentences answers often answers the latter two.

> Paul: I feel very strongly that we should not highlight the word returns. The word returns is still there, we still right docs around it, but it’s not a keyword and isn’t special (and the whole point of functional languages is that things are returned). Could you remove it pls?

Alice decides to just take it out for now, since it's easy to bring back when users have vocally express they want it.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

