### PR TITLE
Make CI work for non-fork pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
             git config --global gc.auto 0 || true
             git clone git@github.com:darklang/dark .
             # This is only available on forked PRs
-            if [[ -v CIRCLE_PR_USERNAME ]]; then
+            if [[ -n "${CIRCLE_PR_USERNAME}" ]]; then
               git fetch --force origin "${CIRCLE_BRANCH}/head:remotes/origin/${CIRCLE_BRANCH}"
             fi
             git checkout -q -B "$CIRCLE_BRANCH"


### PR DESCRIPTION
In #2492 I managed to make CI work for forked PRs, but (once again) broke it for non-forked PRs. This makes it work for non-forked PRs by correctly checking whether it needs to pull a remote (only needed on PRs, it was erroring when we weren't on PRs).

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
