### PR TITLE
Sample stroller events

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -68,6 +68,10 @@ data:
       - labelSelector: "app in (bwd-app, editor-app, qw-worker)"
         containerName: stroller
         dataset: kubernetes-stroller
+        processors:
+        - sample:
+            type: static
+            rate: 100
         parser: json
       - labelSelector: "app=scheduler-worker"
         containerName: scheduler-ctr


### PR DESCRIPTION
Why?
====

Per https://ui.honeycomb.io/teams/dark/usage, we're at about our daily
events target for the plan we're in; and 15.68% of our events in May
2020 were stroller events. (So this is costly.)

Those events don't seem to bring us much value; I can't remember
looking at these since stroller was new, and dstrelau can't recall
looking at them at all.

Implementation
==============
So, we sample - 1/100 events was picked somewhat arbitrarily (and is
aggressive!), but that'd
lead to stroller being ~1.57% of our events, which seems reasonable.

(235M for the first 3 weeks of May, is ~313M/month, 1/100th of that is
~3M/month out of a 1500M quota)

See https://github.com/honeycombio/honeycomb-kubernetes-agent/blob/master/docs/example-configurations.md and https://docs.honeycomb.io/getting-data-in/integrations/kubernetes/configuration/#sample for docs re this kind of sampling.

Alternatives
============
1. I bet we could condense some of these events - for instance, we have
an event for "pushing to stroller" and one for the response; and a
similar request/response pair for segment.

I decided that it wasn't worth the effort right now; just using static
sampling achieves our goals ("spending less on low-value events")
without requiring a bigger project.

https://trello.com/c/7dJdfP2l/3133-evaluate-stroller-logs-see-if-we-can-sample-and-or-remove-events

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

