### PR TITLE
Make the "User shared dark" event call ourselves

### DIFF
--- a/client/src/components/SettingsView.ml
+++ b/client/src/components/SettingsView.ml
@@ -38,7 +38,6 @@ let validateForm (tab : settingsTab) : bool * settingsTab =
 
 let submitForm (m : Types.model) : Types.model * Types.msg Cmd.t =
   let tab = m.settingsView.tab in
-  Entry.sendSegmentMessage InviteUser ;
   match tab with
   | InviteUser info ->
       let sendInviteMsg =


### PR DESCRIPTION
**Problem:** We integrate with segment using an analytics.js library that gets blocked by ad-blockers. So we aren't able to track all users with ad-block that invited their friends. We want to [track this event more accurately](https://trello.com/c/BSPxLg4r/2737-make-user-shared-dark-event-in-segment-a-backend-event-so-that-it-is-tracked-more-accurately).

**Solution:** 
Going for the easiest solution here. Since send-invite is [handled by an endpoint in Dark](https://darklang.com/a/ops-adduser#handler=559386368), we can just make an async request to segment from that handler by passing it to the [sendToSegment worker](https://darklang.com/a/ops-adduser#handler=253330102).

**Alt Solutions:** Ian Smith suggested
```
Ian Smith 1 minute ago
options: DarkInternal::sendToSegment that can be put in the createAccount ufn in ops-adduser, or impl the segment api in Darklang

Ian Smith 1 minute ago
the former is probs smarter
```
But it seems like way too much work (I also don't know how to make API calls in ocaml-ocaml, and not sure is learning that for this ticket the best use of time). If we can't trust Dark, how do we expect other people to trust Dark.

**Actual Code change in this PR:** just removes our client call, so we don't double count. I kept the event type still in the code just in case we decide to go back on this decision.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

