### PR TITLE
Show references in order

### DIFF
--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -3,7 +3,6 @@ open Tc
 (* == legacy aliases == *)
 module TLIDDict = TLID.Dict
 module TLIDSet = TLID.Set
-module IDSet = ID.Set
 
 type analysisID = ID.t [@@deriving show]
 
@@ -1746,7 +1745,7 @@ and model =
    *
    * which you can read as "repl2 refersTo myfunc". So a TLID.t points to the TLs
    * it uses. *)
-  ; tlRefersTo : IDPairSet.t TLIDDict.t
+  ; tlRefersTo : (TLID.t * ID.t) list TLIDDict.t
         (* tlUsedIn: to answer the question "what TLs is this TL's name used in".  eg
    * if myFunc was called in Repl2, the dict would
    *

--- a/client/src/toplevels/Introspect.ml
+++ b/client/src/toplevels/Introspect.ml
@@ -97,21 +97,31 @@ let tlidsToUpdateUsage (ops : op list) : TLID.t list =
   |> List.uniqueBy ~f:TLID.toString
 
 
+let rec updateAssocList
+    ~(key : 'k) ~(f : 'v option -> 'v option) (assoc : ('k * 'v) list) :
+    ('k * 'v) list =
+  match assoc with
+  | (k, v) :: xs ->
+      if key = k
+      then match f (Some v) with Some nw -> (key, nw) :: xs | None -> xs
+      else (k, v) :: updateAssocList ~key ~f xs
+  | [] ->
+    (match f None with Some nw -> [(key, nw)] | None -> [])
+
+
 let allRefersTo (tlid : TLID.t) (m : model) : (toplevel * ID.t list) list =
   m.tlRefersTo
   |> TLIDDict.get ~tlid
-  |> Option.withDefault ~default:IDPairSet.empty
-  |> IDPairSet.toList
-  |> List.foldl ~init:TLIDDict.empty ~f:(fun (tlid, id) dict ->
-         ( TLIDDict.update ~tlid dict ~f:(function
+  |> Option.withDefault ~default:[]
+  |> List.foldl ~init:[] ~f:(fun (tlid, id) assoc ->
+         ( updateAssocList ~key:tlid assoc ~f:(function
                | None ->
-                   Some (IDSet.fromList [id])
-               | Some set ->
-                   Some (IDSet.add ~value:id set))
-           : IDSet.t TLIDDict.t ))
-  |> TD.toList
+                   Some [id]
+               | Some lst ->
+                   Some (lst @ [id]))
+           : (TLID.t * ID.t list) list ))
   |> List.filterMap ~f:(fun (tlid, ids) ->
-         TL.get m tlid |> Option.map ~f:(fun tl -> (tl, IDSet.toList ids)))
+         TL.get m tlid |> Option.map ~f:(fun tl -> (tl, ids)))
 
 
 let allUsedIn (tlid : TLID.t) (m : model) : toplevel list =
@@ -215,10 +225,13 @@ let refreshUsages (m : model) (tlids : TLID.t list) : model =
          ~init:(tlUsedInDict, tlRefersToDict)
          ~f:(fun usage (usedIn, refersTo) ->
            let newRefersTo =
-             TD.get ~tlid:usage.refersTo refersTo
-             |> Option.withDefault ~default:TLIDSet.empty
-             |> IDPairSet.add ~value:(usage.usedIn, usage.id)
-             |> fun value -> TD.insert ~tlid:usage.refersTo ~value refersTo
+             TD.insert
+               ~tlid:usage.refersTo
+               ~value:
+                 ( ( TD.get ~tlid:usage.refersTo refersTo
+                   |> Option.withDefault ~default:[] )
+                 @ [(usage.usedIn, usage.id)] )
+               refersTo
            in
            let newUsedIn =
              TD.get ~tlid:usage.usedIn usedIn

--- a/client/test/introspect_test.ml
+++ b/client/test/introspect_test.ml
@@ -85,5 +85,15 @@ let run () =
                 ; ufAST = FluidAST.ofExpr (FluidExpression.newB ()) } ]
           in
           expect (tlidsToUpdateUsage ops) |> toEqual [h1tlid; fntlid]) ;
+      test "updateAssocList from empty" (fun () ->
+          expect
+            (updateAssocList ~key:"a" [] ~f:(fun u ->
+                 match u with Some v -> Some v | None -> Some 1))
+          |> toEqual [("a", 1)]) ;
+      test "updateAssocList add non existing" (fun () ->
+          expect
+            (updateAssocList ~key:"b" [("a", 1)] ~f:(fun u ->
+                 match u with Some v -> Some v | None -> Some 1))
+          |> toEqual [("a", 1); ("b", 1)]) ;
       ()) ;
   ()


### PR DESCRIPTION
To preserve the order of references, they are now stored in an association list instead of a dictionary. I added some tests to check that the association list updates works in the right way.