### PR TITLE
Explain need for gcp-authorize-kubectl when creating custom domains

### DIFF
--- a/docs/custom-domains.md
+++ b/docs/custom-domains.md
@@ -19,10 +19,11 @@ Our former constraint of <= 15 certs is no longer applicable! Yay.
   again, for redirects, not SSL certs.
 
 ## Dark ops instructions
-- Run `scripts/add-custom-domain` and provide the domain; we'll get the canvas
+- Make sure you have run `scripts/gcp-authorize-kubectl` (if you have not, you might get `The connection to the server localhost:8080 was refused - did you specify the right host or port?` in the next step)
+- Run `scripts/add-custom-domain` and provide the domain (eg `api.example.com`); we'll get the canvas
   name from the CNAME, which also verifies that the CNAME DNS record is in
 place.
-  Make sure to supply the DOMAIN without the `https://` prefix and the raw CANVAS name without `builtwithdark`.
+  Make sure to supply the DOMAIN without the `https://` prefix.
 - The CNAME must exist before the below is done because Let's Encrypt uses an
   HTTP request to verify that "we" (the user) control the domain before issuing
 a cert.


### PR DESCRIPTION
https://trello.com/c/TkHnh6sF/3017-followup-document-need-to-run-scripts-gcp-authorize-kubectl-for-custom-domains is a followup for https://trello.com/c/9i2tZS78/3015-help-gunar-get-his-custom-domain-set-up

The basic issue is that if you don't run `gcp-authorize-kubectl`, the custom domain script will fail with an unhelpful message. Ideally we would improve the message, but that is harder. For now, documenting the need to authorize and the unhelpful message should help others avoid my confusion in the future.