### PR TITLE
Make manual GC easier by putting garbage_collector.exe in the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ jobs:
             # Just enough for integration tests and deploy
             - _build/default/backend/bin/server.exe
             - _build/default/backend/bin/emergency_login_script.exe
+            - _build/default/backend/bin/garbage_collector.exe
             - _build/default/backend/bin/queue_worker.exe
             - _build/default/backend/bin/cron_checker.exe
             - backend/static/analysis.js

--- a/scripts/gcp-build-containers
+++ b/scripts/gcp-build-containers
@@ -50,6 +50,10 @@ if [[ "${SKIP_OCAML}" == "" ]]; then
   # there in an env with access to production postgres
   cp -f _build/default/backend/bin/emergency_login_script.exe "$DIR/bin/"
 
+  # We're still doing GC manually, but this means it's just there to be run
+  # instead of having to `kubectl cp` it in every time a deploy goes out.
+  cp -f _build/default/backend/bin/garbage_collector.exe "$DIR/bin/"
+
   mkdir -p "$DIR/webroot"
   cp -Rf backend/static "$DIR/webroot/"
 


### PR DESCRIPTION
So I don't have to `kubectl cp` it in every time a deploy goes out.

https://trello.com/c/UhpUHJcj/3186-fix-garbage-collection-of-old-traces

- [X] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
