### PR TITLE
Remove maxim's special qws (which no longer exist) from tunnel ingress

### DIFF
--- a/scripts/support/kubernetes/tunnel/isolate-tunnel.yaml
+++ b/scripts/support/kubernetes/tunnel/isolate-tunnel.yaml
@@ -25,4 +25,4 @@ spec:
             matchExpressions:
             - key: app
               operator: In
-              values: [bwd-app, qw-worker, cron-checker, maxim-qw-worker, editor-app]
+              values: [bwd-app, qw-worker, cron-checker, editor-app]


### PR DESCRIPTION
The tunnel service's network policy only allows ingress from pods with
particular labels - that is, only our ocaml apps. (bwd-app, qw-worker,
cron-checker, editor-app.)

Shortly before strangeloop (2019), we had problems where a particular user was
overwhelming the queue workers and consuming all the compute. As a
short-term fix, we launched a special deployment of qw pods just for
that user, and so we had to add that pod to the allowed ingresses.

We eventually fixed the problem and took down the
special-one-user-deployment, but the tunnel network policy was
overlooked.

This change is a no-op; it's just removing obsolete cruft.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

