### PR TITLE
Fix overriding css

### DIFF
--- a/client/styles/_canvas.scss
+++ b/client/styles/_canvas.scss
@@ -131,16 +131,8 @@ body {
 }
 
 /* Body */
-body #app * {
-  &:not(.fa) {
-    // skip fontawesome
-    font-family: "Fira Mono", monospace;
-  }
 
-  i.di {
-    @extend .dark-icon-font;
-  }
-
+body {
   a {
     &,
     &:link,
@@ -152,6 +144,17 @@ body #app * {
     &:active {
       color: $purple;
     }
+  }
+}
+
+body #app * {
+  &:not(.fa) {
+    // skip fontawesome
+    font-family: "Fira Mono", monospace;
+  }
+
+  i.di {
+    @extend .dark-icon-font;
   }
 }
 


### PR DESCRIPTION
Problem: In PR #2506 I mean to write a selector `body a {...}` but accidentally put it in `body #app *`. Because ID-selectors (ie: `#app`) takes a higher precedence, it overwrote all the links styling.

Solution: Moved the link selector to originally intended `body` selector.

Before:
<img width="411" alt="Screen Shot 2020-06-05 at 12 23 16 PM" src="https://user-images.githubusercontent.com/244152/83915167-9266df80-a727-11ea-9f81-bf0f03d408a1.png">

After:
<img width="411" alt="Screen Shot 2020-06-05 at 12 24 25 PM" src="https://user-images.githubusercontent.com/244152/83915178-97c42a00-a727-11ea-91ed-78206ec8148b.png">
