### PR TITLE
Update bs-deriving and ppx-deriving to 44.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jsdom-global": "3.0.2",
     "node-sass": "4.14.1",
     "npm-run-all": "4.1.5",
-    "ppx-deriving": "44.1.1",
+    "ppx-deriving": "44.1.2",
     "prettier": "2.0.5",
     "testcafe": "^1.8.5"
   },
@@ -22,7 +22,7 @@
     "@glennsl/bs-json": "5.0.2",
     "acorn": ">=7.2.0",
     "analytics-node": "^3.4.0-beta.1",
-    "bs-deriving": "44.1.1",
+    "bs-deriving": "44.1.2",
     "bs-fetch": "0.5.2",
     "bs-uuid": "0.3.1",
     "bs-webapi": "0.15.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,10 +1376,10 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
-bs-deriving@44.1.1:
-  version "44.1.1"
-  resolved "https://registry.yarnpkg.com/bs-deriving/-/bs-deriving-44.1.1.tgz#8282cccebbfd37235b1a165d38bf09ed13d50f6b"
-  integrity sha512-EYlG4neHeC+ZYEnnZZYhKFyaEIVYbm6uuhyXLSF2hIhOIlGs68pBFg4FSKYro5GOkXCuqe0fEqftDAW5vICD6w==
+bs-deriving@44.1.2:
+  version "44.1.2"
+  resolved "https://registry.yarnpkg.com/bs-deriving/-/bs-deriving-44.1.2.tgz#7be05116987e5d1c9d186dfdc6be9c96b96563b8"
+  integrity sha512-7eL9fSRXeu5w030ec8d9X5iKmh5GcK/qf2udbFIBNio+AtmoAqTAuFstLBvVa6sIpKC7G74egtA80uUWPcfZ9w==
   dependencies:
     "@elliottcable/bs-result" "^12.0.0-pre.2"
 
@@ -4242,10 +4242,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-ppx-deriving@44.1.1:
-  version "44.1.1"
-  resolved "https://registry.yarnpkg.com/ppx-deriving/-/ppx-deriving-44.1.1.tgz#f35fc0c43f6a36bc720e98594436a132d917411e"
-  integrity sha512-D+OEVxB15AeUDf03i9eusG5M+qYJcvKfzjZ2rKwR+BoT9k9TgUTILpnspP8JXjyzfNkQ55fX8Sa6BAKr3uTEcw==
+ppx-deriving@44.1.2:
+  version "44.1.2"
+  resolved "https://registry.yarnpkg.com/ppx-deriving/-/ppx-deriving-44.1.2.tgz#e8979aa9d87a694dc063b909824773f3b201ead1"
+  integrity sha512-UtIW4u9vcp8aNa4o5NJIU2K7l9zEn35DJkQ5gpT4PMNKVKTJIN+rDMJNsBUys+4biTInQVO8OFqf10ijoM8fCg==
   dependencies:
     arch "^2.1.1"
 


### PR DESCRIPTION
Dependabot gave us two separate PRs (#2373, #2374), and I didn't know whether to sync them in a particular order or not.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

