### PR TITLE
Rename event name to handler_name

### DIFF
--- a/backend/libbackend/event_queue.ml
+++ b/backend/libbackend/event_queue.ml
@@ -228,7 +228,7 @@ let dequeue (parent : Span.t) (transaction : Int63.t) : expr t option =
               @ [ ("host", `String host)
                 ; ("canvas_id", `String canvas_id)
                 ; ("space", `String space)
-                ; ("name", `String name)
+                ; ("handler_name", `String name)
                 ; ("modifier", `String modifier) ] ) ;
             Some
               { id = int_of_string id


### PR DESCRIPTION
'name' here the name of a span, we don't want this collision

This is what happens pre-PR; ipInfo is the name of a user's event handler, not a thing we want in our spans
![image](https://user-images.githubusercontent.com/172694/82971582-e0d9e880-9f87-11ea-9269-6357f52e3caa.png)

https://trello.com/c/kYhhLNT0/3139-add-traces-to-event-queue-so-we-can-see-if-transactions-are-being-tied-up

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
