### PR TITLE
Add info about needing python for vim+merlin integration

### DIFF
--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -24,7 +24,9 @@ those scripts first in your `$PATH`.
     - copy snippet to your bashrc/shell config. DO NOT DO THIS FOR zsh. SEE BELOW.
   - `opam install merlin.3.2.2`
 - Install editor integration:
-  - vim+plug: `Plug '~/.opam/default/share/merlin', { 'for': ['ocaml', 'merlin' ], 'rtp': 'vim' }`
+  - vim+plug:
+    - make sure you have a python provider for vim. Gvim comes with one. If you're using neovim, you can get one with `pip3 install pynvim`
+    - add `Plug '~/.opam/default/share/merlin', { 'for': ['ocaml', 'merlin' ], 'rtp': 'vim' }` to your vim config file
   - others: ??
 
 CAVEAT: If you install the zsh config that merlin recommends, it will


### PR DESCRIPTION
## What is the problem/goal being addressed?
The editor-setup doc instructions on integrating merlin is missing information if the contributor is using vim or neovim.

## What is the solution to this problem?
I added that information to the doc

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*

## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
