### PR TITLE
Result functions on the error rail

### DIFF
--- a/backend/libexecution/libresult.ml
+++ b/backend/libexecution/libresult.ml
@@ -47,7 +47,7 @@ let fns =
   ; { prefix_names = ["Result::mapError"]
     ; infix_names = []
     ; parameters = [par "result" TResult; func ["val"]]
-    ; return_type = TAny
+    ; return_type = TResult
     ; description =
         "If `result` is `Error msg`, returns `Error (f msg)` (the lambda `f` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok value`, returns `result` unchanged."
     ; func =
@@ -67,7 +67,7 @@ let fns =
   ; { prefix_names = ["Result::mapError_v1"]
     ; infix_names = []
     ; parameters = [par "result" TResult; func ["val"]]
-    ; return_type = TAny
+    ; return_type = TResult
     ; description =
         "If `result` is `Error msg`, returns `Error (f msg)` (the lambda `f` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok value`, returns `result` unchanged."
     ; func =
@@ -145,7 +145,7 @@ let fns =
   ; { prefix_names = ["Result::toOption"]
     ; infix_names = []
     ; parameters = [par "result" TResult]
-    ; return_type = TAny
+    ; return_type = TOption
     ; description = "Turn a result into an option."
     ; func =
         InProcess
@@ -163,7 +163,7 @@ let fns =
   ; { prefix_names = ["Result::toOption_v1"]
     ; infix_names = []
     ; parameters = [par "result" TResult]
-    ; return_type = TAny
+    ; return_type = TOption
     ; description = "Turn a result into an option."
     ; func =
         InProcess


### PR DESCRIPTION
Ellen mentioned in passing that Result::map2 didn't go to the error rail (used TAny instead of TResult), so I fixed that.

However, it seemed a bunch of other functions also returned TAny, so I also fixed them.

I did not make new versions of the functions: changing the return type is one of the few changes to functions that we can make without making a new version, I believe.

https://trello.com/c/qz0PxmB0/3000-resultmap-goes-to-the-error-rail-but-resultmap2-does-not

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

