### PR TITLE
Fix copy icon is positioned by warning message

### DIFF
--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -150,6 +150,10 @@ $ff-color: adjust-hue($purple, -40deg);
     border-bottom: 1px dashed grey;
     margin-bottom: $spacing-small;
   }
+
+  .value {
+    position: relative;
+  }
 }
 
 #fluid-status {


### PR DESCRIPTION
This PR fixes #2507 , bug is caused by nearest `position: relative` container is not `value` when `warning-message` appears, so the position is wrong.
By adding `position: relative` to `.return-value.value`, it will position by `value` itself.
![copy-icon-changes](https://user-images.githubusercontent.com/1086461/84082935-ff58ce80-a9e0-11ea-8adb-fa57087d86f8.png)

