### PR TITLE
Disable flaky exe_flow_fades test

### DIFF
--- a/client/src/app/IntegrationTest.ml
+++ b/client/src/app/IntegrationTest.ml
@@ -869,7 +869,7 @@ let function_docstrings_are_valid (m : model) : testResult =
 
 let record_consent_saved_across_canvases (_m : model) : testResult = pass
 
-let exe_flow_fades (_m : model) : testResult = pass
+(* let exe_flow_fades (_m : model) : testResult = pass *)
 
 let unexe_code_unfades_on_focus (_m : model) : testResult = pass
 
@@ -1031,8 +1031,8 @@ let trigger (test_name : string) : integrationTestState =
         function_docstrings_are_valid
     | "record_consent_saved_across_canvases" ->
         record_consent_saved_across_canvases
-    | "exe_flow_fades" ->
-        exe_flow_fades
+    (* | "exe_flow_fades" ->
+        exe_flow_fades *)
     | "unexe_code_unfades_on_focus" ->
         unexe_code_unfades_on_focus
     | "create_from_404" ->

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -1340,6 +1340,9 @@ test("record_consent_saved_across_canvases", async t => {
   await t.navigateTo(`${BASE_URL}${testname}?integration-test=true`);
 });
 
+// This test is flaky; last attempt to fix it added the 1000ms timeout, but that
+// didn't solve the problem
+/*
 test("exe_flow_fades", async t => {
   const timestamp = new Date();
   await t.click(".fluid-entry");
@@ -1349,6 +1352,7 @@ test("exe_flow_fades", async t => {
     .expect(Selector(".fluid-not-executed", { timeout: 1000 }).exists)
     .ok();
 });
+*/
 
 test("unexe_code_unfades_on_focus", async t => {
   const timestamp = new Date();


### PR DESCRIPTION
We took a shot at adding an explicit timeout, but this test still fails
often, so removing it.

Honeycomb: https://ui.honeycomb.io/dark/datasets/integration-tests/result/dHp72neRgVN

Graph shows 3 integration tests that have failed in the last 14 days.
This test has failed 36 times out of 154 runs - 20%. The other two tests
fail much less often - 11 and 2 times in that same span - so 36 is an
outlier.

(This is a follow up to
https://trello.com/c/HoIkaNzv/3161-attempt-to-make-exeflowfades-test-more-reliable
)

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
