### PR TITLE
Change error message for 502 (AddOps)

### DIFF
--- a/client/src/api/APIError.ml
+++ b/client/src/api/APIError.ml
@@ -121,30 +121,33 @@ let isBadAuth (e : apiError) : bool =
 
 
 let msg (e : apiError) : string =
-  let withoutContext =
+  let withoutContext, context =
     match e.originalError with
     | Http.BadUrl str ->
-        "Bad url: " ^ str
+        ("Bad url: " ^ str, e.context)
     | Http.Timeout ->
-        "Timeout"
+        ("Timeout", e.context)
     | Http.NetworkError when e.context = "TriggerSendInviteCallback" ->
-        "Network error - Please contact Dark"
+        ("Network error - Please contact Dark", e.context)
     | Http.NetworkError ->
-        "Network error - is the server running?"
+        ("Network error - is the server running?", e.context)
     | Http.BadStatus response ->
         if response.status.code = 502
-        then "502"
+        then
+          ( "We're sorry, but we were unable to save your most recent edit. Please refresh and try again."
+          , "" )
         else
-          "Bad status: "
-          ^ response.status.message
-          ^ " - "
-          ^ parseResponse response.body
+          ( "Bad status: "
+            ^ response.status.message
+            ^ " - "
+            ^ parseResponse response.body
+          , e.context )
     | Http.BadPayload (msg, _) ->
-        "Bad payload : " ^ msg
+        ("Bad payload : " ^ msg, e.context)
     | Http.Aborted ->
-        "Request Aborted"
+        ("Request Aborted", e.context)
   in
-  withoutContext ^ " (" ^ e.context ^ ")"
+  if context = "" then withoutContext else withoutContext ^ " (" ^ context ^ ")"
 
 
 let make ?requestParams ~reload ~context ~importance originalError =

--- a/client/src/api/APIError.ml
+++ b/client/src/api/APIError.ml
@@ -132,7 +132,7 @@ let msg (e : apiError) : string =
     | Http.NetworkError ->
         ("Network error - is the server running?", e.context)
     | Http.BadStatus response ->
-        if response.status.code = 502
+        if response.status.code = 502 && e.context = "AddOps"
         then
           ( "We're sorry, but we were unable to save your most recent edit. Please refresh and try again."
           , "" )

--- a/client/test/api_error_test.ml
+++ b/client/test/api_error_test.ml
@@ -1,0 +1,39 @@
+open Prelude
+open Tester
+module APIError = APIError
+module Http = Tea.Http
+module StringMap = Map.Make (Caml.String)
+
+let addOpsError =
+  { context = "AddOps"
+  ; originalError =
+      Http.BadStatus
+        { url = "url"
+        ; headers = StringMap.empty
+        ; body = StringResponse "body response"
+        ; status = {code = 502; message = "Error msg"} }
+  ; requestParams = None
+  ; reload = false
+  ; importance = IgnorableError }
+
+
+let networkError =
+  { context = "Network error context"
+  ; originalError = Http.NetworkError
+  ; requestParams = None
+  ; reload = false
+  ; importance = IgnorableError }
+
+
+let run () =
+  describe "msg" (fun () ->
+      test " 502 AddOps msg" (fun () ->
+          expect (APIError.msg addOpsError)
+          |> toEqual
+               "We're sorry, but we were unable to save your most recent edit. Please refresh and try again.") ;
+      test "NetworkError msg" (fun () ->
+          expect (APIError.msg networkError)
+          |> toEqual
+               "Network error - is the server running? (Network error context)") ;
+      ()) ;
+  ()

--- a/client/test/api_error_test.ml
+++ b/client/test/api_error_test.ml
@@ -16,6 +16,18 @@ let addOpsError =
   ; reload = false
   ; importance = IgnorableError }
 
+let other502Error =
+  { context = "Error context"
+  ; originalError =
+      Http.BadStatus
+        { url = "url"
+        ; headers = StringMap.empty
+        ; body = StringResponse "body response"
+        ; status = {code = 502; message = "Error msg"} }
+  ; requestParams = None
+  ; reload = false
+  ; importance = IgnorableError }
+
 
 let networkError =
   { context = "Network error context"
@@ -27,10 +39,14 @@ let networkError =
 
 let run () =
   describe "msg" (fun () ->
-      test " 502 AddOps msg" (fun () ->
+      test "502 AddOps" (fun () ->
           expect (APIError.msg addOpsError)
           |> toEqual
                "We're sorry, but we were unable to save your most recent edit. Please refresh and try again.") ;
+      test "502 other than AddOps" (fun () ->
+          expect (APIError.msg other502Error)
+          |> toEqual
+               "Bad status: Error msg - body response (Error context)") ;
       test "NetworkError msg" (fun () ->
           expect (APIError.msg networkError)
           |> toEqual

--- a/client/test/api_error_test.ml
+++ b/client/test/api_error_test.ml
@@ -16,6 +16,7 @@ let addOpsError =
   ; reload = false
   ; importance = IgnorableError }
 
+
 let other502Error =
   { context = "Error context"
   ; originalError =
@@ -45,8 +46,7 @@ let run () =
                "We're sorry, but we were unable to save your most recent edit. Please refresh and try again.") ;
       test "502 other than AddOps" (fun () ->
           expect (APIError.msg other502Error)
-          |> toEqual
-               "Bad status: Error msg - body response (Error context)") ;
+          |> toEqual "Bad status: Error msg - body response (Error context)") ;
       test "NetworkError msg" (fun () ->
           expect (APIError.msg networkError)
           |> toEqual

--- a/client/test/unittests.ml
+++ b/client/test/unittests.ml
@@ -34,6 +34,7 @@ let () =
   let open Tester in
   process_cmdline_args () ;
   describe "Analysis_test" Analysis_test.run ;
+  describe "APIError test" Api_error_test.run ;
   describe "Ast_test" Ast_test.run ;
   describe "Autocomplete_test" Autocomplete_test.run ;
   describe "Curl_test" Curl_test.run ;


### PR DESCRIPTION
Fixes #2538

The solution proposed was to change `APIError.msg` function to stop returning the error context for some errors (in this case `Http.BadStatus` when code is 502).

I also created a test file for the `APIError` file and added 2 tests to it. One that tests the new behavior for the error 502 and another for `Http.NetworkError` to verify that the behavior of other error messages is preserved.

Screenshot before the change:
![image](https://user-images.githubusercontent.com/1580375/84584051-5c37f880-add6-11ea-9a91-dc5c5511d02e.png)


Screenshot after the change:
![image](https://user-images.githubusercontent.com/1580375/84583955-8ccb6280-add5-11ea-90da-c4ffbf078b54.png)


- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
