### PR TITLE
We do not use the PUSHER_SECRET in OCaml, so it's not necessary here

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
+++ b/scripts/support/kubernetes/builtwithdark/bwd-deployment.yaml.template
@@ -66,12 +66,6 @@ spec:
                 secretKeyRef:
                   name: pusher-account-credentials
                   key: key
-            - name: DARK_CONFIG_PUSHER_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: pusher-account-credentials
-                  key: secret
-
 
 #########################
 # Postgres proxy config

--- a/scripts/support/kubernetes/builtwithdark/editor-deployment.yaml.template
+++ b/scripts/support/kubernetes/builtwithdark/editor-deployment.yaml.template
@@ -66,12 +66,6 @@ spec:
                 secretKeyRef:
                   name: pusher-account-credentials
                   key: key
-            - name: DARK_CONFIG_PUSHER_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: pusher-account-credentials
-                  key: secret
-
 #########################
 # Postgres proxy config
 # To connect to postgres from kubernetes, we need to add a proxy. See

--- a/scripts/support/kubernetes/cronchecker/cron-deployment.yaml.template
+++ b/scripts/support/kubernetes/cronchecker/cron-deployment.yaml.template
@@ -41,12 +41,6 @@ spec:
                 secretKeyRef:
                   name: pusher-account-credentials
                   key: key
-            - name: DARK_CONFIG_PUSHER_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: pusher-account-credentials
-                  key: secret
-
 #########################
 # Postgres proxy config
 # To connect to postgres from kubernetes, we need to add a proxy. See

--- a/scripts/support/kubernetes/queueworker/qw-deployment.yaml.template
+++ b/scripts/support/kubernetes/queueworker/qw-deployment.yaml.template
@@ -39,13 +39,6 @@ spec:
                 secretKeyRef:
                   name: pusher-account-credentials
                   key: key
-            - name: DARK_CONFIG_PUSHER_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: pusher-account-credentials
-                  key: secret
-
-
 #########################
 # Postgres proxy config
 # To connect to postgres from kubernetes, we need to add a proxy. See

--- a/scripts/support/kubernetes/queueworker/scheduler-deployment.yaml.template
+++ b/scripts/support/kubernetes/queueworker/scheduler-deployment.yaml.template
@@ -39,12 +39,6 @@ spec:
                 secretKeyRef:
                   name: pusher-account-credentials
                   key: key
-            - name: DARK_CONFIG_PUSHER_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: pusher-account-credentials
-                  key: secret
-
 #########################
 # Postgres proxy config
 # To connect to postgres from kubernetes, we need to add a proxy. See


### PR DESCRIPTION
I moved secrets to k8s to open the repo, but this one was actually not needed, as we don't use PUSHER_SECRET in OCaml code. Stroller uses it, and this PR does not change anything for stroller.

- [ ] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists
