### PR TITLE
Update error msg copy for field access

### DIFF
--- a/backend/libexecution/ast.ml
+++ b/backend/libexecution/ast.ml
@@ -580,11 +580,18 @@ and exec ~(state : expr exec_state) (st : expr symtable) (expr : expr) :
           | DErrorRail _ ->
               obj
           | x ->
+              let actualTipe =
+                match Dval.tipe_of x with
+                | TDB ->
+                    "it's a Datastore. Use DB:: standard library functions to interact with Datastores"
+                | tipe ->
+                    "it's a " ^ Dval.tipe_to_string tipe
+              in
               DError
                 ( sourceId id
-                , "Attempting to access of a field of something that isn't an object but is a "
-                  ^ (x |> Dval.tipe_of |> Dval.tipe_to_string)
-                  ^ "" )
+                , "Attempting to access a field of something that isn't a record or dict, ("
+                  ^ actualTipe
+                  ^ ")." )
         in
         result
     | Filled (id, Constructor (name, args)) ->


### PR DESCRIPTION
Treelo: [Improve error message for trying to do field access on a datastore](https://trello.com/c/QLtYbXmQ/3075-improve-error-message-for-trying-to-do-field-access-on-a-datastore)

For datastore:
<img width="372" alt="Screen Shot 2020-06-04 at 1 00 24 PM" src="https://user-images.githubusercontent.com/244152/83805576-fa082680-a664-11ea-91ab-7ee9b8998084.png">

For other unmatched types:
<img width="372" alt="Screen Shot 2020-06-04 at 1 01 11 PM" src="https://user-images.githubusercontent.com/244152/83805597-02f8f800-a665-11ea-8437-24935ca17d2c.png">


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [x] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists
