### PR TITLE
Add a dark user

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,38 +72,9 @@ dig testing.builtwithdark.localhost @127.0.0.1
 - Wait until the terminal says "Finished initial compile" - this means the build server is ready
 - If you see "initial compile failed", it may be a memory issue. Ensure you
   have docker configured to provide 4GB of memory.
-- Open your browser to http://darklang.localhost:8000/a/YOURNAME/
-- Edit code normally - on each save in your filesystem, the app will be rebuilt and the browser will reload as necessary
+- Open your browser to http://darklang.localhost:8000/a/dark/, username "dark", password "what"
+- Edit code normally - on each save to your filesystem, the app will be rebuilt and the browser will reload as necessary
 
-
-#### Get a Dark account for yourself
-
-To add your account to local dev for yourself, run:
-```
-scripts/run-in-docker _build/default/backend/bin/add_admin.exe --prompt-for-password
-```
-which will prompt you for your password, username, email, and name.
-
-This will output
-```
-  upsert_admin_exn
-      { username = "YOURNAME"
-      ; password =
-          Password.from_hash
-            "..."
-      ; email = "developer@example.com"
-      ; name = "Ada Lovelace"};
-```
-
-Dark employees should open a PR adding this account data to `account.ml` in the
-`upsert_admins` function.
-
-Contributors should add this to the `upsert_admins` function in account.ml -
-that will restart the Dark server, causing your user to be added. You won't
-need this anymore then.
-
-Note: this password is _not_ used in production; it may be different
-from your password on darklang.com.
 
 ## Other ways to run the dev container
 
@@ -287,6 +258,35 @@ flag to see the commands run. You'll see something that looks like this:
 
 Run that without the --dump-ast and then look at the .pp.ml file to find
 the preprocessed version.
+
+## Get a Dark account for yourself 
+
+(note: this appears to be broken at the moment)
+
+To add your account to local dev for yourself, run:
+```
+scripts/run-in-docker _build/default/backend/bin/add_admin.exe --prompt-for-password
+```
+which will prompt you for your password, username, email, and name.
+
+This will output
+```
+  upsert_admin_exn
+      { username = "YOURNAME"
+      ; password =
+          Password.from_hash
+            "..."
+      ; email = "developer@example.com"
+      ; name = "Ada Lovelace"};
+```
+
+Dark employees should open a PR adding this account data to `account.ml` in the
+`upsert_admins` function.
+
+Note: this password is _not_ used in production; it may be different
+from your password on darklang.com.
+
+
 
 ## Other important docs:
 

--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -417,6 +417,13 @@ let init_testing () : unit =
 
 let upsert_admins () : unit =
   upsert_admin_exn
+    { username = "dark"
+    ; password =
+        Password.from_hash
+          "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkcEQxWXBLOG1aVStnUUJUYXdKZytkQSR3TWFXb1hHOER1UzVGd2NDYzRXQVc3RlZGN0VYdVpnMndvZEJ0QnY1bkdJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    ; email = "ops+darkuser@darklang.com"
+    ; name = "Kiera Dubh" } ;
+  upsert_admin_exn
     { username = "paul"
     ; password =
         Password.from_hash
@@ -476,13 +483,7 @@ let upsert_useful_canvases () : unit =
     { username = "sample"
     ; password = Password.invalid
     ; email = "ops+sample@darklang.com"
-    ; name = "Sample Owner" } ;
-  upsert_account_exn
-    ~validate:false
-    { username = "dark"
-    ; password = Password.invalid
-    ; email = "ops+dark@darklang.com"
-    ; name = "Dark Inc." }
+    ; name = "Sample Owner" }
 
 
 let upsert_banned_accounts () : unit =


### PR DESCRIPTION
Why ask people to add a user when we can have a default user.

Note that employees still need their own users to sign in via prodclone. Also, it seems that creating new users is broken (none of them seem to be able to log in).

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists
