### PR TITLE
Add support to Visual Studio Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,73 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Note: You can use any Debian/Ubuntu based image you want. 
+FROM ubuntu:18.04@sha256:3235326357dfb65f1781dbc4df3b834546d8bf914e82cce58e6e6b676e23ce8f
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+USER root
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt update --allow-releaseinfo-change && \
+  DEBIAN_FRONTEND=noninteractive \
+  apt install \
+  -y \
+  --no-install-recommends \
+  curl \
+  apt-transport-https \
+  ca-certificates \
+  lsb-core \
+  less \
+  gpg \
+  gpg-agent \
+  && apt clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
+# Deps:
+# - apt-transport-https for npm
+# - expect for unbuffer
+# - most libs re for ocaml
+# - net-tools for netstat
+# - esy packages need texinfo
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt update --allow-releaseinfo-change && \
+  DEBIAN_FRONTEND=noninteractive \
+  apt install \
+  --no-install-recommends \
+  -y \
+  software-properties-common \
+  make \
+  rsync \
+  git \
+  wget \
+  sudo \
+  locales \
+  expect \
+  tcl8.6 \
+  libev-dev \
+  libgmp-dev \
+  pkg-config \
+  libcurl4-gnutls-dev \
+  libpq-dev \
+  vim \
+  unzip \
+  docker-ce \
+  fswatch \
+  python3-pip \
+  python3-setuptools \
+  python3-dev \
+  ssh
+
+RUN pip3 install livereload

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,11 @@
+
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
 # Note: You can use any Debian/Ubuntu based image you want. 
