### PR TITLE
404s tip

### DIFF
--- a/client/src/components/UserTutorial.ml
+++ b/client/src/components/UserTutorial.ml
@@ -107,42 +107,49 @@ let htmlForTempTooltip (tooltip : tooltip) : msg Html.html =
     match tooltip with
     | Http ->
         let link = Some "https://darklang.github.io/docs/first-api-endpoint" in
-        ("Click the plus sign to create a REST API endpoint.", link)
+        (["Click the plus sign to create a REST API endpoint."], link)
     | Worker ->
         let link = Some "https://darklang.github.io/docs/first-worker" in
-        ( "Click the plus sign to create a worker to process asynchronous tasks."
+        ( [ "Click the plus sign to create a worker to process asynchronous tasks."
+          ]
         , link )
     | Cron ->
         let link = Some "https://darklang.github.io/docs/first-cron" in
-        ("Click the plus sign to create a scheduled job.", link)
+        (["Click the plus sign to create a scheduled job."], link)
     | Repl ->
         let link = Some "https://darklang.github.io/docs/first-repl" in
-        ("Click the plus sign to create a general purpose coding block.", link)
+        (["Click the plus sign to create a general purpose coding block."], link)
     | Datastore ->
         let link = Some "https://darklang.github.io/docs/first-datastore" in
-        ("Click to create a key-value store.", link)
+        (["Click to create a key-value store."], link)
     | Function ->
         let link = Some "https://darklang.github.io/docs/first-function" in
-        ("Click to create a reusable block of code.", link)
+        (["Click to create a reusable block of code."], link)
     | FourOhFour ->
         let link =
           Some "https://darklang.github.io/docs/trace-driven-development"
         in
-        ("Attempts to hit endpoints that do not exist are added here.", link)
+        ( [ "Attempts to hit endpoints that do not yet have handlers appear here."
+          ; "If you're looking for a 404 but not seeing it in this list, check the 'Deleted' section of the sidebar."
+          ]
+        , link )
     | Deleted ->
         let link = None in
-        ("Deleted handlers appear here.", link)
+        (["Deleted handlers appear here."], link)
     | PackageManager ->
         let link = None in
-        ( "A list of built-in Dark functions. Click on the name of the function to preview it. To use the function in your canvas, start typing its name in your handler and select it from autocomplete."
+        ( [ "A list of built-in Dark functions. Click on the name of the function to preview it."
+          ; "To use the function in your canvas, start typing its name in your handler and select it from autocomplete."
+          ]
         , link )
     | StaticAssets ->
         let link = Some "https://darklang.github.io/docs/static-assets" in
-        ("Learn more about hosting static assets here.", link)
+        (["Learn more about hosting static assets here."], link)
   in
   Html.div
     [Html.class' "tutorial-txt"]
-    [Html.p [] [Html.text content]; learnMoreLink link]
+    ( (content |> List.map ~f:(fun p -> Html.p [] [Html.text p]))
+    @ [learnMoreLink link] )
 
 
 let htmlForStep (step : tutorialStep) (username : string) : msg Html.html =


### PR DESCRIPTION
Not all 404s show up in the 404s section. If a handler for the corresponding endpoint has been deleted, it shows up in the Deleted section instead. Via Fullstory, we realized that this behavior is confusing -- people sometimes fail to look in the Deleted section at all. Fixing this problem comprehensively is challenging, and we would like to mitigate this problem in the short term.

This PR changes the copy of the "tooltip" that appears when clicking on the 404s section of the sidebar when it contains no entries, per https://trello.com/c/jaUbFMCb/3154-add-text-to-404s-tip-about-deleted-404s. This "tooltip" is currently styled as a sidebar pending implementation of https://www.notion.so/darklang/Tooltip-Component-Spec-7570a243f59d4bd99642c3c9a5d9cb4f

# Before (404s "tooltip"):
<img width="330" alt="Screen Shot 2020-06-01 at 10 18 54 AM" src="https://user-images.githubusercontent.com/438112/83436453-b908db80-a3f2-11ea-9e97-b6e6871a29d0.png">

# After (404s "tooltip"):
<img width="315" alt="Screen Shot 2020-06-01 at 10 17 55 AM" src="https://user-images.githubusercontent.com/438112/83436495-c920bb00-a3f2-11ea-979b-4043238c8f25.png">

# Also (package manager "tooltip" -- this PR now enables multiple paragraphs in these tooltips):
<img width="318" alt="Screen Shot 2020-06-01 at 10 16 43 AM" src="https://user-images.githubusercontent.com/438112/83436506-cf169c00-a3f2-11ea-9e00-f3a265cc7def.png">


