### PR TITLE
support Date::hour_v1 in query compiler and allow appending of Dark arg in unary_ops

### DIFF
--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -1100,7 +1100,7 @@ let t_db_query_works () =
       [ ("height", int 72)
       ; ("name", str " Chandler ")
       ; ("human", bool true)
-      ; ("dob", fn ~ster:Rail "Date::parse_v2" [str "1969-08-19T00:00:00Z"])
+      ; ("dob", fn ~ster:Rail "Date::parse_v2" [str "1969-08-19T10:00:00Z"])
       ; ("income", float' 83 00) ]
   in
   let cat_expr =
@@ -1491,6 +1491,11 @@ let t_db_query_works () =
     (DList [chandler])
     ( queryv
         (binop "==" (fn "String::trimEnd" [field "v" "name"]) (str " Chandler"))
+    |> execs ) ;
+  check_dval
+    "date::hour"
+    (DList [chandler])
+    ( queryv (binop "==" (fn "Date::hour_v1" [field "v" "dob"]) (int 10))
     |> execs ) ;
   (* -------------- *)
   (* Test partial evaluation *)


### PR DESCRIPTION
Done as part of initiative to expand query compiler. #2424
I've added Date::hour_v1 to the unary_op_to_sql function, mapping the Dark function to respective Postgres function (date_part('hour', ...).
This will allow the Db::query family of functions to compile the aforementioned Date::hour_v1 function successfully when applied to DB record date values.

I had to add the ability to pass the Dark unary op argument (in this case a Date) as the last argument as opposed to the first where it is evaluated in lambda_to_sql. This probably isn't the most elegant solution and likely this will need to become even more sophisticated later on for unary Dark ops that translate to postgres functions with more than 2 args.

Closes #2616