### PR TITLE
Add a test for Bool::not (false) and Bool::not (true)

### DIFF
--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -1738,6 +1738,14 @@ let t_bool_stdlibs () =
     "Bool::xor works (true, true)"
     (exec_ast' (fn "Bool::xor" [bool true; bool true]))
     (DBool false) ;
+  check_dval
+    "Bool::not works (true)"
+    (exec_ast' (fn "Bool::not" [bool true]))
+    (DBool false) ;
+  check_dval
+    "Bool::not works (false)"
+    (exec_ast' (fn "Bool::not" [bool false]))
+    (DBool true) ;
   ()
 
 


### PR DESCRIPTION
Hi - this is my first pull request. I noticed that Bool::not didn't have any tests so I added two.
