### PR TITLE
Ismith/fix tunnel bug

### DIFF
--- a/scripts/support/kubernetes/tunnel/isolate-tunnel.yaml
+++ b/scripts/support/kubernetes/tunnel/isolate-tunnel.yaml
@@ -8,7 +8,17 @@ spec:
       app:
         tunnel-app
   policyTypes:
+  - Egress
   - Ingress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        # make sure to block link-local addresses,
+        # since there's sensitive data in http://metadata
+        - 169.254.0.0/16
+
   ingress:
     - from:
         - podSelector:


### PR DESCRIPTION
Disallow hitting 169.254.* from the tunnel

This means that http://metadata will no longer be reachable in Darklang
by using `HttpClient::get`.

Tested:
- deployed a new cluster
- confirmed, pre-this-commit, that I could `kubectl exec` into the
  tunnel and curl both http://metadata and http://neverssl.com
- deployed the network policy in this PR
- confirmed I could not curl http://metadata anymore, but
  http://neverssl.com still works

No special action needed to get the NetworkPolicy picked up - I did not
have to, eg, restart the tunnel pod. Nor did I have to enable
NetworkPolicies in cloud console web ui; that was mentioned in the
original NetworkPolicy PRs (see #72), and is/was a cluster-level
setting, but did not seem to be necessary when I ran gke-create-cluster;
I assume we copied it over from the prod cluster or something.

Post-deploy, I'll confirm that HttpClient::get works for known-good
cases (google.com, neverssl.com) and fails for http://metadata. That
closes the hole.

More followup is needed around logging and possible further investigation into whether this was eve exploited, notes on that to follow.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

