### PR TITLE
Remove restriction on the "id" field in datastores

### DIFF
--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -348,11 +348,7 @@ let validate (tl : toplevel) (pd : blankOrData) (value : string) : string option
   | PDBColType _ ->
       v AC.dbColTypeValidator "DB type"
   | PDBColName _ ->
-      if value = "id"
-      then
-        Some
-          "The field name 'id' was reserved when IDs were implicit. We are transitioning to allowing it, but we're not there just yet. Sorry!"
-      else v AC.dbColNameValidator "DB column name"
+      v AC.dbColNameValidator "DB column name"
   | PEventName _ ->
       if TL.isHTTPHandler tl
       then


### PR DESCRIPTION
Fixes #2419

All I did was deleted the if/else statement. Hopefully that did the trick?