### PR TITLE
Make it harder to connect to the wrong DB

### DIFF
--- a/scripts/gcp-proxy-db
+++ b/scripts/gcp-proxy-db
@@ -40,11 +40,13 @@ REPLICA_DB=dark-west-read-replica
 
 
 if [ "${target}x" == "productionx" ]; then
-  echo "Connecting to production"
+  echo "Connecting to production (port 2346)"
   DB="${PROD_DB}"
+  PORT=2346
 else
-  echo "Connecting to the replica"
+  echo "Connecting to the replica (port 2347)"
   DB="${REPLICA_DB}"
+  PORT=2347
 fi
 
 INSTANCE="${PROJECT}:${REGION}:${DB}"
@@ -53,6 +55,6 @@ echo "Setting up proxy to ${INSTANCE}"
 
 cloud_sql_proxy \
     -verbose=false \
-    -instances "${INSTANCE}=tcp:2345" 
+    -instances "${INSTANCE}=tcp:${PORT}" 
 
 

--- a/scripts/gcp-psql
+++ b/scripts/gcp-psql
@@ -15,6 +15,13 @@ arg="${1:-}"
 # Make sure it has time to come up before we try to connect to it
 sleep 1s
 
+if [[ "${arg}x" = "--productionx" ]];
+then
+  PORT=2346
+else
+  PORT=2347
+fi
+
 SECRET=$(kubectl get secrets cloudsql-db-credentials -o json)
 
 PGUSERNAME=$(echo "${SECRET}" |  jq -r '.data.username' | base64 -d)
@@ -22,10 +29,11 @@ PGPASSWORD=$(echo "${SECRET}" |  jq -r '.data.password' | base64 -d)
 export PGUSERNAME
 export PGPASSWORD
 
-# If we're in a terminal (not a pipe), use pgcli, which has nice interactive fea tures like autocomplete of columns.
+# If we're in a terminal (not a pipe), use pgcli, which has nice interactive features like autocomplete of columns.
 # If we're in a pipe, then use psql (pgcli doesn't let you pipe in a query, psql does)
+echo "Connecting to port $PORT"
 if [[ -t 0 ]]; then
-    pgcli -h localhost -p 2345 --username=${PGUSERNAME} postgres
+    pgcli -h localhost -p "${PORT}" --username=${PGUSERNAME} postgres
 else
-    psql -h localhost -p 2345 --user=${PGUSERNAME} postgres
+    psql -h localhost -p "${PORT}" --user=${PGUSERNAME} postgres
 fi


### PR DESCRIPTION
I noticed I accidentally connected to the wrong DB via the SQL proxies (if a connection was already established, it would use that instead of the one I was connecting to).