### PR TITLE
Ismith/script http authorization and cookie headers from honeycomb

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -112,9 +112,9 @@ data:
             config_file: /etc/nginx/conf.d/nginx.conf
             log_format: '$remote_addr - $remote_user [$time_local] $host "$request" $status $bytes_sent $body_bytes_sent $request_time "$http_referer" "$http_user_agent" $request_length "$http_authorization" "$http_x_forwarded_proto" "$http_x_forwarded_for" $server_name "$upstream_http_x_darklang_execution_id" "$http_cookie" "$upstream_http_x_dark_username" "$http_x_darklang_client_version" "$upstream_http_x_darklang_server_version"'
         processors:
-        - scrub_field:
+        - drop_field:
             field: http_authorization
-        - scrub_field:
+        - drop_field:
             field: http_cookie
         - request_shape:
             field: request


### PR DESCRIPTION
Cookie and authorization headers are sensitive, don't log to honeycomb in raw form

The ticket said "ideally we should whitelist the headers that go to
HC", which I agree with, and we do (in scripts/support/nginx.conf, we
set a log_format which must match the format in
scripts/support/kubernetes/builtwithdark/honeycomb.yaml).

(Why drop_field vs removing from both log_format lines? B/c honeytail
has a similar processor, scrub_field, which replaces them with a SHA256
hash, and it may be useful to be able to look for specific sessions, or
count sessions. We can't currently use this b/c it's in honeytail but
not the kubernetes agent, but if they change that, it'll be a one-line
change to replace drop_field with scrub_field. I've asked in their slack why the discrepancy)

ALSO:  while I was in here, dropped an item from logging we no longer need - we used to double-write request/handler_name fields, see comment in deleted config.

https://trello.com/c/Hy4HrdVM/3042-authorization-and-cookie-headers-should-not-go-to-honeycomb-in-raw-form


- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

