### PR TITLE
Remove logic that colors request dots red

### DIFF
--- a/client/src/toplevels/ViewData.ml
+++ b/client/src/toplevels/ViewData.ml
@@ -46,13 +46,11 @@ let viewTrace
     (timestamp : string option)
     (isActive : bool)
     (isHover : bool)
-    (isUnfetchable : bool)
-    (tipe : tipe) : msg Html.html =
+    (isUnfetchable : bool) : msg Html.html =
   let tlid = TL.id tl in
   let classes =
     [ ("active", isActive)
     ; ("mouseovered", isHover)
-    ; ("tipe-" ^ Runtime.tipe2str tipe, true)
     ; ("traceid-" ^ traceID, true)
     ; ("unfetchable", isUnfetchable) ]
   in
@@ -118,7 +116,7 @@ let viewTrace
   Html.li props (dotHtml @ [viewData])
 
 
-let viewTraces (vs : ViewUtils.viewState) (astID : ID.t) : msg Html.html list =
+let viewTraces (vs : ViewUtils.viewState) : msg Html.html list =
   let traceToHtml ((traceID, traceData) : trace) =
     let value =
       Option.map ~f:(fun td -> td.input) (traceData |> Result.to_option)
@@ -136,26 +134,13 @@ let viewTraces (vs : ViewUtils.viewState) (astID : ID.t) : msg Html.html list =
     let isUnfetchable =
       match traceData with Error MaximumCallStackError -> true | _ -> false
     in
-    let astTipe =
-      Analysis.getTipeOf' vs.analysisStore astID
-      |> Option.withDefault ~default:TIncomplete
-    in
-    viewTrace
-      vs.tl
-      traceID
-      value
-      timestamp
-      isActive
-      isHover
-      isUnfetchable
-      astTipe
+    viewTrace vs.tl traceID value timestamp isActive isHover isUnfetchable
   in
   List.map ~f:traceToHtml vs.traces
 
 
 let viewData (vs : ViewUtils.viewState) : msg Html.html list =
-  let astID = FluidAST.toID vs.ast in
-  let requestEls = viewTraces vs astID in
+  let requestEls = viewTraces vs in
   let tlSelected =
     match CursorState.tlidOf vs.cursorState with
     | Some tlid when tlid = vs.tlid ->

--- a/client/styles/_live-data.scss
+++ b/client/styles/_live-data.scss
@@ -78,10 +78,6 @@
       justify-content: center;
       color: $grey2;
 
-      &.tipe-Error {
-        color: $red;
-      }
-
       &.unfetchable {
         cursor: not-allowed;
 


### PR DESCRIPTION
Ellen wants to just [remove the red dots because we can't figure out why the wrong dots are turning red](https://trello.com/c/h0lyl9CJ/2887-disable-error-traces-being-red-for-now-fix-if-easy-solution).

Before
<img width="397" alt="Screen Shot 2020-05-01 at 2 48 52 PM" src="https://user-images.githubusercontent.com/244152/80844388-5c2fc080-8bbb-11ea-918f-306af2b7bfe9.png">

After
<img width="397" alt="Screen Shot 2020-05-01 at 2 49 20 PM" src="https://user-images.githubusercontent.com/244152/80844398-605bde00-8bbb-11ea-8516-c99c7d916bb6.png">


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

