### PR TITLE
float_of_string_opt, not the exn version

### DIFF
--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -221,12 +221,15 @@ let dequeue (parent : Span.t) (transaction : Int63.t) : expr t option =
             log_queue_size Dequeue ~host canvas_id space name modifier ;
             Span.set_attrs
               parent
-              [ ("queue_delay", `Float (float_of_string queue_delay_ms))
-              ; ("host", `String host)
-              ; ("canvas_id", `String canvas_id)
-              ; ("space", `String space)
-              ; ("name", `String name)
-              ; ("modifier", `String modifier) ] ;
+              ( ( queue_delay_ms
+                |> float_of_string_opt
+                |> Option.map ~f:(fun qd -> [("queue_delay", `Float qd)])
+                |> Option.value ~default:[] )
+              @ [ ("host", `String host)
+                ; ("canvas_id", `String canvas_id)
+                ; ("space", `String space)
+                ; ("name", `String name)
+                ; ("modifier", `String modifier) ] ) ;
             Some
               { id = int_of_string id
               ; value =


### PR DESCRIPTION
I thought this was a safe place to use float_of_string, but rollbar says
I was wrong:
https://rollbar.com/darkops/darklang/items/1181/

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
