### PR TITLE
Fix fullstory off-after-48hrs behavior

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -299,18 +299,21 @@ window.Dark = {
         48 /* hrs */ * 60 /* min/hr */ * 60 /* sec/min */ * 1000; /* ms/sec */
       const msSinceAccountCreated = new Date() - accountCreationDate;
 
-      const isOlderThanWeWantToRecord = msSinceAccountCreated > maxAccountAgeToRecordMs;
+      const isOlderThanWeWantToRecord =
+        msSinceAccountCreated > maxAccountAgeToRecordMs;
 
       // the actual behavior is in FullStory.init's devMode flag, but this log
       // is here in hopes of reassuring users who look in console.
       if (isAdmin || isOlderThanWeWantToRecord) {
-        console.log("FullStory is not enabled for this user because the account is too old; console warnings that it is in dev mode may be safely ignored.");
+        console.log(
+          "FullStory is not enabled for this user because the account is too old; console warnings that it is in dev mode may be safely ignored.",
+        );
       }
 
       /* If devMode is set to true, FullStory will shutdown recording and all subsequent SDK method calls will be no-ops. */
       FullStory.init({
         orgId: "TMVRZ",
-        devMode: (isAdmin || isOlderThanWeWantToRecord),
+        devMode: isAdmin || isOlderThanWeWantToRecord,
       });
       FullStory.identify(username, {
         displayName: username,


### PR DESCRIPTION
Follow up to #2573

As we thought might happen
(https://github.com/darklang/dark/pull/2573#discussion_r437801650), the
behavior in 2573 results in users we want to exclude (older than 48 hrs)
having _very brief_ sessions recorded. That's no good, because our quota
is per-session.

This PR fixes that by turning on the devMode flag for those users - see
doc at: https://www.npmjs.com/package/@fullstory/browser

"devMode - Set to true if you want to deactivate FullStory in your
development environment. When set to true, FullStory will shutdown
recording and all subsequent SDK method calls will be no-ops. At the
time init is called with devMode: true, a single event call will be sent
to FullStory to indicate that the SDK is in devMode; this is to help
trouble-shoot the case that the SDK was accidentally set to devMode:
true in a production environment. Additionally, any calls to SDK methods
will console.warn that FullStory is in devMode. Defaults to false."

So this is mostly the behavior we want; it is a little unfortunate that
there is the console.warn() log mentioned in that quote. I have
addressed that with a console log on startup that this is expected and
fine.

Here's a screenshot of the warning:
![fullstory-warnings](https://user-images.githubusercontent.com/172694/84542747-f00ea500-acae-11ea-94c4-eedc2f79c4b6.png)


Once this has shipped, I'll coordinate with Victoria around testing.

https://trello.com/c/MD4bmVrK/3163-only-record-fullstory-for-users-whose-accounts-were-created-in-the-past-48-hours?menu=filter&filter=member:iansmith286

- [x] Trello link included
- [x] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [x] No useful information
- [x] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [x] No followups
- [ ] Reversion plan exists
  - [x] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
