### PR TITLE
Fix slugify, which ~barely~ "worked"!

### DIFF
--- a/backend/libexecution/libstring.ml
+++ b/backend/libexecution/libstring.ml
@@ -355,6 +355,35 @@ let fns : expr fn list =
           | args ->
               fail args)
     ; preview_safety = Safe
+    ; deprecated = true }
+  ; { prefix_names = ["String::slugify_v1"]
+    ; infix_names = []
+    ; parameters = [par "string" TStr]
+    ; return_type = TStr
+    ; description = "Turns a string into a slug"
+    ; func =
+        InProcess
+          (function
+          | _, [DStr s] ->
+              let replace = Unicode_string.regexp_replace in
+              let to_remove = "[^\\w\\s_-]" in
+              let trim = "^\\s+|\\s+$" in
+              let newspaces = "[-_\\s]+" in
+              s
+              |> replace
+                   ~pattern:to_remove
+                   ~replacement:(Unicode_string.of_string_exn "")
+              |> replace
+                   ~pattern:trim
+                   ~replacement:(Unicode_string.of_string_exn "")
+              |> replace
+                   ~pattern:newspaces
+                   ~replacement:(Unicode_string.of_string_exn "-")
+              |> Unicode_string.lowercase
+              |> fun s -> DStr s
+          | args ->
+              fail args)
+    ; preview_safety = Safe
     ; deprecated = false }
   ; { prefix_names = ["String::reverse"]
     ; infix_names = []

--- a/backend/test/test_string_libs.ml
+++ b/backend/test/test_string_libs.ml
@@ -112,6 +112,19 @@ let t_html_escaping () =
     (exec_ast "(String::htmlEscape 'test<>&\\\"')")
 
 
+let t_slugify_works () =
+  check_dval
+    "slugify escaping works"
+    (Dval.dstr_of_string_exn
+       "my-super-really-excellent-uber-amazing-very-clever-thing-coffee")
+    (exec_ast'
+       (fn
+          "String::slugify_v1"
+          [ str
+              "  m@y  'super'  really- excellent *uber_ amazing* ~very  ~ \"clever\" thing: coffee😭!"
+          ]))
+
+
 let t_uuid_string_roundtrip () =
   let ast =
     "(let i (Uuid::generate)
@@ -200,6 +213,7 @@ let suite =
     , t_string_trim_preserves_emoji )
   ; ("HTML escaping works reasonably", `Quick, t_html_escaping)
   ; ("UUIDs round-trip to/from strings", `Quick, t_uuid_string_roundtrip)
+  ; ("Slugify works", `Quick, t_slugify_works)
   ; ("substring works", `Quick, t_substring_works)
   ; ("startsWith works", `Quick, t_startsWith_works)
   ; ("endsWith works", `Quick, t_endsWith_works) ]


### PR DESCRIPTION
https://trello.com/c/IBaJRoiP/2953-stringslugifyv1

Some users (https://darkcommunity.slack.com/archives/CP3FBU3T8/p1587230202166100) found String::slugify didn't handle quotes. Honestly, I have no idea what it did.

Made a new version which slugifies properly (with a test!)

`"fix-slugify-which-~barely~-"worked"!"`

vs

`"fix-slugify-which-barely-worked"`

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

