### PR TITLE
Fix parameter positions after function rename

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -1853,9 +1853,8 @@ let replacePartialWithArguments
     then Rail
     else NoRail
   in
-  (* Compare two params function,
-   * params are aligned if both name and type are the same,
-   * Params are type and position matched if both type and position are the same *)
+  (* Compare two parameters, params are aligned if both name 
+    * and type are the same, or if both type and position are the same *)
   let compareParams p1 p2 =
     match (p1, p2) with
     | Some (name, tipe, _, index), Some (name', tipe', _, index') ->
@@ -1916,10 +1915,7 @@ let replacePartialWithArguments
                (* Divide old existing params to matched and mismatched lists*)
                let matchedParams, mismatchedParams =
                  List.partitionMap oldParams ~f:(fun p ->
-                     (* compare old param with all new param,
-                      * to check if there is any aligned or type and position matched,
-                      * needs to compare with all new params
-                      * because same old param could align and type matched with multiple new params *)
+                     (* Split out the "aligned" parameters (parameters from the old fnCall that match the new fnCall) *)
                      let comparedResults =
                        List.map newParams ~f:(compareParams p)
                      in

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -1964,6 +1964,21 @@ let run () =
         ~pos:5
         (inputs [InsertText "s"; InsertText "q"; keypress K.Enter])
         "Int::sqrt ~_________" ;
+      t
+        "renaming a function maintains aligned params to correct positions"
+        (partial
+           "HttpClient::"
+           (fn
+              "HttpClient::get_v3"
+              [EString (gid (), "someurl"); emptyRecord; emptyRecord]))
+        ~pos:12
+        (inputs
+           [ InsertText "p"
+           ; InsertText "o"
+           ; InsertText "s"
+           ; InsertText "t"
+           ; keypress K.Enter ])
+        "HttpClient::postv4 ~\"someurl\" ____________ {} {}" ;
       (* TODO: functions are not implemented fully. I deld bs and
        * del because we were switching to partials, but this isn't
        * implemented. Some tests we need:


### PR DESCRIPTION
## What is the problem/goal being addressed?
Original bug caused by using old parameter `index` as new parameter `index` for aligned parameters. This PR is to fix #2682 

## What is the solution to this problem?
Using `compareParams` to check two different parameters matched case `Aligned` and `TypeAndPositionMatched` to keep parameter.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*
![args-rename-fun-2020-07-13-23032](https://user-images.githubusercontent.com/1086461/87354065-367d4b00-c55e-11ea-92bf-b788088d6405.gif)


## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
