### PR TITLE
Put single quotes around the url in cURL command

### DIFF
--- a/client/src/toplevels/CurlCommand.ml
+++ b/client/src/toplevels/CurlCommand.ml
@@ -146,7 +146,7 @@ let curlFromCurrentTrace (m : model) (tlid : TLID.t) : string option =
                    |> Option.andThen ~f:(fun s -> Some ("-X " ^ s))
                    |> wrapInList
                  in
-                 ("curl" :: headers) @ body @ meth @ [url]
+                 ("curl" :: headers) @ body @ meth @ ["'" ^ url ^ "'"]
                  |> String.join ~sep:" "
                  |> Option.some
              | _ ->

--- a/client/test/curl_test.ml
+++ b/client/test/curl_test.ml
@@ -119,7 +119,7 @@ let run () =
           expect (curlFromCurrentTrace m defaultTLID)
           |> toEqual
                (Some
-                  "curl -H 'Authorization:Bearer abc123' -H 'Content-Type:application/json' -X GET http://test-curl.builtwithdark.com/test")) ;
+                  "curl -H 'Authorization:Bearer abc123' -H 'Content-Type:application/json' -X GET 'http://test-curl.builtwithdark.com/test'")) ;
       test "returns command for /test POST with body" (fun () ->
           let input =
             StrDict.empty
@@ -147,5 +147,5 @@ let run () =
           expect (curlFromCurrentTrace m defaultTLID)
           |> toEqual
                (Some
-                  "curl -d '{\"a\":1,\"b\":false}' -X POST http://test-curl.builtwithdark.com/test"))) ;
+                  "curl -d '{\"a\":1,\"b\":false}' -X POST 'http://test-curl.builtwithdark.com/test'"))) ;
   ()


### PR DESCRIPTION
This is to make sure the url is directly copy-pastable in the shell,
otherwise the shell might interpret characters from the url specially

Changed the tests that expected no single quotes
