### PR TITLE
Remove relatively expensive, semi-frequent, unnecessary computation

### DIFF
--- a/client/src/analysis/Analysis.ml
+++ b/client/src/analysis/Analysis.ml
@@ -29,8 +29,8 @@ let defaultTraceIDForTL ~(tlid : TLID.t) =
 
 let getTraces (m : model) (tlid : TLID.t) : trace list =
   StrDict.get ~key:(TLID.toString tlid) m.traces
-  |> Option.withDefault
-       ~default:[(defaultTraceIDForTL ~tlid, Result.fail NoneYet)]
+  |> Option.withDefaultLazy ~default:(fun () ->
+         [(defaultTraceIDForTL ~tlid, Result.fail NoneYet)])
 
 
 let getTrace (m : model) (tlid : TLID.t) (traceID : traceID) : trace option =


### PR DESCRIPTION
This happens on every cache key, and contributed about 1ms to doRender (For small/no selected handlers, this is about 25% of the run-time. For medium and large, it's about 6% and 2%).

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

