### PR TITLE
Add String::replaceAll to sql compiler

### DIFF
--- a/backend/libbackend/sql_compiler.ml
+++ b/backend/libbackend/sql_compiler.ml
@@ -319,8 +319,16 @@ let rec lambda_to_sql
   | EFnCall (_, "String::contains", [lookingIn; searchingFor], NoRail) ->
       (* strpos returns indexed from 1; 0 means missing *)
       "(strpos(" ^ lts TStr lookingIn ^ ", " ^ lts TStr searchingFor ^ ") > 0)"
-  | EFnCall (_, "String::replaceAll", [lookingIn; searchingFor; replaceWith], NoRail) ->
-                  "(replace(" ^ lts TStr lookingIn ^ ", " ^ lts TStr searchingFor ^ ", " ^ lts TStr replaceWith ^ "))"
+  | EFnCall
+      (_, "String::replaceAll", [lookingIn; searchingFor; replaceWith], NoRail)
+    ->
+      "(replace("
+      ^ lts TStr lookingIn
+      ^ ", "
+      ^ lts TStr searchingFor
+      ^ ", "
+      ^ lts TStr replaceWith
+      ^ "))"
   | EFnCall (_, op, [l; r], NoRail) | EBinOp (_, op, l, r, NoRail) ->
       let ltipe, rtipe, result_tipe, opname = binop_to_sql op in
       typecheck op result_tipe expected_tipe ;

--- a/backend/libbackend/sql_compiler.ml
+++ b/backend/libbackend/sql_compiler.ml
@@ -319,6 +319,8 @@ let rec lambda_to_sql
   | EFnCall (_, "String::contains", [lookingIn; searchingFor], NoRail) ->
       (* strpos returns indexed from 1; 0 means missing *)
       "(strpos(" ^ lts TStr lookingIn ^ ", " ^ lts TStr searchingFor ^ ") > 0)"
+  | EFnCall (_, "String::replaceAll", [lookingIn; searchingFor; replaceWith], NoRail) ->
+                  "(replace(" ^ lts TStr lookingIn ^ ", " ^ lts TStr searchingFor ^ ", " ^ lts TStr replaceWith ^ "))"
   | EFnCall (_, op, [l; r], NoRail) | EBinOp (_, op, l, r, NoRail) ->
       let ltipe, rtipe, result_tipe, opname = binop_to_sql op in
       typecheck op result_tipe expected_tipe ;

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -1498,13 +1498,33 @@ let t_db_query_works () =
     ( queryv (binop "==" (fn "Date::hour_v1" [field "v" "dob"]) (int 10))
     |> execs ) ;
   check_dval
-    "string::replaceAll"
+    "string::replaceAll one replacement"
     (DList [chandler])
     ( queryv
         (binop
            "=="
            (fn "String::replaceAll" [field "v" "name"; str "handle"; str "he"])
            (str " Cher "))
+    |> execs ) ;
+  check_dval
+    "string::replaceAll two replacements"
+    (DList [chandler])
+    ( queryv
+        (binop
+           "=="
+           (fn "String::replaceAll" [field "v" "name"; str " "; str "Xx"])
+           (str "XxChandlerXx"))
+    |> execs ) ;
+  check_dval
+    "string::replaceAll 0 replacements"
+    (DList [chandler])
+    ( queryv
+        (binop
+           "=="
+           (fn
+              "String::replaceAll"
+              [field "v" "name"; str "xxx"; str "willNotBeInserted"])
+           (str " Chandler "))
     |> execs ) ;
   (* -------------- *)
   (* Test partial evaluation *)

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -1500,7 +1500,11 @@ let t_db_query_works () =
   check_dval
     "string::replaceAll"
     (DList [chandler])
-    ( queryv (binop "==" (fn "String::replaceAll" [(field "v" "name"); str "handle"; str "he"]) (str " Cher "))
+    ( queryv
+        (binop
+           "=="
+           (fn "String::replaceAll" [field "v" "name"; str "handle"; str "he"])
+           (str " Cher "))
     |> execs ) ;
   (* -------------- *)
   (* Test partial evaluation *)

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -1497,6 +1497,11 @@ let t_db_query_works () =
     (DList [chandler])
     ( queryv (binop "==" (fn "Date::hour_v1" [field "v" "dob"]) (int 10))
     |> execs ) ;
+  check_dval
+    "string::replaceAll"
+    (DList [chandler])
+    ( queryv (binop "==" (fn "String::replaceAll" [(field "v" "name"); str "handle"; str "he"]) (str " Cher "))
+    |> execs ) ;
   (* -------------- *)
   (* Test partial evaluation *)
   (* -------------- *)


### PR DESCRIPTION
Done as part of initiative to expand query compiler. #2424 
I've added String::replaceAll to the lambda_to_sql function, mapping to the postgres function "replace", and wrote a test to verify it works
This will allow the Db::query family of functions to compile the aforementioned String::replaceAll function successfully when applied to DB record values.

I think likely there should be another function to contain the logic of functions with 3 arguments (like unary and binop functions) but for now I just really want the functionality. We've also discussed evolving where the logic for each function is stored, but I'm still just focusing on expanding support within the existing infrastructure (what I'm capable of right now).

Closes #2691