### PR TITLE
Add DARK_CONFIG_PUSHER_{KEY,SECRET} to stroller

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
+++ b/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
@@ -131,6 +131,17 @@ spec:
           envFrom:
             - configMapRef:
                 name: gke-dark-prod
+          env:
+            - name: DARK_CONFIG_PUSHER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: key
+            - name: DARK_CONFIG_PUSHER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: secret
           lifecycle:
             preStop:
               httpGet:

--- a/scripts/support/kubernetes/builtwithdark/editor-deployment.yaml.template
+++ b/scripts/support/kubernetes/builtwithdark/editor-deployment.yaml.template
@@ -130,6 +130,17 @@ spec:
           envFrom:
             - configMapRef:
                 name: gke-dark-prod
+          env:
+            - name: DARK_CONFIG_PUSHER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: key
+            - name: DARK_CONFIG_PUSHER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: secret
           lifecycle:
             preStop:
               httpGet:

--- a/scripts/support/kubernetes/queueworker/qw-deployment.yaml.template
+++ b/scripts/support/kubernetes/queueworker/qw-deployment.yaml.template
@@ -98,6 +98,17 @@ spec:
           envFrom:
             - configMapRef:
                 name: gke-dark-prod
+          env:
+            - name: DARK_CONFIG_PUSHER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: key
+            - name: DARK_CONFIG_PUSHER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: secret
           lifecycle:
             preStop:
               httpGet:


### PR DESCRIPTION
When I moved pusher creds into kubernetes, I only added them to the OCaml containers, not to the stroller container. This also adds them to the stroller container.

This was reported by a user who noticed traces were no longer being reported. My investigation is here: https://dark-inc.slack.com/archives/C012RAN8MCM/p1590259417001600

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists

Reviewer checklist:
- Product:
  - [ ] PR matches stated goal and Trello ticket.
  - [ ] Out-of-scope product changes have been explained.
  - [ ] I pulled the branch and tested out the feature.
- User facing:
  - [ ] Existing stdlib and language semantics are unchanged.
  - [ ] Existing granduser HTTP responses are unchanged.
  - [ ] All existing canvases should continue to work.
  - [ ] New features are documented in the User Manual (or Trellos are filed).
- Engineering:
  - [ ] Tests are included (required for regressions) or unnecessary.
  - [ ] Functions and variables are well-named and self-documenting.
  - [ ] Comments have been added for all explanations in PR review comment.
  - [ ] Serialization format changes look good and have been double-checked and tested against local prodclone.
  - [ ] Unneeded code has been removed.

