### PR TITLE
Use display property to toggle hover account actions

### DIFF
--- a/client/styles/_canvas.scss
+++ b/client/styles/_canvas.scss
@@ -283,13 +283,12 @@ body #app * {
   }
 
   .account-actions {
-    height: 0;
-    padding: 0;
+    display: none;
+    padding: 5px $spacing-medium;
     box-sizing: border-box;
     background: $black3;
     overflow: hidden;
 
-    display: flex;
     flex-direction: column;
     justify-content: space-around;
     text-align: right;
@@ -316,7 +315,6 @@ body #app * {
   }
 
   &:hover > .account-actions {
-    height: auto;
-    padding: 5px $spacing-medium;
+    display: flex;
   }
 }


### PR DESCRIPTION
This PR fixes #2531 , it is css styling issue to retain hidden content width for `account-actions` div

After fix screen shot:
![simplescreenrecorder-2020-06-08](https://user-images.githubusercontent.com/1086461/84079149-61620580-a9da-11ea-96e0-40c8c2de0cb6.gif)
