### PR TITLE
Convert more to fluid

### DIFF
--- a/backend/bin/validate_data_loads.ml
+++ b/backend/bin/validate_data_loads.ml
@@ -25,7 +25,7 @@ let validate_row (table : string) (values : string list) : unit =
         [("table", table); ("canvas", canvas_name); ("trace_id", trace_id)]
       in
       ( try
-          let (_ : RTT.expr RTT.dval) =
+          let (_ : Types.fluid_expr RTT.dval) =
             Dval.of_internal_roundtrippable_v0 value
           in
           Log.infO "successful roundtrip" ~params

--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -232,7 +232,8 @@ let dequeue transaction : expr t option =
         ~jsonparams:queue_delay ;
       Some
         { id = int_of_string id
-        ; value = Dval.of_internal_roundtrippable_v0 value
+        ; value =
+            value |> Dval.of_internal_roundtrippable_v0 |> Fluid.dval_of_fluid
         ; retries = int_of_string retries
         ; canvas_id = Util.uuid_of_string canvas_id
         ; host

--- a/backend/libbackend/legacy.ml
+++ b/backend/libbackend/legacy.ml
@@ -768,7 +768,7 @@ module LibhttpclientV0 = struct
       if has_form_header headers
       then Dval.of_form_encoding result
       else if has_json_header headers
-      then Dval.of_unknown_json_v0 result
+      then Dval.of_unknown_json_v0 result |> Fluid.dval_of_fluid
       else Dval.dstr_of_string_exn result
     in
     let parsed_headers =
@@ -917,7 +917,7 @@ module LibhttpclientV1 = struct
         with _ -> Dval.dstr_of_string_exn "form decoding error"
       else if has_json_header headers
       then
-        try Dval.of_unknown_json_v0 result
+        try Dval.of_unknown_json_v0 result |> Fluid.dval_of_fluid
         with _ -> Dval.dstr_of_string_exn "json decoding error"
       else
         try Dval.dstr_of_string_exn result
@@ -1047,7 +1047,7 @@ module LibhttpclientV2 = struct
         with _ -> Dval.dstr_of_string_exn "form decoding error"
       else if has_json_header headers
       then
-        try Dval.of_unknown_json_v0 result
+        try Dval.of_unknown_json_v0 result |> Fluid.dval_of_fluid
         with _ -> Dval.dstr_of_string_exn "json decoding error"
       else
         try Dval.dstr_of_string_exn result

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -793,7 +793,7 @@ that's already taken, returns an error."
                              [ ("path", Dval.dstr_of_string_exn path)
                              ; ("traceid", DUuid traceid)
                              ; ("time", DDate time)
-                             ; ("event", data) ]
+                             ; ("event", Fluid.dval_of_fluid data) ]
                              |> DvalMap.from_list
                              |> fun o -> DObj o)
                       |> fun l -> DList l

--- a/backend/libbackend/libhttpclient.ml
+++ b/backend/libbackend/libhttpclient.ml
@@ -124,7 +124,9 @@ let send_request
       with _ -> Dval.dstr_of_string_exn "form decoding error"
     else if has_json_header raw_response_headers
     then
-      try Dval.of_unknown_json_v0 raw_response_body
+      try
+        Dval.of_unknown_json_v0 raw_response_body
+        |> Libexecution.Fluid.dval_of_fluid
       with _ -> Dval.dstr_of_string_exn "json decoding error"
     else
       try Dval.dstr_of_string_exn raw_response_body

--- a/backend/libbackend/libjwt.ml
+++ b/backend/libbackend/libjwt.ml
@@ -261,8 +261,11 @@ let fns =
                     ~token:(Unicode_string.to_string token)
                 with
               | Some (headers, payload) ->
-                  [ ("header", Dval.of_unknown_json_v1 headers)
-                  ; ("payload", Dval.of_unknown_json_v1 payload) ]
+                  [ ( "header"
+                    , Dval.of_unknown_json_v1 headers |> Fluid.dval_of_fluid )
+                  ; ( "payload"
+                    , Dval.of_unknown_json_v1 payload |> Fluid.dval_of_fluid )
+                  ]
                   |> Prelude.StrDict.from_list_exn
                   |> DObj
                   |> OptJust
