### PR TITLE
Error handling for http client

### DIFF
--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -2343,6 +2343,17 @@ let t_libhttp () =
   ()
 
 
+let t_libhttpclient () =
+  check_error_contains
+    "HttpClient::get_v5 illegal urls"
+    (exec_ast
+       (fn
+          "HttpClient::get_v5"
+          [str "http://thenonexistingurlforsure.com"; record []; record []]))
+    "Couldn't resolve host name" ;
+  ()
+
+
 (* This test doesn't bother to destructure + examine the contents of the dobj;
  * it's just intended to ensure that the thing runs and doesn't DError. Esp
  * since the contents of the DObj depend on the database's stats and those
@@ -2383,4 +2394,4 @@ let suite =
   ; ("Math stdlibs work", `Quick, t_math_stdlibs)
   ; ("HTTP stdlibs work", `Quick, t_libhttp)
   ; ("DarkInternal::table_stats works", `Quick, t_darkinternal_table_stats_works)
-  ]
+  ; ("HttpClient error handling", `Quick, t_libhttpclient) ]


### PR DESCRIPTION
As Julian described:
> libhttpclient.ml's send_request uses httpclient.ml's http_call, which uses httpclient.ml's http_call_with_code, which raises Exception.Code when passed a URL that doesn't resolve.

@pbiggar This is more like a first draft but just wanted to make sure I'm looking in the right direction. My idea is to intercept all kind `DarkException` and wrap them as `DResult` so it can be handled on the rail. This is in this PR.

On the other hand, maybe it would be better to find some global interceptor/filter and catch all kind of issues like this (if there is such a intersection)