-FROM ubuntu:18.04@sha256:3235326357dfb65f1781dbc4df3b834546d8bf914e82cce58e6e6b676e23ce8f
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-debian-10
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
@@ -14,60 +15,83 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-USER root
-RUN DEBIAN_FRONTEND=noninteractive \
-  apt update --allow-releaseinfo-change && \
-  DEBIAN_FRONTEND=noninteractive \
-  apt install \
-  -y \
-  --no-install-recommends \
-  curl \
-  apt-transport-https \
-  ca-certificates \
-  lsb-core \
-  less \
-  gpg \
-  gpg-agent \
-  && apt clean \
-  && rm -rf /var/lib/apt/lists/*
+# Docker script args, location, and expected SHA - SHA generated on release
+ARG DOCKER_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.117.1/script-library/docker-debian.sh"
+ARG DOCKER_SCRIPT_SHA="23a9e56a563e66a7339c43a67719fda06e70ce4d1fa2a870392e32a57aa42136"
+ARG ENABLE_NONROOT_DOCKER="true"
+ARG SOURCE_SOCKET=/var/run/docker-host.sock
+ARG TARGET_SOCKET=/var/run/docker.sock
 
-RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+# ========= DOCKER CE INSTALLATION ==========
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Deps:
-# - apt-transport-https for npm
-# - expect for unbuffer
-# - most libs re for ocaml
-# - net-tools for netstat
-# - esy packages need texinfo
-RUN DEBIAN_FRONTEND=noninteractive \
-  apt update --allow-releaseinfo-change && \
-  DEBIAN_FRONTEND=noninteractive \
-  apt install \
-  --no-install-recommends \
-  -y \
-  software-properties-common \
-  make \
-  rsync \
-  git \
-  wget \
-  sudo \
-  locales \
-  expect \
-  tcl8.6 \
-  libev-dev \
-  libgmp-dev \
-  pkg-config \
-  libcurl4-gnutls-dev \
-  libpq-dev \
-  vim \
-  unzip \
-  docker-ce \
-  fswatch \
-  python3-pip \
-  python3-setuptools \
-  python3-dev \
-  ssh
+RUN apt-get update \
+    # Verify common dependencies and utilities are installed
+    && apt-get -y install --no-install-recommends apt-utils dialog git openssh-client curl less iproute2 procps 2>&1 \
+    #
+    # Create a non-root user to use if not already available - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && if [ $(getent passwd $USERNAME) ]; then \
+    # If exists, see if we need to tweak the GID/UID
+    if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+    groupmod --gid $USER_GID $USERNAME \
+    && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
+    && chown -R $USER_UID:$USER_GID /home/$USERNAME; \
+    fi; \
+    else \
+    # Otherwise ccreate the non-root user
+    groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME; \
+    fi \
+    #
+    # Use Docker script from script library to set things up
+    && curl -sSL $DOCKER_SCRIPT_SOURCE -o /tmp/docker-setup.sh \
+    && if [ "$DOCKER_SCRIPT_SHA" != "dev-mode" ]; then echo "$DOCKER_SCRIPT_SHA /tmp/docker-setup.sh" | sha256sum -c - ; fi \
+    && /bin/bash /tmp/docker-setup.sh "${ENABLE_NONROOT_DOCKER}" "${SOURCE_SOCKET}" "${TARGET_SOCKET}" "${USERNAME}" \
+    && rm /tmp/docker-setup.sh \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+# Setting the ENTRYPOINT to docker-init.sh will configure non-root access to 
+# the Docker socket if "overrideCommand": false is set in devcontainer.json. 
+# The script will also execute CMD if you need to alter startup behaviors.
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]
+
+# ========= END DOCKER CE INSTALLATION ==========
+
+# Install required dependencies for dark
+RUN apt-get update \
+    && apt install \
+    --no-install-recommends \
+    -y \
+    software-properties-common \
+    make \
+    git \
+    wget \
+    locales \
+    expect \
+    tcl8.6 \
+    libev-dev \
+    libgmp-dev \
+    pkg-config \
+    vim \
+    python3-pip \
+    python3-setuptools \
+    fswatch \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install livereload

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,24 +6,23 @@
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
   ],
-
+  "remoteEnv": {
+    "CODESPACE": "true"
+  },
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"
   },
-
   // Add the IDs of extensions you want installed when the container is created.
-  "extensions": ["ms-azuretools.vscode-docker"],
-
+  "extensions": [
+    "ms-azuretools.vscode-docker"
+  ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "docker --version",
-
   // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
   // "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
   // Uncomment the next two lines to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
   "overrideCommand": false,
   "remoteUser": "vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/docker-in-docker
+{
+  "name": "Docker in Docker",
+  "dockerFile": "Dockerfile",
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+  ],
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": []
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "docker --version",
+  // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+  // "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+  // Uncomment the next two lines to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  // "overrideCommand": false,
+  // "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,19 +6,25 @@
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
   ],
+
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"
   },
+
   // Add the IDs of extensions you want installed when the container is created.
-  "extensions": []
+  "extensions": ["ms-azuretools.vscode-docker"],
+
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
+
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "docker --version",
+
   // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
   // "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
   // Uncomment the next two lines to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-  // "overrideCommand": false,
-  // "remoteUser": "vscode"
+  "overrideCommand": false,
+  "remoteUser": "vscode"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       && rm -rf /var/lib/apt/lists/*
 
 # Latest NPM (taken from  https://deb.nodesource.com/setup_8.x )
-RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+RUN curl -ksSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -

--- a/scripts/builder
+++ b/scripts/builder
@@ -150,8 +150,13 @@ fi
 # --------------
 # create the network
 # --------------
-./scripts/support/create-dark-dev-network
-
+if [ -v CODESPACE ]; then
+  DNS=''
+else
+  ./scripts/support/create-dark-dev-network
+  DNS='--dns 8.8.8.8 \
+        --dns 8.8.4.4'
+fi
 # --------------
 # --------------
 echo "Run the build"
@@ -166,8 +171,7 @@ $FSWATCH | docker run \
              --init \
              --rm \
              -i \
-             --dns 8.8.8.8 \
-             --dns 8.8.4.4 \
+             $DNS \
              --name dark-dev \
              --hostname dark-dev \
              --env-file "$ENV_FILE" \

--- a/scripts/builder
+++ b/scripts/builder
@@ -59,8 +59,7 @@ fi
 if [ -v CI ]; then
   # see "copy in data" in .circleci/config.yml
   MOUNTS="--volumes-from vols"
-fi
-if [-v CODESPACE]; then
+elif [ -v CODESPACE ]; then
   # when running inside codespace different directory needs to be mounted.
   MOUNTS="--mount type=bind,src=/var/lib/docker/vsonlinemount/workspace,dst=/home/dark/app"
 else 

--- a/scripts/builder
+++ b/scripts/builder
@@ -59,7 +59,11 @@ fi
 if [ -v CI ]; then
   # see "copy in data" in .circleci/config.yml
   MOUNTS="--volumes-from vols"
-else
+fi
+if [-v CODESPACE]; then
+  # when running inside codespace different directory needs to be mounted.
+  MOUNTS="--mount type=bind,src=/var/lib/docker/vsonlinemount/workspace,dst=/home/dark/app"
+else 
   MOUNTS="--mount type=bind,src=$PWD,dst=/home/dark/app"
 
   # Avoid docker syncing everything to the host, slowing compiles down by 5x
@@ -86,7 +90,7 @@ else
   fi
   # make sure this exists first, so it doesn't get created as a directory
   touch "$HOME/.dark_bash_history"
-  MOUNTS="$MOUNTS --mount type=bind,src=$HOME/.dark_bash_history,dst=/home/dark/.bash_history"
+  # MOUNTS="$MOUNTS --mount type=bind,src=$HOME/.dark_bash_history,dst=/home/dark/.bash_history"
 fi
 
 # --------------


### PR DESCRIPTION
**Problem:**
My machine is quite old and unable to compile darklang without spinning all fans like crazy for 40 minutes and crashing after that.
**Documentation:**
- [Codespaces](https://code.visualstudio.com/docs/remote/codespaces)
- Not sure where to put docs on how to use this for other devs. Readme?
**Solution:**
Using the power of virtualization we can get any kind of machine. With the latest additions to VSCode and Visual studio, the setup to be productive in a remote environment is minimal. 
With this setup
```
scripts/builder --compile --watch --test
```
Can be run in either:
- A docker container which removes the need to have python3 and fswatch on the host machine.
- For my case in codespace - it will use the same config.

**Limitations:**
- It's required to clone the GitHub repo using **https** not via ssh. As far as I understand the reason is that for now codespaces don't yet support proxying of ssh keys into the codespace.
- To be investigated how does it work with dnsmasq - this is only initial setup. Will be doing more PR's which will add port forwarding and etc.

- [N/A ] Trello link included
- [x ] Discussed goals, problem and solution
- [ x] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [x ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [x ] No spec exists