@@ -299,8 +302,12 @@ let fns =
                         ~token:(Unicode_string.to_string token)
                     with
                   | Ok (headers, payload) ->
-                      [ ("header", Dval.of_unknown_json_v1 headers)
-                      ; ("payload", Dval.of_unknown_json_v1 payload) ]
+                      [ ( "header"
+                        , Dval.of_unknown_json_v1 headers |> Fluid.dval_of_fluid
+                        )
+                      ; ( "payload"
+                        , Dval.of_unknown_json_v1 payload |> Fluid.dval_of_fluid
+                        ) ]
                       |> Prelude.StrDict.from_list_exn
                       |> DObj
                       |> ResOk

--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -70,7 +70,7 @@ let dequeue_and_process execution_id :
                                   ~trace_id
                                   ~canvas_id
                                   desc
-                                  event.value
+                                  (Fluid.dval_to_fluid event.value)
                               in
                               let h =
                                 !c.handlers
@@ -124,14 +124,20 @@ let dequeue_and_process execution_id :
                                       ~user_fns:(!c.user_functions |> IDMap.data)
                                       ~package_fns:!c.package_fns
                                       ~account_id:!c.owner
-                                      ~store_fn_arguments:
-                                        (Stored_function_arguments.store
-                                           ~canvas_id
-                                           ~trace_id)
+                                      ~store_fn_arguments:(fun tlid dvalmap ->
+                                        Stored_function_arguments.store
+                                          ~canvas_id
+                                          ~trace_id
+                                          tlid
+                                          (Fluid.dval_map_to_fluid dvalmap))
                                       ~store_fn_result:
-                                        (Stored_function_result.store
-                                           ~canvas_id
-                                           ~trace_id)
+                                        (fun funcdesc args result ->
+                                        Stored_function_result.store
+                                          ~canvas_id
+                                          ~trace_id
+                                          funcdesc
+                                          (List.map ~f:Fluid.dval_to_fluid args)
+                                          (Fluid.dval_to_fluid result))
                                       ~canvas_id
                                   in
                                   Stroller.push_new_trace_id

--- a/backend/libbackend/stored_event.ml
+++ b/backend/libbackend/stored_event.ml
@@ -19,7 +19,7 @@ let store_event
     ~(trace_id : Uuidm.t)
     ~(canvas_id : Uuidm.t)
     ((module_, path, modifier) : event_desc)
-    (event : RTT.expr RTT.dval) : RTT.time =
+    (event : Types.fluid_expr RTT.dval) : RTT.time =
   Db.fetch_one
     ~name:"stored_event.store_event"
     ~subject:(event_subject module_ path modifier)
@@ -81,7 +81,7 @@ let list_events ~(limit : [`All | `Since of RTT.time]) ~(canvas_id : Uuidm.t) ()
 
 
 let load_events ~(canvas_id : Uuidm.t) ((module_, route, modifier) : event_desc)
-    : (string * Uuidm.t * RTT.time * RTT.expr RTT.dval) list =
+    : (string * Uuidm.t * RTT.time * Types.fluid_expr RTT.dval) list =
   let route = Http.route_to_postgres_pattern route in
   Db.fetch
     ~name:"load_events"
@@ -106,7 +106,7 @@ let load_events ~(canvas_id : Uuidm.t) ((module_, route, modifier) : event_desc)
 
 
 let load_event_for_trace ~(canvas_id : Uuidm.t) (trace_id : Uuidm.t) :
-    (string * RTT.time * RTT.expr RTT.dval) option =
+    (string * RTT.time * Types.fluid_expr RTT.dval) option =
   Db.fetch
     ~name:"load_event_for_trace"
     ~subject:(Uuidm.to_string trace_id)

--- a/backend/libbackend/stored_event.mli
+++ b/backend/libbackend/stored_event.mli
@@ -17,13 +17,13 @@ val store_event :
      trace_id:Uuidm.t
   -> canvas_id:Uuidm.t
   -> event_desc
-  -> Types.RuntimeT.expr Types.RuntimeT.dval
+  -> Types.fluid_expr Types.RuntimeT.dval
   -> Types.RuntimeT.time
 
 val load_event_for_trace :
      canvas_id:Uuidm.t
   -> Uuidm.t
