### PR TITLE
Add stdlib tests for List::contains

### DIFF
--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -905,19 +905,19 @@ let t_list_stdlibs_work () =
     (* Can't check randomness deterministically in test so only 1 element*)
     (exec_ast (fn "List::randomElement" [list [int 1]])) ;
   check_dval
-    "List:member works for empty lists"
+    "List::member works for empty lists"
     (DBool false)
     (exec_ast (fn "List::member" [list []; int 1])) ;
   check_dval
-    "List:contains works (value in list)"
+    "List::contains works (value in list)"
     (DBool true)
     (exec_ast (fn "List::contains" [list [int 1; int 2; int 3]; int 2])) ;
   check_dval
-    "List:contains works (value not in list)"
+    "List::contains works (value not in list)"
     (DBool false)
     (exec_ast (fn "List::contains" [list [int 1; int 2; int 3]; int 4])) ;
   check_dval
-    "List:contains works (empty list)"
+    "List::contains works (empty list)"
     (DBool false)
     (exec_ast (fn "List::contains" [list []; int 1])) ;
   check_dval

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -909,6 +909,18 @@ let t_list_stdlibs_work () =
     (DBool false)
     (exec_ast (fn "List::member" [list []; int 1])) ;
   check_dval
+    "List:contains works (value in list)"
+    (DBool true)
+    (exec_ast (fn "List::contains" [list [int 1; int 2; int 3]; int 2])) ;
+  check_dval
+    "List:contains works (value not in list)"
+    (DBool false)
+    (exec_ast (fn "List::contains" [list [int 1; int 2; int 3]; int 4])) ;
+  check_dval
+    "List:contains works (empty list)"
+    (DBool false)
+    (exec_ast (fn "List::contains" [list []; int 1])) ;
+  check_dval
     "List::takeWhile works"
     (DList [Dval.dint 1; Dval.dint 2])
     (exec_ast


### PR DESCRIPTION
## What is the problem/goal being addressed?
Tests were missing for the standard library function List::contains.

## What is the solution to this problem?
To add the missing tests.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
Three tests were added:
(1) Testing on a list containing the value queried.
(4) Testing on a list NOT containing the value queried.
(3) Testing on an empty list.