### PR TITLE
Validate db name when creating from the omnibox

### DIFF
--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -1940,9 +1940,8 @@ let update_ (msg : msg) (m : model) : modification =
       let center = Viewport.findNewPos m in
       Entry.submitOmniAction m center action
   | CreateDBTable ->
-      let center = Viewport.findNewPos m
-      and genName = DB.generateDBName () in
-      Entry.newDB genName center
+      let center = Viewport.findNewPos m in
+      Refactor.createNewDB m None center
   | CreateGroup ->
       let center = Viewport.findNewPos m in
       Groups.createEmptyGroup None center


### PR DESCRIPTION
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists


### Trello:
https://trello.com/c/RTZsRGTJ/2943-i-can-create-multiple-dbs-with-the-same-name

### What/why:
**What i thought before:** 
Previously users were able to create db's with duplicate name and this causes all kinds of weird problems when doing anything that references either of the db's. Now we will validate that the db name is valid and unique before creating it.


**What I know after a mid-review chat**
Ian C pointed out that this would be a bug on the backend but after we looked into the bug and it seemed like it is only a problem on one of my canvases. I tried to look into _why_ it is broken on my one canvas but was unable to figure it out after around 30 mins and I don't think it's worth the time investigating right now. 

You are currently prevented from creating any duplicate db's on any new canvases by the backend, and now we are just adding validation on the front end.

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