-  -> (string * Types.RuntimeT.time * Types.RuntimeT.expr Types.RuntimeT.dval)
+  -> (string * Types.RuntimeT.time * Types.fluid_expr Types.RuntimeT.dval)
      option
 
 val load_events :
@@ -32,7 +32,7 @@ val load_events :
   -> ( string
      * Uuidm.t
      * Types.RuntimeT.time
-     * Types.RuntimeT.expr Types.RuntimeT.dval )
+     * Types.fluid_expr Types.RuntimeT.dval )
      list
 
 val load_event_ids : canvas_id:Uuidm.t -> event_desc -> (Uuidm.t * string) list

--- a/backend/libbackend/stored_function_arguments.ml
+++ b/backend/libbackend/stored_function_arguments.ml
@@ -17,7 +17,7 @@ let store ~canvas_id ~trace_id tlid args =
 
 
 let load_for_analysis ~canvas_id tlid (trace_id : Uuidm.t) :
-    (RTT.expr Analysis_types.input_vars * RTT.time) option =
+    (Types.fluid_expr Analysis_types.input_vars * RTT.time) option =
   (* We need to alias the subquery (here aliased as `q`) because Postgres
    * requires inner SELECTs to be aliased. *)
   Db.fetch

--- a/backend/libbackend/stored_function_arguments.mli
+++ b/backend/libbackend/stored_function_arguments.mli
@@ -5,15 +5,14 @@ val store :
      canvas_id:Uuidm.t
   -> trace_id:Uuidm.t
   -> Types.tlid
-  -> Types.RuntimeT.expr Types.RuntimeT.dval_map
+  -> Types.fluid_expr Types.RuntimeT.dval_map
   -> unit
 
 val load_for_analysis :
      canvas_id:Uuidm.t
   -> Types.tlid
   -> Uuidm.t
-  -> (Types.RuntimeT.expr Analysis_types.input_vars * Types.RuntimeT.time)
-     option
+  -> (Types.fluid_expr Analysis_types.input_vars * Types.RuntimeT.time) option
 
 val load_traceids : canvas_id:Uuidm.t -> Types.tlid -> Uuidm.t list
 

--- a/backend/libbackend/stored_function_result.ml
+++ b/backend/libbackend/stored_function_result.ml
@@ -8,7 +8,12 @@ module RTT = Types.RuntimeT
 (* External *)
 (* ------------------------- *)
 
-let store ~canvas_id ~trace_id (tlid, fnname, id) arglist result =
+let store
+    ~canvas_id
+    ~trace_id
+    (tlid, fnname, id)
+    (arglist : Types.fluid_expr RTT.dval list)
+    result =
   Db.run
     ~name:"stored_function_result.store"
     "INSERT INTO function_results_v2
@@ -25,7 +30,7 @@ let store ~canvas_id ~trace_id (tlid, fnname, id) arglist result =
       ; RoundtrippableDval result ]
 
 
-let load ~canvas_id ~trace_id tlid : RTT.expr function_result list =
+let load ~canvas_id ~trace_id tlid : Types.fluid_expr function_result list =
   (* Right now, we don't allow the user to see multiple results when a function
    * is called in a loop. But, there's a lot of data when functions are called
    * in a loop, so avoid massive responses. *)

--- a/backend/libbackend/stored_function_result.mli
+++ b/backend/libbackend/stored_function_result.mli
@@ -5,15 +5,15 @@ val store :
      canvas_id:Uuidm.t
   -> trace_id:Uuidm.t
   -> Types.RuntimeT.function_desc
-  -> Types.RuntimeT.expr Types.RuntimeT.dval list
-  -> Types.RuntimeT.expr Types.RuntimeT.dval
+  -> Types.fluid_expr Types.RuntimeT.dval list
+  -> Types.fluid_expr Types.RuntimeT.dval
   -> unit
 
 val load :
      canvas_id:Uuidm.t
   -> trace_id:Uuidm.t
   -> Types.tlid
-  -> Types.RuntimeT.expr Analysis_types.function_result list
+  -> Types.fluid_expr Analysis_types.function_result list
 
 val trim_results : unit -> int
 

--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -559,11 +559,24 @@ let user_page_handler
               ~package_fns:!c.package_fns
               ~tlid:page.tlid
               ~dbs:(TL.dbs !c.dbs)
