### PR TITLE
Fix playbutton z-index with dropdown

### DIFF
--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -354,7 +354,7 @@ $ff-color: adjust-hue($purple, -40deg);
       right: -8px;
       top: 0px;
       transition: color linear 0.1s;
-      z-index: 1000;
+      z-index: 100;
 
       &:hover {
         font-size: 75%;


### PR DESCRIPTION
## What is the problem/goal being addressed?
Change `playbutton` z-index to `100` to be lower than `dropdown`.
Fixes #2676 

## What is the solution to this problem?
Change `z-index`, since these elements are not siblings and positioned `absolute`.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*

![play-button-position](https://user-images.githubusercontent.com/1086461/87095456-0d4c7a00-c241-11ea-8b9b-6c65baf826f7.png)

## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
