### PR TITLE
Document how to put a new cert in a kubernetes secret

### DIFF
--- a/docs/production/tls-2018-08-03.markdown
+++ b/docs/production/tls-2018-08-03.markdown
@@ -190,3 +190,47 @@ ssl-certificate record and updating the load balancer to use it ...)
 
 Resulting files (.crt, .key) are stored in Vault, shared by IanS, Paul, and
 Ellen.
+
+
+Update, 2020-06-03
+##################
+When the AddTrust problem
+(https://trello.com/c/pSHmm177/3167-follow-up-after-ssl-incident) happened, we
+solved the problem by re-creating our cert chains using
+https://whatsmychaincert.com ; it takes a domain, checks the cert, and gives you
+a new one. You can also give it a crt file (not yet deployed)
+
+While I do not believe it will be necessary to do that in the future, I do want
+to document here the process for replacing a tls secret in kubernetes.
+
+Assuming `<name>` is the name of the secret holding the cert:
+
+1. Get the existing cert and keep it as a backup: 
+`kubectl get secret <name> -o yaml > old-<name>.yaml`
+
+2. Base64 encode the new cert:
+`cat <new cert> | base64 | xsel -ib` (`xsel` is Linux-specific, you can just
+copy to your clipboard by hand on OS X)
+
+3. Copy `old-<name>.yaml` to `new-<name>.yaml` and manually replace the value
+   `.data."tls.crt"` with the new data from step 2.
+
+4. Confirm that your editing resulted in `.data."tls.crt"` being valid - this is
+   a defense against copy-paste and whitespace errors:
+`yq -r '.data."tls.crt"' new-<name>.yaml | base64 -d` (we expect the output to
+be one or more certificates; you can pipe that to md5sum and compare it with the
+cert file it came from)
+
+5. Deploy time! `kubectl apply -f new-<name>.yaml`. This will give you a
+   warning: `Warning: kubectl apply should be used on resource created by either
+kubectl create --save-config or kubectl apply`, but this is ignorable. There's
+a PR to maybe improve the messaging
+(https://github.com/kubernetes/kubernetes/issues/91425), so that messaging may vary some.
+
+6. The new cert isn't effective until the next deploy goes out, because the
+   ingress pod needs to be restarted or replaced.
+
+7. Once it's out, check that the new cert is being served -
+   https://ssllabs.com/ssltest/ is probably the easiest way to do this, or
+`openssl s_client -connect <host>:443 | openssl x509 -noout -dates` will show
+you the notBefore and notAfter (expiration) dates.


### PR DESCRIPTION
For those certs we purchased manually, which is 3:
- `*.builtwithdark.com`
- `*.darklang.com`
- `www.hellobirb.com`

Docs learnings from
https://trello.com/c/pSHmm177/3167-follow-up-after-ssl-incident , but
will be useful when
https://trello.com/c/B0dQqQLe/3043-builtwithdarkcom-cert-expires-in-90-days-we-should-renew-it
is unblocked, hopefully soon.

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
