### PR TITLE
Also get the username from cloudsql-db-credentials

### DIFF
--- a/scripts/gcp-psql
+++ b/scripts/gcp-psql
@@ -34,13 +34,15 @@ cloud_sql_proxy \
 # Make sure it has time to come up before we try to connect to it
 sleep 1s
 
+PGUSERNAME=$(kubectl get secrets cloudsql-db-credentials -o json |  jq -r '.data.username' | base64 -d)
 PGPASSWORD=$(kubectl get secrets cloudsql-db-credentials -o json |  jq -r '.data.password' | base64 -d)
+export PGUSERNAME
 export PGPASSWORD
 
 # If we're in a terminal (not a pipe), use pgcli, which has nice interactive fea tures like autocomplete of columns.
 # If we're in a pipe, then use psql (pgcli doesn't let you pipe in a query, psql does)
 if [[ -t 0 ]]; then
-    pgcli -h /tmp/cloud_sql_proxy --username=postgres
+    pgcli -h /tmp/cloud_sql_proxy --username=${PGUSERNAME} postgres
 else
-    psql -h /tmp/cloud_sql_proxy --user=postgres
+    psql -h /tmp/cloud_sql_proxy --user=${PGUSERNAME} postgres
 fi


### PR DESCRIPTION
I doubt we'll ever change the username of our Cloud SQL instance, but during the time where I thought this was a good idea, I found I needed this change.

It pulls the username, as well as the password, from our production secret.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists
