### PR TITLE
Add a build-hash to frontend and backend headers

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1734,14 +1734,14 @@ let admin_api_handler
     then Log.add_log_annotations [("canvas", `String canvas)] (fun _ -> f p)
     else respond ~execution_id `Unauthorized "Unauthorized"
   in
-  let client_buildhash =
+  let client_version =
     req
     |> CRequest.headers
-    |> fun hs -> Cohttp.Header.get hs Libshared.Header.client_buildhash
+    |> (fun hs -> Cohttp.Header.get hs Libshared.Header.client_version)
+    |> Tc.Option.withDefault ~default:""
   in
   Log.add_log_annotations
-    [ ( Libshared.Header.client_buildhash
-      , `String (client_buildhash |> Tc.Option.withDefault ~default:"") ) ]
+    [(Libshared.Header.client_version, `String client_version)]
     (fun () ->
       match (verb, path) with
       (* Operational APIs.... maybe these shouldn't be here, but

--- a/client/src/api/API.ml
+++ b/client/src/api/API.ml
@@ -1,7 +1,7 @@
 open Prelude
 
-let client_buildhash_header m : Tea_http.header =
-  Header (Client_header.client_buildhash, m.buildHash)
+let clientVersionHeader m : Tea_http.header =
+  Header (Header.client_version, m.buildHash)
 
 
 let apiCallNoParams
@@ -16,7 +16,7 @@ let apiCallNoParams
       ; headers =
           [ Header ("Content-type", "application/json")
           ; Header ("X-CSRF-Token", m.csrfToken)
-          ; client_buildhash_header m ]
+          ; clientVersionHeader m ]
       ; url
       ; body = Web.XMLHttpRequest.EmptyBody
       ; expect = Tea.Http.expectStringResponse (Decoders.wrapExpect decoder)
@@ -56,7 +56,7 @@ let apiCall
     (endpoint : string) : msg Tea.Cmd.t =
   let request =
     postJson
-      ~headers:[client_buildhash_header m]
+      ~headers:[clientVersionHeader m]
       decoder
       m.csrfToken
       ("/api/" ^ Tea.Http.encodeUri m.canvasName ^ endpoint)
@@ -199,7 +199,7 @@ let sendPresence (m : model) (av : avatarModelMessage) : msg Tea.Cmd.t =
   let url = "https://presence.darklang.com/presence" in
   let request =
     postJson
-      ~headers:[client_buildhash_header m]
+      ~headers:[clientVersionHeader m]
       ~withCredentials:true
       (fun _ -> ())
       m.csrfToken
@@ -223,7 +223,7 @@ let sendInvite (m : model) (invite : SettingsViewTypes.inviteFormMessage) :
   let url = "https://accounts.darklang.com/send-invite" in
   let request =
     postJson
-      ~headers:[client_buildhash_header m]
+      ~headers:[clientVersionHeader m]
       ~withCredentials:true
       (fun _ -> ())
       m.csrfToken
@@ -249,7 +249,7 @@ let getCanvasInfo (m : model) : msg Tea.Cmd.t =
   let url = "https://accounts.darklang.com/canvas-info" in
   let request =
     postJson
-      ~headers:[client_buildhash_header m]
+      ~headers:[clientVersionHeader m]
       ~withCredentials:true
       Decoders.loadCanvasInfoAPIResult
       m.csrfToken
@@ -276,7 +276,7 @@ let sendCanvasInfo (m : model) (canvasInfo : SettingsViewTypes.updateCanvasInfo)
   let url = "https://accounts.darklang.com/update-canvas-info" in
   let request =
     postJson
-      ~headers:[client_buildhash_header m]
+      ~headers:[clientVersionHeader m]
       ~withCredentials:true
       (fun _ -> ())
       m.csrfToken

--- a/client/src/api/APIError.ml
+++ b/client/src/api/APIError.ml
@@ -12,7 +12,7 @@ let serverVersionOf (e : apiError) : string option =
       let module StringMap = Map.Make (Caml.String) in
       response.headers
       |> StringMap.find_first_opt (fun key ->
-             String.toLower key = Client_header.server_version)
+             String.toLower key = Header.server_version)
       |> Option.map ~f:Tuple2.second
 
 

--- a/client/src/api/client_header.ml
+++ b/client/src/api/client_header.ml
@@ -1,5 +1,0 @@
-(* This exists because Libshared is available in the worker but not the client *)
-
-let server_version = "x-darklang-server-version"
-
-let client_buildhash = "x-darklang-client-buildhash"

--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -410,7 +410,7 @@ setTimeout(function() {
   }
   let rollbarConfigSetup =
     "const rollbarConfig = '" + JSON.stringify(rollbarConfig) + "';\n\n";
-  let buildHashSetup = "const buildHash = " + JSON.stringify(buildHash) + ";\n\n";
+  let buildHashSetup = "const buildHash = '" + buildHash + "';\n\n";
 
   let analysisjs = fetcher("/analysis.js");
   let analysiswrapperjs = fetcher("/analysiswrapper.js");

--- a/client/workers/Fetcher.ml
+++ b/client/workers/Fetcher.ml
@@ -41,7 +41,7 @@ let fetch_
             (Js.Dict.fromList
                [ ("Content-Type", "application/json")
                ; ("X-CSRF-TOKEN", context.csrfToken)
-               ; ("x-darklang-client-buildhash", buildHash) ]))
+               ; (Header.client_version, buildHash) ]))
        ())
   |> then_ (fun (resp : Fetch.response) ->
          (* The result not be there because we haven't saved the handler yet.

--- a/libshared/Header.ml
+++ b/libshared/Header.ml
@@ -2,4 +2,4 @@ let execution_id = "x-darklang-execution-id"
 
 let server_version = "x-darklang-server-version"
 
-let client_buildhash = "x-darklang-client-buildhash"
+let client_version = "x-darklang-client-version"

--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -129,7 +129,7 @@ data:
           dataset: kubernetes-bwd-nginx
           options:
             config_file: /etc/nginx/conf.d/nginx.conf
-            log_format: '$remote_addr - $remote_user [$time_local] $host "$request" $status $bytes_sent $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $request_length "$http_authorization" "$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name "$upstream_http_x_darklang_execution_id" "$http_cookie" "$upstream_http_x_dark_username" "$http_x_darklang_client_buildhash" "$upstream_http_x_darklang_server_version"'
+            log_format: '$remote_addr - $remote_user [$time_local] $host "$request" $status $bytes_sent $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $request_length "$http_authorization" "$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name "$upstream_http_x_darklang_execution_id" "$http_cookie" "$upstream_http_x_dark_username" "$http_x_darklang_client_version" "$upstream_http_x_darklang_server_version"'
         processors:
         - request_shape:
             field: request

--- a/scripts/support/nginx.conf
+++ b/scripts/support/nginx.conf
@@ -46,7 +46,7 @@ log_format honeycomb '$remote_addr - $remote_user [$time_local] $host '
     '"$request" $status $bytes_sent $body_bytes_sent $request_time '
     '"$http_referer" "$http_user_agent" $request_length "$http_authorization" '
     '"$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name '
-    '"$upstream_http_x_darklang_execution_id" "$http_cookie" "$upstream_http_x_dark_username" "$http_x_darklang_client_buildhash" "$upstream_http_x_darklang_server_version"';
+    '"$upstream_http_x_darklang_execution_id" "$http_cookie" "$upstream_http_x_dark_username" "$http_x_darklang_client_version" "$upstream_http_x_darklang_server_version"';
 access_log /var/log/nginx/access.log honeycomb;
 
 # 'trust' all ips, rather than the footgun of "oops, changed our incoming ip,


### PR DESCRIPTION
Adds "x-darklang-buildhash" to client requests and server responses.

For the client, this is straightforward. I chose lowercase because lowercase is how HTTP headers actually work as i understand it, and it seems clearer. I didn't change the existing headers in case anything relies on it (honeycomb? seems unlikely but whatever).

For the server, I added the response in the same place as we add execution IDs in for API responses. This is not visible in grand user execution (i dont have an opinion on whether we should or not).

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

