### PR TITLE
See if this await makes exe_flow_fades less flakey

### DIFF
--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -1345,8 +1345,9 @@ test("exe_flow_fades", async t => {
   await t.click(".fluid-entry");
   awaitAnalysis(t, timestamp);
   // wait up to 1000ms for this selector to appear
-  await Selector(".fluid-not-executed", { timeout: 1000});
-  await t.expect(Selector(".fluid-not-executed").exists).ok();
+  await t
+    .expect(Selector(".fluid-not-executed", { timeout: 1000 }).exists)
+    .ok();
 });
 
 test("unexe_code_unfades_on_focus", async t => {


### PR DESCRIPTION
In the last 14 days, it's failed 23/(23+125), or ~1/6 of the time:
https://ui.honeycomb.io/dark/datasets/integration-tests/result/CAFiQjHMqvP

Non-determistic, so we'll see if this helps or not; can check the above
query in a week or so.

https://trello.com/c/HoIkaNzv/3161-attempt-to-make-exeflowfades-test-more-reliable

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
