### PR TITLE
Show canvas name

### DIFF
--- a/backend/libbackend/webserver.ml
+++ b/backend/libbackend/webserver.ml
@@ -1456,6 +1456,7 @@ let admin_ui_template = File.readfile ~root:Templates "ui.html"
 
 let admin_ui_html
     ~(canvas_id : Uuidm.t)
+    ~(canvas : string)
     ~(csrf_token : string)
     ~(local : string option)
     ~(account_created : Core_kernel.Time.t)
@@ -1505,6 +1506,7 @@ let admin_ui_html
        |> Option.value_exn
        |> Uuidm.to_string )
   |> Util.string_replace "{{CANVAS_ID}}" (Uuidm.to_string canvas_id)
+  |> Util.string_replace "{{CANVAS}}" canvas
   |> Util.string_replace
        "{{APPSUPPORT}}"
        (File.readfile ~root:Webroot "appsupport.js")
@@ -1803,6 +1805,7 @@ let admin_ui_handler
           let html =
             admin_ui_html
               ~canvas_id
+              ~canvas
               ~csrf_token
               ~local
               ~account_created

--- a/backend/templates/ui.html
+++ b/backend/templates/ui.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Dark</title>
+    <title>{{CANVAS}} - Dark</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta
       name="viewport"
@@ -45,6 +45,7 @@
       const username = "{{USERNAME}}";
       const userId = "{{USER_ID}}";
       const canvasId = "{{CANVAS_ID}}";
+      const canvas = "{{CANVAS}}";
       const csrfToken = "{{CSRF_TOKEN}}";
       const staticUrl = "{{STATIC}}";
       const buildHash = "{{BUILD_HASH}}";

--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -1,5 +1,3 @@
-document.title = window.location.hostname.split(".")[0] + " - Dark";
-
 const FullStory = require("@fullstory/browser");
 
 const mousewheel = function (callback) {

--- a/scripts/bsb-wrapper.sh
+++ b/scripts/bsb-wrapper.sh
@@ -17,6 +17,9 @@ unbuffer bsb "$@" 2>&1 | while read -r line; do
   if [[ "$line" == *"Fatal error: exception Unix.Unix_error(Unix.ENOENT, \"execv\", \"/home/dark/app/node_modules/bs-platform/lib/ninja.exe\")"* ]]; then
     error=1;
     errorline="$line";
+  elif [[ "$line" == *"make inconsistent assumptions over interface"* ]]; then
+    error=1;
+    errorline="$line";
   fi
   echo "$line";
 done

--- a/scripts/clear-node-modules
+++ b/scripts/clear-node-modules
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 . ./scripts/support/assert-in-container "$0" "$@"
 
-set -euo pipefail
+set -uo pipefail
 
 rm -Rf node_modules/*
-rm -Rf node_modules/.*
+rm -Rf node_modules/.* 2> /dev/null


### PR DESCRIPTION
## What is the problem/goal being addressed?

All dark tabs say "darklang - Dark", which is confusing when you have multiple canvases open.

## What is the solution to this problem?

Show the canvas name instead: "canvasname - Dark"

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*

![image](https://user-images.githubusercontent.com/181762/86967534-c1161280-c138-11ea-8792-fb8b9454b3af.png)

## How are you sure this works/how was this tested?
## What is the reversion plan if this fails after shipping?
## Has this information been included in the comments?
