### PR TITLE
Add links to contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Dark
 
+## Contributing
+
+We have a [set of contributor
+docs](https://darklang.github.io/docs/contributing/getting-started) to guide
+you through your first PR, find good projects to contribute to, and learn about
+the code base, available on our docs site.
+
 ## Getting Started
 
 ### Requirements
@@ -300,6 +307,7 @@ from your password on darklang.com.
 - [docs/oplist-serialization.md](docs/oplist-serialization.md)
 - [docs/bs-tea.md](docs/bs-tea.md)
 - [docs/writing-docstrings.md](docs/writing-docstrings.md)
+- [contributor docs](https://darklang.github.io/docs/contributing/getting-started)
 
 
 


### PR DESCRIPTION
Make sure that people who just go to the repo find the other docs.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