-              ~input_vars:([("request", PReq.to_dval input)] @ bound)
-              ~store_fn_arguments:
-                (Stored_function_arguments.store ~canvas_id ~trace_id)
-              ~store_fn_result:
-                (Stored_function_result.store ~canvas_id ~trace_id)
+              ~input_vars:
+                ( [ ( "request"
+                    , PReq.to_dval input |> Libexecution.Fluid.dval_of_fluid )
+                  ]
+                @ bound )
+              ~store_fn_arguments:(fun tlid dvalmap ->
+                Stored_function_arguments.store
+                  ~canvas_id
+                  ~trace_id
+                  tlid
+                  (Libexecution.Fluid.dval_map_to_fluid dvalmap))
+              ~store_fn_result:(fun funcdesc args result ->
+                Stored_function_result.store
+                  ~canvas_id
+                  ~trace_id
+                  funcdesc
+                  (List.map ~f:Libexecution.Fluid.dval_to_fluid args)
+                  (Libexecution.Fluid.dval_to_fluid result))
           in
           Stroller.push_new_trace_id
             ~execution_id
@@ -1093,10 +1106,19 @@ let trigger_handler ~(execution_id : Types.id) (host : string) body :
                 ~package_fns:!c.package_fns
                 ~account_id:!c.owner
                 ~canvas_id
-                ~store_fn_arguments:
-                  (Stored_function_arguments.store ~canvas_id ~trace_id)
-                ~store_fn_result:
-                  (Stored_function_result.store ~canvas_id ~trace_id)
+                ~store_fn_arguments:(fun tlid dvalmap ->
+                  Stored_function_arguments.store
+                    ~canvas_id
+                    ~trace_id
+                    tlid
+                    (Libexecution.Fluid.dval_map_to_fluid dvalmap))
+                ~store_fn_result:(fun funcdesc args result ->
+                  Stored_function_result.store
+                    ~canvas_id
+                    ~trace_id
+                    funcdesc
+                    (List.map ~f:Libexecution.Fluid.dval_to_fluid args)
+                    (Libexecution.Fluid.dval_to_fluid result))
             in
             touched_tlids)
   in

--- a/backend/libexecution/dval.ml
+++ b/backend/libexecution/dval.ml
@@ -381,7 +381,7 @@ let empty_dobj : 'expr_type dval = DObj DvalMap.empty
  * and we really need to move off it, but for now we're here. Do not change
  * existing encodings - this will break everything.
  *)
