### PR TITLE
Show unused functions using a darker grey

### DIFF
--- a/client/src/canvas/ViewSidebar.ml
+++ b/client/src/canvas/ViewSidebar.ml
@@ -543,7 +543,11 @@ let viewEntry (m : model) (e : entry) : msg Html.html =
     in
     match e.onClick with
     | Destination dest ->
-        let cls = "toplevel-link" ^ if isSelected then " selected" else "" in
+        let cls =
+          let selected = if isSelected then " selected" else "" in
+          let unused = if e.uses = Some 0 then " unused" else "" in
+          "toplevel-link" ^ selected ^ unused
+        in
         let path = Html.span [Html.class' "path"] [Html.text name] in
         Html.span
           [Html.class' "toplevel-name"]

--- a/client/styles/_sidebar.scss
+++ b/client/styles/_sidebar.scss
@@ -357,6 +357,9 @@ $icSize: 1em;
 
     a.toplevel-link {
       color: $primaryColor;
+      &.unused {
+        color: $secondaryColor;
+      }
       text-decoration: none;
       outline: none;
 


### PR DESCRIPTION
## What is the problem/goal being addressed?

We used to show unused functions in a different color in the sidebar. I don't know where it went but it was really useful.

## What is the solution to this problem?

A css tag based on the `uses` field, which was still there.


## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*

![image](https://user-images.githubusercontent.com/181762/87084717-aefda800-c1fc-11ea-8575-df1c943ae0d6.png)

## How are you sure this works/how was this tested?

Manually tested

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
