### PR TITLE
Add List::interpose to the stdlib

### DIFF
--- a/backend/libexecution/liblist.ml
+++ b/backend/libexecution/liblist.ml
@@ -359,14 +359,14 @@ let fns : fn list =
     ; deprecated = false }
   ; { prefix_names = ["List::interpose"]
     ; infix_names = []
-    ; parameters = [par "sep" TAny; par "list" TList]
+    ; parameters = [par "list" TList; par "sep" TAny]
     ; return_type = TList
     ; description =
         "Returns a single list containing the values of `list` separated by `sep`."
     ; func =
         InProcess
           (function
-          | _, [i; DList l] ->
+          | _, [DList l; i] ->
               let rec join ls =
                 match ls with
                 | [] ->

--- a/backend/libexecution/liblist.ml
+++ b/backend/libexecution/liblist.ml
@@ -361,18 +361,19 @@ let fns : fn list =
     ; infix_names = []
     ; parameters = [par "sep" TAny; par "list" TList]
     ; return_type = TList
-    ; description = "Returns a single list containing the values of `list` separated by `sep`."
+    ; description =
+        "Returns a single list containing the values of `list` separated by `sep`."
     ; func =
         InProcess
           (function
           | _, [i; DList l] ->
               let rec join ls =
                 match ls with
-                | [] -> []
+                | [] ->
+                    []
                 | h :: t ->
-                    ( match t with
-                    | [] -> [h]
-                    | t -> [h] @ [i] @ join t ) in
+                  (match t with [] -> [h] | t -> [h] @ [i] @ join t)
+              in
               DList (join l)
           | args ->
               fail args)

--- a/backend/libexecution/liblist.ml
+++ b/backend/libexecution/liblist.ml
@@ -357,6 +357,27 @@ let fns : fn list =
               fail args)
     ; preview_safety = Safe
     ; deprecated = false }
+  ; { prefix_names = ["List::interpose"]
+    ; infix_names = []
+    ; parameters = [par "sep" TAny; par "list" TList]
+    ; return_type = TList
+    ; description = "Returns a single list containing the values of `list` separated by `sep`."
+    ; func =
+        InProcess
+          (function
+          | _, [i; DList l] ->
+              let rec join ls =
+                match ls with
+                | [] -> []
+                | h :: t ->
+                    ( match t with
+                    | [] -> [h]
+                    | t -> [h] @ [i] @ join t ) in
+              DList (join l)
+          | args ->
+              fail args)
+    ; preview_safety = Safe
+    ; deprecated = false }
   ; { prefix_names = ["List::uniqueBy"]
     ; infix_names = []
     ; parameters = [par "list" TList; func ["val"]]

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -929,6 +929,10 @@ let t_list_stdlibs_work () =
     (DList [])
     (exec_ast (fn "List::interpose" [int 5; list []])) ;
   check_dval
+    "List::interpose works (single value)"
+    (DList [Dval.dint 1])
+    (exec_ast (fn "List::interpose" [int 5; list [int 1]])) ;
+  check_dval
     "List::takeWhile works"
     (DList [Dval.dint 1; Dval.dint 2])
     (exec_ast

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -923,15 +923,15 @@ let t_list_stdlibs_work () =
   check_dval
     "List::interpose works"
     (DList [Dval.dint 1; Dval.dint 5; Dval.dint 2; Dval.dint 5; Dval.dint 3])
-    (exec_ast (fn "List::interpose" [int 5; list [int 1; int 2; int 3]])) ;
+    (exec_ast (fn "List::interpose" [list [int 1; int 2; int 3]; int 5])) ;
   check_dval
     "List::interpose works (empty)"
     (DList [])
-    (exec_ast (fn "List::interpose" [int 5; list []])) ;
+    (exec_ast (fn "List::interpose" [list []; int 5])) ;
   check_dval
     "List::interpose works (single value)"
     (DList [Dval.dint 1])
-    (exec_ast (fn "List::interpose" [int 5; list [int 1]])) ;
+    (exec_ast (fn "List::interpose" [list [int 1]; int 5])) ;
   check_dval
     "List::takeWhile works"
     (DList [Dval.dint 1; Dval.dint 2])

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -921,6 +921,14 @@ let t_list_stdlibs_work () =
     (DBool false)
     (exec_ast (fn "List::contains" [list []; int 1])) ;
   check_dval
+    "List::interpose works"
+    (DList [Dval.dint 1; Dval.dint 5; Dval.dint 2; Dval.dint 5; Dval.dint 3])
+    (exec_ast (fn "List::interpose" [int 5; list [int 1; int 2; int 3]])) ;
+  check_dval
+    "List::interpose works (empty)"
+    (DList [])
+    (exec_ast (fn "List::interpose" [int 5; list []])) ;
+  check_dval
     "List::takeWhile works"
     (DList [Dval.dint 1; Dval.dint 2])
     (exec_ast


### PR DESCRIPTION
## What is the problem/goal being addressed?
Issue #2466: Standard library lacks a list interpose/join function.

## What is the solution to this problem?
To add List::interpose to the stdlib, along with the required tests.

## How are you sure this works/how was this tested?
List::interpose tests completed successfully.