### PR TITLE
Move caret to text of end when paste in front of open quote

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -5415,15 +5415,14 @@ let pasteOverSelection (data : clipboardContents) (astInfo : ASTInfo.t) :
           astInfo |> ASTInfo.setAST newAST |> moveToCaretTarget caretTarget
       | EString (id, str), _, Some {astRef = ARString (_, SPOpenQuote); offset}
         ->
-          (* Paste into a string, to take care of newlines.
-           * Note: pasting before an open quote
-           * places the caret one unit left of the text end *)
           let replacement =
             E.EString (id, String.insertAt ~insert:text ~index:(offset - 1) str)
           in
           let newAST = FluidAST.replace ~replacement id ast in
           let caretTarget =
-            CT.forARStringOpenQuote id (offset + String.length text)
+            if offset = 0
+            then CT.forARStringOpenQuote id (String.length text + 1)
+            else CT.forARStringOpenQuote id (offset + String.length text)
           in
           astInfo |> ASTInfo.setAST newAST |> moveToCaretTarget caretTarget
       | ( ERecord (id, oldKVs)

--- a/client/test/fluid_clipboard_test.ml
+++ b/client/test/fluid_clipboard_test.ml
@@ -507,6 +507,12 @@ let run () =
         (11, 15)
         (record [("key1", int 9876)])
         "\"abcd EFGH {\n  key1 : 9876\n}~ 1234\"" ;
+      testPasteText
+        "pasting a string before open quote should paste string inside quotes and move caret to end of text"
+        (str "")
+        (-1, 0)
+        "abcd"
+        "\"abcd~\"" ;
       ()) ;
   describe "Floats" (fun () ->
       testCopy


### PR DESCRIPTION
## What is the problem/goal being addressed?
Put caret at the end of text if paste in front of open quote, to fix #2675 

## What is the solution to this problem?

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*
![paste-before-open-quote-2020-07](https://user-images.githubusercontent.com/1086461/87472840-e2876a80-c620-11ea-8dde-7567a230a12d.gif)

## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
