### PR TITLE
Add test for String::toInt

### DIFF
--- a/backend/test/test_string_libs.ml
+++ b/backend/test/test_string_libs.ml
@@ -191,7 +191,11 @@ let t_toint_works () =
   check_dval
     "String::toInt works"
     (exec_ast' (fn "String::toInt" [str "1"]))
-    (DInt Dint.one)
+    (DInt Dint.one) ;
+  check_dval
+    "String::toInt works"
+    (exec_ast' (fn "String::toInt_v1" [str "1"]))
+    (DResult (ResOk (Dval.dint 1)))
 
 
 let suite =


### PR DESCRIPTION
Hi - this is my first pull request. I noticed that String::toInt didn't have any tests so I added one.