### PR TITLE
Support String::contains in the SQL compiler

### DIFF
--- a/backend/libbackend/sql_compiler.ml
+++ b/backend/libbackend/sql_compiler.ml
@@ -292,7 +292,8 @@ let rec lambda_to_sql
   | Filled (_, FnCall ("!=", [Filled (_, Value "null"); e]))
   | Filled (_, FnCall ("!=", [e; Filled (_, Value "null")])) ->
       "(" ^ lts TNull e ^ " is not null)"
-  | Filled (_, FnCall ("String::isSubstring_v1", [lookingIn; searchingFor])) ->
+  | Filled (_, FnCall ("String::isSubstring_v1", [lookingIn; searchingFor]))
+  | Filled (_, FnCall ("String::contains", [lookingIn; searchingFor])) ->
       (* strpos returns indexed from 1; 0 means missing *)
       "(strpos(" ^ lts TStr lookingIn ^ ", " ^ lts TStr searchingFor ^ ") > 0)"
   | Filled (_, FnCall (op, [l; r])) ->

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -1016,6 +1016,23 @@ let t_db_query_works () =
     (DList [Dval.dint 10; Dval.dint 65; Dval.dint 73])
     (* matches the ocaml version: "" is a substring of all strings *)
     (queryv (fn "String::isSubstring_v1" [field "v" "name"; str ""]) |> execs) ;
+  check_dval
+    "string::contains"
+    (DList [Dval.dint 65; Dval.dint 73])
+    (queryv (fn "String::contains" [field "v" "name"; str "R"]) |> execs) ;
+  check_dval
+    "string::contains case-sensitive"
+    (DList [])
+    (queryv (fn "String::contains" [field "v" "name"; str "ROSS"]) |> execs) ;
+  check_dval
+    "string::contains when empty"
+    (DList [])
+    (queryv (fn "String::contains" [field "v" "name"; str "ZZZ"]) |> execs) ;
+  check_dval
+    "string::contains empty arg"
+    (DList [Dval.dint 10; Dval.dint 65; Dval.dint 73])
+    (* matches the ocaml version: "" is a substring of all strings *)
+    (queryv (fn "String::contains" [field "v" "name"; str ""]) |> execs) ;
   (* -------------- *)
   (* Test partial evaluation *)
   (* -------------- *)


### PR DESCRIPTION
https://trello.com/c/R0IUpfFx/2959-support-stringcontains-in-sql-compiler

String::contains is the new name for String::isSubstring_v1, which is deprecated. However, we didn't update the SQL compiler.

It would be good to change the fn representation to include the SQL compiler in the definition, but that's not a small job so I didn't want to increase the scope.


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

