### PR TITLE
Don't sanitize . out of urls in integration test metrics

### DIFF
--- a/scripts/support/process-integration-test-results.sh
+++ b/scripts/support/process-integration-test-results.sh
@@ -40,7 +40,7 @@ jq '.fixtures[0].tests[]' \
                    -e CIRCLE_PULL_REQUEST \
                    -e CIRCLE_SHA1 \
                    -e CIRCLE_USERNAME \
-            | sed -e 's/[^A-Za-z0-9_ =:/-]//g' \
+            | sed -e 's/[^A-Za-z0-9_ =:/.-]//g' \
             | sed -e 's/\(.*\)=\(.*\)/{"\1": "\2"}/' \
             | jq -s add) \
         '. + $env_vars' \


### PR DESCRIPTION
That breaks urls; we got a link to
https://circlecicom/gh/darklang/dark/60346, which needs '.' to be
circleci.com.

Followup to #2270

- [ ] Trello link included
- [X] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

