### PR TITLE
[WIP] comprehensively prevent broken asts due to pipes when updating the ast

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -1948,7 +1948,7 @@ let replacePartialWithArguments
          | _ ->
              mkExprAndTarget newExpr)
   |> Option.map ~f:(fun (newExpr, target) ->
-         (FluidAST.replace id ~replacement:newExpr ast, target))
+         (FluidAST.replace2 id ~replacement:newExpr ast, target))
   |> recoverOpt
        "replacePartialWithArguments"
        ~default:(ast, {astRef = ARInvalid; offset = 0})
@@ -2417,7 +2417,7 @@ let updateFromACItem
         (* when committing `if` in front of another expression, put the expr into the if condition *)
         let _ = Debug.loG "updateFromACItem - Q" () in
         let replacement = EIf (ifID, expr, E.newB (), E.newB ()) in
-        let newAST = FluidAST.replace ~replacement pID ast in
+        let newAST = FluidAST.replace2 ~replacement pID ast in
         (newAST, caretTargetForStartOfExpr' expr)
     | ( TLeftPartial _
       , Some (ELeftPartial (pID, _, expr))
@@ -2436,12 +2436,13 @@ let updateFromACItem
         let _ = Debug.loG "updateFromACItem - O" () in
         let blank = E.newB () in
         let replacement = ELet (letID, "", expr, E.newB ()) in
-        let newAST = FluidAST.replace ~replacement pID ast in
+        let newAST = FluidAST.replace2 ~replacement pID ast in
         (newAST, caretTargetForStartOfExpr' blank)
-    | TPartial _, _, Some (EPipe _), Expr (EBinOp (bID, name, _, rhs, str)) ->
+(*     | TPartial _, _, Some (EPipe _), Expr (EBinOp (bID, name, lhs, rhs, str)) ->
         let _ = Debug.loG "updateFromACItem - E" () in
-        let newAST = FluidAST.replace ~replacement id ast in
-        (newAST, caretTargetForEndOfExpr' replacement)
+        let replacement = EBinOp (bID, name, lhs, rhs, str) in
+        let newAST = FluidAST.replace2 ~replacement id ast in
+        (newAST, caretTargetForEndOfExpr' replacement) *)
     | TPartial _, Some oldExpr, Some (EPipe (_, firstExpr :: _)), Expr newExpr
       when oldExpr = firstExpr ->
         let _ = Debug.loG "updateFromACItem - F" () in
@@ -2463,7 +2464,7 @@ let updateFromACItem
       , Expr (EBinOp (bID, name, _, _, str)) ) ->
         let _ = Debug.loG "updateFromACItem - H" () in
         let replacement = EBinOp (bID, name, lhs, rhs, str) in
-        let newAST = FluidAST.replace ~replacement id ast in
+        let newAST = FluidAST.replace2 ~replacement id ast in
         (newAST, caretTargetForStartOfExpr' rhs)
     | TPartial _, _, _, Expr newExpr ->
         (* We can't use the newTarget because it might point to eg a blank
@@ -2475,7 +2476,7 @@ let updateFromACItem
       , _
       , Expr (EBinOp (bID, name, _, rhs, str)) ) ->
         let replacement = EBinOp (bID, name, oldExpr, rhs, str) in
-        let newAST = FluidAST.replace ~replacement id ast in
+        let newAST = FluidAST.replace2 ~replacement id ast in
         let _ = Debug.loG "updateFromACItem - J" () in
         (newAST, caretTargetForStartOfExpr' rhs)
     | ( (TFieldName _ | TFieldPartial _ | TBlank _)
@@ -2486,10 +2487,11 @@ let updateFromACItem
       , Expr (EFieldAccess (_, _, newname)) ) ->
         let _ = Debug.loG "updateFromACItem - K" () in
         let replacement = EFieldAccess (faID, expr, newname) in
-        let newAST = FluidAST.replace ~replacement id ast in
+        let newAST = FluidAST.replace2 ~replacement id ast in
         (newAST, caretTargetForEndOfExpr' replacement)
     | _, _, _, Expr newExpr ->
         let _ = Debug.loG "updateFromACItem - L" () in
+        let newAST = FluidAST.replace2 ~replacement:newExpr id ast in
         (newAST, newTarget)
     | _, _, _, Pat _ ->
         let _ = Debug.loG "updateFromACItem - M" () in

--- a/libshared/FluidAST.ml
+++ b/libshared/FluidAST.ml
@@ -17,6 +17,9 @@ let map ~(f : E.t -> E.t) (ast : t) : t = toExpr ast |> f |> ofExpr
 let replace ~(replacement : E.t) (target : Shared.id) (ast : t) : t =
   map ast ~f:(E.replace ~replacement target)
 
+let replace2 ~(replacement : E.t) (target : Shared.id) (ast : t) : t =
+  map ast ~f:(E.replaceParentAware ~parent:None ~replacement target)
+
 
 let update
     ?(failIfMissing = true) ~(f : E.t -> E.t) (target : Shared.id) (ast : t) : t

--- a/libshared/FluidAST.mli
+++ b/libshared/FluidAST.mli
@@ -42,6 +42,8 @@ val map : f:(FluidExpression.t -> FluidExpression.t) -> t -> t
   * See FluidExpression.replace *)
 val replace : replacement:FluidExpression.t -> Shared.id -> t -> t
 
+val replace2 : replacement:FluidExpression.t -> Shared.id -> t -> t
+
 (** [update f target ast] recursively searches [ast] for the expression having
   * an id of [target].
   *

--- a/libshared/FluidExpression.mli
+++ b/libshared/FluidExpression.mli
@@ -81,6 +81,9 @@ type fluidPatOrExpr =
   | Pat of FluidPattern.t
 [@@deriving show {with_path = false}, eq]
 
+type replacementAndResult = {replacement: t; result : t}
+[@@deriving show {with_path = false}, eq]
+
 val toID : t -> Shared.id
 
 (** Generate a new EBlank *)
@@ -167,6 +170,17 @@ val update : ?failIfMissing:bool -> f:(t -> t) -> Shared.id -> t -> t
 
 (** [replace replacement target ast] finds the expression with Shared.id of [target] in the [ast] and replaces it with [replacement]. *)
 val replace : replacement:t -> Shared.id -> t -> t
+
+(** [replaceParentAware failIfMissing? parent replacement target expr] recursively searches [expr] for an expression [e]
+    having an [Shared.id] of [target]. [parent] must be the current parent of [expr].
+
+    If found, replaces [e] with [replacement] and returns the new ast, having corrected for [e]'s parent
+    by stripping or adding pipe targets to [replacement] as needed.
+    If not found, returns the unmodified [ast].
+    If [failIfMissing] is [true], as it is by default,
+    calls [Recover.asserT] before returning. *)
+val replaceParentAware :
+  ?failIfMissing:bool -> parent:t option -> replacement:t -> Shared.id -> t -> t (* replacementAndResult *)
 
 val removeVariableUse : string -> t -> t
 


### PR DESCRIPTION
In https://trello.com/c/MVsPLQf9/3051-followup-changing-a-binop-at-the-root-of-a-pipe-adds-a-pipe-target-in-the-wrong-place I discovered a way to break the AST due to pipe targets ending up where they shouldn't.

In an earlier PR: https://github.com/darklang/dark/pull/2298 I fixed a similar problem happening as a result of pasting, and @pbiggar suggested (https://github.com/darklang/dark/pull/2298#pullrequestreview-404686640) that we might want to implement a fix at the level of updating an expression within the AST. I created this followup from that: https://trello.com/c/8C0qnayu/3040-as-a-followup-to-https-githubcom-darklang-dark-pull-2298-consider-using-eupdate-for-changes

In this draft PR, I'm exploring how we might make do this, using the open binop problem as a case to be fixed.

Using the new `replace2` function in this draft seems very promising, but there's a significant problem.

Consider the signature:

```let replace2 ~(replacement : E.t) (target : Shared.id) (ast : t) : t =```

Note that `replacement` is a compound expression supplied by the caller. This expression frequently contains a subexpression with an id that is used by the caller to determine the caret target after the replacement has happened. Unfortunately, as part of `replace2`, `replacement` is not preserved as-is in order to reconcile pipe targets (that's the whole point of the attempted fix!). Consequently, the caret target generated by the caller might reference an id that is no longer present in the ast returned by `replace2`, and we get errors like this:
```
An unexpected but recoverable error happened:  Recover: We expected to find the given caretTarget in the token stream but couldn't. { astRef = (ARVariable (ID "1472828422")); offset = 7 }
Trace
    at Object.reportError (/home/dark/app/lib/js/client/src/prelude/Unshared.bs.js:34:11)
    at Object.recover (/home/dark/app/lib/js/libshared/Shared.bs.js:50:12)
    at posFromCaretTarget (/home/dark/app/lib/js/client/src/fluid/Fluid.bs.js:1337:20)
    at moveToCaretTarget (/home/dark/app/lib/js/client/src/fluid/Fluid.bs.js:1349:21)
    at acMoveBasedOnKey (/home/dark/app/lib/js/client/src/fluid/Fluid.bs.js:3844:10)
    at updateFromACItem (/home/dark/app/lib/js/client/src/fluid/Fluid.bs.js:4284:10)
    at acEnter (/home/dark/app/lib/js/client/src/fluid/Fluid.bs.js:4316:14)
    at updateKey (/home/dark/app/lib/js/client/src/fluid/Fluid.bs.js:7043:31)
    at Object.updateMsg$prime (/home/dark/app/lib/js/client/src/fluid/Fluid.bs.js:9775:42)
    at /home/dark/app/lib/js/client/test/fluid_test.bs.js:301:30
    ❌ variable moves to right place - `req`
    Expected: None
      Actual: Caml_js_exceptions.Error(_)
```

I don't know how to best proceed to rectify this problem. Possible solutions I've considered:

A) return not just the new AST but also an updated `replacement` subtree.
B) pass the desired caret target to `replace2`

Neither of these solutions seems ideal and I'd like suggestions on how to proceed.

A completely different approach that also seems like a lot of work and isn't as comprehensive might be to modify the definition of `EPipe` to separate the thing being piped from the chain it is being piped into. That would make it a bit easier to remember to preserve the invariant that the thing being piped may not have a pipe target, but every other subtree of the pipe must contain a pipe target.

<!---
@huboard:{"milestone_order":3991.5}
-->
