### PR TITLE
support Date::hour_v1 in query compiler and allow appending of Dark arg in unary_ops

### DIFF
--- a/backend/libbackend/sql_compiler.ml
+++ b/backend/libbackend/sql_compiler.ml
@@ -11,6 +11,10 @@ let error str = raise (DBQueryException str)
 
 let error2 msg str = error (msg ^ ": " ^ str)
 
+type position =
+  | First
+  | Last
+
 let binop_to_sql (op : string) : tipe_ * tipe_ * tipe_ * string =
   let allInts str = (TInt, TInt, TInt, str) in
   let allFloats str = (TFloat, TFloat, TFloat, str) in
@@ -85,30 +89,30 @@ let binop_to_sql (op : string) : tipe_ * tipe_ * tipe_ * string =
       error2 "This function is not yet implemented" op
 
 
-let unary_op_to_sql op : tipe_ * tipe_ * string * string list * bool =
+let unary_op_to_sql op : tipe_ * tipe_ * string * string list * position =
   (* Returns a postgres function name, and arguments to the function. The
-   * argument the user provides will be inserted as the first argument. *)
+   * argument the user provides will be inserted as the First or Last argument. *)
   match op with
   | "Bool::not" ->
-      (TBool, TBool, "not", [], false)
+      (TBool, TBool, "not", [], First)
   (* Not sure if any of the string functions are strictly correct for unicode *)
   | "String::toLowercase" | "String::toLowercase_v1" ->
-      (TStr, TStr, "lower", [], false)
+      (TStr, TStr, "lower", [], First)
   | "String::toUppercase" | "String::toUppercase_v1" ->
-      (TStr, TStr, "upper", [], false)
+      (TStr, TStr, "upper", [], First)
   | "String::length" ->
       (* There is a unicode version of length but it only works on bytea data *)
-      (TStr, TInt, "length", [], false)
+      (TStr, TInt, "length", [], First)
   | "String::reverse" ->
-      (TStr, TStr, "reverse", [], false)
+      (TStr, TStr, "reverse", [], First)
   | "String::trim" ->
-      (TStr, TStr, "trim", [], false)
+      (TStr, TStr, "trim", [], First)
   | "String::trimStart" ->
-      (TStr, TStr, "ltrim", [], false)
+      (TStr, TStr, "ltrim", [], First)
   | "String::trimEnd" ->
-      (TStr, TStr, "rtrim", [], false)
+      (TStr, TStr, "rtrim", [], First)
   | "Date::hour_v1" ->
-      (TDate, TInt, "date_part", ["'hour'"], true)
+      (TDate, TInt, "date_part", ["'hour'"], Last)
   | _ ->
       error2 "This function is not yet implemented" op
 
@@ -321,12 +325,14 @@ let rec lambda_to_sql
       typecheck op result_tipe expected_tipe ;
       "(" ^ lts ltipe l ^ " " ^ opname ^ " " ^ lts rtipe r ^ ")"
   | EFnCall (_, op, [e], NoRail) ->
-      let arg_tipe, result_tipe, opname, args, append = unary_op_to_sql op in
+      let arg_tipe, result_tipe, opname, args, position = unary_op_to_sql op in
       typecheck op result_tipe expected_tipe ;
       let args =
-        if append
-        then Tc.String.join ~sep:", " (List.append args [lts arg_tipe e])
-        else Tc.String.join ~sep:", " (lts arg_tipe e :: args)
+        match position with
+        | First ->
+            Tc.String.join ~sep:", " (lts arg_tipe e :: args)
+        | Last ->
+            Tc.String.join ~sep:", " (List.append args [lts arg_tipe e])
       in
       "(" ^ opname ^ " (" ^ args ^ "))"
   | EVariable (_, name) ->

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -1100,7 +1100,7 @@ let t_db_query_works () =
       [ ("height", int 72)
       ; ("name", str " Chandler ")
       ; ("human", bool true)
-      ; ("dob", fn ~ster:Rail "Date::parse_v2" [str "1969-08-19T00:00:00Z"])
+      ; ("dob", fn ~ster:Rail "Date::parse_v2" [str "1969-08-19T10:00:00Z"])
       ; ("income", float' 83 00) ]
   in
   let cat_expr =
@@ -1491,6 +1491,11 @@ let t_db_query_works () =
     (DList [chandler])
     ( queryv
         (binop "==" (fn "String::trimEnd" [field "v" "name"]) (str " Chandler"))
+    |> execs ) ;
+  check_dval
+    "date::hour"
+    (DList [chandler])
+    ( queryv (binop "==" (fn "Date::hour_v1" [field "v" "dob"]) (int 10))
     |> execs ) ;
   (* -------------- *)
   (* Test partial evaluation *)


### PR DESCRIPTION
Done as part of initiative to expand query compiler. #2424 
I've added Date::hour_v1 to the unary_op_to_sql function, mapping the Dark function to respective Postgres function (date_part('hour', ...).
This will allow the Db::query family of functions to compile the aforementioned Date::hour_v1 function successfully when applied to DB record date values.

I had to add the ability to pass the Dark unary op argument (in this case a Date) as the last argument as opposed to the first where it is evaluated in lambda_to_sql. This probably isn't the most elegant solution and likely this will need to become even more sophisticated later on for unary Dark ops that translate to postgres functions with more than 2 args.

Closes #2616