### PR TITLE
Implement function description using BlankOrs

### DIFF
--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -942,7 +942,7 @@ let t_list_stdlibs_work () =
   check_dval
     "List::dropWhile works"
     (DList [Dval.dint 3; Dval.dint 4])
-    (exec_ast'
+    (exec_ast
        (fn
           "List::dropWhile"
           [ list [int 1; int 2; int 3; int 4]
@@ -950,7 +950,7 @@ let t_list_stdlibs_work () =
   check_dval
     "List::dropWhile stops upon false"
     (DList [Dval.dint 5; Dval.dint 2; Dval.dint 2])
-    (exec_ast'
+    (exec_ast
        (fn
           "List::dropWhile"
           [ list [int 1; int 5; int 2; int 2]
@@ -959,21 +959,21 @@ let t_list_stdlibs_work () =
   check_dval
     "List::dropWhile works with empty input"
     (DList [])
-    (exec_ast'
+    (exec_ast
        (fn
           "List::dropWhile"
           [list []; lambda ["item"] (binop "<" (var "item") (int 3))])) ;
   check_dval
     "List::dropWhile works with empty output"
     (DList [])
-    (exec_ast'
+    (exec_ast
        (fn
           "List::dropWhile"
           [ list [int 1; int 2; int 3; int 4]
           ; lambda ["item"] (binop ">=" (var "item") (int 1)) ])) ;
   check_error_contains
     "List::dropWhile gives error with incorrect return type"
-    (exec_ast'
+    (exec_ast
        (fn
           "List::dropWhile"
           [ list [int 1; int 2; int 3; int 4]

--- a/backend/test_appdata/test-change_fn_description.json
+++ b/backend/test_appdata/test-change_fn_description.json
@@ -1,0 +1,17 @@
+[
+  [ "TLSavepoint", 86953439 ],
+  [
+    "SetFunction",
+    {
+      "tlid": 86953439,
+      "metadata": {
+        "name": [ "Filled", 1661671248, "always5" ],
+        "parameters": [],
+        "return_type": [ "Filled", 1845185814, [ "TAny" ] ],
+        "description": "always5 returns the value 5",
+        "infix": false
+      },
+      "ast": [ "Filled", 1296744364, [ "Value", "5" ] ]
+    }
+  ]
+]

--- a/client/src/app/IntegrationTest.ml
+++ b/client/src/app/IntegrationTest.ml
@@ -43,6 +43,14 @@ let testInt ~(errMsg : string) ~(expected : int) ~(actual : int) : testResult =
       ^ ")" )
 
 
+let testString ~(errMsg : string) ~(expected : string) ~(actual : string) :
+    testResult =
+  if actual = expected
+  then pass
+  else
+    fail (Printf.sprintf "%s (Actual: %s, Expected: %s)" errMsg actual expected)
+
+
 let showToplevels tls = tls |> TD.values |> show_list ~f:show_toplevel
 
 let onlyTL (m : model) : toplevel option =
@@ -425,6 +433,17 @@ let select_route (m : model) : testResult =
 let function_analysis_works (_m : model) : testResult =
   (* The test logic is in tests.js *)
   pass
+
+
+let change_fn_description (m : model) : testResult =
+  match UserFunctions.findByName m "always5" with
+  | Some fn ->
+      testString
+        ~errMsg:"wrong description"
+        ~expected:"always5 returns the value 5!?"
+        ~actual:fn.ufMetadata.ufmDescription
+  | None ->
+      fail "function does not exist"
 
 
 let jump_to_error (m : model) : testResult =
@@ -945,6 +964,8 @@ let trigger (test_name : string) : integrationTestState =
         select_route
     | "function_analysis_works" ->
         function_analysis_works
+    | "change_fn_description" ->
+        change_fn_description
     | "jump_to_error" ->
         jump_to_error
     | "fourohfours_parse" ->

--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -990,6 +990,18 @@ let update_ (msg : msg) (m : model) : modification =
         [ AutocompleteMod (ACSetQuery query)
         ; AutocompleteMod (ACSetVisible true)
         ; MakeCmd (CursorState.focusEntry m) ]
+  | MultilineEntryInputMsg text ->
+      (* XXX(JULIAN): This is off by one character because the model passed to commit
+       * is from before the change *)
+      Many
+        [ AutocompleteMod (ACSetQuery text)
+        ; AutocompleteMod (ACSetVisible false)
+        ; MakeCmd (CursorState.focusEntry m)
+        ; ( match CursorState.unwrap m.cursorState with
+          | Entering (Filling _ as cursor) ->
+              Entry.commit m cursor
+          | _ ->
+              NoChange ) ]
   | EntrySubmitMsg ->
       NoChange
   | AutocompleteClick index ->

--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -321,7 +321,10 @@ let rec updateMod (mod_ : modification) ((m, cmd) : model * msg Cmd.t) :
         in
         let withFocus, wfCmd =
           updateMod
-            (Many [AutocompleteMod ACReset; processFocus localM focus])
+            (* HACK: (ACSetQuery "") here ensures autocomplete queries don't persist after commit, but allow commit as you type.
+            Note that we should instead call ACReset as a final step in situations where you want to save and focus elsewhere.
+            The current approach is asynchronous and can lead to timing-related bugs. *)
+            (Many [AutocompleteMod (ACSetQuery ""); processFocus localM focus])
             (localM, Cmd.none)
         in
         (withFocus, Cmd.batch [wfCmd; API.addOp withFocus FocusNoChange params])

--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -147,12 +147,15 @@ let processFocus (m : model) (focus : focus) : modification =
         ( match next with
         | Some id ->
             Enter (Filling (tlid, id))
+            Many [(AutocompleteMod ACReset); Enter (Filling (tlid, id))]
         | None ->
           ( match pred with
           | Some id ->
               Select (tlid, STID id)
+              Many [(AutocompleteMod ACReset); Select (tlid, STID id);]
           | None ->
               Select (tlid, STTopLevelRoot) ) ) )
+              Many [(AutocompleteMod ACReset); Select (tlid, STTopLevelRoot)] ) ) )
   | FocusExact (tlid, id) ->
     ( match TL.getPD m tlid id with
     | Some pd ->

--- a/client/src/core/Decoders.ml
+++ b/client/src/core/Decoders.ml
@@ -293,6 +293,7 @@ let blankOrData j : blankOrData =
     ; ("PDBColName", dv1 (fun x -> PDBColName x) (blankOr string))
     ; ("PDBColType", dv1 (fun x -> PDBColType x) (blankOr string))
     ; ("PFnName", dv1 (fun x -> PFnName x) (blankOr string))
+    ; ("PFnDescription", dv1 (fun x -> PFnDescription x) (blankOr string))
     ; ("PParamName", dv1 (fun x -> PParamName x) (blankOr string))
     ; ("PParamTipe", dv1 (fun x -> PParamTipe x) (blankOr tipe))
     ; ("PTypeFieldName", dv1 (fun x -> PTypeFieldName x) (blankOr string))

--- a/client/src/core/Encoders.ml
+++ b/client/src/core/Encoders.ml
@@ -182,6 +182,8 @@ and blankOrData (pd : Types.blankOrData) : Js.Json.t =
       ev "PDBColType" [blankOr string coltype]
   | PFnName msg ->
       ev "PFnName" [blankOr string msg]
+  | PFnDescription msg ->
+      ev "PFnDescription" [blankOr string msg]
   | PFnReturnTipe msg ->
       ev "PFnReturnTipe" [blankOr tipe msg]
   | PParamName msg ->

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -148,6 +148,7 @@ and blankOrData =
   | PDBColName of string blankOr
   | PDBColType of string blankOr
   | PFnName of string blankOr
+  | PFnDescription of string blankOr
   | PFnReturnTipe of tipe blankOr
   | PParamName of string blankOr
   | PParamTipe of tipe blankOr
@@ -164,6 +165,7 @@ and blankOrType =
   | DBColName
   | DBColType
   | FnName
+  | FnDescription
   | FnReturnTipe
   | ParamName
   | ParamTipe

--- a/client/src/core/Types.ml
+++ b/client/src/core/Types.ml
@@ -910,6 +910,7 @@ and autocompleteItem =
   | ACDBColName of string
   (* User functions *)
   | ACFnName of string
+  | ACFnDescription of string
   | ACParamName of string
   | ACParamTipe of tipe
   | ACReturnTipe of tipe
@@ -1286,6 +1287,7 @@ and msg =
   | ToplevelDeleteForever of TLID.t
   | DragToplevel of TLID.t * Tea.Mouse.position [@printer opaque "DragToplevel"]
   | EntryInputMsg of string
+  | MultilineEntryInputMsg of string
   | EntrySubmitMsg
   | GlobalKeyPress of Keyboard.keyEvent
   | AutocompleteClick of int

--- a/client/src/forms/Autocomplete.ml
+++ b/client/src/forms/Autocomplete.ml
@@ -106,6 +106,8 @@ let asName (aci : autocompleteItem) : string =
   | ACTypeFieldName name
   | ACGroupName name ->
       name
+  | ACFnDescription description ->
+      description
   | ACReturnTipe tipe | ACTypeFieldTipe tipe ->
       RT.tipe2str tipe
 
@@ -140,6 +142,8 @@ let asTypeString (item : autocompleteItem) : string =
       "event modifier"
   | ACFnName _ ->
       "function name"
+  | ACFnDescription _ ->
+      "function description"
   | ACParamName _ ->
       "param name"
   | ACTypeName _ ->
@@ -897,6 +901,8 @@ let documentationForItem (aci : autocompleteItem) : 'a Vdom.t list option =
       simpleDoc ("Set event modifier to " ^ name)
   | ACFnName fnName ->
       simpleDoc ("Set function name to " ^ fnName)
+  | ACFnDescription fnDescription ->
+      simpleDoc ("Set function description to " ^ fnDescription)
   | ACParamName paramName ->
       simpleDoc ("Set param name to " ^ paramName)
   | ACTypeName typeName ->

--- a/client/src/forms/Autocomplete.ml
+++ b/client/src/forms/Autocomplete.ml
@@ -717,6 +717,7 @@ let generate (m : model) (a : autocomplete) : autocomplete =
       | DBName
       | DBColName
       | FnName
+      | FnDescription
       | ParamName
       | TypeName
       | TypeFieldName

--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -605,7 +605,7 @@ let submitACItem
                 in
                 let changedNames = Refactor.renameFunction m old value in
                 wrapNew (SetFunction new_ :: changedNames) newPD
-          | PFnDescription old, ACFnDescription desc, _ ->
+          | PFnDescription _, ACFnDescription desc, _ ->
               replace (PFnDescription (F (id, desc)))
           | PFnReturnTipe _, ACReturnTipe tipe, _ ->
               replace (PFnReturnTipe (F (id, tipe)))

--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -629,7 +629,21 @@ let submitACItem
               replace (PTypeFieldTipe (F (id, tipe)))
           | PGroupName _, ACGroupName name, _ ->
               replace (PGroupName (F (id, name)))
-          | pd, item, _ ->
+          | PDBName _, item, _
+          | PDBColType _, item, _
+          | PDBColName _, item, _
+          | PEventName _, item, _
+          | PEventModifier _, item, _
+          | PEventSpace _, item, _
+          | PFnName _, item, _
+          | PFnDescription _, item, _
+          | PFnReturnTipe _, item, _
+          | PParamName _, item, _
+          | PParamTipe _, item, _
+          | PTypeName _, item, _
+          | PTypeFieldName _, item, _
+          | PTypeFieldTipe _, item, _
+          | PGroupName _, item, _ ->
               ReplaceAllModificationsWithThisOne
                 (fun m ->
                   let custom =

--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -369,7 +369,7 @@ let validate (tl : toplevel) (pd : blankOrData) (value : string) : string option
       then v AC.packageFnNameValidator "function name"
       else v AC.fnNameValidator "function name"
   | PFnDescription _ ->
-      Some value
+      None
   | PFnReturnTipe _ ->
       v AC.paramTypeValidator "return type"
   | PParamName oldParam ->
@@ -605,6 +605,8 @@ let submitACItem
                 in
                 let changedNames = Refactor.renameFunction m old value in
                 wrapNew (SetFunction new_ :: changedNames) newPD
+          | PFnDescription old, ACFnDescription desc, _ ->
+              replace (PFnDescription (F (id, desc)))
           | PFnReturnTipe _, ACReturnTipe tipe, _ ->
               replace (PFnReturnTipe (F (id, tipe)))
           | PParamName _, ACParamName value, _ ->
@@ -676,6 +678,8 @@ let submit (m : model) (cursor : entryCursor) (move : nextMove) : modification =
                 Some (ACDBColName value)
             | FnName ->
                 Some (ACFnName value)
+            | FnDescription ->
+                Some (ACFnDescription value)
             | ParamName ->
                 Some (ACParamName value)
             | TypeName ->
@@ -691,7 +695,6 @@ let submit (m : model) (cursor : entryCursor) (move : nextMove) : modification =
             | EventName
             | EventSpace
             | DBName
-            | FnDescription
             | FnReturnTipe
             | ParamTipe
             | TypeFieldTipe ->

--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -687,7 +687,14 @@ let submit (m : model) (cursor : entryCursor) (move : nextMove) : modification =
             | EventModifier ->
                 (* Does not accept freeform inputs, but goes to validation call for more specific error message displayed to user *)
                 Some (ACEventModifier value)
-            | _ ->
+            | DBColType
+            | EventName
+            | EventSpace
+            | DBName
+            | FnDescription
+            | FnReturnTipe
+            | ParamTipe
+            | TypeFieldTipe ->
                 None )
           | None ->
               None

--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -368,6 +368,8 @@ let validate (tl : toplevel) (pd : blankOrData) (value : string) : string option
       if String.startsWith ~prefix:"dark/" value
       then v AC.packageFnNameValidator "function name"
       else v AC.fnNameValidator "function name"
+  | PFnDescription _ ->
+      Some value
   | PFnReturnTipe _ ->
       v AC.paramTypeValidator "return type"
   | PParamName oldParam ->

--- a/client/src/forms/Entry.ml
+++ b/client/src/forms/Entry.ml
@@ -412,19 +412,14 @@ let submitACItem
             let wasEditing = P.isBlank pd |> not in
             let focus =
               if wasEditing && move = StayHere
-              then (
+              then
                 match next with
                 | None ->
-                    Debug.loG "FOCUSSAME" () ;
                     FocusSame
                 | Some nextID ->
-                    Debug.loG "FocusExact" () ;
-                    FocusExact (tlid, nextID) )
-              else (
-                Debug.loG "FocusNext" () ;
-                FocusNext (tlid, next) )
+                    FocusExact (tlid, nextID)
+              else FocusNext (tlid, next)
             in
-            Debug.loG "AddOpsFocus" () ;
             AddOps (ops, focus)
           in
           let wrapID ops = wrap ops (Some id) in

--- a/client/src/forms/Pointer.ml
+++ b/client/src/forms/Pointer.ml
@@ -23,6 +23,8 @@ let typeOf (pd : blankOrData) : blankOrType =
       DBColType
   | PFnName _ ->
       FnName
+  | PFnDescription _ ->
+      FnDescription
   | PFnReturnTipe _ ->
       FnReturnTipe
   | PParamName _ ->
@@ -56,6 +58,8 @@ let emptyD (pt : blankOrType) : blankOrData =
       PDBColType (Blank id)
   | FnName ->
       PFnName (Blank id)
+  | FnDescription ->
+      PFnDescription (Blank id)
   | FnReturnTipe ->
       PFnReturnTipe (Blank id)
   | ParamName ->
@@ -74,33 +78,20 @@ let emptyD (pt : blankOrType) : blankOrData =
 
 let toID (pd : blankOrData) : ID.t =
   match pd with
-  | PEventModifier d ->
-      B.toID d
-  | PEventName d ->
-      B.toID d
-  | PEventSpace d ->
-      B.toID d
-  | PDBName d ->
-      B.toID d
-  | PDBColName d ->
-      B.toID d
-  | PDBColType d ->
-      B.toID d
-  | PFnName d ->
-      B.toID d
-  | PFnReturnTipe d ->
-      B.toID d
-  | PParamName d ->
-      B.toID d
-  | PParamTipe d ->
-      B.toID d
-  | PTypeName d ->
-      B.toID d
-  | PTypeFieldName d ->
-      B.toID d
-  | PTypeFieldTipe d ->
-      B.toID d
+  | PEventModifier d
+  | PEventName d
+  | PEventSpace d
+  | PDBName d
+  | PDBColName d
+  | PDBColType d
+  | PFnName d
+  | PFnDescription d
+  | PParamName d
+  | PTypeName d
+  | PTypeFieldName d
   | PGroupName d ->
+      B.toID d
+  | PTypeFieldTipe d | PFnReturnTipe d | PParamTipe d ->
       B.toID d
 
 
@@ -113,6 +104,7 @@ let isBlank (pd : blankOrData) : bool =
   | PDBColName str
   | PDBColType str
   | PFnName str
+  | PFnDescription str
   | PParamName str
   | PTypeName str
   | PTypeFieldName str
@@ -145,6 +137,8 @@ let strMap (pd : blankOrData) ~(f : string -> string) : blankOrData =
       PDBColType (bf d)
   | PFnName d ->
       PFnName (bf d)
+  | PFnDescription d ->
+      PFnDescription (bf d)
   | PFnReturnTipe d ->
       PFnReturnTipe d
   | PParamName d ->
@@ -171,6 +165,7 @@ let toContent (pd : blankOrData) : string =
   | PDBColName d
   | PDBColType d
   | PFnName d
+  | PFnDescription d
   | PParamName d
   | PTypeName d
   | PTypeFieldName d

--- a/client/src/forms/ViewBlankOr.ml
+++ b/client/src/forms/ViewBlankOr.ml
@@ -201,6 +201,7 @@ let viewMultilineText
   let txt = match str with F (_, str) -> str | Blank _ -> "" in
   Html.textarea ~unique attrs [Html.text txt]
 
+
 let viewText
     ~(enterable : bool)
     ~(classes : string list)

--- a/client/src/forms/ViewBlankOr.ml
+++ b/client/src/forms/ViewBlankOr.ml
@@ -182,8 +182,15 @@ let viewMultilineText
        * noProp to indicate that the property at idx N has changed. *)
       [Vdom.noProp; Vdom.noProp; Vdom.noProp; Vdom.noProp]
   in
-  (* TODO(JULIAN): fix the missing entry-box id when you click on the blankOr *)
-  let idAttr = Html.id (ID.toString id) in
+  let idAttr =
+    match vp.cursorState with
+    | Entering (Filling (_, thisID)) when thisID = id ->
+        (* Other blankors entirely change the HTML structure when being edited.
+         * Use the same id as other being-edited blankors for consistency. *)
+        Html.id Defaults.entryID
+    | _ ->
+        Html.id (ID.toString id)
+  in
   let readonly =
     (* Attribute.readonly is fixed in bstea 0.15.0 *)
     if enterable then Vdom.noProp else Vdom.attribute "" "readonly" "readonly"

--- a/client/src/forms/ViewBlankOr.ml
+++ b/client/src/forms/ViewBlankOr.ml
@@ -4,6 +4,7 @@ open Prelude
 module B = BlankOr
 module TL = Toplevel
 module Attributes = Tea.Html2.Attributes
+module Events = Tea.Html2.Events
 
 (* Create a Html.div for this ID, incorporating all ID-related data, *)
 (* such as whether it's selected, appropriate events, mouseover, etc. *)
@@ -176,11 +177,14 @@ let viewMultilineText
       ; event "mouseenter" ~key:("me-" ^ keyStr) (fun x ->
             BlankOrMouseEnter (tlid, id, x))
       ; event "mouseleave" ~key:("ml-" ^ keyStr) (fun x ->
-            BlankOrMouseLeave (tlid, id, x)) ]
+            BlankOrMouseLeave (tlid, id, x))
+        (* This event updates the "autocomplete" value and persists it right away
+         * rather than waiting for you to click away. *)
+      ; Events.onInput (fun x -> MultilineEntryInputMsg x) ]
     else
       (* Rather than relying on property lengths changing, we should use
        * noProp to indicate that the property at idx N has changed. *)
-      [Vdom.noProp; Vdom.noProp; Vdom.noProp; Vdom.noProp]
+      [Vdom.noProp; Vdom.noProp; Vdom.noProp; Vdom.noProp; Vdom.noProp]
   in
   let idAttr =
     match vp.cursorState with

--- a/client/src/forms/ViewBlankOr.ml
+++ b/client/src/forms/ViewBlankOr.ml
@@ -157,7 +157,7 @@ let viewBlankOr
 let viewMultilineText
     ~(enterable : bool)
     ~(classes : string list)
-    (_pt : blankOrType)
+    (pt : blankOrType)
     (vp : ViewUtils.viewProps)
     (str : string blankOr) : msg Html.html =
   let id = B.toID str in
@@ -199,7 +199,7 @@ let viewMultilineText
   let attrs =
     idAttr
     :: readonly
-    :: Html.placeholder "What does this function do?"
+    :: Html.placeholder (placeHolderFor vp pt)
     :: Attributes.rows 3
     :: preventPanningOnScroll
     :: classAttr

--- a/client/src/forms/ViewBlankOr.ml
+++ b/client/src/forms/ViewBlankOr.ml
@@ -93,6 +93,8 @@ let placeHolderFor (vp : ViewUtils.viewProps) (pt : blankOrType) : string =
       "db type"
   | FnName ->
       "function name"
+  | FnDescription ->
+      "What does this function do?"
   | FnReturnTipe ->
       "return type"
   | ParamName ->

--- a/client/src/forms/ViewBlankOr.ml
+++ b/client/src/forms/ViewBlankOr.ml
@@ -188,7 +188,8 @@ let viewMultilineText
   in
   let idAttr =
     match vp.cursorState with
-    | Entering (Filling (_, thisID)) when thisID = id ->
+    | (Selecting (_, Some thisID) | Entering (Filling (_, thisID)))
+      when thisID = id ->
         (* Other blankors entirely change the HTML structure when being edited.
          * Use the same id as other being-edited blankors for consistency. *)
         Html.id Defaults.entryID

--- a/client/src/toplevels/Toplevel.ml
+++ b/client/src/toplevels/Toplevel.ml
@@ -312,6 +312,14 @@ let replace (p : blankOrData) (replacement : blankOrData) (tl : toplevel) :
     )
   | PDBName _ | PDBColType _ | PDBColName _ ->
       tl
+  | PFnDescription desc ->
+      let ufmDescription =
+        match desc with Blank _ -> "" | F (_, desc) -> desc
+      in
+      asUserFunction tl
+      |> Option.map ~f:(fun fn ->
+             TLFunc {fn with ufMetadata = {fn.ufMetadata with ufmDescription}})
+      |> recoverOpt "Changing fn description on non-fn" ~default:tl
   | PFnName _ | PFnReturnTipe _ | PParamName _ | PParamTipe _ ->
     ( match asUserFunction tl with
     | Some fn ->

--- a/client/src/toplevels/UserFunctions.ml
+++ b/client/src/toplevels/UserFunctions.ml
@@ -77,8 +77,20 @@ let allParamData (uf : userFunction) : blankOrData list =
   List.concat (List.map ~f:paramData uf.ufMetadata.ufmParameters)
 
 
+let descriptionBlankOr ~(tlid : TLID.t) (fn : functionTypes) =
+  let descText =
+    match fn with
+    | UserFunction fn ->
+        fn.ufMetadata.ufmDescription
+    | PackageFn fn ->
+        fn.description
+  in
+  F (ID.fromString (TLID.toString tlid ^ "-fndesc"), descText)
+
+
 let blankOrData (uf : userFunction) : blankOrData list =
   PFnName uf.ufMetadata.ufmName
+  :: PFnDescription (descriptionBlankOr ~tlid:uf.ufTLID (UserFunction uf))
   :: PFnReturnTipe uf.ufMetadata.ufmReturnTipe
   :: allParamData uf
 

--- a/client/src/toplevels/ViewUserFunction.ml
+++ b/client/src/toplevels/ViewUserFunction.ml
@@ -91,6 +91,7 @@ let viewMetadata (vp : viewProps) (fn : functionTypes) : msg Html.html =
           BlankOr.newF (fn.fnname ^ "_v" ^ string_of_int fn.version)
     in
     let description =
+      (* Spec: https://www.notion.so/darklang/MVP-for-User-function-description-1c2d6540d3f94e52b45935e11d679b50 *)
       let classes = ["fn-description"] in
       ViewBlankOr.viewMultilineText
         ~classes

--- a/client/src/toplevels/ViewUserFunction.ml
+++ b/client/src/toplevels/ViewUserFunction.ml
@@ -95,7 +95,11 @@ let viewMetadata (vp : viewProps) (fn : functionTypes) : msg Html.html =
       ViewBlankOr.viewMultilineText
         ~classes
         ~enterable:
-          (match fn with UserFunction _ -> true | PackageFn _ -> false)
+          ( match fn with
+          | UserFunction _ ->
+              vp.permission = Some ReadWrite
+          | PackageFn _ ->
+              false )
         FnDescription
         vp
         (UserFunctions.descriptionBlankOr ~tlid:vp.tlid fn)

--- a/client/src/toplevels/ViewUserFunction.ml
+++ b/client/src/toplevels/ViewUserFunction.ml
@@ -139,7 +139,7 @@ let viewMetadata (vp : viewProps) (fn : functionTypes) : msg Html.html =
           in
           Html.div [Html.class' "fn-actions"] [viewExecuteBtn vp fn; menuView]
       | PackageFn _ ->
-          Html.div [Html.class' "fn-actions"] []
+          Html.span [Html.class' "fn-readonly"] [Html.text "Read Only"]
     in
     Html.div
       [Html.class' "fn-info"]

--- a/client/styles/_function.scss
+++ b/client/styles/_function.scss
@@ -3,12 +3,26 @@
   border-bottom: 1px dashed darken($user-functions, 30%);
   margin-bottom: $spacing-small;
 
+  .fn-info {
+    border-bottom: 1px solid $user-functions;
+  }
+
+  .fn-description {
+    padding: 0.5rem;
+    width: calc(100% - 20px);
+    color: $grey3;
+    background-color: $black3;
+    font-size: $code-font-size;
+    resize: none;
+    margin: 10px 10px 15px 10px;
+  }
+
   .spec-header {
     display: flex;
     flex-wrap: nowrap;
     justify-content: space-between;
     flex-direction: row;
-    border-bottom: 1px solid $user-functions;
+    border-bottom: none;
     cursor: default;
 
     .di-fn {

--- a/integration-tests/clear-db.sh
+++ b/integration-tests/clear-db.sh
@@ -39,7 +39,7 @@ SCRIPT+="INSERT INTO packages_v0 (tlid, user_id, package, module, fnname,
 version, description, body, return_type, parameters, author_id, deprecated,
 updated_at, created_at) VALUES
 ( '4186046771064433369', (SELECT id FROM accounts WHERE username = 'test_admin'), 'stdlib',
-'Test', 'one', 0, '', decode('/NlqdxJcXNMXOgH9v2pBKQYBMAo=', 'base64')::bytea, 'Any',
+'Test', 'one', 0, 'Test::one returns 0.', decode('/NlqdxJcXNMXOgH9v2pBKQYBMAo=', 'base64')::bytea, 'Any',
 '[]'::jsonb,
 (SELECT id FROM accounts WHERE username = 'test_admin'), False, now(), now());";
 run_sql "$SCRIPT";

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -735,6 +735,34 @@ test("function_analysis_works", async t => {
     .eql("10", { timeout: 5000 });
 });
 
+test("change_fn_description", async t => {
+  const initialText = "always5 returns the value 5";
+  const nextText = "always5 returns the value 5!";
+  const expectedText = "always5 returns the value 5!?";
+  const fnDescription = Selector(".tl-86953439 .fn-description");
+  await t
+    .navigateTo("#fn=86953439")
+    .expect(fnDescription.textContent)
+    .eql(initialText)
+    // HACK: On first click, blankors misplace the caret
+    // so we click and then position the caret.
+    // Once we fix this behavior, we can get rid of the click call.
+    .click(fnDescription)
+    .typeText(fnDescription, "!?", { caretPos: initialText.length });
+
+  await t
+    // Navigate away and back to check for persistence
+    .navigateTo("#")
+    .navigateTo("#fn=86953439")
+    .expect(available(fnDescription))
+    .ok({ timeout: 1000 })
+    // Note that `value` is the appropriate JS property to use for dynamically-updated text,
+    // but we are using `textContent` because we want to check the contents after they have persisted
+    // and have become the default content of the textarea
+    .expect(fnDescription.textContent)
+    .eql(expectedText);
+});
+
 test("jump_to_error", async t => {
   await t
     .navigateTo("#handler=123")

--- a/integration-tests/tests.js
+++ b/integration-tests/tests.js
@@ -1128,6 +1128,13 @@ test("fluid_creating_an_http_handler_focuses_the_verb", async t => {
     .ok();
 });
 
+/*
+* These tests seem to simulate tabbing differently than
+* what happens when you press tab in a real browser.
+* We're disabling them for now because they give the false
+* impression that tabbing currently works as intended, even though
+* it is broken.
+
 test("fluid_tabbing_from_an_http_handler_spec_to_ast", async t => {
   await createHTTPHandler(t);
   await t
@@ -1148,6 +1155,7 @@ test("fluid_tabbing_from_handler_spec_past_ast_back_to_verb", async t => {
     .expect(acHighlightedText("GET"))
     .ok();
 });
+*/
 
 test("fluid_shift_tabbing_from_handler_ast_back_to_route", async t => {
   await createHTTPHandler(t);


### PR DESCRIPTION
https://trello.com/c/btt9BT48/3058-re-implement-docstring-spec

This makes user function descriptions editable and displays function descriptions for user functions and package manager functions. This is a new attempt at https://github.com/darklang/dark/pull/2394 using `blankOr`s instead. Spec is here: https://www.notion.so/darklang/MVP-for-User-function-description-1c2d6540d3f94e52b45935e11d679b50

## Before this PR:
<img width="548" alt="Screen Shot 2020-06-09 at 2 14 33 PM" src="https://user-images.githubusercontent.com/438112/84200387-8ba7d780-aa5b-11ea-86f3-1225595e4c03.png">

## Without a Description typed:
<img width="766" alt="Screen Shot 2020-06-09 at 2 12 20 PM" src="https://user-images.githubusercontent.com/438112/84200225-3cfa3d80-aa5b-11ea-987c-e7974782bab8.png">

## With a description typed:
<img width="471" alt="Screen Shot 2020-06-09 at 2 13 39 PM" src="https://user-images.githubusercontent.com/438112/84200333-6c10af00-aa5b-11ea-9341-21139fdd2621.png">

## Package Manager function:
<img width="741" alt="Screen Shot 2020-06-09 at 2 18 19 PM" src="https://user-images.githubusercontent.com/438112/84200781-1c7eb300-aa5c-11ea-9abc-0c8650c006c5.png">

# Relative to the previous PR
- The implementation extends `blankOr`s and autocomplete instead of introducing a new `cursorState`
- The visuals look closer to the spec thanks to @sydNoteboom
- Only User Function descriptions with Read/Write permissions can be edited
- The integration test asserts that the model has updated and checks the initial state as a precondition.

# Quirks
- This uses autocomplete and changes a central integration point of autocomplete in order to commit on every keystroke. I haven't been able to find any negative consequences, but they likely exist. The fact that this uses autocomplete at all seems problematic, because descriptions are not autocompletable and will likely never be, but I don't know how to bypass it properly.
- Clicking in a multiline blankOr misplaces the caret. This is because blankOrs in general are divs that become input boxes only when you click in them, and we use some hacky math to place the caret during the transition from div to input, which relies on assumptions such as single-line, non-wrapping input. That entire process is unnecessary but fixing it is out of scope IMO.
- [x] Trello link included
- [x] Discussed goals, problem and solution
- [x] Information from this description is also in comments
  - [ ] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [x] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [x] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
