### PR TITLE
Allow update rebounded variable name

### DIFF
--- a/client/test/fluid_expression_test.ml
+++ b/client/test/fluid_expression_test.ml
@@ -214,4 +214,27 @@ let run () =
         "right partials with diff exprs"
         (rightPartial "++" (str "foo"))
         (rightPartial "++" (str "bar")) ;
+      describe "renameVariableUses" (fun () ->
+          test "with variable used in right hand side" (fun () ->
+              let exprAst = let' "a" (var "x") (E.newB ()) in
+              expect
+                ( E.renameVariableUses ~oldName:"x" ~newName:"x1" exprAst
+                |> FluidPrinter.eToTestString )
+              |> toEqual "let a = x1\n___") ;
+          test "with rebound let expression" (fun () ->
+              let exprAst = let' "x" (int 6) (let' "a" (var "x") (E.newB ())) in
+              expect
+                ( E.renameVariableUses ~oldName:"x" ~newName:"x1" exprAst
+                |> FluidPrinter.eToTestString )
+              |> toEqual "let x = 6\nlet a = x\n___") ;
+          test
+            "ith rebound let expression and used as variable in right hand side"
+            (fun () ->
+              let exprAst =
+                let' "x" (fn "Int::add" [var "x"; int 6]) (E.newB ())
+              in
+              expect
+                ( E.renameVariableUses ~oldName:"x" ~newName:"x1" exprAst
+                |> FluidPrinter.eToTestString )
+              |> toEqual "let x = Int::add x1 6\n___")) ;
       ())

--- a/libshared/FluidExpression.ml
+++ b/libshared/FluidExpression.ml
@@ -457,8 +457,8 @@ let rec updateVariableUses (oldVarName : string) ~(f : t -> t) (ast : t) : t =
   | EVariable (_, varName) ->
       if varName = oldVarName then f ast else ast
   | ELet (id, lhs, rhs, body) ->
-      if oldVarName = lhs (* if variable name is rebound *)
-      then ast
+      if oldVarName = lhs
+      then ELet (id, lhs, u rhs, body)
       else ELet (id, lhs, u rhs, u body)
   | ELambda (id, vars, lexpr) ->
       if List.map ~f:Tuple2.second vars |> List.member ~value:oldVarName


### PR DESCRIPTION
## What is the problem/goal being addressed?
Allow to update variable name even it has been rebounded, to fix #2712 

## What is the solution to this problem?
Currently, it is not allow to rename rebounded variable. Enable this might lead to other unexpected behaviour, eg if new variable name is same for other variable than rebounded variable name, then all referenced places will be marked as updated variable.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*
![rename-shadow-definition-2020-07](https://user-images.githubusercontent.com/1086461/87200571-2286de80-c2fd-11ea-82cf-8d9cacc5ee3f.gif)


## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
The original implementation seems disable rename rebounded variable intentionally, is to enable it has been well thought about in this case?
