### PR TITLE
Fix decoder bugs

### DIFF
--- a/client/src/core/Decoders.ml
+++ b/client/src/core/Decoders.ml
@@ -221,16 +221,12 @@ let rec fluidPattern j : FluidPattern.t =
       )
     ; ("FPInteger", dv3 (fun a b c -> P.FPInteger (a, b, c)) id id string)
     ; ("FPBool", dv3 (fun a b c -> P.FPBool (a, b, c)) id id bool)
-      (* Warning: this is a bit dangerous due to ordering; we'll need to find a saner way to do this.
-      * Unfortunately, this is the first time that we have needed to decode an inline record,
-      * and implementing that decoding is a bit tricky.
-      *)
     ; ( "FPString"
-      , dv3
-          (fun matchID patternID c -> P.FPString {patternID; matchID; str = c})
-          id
-          id
-          string )
+      , recordVariant3
+          (fun matchID patternID str -> P.FPString {matchID; patternID; str})
+          ("matchID", id)
+          ("patternID", id)
+          ("str", string) )
     ; ( "FPFloat"
       , dv4 (fun a b c d -> P.FPFloat (a, b, c, d)) id id string string )
     ; ("FPNull", dv2 (fun a b -> P.FPNull (a, b)) id id)

--- a/client/src/core/Encoders.ml
+++ b/client/src/core/Encoders.ml
@@ -698,7 +698,12 @@ and fluidPattern (pattern : FluidPattern.t) : Js.Json.t =
   | FPFloat (id', mid, whole, fraction) ->
       ev "FPFloat" [id id'; id mid; string whole; string fraction]
   | FPString {matchID; patternID; str = v} ->
-      ev "FPString" [id matchID; id patternID; string v]
+      ev
+        "FPString"
+        [ object_
+            [ ("matchID", id matchID)
+            ; ("patternID", id patternID)
+            ; ("str", string v) ] ]
   | FPNull (id', mid) ->
       ev "FPNull" [id id'; id mid]
   | FPBlank (id', mid) ->

--- a/client/src/prelude/Json_decode_extended.ml
+++ b/client/src/prelude/Json_decode_extended.ml
@@ -47,6 +47,14 @@ let variant5 constructor d1 d2 d3 d4 d5 =
     (index 5 d5)
 
 
+let recordVariant3 constructor (k1, d1) (k2, d2) (k3, d3) =
+  map3
+    constructor
+    (index 1 (field k1 d1))
+    (index 1 (field k2 d2))
+    (index 1 (field k3 d3))
+
+
 let variants decoders =
   index 0 string
   |> andThen (fun str_constructor ->

--- a/client/src/prelude/Json_decode_extended.mli
+++ b/client/src/prelude/Json_decode_extended.mli
@@ -29,6 +29,25 @@ val variant1 : ('b -> 'a) -> 'b decoder -> 'a decoder
 
 val variant0 : 'a -> 'a decoder
 
+(* For variants with record types, provide a constructor and three fields with
+ * the field types, and decode them. For example, for the type:
+ * FPString { matchID: id; patternID : id; str : string }
+ *
+ * the decoder would be
+ *
+ * recordVariant3
+ *    (fun matchID patternID str -> P.FPString {matchID; patternID; str})
+ *    ("matchID", id)
+ *    ("patternID", id)
+ *    ("str", string)
+ *)
+val recordVariant3 :
+     ('b -> 'c -> 'd -> 'a)
+  -> string * 'b decoder
+  -> string * 'c decoder
+  -> string * 'd decoder
+  -> 'a decoder
+
 val variants : (string * 'a decoder) list -> 'a decoder
 
 val succeed : 'a -> 'a decoder


### PR DESCRIPTION
https://trello.com/c/CC8o6KTX/2939-fix-decoder-bug-with-fluid-match-patterns

Dean reported this problem to me earlier today:

![2020-04-15 12 09 00](https://user-images.githubusercontent.com/181762/79384292-9569fe80-7f34-11ea-9ece-d82244eca819.gif)

The problem occurred as the client-side decoder for fluid pattern strings did not use the same format as the derived yojson one (as I recall, it was a bit tricky and I skipped it at the time).

It turns out this is related to the decoder problem for which I had to revert #2216. In #2216 I enabled fluid across the board, and so this incorrect format was decoded in InitialLoad (which is to say, it got called on every canvas load, and triggered the error if there was a match anywhere on the canvas).

When I disabled #2216, the bad code remained but it only triggered in a stroller callback (which is to say, only when you editing a match with a pattern string).

After I merge this, it should be safe to proceed with #2224 after some testing.

This is exercised by a roundtrip test that specifically checks this case. Since no other Fluid code uses record variants, I expect this doesn't exist anywhere else. 

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

