### PR TITLE
Replace start and end quotes for live value copy text

### DIFF
--- a/client/src/app/Main.ml
+++ b/client/src/app/Main.ml
@@ -2022,6 +2022,7 @@ let update_ (msg : msg) (m : model) : modification =
       in
       Many [SetClipboardContents (copyData, e); mod_; toast]
   | ClipboardCopyLivevalue (lv, pos) ->
+      let lv = lv |> Regex.replace ~re:(Regex.regex "(^\")|(\"$)") ~repl:"" in
       Native.Clipboard.copyToClipboard lv ;
       ReplaceAllModificationsWithThisOne
         (fun m ->


### PR DESCRIPTION
## What is the problem/goal being addressed?
Replace start and end quotes for live value copy, to fix #2684 

## What is the solution to this problem?
Replace start and end quotes for live value through `copy-value` button.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*

## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