-let rec unsafe_dval_of_yojson_v0 (json : Yojson.Safe.t) : 'expr_type dval =
+let rec unsafe_dval_of_yojson_v0 (json : Yojson.Safe.t) : fluid_expr dval =
   (* sort so this isn't key-order-dependent. *)
   let json = Yojson.Safe.sort json in
   match json with
@@ -438,7 +438,9 @@ let rec unsafe_dval_of_yojson_v0 (json : Yojson.Safe.t) : 'expr_type dval =
     | "block" ->
         (* See docs/dblock-serialization.ml *)
         DBlock
-          {body = Blank (id_of_int 56789); symtable = DvalMap.empty; params = []}
+          { body = EBlank (id_of_int 56789)
+          ; symtable = DvalMap.empty
+          ; params = [] }
     | "errorrail" ->
         DErrorRail DNull
     | _ ->
@@ -485,7 +487,7 @@ and unsafe_dvalmap_of_yojson_v0 (json : Yojson.Safe.t) : 'expr_type dval_map =
       Exception.internal "Not a json object"
 
 
-let rec unsafe_dval_of_yojson_v1 (json : Yojson.Safe.t) : expr dval =
+let rec unsafe_dval_of_yojson_v1 (json : Yojson.Safe.t) : fluid_expr dval =
   (* sort so this isn't key-order-dependent. *)
   let json = Yojson.Safe.sort json in
   match json with
@@ -542,7 +544,7 @@ let rec unsafe_dval_of_yojson_v1 (json : Yojson.Safe.t) : expr dval =
   | `Assoc [("type", `String "block"); ("value", `Null)] ->
       (* See docs/dblock-serialization.ml *)
       DBlock
-        {body = Blank (id_of_int 23456); symtable = DvalMap.empty; params = []}
+        {body = EBlank (id_of_int 23456); symtable = DvalMap.empty; params = []}
   | `Assoc [("type", `String "errorrail"); ("value", dv)] ->
       DErrorRail (unsafe_dval_of_yojson_v1 dv)
   | `Assoc [("type", `String "date"); ("value", `String v)] ->
@@ -718,7 +720,7 @@ let of_internal_roundtrippable_json_v0 j =
   |> Result.map_error ~f:Exception.to_string
 
 
-let of_internal_roundtrippable_v0 str : expr dval =
+let of_internal_roundtrippable_v0 str : fluid_expr dval =
   str |> Yojson.Safe.from_string |> unsafe_dval_of_yojson_v1
 
 
@@ -730,7 +732,7 @@ let to_internal_queryable_v0 dval : string =
   dval |> unsafe_dval_to_yojson_v0 ~redact:false |> Yojson.Safe.to_string
 
 
-let of_internal_queryable_v0 (str : string) : expr dval =
+let of_internal_queryable_v0 (str : string) : fluid_expr dval =
   str |> Yojson.Safe.from_string |> unsafe_dval_of_yojson_v0
 
 

--- a/backend/libexecution/dval.mli
+++ b/backend/libexecution/dval.mli
@@ -45,11 +45,11 @@ val to_internal_roundtrippable_v0 : 'expr_type Types.RuntimeT.dval -> string
  * rare cases where it will parse incorrectly without error. Throws on Json
  * bugs. *)
 val of_internal_roundtrippable_v0 :
-  string -> Types.RuntimeT.expr Types.RuntimeT.dval
+  string -> Types.fluid_expr Types.RuntimeT.dval
 
 val of_internal_roundtrippable_json_v0 :
      Yojson.Safe.t
-  -> (Types.RuntimeT.expr Types.RuntimeT.dval, string) Core_kernel._result
+  -> (Types.fluid_expr Types.RuntimeT.dval, string) Core_kernel._result
 
 (* This is a format used for roundtripping dvals internally, while still being
  * queryable using jsonb in our DB. v0 has bugs due to a legacy of trying to
@@ -60,7 +60,7 @@ val to_internal_queryable_v0 : 'expr_type Types.RuntimeT.dval -> string
 (* This is a format used for roundtripping dvals internally, while still being
  * queryable using jsonb in our DB. There are some rare cases where it will
  * parse incorrectly without error. Throws on Json bugs. *)
-val of_internal_queryable_v0 : string -> Types.RuntimeT.expr Types.RuntimeT.dval
+val of_internal_queryable_v0 : string -> Types.fluid_expr Types.RuntimeT.dval
 
 (* This is a format used for roundtripping dvals internally, while still being
  * queryable using jsonb in our DB. This reduces some of the v0 bugs, but at
@@ -113,11 +113,11 @@ val to_pretty_machine_json_v1 : 'expr_type Types.RuntimeT.dval -> string
 (* When receiving unknown json from the user, or via a HTTP API, attempt to
  * convert everything into reasonable types, in the absense of a schema.
  * This does type conversion, which it shouldn't and should be avoided for new code. *)
-val of_unknown_json_v0 : string -> Types.RuntimeT.expr_dval
+val of_unknown_json_v0 : string -> Types.RuntimeT.fluid_dval
 
 (* When receiving unknown json from the user, or via a HTTP API, attempt to
  * convert everything into reasonable types, in the absense of a schema. *)
-val of_unknown_json_v1 : string -> Types.RuntimeT.expr_dval
+val of_unknown_json_v1 : string -> Types.RuntimeT.fluid_dval
 
 (* For debugging internally, redacts passwords. Never throws. *)
 val show : 'expr_type Types.RuntimeT.dval -> string

--- a/backend/libexecution/libjson.ml
+++ b/backend/libexecution/libjson.ml
@@ -14,7 +14,11 @@ let fns : expr fn list =
         InProcess
           (function
           | _, [DStr json] ->
-            ( try Dval.of_unknown_json_v0 (Unicode_string.to_string json)
+            ( try
+                json
+                |> Unicode_string.to_string
+                |> Dval.of_unknown_json_v0
+                |> Fluid.dval_of_fluid
               with _ -> DNull )
           | args ->
               fail args)
@@ -30,7 +34,10 @@ let fns : expr fn list =
         InProcess
           (function
           | _, [DStr json] ->
-              Dval.of_unknown_json_v1 (Unicode_string.to_string json)
+              json
+              |> Unicode_string.to_string
+              |> Dval.of_unknown_json_v1
+              |> Fluid.dval_of_fluid
           | args ->
               fail args)
     ; preview_safety = Safe
@@ -45,7 +52,10 @@ let fns : expr fn list =
         InProcess
           (function
           | _, [DStr json] ->
-              Dval.of_unknown_json_v1 (Unicode_string.to_string json)
+              json
+              |> Unicode_string.to_string
+              |> Dval.of_unknown_json_v1
+              |> Fluid.dval_of_fluid
           | args ->
               fail args)
     ; preview_safety = Safe
@@ -62,7 +72,10 @@ let fns : expr fn list =
           | _, [DStr json] ->
             ( try
                 let dval =
-                  Dval.of_unknown_json_v1 (Unicode_string.to_string json)
+                  json
+                  |> Unicode_string.to_string
+                  |> Dval.of_unknown_json_v1
+                  |> Fluid.dval_of_fluid
                 in
                 DResult (ResOk dval)
               with e ->

--- a/backend/libexecution/parsed_request.mli
+++ b/backend/libexecution/parsed_request.mli
@@ -12,7 +12,7 @@ val from_request :
   -> header list
   -> query_val list
   -> string
-  -> Types.RuntimeT.expr t
+  -> Types.fluid_expr t
 
 val to_dval : 'expr_type t -> 'expr_type Types.RuntimeT.dval
 

--- a/backend/test/test_framework.ml
+++ b/backend/test/test_framework.ml
@@ -93,16 +93,16 @@ let t_stored_event_roundtrip () =
     (List.sort ~compare [t6])
     (List.sort ~compare loaded) ;
   let loaded1 = SE.load_events ~canvas_id:id1 desc1 |> List.map ~f:t4_get4th in
-  check_dval_list
+  check_dval_list'
     "load GET events"
     [Dval.dstr_of_string_exn "2"; Dval.dstr_of_string_exn "1"]
     loaded1 ;
   let loaded2 = SE.load_events ~canvas_id:id1 desc3 |> List.map ~f:t4_get4th in
-  check_dval_list "load POST events" [Dval.dstr_of_string_exn "3"] loaded2 ;
+  check_dval_list' "load POST events" [Dval.dstr_of_string_exn "3"] loaded2 ;
   let loaded3 = SE.load_events ~canvas_id:id2 desc3 |> List.map ~f:t4_get4th in
-  check_dval_list "load no host2 events" [] loaded3 ;
+  check_dval_list' "load no host2 events" [] loaded3 ;
   let loaded4 = SE.load_events ~canvas_id:id2 desc2 |> List.map ~f:t4_get4th in
-  check_dval_list "load host2 events" [Dval.dstr_of_string_exn "3"] loaded4 ;
+  check_dval_list' "load host2 events" [Dval.dstr_of_string_exn "3"] loaded4 ;
   ()
 
 
@@ -159,7 +159,7 @@ let t_route_variables_work_with_stored_events () =
        (Dval.dstr_of_string_exn "1")) ;
   (* check we get back the path for a route with a variable in it *)
   let loaded1 = SE.load_events ~canvas_id:!c.id route in
-  check_dval_list
+  check_dval_list'
     "load GET events"
     [Dval.dstr_of_string_exn "1"]
     (loaded1 |> List.map ~f:t4_get4th) ;
@@ -196,7 +196,7 @@ let t_route_variables_work_with_stored_events_and_wildcards () =
        (Dval.dstr_of_string_exn "1")) ;
   (* check we get back the path for a route with a variable in it *)
   let loaded1 = SE.load_events ~canvas_id:!c.id route in
-  check_dval_list "load GET events" [] (loaded1 |> List.map ~f:t4_get4th) ;
+  check_dval_list' "load GET events" [] (loaded1 |> List.map ~f:t4_get4th) ;
   ()
 
 

--- a/backend/test/test_http.ml
+++ b/backend/test/test_http.ml
@@ -279,7 +279,7 @@ let t_parsed_request_cookies () =
   in
   let with_cookies c = with_headers [("cookie", c)] in
   AT.check
-    (AT.list at_dval)
+    (AT.list at_dval')
     "Parsed_request.from_request parses cookies correctly."
     [ with_headers []
     ; with_cookies ""
@@ -321,12 +321,12 @@ let t_parsed_request_bodies () =
     Dval.to_dobj_exn [("field1", Dval.dstr_of_string_exn "value1")]
   in
   AT.check
-    (AT.pair at_dval at_dval)
+    (AT.pair at_dval' at_dval')
     "form no json"
     (DNull, expectedObj)
     (parse formHeader "field1=value1") ;
   AT.check
-    (AT.pair at_dval at_dval)
+    (AT.pair at_dval' at_dval')
     "json no form"
     (expectedObj, DNull)
     (parse jsonHeader "{ \"field1\": \"value1\" }") ;

--- a/backend/test/test_json.ml
+++ b/backend/test/test_json.ml
@@ -9,7 +9,7 @@ module Header = Cohttp.Header
 module AT = Alcotest
 
 let t_internal_roundtrippable_doesnt_care_about_order () =
-  check_dval
+  check_dval'
     "internal_roundtrippable doesn't care about key order"
     (Dval.of_internal_roundtrippable_v0
        "{
@@ -29,21 +29,24 @@ let t_dval_yojson_roundtrips () =
       , Dval.to_internal_roundtrippable_v0
       , Dval.of_internal_roundtrippable_v0 )
     ; ( "safe"
-      , (fun v -> v |> dval_to_yojson expr_to_yojson |> Yojson.Safe.to_string)
+      , (fun v ->
+          v
+          |> dval_to_yojson Types.fluid_expr_to_yojson
+          |> Yojson.Safe.to_string)
       , fun v ->
           v
           |> Yojson.Safe.from_string
-          |> dval_of_yojson expr_of_yojson
+          |> dval_of_yojson Types.fluid_expr_of_yojson
           |> Result.ok_or_failwith ) ]
   in
-  let check name (v : expr dval) =
+  let check name (v : Types.fluid_expr dval) =
     List.iter
       checks
       ~f:(fun ( test_name
-              , (encode : expr dval -> string)
-              , (decode : string -> expr dval) )
+              , (encode : Types.fluid_expr dval -> string)
+              , (decode : string -> Types.fluid_expr dval) )
               ->
-        check_dval (test_name ^ ": " ^ name) v (v |> encode |> decode) ;
+        check_dval' (test_name ^ ": " ^ name) v (v |> encode |> decode) ;
         AT.check
           AT.string
           (test_name ^ " as string: " ^ name)
@@ -94,9 +97,9 @@ let t_dval_user_db_v1_migration () =
     |> Dval.to_internal_queryable_v1
     |> Dval.of_internal_queryable_v0
   in
-  let check name (v : expr dval) =
-    check_dval ("forward: " ^ name) v (forward v) ;
-    check_dval ("backwards: " ^ name) v (backwards v) ;
+  let check name (v : Types.fluid_expr dval) =
+    check_dval' ("forward: " ^ name) v (forward v) ;
+    check_dval' ("backwards: " ^ name) v (backwards v) ;
     ()
   in
   let fields =
@@ -269,7 +272,7 @@ let date_migration_has_correct_formats () =
 
 let t_password_json_round_trip_forwards () =
   let password = DPassword (Bytes.of_string "x") in
-  check_dval
+  check_dval'
     "Passwords serialize and deserialize if there's no redaction."
     password
     ( password
@@ -295,7 +298,7 @@ let t_password_serialization () =
     let bytes = Bytes.of_string "encryptedbytes" in
     let password = DPassword bytes in
     AT.check
-      at_dval
+      at_dval'
       ("Passwords serialize in non-redaction function: " ^ name)
       password
       (password |> serialize |> deserialize |> serialize |> deserialize)


### PR DESCRIPTION
This is part of trying to finish the fluid migration on the backend.

This is a pretty mechanical change of more things to fluid. It converts stored_event, stored_function_arguments and stored_function_result to fluid.

Nothing much interesting happens here. The main thing is that when "deserializing" DBlocks, use EBlank instead of Blank. I put "deserializing" in quotes because we have never actually stored DBlocks, and so we just actually create DBlocks with a blank in them.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

