### PR TITLE
When event handler is missing, mark event.

### DIFF
--- a/backend/libbackend/event_queue.mli
+++ b/backend/libbackend/event_queue.mli
@@ -36,7 +36,10 @@ val with_transaction :
 val dequeue : transaction -> RuntimeT.expr t option
 
 val put_back :
-  transaction -> 'expr_type t -> status:[`OK | `Err | `Incomplete] -> unit
+     transaction
+  -> 'expr_type t
+  -> status:[`OK | `Err | `Incomplete | `Missing]
+  -> unit
 
 val finish : transaction -> 'expr_type t -> unit
 

--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -101,7 +101,7 @@ let dequeue_and_process execution_id :
                                   Event_queue.put_back
                                     transaction
                                     event
-                                    `Incomplete ;
+                                    `Missing ;
                                   Ok None
                               | Some h ->
                                   Log.infO

--- a/backend/migrations/20200519_110236_add-events-status-missing.sql
+++ b/backend/migrations/20200519_110236_add-events-status-missing.sql
@@ -1,0 +1,4 @@
+--#[no_tx]
+-- ALTER TYPE .. ADD VALUE cannot be run in a transaction or in multi-line statements.
+-- see https://www.postgresql.org/docs/9.5/sql-altertype.html
+ALTER TYPE queue_status ADD VALUE 'missing'


### PR DESCRIPTION
Previously, events that were destined for worker that didn't exist went
through the `Incomplete path of put_back, meaning they were marked as
"new" again and retried in 5 minutes, indefinitely.

This is causing operational trouble, as we have many, many events in
this state that are all getting retried every 5 minutes.

Instead, if the handler doesn't exist at all, mark the event as
"missing", essentially dropping it on the floor for now (we can have a
way to re-schedule these events in the future).

Note that 1) we still record the 404 and 2) this does not change
behavior for when the worker exists but the result is incomplete.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists