### PR TITLE
compiler support for Date::(atStartOfDay,day,minute,month,second,year…

### DIFF
--- a/backend/libbackend/sql_compiler.ml
+++ b/backend/libbackend/sql_compiler.ml
@@ -113,6 +113,18 @@ let unary_op_to_sql op : tipe * tipe * string * string list * position =
       (TStr, TStr, "rtrim", [], First)
   | "Date::hour_v1" ->
       (TDate, TInt, "date_part", ["'hour'"], Last)
+  | "Date::day" ->
+      (TDate, TInt, "date_part", ["'day'"], Last)
+  | "Date::minute" ->
+      (TDate, TInt, "date_part", ["'minute'"], Last)
+  | "Date::month" ->
+      (TDate, TInt, "date_part", ["'month'"], Last)
+  | "Date::second" ->
+      (TDate, TInt, "date_part", ["'second'"], Last)
+  | "Date::year" ->
+      (TDate, TInt, "date_part", ["'year'"], Last)
+  | "Date::atStartOfDay" ->
+      (TDate, TInt, "date_trunc", ["'day'"], Last)
   | _ ->
       error2 "This function is not yet implemented" op
 

--- a/backend/test/test_db_libs.ml
+++ b/backend/test/test_db_libs.ml
@@ -1100,7 +1100,7 @@ let t_db_query_works () =
       [ ("height", int 72)
       ; ("name", str " Chandler ")
       ; ("human", bool true)
-      ; ("dob", fn ~ster:Rail "Date::parse_v2" [str "1969-08-19T10:00:00Z"])
+      ; ("dob", fn ~ster:Rail "Date::parse_v2" [str "1969-08-19T10:13:42Z"])
       ; ("income", float' 83 00) ]
   in
   let cat_expr =
@@ -1526,6 +1526,35 @@ let t_db_query_works () =
               [field "v" "name"; str "xxx"; str "willNotBeInserted"])
            (str " Chandler "))
     |> execs ) ;
+  check_dval
+    "date::atStartOfDay"
+    (DList [chandler])
+    ( queryv
+        (binop
+           "=="
+           (fn "Date::atStartOfDay" [field "v" "dob"])
+           (fn "Date::parse" [str "1969-08-19T00:00:00Z"]))
+    |> execs ) ;
+  check_dval
+    "date::day"
+    (DList [chandler])
+    (queryv (binop "==" (fn "Date::day" [field "v" "dob"]) (int 19)) |> execs) ;
+  check_dval
+    "date::minute"
+    (DList [chandler])
+    (queryv (binop "==" (fn "Date::minute" [field "v" "dob"]) (int 13)) |> execs) ;
+  check_dval
+    "date::month"
+    (DList [chandler])
+    (queryv (binop "==" (fn "Date::month" [field "v" "dob"]) (int 8)) |> execs) ;
+  check_dval
+    "date::second"
+    (DList [chandler])
+    (queryv (binop "==" (fn "Date::second" [field "v" "dob"]) (int 42)) |> execs) ;
+  check_dval
+    "date::year"
+    (DList [rachel; chandler])
+    (queryv (binop "==" (fn "Date::year" [field "v" "dob"]) (int 1969)) |> execs) ;
   (* -------------- *)
   (* Test partial evaluation *)
   (* -------------- *)


### PR DESCRIPTION
…) & tests

Done as part of initiative to expand query compiler. #2424 
I've added a slew of Date function to the query compiler, and wrote tests to verify they work
This will allow the Db::query family of functions to compile the aforementioned functions successfully when applied to DB record values.

- Date::atStartOfDay
- Date::day
- Date::minute
- Date::month
- Date::second
- Date::year
Other than Date::atStartOfDay these are just further expansion of existing logic for date_part postgres function used for Date::hour_v1 previously

Closes #2719 