### PR TITLE
Fix selection crash

### DIFF
--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -169,10 +169,10 @@ let setFluidSelectionRange (beginIdx : int) (endIdx : int) : unit =
          let maxChars = editor |> Element.textContent |> String.length in
          let anchorBound = beginIdx |> clamp 0 maxChars in
          let focusBound = endIdx |> clamp 0 maxChars in
+         let childNodes = Element.childNodes editor |> NodeList.toArray in
          let findNodeAndOffset (bound : int) : Node.t option * int =
            let offset = ref bound in
-           Element.childNodes editor
-           |> NodeList.toArray
+           childNodes
            |> Array.find ~f:(fun child ->
                   let nodeLen =
                     child


### PR DESCRIPTION
https://trello.com/c/fms5kFpw/2955-fix-setandextent-problem-when-highlighting-partial

When highlight you highlight this code:

![image](https://user-images.githubusercontent.com/181762/79688894-60ed8f80-821f-11ea-9b53-db017a4637e3.png)

From right to left,like this:
![image](https://user-images.githubusercontent.com/181762/79688902-6e0a7e80-821f-11ea-928e-65785cfe2b5e.png)


your selection includes the entire contents of the autocomplete. This messed up a calculation, causing this (browser crashed):

![image](https://user-images.githubusercontent.com/181762/79688881-4fa48300-821f-11ea-8b41-b4de82883472.png)

This was reported by a user (it was related to a thing I've seen go by in rollbar, but alas was not the thing in rollbar).

Also took the opportunity to do a very small performance improvement, good for about 0.5ms of doRender on tair-snippy, which isn't much but also isn't nothing.

My understanding is that testcafe doesn't work on selections (though that was a different selection thing, not sure) so no test. Type safety is pretty good here though. 

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

