### PR TITLE
Remove two calls to tokenize by reusing existing tokenization

### DIFF
--- a/client/src/canvas/View.ml
+++ b/client/src/canvas/View.ml
@@ -85,7 +85,7 @@ let viewTL_ (m : model) (tl : toplevel) : msg Html.html =
     ; ("group", match tl with TLGroup _ -> true | _ -> false) ]
   in
   let id =
-    Fluid.getToken vs.ast vs.fluidState
+    Fluid.getToken' vs.tokens vs.fluidState
     |> Option.map ~f:(fun ti -> FluidToken.tid ti.token)
     |> Option.orElse (CursorState.idOf m.cursorState)
   in

--- a/client/src/fluid/FluidEditorView.ml
+++ b/client/src/fluid/FluidEditorView.ml
@@ -86,7 +86,7 @@ let toHtml (s : state) : Types.msg Html.html list =
     | _ ->
         UnknownExecution
   in
-  let currentTokenInfo = Fluid.getToken s.ast s.fluidState in
+  let currentTokenInfo = Fluid.getToken' s.tokens s.fluidState in
   let caretRow = currentTokenInfo |> Option.map ~f:(fun ti -> ti.startRow) in
   let sourceOfCurrentToken onTi =
     currentTokenInfo


### PR DESCRIPTION
There were three calls to tokenize in in doRender, and at most one was necessary.

Before:
![image](https://user-images.githubusercontent.com/181762/79611531-cbd88280-80c8-11ea-9749-250a6bc39c4b.png)

After
![image](https://user-images.githubusercontent.com/181762/79611498-bfecc080-80c8-11ea-83cd-21f37603d24b.png)

This shaves off 2ms from a 19ms call.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

