### PR TITLE
Fix the overlay to always show up in the viewport when active

### DIFF
--- a/client/styles/_canvas.scss
+++ b/client/styles/_canvas.scss
@@ -159,11 +159,11 @@ body #app * {
 
 .overlay {
   position: fixed;
-  top: -1 * $ridiculously-large;
-  left: -1 * $ridiculously-large;
+  top: 0;
+  left: 0;
   display: none;
-  height: 2 * $ridiculously-large;
-  width: 2 * $ridiculously-large;
+  height: 100vh;
+  width: 100vw;
   overflow: visible;
   background-color: rgba(72, 72, 72, 0.75);
 


### PR DESCRIPTION
This fixes https://trello.com/c/GvFte2vr/3073-followup-focused-toplevel-no-longer-fades-out-other-things-on-canvas. It's a followup to the positioning bug fix -- @9ae discovered that in the process of fixing the positioning bug, it looks like I broke the overlay that makes specific nodes look focused.

IMO the ideal fix for this would be to make some CSS changes and rearrange the HTML hierarchy such that the overlay isn't part of the canvas.

I wasn't smart enough to figure out how to do that, given the absolute bonkers way that CSS stacking contexts work, so this provides an alternate solution that is guaranteed to work but might be less performant.

The approach here is to apply a transform to the `#overlay` that is the inverse of its parent `#canvas` transform. Doing so ensures that the overlay is always within the browser viewport, so long as `#canvas` with an identity transformation matrix (no rotation, no translation, no zoom) is positioned in the top-left corner.

Best resources I found while trying to learn how stacking contexts work:
- Chrome plugin to show stacking context info for a selected node as text https://chrome.google.com/webstore/detail/z-context/jigamimbjojkdgnlldajknogfgncplbh?hl=en
- The MDN guide here https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index in particular this example: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_2
- The MS Edge 3d z-index debugger (seemed promising, but for some reason I couldn't get it to display the canvas or overlay nodes, so it was ultimately useless, but could be helpful for things with specific width and height like the code nodes) https://docs.google.com/document/d/16xsQbr1YjjuoxHJlCsAaIzK-s4Ogd6fEuhrSajdVivA/edit?pli=1

Before:
![](https://trello-attachments.s3.amazonaws.com/5bc4c6f5450b4b3ed2856bb5/5eb9f3cd95e60d0ed5040924/83a448b98f342e220bb39be300c6304b/Screen_Shot_2020-05-11_at_5.47.55_PM.png)

After:
![](https://trello-attachments.s3.amazonaws.com/5bc4c6f5450b4b3ed2856bb5/5eb9f3cd95e60d0ed5040924/ed8895ca0e48951f141cc5defa83d029/Screen_Shot_2020-05-11_at_5.49.06_PM.png)

No tests included -- given how Dark is written, I think we would need a pixel-based comparison test, which seems like a nightmare to maintain.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

