### PR TITLE
When reporting to segment, use the canvas name instead of the IP

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -2267,7 +2267,7 @@ let canvas_handler
         ~canvas_id:Uuidm.nil
         ~canvas
         ~execution_id (* TODO should username be the canvas owner, or the ip? *)
-        ~username:ip
+        ~username:("canvas::" ^ canvas)
         ~event:"canvas_traffic"
         Track
         (`Assoc


### PR DESCRIPTION
This mostly motivated by reducing the segment bill.

- [ ] Trello link included
- [ ] Discussed goals, problem and solution
- [ ] Information from this description is also in comments
  - [ ] No useful information
- [ ] Before/after screenshots are included
  - [ ] Screenshots aren't useful
- [ ] Intended followups are trelloed
  - [ ] No followups
- [ ] Reversion plan exists
  - [ ] Standard git revert is fine
- [ ] Tests are included (required for regressions)
  - [ ] The type system will catch it
- [ ] Specs (docs/trello) are linked in code 
  - [ ] No spec exists
