### PR TITLE
Support either fluid or old exprs in APIs that take dvals

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -994,7 +994,7 @@ let execute_function ~(execution_id : Types.id) (host : string) body :
           ~tlid:params.tlid
           ~trace_id:params.trace_id
           ~caller_id:params.caller_id
-          ~args:params.args)
+          ~args:(List.map ~f:Libexecution.Fluid.dval_of_fluid params.args))
   in
   let t4, unlocked =
     time "4-analyze-unlocked-dbs" (fun _ -> Analysis.unlocked !c)
@@ -1085,7 +1085,12 @@ let trigger_handler ~(execution_id : Types.id) (host : string) body :
                 handler
                 ~execution_id
                 ~tlid:params.tlid
-                ~input_vars:params.input
+                ~input_vars:
+                  (List.map
+                     params.input
+                     ~f:
+                       (Tc.Tuple2.map_second
+                          ~f:Libexecution.Fluid.dval_of_fluid))
                 ~dbs:(TL.dbs !c.dbs)
                 ~user_tipes:(!c.user_tipes |> Map.data)
                 ~user_fns:(!c.user_functions |> Map.data)


### PR DESCRIPTION
This makes the server accept dvals encoded using exprs or fluid_exprs (previously they were only encoded with exprs).

This only matters for dblock_args (in which the lambda is an expr or a fluid_expr).

The client still sends exprs, but this allows changing to fluid_exprs.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

