### PR TITLE
Add checking duplicated record filed name in fluid editor

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -1729,13 +1729,18 @@ let addRecordRowToBack (id : ID.t) (ast : FluidAST.t) : FluidAST.t =
           recover "Not a record in addRecordRowToTheBack" ~debug:e e)
 
 
+let recordFields (recordID : ID.t) (ast : FluidExpression.t) :
+    (string * fluidExpr) list option =
+  E.find recordID ast
+  |> Option.andThen ~f:(fun expr ->
+         match expr with E.ERecord (_, fields) -> Some fields | _ -> None)
+
+
 (* recordFieldAtIndex gets the field for the record in the ast with recordID at index,
    or None if the record has no field with that index *)
 let recordFieldAtIndex (recordID : ID.t) (index : int) (ast : FluidExpression.t)
     : (string * fluidExpr) option =
-  E.find recordID ast
-  |> Option.andThen ~f:(fun expr ->
-         match expr with E.ERecord (_, fields) -> Some fields | _ -> None)
+  recordFields recordID ast
   |> Option.andThen ~f:(fun fields -> List.getAt ~index fields)
 
 


### PR DESCRIPTION
## What is the problem/goal being addressed?
Adding `fluid-error` for duplicated record filed name, to fix #2686 

## What is the solution to this problem?
Checking record filed names to see duplicated tokens, and add `fluid-error` to them.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*
![highlighted-duplicated-field-name](https://user-images.githubusercontent.com/1086461/86840072-937e8a00-c0a2-11ea-8f79-36c593dece70.png)

## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
