### PR TITLE
Delete leading blank in list removes the blank

### DIFF
--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -4056,6 +4056,18 @@ let run () =
         ~pos:1
         bs
         "~56" ;
+      t
+        "a delete with caret before a blank in front of a list will delete the blank"
+        listWithBlankAtStart
+        ~pos:1
+        del
+        "[~56,78,56]" ;
+      t
+        "a delete with caret before a list with just a blank removes the blank"
+        listWithJustABlank
+        ~pos:1
+        del
+        "[~]" ;
       ()) ;
   describe "Records" (fun () ->
       t "create record" b ~pos:0 (ins "{") "{~}" ;

--- a/client/test/fluid_test_data.ml
+++ b/client/test/fluid_test_data.ml
@@ -428,6 +428,10 @@ let veryLongList =
 
 let listWithBlank = list [fiftySix; seventyEight; b; fiftySix]
 
+let listWithBlankAtStart = list [b; fiftySix; seventyEight; fiftySix]
+
+let listWithJustABlank = list [b]
+
 let listWithRecord = list [emptyRecord]
 
 let multiWithStrs = list [str "ab"; str "cd"; str "ef"]


### PR DESCRIPTION
Fixes #2478 

Pressing delete with the caret like below now deletes the blank
let a = [ |__, 1, 2 ]

Added one test to confirm this behaviour

I believe this is the best way to do this, my investigation is explained in the issue