### PR TITLE
Add a timeout for HTTPClient:: calls

### DIFF
--- a/backend/libbackend/httpclient.ml
+++ b/backend/libbackend/httpclient.ml
@@ -166,6 +166,7 @@ let http_call_with_code
       C.set_writefunction c responsefn ;
       C.set_httpheader c headers ;
       C.set_headerfunction c headerfn ;
+      C.setopt c (Curl.CURLOPT_TIMEOUT 30) (* timeout is infinite by default *) ;
       (* This tells CURL to send an Accept-Encoding header including all
         * of the encodings it supports *and* tells it to automagically decode
         * responses in those encodings. This works even if someone manually specifies


### PR DESCRIPTION
## What is the problem/goal being addressed?

We had an operational incident today because we didn't have a timeout for Curl. As a result, requests to a bad server waited 5m, which took up all the queue servers.

## What is the solution to this problem?

Set a timeout to 30s. We could probably go lower, but might want to alert customers if we do.