### PR TITLE
Add List::interleave to the standard library

### DIFF
--- a/backend/libexecution/liblist.ml
+++ b/backend/libexecution/liblist.ml
@@ -379,6 +379,28 @@ let fns : fn list =
               fail args)
     ; preview_safety = Safe
     ; deprecated = false }
+  ; { prefix_names = ["List::interleave"]
+    ; infix_names = []
+    ; parameters = [par "as" TList; par "bs" TList]
+    ; return_type = TList
+    ; description =
+        "Returns a new list with the first value from `as` then the first value from `bs`, then the second value from `as` then the second value from `bs`, etc, until one list ends, then the remaining items from the other list."
+    ; func =
+        InProcess
+          (function
+          | _, [DList l1; DList l2] ->
+              let rec f l1 l2 =
+                match l1 with
+                | [] ->
+                    l2
+                | x :: xs ->
+                  (match l2 with [] -> l1 | y :: ys -> x :: y :: f xs ys)
+              in
+              DList (f l1 l2)
+          | args ->
+              fail args)
+    ; preview_safety = Safe
+    ; deprecated = false }
   ; { prefix_names = ["List::uniqueBy"]
     ; infix_names = []
     ; parameters = [par "list" TList; func ["val"]]

--- a/backend/libexecution/liblist.ml
+++ b/backend/libexecution/liblist.ml
@@ -384,7 +384,7 @@ let fns : fn list =
     ; parameters = [par "as" TList; par "bs" TList]
     ; return_type = TList
     ; description =
-        "Returns a new list with the first value from `as` then the first value from `bs`, then the second value from `as` then the second value from `bs`, etc, until one list ends, then the remaining items from the other list."
+        "Returns a new list with the first value from <param as> then the first value from <param bs>, then the second value from <param as> then the second value from <param bs>, etc, until one list ends, then the remaining items from the other list."
     ; func =
         InProcess
           (function

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -933,6 +933,54 @@ let t_list_stdlibs_work () =
     (DList [Dval.dint 1])
     (exec_ast (fn "List::interpose" [list [int 1]; int 5])) ;
   check_dval
+    "List::interleave works"
+    (DList
+       [ Dval.dint 1
+       ; Dval.dint 4
+       ; Dval.dint 2
+       ; Dval.dint 5
+       ; Dval.dint 3
+       ; Dval.dint 6 ])
+    (exec_ast
+       (fn
+          "List::interleave"
+          [list [int 1; int 2; int 3]; list [int 4; int 5; int 6]])) ;
+  check_dval
+    "List::interleave works (a longer than b)"
+    (DList [Dval.dint 1; Dval.dint 4; Dval.dint 2; Dval.dint 3])
+    (exec_ast
+       (fn "List::interleave" [list [int 1; int 2; int 3]; list [int 4]])) ;
+  check_dval
+    "List::interleave works (b longer than a)"
+    (DList [Dval.dint 1; Dval.dint 4; Dval.dint 5; Dval.dint 6])
+    (exec_ast
+       (fn "List::interleave" [list [int 1]; list [int 4; int 5; int 6]])) ;
+  check_dval
+    "List::interleave works (a empty)"
+    (DList [Dval.dint 4; Dval.dint 5; Dval.dint 6])
+    (exec_ast (fn "List::interleave" [list []; list [int 4; int 5; int 6]])) ;
+  check_dval
+    "List::interleave works (b empty)"
+    (DList [Dval.dint 1; Dval.dint 2; Dval.dint 3])
+    (exec_ast (fn "List::interleave" [list [int 1; int 2; int 3]; list []])) ;
+  check_dval
+    "List::interleave works (both empty)"
+    (DList [])
+    (exec_ast (fn "List::interleave" [list []; list []])) ;
+  check_dval
+    "List::interleave works (mixed types)"
+    (DList
+       [ Dval.dint 1
+       ; Dval.dstr_of_string_exn "a"
+       ; Dval.dint 2
+       ; Dval.dstr_of_string_exn "b"
+       ; Dval.dint 3
+       ; Dval.dstr_of_string_exn "c" ])
+    (exec_ast
+       (fn
+          "List::interleave"
+          [list [int 1; int 2; int 3]; list [str "a"; str "b"; str "c"]])) ;
+  check_dval
     "List::takeWhile works"
     (DList [Dval.dint 1; Dval.dint 2])
     (exec_ast

--- a/backend/test/test_other_libs.ml
+++ b/backend/test/test_other_libs.ml
@@ -968,19 +968,6 @@ let t_list_stdlibs_work () =
     (DList [])
     (exec_ast (fn "List::interleave" [list []; list []])) ;
   check_dval
-    "List::interleave works (mixed types)"
-    (DList
-       [ Dval.dint 1
-       ; Dval.dstr_of_string_exn "a"
-       ; Dval.dint 2
-       ; Dval.dstr_of_string_exn "b"
-       ; Dval.dint 3
-       ; Dval.dstr_of_string_exn "c" ])
-    (exec_ast
-       (fn
-          "List::interleave"
-          [list [int 1; int 2; int 3]; list [str "a"; str "b"; str "c"]])) ;
-  check_dval
     "List::takeWhile works"
     (DList [Dval.dint 1; Dval.dint 2])
     (exec_ast


### PR DESCRIPTION
Adds List::interleave to the standard library. #2465 

I tried multiple different takes on the description and settled with this very verbose one as a starting point.  I failed to find any example descriptions from other standard libraries to work from.

The "List::interleave works (mixed types)" test probably isn't necessary as it's kind of a given I think, I just wanted to verify it worked as I expected.  Let me know if you want it removed.