### PR TITLE
Make FnReturnTypeVariant the default

### DIFF
--- a/client/src/app/VariantTesting.ml
+++ b/client/src/app/VariantTesting.ml
@@ -19,8 +19,6 @@ let toVariantTest (s : string) : variantTest option =
       Some NgrokVariant
   | "lpartial" ->
       Some LeftPartialVariant
-  | "fnreturn" ->
-      Some FnReturnVariant
   | _ ->
       None
 
@@ -36,15 +34,11 @@ let nameOf (vt : variantTest) : string =
       "localhost-assets"
   | LeftPartialVariant ->
       "lpartial"
-  | FnReturnVariant ->
-      "fnreturn"
 
 
 let toCSSClass (vt : variantTest) : string = nameOf vt ^ "-variant"
 
-let availableAdminVariants : variantTest list =
-  [FnReturnVariant; NgrokVariant; GroupVariant]
-
+let availableAdminVariants : variantTest list = [NgrokVariant; GroupVariant]
 
 let activeCSSClasses (m : model) : string =
   m.tests |> List.map ~f:toCSSClass |> String.join ~sep:" "
@@ -52,7 +46,7 @@ let activeCSSClasses (m : model) : string =
 
 let enabledVariantTests (isAdmin : bool) : variantTest list =
   (* admins have these enabled by default, but can opt-out via query param *)
-  let init = if isAdmin then [FnReturnVariant] else [] in
+  let init = if isAdmin then [] else [] in
   Url.queryParams ()
   (* convert a (string * bool) list to a (variantTest * bool) list,
    * ignoring any unknown query params *)

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -1413,7 +1413,6 @@ and variantTest =
   | GroupVariant
   | NgrokVariant
   | LeftPartialVariant
-  | FnReturnVariant
 
 (* ----------------------------- *)
 (* FeatureFlags *)

--- a/client/src/toplevels/ViewUserFunction.ml
+++ b/client/src/toplevels/ViewUserFunction.ml
@@ -160,25 +160,22 @@ let viewMetadata (vp : viewProps) (fn : functionTypes) : msg Html.html =
       (FnParams.view fn vp @ [addParamBtn])
   in
   let returnRow =
-    if VariantTesting.variantIsActive' vp.testVariants FnReturnVariant
-    then
-      let returnType =
-        match fn with
-        | UserFunction fn ->
-            fn.ufMetadata.ufmReturnTipe
-        | PackageFn fn ->
-            BlankOr.newF fn.return_type
-      in
-      Html.div
-        [Html.id "fnreturn"; Html.class' "col param"]
-        [ fontAwesome "level-down-alt"
-        ; ViewBlankOr.viewTipe
-            ~classes:["type"]
-            ~enterable:true
-            FnReturnTipe
-            vp
-            returnType ]
-    else Vdom.noNode
+    let returnType =
+      match fn with
+      | UserFunction fn ->
+          fn.ufMetadata.ufmReturnTipe
+      | PackageFn fn ->
+          BlankOr.newF fn.return_type
+    in
+    Html.div
+      [Html.id "fnreturn"; Html.class' "col param"]
+      [ fontAwesome "level-down-alt"
+      ; ViewBlankOr.viewTipe
+          ~classes:["type"]
+          ~enterable:true
+          FnReturnTipe
+          vp
+          returnType ]
   in
   Html.div [Html.class' "fn-header"] [titleRow; paramRows; returnRow]
 


### PR DESCRIPTION
This removes the feature flag so that all users can change their return type. Last step in https://trello.com/c/ePW0Qr67/2829-return-types-for-functions

It's been approved to go out by Victoria.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists
