### PR TITLE
link to desktop-client in browser support modal

### DIFF
--- a/client/src/canvas/ViewModal.ml
+++ b/client/src/canvas/ViewModal.ml
@@ -12,6 +12,16 @@ let viewBrowserMessage : msg Html.html =
         [Html.class' "title"]
         [ Html.text
             "Unfortunately we only support Dark on desktop Chrome right now. Between browser different input models, differences in scripting and rendering performance, and differing web platform support, we don't have the capacity to support other browsers at the moment. We hope to support Firefox, Safari, and mobile use once we've really nailed the experience on Chrome. Thanks for understanding!"
+        ]
+    ; Html.p
+        [Html.class' "title"]
+        [ Html.text "A "
+        ; Html.a
+            [ Html.href "http://darklang.com/desktop-client"
+            ; Html.target "_blank" ]
+            [Html.text "desktop client"]
+        ; Html.text
+            " is available as well. It is still in the beta phase, so the experience may be slightly different than in Chrome."
         ] ]
 
 

--- a/client/styles/_canvas.scss
+++ b/client/styles/_canvas.scss
@@ -140,6 +140,19 @@ body #app * {
   i.di {
     @extend .dark-icon-font;
   }
+
+  a {
+    &,
+    &:link,
+    &:visited {
+      color: $blue;
+    }
+
+    &:hover,
+    &:active {
+      color: $purple;
+    }
+  }
 }
 
 #canvas {


### PR DESCRIPTION
trello: https://trello.com/c/ojmMR6Fi/3179-add-desktop-client-link-to-chrome-blocking-modal

To test: open a canvas in some other browser (safari, FF, etc.)


- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [ ] Before/after screenshots are included
  - [x] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - x ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x] No spec exists
