### PR TITLE
Show un-deprecated versions first on functions autocomplete

### DIFF
--- a/client/test/fluid_ac_test.ml
+++ b/client/test/fluid_ac_test.ml
@@ -248,12 +248,12 @@ let run () =
           test "DB::get_v1 occurs before DB::getAll_v1" (fun () ->
               expect (acForQuery "DB::get" |> List.head)
               |> toEqual (Some "DB::get_v1")) ;
-          test "DB::getAll_v1 occurs before DB::getAll_v2" (fun () ->
+          test "DB::getAll_v2 occurs before DB::getAll_v1" (fun () ->
               expect (acForQuery "DB::getA" |> List.head)
-              |> toEqual (Some "DB::getAll_v1")) ;
-          test "DB::getAll_v2 is reachable" (fun () ->
+              |> toEqual (Some "DB::getAll_v2")) ;
+          test "DB::getAll_v1 is reachable" (fun () ->
               expect (acForQuery "DB::getA")
-              |> toEqual ["DB::getAll_v1"; "DB::getAll_v2"]) ;
+              |> toEqual ["DB::getAll_v2"; "DB::getAll_v1"]) ;
           test "search finds only prefixed" (fun () ->
               expect (acForQuery "twit::y") |> toEqual ["Twit::yetAnother"]) ;
           test "show results when the only option is the setQuery" (fun () ->


### PR DESCRIPTION
Fixes #2407

The solution I'm proposing is: after the functions have been sorted (in increasing order from `List.sortBy`), I grouped the functions with same name (with their version stripped out) and reverse each group, so the un-deprecated version of each function appears first.

Screenshot before the change:
![image](https://user-images.githubusercontent.com/1580375/83935500-7f3c2a00-a790-11ea-988a-139405d410bd.png)


Screenshot after the change:
![image](https://user-images.githubusercontent.com/1580375/83935442-063cd280-a790-11ea-81eb-9097d50d88ae.png)

The tests that verified the old behavior have been changed
to verify the new one

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
