### PR TITLE
Add an 'expr_type parameter to dval, dval_map, etc

### DIFF
--- a/backend/bin/get_functions_and_tlids.ml
+++ b/backend/bin/get_functions_and_tlids.ml
@@ -116,14 +116,14 @@ let () =
   *)
 
 let filterFnsNotInStaticFns (fn : fn) =
-  let (realfn : RuntimeT.fn option) =
+  let (realfn : RuntimeT.expr RuntimeT.fn option) =
     Libs.FnMap.find !Libs.static_fns fn.fnname
   in
   match realfn with Some _ -> false | None -> true
 
 
 let isDeprecated (fn : fn) =
-  let (realfn : RuntimeT.fn option) =
+  let (realfn : RuntimeT.expr RuntimeT.fn option) =
     Libs.FnMap.find !Libs.static_fns fn.fnname
   in
   match realfn with Some realfn -> realfn.deprecated | None -> false

--- a/backend/bin/validate_data_loads.ml
+++ b/backend/bin/validate_data_loads.ml
@@ -25,7 +25,9 @@ let validate_row (table : string) (values : string list) : unit =
         [("table", table); ("canvas", canvas_name); ("trace_id", trace_id)]
       in
       ( try
-          let (_ : RTT.dval) = Dval.of_internal_roundtrippable_v0 value in
+          let (_ : RTT.expr RTT.dval) =
+            Dval.of_internal_roundtrippable_v0 value
+          in
           Log.infO "successful roundtrip" ~params
         with _ ->
           let params = ("value", value) :: params in
@@ -110,7 +112,7 @@ let () =
                    | Blank _ ->
                        "no name"
                  in
-                 let state : Libexecution.Types.RuntimeT.exec_state =
+                 let state : RTT.expr RTT.exec_state =
                    { tlid = db.tlid
                    ; account_id = !c.owner
                    ; canvas_id = !c.id

--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -105,7 +105,7 @@ let validate_account (account : account) : (unit, string) Result.t =
 
 let insert_account
     ?(validate : bool = true)
-    ~(segment_metadata : Types.RuntimeT.dval_map option)
+    ~(segment_metadata : Types.RuntimeT.expr_dval_map option)
     (account : account) : (unit, string) Result.t =
   let result = if validate then validate_account account else Ok () in
   let segment_metadata =
@@ -373,7 +373,7 @@ let insert_user
     ~(username : string)
     ~(email : string)
     ~(name : string)
-    ?(segment_metadata : Types.RuntimeT.dval_map option)
+    ?(segment_metadata : Types.RuntimeT.expr_dval_map option)
     () : (unit, string) Result.t =
   (* As of the move to auth0, we  no longer store passwords in postgres. We do
    * still use postgres locally, which is why we're not removing the field

--- a/backend/libbackend/account.mli
+++ b/backend/libbackend/account.mli
@@ -45,7 +45,7 @@ val insert_user :
      username:string
   -> email:string
   -> name:string
-  -> ?segment_metadata:Libexecution.Types.RuntimeT.dval_map
+  -> ?segment_metadata:Libexecution.Types.RuntimeT.expr_dval_map
   -> unit
   -> (unit, string) Result.t
 

--- a/backend/libbackend/api.ml
+++ b/backend/libbackend/api.ml
@@ -24,7 +24,7 @@ type execute_function_rpc_params =
   { tlid : tlid
   ; trace_id : RuntimeT.uuid
   ; caller_id : id
-  ; args : RuntimeT.dval list
+  ; args : RuntimeT.expr RuntimeT.dval list
   ; fnname : string }
 [@@deriving yojson]
 
@@ -44,7 +44,7 @@ let to_upload_function_rpc_params (payload : string) :
 type trigger_handler_rpc_params =
   { tlid : tlid
   ; trace_id : RuntimeT.uuid
-  ; input : input_vars }
+  ; input : RuntimeT.expr input_vars }
 [@@deriving yojson]
 
 type route_params =
@@ -154,7 +154,7 @@ let functions ~username =
   |> List.filter ~f:(fun (k, _) ->
          Account.can_access_operations username
          || not (String.is_prefix ~prefix:"DarkInternal::" k))
-  |> List.map ~f:(fun (k, (v : RuntimeT.fn)) ->
+  |> List.map ~f:(fun (k, (v : RuntimeT.expr RuntimeT.fn)) ->
          { name = k
          ; parameters =
              List.map

--- a/backend/libbackend/canvas.ml
+++ b/backend/libbackend/canvas.ml
@@ -22,7 +22,7 @@ type 'expr_type canvas =
   ; dbs : 'expr_type TL.toplevels
   ; user_functions : 'expr_type RTT.user_fn IDMap.t
   ; user_tipes : RTT.user_tipe IDMap.t
-  ; package_fns : RTT.fn list [@opaque]
+  ; package_fns : 'expr_type RTT.fn list [@opaque]
   ; deleted_handlers : 'expr_type TL.toplevels
   ; deleted_dbs : 'expr_type TL.toplevels
   ; deleted_user_functions : 'expr_type RTT.user_fn IDMap.t
@@ -38,7 +38,7 @@ let to_fluid (c : RTT.expr canvas) : Types.fluid_expr canvas =
   ; id = c.id
   ; creation_date = c.creation_date
   ; cors_setting = c.cors_setting
-  ; package_fns = c.package_fns
+  ; package_fns = List.map ~f:Toplevel.fn_to_fluid c.package_fns
   ; ops =
       List.map c.ops ~f:(fun (tlid, oplist) ->
           (tlid, Op.oplist_to_fluid oplist))
@@ -63,7 +63,7 @@ let of_fluid (c : Types.fluid_expr canvas) : RTT.expr canvas =
   ; id = c.id
   ; creation_date = c.creation_date
   ; cors_setting = c.cors_setting
-  ; package_fns = c.package_fns
+  ; package_fns = List.map ~f:Toplevel.fn_of_fluid c.package_fns
   ; ops =
       List.map c.ops ~f:(fun (tlid, oplist) ->
           (tlid, Op.oplist_of_fluid oplist))
@@ -451,7 +451,7 @@ let id_for_name (name : string) : Uuidm.t =
 
 let update_cors_setting
     (c : 'expr_type canvas ref) (setting : cors_setting option) : unit =
-  let cors_setting_to_db (setting : cors_setting option) : Db.param =
+  let cors_setting_to_db (setting : cors_setting option) : 'expr_type Db.param =
     match setting with
     | None ->
         Db.Null
@@ -671,7 +671,7 @@ let load_tlids_with_context_from_cache ~tlids host :
   load_from_cache ~tlids host owner
 
 
-let load_for_event_from_cache (event : Event_queue.t) :
+let load_for_event_from_cache (event : RTT.expr Event_queue.t) :
     (RTT.expr canvas ref, string list) Result.t =
   let owner = Account.for_host_exn event.host in
   let canvas_id = Serialize.fetch_canvas_id owner event.host in

--- a/backend/libbackend/db.ml
+++ b/backend/libbackend/db.ml
@@ -25,7 +25,7 @@ let date_to_sqlstring (d : Core_kernel.Time.t) : string =
   Core.Time.format d "%Y-%m-%d %H:%M:%S" ~zone:Core.Time.Zone.utc
 
 
-type param =
+type 'expr_type param =
   | Int of int
   | Int63 of Int63.t
   | ID of Types.id
@@ -35,13 +35,13 @@ type param =
   | Binary of string
   (* only works for passed params *)
   | Secret of string
-  | RoundtrippableDval of Types.RuntimeT.dval
-  | RoundtrippableDvalmap of Types.RuntimeT.dval_map
-  | QueryableDval of Types.RuntimeT.dval
-  | QueryableDvalmap of Types.RuntimeT.dval_map
+  | RoundtrippableDval of 'expr_type Types.RuntimeT.dval
+  | RoundtrippableDvalmap of 'expr_type Types.RuntimeT.dval_map
+  | QueryableDval of 'expr_type Types.RuntimeT.dval
+  | QueryableDvalmap of 'expr_type Types.RuntimeT.dval_map
   | Time of Types.RuntimeT.time
   | Null
-  | List of param list
+  | List of 'expr_type param list
   | Bool of bool
 [@@deriving show]
 
@@ -55,7 +55,7 @@ let to_binary_bool param : bool =
   match param with Binary _ -> true | _ -> false
 
 
-let rec escape (param : param) : string =
+let rec escape (param : 'expr_type param) : string =
   match param with
   | Int i ->
       string_of_int i
@@ -358,7 +358,7 @@ let iter_with_cursor
 (* SQL Commands *)
 (* ------------------------- *)
 let run
-    ~(params : param list)
+    ~(params : 'expr_type param list)
     ?(result = TextResult)
     ~(name : string)
     ?subject
@@ -393,7 +393,7 @@ let transaction ~(name : string) (f : unit -> unit) : unit =
 
 
 let delete
-    ~(params : param list)
+    ~(params : 'expr_type param list)
     ?(result = TextResult)
     ~(name : string)
     ?subject
@@ -410,7 +410,7 @@ let delete
 
 
 let fetch
-    ~(params : param list)
+    ~(params : 'expr_type param list)
     ?(result = TextResult)
     ~(name : string)
     ?subject
@@ -430,7 +430,7 @@ let fetch
 
 
 let fetch_one
-    ~(params : param list)
+    ~(params : 'expr_type param list)
     ?(result = TextResult)
     ~(name : string)
     ?subject
@@ -456,7 +456,7 @@ let fetch_one
 
 
 let fetch_one_option
-    ~(params : param list)
+    ~(params : 'expr_type param list)
     ?(result = TextResult)
     ~(name : string)
     ?subject
@@ -481,7 +481,8 @@ let fetch_one_option
           Exception.storage "Expected exactly one result, got many")
 
 
-let exists ~(params : param list) ~(name : string) ?subject (sql : string) :
+let exists
+    ~(params : 'expr_type param list) ~(name : string) ?subject (sql : string) :
     bool =
   execute
     ~op:"exists"

--- a/backend/libbackend/db.mli
+++ b/backend/libbackend/db.mli
@@ -3,7 +3,7 @@ open Libexecution
 
 (* Low-level API *)
 
-type param =
+type 'expr_type param =
   | Int of int
   | Int63 of Int63.t
   | ID of Types.id
@@ -13,14 +13,14 @@ type param =
   | Binary of string
   (* only works for passed params *)
   | Secret of string
-  | RoundtrippableDval of Types.RuntimeT.dval
-  | RoundtrippableDvalmap of Types.RuntimeT.dval_map
+  | RoundtrippableDval of 'expr_type Types.RuntimeT.dval
+  | RoundtrippableDvalmap of 'expr_type Types.RuntimeT.dval_map
   (* Queryable are stored as jsonb so that they can be queried. *)
-  | QueryableDval of Types.RuntimeT.dval
-  | QueryableDvalmap of Types.RuntimeT.dval_map
+  | QueryableDval of 'expr_type Types.RuntimeT.dval
+  | QueryableDvalmap of 'expr_type Types.RuntimeT.dval_map
   | Time of Types.RuntimeT.time
   | Null
-  | List of param list
+  | List of 'expr_type param list
   | Bool of bool
 [@@deriving show]
 
@@ -36,7 +36,7 @@ type result =
 (* NOTE: run is not allowed to receive multiple commands. If you
  * want multiple statements, use [transaction] *)
 val run :
-     params:param list
+     params:'expr_type param list
   -> ?result:result
   -> name:string
   -> ?subject:string
@@ -46,7 +46,7 @@ val run :
 val transaction : name:string -> (unit -> unit) -> unit
 
 val delete :
-     params:param list
+     params:'expr_type param list
   -> ?result:result
   -> name:string
   -> ?subject:string
@@ -54,7 +54,7 @@ val delete :
   -> int
 
 val fetch :
-     params:param list
+     params:'expr_type param list
   -> ?result:result
   -> name:string
   -> ?subject:string
@@ -62,7 +62,7 @@ val fetch :
   -> string list list
 
 val fetch_one :
-     params:param list
+     params:'expr_type param list
   -> ?result:result
   -> name:string
   -> ?subject:string
@@ -70,7 +70,7 @@ val fetch_one :
   -> string list
 
 val fetch_one_option :
-     params:param list
+     params:'expr_type param list
   -> ?result:result
   -> name:string
   -> ?subject:string
@@ -79,19 +79,23 @@ val fetch_one_option :
 
 val iter_with_cursor :
      name:string
-  -> params:param list
+  -> params:'expr_type param list
   -> ?result:result
   -> f:(string list -> unit)
   -> string
   -> unit
 
 val exists :
-  params:param list -> name:string -> ?subject:string -> string -> bool
+     params:'expr_type param list
+  -> name:string
+  -> ?subject:string
+  -> string
+  -> bool
 
 (* Occasionally, we're trying to do something dynamic, or maybe multiple
  * things in a single sql statement and then the above statements don't
  * work, so we need to escape manually *)
-val escape : param -> string
+val escape : 'expr_type param -> string
 
 val escape_string : string -> string
 

--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -6,9 +6,9 @@ open Libcommon
 
 type transaction = id
 
-type t =
+type 'expr_type t =
   { id : int
-  ; value : dval
+  ; value : 'expr_type dval
   ; retries : int
   ; canvas_id : Uuidm.t
   ; host : string
@@ -170,7 +170,7 @@ let enqueue
     (space : string)
     (name : string)
     (modifier : string)
-    (data : dval) : unit =
+    (data : 'expr_type dval) : unit =
   log_queue_size Enqueue (canvas_id |> Uuidm.to_string) space name modifier ;
   Db.run
     ~name:"enqueue"
@@ -187,7 +187,7 @@ let enqueue
       ; RoundtrippableDval data ]
 
 
-let dequeue transaction : t option =
+let dequeue transaction : expr t option =
   let fetched =
     Db.fetch_one_option
       ~name:"dequeue_fetch"
@@ -392,7 +392,7 @@ let with_transaction f =
   result
 
 
-let put_back transaction (item : t) ~status : unit =
+let put_back transaction (item : 'expr_type t) ~status : unit =
   let show_status s =
     match s with `OK -> "Ok" | `Err -> "Err" | `Incomplete -> "Incomplete"
   in
@@ -440,4 +440,5 @@ let put_back transaction (item : t) ~status : unit =
         ~params:[Int item.id]
 
 
-let finish transaction (item : t) : unit = put_back transaction ~status:`OK item
+let finish transaction (item : 'expr_type t) : unit =
+  put_back transaction ~status:`OK item

--- a/backend/libbackend/event_queue.mli
+++ b/backend/libbackend/event_queue.mli
@@ -7,9 +7,9 @@ open Types
  * passing a variable that'll unify *)
 type transaction
 
-type t =
+type 'expr_type t =
   { id : int
-  ; value : RuntimeT.dval
+  ; value : 'expr_type RuntimeT.dval
   ; retries : int
   ; canvas_id : Uuidm.t
   ; host : string
@@ -17,7 +17,7 @@ type t =
   ; name : string
   ; modifier : string }
 
-val to_event_desc : t -> Stored_event.event_desc
+val to_event_desc : 'expr_type t -> Stored_event.event_desc
 
 val enqueue :
      account_id:Uuidm.t
@@ -25,18 +25,20 @@ val enqueue :
   -> string
   -> string
   -> string
-  -> RuntimeT.dval
+  -> 'expr_type RuntimeT.dval
   -> unit
 
 val with_transaction :
-     (transaction -> (RuntimeT.dval option, Exception.captured) Result.t)
-  -> (RuntimeT.dval option, Exception.captured) Result.t
+     (   transaction
+      -> ('expr_type RuntimeT.dval option, Exception.captured) Result.t)
+  -> ('expr_type RuntimeT.dval option, Exception.captured) Result.t
 
-val dequeue : transaction -> t option
+val dequeue : transaction -> RuntimeT.expr t option
 
-val put_back : transaction -> t -> status:[`OK | `Err | `Incomplete] -> unit
+val put_back :
+  transaction -> 'expr_type t -> status:[`OK | `Err | `Incomplete] -> unit
 
-val finish : transaction -> t -> unit
+val finish : transaction -> 'expr_type t -> unit
 
 val schedule_all : unit -> unit
 
@@ -57,7 +59,7 @@ module Scheduling_rule : sig
 
   val rule_type_to_string : rule_type -> string
 
-  val to_dval : t -> dval
+  val to_dval : t -> 'expr_type dval
 end
 
 module Worker_states : sig

--- a/backend/libbackend/legacy.ml
+++ b/backend/libbackend/legacy.ml
@@ -750,10 +750,10 @@ module LibhttpclientV0 = struct
   let send_request
       (uri : string)
       (verb : Httpclient.verb)
-      (json_fn : dval -> string)
-      (body : dval)
-      (query : dval)
-      (headers : dval) : dval =
+      (json_fn : 'expr_type dval -> string)
+      (body : 'expr_type dval)
+      (query : 'expr_type dval)
+      (headers : 'expr_type dval) : 'expr_type dval =
     let query = Dval.dval_to_query query in
     let headers = Dval.to_string_pairs_exn headers in
     let body =
@@ -822,10 +822,10 @@ module LibhttpclientV0 = struct
   let wrapped_send_request
       (uri : string)
       (verb : Httpclient.verb)
-      (json_fn : dval -> string)
-      (body : dval)
-      (query : dval)
-      (headers : dval) : dval =
+      (json_fn : 'expr_type dval -> string)
+      (body : 'expr_type dval)
+      (query : 'expr_type dval)
+      (headers : 'expr_type dval) : 'expr_type dval =
     Libcommon.Log.inspecT "uri" uri ;
     Libcommon.Log.inspecT "body" body ;
     Libcommon.Log.inspecT "query" query ;
@@ -894,10 +894,10 @@ module LibhttpclientV1 = struct
   let send_request
       (uri : string)
       (verb : Httpclient.verb)
-      (json_fn : dval -> string)
-      (body : dval)
-      (query : dval)
-      (headers : dval) : dval =
+      (json_fn : 'expr_type dval -> string)
+      (body : 'expr_type dval)
+      (query : 'expr_type dval)
+      (headers : 'expr_type dval) : 'expr_type dval =
     let query = Dval.dval_to_query query in
     let headers = Dval.to_string_pairs_exn headers in
     let body =
@@ -1024,10 +1024,10 @@ module LibhttpclientV2 = struct
   let send_request
       (uri : string)
       (verb : Httpclient.verb)
-      (json_fn : dval -> string)
-      (body : dval)
-      (query : dval)
-      (headers : dval) : dval =
+      (json_fn : 'expr_type dval -> string)
+      (body : 'expr_type dval)
+      (query : 'expr_type dval)
+      (headers : 'expr_type dval) : 'expr_type dval =
     let query = Dval.dval_to_query query in
     let headers = Dval.to_string_pairs_exn headers in
     let body =

--- a/backend/libbackend/legacy.mli
+++ b/backend/libbackend/legacy.mli
@@ -69,42 +69,43 @@ end
  * throw an exception on a non-2xx error code, or
  * those that simply wrap the exception in a Result *)
 module LibhttpclientV0 : sig
-  val call : Httpclient.verb -> (dval -> string) -> funcimpl
+  val call : Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 
-  val call_no_body : Httpclient.verb -> (dval -> string) -> funcimpl
+  val call_no_body : Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 
   val wrapped_send_request :
        string
     -> Httpclient.verb
-    -> (dval -> string)
-    -> dval
-    -> dval
-    -> dval
-    -> dval
+    -> (expr dval -> string)
+    -> expr_dval
+    -> expr_dval
+    -> expr_dval
+    -> expr_dval
 
-  val wrapped_call : Httpclient.verb -> (dval -> string) -> funcimpl
+  val wrapped_call : Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 
-  val wrapped_call_no_body : Httpclient.verb -> (dval -> string) -> funcimpl
+  val wrapped_call_no_body :
+    Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 end
 
 (*These functions call the bugged HttpclientV1 impls *)
 module LibhttpclientV1 : sig
-  val call : Httpclient.verb -> (dval -> string) -> funcimpl
+  val call : Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 
-  val call_no_body : Httpclient.verb -> (dval -> string) -> funcimpl
+  val call_no_body : Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 end
 
 module LibhttpclientV2 : sig
   val send_request :
        string
     -> Httpclient.verb
-    -> (dval -> string)
-    -> dval
-    -> dval
-    -> dval
-    -> dval
+    -> (expr_dval -> string)
+    -> expr_dval
+    -> expr_dval
+    -> expr_dval
+    -> expr_dval
 
-  val call : Httpclient.verb -> (dval -> string) -> funcimpl
+  val call : Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 
-  val call_no_body : Httpclient.verb -> (dval -> string) -> funcimpl
+  val call_no_body : Httpclient.verb -> (expr_dval -> string) -> expr funcimpl
 end

--- a/backend/libbackend/libcrypto.ml
+++ b/backend/libbackend/libcrypto.ml
@@ -13,7 +13,7 @@ let digest_to_bytes (digest : Nocrypto.Hash.digest) :
   bytes
 
 
-let fns : fn list =
+let fns : expr fn list =
   [ (* ====================================== *)
     (* Password *)
     (* ====================================== *)

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -9,7 +9,7 @@ module Unicode = Libexecution.Unicode_string
 
 (* Apply this to function to wrap that function in an InProcess that checks
  * permissions for the dark internal functions and logs status. *)
-let internal_fn (f : exec_state * dval list -> dval) =
+let internal_fn (f : expr exec_state * expr dval list -> expr dval) =
   InProcess
     (fun (es, params) ->
       match es.account_id |> Account.username_of_id with
@@ -50,7 +50,7 @@ let modify_schedule fn =
           fail args)
 
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["DarkInternal::checkAccess"]
     ; infix_names = []
     ; parameters = []
@@ -595,7 +595,7 @@ that's already taken, returns an error."
         internal_fn (function
             | _, [DStr host] ->
                 let cors_setting_to_dval (setting : Canvas.cors_setting option)
-                    : dval =
+                    : expr dval =
                   match setting with
                   | None ->
                       DOption OptNothing
@@ -627,7 +627,7 @@ that's already taken, returns an error."
     ; func =
         internal_fn (function
             | _, [DStr host; DOption s] ->
-                let cors_setting (opt : optionT) :
+                let cors_setting (opt : expr optionT) :
                     (Canvas.cors_setting option, string) result =
                   (* Error: error converting the dval to a cors setting.
                    * Ok None: the dval is "unset the cors value"

--- a/backend/libbackend/libdb.ml
+++ b/backend/libbackend/libdb.ml
@@ -4,7 +4,7 @@ open Lib
 open Runtime
 open Types.RuntimeT
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["DB::insert"]
     ; infix_names = []
     ; parameters = [par "val" TObj; par "table" TDB]

--- a/backend/libbackend/libdb2.ml
+++ b/backend/libbackend/libdb2.ml
@@ -8,7 +8,7 @@ module Unicode_string = Libexecution.Unicode_string
 
 let find_db = Libexecution.Ast.find_db
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["DB::set_v1"]
     ; infix_names = []
     ; parameters = [par "val" TObj; par "key" TStr; par "table" TDB]

--- a/backend/libbackend/libevent.ml
+++ b/backend/libbackend/libevent.ml
@@ -4,7 +4,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["emit"]
     ; infix_names = []
     ; parameters = [par "Data" TAny; par "Space" TStr; par "Name" TStr]

--- a/backend/libbackend/libhttpclient.ml
+++ b/backend/libbackend/libhttpclient.ml
@@ -45,7 +45,7 @@ let with_default_content_type ~(ct : string) (headers : headers) : headers =
  * the `Content-Type` header provided by the user in [headers] to make ~magic~ decisions about
  * how to encode said body. Returns a tuple of the encoded body, and the passed headers that
  * have potentially had a Content-Type added to them based on the magic decision we've made. *)
-let encode_request_body (headers : headers) (body : dval option) :
+let encode_request_body (headers : headers) (body : 'expr_type dval option) :
     string option * headers =
   match body with
   | Some dv ->
@@ -95,9 +95,9 @@ let encode_request_body (headers : headers) (body : dval option) :
 let send_request
     (uri : string)
     (verb : Httpclient.verb)
-    (request_body : dval option)
-    (query : dval)
-    (request_headers : dval) : dval =
+    (request_body : 'expr_type dval option)
+    (query : 'expr_type dval)
+    (request_headers : 'expr_type dval) : 'expr_type dval =
   let raw_response_body, raw_response_headers, response_code =
     let encoded_query = Dval.dval_to_query query in
     let encoded_request_headers = Dval.to_string_pairs_exn request_headers in
@@ -222,7 +222,7 @@ let call_no_body verb =
         fail args)
 
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["HttpClient::post"]
     ; infix_names = []
     ; parameters = params

--- a/backend/libbackend/libjwt.ml
+++ b/backend/libbackend/libjwt.ml
@@ -120,7 +120,7 @@ let verify_and_extract_v1 ~(key : Rsa.pub) ~(token : string) :
       Error "Invalid token format"
 
 
-let handle_error (fn : unit -> dval) =
+let handle_error (fn : unit -> expr dval) =
   try DResult (ResOk (fn ()))
   with Invalid_argument msg ->
     let msg =

--- a/backend/libbackend/libstaticassets.ml
+++ b/backend/libbackend/libstaticassets.ml
@@ -6,7 +6,7 @@ open Libexecution.Lib
 module Unicode_string = Libexecution.Unicode_string
 module Dval = Libexecution.Dval
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["StaticAssets::baseUrlFor"]
     ; infix_names = []
     ; parameters = [par "deploy_hash" TStr]

--- a/backend/libbackend/libtwilio.ml
+++ b/backend/libbackend/libtwilio.ml
@@ -3,7 +3,7 @@ open Libexecution.Lib
 open Libexecution.Runtime
 open Libexecution.Types.RuntimeT
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Twilio::sendText"]
     ; infix_names = []
     ; parameters =

--- a/backend/libbackend/libtwitter.ml
+++ b/backend/libbackend/libtwitter.ml
@@ -4,7 +4,8 @@ open Libexecution.Types
 open Libexecution.Types.RuntimeT
 module Dval = Libexecution.Dval
 
-let call (endpoint : string) (verb : string) (args : dval_map) : dval =
+let call (endpoint : string) (verb : string) (args : 'expr_type dval_map) :
+    'expr_type dval =
   let prefix = "https://api.twitter.com" in
   let url = prefix ^ endpoint in
   let auth : Twitter.auth =
@@ -113,7 +114,7 @@ let auth_param : param =
   }
 
 
-let fns =
+let fns : expr fn list =
   schema.apis
   |> List.filter ~f:(fun (api : Swagger.api) ->
          (* There are a bunch of apis that have "{id}" or "{format}" in their

--- a/backend/libbackend/libx509.ml
+++ b/backend/libbackend/libx509.ml
@@ -3,7 +3,7 @@ open Libexecution
 open Libexecution.Lib
 module U = Libexecution.Unicode_string
 
-let fns : Types.RuntimeT.fn list =
+let fns : Types.RuntimeT.expr Types.RuntimeT.fn list =
   [ { prefix_names = ["X509::pemCertificatePublicKey"]
     ; infix_names = []
     ; parameters = [par "pemCert" TStr]

--- a/backend/libbackend/package_manager.ml
+++ b/backend/libbackend/package_manager.ml
@@ -415,7 +415,7 @@ let all_functions () : fn list =
   functions
 
 
-let runtime_fn_of_package_fn (fn : fn) : RuntimeT.fn =
+let runtime_fn_of_package_fn (fn : fn) : RuntimeT.expr RuntimeT.fn =
   ( { prefix_names = [to_name fn]
     ; infix_names = []
     ; parameters = fn.parameters |> List.map ~f:runtime_param_of_parameter
@@ -424,7 +424,7 @@ let runtime_fn_of_package_fn (fn : fn) : RuntimeT.fn =
     ; func = PackageFunction fn.body
     ; preview_safety = Unsafe
     ; deprecated = fn.deprecated }
-    : RuntimeT.fn )
+    : RuntimeT.expr RuntimeT.fn )
 
 
 let to_get_packages_rpc_result packages : string =

--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -7,7 +7,7 @@ module C = Canvas
 module TL = Toplevel
 
 let dequeue_and_process execution_id :
-    (RTT.dval option, Exception.captured) Result.t =
+    (RTT.expr RTT.dval option, Exception.captured) Result.t =
   Event_queue.with_transaction (fun transaction ->
       let event =
         try Ok (Event_queue.dequeue transaction)
@@ -139,7 +139,7 @@ let dequeue_and_process execution_id :
                                     ~canvas_id
                                     trace_id
                                     (h.tlid :: touched_tlids) ;
-                                  let result_tipe (r : RTT.dval) =
+                                  let result_tipe (r : RTT.expr RTT.dval) =
                                     match r with
                                     | DResult (ResOk _) ->
                                         "ResOk"
@@ -185,7 +185,7 @@ exception in Event_queue.put_back"
 
 
 let run (execution_id : Types.id) :
-    (RTT.dval option, Exception.captured) Result.t =
+    (RTT.expr RTT.dval option, Exception.captured) Result.t =
   if String.Caseless.equal
        Libservice.Config.postgres_settings.dbname
        "prodclone"

--- a/backend/libbackend/queue_worker.mli
+++ b/backend/libbackend/queue_worker.mli
@@ -1,4 +1,8 @@
 open Core_kernel
 open Libexecution
 
-val run : Types.id -> (Types.RuntimeT.dval option, Exception.captured) Result.t
+val run :
+     Types.id
+  -> ( Types.RuntimeT.expr Types.RuntimeT.dval option
+     , Exception.captured )
+     Result.t

--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -365,8 +365,8 @@ let fetch_relevant_tlids_for_execution ~host ~canvas_id () : Types.tlid list =
              Exception.internal "Shape of per_tlid oplists")
 
 
-let fetch_relevant_tlids_for_event ~(event : Event_queue.t) ~canvas_id () :
-    Types.tlid list =
+let fetch_relevant_tlids_for_event
+    ~(event : RTT.expr Event_queue.t) ~canvas_id () : Types.tlid list =
   Db.fetch
     ~name:"fetch_relevant_tlids_for_event"
     "SELECT tlid FROM toplevel_oplists

--- a/backend/libbackend/sql_compiler.ml
+++ b/backend/libbackend/sql_compiler.ml
@@ -143,7 +143,7 @@ let rec canonicalize expr =
       Ast.deprecated_traverse ~f:canonicalize expr
 
 
-let dval_to_sql (dval : dval) : string =
+let dval_to_sql (dval : expr dval) : string =
   match dval with
   | DObj _
   | DList _
@@ -187,7 +187,8 @@ let dval_to_sql (dval : dval) : string =
 (* TODO: support characters, floats, dates, and uuids. And maybe lists and
  * bytes. Probably something can be done with options and results. *)
 
-let typecheckDval (name : string) (dval : dval) (expected_tipe : tipe_) : unit =
+let typecheckDval (name : string) (dval : expr dval) (expected_tipe : tipe_) :
+    unit =
   if Dval.tipe_of dval = expected_tipe || expected_tipe = TAny
   then ()
   else
@@ -276,7 +277,7 @@ let rec inline
 (* Generate SQL from an Expr. This expects that all the hard stuff has been
  * removed by previous passes, and should only be called as the final pass. *)
 let rec lambda_to_sql
-    (symtable : dval_map)
+    (symtable : expr dval_map)
     (paramName : string)
     (dbFields : tipe_ Prelude.StrDict.t)
     (expected_tipe : tipe_)
@@ -374,10 +375,10 @@ let rec lambda_to_sql
  * Expects inlining to have finished first, so that it has all the values it
  * needs in the right place. *)
 let partially_evaluate
-    (state : exec_state)
+    (state : expr exec_state)
     (param_name : string)
-    (symtable : dval_map)
-    (body : expr) : dval_map * expr =
+    (symtable : expr dval_map)
+    (body : expr) : expr dval_map * expr =
   (* This isn't really a good implementation, but right now we only do
    * straight-line code here, so it should work *)
   let symtable = ref symtable in
@@ -414,8 +415,8 @@ let partially_evaluate
 
 
 let compile_lambda
-    ~(state : exec_state)
-    (symtable : dval_map)
+    ~(state : expr exec_state)
+    (symtable : expr dval_map)
     (param_name : string)
     (db_fields : tipe_ Prelude.StrDict.t)
     (body : expr) : string =

--- a/backend/libbackend/stored_event.ml
+++ b/backend/libbackend/stored_event.ml
@@ -19,7 +19,7 @@ let store_event
     ~(trace_id : Uuidm.t)
     ~(canvas_id : Uuidm.t)
     ((module_, path, modifier) : event_desc)
-    (event : RTT.dval) : RTT.time =
+    (event : RTT.expr RTT.dval) : RTT.time =
   Db.fetch_one
     ~name:"stored_event.store_event"
     ~subject:(event_subject module_ path modifier)
@@ -81,7 +81,7 @@ let list_events ~(limit : [`All | `Since of RTT.time]) ~(canvas_id : Uuidm.t) ()
 
 
 let load_events ~(canvas_id : Uuidm.t) ((module_, route, modifier) : event_desc)
-    : (string * Uuidm.t * RTT.time * RTT.dval) list =
+    : (string * Uuidm.t * RTT.time * RTT.expr RTT.dval) list =
   let route = Http.route_to_postgres_pattern route in
   Db.fetch
     ~name:"load_events"
@@ -106,7 +106,7 @@ let load_events ~(canvas_id : Uuidm.t) ((module_, route, modifier) : event_desc)
 
 
 let load_event_for_trace ~(canvas_id : Uuidm.t) (trace_id : Uuidm.t) :
-    (string * RTT.time * RTT.dval) option =
+    (string * RTT.time * RTT.expr RTT.dval) option =
   Db.fetch
     ~name:"load_event_for_trace"
     ~subject:(Uuidm.to_string trace_id)

--- a/backend/libbackend/stored_event.mli
+++ b/backend/libbackend/stored_event.mli
@@ -17,18 +17,23 @@ val store_event :
      trace_id:Uuidm.t
   -> canvas_id:Uuidm.t
   -> event_desc
-  -> Types.RuntimeT.dval
+  -> Types.RuntimeT.expr Types.RuntimeT.dval
   -> Types.RuntimeT.time
 
 val load_event_for_trace :
      canvas_id:Uuidm.t
   -> Uuidm.t
-  -> (string * Types.RuntimeT.time * Types.RuntimeT.dval) option
+  -> (string * Types.RuntimeT.time * Types.RuntimeT.expr Types.RuntimeT.dval)
+     option
 
 val load_events :
      canvas_id:Uuidm.t
   -> event_desc
-  -> (string * Uuidm.t * Types.RuntimeT.time * Types.RuntimeT.dval) list
+  -> ( string
+     * Uuidm.t
+     * Types.RuntimeT.time
+     * Types.RuntimeT.expr Types.RuntimeT.dval )
+     list
 
 val load_event_ids : canvas_id:Uuidm.t -> event_desc -> (Uuidm.t * string) list
 

--- a/backend/libbackend/stored_function_arguments.ml
+++ b/backend/libbackend/stored_function_arguments.ml
@@ -17,7 +17,7 @@ let store ~canvas_id ~trace_id tlid args =
 
 
 let load_for_analysis ~canvas_id tlid (trace_id : Uuidm.t) :
-    (Analysis_types.input_vars * RTT.time) option =
+    (RTT.expr Analysis_types.input_vars * RTT.time) option =
   (* We need to alias the subquery (here aliased as `q`) because Postgres
    * requires inner SELECTs to be aliased. *)
   Db.fetch

--- a/backend/libbackend/stored_function_arguments.mli
+++ b/backend/libbackend/stored_function_arguments.mli
@@ -5,14 +5,15 @@ val store :
      canvas_id:Uuidm.t
   -> trace_id:Uuidm.t
   -> Types.tlid
-  -> Types.RuntimeT.dval_map
+  -> Types.RuntimeT.expr Types.RuntimeT.dval_map
   -> unit
 
 val load_for_analysis :
      canvas_id:Uuidm.t
   -> Types.tlid
   -> Uuidm.t
-  -> (Analysis_types.input_vars * Types.RuntimeT.time) option
+  -> (Types.RuntimeT.expr Analysis_types.input_vars * Types.RuntimeT.time)
+     option
 
 val load_traceids : canvas_id:Uuidm.t -> Types.tlid -> Uuidm.t list
 

--- a/backend/libbackend/stored_function_result.ml
+++ b/backend/libbackend/stored_function_result.ml
@@ -25,7 +25,7 @@ let store ~canvas_id ~trace_id (tlid, fnname, id) arglist result =
       ; RoundtrippableDval result ]
 
 
-let load ~canvas_id ~trace_id tlid : function_result list =
+let load ~canvas_id ~trace_id tlid : RTT.expr function_result list =
   (* Right now, we don't allow the user to see multiple results when a function
    * is called in a loop. But, there's a lot of data when functions are called
    * in a loop, so avoid massive responses. *)

--- a/backend/libbackend/stored_function_result.mli
+++ b/backend/libbackend/stored_function_result.mli
@@ -5,15 +5,15 @@ val store :
      canvas_id:Uuidm.t
   -> trace_id:Uuidm.t
   -> Types.RuntimeT.function_desc
-  -> Types.RuntimeT.dval list
-  -> Types.RuntimeT.dval
+  -> Types.RuntimeT.expr Types.RuntimeT.dval list
+  -> Types.RuntimeT.expr Types.RuntimeT.dval
   -> unit
 
 val load :
      canvas_id:Uuidm.t
   -> trace_id:Uuidm.t
   -> Types.tlid
-  -> Analysis_types.function_result list
+  -> Types.RuntimeT.expr Analysis_types.function_result list
 
 val trim_results : unit -> int
 

--- a/backend/libbackend/user_db.ml
+++ b/backend/libbackend/user_db.ml
@@ -45,7 +45,8 @@ let cols_for (db : 'expr_type db) : (string * tipe) list =
              None)
 
 
-let rec query_exact_fields ~state db query_obj : (string * dval) list =
+let rec query_exact_fields ~state db query_obj : (string * 'expr_type dval) list
+    =
   let sql =
     "SELECT key, data
      FROM user_data
@@ -76,7 +77,7 @@ let rec query_exact_fields ~state db query_obj : (string * dval) list =
 and
     (* PG returns lists of strings. This converts them to types using the
  * row info provided *)
-    to_obj db (db_strings : string list) : dval =
+    to_obj db (db_strings : string list) : 'expr_type dval =
   match db_strings with
   | [obj] ->
       let p_obj =
@@ -119,7 +120,7 @@ and
 
 
 (* TODO: Unify with Type_checker.ml *)
-and type_check db (obj : dval_map) : dval_map =
+and type_check db (obj : 'expr_type dval_map) : 'expr_type dval_map =
   let cols = cols_for db |> TipeMap.of_alist_exn in
   let tipe_keys = cols |> TipeMap.keys |> String.Set.of_list in
   let obj_keys = obj |> DvalMap.keys |> String.Set.of_list in
@@ -182,8 +183,12 @@ and type_check db (obj : dval_map) : dval_map =
           "Type checker error! Deduced expected and actual did not unify, but could not find any examples!"
 
 
-and set ~state ~upsert (db : 'expr_type db) (key : string) (vals : dval_map) :
-    Uuidm.t =
+and set
+    ~state
+    ~upsert
+    (db : 'expr_type db)
+    (key : string)
+    (vals : 'expr_type dval_map) : Uuidm.t =
   let id = Util.create_uuid () in
   let merged = type_check db vals in
   let query =
@@ -212,7 +217,8 @@ and set ~state ~upsert (db : 'expr_type db) (key : string) (vals : dval_map) :
   id
 
 
-and get_option ~state (db : 'expr_type db) (key : string) : dval option =
+and get_option ~state (db : 'expr_type db) (key : string) :
+    'expr_type dval option =
   Db.fetch_one_option
     ~name:"get"
     "SELECT data
@@ -234,7 +240,7 @@ and get_option ~state (db : 'expr_type db) (key : string) : dval option =
 
 
 and get_many ~state (db : 'expr_type db) (keys : string list) :
-    (string * dval) list =
+    (string * 'expr_type dval) list =
   Db.fetch
     ~name:"get_many"
     "SELECT key, data
@@ -263,7 +269,7 @@ and get_many ~state (db : 'expr_type db) (keys : string list) :
 
 
 and get_many_with_keys ~state (db : 'expr_type db) (keys : string list) :
-    (string * dval) list =
+    (string * 'expr_type dval) list =
   Db.fetch
     ~name:"get_many_with_keys"
     "SELECT key, data
@@ -291,7 +297,7 @@ and get_many_with_keys ~state (db : 'expr_type db) (keys : string list) :
              Exception.internal "bad format received in get_many_with_keys")
 
 
-let get_all ~state (db : 'expr_type db) : (string * dval) list =
+let get_all ~state (db : 'expr_type db) : (string * 'expr_type dval) list =
   Db.fetch
     ~name:"get_all"
     "SELECT key, data
@@ -324,7 +330,8 @@ let get_db_fields (db : 'expr_type db) : (string * tipe_) list =
           None)
 
 
-let query ~state (db : 'expr_type db) (b : dblock_args) : (string * dval) list =
+let query ~state (db : expr db) (b : expr dblock_args) :
+    (string * expr dval) list =
   let db_fields = Tablecloth.StrDict.from_list (get_db_fields db) in
   let param_name =
     match b.params with
@@ -457,7 +464,7 @@ let delete_all ~state (db : 'expr_type db) =
 (* stats/locked/unlocked (not _locking_) *)
 (* ------------------------- *)
 let stats_pluck ~account_id ~canvas_id (db : 'expr_type db) :
-    (dval * string) option =
+    ('expr_type dval * string) option =
   let latest =
     Db.fetch
       ~name:"stats_pluck"

--- a/backend/libbackend/user_db.mli
+++ b/backend/libbackend/user_db.mli
@@ -8,36 +8,56 @@ val cols_for : 'expr_type DbT.db -> (string * tipe) list
 
 (* DB runtime functions *)
 val set :
-     state:exec_state
+     state:'expr_type exec_state
   -> upsert:bool
   -> 'expr_type DbT.db
   -> string
-  -> dval_map
+  -> 'expr_type dval_map
   -> Uuidm.t
 
-val get_option : state:exec_state -> 'expr_type DbT.db -> string -> dval option
+val get_option :
+     state:'expr_type exec_state
+  -> 'expr_type DbT.db
+  -> string
+  -> 'expr_type dval option
 
 val get_many :
-  state:exec_state -> 'expr_type DbT.db -> string list -> (string * dval) list
+     state:'expr_type exec_state
+  -> 'expr_type DbT.db
+  -> string list
+  -> (string * 'expr_type dval) list
 
 val get_many_with_keys :
-  state:exec_state -> 'expr_type DbT.db -> string list -> (string * dval) list
+     state:'expr_type exec_state
+  -> 'expr_type DbT.db
+  -> string list
+  -> (string * 'expr_type dval) list
 
-val get_all : state:exec_state -> 'expr_type DbT.db -> (string * dval) list
+val get_all :
+     state:'expr_type exec_state
+  -> 'expr_type DbT.db
+  -> (string * 'expr_type dval) list
 
-val get_all_keys : state:exec_state -> 'expr_type DbT.db -> string list
+val get_all_keys :
+  state:'expr_type exec_state -> 'expr_type DbT.db -> string list
 
 val query_exact_fields :
-  state:exec_state -> 'expr_type DbT.db -> dval -> (string * dval) list
+     state:'expr_type exec_state
+  -> 'expr_type DbT.db
+  -> 'expr_type dval
+  -> (string * 'expr_type dval) list
 
 val query :
-  state:exec_state -> 'expr_type DbT.db -> dblock_args -> (string * dval) list
+     state:Types.RuntimeT.expr exec_state
+  -> Types.RuntimeT.expr DbT.db
+  -> Types.RuntimeT.expr dblock_args
+  -> (string * Types.RuntimeT.expr dval) list
 
-val count : state:exec_state -> 'expr_type DbT.db -> int
+val count : state:'expr_type exec_state -> 'expr_type DbT.db -> int
 
-val delete : state:exec_state -> 'expr_type DbT.db -> string -> unit
+val delete : state:'expr_type exec_state -> 'expr_type DbT.db -> string -> unit
 
-val delete_all : state:exec_state -> 'expr_type DbT.db -> unit
+val delete_all : state:'expr_type exec_state -> 'expr_type DbT.db -> unit
 
 (* Stats fns *)
 
@@ -48,7 +68,7 @@ val stats_pluck :
      account_id:Uuidm.t
   -> canvas_id:Uuidm.t
   -> 'expr_type DbT.db
-  -> (dval * string) option
+  -> ('expr_type dval * string) option
 
 (* DB schema modifications *)
 val create : string -> tlid -> 'expr_type DbT.db

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -363,7 +363,7 @@ let result_to_response
     ~(c : RTT.expr Canvas.canvas ref)
     ~(execution_id : Types.id)
     ~(req : CRequest.t)
-    (result : RTT.dval) =
+    (result : RTT.expr RTT.dval) =
   let maybe_infer_cors headers =
     (* Add the Access-Control-ALlow-Origin, if it doens't exist
        and if infer_cors_header tells us to. *)
@@ -544,7 +544,10 @@ let user_page_handler
           | _ ->
               () ) ;
           let bound =
+            let page = Libexecution.Toplevel.handler_to_fluid page in
             Libexecution.Execution.http_route_input_vars page (Uri.path uri)
+            |> List.map ~f:(fun (a, b) ->
+                   (a, Libexecution.Fluid.dval_of_fluid b))
           in
           let result, touched_tlids =
             Libexecution.Execution.execute_handler
@@ -1003,7 +1006,7 @@ let execute_function ~(execution_id : Types.id) (host : string) body :
           Dval.current_hash_version
           tlids
           unlocked
-          result)
+          (Libexecution.Fluid.dval_to_fluid result))
   in
   respond
     ~execution_id

--- a/backend/libexecution/analysis_types.ml
+++ b/backend/libexecution/analysis_types.ml
@@ -12,7 +12,7 @@ module PReq = Parsed_request
 
 module Symtable = DvalMap
 
-type symtable = dval_map
+type 'expr_type symtable = 'expr_type dval_map
 
 let input_vars2symtable vars = Symtable.from_list vars
 
@@ -24,19 +24,23 @@ let ht_to_json_dict ds ~f =
   `Assoc (List.map ~f:(fun (id, v) -> (string_of_id id, f v)) alist)
 
 
-type intermediate_result_store = execution_result IDTable.t
+type 'expr_type intermediate_result_store =
+  'expr_type execution_result IDTable.t
 
-let intermediate_result_store_to_yojson (ds : intermediate_result_store) :
-    Yojson.Safe.t =
-  ht_to_json_dict ds ~f:execution_result_to_yojson
+let intermediate_result_store_to_yojson
+    (f : 'expr_type -> Yojson.Safe.t)
+    (ds : 'expr_type intermediate_result_store) : Yojson.Safe.t =
+  ht_to_json_dict ds ~f:(execution_result_to_yojson f)
 
 
 (* -------------------- *)
 (* Analysis result *)
 (* -------------------- *)
-type analysis = intermediate_result_store [@@deriving to_yojson]
+type 'expr_type analysis = 'expr_type intermediate_result_store
+[@@deriving to_yojson]
 
-type input_vars = (string * dval) list [@@deriving eq, show, yojson]
+type 'expr_type input_vars = (string * 'expr_type dval) list
+[@@deriving eq, show, yojson]
 
 type function_arg_hash = string [@@deriving eq, show, yojson]
 
@@ -44,20 +48,23 @@ type hash_version = int [@@deriving eq, show, yojson]
 
 type fnname = string [@@deriving yojson]
 
-type function_result = fnname * id * function_arg_hash * hash_version * dval
+type 'expr_type function_result =
+  fnname * id * function_arg_hash * hash_version * 'expr_type dval
 [@@deriving eq, show, yojson]
 
 type traceid = uuid [@@deriving show, yojson]
 
-type trace_data =
-  { input : input_vars
+type 'expr_type trace_data =
+  { input : 'expr_type input_vars
   ; timestamp : time
-  ; function_results : function_result list }
+  ; function_results : 'expr_type function_result list }
 [@@deriving eq, show, yojson]
 
-type trace = traceid * trace_data option [@@deriving yojson]
+type 'expr_type trace = traceid * 'expr_type trace_data option
+[@@deriving yojson]
 
-type tlid_traces = tlid * trace list [@@deriving to_yojson]
+type 'expr_type tlid_traces = tlid * 'expr_type trace list
+[@@deriving to_yojson]
 
 type tlid_traceid = tlid * traceid [@@deriving to_yojson]
 

--- a/backend/libexecution/ast.mli
+++ b/backend/libexecution/ast.mli
@@ -32,26 +32,26 @@ val find_db :
   -> Types.RuntimeT.expr Types.RuntimeT.DbT.db
 
 val execute_dblock :
-     state:Types.RuntimeT.exec_state
-  -> Types.RuntimeT.dblock_args
-  -> Types.RuntimeT.dval list
-  -> Types.RuntimeT.dval
+     state:Types.RuntimeT.expr Types.RuntimeT.exec_state
+  -> Types.RuntimeT.expr Types.RuntimeT.dblock_args
+  -> Types.RuntimeT.expr Types.RuntimeT.dval list
+  -> Types.RuntimeT.expr Types.RuntimeT.dval
 
 val exec :
-     state:Types.RuntimeT.exec_state
-  -> Types.RuntimeT.dval_map
+     state:Types.RuntimeT.expr Types.RuntimeT.exec_state
+  -> Types.RuntimeT.expr Types.RuntimeT.dval_map
   -> Types.RuntimeT.expr
-  -> Types.RuntimeT.dval
+  -> Types.RuntimeT.expr Types.RuntimeT.dval
 
 val execute_ast :
-     state:Types.RuntimeT.exec_state
-  -> input_vars:Types.RuntimeT.input_vars
+     state:Types.RuntimeT.expr Types.RuntimeT.exec_state
+  -> input_vars:Types.RuntimeT.expr Types.RuntimeT.input_vars
   -> Types.RuntimeT.expr
-  -> Types.RuntimeT.dval
+  -> Types.RuntimeT.expr Types.RuntimeT.dval
 
 val execute_fn :
-     state:Types.RuntimeT.exec_state
+     state:Types.RuntimeT.expr Types.RuntimeT.exec_state
   -> string
   -> Types.id
-  -> Types.RuntimeT.dval list
-  -> Types.RuntimeT.dval
+  -> Types.RuntimeT.expr Types.RuntimeT.dval list
+  -> Types.RuntimeT.expr Types.RuntimeT.dval

--- a/backend/libexecution/dval.ml
+++ b/backend/libexecution/dval.ml
@@ -5,11 +5,11 @@ open Types.RuntimeT
 (* ------------------------- *)
 (* Strings *)
 (* ------------------------- *)
-let dstr_of_string (s : string) : dval option =
+let dstr_of_string (s : string) : 'expr_type dval option =
   s |> Unicode_string.of_string |> Option.map ~f:(fun s -> DStr s)
 
 
-let dstr_of_string_exn (s : string) : dval =
+let dstr_of_string_exn (s : string) : 'expr_type dval =
   s |> dstr_of_string |> Option.value_exn ~message:("Invalid UTF-8 string:" ^ s)
 
 
@@ -239,7 +239,7 @@ and parse_list_tipe (list_tipe : string) : tipe =
       Exception.internal ("Unhandled parse_list_tipe: " ^ list_tipe)
 
 
-let rec tipe_of (dv : dval) : tipe =
+let rec tipe_of (dv : 'expr_type dval) : tipe =
   match dv with
   | DInt _ ->
       TInt
@@ -284,11 +284,13 @@ let rec tipe_of (dv : dval) : tipe =
 
 
 (* Users should not be aware of this *)
-let tipename (dv : dval) : string =
+let tipename (dv : 'expr_type dval) : string =
   dv |> tipe_of |> tipe_to_string |> String.lowercase
 
 
-let pretty_tipename (dv : dval) : string = dv |> tipe_of |> tipe_to_string
+let pretty_tipename (dv : 'expr_type dval) : string =
+  dv |> tipe_of |> tipe_to_string
+
 
 let unsafe_tipe_to_yojson (t : tipe) : Yojson.Safe.t =
   `String (t |> tipe_to_string |> String.lowercase)
@@ -308,7 +310,7 @@ let unsafe_tipe_of_yojson (json : Yojson.Safe.t) =
 
 let is_errorrail e = match e with DErrorRail _ -> true | _ -> false
 
-let unwrap_from_errorrail (dv : dval) =
+let unwrap_from_errorrail (dv : 'expr_type dval) =
   match dv with DErrorRail dv -> dv | other -> other
 
 
@@ -320,27 +322,27 @@ let exception_to_dval (exc : Exn.t) (src : dval_source) =
  * These types of values are stand-ins/markers for some static property about the
  * code. They should be propagated through the programs execution whenever they are
  * found.*)
-let is_fake_marker_dval (dv : dval) =
+let is_fake_marker_dval (dv : 'expr_type dval) =
   match dv with DErrorRail _ | DIncomplete _ | DError _ -> true | _ -> false
 
 
 (* Anytime we create a dlist with the except of list literals,
  * we need to make sure that there are no incomplete, error rail
  * values within the list *)
-let to_list (l : dval list) : dval =
+let to_list (l : 'expr_type dval list) : 'expr_type dval =
   let found = List.find l ~f:is_fake_marker_dval in
   match found with Some v -> v | None -> DList l
 
 
-let to_res_ok (dv : dval) : dval =
+let to_res_ok (dv : 'expr_type dval) : 'expr_type dval =
   if is_fake_marker_dval dv then dv else DResult (ResOk dv)
 
 
-let to_res_err (dv : dval) : dval =
+let to_res_err (dv : 'expr_type dval) : 'expr_type dval =
   if is_fake_marker_dval dv then dv else DResult (ResError dv)
 
 
-let to_opt_just (dv : dval) : dval =
+let to_opt_just (dv : 'expr_type dval) : 'expr_type dval =
   if is_fake_marker_dval dv then dv else DOption (OptJust dv)
 
 
@@ -348,14 +350,14 @@ let to_opt_just (dv : dval) : dval =
  * type as long as we can, because we don't have a way to express (in ocaml)
  * 'DOption'. But then we have to convert it to a proper (DOption of OptJust
  * dval | OptNothing at the end *)
-let dopt_of_option (dv : dval option) : dval =
+let dopt_of_option (dv : 'expr_type dval option) : 'expr_type dval =
   match dv with None -> DOption OptNothing | Some dv -> dv |> to_opt_just
 
 
 (* ------------------------- *)
 (* Obj Functions *)
 (* ------------------------- *)
-let obj_merge (l : dval) (r : dval) : dval =
+let obj_merge (l : 'expr_type dval) (r : 'expr_type dval) : 'expr_type dval =
   match (l, r) with
   | DObj l, DObj r ->
       DObj (Util.merge_left l r)
@@ -367,7 +369,7 @@ let obj_merge (l : dval) (r : dval) : dval =
       Exception.code "was expecting objs"
 
 
-let empty_dobj : dval = DObj DvalMap.empty
+let empty_dobj : 'expr_type dval = DObj DvalMap.empty
 
 (* ------------------------- *)
 (* Json *)
@@ -379,7 +381,7 @@ let empty_dobj : dval = DObj DvalMap.empty
  * and we really need to move off it, but for now we're here. Do not change
  * existing encodings - this will break everything.
  *)
-let rec unsafe_dval_of_yojson_v0 (json : Yojson.Safe.t) : dval =
+let rec unsafe_dval_of_yojson_v0 (json : Yojson.Safe.t) : 'expr_type dval =
   (* sort so this isn't key-order-dependent. *)
   let json = Yojson.Safe.sort json in
   match json with
@@ -471,7 +473,7 @@ let rec unsafe_dval_of_yojson_v0 (json : Yojson.Safe.t) : dval =
       DObj (unsafe_dvalmap_of_yojson_v0 json)
 
 
-and unsafe_dvalmap_of_yojson_v0 (json : Yojson.Safe.t) : dval_map =
+and unsafe_dvalmap_of_yojson_v0 (json : Yojson.Safe.t) : 'expr_type dval_map =
   match json with
   | `Assoc alist ->
       List.fold_left
@@ -483,7 +485,7 @@ and unsafe_dvalmap_of_yojson_v0 (json : Yojson.Safe.t) : dval_map =
       Exception.internal "Not a json object"
 
 
-let rec unsafe_dval_of_yojson_v1 (json : Yojson.Safe.t) : dval =
+let rec unsafe_dval_of_yojson_v1 (json : Yojson.Safe.t) : expr dval =
   (* sort so this isn't key-order-dependent. *)
   let json = Yojson.Safe.sort json in
   match json with
@@ -562,7 +564,7 @@ let rec unsafe_dval_of_yojson_v1 (json : Yojson.Safe.t) : dval =
       DObj (unsafe_dvalmap_of_yojson_v1 json)
 
 
-and unsafe_dvalmap_of_yojson_v1 (json : Yojson.Safe.t) : dval_map =
+and unsafe_dvalmap_of_yojson_v1 (json : Yojson.Safe.t) : 'expr_type dval_map =
   match json with
   | `Assoc alist ->
       List.fold_left
@@ -574,7 +576,8 @@ and unsafe_dvalmap_of_yojson_v1 (json : Yojson.Safe.t) : dval_map =
       Exception.internal "Not a json object"
 
 
-let rec unsafe_dval_to_yojson_v0 ?(redact = true) (dv : dval) : Yojson.Safe.t =
+let rec unsafe_dval_to_yojson_v0 ?(redact = true) (dv : 'expr_type dval) :
+    Yojson.Safe.t =
   let tipe = dv |> tipe_of |> unsafe_tipe_to_yojson in
   let wrap_user_type value = `Assoc [("type", tipe); ("value", value)] in
   let wrap_constructed_type cons values =
@@ -644,7 +647,8 @@ let rec unsafe_dval_to_yojson_v0 ?(redact = true) (dv : dval) : Yojson.Safe.t =
       bytes |> RawBytes.to_string |> B64.encode |> wrap_user_str
 
 
-let unsafe_dval_to_yojson_v1 ?(redact = true) (dv : dval) : Yojson.Safe.t =
+let unsafe_dval_to_yojson_v1 ?(redact = true) (dv : 'expr_type dval) :
+    Yojson.Safe.t =
   unsafe_dval_to_yojson_v0 ~redact dv
 
 
@@ -669,8 +673,9 @@ let dhttp_to_formatted_string (d : dhttp) : string =
       string_of_int c ^ " " ^ string_of_headers hs
 
 
-let rec to_nested_string ~(reprfn : dval -> string) (dv : dval) : string =
-  let rec inner (indent : int) (dv : dval) : string =
+let rec to_nested_string
+    ~(reprfn : 'expr_type dval -> string) (dv : 'expr_type dval) : string =
+  let rec inner (indent : int) (dv : 'expr_type dval) : string =
     let nl = "\n" ^ String.make indent ' ' in
     let inl = "\n" ^ String.make (indent + 2) ' ' in
     let indent = indent + 2 in
@@ -713,7 +718,7 @@ let of_internal_roundtrippable_json_v0 j =
   |> Result.map_error ~f:Exception.to_string
 
 
-let of_internal_roundtrippable_v0 str : dval =
+let of_internal_roundtrippable_v0 str : expr dval =
   str |> Yojson.Safe.from_string |> unsafe_dval_of_yojson_v1
 
 
@@ -725,7 +730,7 @@ let to_internal_queryable_v0 dval : string =
   dval |> unsafe_dval_to_yojson_v0 ~redact:false |> Yojson.Safe.to_string
 
 
-let of_internal_queryable_v0 (str : string) : dval =
+let of_internal_queryable_v0 (str : string) : expr dval =
   str |> Yojson.Safe.from_string |> unsafe_dval_of_yojson_v0
 
 
@@ -737,7 +742,7 @@ let to_internal_queryable_field_v1 dval : string =
   dval |> to_internal_queryable_field_json_v1 |> Yojson.Safe.to_string
 
 
-let to_internal_queryable_v1 (dval_map : dval_map) : string =
+let to_internal_queryable_v1 (dval_map : 'expr_type dval_map) : string =
   dval_map
   |> DvalMap.toList
   |> List.map ~f:(fun (k, dval) ->
@@ -745,9 +750,9 @@ let to_internal_queryable_v1 (dval_map : dval_map) : string =
   |> fun l -> `Assoc l |> Yojson.Safe.to_string
 
 
-let of_internal_queryable_v1 (str : string) : dval =
+let of_internal_queryable_v1 (str : string) : 'expr_type dval =
   (* The first level _must_ be an object at the moment *)
-  let rec convert_top_level (json : Yojson.Safe.t) : dval =
+  let rec convert_top_level (json : Yojson.Safe.t) : 'expr_type dval =
     match json with
     | `Assoc alist ->
         DObj
@@ -757,7 +762,7 @@ let of_internal_queryable_v1 (str : string) : dval =
              ~init:DvalMap.empty)
     | _ ->
         Exception.internal "Value that isn't an object"
-  and convert (json : Yojson.Safe.t) : dval =
+  and convert (json : Yojson.Safe.t) : 'expr_type dval =
     (* sort so this isn't key-order-dependent. *)
     let json = Yojson.Safe.sort json in
     match json with
@@ -869,8 +874,8 @@ let rec to_enduser_readable_text_v0 dval =
 
 let to_enduser_readable_html_v0 dv = to_enduser_readable_text_v0 dv
 
-let rec to_developer_repr_v0 (dv : dval) : string =
-  let rec to_repr_ (indent : int) (dv : dval) : string =
+let rec to_developer_repr_v0 (dv : 'expr_type dval) : string =
+  let rec to_repr_ (indent : int) (dv : 'expr_type dval) : string =
     let nl = "\n" ^ String.make indent ' ' in
     let inl = "\n" ^ String.make (indent + 2) ' ' in
     let indent = indent + 2 in
@@ -1095,7 +1100,7 @@ let rec show dv =
       "<Bytes: length=" ^ string_of_int (RawBytes.length bytes) ^ ">"
 
 
-let parse_literal (str : string) : dval option =
+let parse_literal (str : string) : 'expr_type dval option =
   let len = String.length str in
   (* Character *)
   if len > 2 && str.[0] = '\'' && str.[len - 1] = '\''
@@ -1147,9 +1152,9 @@ let to_float dv : Float.t option =
   match dv with DFloat f -> Some f | _ -> None
 
 
-let dint (i : int) : dval = DInt (Dint.of_int i)
+let dint (i : int) : 'expr_type dval = DInt (Dint.of_int i)
 
-let to_dobj_exn (pairs : (string * dval) list) : dval =
+let to_dobj_exn (pairs : (string * 'expr_type dval) list) : 'expr_type dval =
   match DvalMap.from_list_unique pairs with
   | Ok ok ->
       DObj ok
@@ -1169,7 +1174,7 @@ let to_string_exn dv : string =
       Exception.code "expecting str" ~actual:(to_developer_repr_v0 dv)
 
 
-let to_dval_pairs_exn dv : (string * dval) list =
+let to_dval_pairs_exn dv : (string * 'expr_type dval) list =
   match dv with
   | DObj obj ->
       DvalMap.to_list obj
@@ -1182,7 +1187,7 @@ let to_string_pairs_exn dv : (string * string) list =
 
 
 (* For putting into URLs as query params *)
-let rec to_url_string_exn (dv : dval) : string =
+let rec to_url_string_exn (dv : 'expr_type dval) : string =
   match dv with
   | DBlock _ ->
       (* See docs/dblock-serialization.ml *)
@@ -1239,7 +1244,7 @@ let rec to_url_string_exn (dv : dval) : string =
 (* Forms and queries Functions *)
 (* ------------------------- *)
 
-let query_to_dval (query : (string * string list) list) : dval =
+let query_to_dval (query : (string * string list) list) : 'expr_type dval =
   query
   |> List.map ~f:(fun (key, vals) ->
          let dval =
@@ -1256,7 +1261,7 @@ let query_to_dval (query : (string * string list) list) : dval =
   |> DObj
 
 
-let dval_to_query (dv : dval) : (string * string list) list =
+let dval_to_query (dv : 'expr_type dval) : (string * string list) list =
   match dv with
   | DObj kvs ->
       kvs
@@ -1273,11 +1278,11 @@ let dval_to_query (dv : dval) : (string * string list) list =
       Exception.code "attempting to use non-object as query param"
 
 
-let to_form_encoding (dv : dval) : string =
+let to_form_encoding (dv : 'expr_type dval) : string =
   dv |> dval_to_query |> Uri.encoded_of_query
 
 
-let of_form_encoding (f : string) : dval =
+let of_form_encoding (f : string) : 'expr_type dval =
   f |> Uri.query_of_encoded |> query_to_dval
 
 
@@ -1289,8 +1294,8 @@ let of_form_encoding (f : string) : dval =
  * amenable to change without a migration. Don't change ANYTHING for existing
  * values, but continue to add representations for new values. Also, inline
  * everything! *)
-let rec to_hashable_repr ?(indent = 0) ?(old_bytes = false) (dv : dval) : string
-    =
+let rec to_hashable_repr
+    ?(indent = 0) ?(old_bytes = false) (dv : 'expr_type dval) : string =
   let nl = "\n" ^ String.make indent ' ' in
   let inl = "\n" ^ String.make (indent + 2) ' ' in
   let indent = indent + 2 in
@@ -1380,7 +1385,7 @@ let current_hash_version = 1
 
 (* Originally to prevent storing sensitive data to disk, this also reduces the
  * size of the data stored by only storing a hash *)
-let hash (version : int) (arglist : dval list) : string =
+let hash (version : int) (arglist : 'expr_type dval list) : string =
   (* Version 0 deprecated because it has a collision between [b"a"; b"bc"] and
    * [b"ab"; b"c"] *)
   match version with

--- a/backend/libexecution/dval.mli
+++ b/backend/libexecution/dval.mli
@@ -5,12 +5,12 @@
 (* Given an OCaml string, turn it into a Dark string. Will return Nothing
  * if the OCaml string is not proper UTF-8. *)
 
-val dstr_of_string : string -> Types.RuntimeT.dval option
+val dstr_of_string : string -> 'expr_type Types.RuntimeT.dval option
 
 (* Given an OCaml string, turn it into a Dark string. Will raise an exception
  * if the OCaml string is not proper UTF-8. *)
 
-val dstr_of_string_exn : string -> Types.RuntimeT.dval
+val dstr_of_string_exn : string -> 'expr_type Types.RuntimeT.dval
 
 (* ------------------------- *)
 (* Types *)
@@ -19,13 +19,13 @@ val tipe_to_string : Types.tipe_ -> string
 
 val tipe_of_string : Core_kernel.String.t -> Types.tipe_
 
-val tipe_of : Types.RuntimeT.dval -> Types.tipe_
+val tipe_of : 'expr_type Types.RuntimeT.dval -> Types.tipe_
 
 (** [tipename dval] produces a non-user-facing name for the type of the given [dval]. *)
-val tipename : Types.RuntimeT.dval -> string
+val tipename : 'expr_type Types.RuntimeT.dval -> string
 
 (** [pretty_tipename dval] produces a user-facing name for the type of the given [dval]. *)
-val pretty_tipename : Types.RuntimeT.dval -> string
+val pretty_tipename : 'expr_type Types.RuntimeT.dval -> string
 
 val unsafe_tipe_to_yojson : Types.RuntimeT.tipe -> Yojson.Safe.t
 
@@ -39,58 +39,60 @@ val unsafe_tipe_of_yojson :
 (* This is a format used for roundtripping dvals internally. v0 has bugs due to
  * a legacy of trying to make one function useful for everything. Does not
  * redact. *)
-val to_internal_roundtrippable_v0 : Types.RuntimeT.dval -> string
+val to_internal_roundtrippable_v0 : 'expr_type Types.RuntimeT.dval -> string
 
 (* This is a format used for roundtripping dvals internally. There are some
  * rare cases where it will parse incorrectly without error. Throws on Json
  * bugs. *)
-val of_internal_roundtrippable_v0 : string -> Types.RuntimeT.dval
+val of_internal_roundtrippable_v0 :
+  string -> Types.RuntimeT.expr Types.RuntimeT.dval
 
 val of_internal_roundtrippable_json_v0 :
-  Yojson.Safe.t -> (Types.RuntimeT.dval, string) Core_kernel._result
+     Yojson.Safe.t
+  -> (Types.RuntimeT.expr Types.RuntimeT.dval, string) Core_kernel._result
 
 (* This is a format used for roundtripping dvals internally, while still being
  * queryable using jsonb in our DB. v0 has bugs due to a legacy of trying to
  * make one function useful for everything. Also roundtrippable. Does not
  * redact. *)
-val to_internal_queryable_v0 : Types.RuntimeT.dval -> string
+val to_internal_queryable_v0 : 'expr_type Types.RuntimeT.dval -> string
 
 (* This is a format used for roundtripping dvals internally, while still being
  * queryable using jsonb in our DB. There are some rare cases where it will
  * parse incorrectly without error. Throws on Json bugs. *)
-val of_internal_queryable_v0 : string -> Types.RuntimeT.dval
+val of_internal_queryable_v0 : string -> Types.RuntimeT.expr Types.RuntimeT.dval
 
 (* This is a format used for roundtripping dvals internally, while still being
  * queryable using jsonb in our DB. This reduces some of the v0 bugs, but at
  * the cost of not supporting many typed that we'll want to put in it.  Also
  * roundtrippable. Does not redact. *)
-val to_internal_queryable_v1 : Types.RuntimeT.dval_map -> string
+val to_internal_queryable_v1 : 'expr_type Types.RuntimeT.dval_map -> string
 
 (* to_internal_queryable_v1 (above) is how we serialize what we put in the user db
  * (a DObj);  to_internal_queryable_field_v1 lets us use the same serializers
  * for fields so we can query safely from sql_compiler.ml *)
-val to_internal_queryable_field_v1 : Types.RuntimeT.dval -> string
+val to_internal_queryable_field_v1 : 'expr_type Types.RuntimeT.dval -> string
 
 (* This is a format used for roundtripping dvals internally, while still being
  * queryable using jsonb in our DB. There are some rare cases where it will
  * parse incorrectly without error. Throws on Json bugs. *)
 
-val of_internal_queryable_v1 : string -> Types.RuntimeT.dval
+val of_internal_queryable_v1 : string -> 'expr_type Types.RuntimeT.dval
 
 (* When printing to grand-users (our users' users) using text/plain, print a
  * human-readable format. TODO: this should probably be part of the functions
  * generating the responses. Redacts passwords. *)
-val to_enduser_readable_text_v0 : Types.RuntimeT.dval -> string
+val to_enduser_readable_text_v0 : 'expr_type Types.RuntimeT.dval -> string
 
 (* When printing to grand-users (our users' users) using text/html, attempt to
  * extract a html-like string. Redacts passwords. TODO: this should probably be
  * part of the functions generating the responses. *)
-val to_enduser_readable_html_v0 : Types.RuntimeT.dval -> string
+val to_enduser_readable_html_v0 : 'expr_type Types.RuntimeT.dval -> string
 
 (* For printing something for the developer to read, as a live-value, error
  * message, etc. This will faithfully represent the code, textually. Redacts
  * passwords. Customers should not come to rely on this format. *)
-val to_developer_repr_v0 : Types.RuntimeT.dval -> string
+val to_developer_repr_v0 : 'expr_type Types.RuntimeT.dval -> string
 
 (* For printing types for the developer to read, in live-values, error
  * messages, etc. Customers should not come to rely on this format. *)
@@ -99,115 +101,127 @@ val tipe_to_developer_repr_v0 : Types.tipe_ -> string
 (* For passing to Dark functions that operate on JSON, such as the JWT fns.
  * This turns Option and Result into plain values, or null/error. String-like
  * values are rendered as string. Redacts passwords. *)
-val to_pretty_machine_yojson_v1 : Types.RuntimeT.dval -> Yojson.Safe.t
+val to_pretty_machine_yojson_v1 :
+  'expr_type Types.RuntimeT.dval -> Yojson.Safe.t
 
 (* When sending json back to the user, or via a HTTP API, attempt to convert
  * everything into reasonable json, in the absence of a schema. This turns
  * Option and Result into plain values, or null/error. String-like values are
  * rendered as string. Redacts passwords. *)
-val to_pretty_machine_json_v1 : Types.RuntimeT.dval -> string
+val to_pretty_machine_json_v1 : 'expr_type Types.RuntimeT.dval -> string
 
 (* When receiving unknown json from the user, or via a HTTP API, attempt to
  * convert everything into reasonable types, in the absense of a schema.
  * This does type conversion, which it shouldn't and should be avoided for new code. *)
-val of_unknown_json_v0 : string -> Types.RuntimeT.dval
+val of_unknown_json_v0 : string -> Types.RuntimeT.expr_dval
 
 (* When receiving unknown json from the user, or via a HTTP API, attempt to
  * convert everything into reasonable types, in the absense of a schema. *)
-val of_unknown_json_v1 : string -> Types.RuntimeT.dval
+val of_unknown_json_v1 : string -> Types.RuntimeT.expr_dval
 
 (* For debugging internally, redacts passwords. Never throws. *)
-val show : Types.RuntimeT.dval -> string
+val show : 'expr_type Types.RuntimeT.dval -> string
 
 (* JSON coming in from the user as part of a known API should have a type which
  * can act as a schema to reconstruct the data perfectly. Redacts passwords. *)
 (* type schema  *)
-(* val of_json_with_schema : schema: schema -> Yojson.Safe.t -> Types.RuntimeT.dval *)
-(* val to_json_with_schema : schema: schema -> Types.RuntimeT.dval -> Yojson.Safe.t  *)
+(* val of_json_with_schema : schema: schema -> Yojson.Safe.t -> 'expr_type Types.RuntimeT.dval *)
+(* val to_json_with_schema : schema: schema -> 'expr_type Types.RuntimeT.dval -> Yojson.Safe.t  *)
 
 (* Parse our internal literal strings (eg AST Values) *)
-val parse_literal : string -> Types.RuntimeT.dval option
+val parse_literal : string -> 'expr_type Types.RuntimeT.dval option
 
 (* ------------------------- *)
 (* Conversion Functions *)
 (* ------------------------- *)
 
 (* queries *)
-val query_to_dval : (string * string list) list -> Types.RuntimeT.dval
+val query_to_dval :
+  (string * string list) list -> 'expr_type Types.RuntimeT.dval
 
-val dval_to_query : Types.RuntimeT.dval -> (string * string list) list
+val dval_to_query :
+  'expr_type Types.RuntimeT.dval -> (string * string list) list
 
 (* forms *)
-val to_form_encoding : Types.RuntimeT.dval -> string
+val to_form_encoding : 'expr_type Types.RuntimeT.dval -> string
 
-val of_form_encoding : string -> Types.RuntimeT.dval
-
-(* ------------------------- *)
-(* Conversion Functions *)
-(* ------------------------- *)
+val of_form_encoding : string -> 'expr_type Types.RuntimeT.dval
 
 (* If a DCharacter, returns `Some char`, as a string (Dark characters are EGCs,
  * and can be longer than a byte. *)
-val to_char : Types.RuntimeT.dval -> string option
+val to_char : 'expr_type Types.RuntimeT.dval -> string option
 
-val to_int : Types.RuntimeT.dval -> Dint.t option
+val to_int : 'expr_type Types.RuntimeT.dval -> Dint.t option
 
-val to_float : Types.RuntimeT.dval -> Base.Float.t option
+val to_float : 'expr_type Types.RuntimeT.dval -> Base.Float.t option
 
-val dint : int -> Types.RuntimeT.dval
+val dint : int -> 'expr_type Types.RuntimeT.dval
 
 (* Converts a Dark String to an OCaml string. *)
-val to_string_opt : Types.RuntimeT.dval -> string option
+val to_string_opt : 'expr_type Types.RuntimeT.dval -> string option
 
 (* Converts a Dark String to an OCaml string. Raises an Exception if not a
  * string. *)
-val to_string_exn : Types.RuntimeT.dval -> string
+val to_string_exn : 'expr_type Types.RuntimeT.dval -> string
 
 (* Converts an object to (string,string) pairs. Raises an exception if not an
  * object. *)
-val to_string_pairs_exn : Types.RuntimeT.dval -> (string * string) list
+val to_string_pairs_exn :
+  'expr_type Types.RuntimeT.dval -> (string * string) list
 
 (* Converts an object to (string,dval) pairs. Raises an exception if not an
  * object. *)
 val to_dval_pairs_exn :
-  Types.RuntimeT.dval -> (string * Types.RuntimeT.dval) list
+     'expr_type Types.RuntimeT.dval
+  -> (string * 'expr_type Types.RuntimeT.dval) list
 
 (* For putting into URLs as query params  *)
-val to_url_string_exn : Types.RuntimeT.dval -> string
+val to_url_string_exn : 'expr_type Types.RuntimeT.dval -> string
 
 (* Errors if the values in the list are not strings, or if any key is
  * duplicated. *)
-val to_dobj_exn : (string * Types.RuntimeT.dval) list -> Types.RuntimeT.dval
+val to_dobj_exn :
+     (string * 'expr_type Types.RuntimeT.dval) list
+  -> 'expr_type Types.RuntimeT.dval
 
 val exception_to_dval :
-  Core_kernel.Exn.t -> Types.RuntimeT.dval_source -> Types.RuntimeT.dval
+     Core_kernel.Exn.t
+  -> Types.RuntimeT.dval_source
+  -> 'expr_type Types.RuntimeT.dval
 
 (* ------------------------- *)
 (* ErrorRail Functions *)
 (* ------------------------- *)
-val is_errorrail : Types.RuntimeT.dval -> bool
+val is_errorrail : 'expr_type Types.RuntimeT.dval -> bool
 
-val unwrap_from_errorrail : Types.RuntimeT.dval -> Types.RuntimeT.dval
+val unwrap_from_errorrail :
+  'expr_type Types.RuntimeT.dval -> 'expr_type Types.RuntimeT.dval
 
-val to_list : Types.RuntimeT.dval list -> Types.RuntimeT.dval
+val to_list :
+  'expr_type Types.RuntimeT.dval list -> 'expr_type Types.RuntimeT.dval
 
-val to_opt_just : Types.RuntimeT.dval -> Types.RuntimeT.dval
+val to_opt_just :
+  'expr_type Types.RuntimeT.dval -> 'expr_type Types.RuntimeT.dval
 
-val dopt_of_option : Types.RuntimeT.dval option -> Types.RuntimeT.dval
+val dopt_of_option :
+  'expr_type Types.RuntimeT.dval option -> 'expr_type Types.RuntimeT.dval
 
-val to_res_ok : Types.RuntimeT.dval -> Types.RuntimeT.dval
+val to_res_ok : 'expr_type Types.RuntimeT.dval -> 'expr_type Types.RuntimeT.dval
 
-val to_res_err : Types.RuntimeT.dval -> Types.RuntimeT.dval
+val to_res_err :
+  'expr_type Types.RuntimeT.dval -> 'expr_type Types.RuntimeT.dval
 
-val is_fake_marker_dval : Types.RuntimeT.dval -> bool
+val is_fake_marker_dval : 'expr_type Types.RuntimeT.dval -> bool
 
 (* ------------------------- *)
 (* Object Functions *)
 (* ------------------------- *)
 val obj_merge :
-  Types.RuntimeT.dval -> Types.RuntimeT.dval -> Types.RuntimeT.dval
+     'expr_type Types.RuntimeT.dval
+  -> 'expr_type Types.RuntimeT.dval
+  -> 'expr_type Types.RuntimeT.dval
 
-val empty_dobj : Types.RuntimeT.dval
+val empty_dobj : 'expr_type Types.RuntimeT.dval
 
 (* ------------------------- *)
 (* Misc *)
@@ -216,4 +230,4 @@ val supported_hash_versions : int list
 
 val current_hash_version : int
 
-val hash : int -> Types.RuntimeT.dval list -> string
+val hash : int -> 'expr_type Types.RuntimeT.dval list -> string

--- a/backend/libexecution/execution.ml
+++ b/backend/libexecution/execution.ml
@@ -8,15 +8,16 @@ module PReq = Parsed_request
 (* -------------------- *)
 (* Input_vars *)
 (* -------------------- *)
-let input_vars_for_user_fn (ufn : 'expr_type user_fn) : dval_map =
-  let param_to_dval (p : param) : dval = DIncomplete SourceNone in
+let input_vars_for_user_fn (ufn : 'expr_type user_fn) : 'expr_type dval_map =
+  let param_to_dval (p : param) : 'expr_type dval = DIncomplete SourceNone in
   ufn.metadata.parameters
   |> List.filter_map ~f:ufn_param_to_param
   |> List.map ~f:(fun f -> (f.name, param_to_dval f))
   |> Analysis_types.Symtable.from_list_exn
 
 
-let dbs_as_input_vars (dbs : 'expr_type DbT.db list) : (string * dval) list =
+let dbs_as_input_vars (dbs : 'expr_type DbT.db list) :
+    (string * 'expr_type dval) list =
   List.filter_map dbs ~f:(fun db ->
       match db.name with
       | Filled (_, name) ->
@@ -26,7 +27,8 @@ let dbs_as_input_vars (dbs : 'expr_type DbT.db list) : (string * dval) list =
 
 
 let http_route_input_vars
-    (h : 'expr_type HandlerT.handler) (request_path : string) : input_vars =
+    (h : fluid_expr HandlerT.handler) (request_path : string) :
+    fluid_expr input_vars =
   let route = Handler.event_name_for_exn h in
   Http.bind_route_variables_exn ~route request_path
 
@@ -42,7 +44,7 @@ let sample_unknown_handler_input_vars =
   sample_request_input_vars @ sample_event_input_vars
 
 
-let sample_module_input_vars h : input_vars =
+let sample_module_input_vars h : 'expr_type input_vars =
   match Handler.module_type h with
   | `Http ->
       sample_request_input_vars
@@ -56,7 +58,8 @@ let sample_module_input_vars h : input_vars =
       sample_unknown_handler_input_vars
 
 
-let sample_route_input_vars (h : 'expr_type HandlerT.handler) : input_vars =
+let sample_route_input_vars (h : 'expr_type HandlerT.handler) :
+    'expr_type input_vars =
   match Handler.event_name_for h with
   | Some n ->
       n
@@ -100,11 +103,11 @@ let execute_handler
     ?(load_fn_arguments = load_no_arguments)
     ?(store_fn_result = store_no_results)
     ?(store_fn_arguments = store_no_arguments)
-    (h : RuntimeT.expr HandlerT.handler) : dval * tlid list =
+    (h : RuntimeT.expr HandlerT.handler) : RuntimeT.expr dval * tlid list =
   let input_vars = dbs_as_input_vars dbs @ input_vars in
   let tlid_store = TLIDTable.create () in
   let trace_tlid tlid = Hashtbl.set tlid_store ~key:tlid ~data:true in
-  let state : exec_state =
+  let state : 'expr_type exec_state =
     { tlid
     ; account_id
     ; canvas_id
@@ -157,7 +160,7 @@ let execute_function
     fnname =
   let tlid_store = TLIDTable.create () in
   let trace_tlid tlid = Hashtbl.set tlid_store ~key:tlid ~data:true in
-  let state : exec_state =
+  let state : 'expr_type exec_state =
     { tlid
     ; account_id
     ; canvas_id
@@ -205,7 +208,7 @@ let analyse_ast
     ~canvas_id
     ?(load_fn_result = load_no_results)
     ?(load_fn_arguments = load_no_arguments)
-    (ast : expr) : analysis =
+    (ast : expr) : 'expr_type analysis =
   let value_store = IDTable.create () in
   let trace ~on_execution_path id dval =
     Hashtbl.set
@@ -217,7 +220,7 @@ let analyse_ast
         else NonExecutedResult dval )
   in
   let input_vars = dbs_as_input_vars dbs @ input_vars in
-  let state : exec_state =
+  let state : 'expr_type exec_state =
     { tlid
     ; account_id
     ; canvas_id

--- a/backend/libexecution/execution.mli
+++ b/backend/libexecution/execution.mli
@@ -4,38 +4,46 @@ open Core_kernel
 (* Input vars *)
 (* ----------------- *)
 val input_vars_for_user_fn :
-  Types.RuntimeT.expr Types.RuntimeT.user_fn -> Types.RuntimeT.dval_map
+     Types.fluid_expr Types.RuntimeT.user_fn
+  -> Types.fluid_expr Types.RuntimeT.dval_map
 
 val dbs_as_input_vars :
-  'expr_type Types.RuntimeT.DbT.db list -> (string * Types.RuntimeT.dval) list
+     'expr_type Types.RuntimeT.DbT.db list
+  -> (string * 'expr_type Types.RuntimeT.dval) list
 
 val http_route_input_vars :
-     'expr_type Types.RuntimeT.HandlerT.handler
+     Types.fluid_expr Types.RuntimeT.HandlerT.handler
   -> string
-  -> Types.RuntimeT.input_vars
+  -> Types.fluid_expr Types.RuntimeT.input_vars
 
 val sample_route_input_vars :
-  'expr_type Types.RuntimeT.HandlerT.handler -> Types.RuntimeT.input_vars
+     Types.fluid_expr Types.RuntimeT.HandlerT.handler
+  -> Types.fluid_expr Types.RuntimeT.input_vars
 
 val sample_input_vars :
-  'expr_type Types.RuntimeT.HandlerT.handler -> Types.RuntimeT.input_vars
+     Types.fluid_expr Types.RuntimeT.HandlerT.handler
+  -> Types.fluid_expr Types.RuntimeT.input_vars
 
 val sample_function_input_vars :
-  'expr_type Types.RuntimeT.user_fn -> Types.RuntimeT.input_vars
+     Types.fluid_expr Types.RuntimeT.user_fn
+  -> Types.fluid_expr Types.RuntimeT.input_vars
 
-val sample_unknown_handler_input_vars : Types.RuntimeT.input_vars
+val sample_unknown_handler_input_vars :
+  Types.fluid_expr Types.RuntimeT.input_vars
 
 (* ----------------- *)
 (* Exec_state *)
 (* ----------------- *)
 
-val store_no_results : Types.RuntimeT.store_fn_result_type
+val store_no_results : Types.RuntimeT.expr Types.RuntimeT.store_fn_result_type
 
-val store_no_arguments : Types.RuntimeT.store_fn_arguments_type
+val store_no_arguments :
+  Types.RuntimeT.expr Types.RuntimeT.store_fn_arguments_type
 
-val load_no_results : Types.RuntimeT.load_fn_result_type
+val load_no_results : Types.RuntimeT.expr Types.RuntimeT.load_fn_result_type
 
-val load_no_arguments : Types.RuntimeT.load_fn_arguments_type
+val load_no_arguments :
+  Types.RuntimeT.expr Types.RuntimeT.load_fn_arguments_type
 
 (* ----------------- *)
 (* Execution *)
@@ -43,19 +51,21 @@ val load_no_arguments : Types.RuntimeT.load_fn_arguments_type
 val execute_handler :
      tlid:Types.tlid
   -> execution_id:Types.tlid
-  -> input_vars:Types.RuntimeT.input_vars
+  -> input_vars:Types.RuntimeT.expr Types.RuntimeT.input_vars
   -> dbs:Types.RuntimeT.expr Types.RuntimeT.DbT.db list
   -> user_fns:Types.RuntimeT.expr Types.RuntimeT.user_fn list
   -> user_tipes:Types.RuntimeT.user_tipe list
-  -> package_fns:Types.RuntimeT.fn list
+  -> package_fns:Types.RuntimeT.expr Types.RuntimeT.fn list
   -> account_id:Uuidm.t
   -> canvas_id:Uuidm.t
-  -> ?load_fn_result:Types.RuntimeT.load_fn_result_type
-  -> ?load_fn_arguments:Types.RuntimeT.load_fn_arguments_type
-  -> ?store_fn_result:Types.RuntimeT.store_fn_result_type
-  -> ?store_fn_arguments:Types.RuntimeT.store_fn_arguments_type
+  -> ?load_fn_result:Types.RuntimeT.expr Types.RuntimeT.load_fn_result_type
+  -> ?load_fn_arguments:
+       Types.RuntimeT.expr Types.RuntimeT.load_fn_arguments_type
+  -> ?store_fn_result:Types.RuntimeT.expr Types.RuntimeT.store_fn_result_type
+  -> ?store_fn_arguments:
+       Types.RuntimeT.expr Types.RuntimeT.store_fn_arguments_type
   -> Types.RuntimeT.expr Types.RuntimeT.HandlerT.handler
-  -> Types.RuntimeT.dval * Types.tlid list
+  -> Types.RuntimeT.expr Types.RuntimeT.dval * Types.tlid list
 
 val execute_function :
      tlid:Types.tlid
@@ -64,15 +74,16 @@ val execute_function :
   -> dbs:Types.RuntimeT.expr Types.RuntimeT.DbT.db list
   -> user_fns:Types.RuntimeT.expr Types.RuntimeT.user_fn list
   -> user_tipes:Types.RuntimeT.user_tipe list
-  -> package_fns:Types.RuntimeT.fn list
+  -> package_fns:Types.RuntimeT.expr Types.RuntimeT.fn list
   -> account_id:Uuidm.t
   -> canvas_id:Uuidm.t
   -> caller_id:Types.id
-  -> args:Types.RuntimeT.dval list
-  -> ?store_fn_result:Types.RuntimeT.store_fn_result_type
-  -> ?store_fn_arguments:Types.RuntimeT.store_fn_arguments_type
+  -> args:Types.RuntimeT.expr Types.RuntimeT.dval list
+  -> ?store_fn_result:Types.RuntimeT.expr Types.RuntimeT.store_fn_result_type
+  -> ?store_fn_arguments:
+       Types.RuntimeT.expr Types.RuntimeT.store_fn_arguments_type
   -> string
-  -> Types.RuntimeT.dval * Types.tlid list
+  -> Types.RuntimeT.expr Types.RuntimeT.dval * Types.tlid list
 
 (* ----------------- *)
 (* Analysis *)
@@ -80,14 +91,15 @@ val execute_function :
 val analyse_ast :
      tlid:Types.tlid
   -> execution_id:Types.tlid
-  -> input_vars:Types.RuntimeT.input_vars
+  -> input_vars:Types.RuntimeT.expr Types.RuntimeT.input_vars
   -> dbs:Types.RuntimeT.expr Types.RuntimeT.DbT.db list
   -> user_fns:Types.RuntimeT.expr Types.RuntimeT.user_fn list
   -> user_tipes:Types.RuntimeT.user_tipe list
-  -> package_fns:Types.RuntimeT.fn list
+  -> package_fns:Types.RuntimeT.expr Types.RuntimeT.fn list
   -> account_id:Uuidm.t
   -> canvas_id:Uuidm.t
-  -> ?load_fn_result:Types.RuntimeT.load_fn_result_type
-  -> ?load_fn_arguments:Types.RuntimeT.load_fn_arguments_type
+  -> ?load_fn_result:Types.RuntimeT.expr Types.RuntimeT.load_fn_result_type
+  -> ?load_fn_arguments:
+       Types.RuntimeT.expr Types.RuntimeT.load_fn_arguments_type
   -> Types.RuntimeT.expr
-  -> Analysis_types.analysis
+  -> Types.RuntimeT.expr Analysis_types.analysis

--- a/backend/libexecution/fluid.ml
+++ b/backend/libexecution/fluid.ml
@@ -454,3 +454,136 @@ let rec testExprEqualIgnoringIds
            |> List.all ~f:identity
     | _ ->
         failwith "impossible" )
+
+
+(* ------------------------- *)
+(* Dval conversion functions - here because cycles *)
+
+(* ------------------------- *)
+
+open Types.RuntimeT
+
+let rec dval_of_fluid (dv : fluid_dval) : expr_dval =
+  match dv with
+  | DInt d ->
+      DInt d
+  | DFloat d ->
+      DFloat d
+  | DBool d ->
+      DBool d
+  | DNull ->
+      DNull
+  | DCharacter d ->
+      DCharacter d
+  | DStr d ->
+      DStr d
+  | DList d ->
+      DList (List.map ~f:dval_of_fluid d)
+  | DObj d ->
+      DObj (dval_map_of_fluid d)
+  | DBlock d ->
+      DBlock (dblock_args_of_fluid d)
+  | DError d ->
+      DError d
+  | DIncomplete d ->
+      DIncomplete d
+  | DResp (h, d) ->
+      DResp (h, dval_of_fluid d)
+  | DDB d ->
+      DDB d
+  | DDate d ->
+      DDate d
+  | DPassword d ->
+      DPassword d
+  | DUuid d ->
+      DUuid d
+  | DOption OptNothing ->
+      DOption OptNothing
+  | DOption (OptJust d) ->
+      DOption (OptJust (dval_of_fluid d))
+  | DErrorRail d ->
+      DErrorRail (dval_of_fluid d)
+  | DResult (ResError d) ->
+      DResult (ResError (dval_of_fluid d))
+  | DResult (ResOk d) ->
+      DResult (ResOk (dval_of_fluid d))
+  | DBytes d ->
+      DBytes d
+
+
+and dval_map_of_fluid (dm : fluid_dval_map) : expr_dval_map =
+  DvalMap.map ~f:dval_of_fluid dm
+
+
+and dblock_args_of_fluid (args : fluid_dblock_args) : expr_dblock_args =
+  { symtable = dval_map_of_fluid args.symtable
+  ; params = args.params
+  ; body = fromFluidExpr args.body }
+
+
+let rec dval_to_fluid (dv : expr_dval) : fluid_dval =
+  match dv with
+  | DInt d ->
+      DInt d
+  | DFloat d ->
+      DFloat d
+  | DBool d ->
+      DBool d
+  | DNull ->
+      DNull
+  | DCharacter d ->
+      DCharacter d
+  | DStr d ->
+      DStr d
+  | DList d ->
+      DList (List.map ~f:dval_to_fluid d)
+  | DObj d ->
+      DObj (dval_map_to_fluid d)
+  | DBlock d ->
+      DBlock (dblock_args_to_fluid d)
+  | DError d ->
+      DError d
+  | DIncomplete d ->
+      DIncomplete d
+  | DResp (h, d) ->
+      DResp (h, dval_to_fluid d)
+  | DDB d ->
+      DDB d
+  | DDate d ->
+      DDate d
+  | DPassword d ->
+      DPassword d
+  | DUuid d ->
+      DUuid d
+  | DOption OptNothing ->
+      DOption OptNothing
+  | DOption (OptJust d) ->
+      DOption (OptJust (dval_to_fluid d))
+  | DErrorRail d ->
+      DErrorRail (dval_to_fluid d)
+  | DResult (ResError d) ->
+      DResult (ResError (dval_to_fluid d))
+  | DResult (ResOk d) ->
+      DResult (ResOk (dval_to_fluid d))
+  | DBytes d ->
+      DBytes d
+
+
+and dval_map_to_fluid (dm : expr_dval_map) : fluid_dval_map =
+  DvalMap.map ~f:dval_to_fluid dm
+
+
+and dblock_args_to_fluid (args : expr_dblock_args) : fluid_dblock_args =
+  { symtable = dval_map_to_fluid args.symtable
+  ; params = args.params
+  ; body = toFluidExpr args.body }
+
+
+let execution_result_to_fluid
+    (er : Types.RuntimeT.expr Types.RuntimeT.execution_result) :
+    Types.fluid_expr Types.RuntimeT.execution_result =
+  match er with
+  | ExecutedResult dval ->
+      ExecutedResult (dval_to_fluid dval)
+  | NonExecutedResult dval ->
+      NonExecutedResult (dval_to_fluid dval)

--- a/backend/libexecution/http.ml
+++ b/backend/libexecution/http.ml
@@ -37,7 +37,7 @@ let route_variables (route : string) : string list =
 
 
 let bind_route_variables ~(route : string) (request_path : string) :
-    (string * RT.dval) list option =
+    (string * 'expr_type RT.dval) list option =
   let do_binding route path =
     (* assumes route length = path length *)
     List.zip_exn route path
@@ -86,7 +86,7 @@ let bind_route_variables ~(route : string) (request_path : string) :
 
 
 let bind_route_variables_exn ~(route : string) (request_path : string) :
-    (string * RT.dval) list =
+    (string * 'expr_type RT.dval) list =
   Option.value_exn
     ~message:"request/route mismatch"
     (bind_route_variables ~route request_path)

--- a/backend/libexecution/legacy.ml
+++ b/backend/libexecution/legacy.ml
@@ -4,7 +4,8 @@ open Types.RuntimeT
 
 module PrettyResponseJsonV0 = struct
   (* At time of writing, this is the same as Dval.unsafe_dval_to_yojson. It's being copied to be certain this format doesn't change. *)
-  let rec unsafe_dval_to_yojson ?(redact = true) (dv : dval) : Yojson.Safe.t =
+  let rec unsafe_dval_to_yojson ?(redact = true) (dv : 'expr_type dval) :
+      Yojson.Safe.t =
     let tipe = dv |> Dval.tipe_of |> Dval.unsafe_tipe_to_yojson in
     let wrap_user_type value = `Assoc [("type", tipe); ("value", value)] in
     let wrap_constructed_type cons values =
@@ -75,7 +76,7 @@ end
 
 module PrettyRequestJsonV0 = struct
   (* Returns the string within string-ish values, without adornment. *)
-  let as_string (dv : dval) : string =
+  let as_string (dv : 'expr_type dval) : string =
     match dv with
     | DInt i ->
         Dint.to_string i
@@ -103,7 +104,7 @@ module PrettyRequestJsonV0 = struct
         "<" ^ (dv |> Dval.tipename) ^ ">"
 
 
-  let as_literal (dv : dval) : string =
+  let as_literal (dv : 'expr_type dval) : string =
     match dv with
     | DStr s ->
         "\"" ^ Unicode_string.to_string s ^ "\""
@@ -113,7 +114,7 @@ module PrettyRequestJsonV0 = struct
         as_string dv
 
 
-  let is_primitive (dv : dval) : bool =
+  let is_primitive (dv : 'expr_type dval) : bool =
     match dv with
     | DInt _ | DFloat _ | DBool _ | DNull | DCharacter _ | DStr _ ->
         true
@@ -121,7 +122,7 @@ module PrettyRequestJsonV0 = struct
         false
 
 
-  let is_stringable (dv : dval) : bool =
+  let is_stringable (dv : 'expr_type dval) : bool =
     match dv with
     | DBlock _
     | DIncomplete _
@@ -138,7 +139,8 @@ module PrettyRequestJsonV0 = struct
   (* A simple representation, showing primitives as their expected literal
    * syntax, and odd types get type info in a readable format. Compund
    * types are listed as their type only *)
-  let to_simple_repr ?(open_ = "<") ?(close_ = ">") (dv : dval) : string =
+  let to_simple_repr ?(open_ = "<") ?(close_ = ">") (dv : 'expr_type dval) :
+      string =
     let wrap value = open_ ^ (dv |> Dval.tipename) ^ ": " ^ value ^ close_ in
     match dv with
     | dv when is_primitive dv ->
@@ -165,12 +167,13 @@ module PrettyRequestJsonV0 = struct
 
   (* A full representation, building on to_simple_repr, but including
  * lists and objects. *)
-  let rec to_pretty_request_json_v0 (dv : dval) : string =
+  let rec to_pretty_request_json_v0 (dv : 'expr_type dval) : string =
     let pp = true in
     let open_ = "<" in
     let close_ = ">" in
     let reprfn = to_simple_repr ~open_ ~close_ in
-    let rec to_repr_ (indent : int) (pp : bool) (dv : dval) : string =
+    let rec to_repr_ (indent : int) (pp : bool) (dv : 'expr_type dval) : string
+        =
       let nl = if pp then "\n" ^ String.make indent ' ' else " " in
       let inl = if pp then "\n" ^ String.make (indent + 2) ' ' else "" in
       let indent = indent + 2 in

--- a/backend/libexecution/legacy.mli
+++ b/backend/libexecution/legacy.mli
@@ -1,7 +1,7 @@
 module PrettyResponseJsonV0 : sig
   (* Original function for sending json back to the user. This uses an object
     * format for dates. *)
-  val to_pretty_response_json_v0 : Types.RuntimeT.dval -> string
+  val to_pretty_response_json_v0 : 'expr_type Types.RuntimeT.dval -> string
 end
 
 module PrettyRequestJsonV0 : sig
@@ -9,5 +9,5 @@ module PrettyRequestJsonV0 : sig
    * invalid) format for dates ("<Date: datestr>"), as well as DBs, Errros,
    * UUIDs and IDs,wraps characters in single quotes (invalid json), errors
    * on results, includes the string "Nothing/Just" for options *)
-  val to_pretty_request_json_v0 : Types.RuntimeT.dval -> string
+  val to_pretty_request_json_v0 : 'expr_type Types.RuntimeT.dval -> string
 end

--- a/backend/libexecution/lib.ml
+++ b/backend/libexecution/lib.ml
@@ -10,7 +10,9 @@ let func ?(d : string = "") ?(name : string = "f") args : param =
   par name TBlock ~args ~d
 
 
-let fail_fn (fnname : string) (fn : fn) (args : dval list) ?msg () : dval =
+let fail_fn
+    (fnname : string) (fn : 'expr_type fn) (args : 'expr_type dval list) ?msg ()
+    : 'expr_type dval =
   let bt = Exception.get_backtrace () in
   let all = List.zip_exn fn.parameters args in
   let invalid =
@@ -32,5 +34,6 @@ let fail_fn (fnname : string) (fn : fn) (args : dval list) ?msg () : dval =
         (fnname ^ " was called with the wrong type to parameter: " ^ p.name)
 
 
-let fail ?msg ((state, args) : exec_state * dval list) : dval =
+let fail ?msg ((state, args) : 'expr_type exec_state * 'expr_type dval list) :
+    'expr_type dval =
   match state.fail_fn with Some fn -> fn ?msg () | None -> DNull

--- a/backend/libexecution/libbool.ml
+++ b/backend/libexecution/libbool.ml
@@ -3,7 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Bool::not"]
     ; infix_names = []
     ; parameters = [par "b" TBool]

--- a/backend/libexecution/libbytes.ml
+++ b/backend/libexecution/libbytes.ml
@@ -3,7 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Bytes::base64Encode"]
     ; infix_names = []
     ; parameters = [par "bytes" TBytes]

--- a/backend/libexecution/libchar.ml
+++ b/backend/libexecution/libchar.ml
@@ -3,7 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Char::toASCIICode"]
     ; infix_names = []
     ; parameters = [par "c" TCharacter]

--- a/backend/libexecution/libdate.ml
+++ b/backend/libexecution/libdate.ml
@@ -3,7 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Date::parse"]
     ; infix_names = []
     ; parameters = [par "s" TStr]

--- a/backend/libexecution/libdict.ml
+++ b/backend/libexecution/libdict.ml
@@ -91,8 +91,16 @@ let fns =
           | state, [DList l] ->
               let fold_fn
                   (idx : int)
-                  (acc : (dval DvalMap.t, dval (* type error *)) result)
-                  (dv : dval) : (dval DvalMap.t, dval (* type error *)) result =
+                  (acc :
+                    ( 'expr_type dval DvalMap.t
+                    , 'expr_type dval
+                    (* type error *) )
+                    result)
+                  (dv : 'expr_type dval) :
+                  ( 'expr_type dval DvalMap.t
+                  , 'expr_type dval
+                  (* type error *) )
+                  result =
                 Result.bind acc ~f:(fun acc ->
                     match dv with
                     | DList [DStr k; value] ->
@@ -161,8 +169,10 @@ let fns =
           (function
           | state, [DList l] ->
               let fold_fn
-                  (idx : int) (acc : (dval DvalMap.t, dval) result) (dv : dval)
-                  : (dval DvalMap.t, dval) result =
+                  (idx : int)
+                  (acc : ('expr_type dval DvalMap.t, 'expr_type dval) result)
+                  (dv : 'expr_type dval) :
+                  ('expr_type dval DvalMap.t, 'expr_type dval) result =
                 (* The dval for the result error could either be [Error DError] (in case of a type error)
                  * or an [Error (DOption OptNothing)] (in case there is a duplicate) *)
                 Result.bind acc ~f:(fun acc ->
@@ -326,7 +336,7 @@ let fns =
         InProcess
           (function
           | state, [DObj o; DBlock b] ->
-              let f ~key ~(data : dval) =
+              let f ~key ~(data : 'expr_type dval) =
                 Ast.execute_dblock ~state b [Dval.dstr_of_string_exn key; data]
               in
               DObj (Map.mapi ~f o)
@@ -346,7 +356,7 @@ let fns =
           (function
           | state, [DObj o; DBlock b] ->
               let incomplete = ref false in
-              let f ~(key : string) ~(data : dval) : bool =
+              let f ~(key : string) ~(data : 'expr_type dval) : bool =
                 let result =
                   Ast.execute_dblock ~state b [Dval.dstr_of_string_exn key; data]
                 in
@@ -428,7 +438,7 @@ let fns =
           (function
           | state, [DObj o; DBlock b] ->
               let abortReason = ref None in
-              let f ~key ~(data : dval) : dval option =
+              let f ~key ~(data : 'expr_type dval) : 'expr_type dval option =
                 if !abortReason = None
                 then (
                   match

--- a/backend/libexecution/libfloat.ml
+++ b/backend/libexecution/libfloat.ml
@@ -4,8 +4,8 @@ open Types.RuntimeT
 module RT = Runtime
 
 (* type coerces one list to another using a function *)
-let list_coerce ~(f : dval -> 'a option) (l : dval list) :
-    ('a list, dval list * dval) Result.t =
+let list_coerce ~(f : 'expr_type dval -> 'a option) (l : 'expr_type dval list) :
+    ('a list, 'expr_type dval list * 'expr_type dval) Result.t =
   l
   |> List.map ~f:(fun dv ->
          match f dv with Some v -> Result.Ok v | None -> Result.Error (l, dv))
@@ -14,7 +14,7 @@ let list_coerce ~(f : dval -> 'a option) (l : dval list) :
 
 let ( >>| ) = Result.( >>| )
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Float::ceiling"; "Float::roundUp"]
     ; infix_names = []
     ; parameters = [par "a" TFloat]

--- a/backend/libexecution/libhttp.ml
+++ b/backend/libexecution/libhttp.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Runtime
 open Lib
 
-let fns : Types.RuntimeT.fn list =
+let fns : Types.RuntimeT.expr Types.RuntimeT.fn list =
   [ { prefix_names = ["Http::respond"]
     ; infix_names = []
     ; parameters = [par "response" TAny; par "code" TInt]

--- a/backend/libexecution/libhttpclient.ml
+++ b/backend/libexecution/libhttpclient.ml
@@ -3,7 +3,7 @@ open Runtime
 open Lib
 open Types.RuntimeT
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["HttpClient::formContentType"]
     ; infix_names = []
     ; parameters = []

--- a/backend/libexecution/libint.ml
+++ b/backend/libexecution/libint.ml
@@ -4,8 +4,8 @@ open Types.RuntimeT
 module RT = Runtime
 
 (* type coerces one list to another using a function *)
-let list_coerce ~(f : dval -> 'a option) (l : dval list) :
-    ('a list, dval list * dval) Result.t =
+let list_coerce ~(f : 'expr_type dval -> 'a option) (l : 'expr_type dval list) :
+    ('a list, 'expr_type dval list * 'expr_type dval) Result.t =
   l
   |> List.map ~f:(fun dv ->
          match f dv with Some v -> Result.Ok v | None -> Result.Error (l, dv))
@@ -14,7 +14,7 @@ let list_coerce ~(f : dval -> 'a option) (l : dval list) :
 
 let ( >>| ) = Result.( >>| )
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Int::mod"]
     ; infix_names = ["%"]
     ; parameters = [par "a" TInt; par "b" TInt]

--- a/backend/libexecution/libjson.ml
+++ b/backend/libexecution/libjson.ml
@@ -3,7 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["JSON::read"]
     ; infix_names = []
     ; parameters = [par "json" TStr]

--- a/backend/libexecution/libmath.ml
+++ b/backend/libexecution/libmath.ml
@@ -13,7 +13,7 @@ let tau =
   6.283185307179586
 
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["Math::pi"]
     ; infix_names = []
     ; parameters = []

--- a/backend/libexecution/libobject.ml
+++ b/backend/libexecution/libobject.ml
@@ -3,7 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns =
+let fns : expr fn list =
   [ { prefix_names = ["Object::empty"]
     ; infix_names = []
     ; parameters = []

--- a/backend/libexecution/liboption.ml
+++ b/backend/libexecution/liboption.ml
@@ -3,20 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-(* type coerces one list to another using a function *)
-let list_coerce ~(f : dval -> 'a option) (l : dval list) :
-    ('a list, dval list * dval) Result.t =
-  l
-  |> List.map ~f:(fun dv ->
-         match f dv with Some v -> Result.Ok v | None -> Result.Error (l, dv))
-  |> Result.all
-
-
-let error_result msg = DResult (ResError (Dval.dstr_of_string_exn msg))
-
-let ( >>| ) = Result.( >>| )
-
-let fns : fn list =
+let fns =
   [ { prefix_names = ["Option::map"]
     ; infix_names = []
     ; parameters = [par "option" TOption; func ["val"]]

--- a/backend/libexecution/libresult.ml
+++ b/backend/libexecution/libresult.ml
@@ -3,7 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-let fns : fn list =
+let fns =
   [ { prefix_names = ["Result::map"]
     ; infix_names = []
     ; parameters = [par "result" TResult; func ["val"]]

--- a/backend/libexecution/libs.ml
+++ b/backend/libexecution/libs.ml
@@ -5,9 +5,10 @@ module RTT = RuntimeT
 module RT = Runtime
 module FnMap = String.Map
 
-type fnmap = RuntimeT.fn FnMap.t
+type 'expr_type fnmap = 'expr_type RuntimeT.fn FnMap.t
 
-let add_fn (m : fnmap) (f : RuntimeT.fn) : fnmap =
+let add_fn (m : 'expr_type fnmap) (f : 'expr_type RuntimeT.fn) :
+    'expr_type fnmap =
   List.fold_left
     ~f:(fun m1 n ->
       FnMap.update m1 n ~f:(fun v ->
@@ -20,11 +21,13 @@ let add_fn (m : fnmap) (f : RuntimeT.fn) : fnmap =
     (f.prefix_names @ f.infix_names)
 
 
-let static_fns : fnmap ref = ref FnMap.empty
+let static_fns : 'expr_type fnmap ref = ref FnMap.empty
 
-let add_static_fn (s : RTT.fn) : unit = static_fns := add_fn !static_fns s
+let add_static_fn (s : 'expr_type RTT.fn) : unit =
+  static_fns := add_fn !static_fns s
 
-let fns (user_fns : RuntimeT.expr RuntimeT.user_fn list) : fnmap =
+
+let fns (user_fns : RuntimeT.expr RuntimeT.user_fn list) : 'expr_type fnmap =
   user_fns
   |> List.filter_map ~f:RuntimeT.user_fn_to_fn
   |> List.fold_left ~init:!static_fns ~f:(fun map uf -> add_fn map uf)
@@ -32,12 +35,12 @@ let fns (user_fns : RuntimeT.expr RuntimeT.user_fn list) : fnmap =
 
 (* Give access to other modules *)
 let get_fn ~(user_fns : RuntimeT.expr RuntimeT.user_fn list) (name : string) :
-    RuntimeT.fn option =
+    'expr_type RuntimeT.fn option =
   FnMap.find (fns user_fns) name
 
 
 let get_fn_exn ~(user_fns : RuntimeT.expr RuntimeT.user_fn list) (name : string)
-    : RuntimeT.fn =
+    : 'expr_type RuntimeT.fn =
   match get_fn ~user_fns name with
   | Some fn ->
       fn
@@ -65,6 +68,6 @@ let filter_out_non_preview_safe_functions_for_tests ~(f : unit -> unit) () :
   ()
 
 
-let init (libs : RTT.fn list) : unit =
+let init (libs : 'expr_type RTT.fn list) : unit =
   List.iter ~f:add_static_fn libs ;
   ()

--- a/backend/libexecution/libstd.ml
+++ b/backend/libexecution/libstd.ml
@@ -4,8 +4,8 @@ open Types.RuntimeT
 module RT = Runtime
 
 (* type coerces one list to another using a function *)
-let list_coerce ~(f : dval -> 'a option) (l : dval list) :
-    ('a list, dval list * dval) Result.t =
+let list_coerce ~(f : 'expr_type dval -> 'a option) (l : 'expr_type dval list) :
+    ('a list, 'expr_type dval list * 'expr_type dval) Result.t =
   l
   |> List.map ~f:(fun dv ->
          match f dv with Some v -> Result.Ok v | None -> Result.Error (l, dv))
@@ -16,7 +16,7 @@ let error_result msg = DResult (ResError (Dval.dstr_of_string_exn msg))
 
 let ( >>| ) = Result.( >>| )
 
-let fns : fn list =
+let fns : 'expr_type fn list =
   [ { prefix_names = ["toString"]
     ; infix_names = []
     ; parameters = [par "v" TAny]
@@ -54,7 +54,8 @@ let fns : fn list =
     ; description = "Returns true if the two value are equal"
     ; func =
         InProcess
-          (function _, [a; b] -> DBool (equal_dval a b) | args -> fail args)
+          (function
+          | _, [a; b] -> DBool (equal_dval equal_expr a b) | args -> fail args)
     ; preview_safety = Safe
     ; deprecated = false }
   ; { prefix_names = ["notEquals"]
@@ -65,7 +66,10 @@ let fns : fn list =
     ; func =
         InProcess
           (function
-          | _, [a; b] -> DBool (not (equal_dval a b)) | args -> fail args)
+          | _, [a; b] ->
+              DBool (not (equal_dval equal_expr a b))
+          | args ->
+              fail args)
     ; preview_safety = Safe
     ; deprecated = false }
   ; { prefix_names = ["assoc"]

--- a/backend/libexecution/libstring.ml
+++ b/backend/libexecution/libstring.ml
@@ -4,8 +4,8 @@ open Types.RuntimeT
 module RT = Runtime
 
 (* type coerces one list to another using a function *)
-let list_coerce ~(f : dval -> 'a option) (l : dval list) :
-    ('a list, dval list * dval) Result.t =
+let list_coerce ~(f : 'expr_type dval -> 'a option) (l : 'expr_type dval list) :
+    ('a list, 'expr_type dval list * 'expr_type dval) Result.t =
   l
   |> List.map ~f:(fun dv ->
          match f dv with Some v -> Result.Ok v | None -> Result.Error (l, dv))
@@ -16,7 +16,7 @@ let error_result msg = DResult (ResError (Dval.dstr_of_string_exn msg))
 
 let ( >>| ) = Result.( >>| )
 
-let fns : fn list =
+let fns : expr fn list =
   [ { prefix_names = ["String::isEmpty"]
     ; infix_names = []
     ; parameters = [par "s" TStr]

--- a/backend/libexecution/libuuid.ml
+++ b/backend/libexecution/libuuid.ml
@@ -3,20 +3,7 @@ open Lib
 open Types.RuntimeT
 module RT = Runtime
 
-(* type coerces one list to another using a function *)
-let list_coerce ~(f : dval -> 'a option) (l : dval list) :
-    ('a list, dval list * dval) Result.t =
-  l
-  |> List.map ~f:(fun dv ->
-         match f dv with Some v -> Result.Ok v | None -> Result.Error (l, dv))
-  |> Result.all
-
-
-let error_result msg = DResult (ResError (Dval.dstr_of_string_exn msg))
-
-let ( >>| ) = Result.( >>| )
-
-let fns : fn list =
+let fns =
   [ { prefix_names = ["Uuid::generate"]
     ; infix_names = []
     ; parameters = []

--- a/backend/libexecution/parsed_request.ml
+++ b/backend/libexecution/parsed_request.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Types.RuntimeT
 
 (* Internal invariant, _must_ be a DObj *)
-type t = dval
+type 'expr_type t = 'expr_type dval
 
 (* ------------------------- *)
 (* Internal *)
@@ -26,7 +26,7 @@ let body_parser_type headers =
   else Unknown
 
 
-let parser_fn p (str : string) : dval =
+let parser_fn p (str : string) : 'expr_type dval =
   match p with
   | Json ->
     ( try Dval.of_unknown_json_v0 str

--- a/backend/libexecution/parsed_request.mli
+++ b/backend/libexecution/parsed_request.mli
@@ -1,6 +1,6 @@
 open Core_kernel
 
-type t
+type 'expr_type t
 
 type header = string * string
 
@@ -12,12 +12,13 @@ val from_request :
   -> header list
   -> query_val list
   -> string
-  -> t
+  -> Types.RuntimeT.expr t
 
-val to_dval : t -> Types.RuntimeT.dval
+val to_dval : 'expr_type t -> 'expr_type Types.RuntimeT.dval
 
-val sample_request : t
+val sample_request : 'expr_type t
 
 (* For testing *)
 
-val parsed_query_string : (string * string list) list -> Types.RuntimeT.dval
+val parsed_query_string :
+  (string * string list) list -> Types.RuntimeT.expr_dval

--- a/backend/libexecution/toplevel.ml
+++ b/backend/libexecution/toplevel.ml
@@ -173,6 +173,164 @@ let user_fn_of_fluid (fn : fluid_expr user_fn) : expr user_fn =
   {tlid = fn.tlid; metadata = fn.metadata; ast = Fluid.fromFluidExpr fn.ast}
 
 
+let rec exec_state_of_fluid (s : Types.fluid_expr Types.RuntimeT.exec_state) :
+    Types.RuntimeT.expr Types.RuntimeT.exec_state =
+  { tlid = s.tlid
+  ; canvas_id = s.canvas_id
+  ; account_id = s.account_id
+  ; user_fns = List.map ~f:user_fn_of_fluid s.user_fns
+  ; user_tipes = s.user_tipes
+  ; package_fns = List.map ~f:fn_of_fluid s.package_fns
+  ; dbs = s.dbs
+  ; trace =
+      (fun ~on_execution_path id dval ->
+        let dval = Fluid.dval_to_fluid dval in
+        s.trace ~on_execution_path id dval)
+  ; trace_tlid = s.trace_tlid
+  ; context = s.context
+  ; execution_id = s.execution_id
+  ; on_execution_path = s.on_execution_path
+  ; exec =
+      (fun ~state args expr ->
+        let state = exec_state_to_fluid state in
+        let args = Fluid.dval_map_to_fluid args in
+        let expr = Fluid.toFluidExpr expr in
+        s.exec ~state args expr |> Fluid.dval_of_fluid)
+  ; load_fn_result =
+      (fun desc args ->
+        let args = List.map ~f:Fluid.dval_to_fluid args in
+        s.load_fn_result desc args
+        |> Option.map ~f:(fun (dval, time) -> (Fluid.dval_of_fluid dval, time)))
+  ; store_fn_result =
+      (fun desc args dval ->
+        let args = List.map ~f:Fluid.dval_to_fluid args in
+        let dval = Fluid.dval_to_fluid dval in
+        s.store_fn_result desc args dval)
+  ; load_fn_arguments =
+      (fun tlid ->
+        s.load_fn_arguments tlid
+        |> List.map ~f:(fun (dvalmap, time) ->
+               (Fluid.dval_map_of_fluid dvalmap, time)))
+  ; store_fn_arguments =
+      (fun tlid dvalmap ->
+        let dvalmap = Fluid.dval_map_to_fluid dvalmap in
+        s.store_fn_arguments tlid dvalmap)
+  ; executing_fnname = s.executing_fnname
+  ; fail_fn =
+      s.fail_fn
+      |> Option.map ~f:(fun f ?(msg = "") () ->
+             f ~msg () |> Fluid.dval_of_fluid) }
+
+
+and funcimpl_of_fluid (fn : fluid_expr funcimpl) : expr funcimpl =
+  match fn with
+  | UserCreated (tlid, expr) ->
+      UserCreated (tlid, Fluid.fromFluidExpr expr)
+  | PackageFunction expr ->
+      PackageFunction (Fluid.fromFluidExpr expr)
+  | API fn ->
+      API
+        (fun (args : expr dval_map) ->
+          let args = Fluid.dval_map_to_fluid args in
+          fn args |> Fluid.dval_of_fluid)
+  | InProcess fn ->
+      InProcess
+        (fun (state, args) ->
+          let state = exec_state_to_fluid state in
+          let args = List.map ~f:Fluid.dval_to_fluid args in
+          fn (state, args) |> Fluid.dval_of_fluid)
+
+
+and fn_of_fluid (s : fluid_expr fn) : expr fn =
+  { prefix_names = s.prefix_names
+  ; infix_names = s.infix_names
+  ; parameters = s.parameters
+  ; return_type = s.return_type
+  ; description = s.description
+  ; func = funcimpl_of_fluid s.func
+  ; preview_safety = s.preview_safety
+  ; deprecated = s.deprecated }
+
+
+and exec_state_to_fluid (s : Types.RuntimeT.expr Types.RuntimeT.exec_state) :
+    Types.fluid_expr Types.RuntimeT.exec_state =
+  { tlid = s.tlid
+  ; canvas_id = s.canvas_id
+  ; account_id = s.account_id
+  ; user_fns = List.map ~f:user_fn_to_fluid s.user_fns
+  ; user_tipes = s.user_tipes
+  ; package_fns = List.map ~f:fn_to_fluid s.package_fns
+  ; dbs = s.dbs
+  ; trace =
+      (fun ~on_execution_path id dval ->
+        let dval = Fluid.dval_of_fluid dval in
+        s.trace ~on_execution_path id dval)
+  ; trace_tlid = s.trace_tlid
+  ; context = s.context
+  ; execution_id = s.execution_id
+  ; on_execution_path = s.on_execution_path
+  ; exec =
+      (fun ~state args expr ->
+        let state = exec_state_of_fluid state in
+        let args = Fluid.dval_map_of_fluid args in
+        let expr = Fluid.fromFluidExpr expr in
+        s.exec ~state args expr |> Fluid.dval_to_fluid)
+  ; load_fn_result =
+      (fun desc args ->
+        let args = List.map ~f:Fluid.dval_of_fluid args in
+        s.load_fn_result desc args
+        |> Option.map ~f:(fun (dval, time) -> (Fluid.dval_to_fluid dval, time)))
+  ; store_fn_result =
+      (fun desc args dval ->
+        let args = List.map ~f:Fluid.dval_of_fluid args in
+        let dval = Fluid.dval_of_fluid dval in
+        s.store_fn_result desc args dval)
+  ; load_fn_arguments =
+      (fun tlid ->
+        s.load_fn_arguments tlid
+        |> List.map ~f:(fun (dvalmap, time) ->
+               (Fluid.dval_map_to_fluid dvalmap, time)))
+  ; store_fn_arguments =
+      (fun tlid dvalmap ->
+        let dvalmap = Fluid.dval_map_of_fluid dvalmap in
+        s.store_fn_arguments tlid dvalmap)
+  ; executing_fnname = s.executing_fnname
+  ; fail_fn =
+      s.fail_fn
+      |> Option.map ~f:(fun f ?(msg = "") () ->
+             f ~msg () |> Fluid.dval_to_fluid) }
+
+
+and funcimpl_to_fluid (fn : expr funcimpl) : fluid_expr funcimpl =
+  match fn with
+  | UserCreated (tlid, expr) ->
+      UserCreated (tlid, Fluid.toFluidExpr expr)
+  | PackageFunction expr ->
+      PackageFunction (Fluid.toFluidExpr expr)
+  | API fn ->
+      API
+        (fun (args : fluid_dval_map) ->
+          let args = Fluid.dval_map_of_fluid args in
+          fn args |> Fluid.dval_to_fluid)
+  | InProcess fn ->
+      InProcess
+        (fun (state, args) ->
+          let state = exec_state_of_fluid state in
+          let args = List.map ~f:Fluid.dval_of_fluid args in
+          fn (state, args) |> Fluid.dval_to_fluid)
+
+
+and fn_to_fluid (s : expr fn) : fluid_expr fn =
+  { prefix_names = s.prefix_names
+  ; infix_names = s.infix_names
+  ; parameters = s.parameters
+  ; return_type = s.return_type
+  ; description = s.description
+  ; func = funcimpl_to_fluid s.func
+  ; preview_safety = s.preview_safety
+  ; deprecated = s.deprecated }
+
+
 (* This has a clone on the frontend in AST.ml. Any changes to
  * this should likely be reflected there too. *)
 let rec expr_to_string ~(indent : int) (e : expr) : string =

--- a/backend/libexecution/type_checker.ml
+++ b/backend/libexecution/type_checker.ml
@@ -4,11 +4,11 @@ open Types
 open Types.RuntimeT
 
 module Error = struct
-  type t =
+  type 'expr_type t =
     | TypeLookupFailure of string * int
     | TypeUnificationFailure of
         { expected_tipe : tipe
-        ; actual_value : dval }
+        ; actual_value : 'expr_type dval }
     | MismatchedRecordFields of
         { expected_fields : String.Set.t
         ; actual_fields : String.Set.t }
@@ -76,8 +76,8 @@ let user_tipe_list_to_type_env (tipes : user_tipe list) : type_env =
 
 let error err = Error [err]
 
-let rec unify ~(type_env : type_env) (expected : tipe) (value : dval) :
-    (unit, Error.t list) Result.t =
+let rec unify ~(type_env : type_env) (expected : tipe) (value : 'expr_type dval)
+    : (unit, 'expr_type Error.t list) Result.t =
   match (expected, value) with
   (* Any should be removed, but we currently allow it as a param tipe
    * in user functions, so we should allow it here.
@@ -133,7 +133,7 @@ let rec unify ~(type_env : type_env) (expected : tipe) (value : dval) :
 and unify_user_record_with_dval_map
     ~(type_env : type_env)
     (definition : user_record_field list)
-    (value : dval_map) : (unit, Error.t list) Result.t =
+    (value : 'expr_type dval_map) : (unit, 'expr_type Error.t list) Result.t =
   let complete_definition =
     definition
     |> List.filter_map ~f:(fun d ->
@@ -164,8 +164,9 @@ and unify_user_record_with_dval_map
 
 
 let check_function_call
-    ~(user_tipes : user_tipe list) (fn : fn) (args : dval_map) :
-    (unit, Error.t list) Result.t =
+    ~(user_tipes : user_tipe list)
+    (fn : 'expr_type fn)
+    (args : 'expr_type dval_map) : (unit, 'expr_type Error.t list) Result.t =
   let type_env = user_tipe_list_to_type_env user_tipes in
   let args = DvalMap.to_list args in
   let with_params =

--- a/backend/libexecution/type_checker.mli
+++ b/backend/libexecution/type_checker.mli
@@ -4,7 +4,7 @@ open Types
 open Types.RuntimeT
 
 module Error : sig
-  type t =
+  type 'expr_type t =
     (* Failed to find a TUserType (name, version) in our type environment.
      * Potentially a type was deleted and we didn't clean-up every use
      * (or a race condition! *)
@@ -12,7 +12,7 @@ module Error : sig
     (* Type error in _values_, ie. expected a string but got an Int *)
     | TypeUnificationFailure of
         { expected_tipe : tipe
-        ; actual_value : dval }
+        ; actual_value : 'expr_type dval }
     (* Type error between a user record definition and the actual object
       * received, specifically in its keys. ie expected {a : *, b : * } but
       * got { a : *, b : *, c : *} -- note we currently expect an _exact_
@@ -21,8 +21,11 @@ module Error : sig
         { expected_fields : String.Set.t
         ; actual_fields : String.Set.t }
 
-  val to_string : t -> string
+  val to_string : 'expr_type t -> string
 end
 
 val check_function_call :
-  user_tipes:user_tipe list -> fn -> dval_map -> (unit, Error.t list) Result.t
+     user_tipes:user_tipe list
+  -> 'expr_type fn
+  -> 'expr_type dval_map
+  -> (unit, 'expr_type Error.t list) Result.t

--- a/backend/libexecution/types.ml
+++ b/backend/libexecution/types.ml
@@ -377,26 +377,26 @@ module RuntimeT = struct
 
   (* To support migrating to fluid, these take a type parameter, which is
    * concretely defined to use `expr` at the bottom. *)
-  type 'expr_type dval_map' = 'expr_type dval' DvalMap.t
+  type 'expr_type dval_map = 'expr_type dval DvalMap.t
 
-  and 'expr_type optionT' =
-    | OptJust of 'expr_type dval'
+  and 'expr_type optionT =
+    | OptJust of 'expr_type dval
     | OptNothing
 
-  and 'expr_type resultT' =
-    | ResOk of dval
-    | ResError of 'expr_type dval'
+  and 'expr_type resultT =
+    | ResOk of 'expr_type dval
+    | ResError of 'expr_type dval
 
   and dval_source =
     | SourceNone
     | SourceId of tlid * id
 
-  and 'expr_type dblock_args' =
-    { symtable : 'expr_type dval_map'
+  and 'expr_type dblock_args =
+    { symtable : 'expr_type dval_map
     ; params : (id * string) list
     ; body : 'expr_type }
 
-  and 'expr_type dval' =
+  and 'expr_type dval =
     (* basic types  *)
     | DInt of Dint.t
     | DFloat of float
@@ -404,51 +404,51 @@ module RuntimeT = struct
     | DNull
     | DStr of Unicode_string.t
     (* compound types *)
-    | DList of 'expr_type dval' list
-    | DObj of 'expr_type dval_map'
+    | DList of 'expr_type dval list
+    | DObj of 'expr_type dval_map
     (* special types - see notes above *)
     | DIncomplete of dval_source
     | DError of (dval_source * string)
-    | DBlock of 'expr_type dblock_args'
-    | DErrorRail of 'expr_type dval'
+    | DBlock of 'expr_type dblock_args
+    | DErrorRail of 'expr_type dval
     (* user types: awaiting a better type system *)
-    | DResp of (dhttp * 'expr_type dval')
+    | DResp of (dhttp * 'expr_type dval)
     | DDB of string
     | DDate of time
     | DPassword of PasswordBytes.t
     | DUuid of uuid
-    | DOption of 'expr_type optionT'
+    | DOption of 'expr_type optionT
     | DCharacter of Unicode_string.Character.t
-    | DResult of 'expr_type resultT'
+    | DResult of 'expr_type resultT
     | DBytes of RawBytes.t
 
-  and 'expr_type dval_list' = 'expr_type dval' list
+  and 'expr_type dval_list = 'expr_type dval list
 
   (* Concrete definitions for expr *)
-  and dval = expr dval'
+  and expr_dval = expr dval
 
-  and dblock_args = expr dblock_args'
+  and expr_dblock_args = expr dblock_args
 
-  and dval_map = expr dval_map'
+  and expr_dval_map = expr dval_map
 
-  and optionT = expr optionT'
+  and expr_optionT = expr optionT
 
-  and resultT = expr resultT'
+  and expr_resultT = expr resultT
 
-  and dval_list = expr dval_list'
+  and expr_dval_list = expr dval_list
 
   (* Concrete definitions for fluid *)
-  and fluid_dval = fluid_expr dval'
+  and fluid_dval = fluid_expr dval
 
-  and fluid_dblock_args = fluid_expr dblock_args'
+  and fluid_dblock_args = fluid_expr dblock_args
 
-  and fluid_dval_map = fluid_expr dval_map'
+  and fluid_dval_map = fluid_expr dval_map
 
-  and fluid_optionT = fluid_expr optionT'
+  and fluid_optionT = fluid_expr optionT
 
-  and fluid_resultT = fluid_expr resultT'
+  and fluid_resultT = fluid_expr resultT
 
-  and fluid_dval_list = fluid_expr dval_list'
+  and fluid_dval_list = fluid_expr dval_list
   [@@deriving show {with_path = false}, eq, ord, yojson]
 
   (* DO NOT CHANGE BELOW WITHOUT READING docs/oplist-serialization.md *)
@@ -460,9 +460,10 @@ module RuntimeT = struct
 
   type tipe_map = tipe String.Map.t
 
-  type string_dval_pair = string * dval [@@deriving show, eq]
+  type 'expr_type string_dval_pair = string * 'expr_type dval
+  [@@deriving show, eq]
 
-  type input_vars = string_dval_pair list
+  type 'expr_type input_vars = 'expr_type string_dval_pair list
 
   (* DO NOT CHANGE BELOW WITHOUT READING docs/oplist-serialization.md *)
   type param =
@@ -519,16 +520,18 @@ module RuntimeT = struct
 
   type function_desc = tlid * string * id [@@deriving yojson]
 
-  type load_fn_result_type =
-    function_desc -> dval list -> (dval * Time.t) option
+  type 'expr_type load_fn_result_type =
+    function_desc -> 'expr_type dval list -> ('expr_type dval * Time.t) option
 
-  type store_fn_result_type = function_desc -> dval list -> dval -> unit
+  type 'expr_type store_fn_result_type =
+    function_desc -> 'expr_type dval list -> 'expr_type dval -> unit
 
-  type load_fn_arguments_type = tlid -> (dval_map * Time.t) list
+  type 'expr_type load_fn_arguments_type =
+    tlid -> ('expr_type dval_map * Time.t) list
 
-  type store_fn_arguments_type = tlid -> dval_map -> unit
+  type 'expr_type store_fn_arguments_type = tlid -> 'expr_type dval_map -> unit
 
-  type fail_fn_type = (?msg:string -> unit -> dval) option
+  type 'expr_type fail_fn_type = (?msg:string -> unit -> 'expr_type dval) option
 
   (* this is _why_ we're executing the AST, to allow us to not
    * emit certain side-effects (eg. DB writes) when showing previews *)
@@ -537,9 +540,9 @@ module RuntimeT = struct
     | Real
   [@@deriving eq, show, yojson]
 
-  type execution_result =
-    | ExecutedResult of dval
-    | NonExecutedResult of dval
+  type 'expr_type execution_result =
+    | ExecutedResult of 'expr_type dval
+    | NonExecutedResult of 'expr_type dval
   [@@deriving eq, show, yojson]
 
   type fn_preview_safety =
@@ -547,15 +550,15 @@ module RuntimeT = struct
     | Unsafe
   [@@deriving eq, show, yojson]
 
-  type exec_state =
+  type 'expr_type exec_state =
     { tlid : tlid
     ; canvas_id : Uuidm.t
     ; account_id : Uuidm.t
-    ; user_fns : expr user_fn list
+    ; user_fns : 'expr_type user_fn list
     ; user_tipes : user_tipe list
-    ; package_fns : fn list
+    ; package_fns : 'expr_type fn list
     ; dbs : expr DbT.db list
-    ; trace : on_execution_path:bool -> id -> dval -> unit
+    ; trace : on_execution_path:bool -> id -> 'expr_type dval -> unit
     ; trace_tlid : tlid -> unit
     ; context : context
     ; execution_id : id
@@ -563,37 +566,44 @@ module RuntimeT = struct
         (* Whether the currently executing code is really being executed (as
          * opposed to being executed for traces) *)
         bool
-    ; exec : state:exec_state -> dval_map -> expr -> dval
+    ; exec :
+           state:'expr_type exec_state
+        -> 'expr_type dval_map
+        -> 'expr_type
+        -> 'expr_type dval
           (* Some parts of the execution need to call AST.exec, but cannot call
            * AST.exec without a cyclic dependency. This function enables that, and it
            * is safe to do so because all of the state is in the exec_state
            * structure. *)
-    ; load_fn_result : load_fn_result_type
-    ; store_fn_result : store_fn_result_type
-    ; load_fn_arguments : load_fn_arguments_type
-    ; store_fn_arguments : store_fn_arguments_type
+    ; load_fn_result : 'expr_type load_fn_result_type
+    ; store_fn_result : 'expr_type store_fn_result_type
+    ; load_fn_arguments : 'expr_type load_fn_arguments_type
+    ; store_fn_arguments : 'expr_type store_fn_arguments_type
     ; executing_fnname : string
-    ; fail_fn : fail_fn_type }
+    ; fail_fn : 'expr_type fail_fn_type }
 
-  and funcimpl =
-    | InProcess of (exec_state * dval list -> dval)
-    | API of (dval_map -> dval)
-    | UserCreated of (tlid * expr)
-    | PackageFunction of expr
+  and 'expr_type funcimpl =
+    | InProcess of
+        ('expr_type exec_state * 'expr_type dval list -> 'expr_type dval)
+    | API of ('expr_type dval_map -> 'expr_type dval)
+    | UserCreated of (tlid * 'expr_type)
+    | PackageFunction of 'expr_type
 
   (* TODO: merge fn and user_fn *)
-  and fn =
+  and 'expr_type fn =
     { prefix_names : string list
     ; infix_names : string list
     ; parameters : param list
     ; return_type : tipe
     ; description : string
-    ; func : funcimpl
+    ; func : 'expr_type funcimpl
     ; preview_safety : fn_preview_safety
     ; deprecated : bool }
 
   (* We need equal_ and show_ for Canvas.canvas to derive *)
-  let equal_fn a b = a.prefix_names = b.prefix_names
+  let equal_fn _ (a : 'expr_type fn) (b : 'expr_type fn) =
+    a.prefix_names = b.prefix_names
+
 
   let ufn_param_to_param (p : ufn_param) : param option =
     match (p.name, p.tipe) with
@@ -608,7 +618,7 @@ module RuntimeT = struct
         None
 
 
-  let user_fn_to_fn (uf : expr user_fn) : fn option =
+  let user_fn_to_fn (uf : 'expr_type user_fn) : 'expr_type fn option =
     let name =
       match uf.metadata.name with Filled (_, n) -> Some n | _ -> None
     in

--- a/backend/test/test_analysis.ml
+++ b/backend/test/test_analysis.ml
@@ -202,7 +202,7 @@ let t_match_evaluation () =
   let check_match
       (msg : string)
       (arg : E.t)
-      (expected : (id * string * execution_result) list) =
+      (expected : (id * string * expr execution_result) list) =
     let ast = astFor arg in
     Log.inspecT "ast" ~f:E.show ast ;
     let dvalStore = exec_save_dvals' ast in

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -356,7 +356,7 @@ let t_db_queryOne_supports_Date_comparison () =
                           (fn op [var "middle"; fieldAccess (var "value") "ts"])
                       ]) ])))
   in
-  let expected (date : string) : dval =
+  let expected (date : string) : expr dval =
     DOption
       (OptJust
          (DObj (DvalMap.singleton "ts" (DDate (date |> Util.date_of_isostring)))))

--- a/backend/test/test_framework.ml
+++ b/backend/test/test_framework.ml
@@ -108,7 +108,7 @@ let t_stored_event_roundtrip () =
 
 let t_trace_data_json_format_redacts_passwords () =
   let id = fid () in
-  let trace_data : Analysis_types.trace_data =
+  let trace_data : expr Analysis_types.trace_data =
     { input = [("event", DPassword (PasswordBytes.of_string "redactme1"))]
     ; timestamp = Time.epoch
     ; function_results =
@@ -118,7 +118,7 @@ let t_trace_data_json_format_redacts_passwords () =
           , 0
           , DPassword (PasswordBytes.of_string "redactme2") ) ] }
   in
-  let expected : Analysis_types.trace_data =
+  let expected : expr Analysis_types.trace_data =
     { input = [("event", DPassword (PasswordBytes.of_string "Redacted"))]
     ; timestamp = Time.epoch
     ; function_results =
@@ -129,13 +129,13 @@ let t_trace_data_json_format_redacts_passwords () =
           , DPassword (PasswordBytes.of_string "Redacted") ) ] }
   in
   trace_data
-  |> Analysis_types.trace_data_to_yojson
-  |> Analysis_types.trace_data_of_yojson
+  |> Analysis_types.trace_data_to_yojson expr_to_yojson
+  |> Analysis_types.trace_data_of_yojson expr_of_yojson
   |> Result.ok_or_failwith
   |> AT.check
        (AT.testable
-          Analysis_types.pp_trace_data
-          Analysis_types.equal_trace_data)
+          (Analysis_types.pp_trace_data pp_expr)
+          (Analysis_types.equal_trace_data equal_expr))
        "trace_data round trip"
        expected
 

--- a/backend/test/test_json.ml
+++ b/backend/test/test_json.ml
@@ -29,17 +29,19 @@ let t_dval_yojson_roundtrips () =
       , Dval.to_internal_roundtrippable_v0
       , Dval.of_internal_roundtrippable_v0 )
     ; ( "safe"
-      , (fun v -> v |> dval_to_yojson |> Yojson.Safe.to_string)
+      , (fun v -> v |> dval_to_yojson expr_to_yojson |> Yojson.Safe.to_string)
       , fun v ->
           v
           |> Yojson.Safe.from_string
-          |> dval_of_yojson
+          |> dval_of_yojson expr_of_yojson
           |> Result.ok_or_failwith ) ]
   in
-  let check name (v : dval) =
+  let check name (v : expr dval) =
     List.iter
       checks
-      ~f:(fun (test_name, (encode : dval -> string), (decode : string -> dval))
+      ~f:(fun ( test_name
+              , (encode : expr dval -> string)
+              , (decode : string -> expr dval) )
               ->
         check_dval (test_name ^ ": " ^ name) v (v |> encode |> decode) ;
         AT.check
@@ -66,7 +68,7 @@ let t_dval_user_db_json_roundtrips () =
     |> Dval.to_internal_queryable_v1
     |> Dval.of_internal_queryable_v1
   in
-  let check name (v : dval) =
+  let check name (v : expr dval) =
     check_dval ("queryable: " ^ name) v (queryable_rt v) ;
     ()
   in
@@ -92,7 +94,7 @@ let t_dval_user_db_v1_migration () =
     |> Dval.to_internal_queryable_v1
     |> Dval.of_internal_queryable_v0
   in
-  let check name (v : dval) =
+  let check name (v : expr dval) =
     check_dval ("forward: " ^ name) v (forward v) ;
     check_dval ("backwards: " ^ name) v (backwards v) ;
     ()

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -1692,7 +1692,7 @@ let t_bool_stdlibs () =
  * - a basic happy-path works
  * - guards for returning non-int or invalid int (not in {-1,0,1}) error *)
 let t_liblist_sort_by_comparator_works () =
-  let dlist_of_intlist (is : int list) : dval =
+  let dlist_of_intlist (is : int list) : expr dval =
     is
     |> List.map ~f:(fun i -> Dint.of_int i |> DInt)
     |> DList

--- a/backend/test/test_string_libs.ml
+++ b/backend/test/test_string_libs.ml
@@ -123,7 +123,11 @@ let t_uuid_string_roundtrip () =
     AT.int
     "A generated id can round-trip"
     0
-    (match exec_ast ast with DList [p1; p2] -> compare_dval p1 p2 | _ -> 1)
+    ( match exec_ast ast with
+    | DList [p1; p2] ->
+        compare_dval compare_expr p1 p2
+    | _ ->
+        1 )
 
 
 let t_substring_works () =

--- a/backend/test/test_user_db.ml
+++ b/backend/test/test_user_db.ml
@@ -109,7 +109,7 @@ let t_uuid_db_roundtrip () =
     0
     ( match exec_handler ~ops ast with
     | DList [p1; p2] ->
-        compare_dval p1 p2
+        compare_dval compare_expr p1 p2
     | _ ->
         1 )
 
@@ -134,7 +134,7 @@ let t_password_hash_db_roundtrip () =
     0
     ( match exec_handler ~ops ast with
     | DList [p1; p2] ->
-        compare_dval p1 p2
+        compare_dval compare_expr p1 p2
     | _ ->
         1 )
 

--- a/backend/test/utils.ml
+++ b/backend/test/utils.ml
@@ -21,12 +21,13 @@ module AT = Alcotest
 (* ------------------- *)
 
 (* Allows us to mock analysis *)
-let test_fn_results : ((function_desc * dval list) * (dval * Time.t)) list ref =
+let test_fn_results :
+    ((function_desc * expr dval list) * (expr dval * Time.t)) list ref =
   ref []
 
 
 (* Not wired up yet *)
-let test_fn_arguments : (dval_map * Time.t) list list ref = ref []
+let test_fn_arguments : (expr dval_map * Time.t) list list ref = ref []
 
 let clear_test_data () : unit =
   test_fn_results := [] ;
@@ -89,12 +90,12 @@ let at_dval =
       | DIncomplete _, DIncomplete _ ->
           true
       | _, _ ->
-          compare_dval a b = 0)
+          compare_dval compare_expr a b = 0)
 
 
 let check_dval = AT.check at_dval
 
-let check_execution_result = AT.check (AT.of_pp pp_execution_result)
+let check_execution_result = AT.check (AT.of_pp (pp_execution_result pp_expr))
 
 let check_dval_list = AT.check (AT.list at_dval)
 
@@ -137,10 +138,10 @@ let testable_handler =
 let testable_id = AT.testable pp_id equal_id
 
 let testable_string_dval_pair =
-  AT.testable pp_string_dval_pair equal_string_dval_pair
+  AT.testable (pp_string_dval_pair pp_expr) (equal_string_dval_pair equal_expr)
 
 
-let check_exception ?(check = fun _ -> true) ~(f : unit -> dval) msg =
+let check_exception ?(check = fun _ -> true) ~(f : unit -> expr dval) msg =
   let e =
     try
       let r = f () in
@@ -166,7 +167,8 @@ let check_exception ?(check = fun _ -> true) ~(f : unit -> dval) msg =
 (* Keep scripts/ocaml-find-unused happy *)
 let _ = check_exception
 
-let check_error_contains (name : string) (result : dval) (substring : string) =
+let check_error_contains
+    (name : string) (result : expr dval) (substring : string) =
   let strresult = Dval.to_developer_repr_v0 result in
   (let open AT in
   check bool)
@@ -331,21 +333,24 @@ let ops2c_exn (host : string) (ops : 'expr_type Op.op list) :
 
 
 let add_test_fn_result
-    (desc : function_desc) (args : dval list) (result : dval * Time.t) : unit =
+    (desc : function_desc) (args : expr dval list) (result : expr dval * Time.t)
+    : unit =
   test_fn_results := ((desc, args), result) :: !test_fn_results ;
   ()
 
 
-let load_test_fn_results (desc : function_desc) (args : dval list) :
-    (dval * Time.t) option =
+let load_test_fn_results (desc : function_desc) (args : expr dval list) :
+    (expr dval * Time.t) option =
   List.find !test_fn_results ~f:(fun ((desc', args'), result) ->
       (desc, args) = (desc', args'))
   |> Option.map ~f:Tuple2.get2
 
 
 let test_execution_data
-    ?(trace_id = Util.create_uuid ()) ?(canvas_name = "test") ops :
-    'expr_type C.canvas ref * exec_state * input_vars =
+    ?(trace_id = Util.create_uuid ())
+    ?(canvas_name = "test")
+    (ops : expr Op.oplist) :
+    expr C.canvas ref * expr exec_state * expr input_vars =
   let c = ops2c_exn canvas_name ops in
   let vars = Execution.dbs_as_input_vars (TL.dbs !c.dbs) in
   let canvas_id = !c.id in
@@ -379,7 +384,7 @@ let test_execution_data
 let execute_ops
     ?(trace_id = Util.create_uuid ())
     ?(canvas_name = "test")
-    (ops : 'expr_type Op.op list) : dval =
+    (ops : 'expr_type Op.op list) : expr dval =
   let ( c
       , { tlid
         ; load_fn_result
@@ -426,7 +431,7 @@ let execute_ops
 
 (* already provided in execute_handler *)
 
-let exec_handler ?(ops = []) (prog : string) : dval =
+let exec_handler ?(ops = []) (prog : string) : expr dval =
   prog
   |> ast_for
   (* |> Log.pp ~f:show_expr *)
@@ -435,7 +440,7 @@ let exec_handler ?(ops = []) (prog : string) : dval =
   |> fun h -> execute_ops (ops @ [h])
 
 
-let exec_handler' ?(ops = []) (ast : Libshared.FluidExpression.t) : dval =
+let exec_handler' ?(ops = []) (ast : Libshared.FluidExpression.t) : expr dval =
   ast
   |> Fluid.fromFluidExpr
   (* |> Log.pp ~f:show_expr *)
@@ -444,7 +449,7 @@ let exec_handler' ?(ops = []) (ast : Libshared.FluidExpression.t) : dval =
   |> fun h -> execute_ops (ops @ [h])
 
 
-let exec_ast ?(ops = []) ?(canvas_name = "test") (prog : string) : dval =
+let exec_ast ?(ops = []) ?(canvas_name = "test") (prog : string) : expr dval =
   let c, state, input_vars = test_execution_data ~canvas_name ops in
   let result = Ast.execute_ast ~input_vars ~state (ast_for prog) in
   result
@@ -452,13 +457,13 @@ let exec_ast ?(ops = []) ?(canvas_name = "test") (prog : string) : dval =
 
 let exec_ast'
     ?(ops = []) ?(canvas_name = "test") (ast : Libshared.FluidExpression.t) :
-    dval =
+    expr dval =
   let c, state, input_vars = test_execution_data ~canvas_name ops in
   let result = Ast.execute_ast ~input_vars ~state (Fluid.fromFluidExpr ast) in
   result
 
 
-let exec_userfn (prog : string) : dval =
+let exec_userfn (prog : string) : expr dval =
   let name = "test_function" in
   let ast = ast_for prog in
   let fn = user_fn name [] ast in
@@ -466,7 +471,7 @@ let exec_userfn (prog : string) : dval =
   Ast.execute_fn ~state name execution_id []
 
 
-let exec_userfn_trace_tlids (prog : string) : dval * tlid list =
+let exec_userfn_trace_tlids (prog : string) : expr dval * tlid list =
   let name = "test_function" in
   let ast = ast_for prog in
   let fn = user_fn name [] ast in
@@ -498,7 +503,7 @@ let exec_userfn_trace_tlids (prog : string) : dval * tlid list =
 
 
 let exec_save_dvals ?(ops = []) ?(canvas_name = "test") (ast : expr) :
-    Analysis_types.intermediate_result_store =
+    expr Analysis_types.intermediate_result_store =
   let c, state, input_vars = test_execution_data ~canvas_name ops in
   let { tlid
       ; execution_id
@@ -530,7 +535,7 @@ let exec_save_dvals ?(ops = []) ?(canvas_name = "test") (ast : expr) :
 
 let exec_save_dvals'
     ?(ops = []) ?(canvas_name = "test") (ast : Libshared.FluidExpression.t) :
-    Analysis_types.intermediate_result_store =
+    expr Analysis_types.intermediate_result_store =
   exec_save_dvals ~ops ~canvas_name (Fluid.fromFluidExpr ast)
 
 


### PR DESCRIPTION
https://trello.com/c/tWzL9O0l/2855-large-handlers-on-canvases-should-have-real-time-typing

This is a step to getting rid of the old exprs, which cause some performance problems due to decoding on the client. Up until now, dvals actually use old exprs for the lambda definition in blocks, so even though we have switched to fluid-exprs for many APIs, dvals still require the old exprs.

This changes the signature from `dval` to `'expr_type dval`, which will allow us to shift over from being most `expr dval` to all `fluid_expr` dval. I plan to make the change to a few APIs at a time to use fluid_exprs instead.

For the frontend, this is the last of the things that are needed to remove expr decoding. 

I haven't looked at the performance here (the problem being that we completely traverse a dval at various points). I don't expect a problem - those are typically points at which we traverse the entire dvals anyway, ocaml is very fast at this sort of thing, and we'll be moving forward with this anyway soon so the problem won't last, if there is one.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

