### PR TITLE
Unfade multiline string and list literal blocks if your caret is inside it

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -199,13 +199,6 @@ let getToken' (s : fluidState) (tokens : T.tokenInfo list) : T.tokenInfo option
 let getToken (ast : FluidAST.t) (s : fluidState) : T.tokenInfo option =
   tokensForActiveEditor ast s |> getToken' s
 
-let getAdjacentTokens (ast : FluidAST.t) (s : fluidState) : (fluidToken option * fluidToken option) =
-  let tokens = tokensForActiveEditor ast s in
-  let left, right, _ = getNeighbours ~pos:s.newPos tokens in
-  let oLeft = match left with L (t, _) -> Some t |_ -> None in
-  let oRight = match right with R (t, _) -> Some t | _ -> None in
-  (oLeft, oRight)
-
 
 (* -------------------- *)
 (* Update fluid state *)

--- a/client/src/fluid/FluidToken.ml
+++ b/client/src/fluid/FluidToken.ml
@@ -259,19 +259,18 @@ let isErrorDisplayable (t : t) : bool =
 let isFieldPartial (t : t) : bool =
   match t with TFieldPartial _ -> true | _ -> false
 
+
 let isMutlilineString (t : fluidToken) : bool =
-    match t with
-    | TStringMLStart _ | TStringMLMiddle _ | TStringMLEnd _ ->
-        true
-    | _ ->
-        false
-    
+  match t with
+  | TStringMLStart _ | TStringMLMiddle _ | TStringMLEnd _ ->
+      true
+  | _ ->
+      false
+
+
 let isListSymbol (t : fluidToken) : bool =
-    match t with
-    | TListOpen _
-    | TListClose _
-    | TListComma _ -> true
-    | _ -> false
+  match t with TListOpen _ | TListClose _ | TListComma _ -> true | _ -> false
+
 
 let toText (t : t) : string =
   let shouldntBeEmpty name =


### PR DESCRIPTION
[Code fade has strange behavior in multiline strings](https://trello.com/c/iZLa7TXJ/2860-code-fade-has-strange-behavior-in-multiline-strings)

# Background
We want to fade out unexecuted code. 
<img width="583" alt="Screen Shot 2020-04-15 at 3 22 08 PM" src="https://user-images.githubusercontent.com/244152/79395628-e7a82100-7f2e-11ea-9904-edfd94329cc6.png">

Fading out makes auto complete all weird and we still want to make it still easy to edit faded-out code and have it more readable, so we settled on a general heuristic of unfading out the line you caret is in. 
<img width="583" alt="Screen Shot 2020-04-15 at 3 22 43 PM" src="https://user-images.githubusercontent.com/244152/79395640-eecf2f00-7f2e-11ea-805b-b17877347dd8.png">


# Problem
A case which renders awkwardly in this heuristic is multiline strings and list literals.
<img width="583" alt="Screen Shot 2020-04-15 at 3 36 04 PM" src="https://user-images.githubusercontent.com/244152/79395671-03abc280-7f2f-11ea-85a4-9f8a8c432423.png">


# Solution
We decided to un-fade the whole string/list block if your caret is in it.
<img width="583" alt="Screen Shot 2020-04-15 at 3 22 23 PM" src="https://user-images.githubusercontent.com/244152/79395689-0c9c9400-7f2f-11ea-8d93-5999cb41c17e.png">
<img width="583" alt="Screen Shot 2020-04-15 at 3 22 32 PM" src="https://user-images.githubusercontent.com/244152/79395693-11f9de80-7f2f-11ea-95fb-dc81c604aa37.png">


# Follow-up
However if your cursor is on a line that has a multiline block, I don't have a good plan on how we should render it yet.
<img width="583" alt="Screen Shot 2020-04-15 at 3 39 21 PM" src="https://user-images.githubusercontent.com/244152/79395822-584f3d80-7f2f-11ea-8cfa-efed6654293a.png">

So I created a follow up to [Figure out how to render the line when the caret is on a line with a multiline block](https://trello.com/c/5hx3SGF6/2940-figure-out-how-to-render-the-line-when-the-caret-is-on-a-line-with-a-multiline-block)

# Testing
Since this is under a variantTest, and we are still hashing out the expected behavior. We are going to hold off writing unit/integration tests until we enable this for everyone.


---
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [x] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [x] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

