### PR TITLE
Use openssl in libcurl, not gnutls, to fix the cert chain problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
       libev-dev \
       libgmp-dev \
       pkg-config \
+      # see https://www.agwa.name/blog/post/fixing_the_addtrust_root_expiration
+      # for why openssl and not gnutls
       libcurl4-openssl-dev \
       libpq-dev \
       postgresql-9.6 \


### PR DESCRIPTION
This was suggested by
https://www.agwa.name/blog/post/fixing_the_addtrust_root_expiration

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
