### PR TITLE
Make honeycomb agent read the "timestamp" field

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -98,6 +98,10 @@ data:
         containerName: cron-ctr
         dataset: kubernetes-bwd-ocaml
         parser: json
+        processors:
+          - timefield:
+              field: timestamp
+              format: "2006-01-02T15:04:05.999999999Z07:00"
       - labelSelector: "app=qw-worker"
         containerName: qw-ctr
         dataset: kubernetes-bwd-ocaml


### PR DESCRIPTION
By default, honeycomb-agent uses the k8s timestamp instead of any passed
`timestamp` key in the JSON. This is incorrect for trace spans, which
require the timestamp to be the start time of the span, not the time it
is logged out (the end time).

By setting this field explicitly, the agent uses our value when it's
passed.

**This was tested manually with a `kubectl apply` so we know it works.**