### PR TITLE
Add Crypto::md5

### DIFF
--- a/backend/libbackend/libcrypto.ml
+++ b/backend/libbackend/libcrypto.ml
@@ -111,6 +111,24 @@ let fns : expr fn list =
               fail args)
     ; preview_safety = Unsafe
     ; deprecated = false }
+  ; { prefix_names = ["Crypto::md5"]
+    ; infix_names = []
+    ; parameters = [par "data" TBytes]
+    ; return_type = TBytes
+    ; description =
+        "Computes the md5 digest of the given `data`. NOTE: There are multiple security problems with md5, see https://en.wikipedia.org/wiki/MD5#Security"
+    ; func =
+        InProcess
+          (function
+          | _, [DBytes data] ->
+              Cstruct.of_bytes data
+              |> Nocrypto.Hash.MD5.digest
+              |> digest_to_bytes
+              |> DBytes
+          | args ->
+              fail args)
+    ; preview_safety = Unsafe
+    ; deprecated = false }
   ; { prefix_names = ["Crypto::sha256hmac"]
     ; infix_names = []
     ; parameters = [par "key" TBytes; par "data" TBytes]

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -1306,6 +1306,11 @@ let t_crypto_sha () =
     (Dval.dstr_of_string_exn
        "38B060A751AC96384CD9327EB1B1E36A21FDB71114BE07434C0CC7BF63F6E1DA274EDEBFE76F65FBD51AD2F14898B95B")
     (exec_ast "(Bytes::hexEncode (Crypto::sha384 (String::toBytes '')))") ;
+  check_dval
+    "Crypto::md5 produces the correct digest"
+    (Dval.dstr_of_string_exn
+      "D41D8CD98F00B204E9800998ECF8427E")
+    (exec_ast "(Bytes::hexEncode (Crypto::md5 (String::toBytes '')))") ;
   ()
 
 


### PR DESCRIPTION
Adds Crypto::md5 standard library function and a test against the empty string.

Part of #2411