### PR TITLE
Remove encoders for old expressions

### DIFF
--- a/client/src/core/Encoders.ml
+++ b/client/src/core/Encoders.ml
@@ -123,7 +123,7 @@ let rec dval (dv : Types.dval) : Js.Json.t =
         object_
           [ ("symtable", tcStrDict dval symtable)
           ; ("params", list (pair id string) params)
-          ; ("body", body |> OldExpr.fromFluidExpr |> expr) ]
+          ; ("body", fluidExpr body) ]
       in
       ev "DBlock" [dblock_args]
   | DIncomplete ds ->
@@ -615,62 +615,6 @@ and userFunctionParameter (p : Types.userFunctionParameter) : Js.Json.t =
     ; ("block_args", list string p.ufpBlock_args)
     ; ("optional", bool p.ufpOptional)
     ; ("description", string p.ufpDescription) ]
-
-
-and expr (expr : OldExpr.expr) : Js.Json.t = blankOr nExpr expr
-
-and nExpr (nexpr : OldExpr.nExpr) : Js.Json.t =
-  let e = expr in
-  let ev = variant in
-  match nexpr with
-  | FnCall (F (_, n), exprs, r) ->
-      let op = if r = Rail then "FnCallSendToRail" else "FnCall" in
-      ev op [string n; list e exprs]
-  | FnCall (Blank _, exprs, r) ->
-      let op = if r = Rail then "FnCallSendToRail" else "FnCall" in
-      let encoded = ev op [string "unknown"; list e exprs] in
-      recover "fnCall hack used" ~debug:nexpr encoded
-  | Let (lhs, rhs, body) ->
-      ev "Let" [blankOr string lhs; e rhs; e body]
-  | Lambda (vars, body) ->
-      ev "Lambda" [list (blankOr string) vars; e body]
-  | FieldAccess (obj, field) ->
-      ev "FieldAccess" [e obj; blankOr string field]
-  | If (cond, then_, else_) ->
-      ev "If" [e cond; e then_; e else_]
-  | Variable v ->
-      ev "Variable" [string v]
-  | Value v ->
-      ev "Value" [string v]
-  | Thread exprs ->
-      ev "Thread" [list e exprs]
-  | ObjectLiteral pairs ->
-      ev "ObjectLiteral" [list (pair (blankOr string) expr) pairs]
-  | ListLiteral elems ->
-      ev "ListLiteral" [list e elems]
-  | FeatureFlag (msg, cond, a, b) ->
-      ev "FeatureFlag" [blankOr string msg; e cond; e a; e b]
-  | Match (matchExpr, cases) ->
-      ev "Match" [e matchExpr; list (pair pattern expr) cases]
-  | Constructor (name, args) ->
-      ev "Constructor" [blankOr string name; list e args]
-  | FluidPartial (name, oldExpr) ->
-      ev "FluidPartial" [string name; e oldExpr]
-  | FluidRightPartial (name, oldExpr) ->
-      ev "FluidRightPartial" [string name; e oldExpr]
-
-
-and pattern (p : OldExpr.pattern) : Js.Json.t = blankOr nPattern p
-
-and nPattern (npat : OldExpr.nPattern) : Js.Json.t =
-  let ev = variant in
-  match npat with
-  | PVariable a ->
-      ev "PVariable" [string a]
-  | PLiteral a ->
-      ev "PLiteral" [string a]
-  | PConstructor (a, b) ->
-      ev "PConstructor" [string a; list pattern b]
 
 
 and sendToRail (sendToRail : FluidExpression.sendToRail) : Js.Json.t =


### PR DESCRIPTION
Cleanup, part of https://trello.com/c/tWzL9O0l/2855-large-handlers-on-canvases-should-have-real-time-typing


The final place the encoders for old exprs were used was in dvals. In #2240, I made it so that they can take fluidExprs - this changes the client side to start sending with fluid encoders.

There are 4 places that use dval encoders:
- functionResults
- traceData
- executeFunction
- triggerHandler

functionResults and traceData encoders are only used to send data to jsanalysis - I verified jsanalysis still works with a lambda payload.

executeFunction and triggerHandler are used to send data to the server. I've validated they both work with a lambda payload.

No performance impact to be expected here, just deleting code.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

