### PR TITLE
Put the readonly keys in the config so they can be used in PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ executors:
     working_directory: ~/app
     environment:
       IN_DEV_CONTAINER: true
+      # these keys are read-only
+      AWS_ACCESS_KEY_ID: "AKIAXJAGP54V756YBAHZ"
+      AWS_SECRET_ACCESS_KEY: "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"
     docker:
       - image: 500377317163.dkr.ecr.us-east-1.amazonaws.com/dark-ci:latest
   # Rust is so big we create a separate container for it and only use that
@@ -21,6 +24,9 @@ executors:
     working_directory: ~/app
     environment:
       IN_DEV_CONTAINER: true
+      # these keys are read-only
+      AWS_ACCESS_KEY_ID: "AKIAXJAGP54V756YBAHZ"
+      AWS_SECRET_ACCESS_KEY: "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"
     docker:
       - image: 500377317163.dkr.ecr.us-east-1.amazonaws.com/dark-ci:rust-latest
 


### PR DESCRIPTION
- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
