### PR TITLE
Linux defaults for fswatch (poll_monitor)

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -105,11 +105,18 @@ do
     # event that has no corresponding flag.") events
     FSWATCH+=" --event=Created --event=Updated --event=Removed --event=Renamed --event=MovedFrom --event=MovedTo"
 
-    # ismith seeing poll_monitor work more reliably than inotify on his laptop
-    # (`fswatch -x -r *` with default inotify only shows IsDir and
-    # PlatformSpecific events)
+    # In case you are working on linux, it seems like poll_monitor is more reliable way
+    # to check for the changes. You can find all monitors available on your platform
+    # using `fswatch -M`. You can always override the monitor mode by passing
+    # custom FSWATCH_MONITOR environment variable.
     if [[ "${FSWATCH_MONITOR-}" != "" ]]; then
-        FSWATCH+=" -m ${FSWATCH_MONITOR}"
+      echo "Using fswatch with monitor from env: ${FSWATCH_MONITOR} (env)"
+      FSWATCH+=" -m ${FSWATCH_MONITOR}"
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      echo "Using fswatch with monitor: poll_monitor (Linux default)"
+      FSWATCH+=" -m poll_monitor"
+    else
+      echo "Using fswatch with monitor: (default)"
     fi
   esac
 done


### PR DESCRIPTION
Hello. This is my first PR so please forgive me if there are some problems.

I've encountered issues on Linux machine with recompilation and rebuild process. I've also got some feedback from @pbiggar that I'm not the only one. It looks reasonable to change the default behaviour on Linux to `poll_monitor` which is more reliable. I still kept the option for customizing this via env variable.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
