### PR TITLE
Add Date::atStartOfDay function.

### DIFF
--- a/backend/libexecution/libdate.ml
+++ b/backend/libexecution/libdate.ml
@@ -473,4 +473,22 @@ let fns : expr fn list =
           | args ->
               fail args)
     ; preview_safety = Safe
+    ; deprecated = false }
+  ; { prefix_names = ["Date::atStartOfDay"]
+    ; infix_names = []
+    ; parameters = [par "date" TDate]
+    ; return_type = TDate
+    ; description = "Returns the Date with the time set to midnight"
+    ; func =
+        InProcess
+          (function
+          | _, [DDate d] ->
+              d
+              |> Time.to_date ~zone:Time.Zone.utc
+              |> (fun x ->
+                   Time.of_date_ofday Time.Zone.utc x Time.Ofday.start_of_day)
+              |> DDate
+          | args ->
+              fail args)
+    ; preview_safety = Safe
     ; deprecated = false } ]

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -1330,6 +1330,13 @@ let t_date_functions_work () =
     "Date >= works - equality"
     (DBool true)
     (exec_ast' (binop "Date::>=" later_date later_date)) ;
+  check_dval
+    "Date::atStartOfDay works"
+    (Dval.dstr_of_string_exn "2019-07-28T00:00:00Z")
+    (exec_ast'
+       (pipe
+          date
+          [fn "Date::atStartOfDay" [pipeTarget]; fn "toString" [pipeTarget]])) ;
   ()
 
 


### PR DESCRIPTION
This PR adds a new `Date` function `atStartOfDay`, which turns an existing date into a new date with the time set to the start of the day, i.e. sets the time to midnight. Please see the example below:

![Screenshot 2020-06-07 at 21 03 30](https://user-images.githubusercontent.com/1190768/83981112-eaae0500-a912-11ea-9515-cef2c972860e.png)

The existing date functions don't seem to be sorted alphabetically, so I added the new function at the end, please let me know if you'd like me to move it somewhere else; the same applies to the test (is one test sufficient?).

This is my first piece of code in OCaml, so I'd be really happy to get any feedback. 

Relates to #2411.