### PR TITLE
Revert "Cron_scheduler query doesn't need to load canvases or oplists at all"

### DIFF
--- a/backend/bin/cron_checker.ml
+++ b/backend/bin/cron_checker.ml
@@ -7,7 +7,7 @@ let shutdown = ref false
 
 let rec cron_checker (pid : int) () =
   let%lwt () = Lwt_unix.sleep 1.0 in
-  let result = Libbackend.Cron.check_and_schedule_work_for_all_crons pid in
+  let result = Libbackend.Cron.check_and_schedule_work_for_all_canvases pid in
   match result with
   | Ok _ ->
       if not !shutdown then (cron_checker pid [@tailcall]) () else exit 0

--- a/backend/libbackend/serialize.ml
+++ b/backend/libbackend/serialize.ml
@@ -3,7 +3,6 @@ open Libcommon
 open Libexecution
 open Types
 module RTT = RuntimeT
-module Span = Telemetry.Span
 
 let handler_of_binary_string (str : string) : RuntimeT.expr RTT.HandlerT.handler
     =
@@ -669,44 +668,3 @@ let fetch_canvas_id (owner : Uuidm.t) (host : string) : Uuidm.t =
     |> List.hd_exn
     |> Uuidm.of_string
     |> Option.value_exn
-
-
-type cron_schedule_data =
-  { canvas_id : Uuidm.t
-  ; owner : Uuidm.t
-  ; host : string
-  ; tlid : string
-  ; name : string
-  ; modifier : string }
-
-(** Fetch cron handlers from the DB. Active here means:
- * - a non-null interval field in the spec
- * - not deleted (When a CRON handler is deleted, we set (module, modifier,
- *   deleted) to (NULL, NULL, True);  so our query `WHERE module = 'CRON'`
- *   ignores deleted CRONs.)
- *)
-let fetch_active_crons (span : Span.t) : cron_schedule_data list =
-  Telemetry.with_span span "Serialize.fetch_crons" (fun _ ->
-      Db.fetch
-        ~name:"get crons for scheduler"
-        "SELECT canvas_id,
-                        tlid,
-                        modifier,
-                        toplevel_oplists.name,
-                        account_id,
-                        canvases.name
-                 FROM toplevel_oplists
-                   JOIN canvases ON toplevel_oplists.canvas_id = canvases.id
-                 WHERE module = $1 AND modifier IS NOT NULL"
-        ~params:[Db.String "CRON"]
-      |> List.map ~f:(function
-             | [canvas_id; tlid; modifier; name; account_id; host] ->
-                 { canvas_id = canvas_id |> Uuidm.of_string |> Option.value_exn
-                 ; tlid
-                 ; modifier
-                 ; name
-                 ; owner = account_id |> Uuidm.of_string |> Option.value_exn
-                 ; host }
-             | _ ->
-                 Exception.internal
-                   "Wrong shape from get_crons_for_scheduler query"))

--- a/backend/test/test_event_queue.ml
+++ b/backend/test/test_event_queue.ml
@@ -97,18 +97,10 @@ let t_cron_sanity () =
   clear_test_data () ;
   let h = daily_cron (ast_for "(+ 5 3)") in
   let c = ops2c_exn "test-cron_works" [hop h] in
-  let cron_schedule_data : Libbackend.Cron.cron_schedule_data =
-    { canvas_id = !c.id
-    ; owner = Uuidm.nil
-    ; host = !c.host
-    ; tlid = h.tlid |> Int63.to_string
-    ; name = (match h.spec.name with Filled (_, s) -> s | _ -> "CAN'T HAPPEN")
-    ; modifier =
-        (match h.spec.modifier with Filled (_, s) -> s | _ -> "CAN'T HAPPEN") }
-  in
+  let handler = !c.handlers |> TL.handlers |> List.hd_exn in
   let ({should_execute; scheduled_run_at; interval}
         : Libbackend.Cron.execution_check_type) =
-    Cron.execution_check (Telemetry.Span.root "test") cron_schedule_data
+    Cron.execution_check (Telemetry.Span.root "test") !c.id handler
   in
   AT.check AT.bool "should_execute should be true" should_execute true ;
   ()
@@ -118,19 +110,11 @@ let t_cron_just_ran () =
   clear_test_data () ;
   let h = daily_cron (ast_for "(+ 5 3)") in
   let c = ops2c_exn "test-cron_works" [hop h] in
-  let cron_schedule_data : Libbackend.Cron.cron_schedule_data =
-    { canvas_id = !c.id
-    ; owner = Uuidm.nil
-    ; host = !c.host
-    ; tlid = h.tlid |> Int63.to_string
-    ; name = (match h.spec.name with Filled (_, s) -> s | _ -> "CAN'T HAPPEN")
-    ; modifier =
-        (match h.spec.modifier with Filled (_, s) -> s | _ -> "CAN'T HAPPEN") }
-  in
-  Cron.record_execution cron_schedule_data ;
+  let handler = !c.handlers |> TL.handlers |> List.hd_exn in
+  Cron.record_execution !c.id handler ;
   let ({should_execute; scheduled_run_at; interval}
         : Libbackend.Cron.execution_check_type) =
-    Cron.execution_check (Telemetry.Span.root "test") cron_schedule_data
+    Cron.execution_check (Telemetry.Span.root "test") !c.id handler
   in
   AT.check AT.bool "should_execute should be false" should_execute false ;
   ()


### PR DESCRIPTION
Reverts darklang/dark#2355