### PR TITLE
Fix deploy

### DIFF
--- a/scripts/support/kubernetes/builtwithdark/bwd-deployment.template.yaml
+++ b/scripts/support/kubernetes/builtwithdark/bwd-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bwd-deployment

--- a/scripts/support/kubernetes/builtwithdark/bwd-ingress.yaml
+++ b/scripts/support/kubernetes/builtwithdark/bwd-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: bwd-tls-ingress

--- a/scripts/support/kubernetes/builtwithdark/bwd-network-policy.yaml
+++ b/scripts/support/kubernetes/builtwithdark/bwd-network-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: bwd-network-policy
@@ -12,6 +12,7 @@ spec:
   egress:
     - to:
         - ipBlock:
+            # Allows all IPs
             cidr: 0.0.0.0/0
             except:
               # make sure to block link-local addresses,

--- a/scripts/support/kubernetes/builtwithdark/darklang-ingress.yaml
+++ b/scripts/support/kubernetes/builtwithdark/darklang-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: darklang-tls-ingress

--- a/scripts/support/kubernetes/builtwithdark/editor-deployment.template.yaml
+++ b/scripts/support/kubernetes/builtwithdark/editor-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: editor-deployment

--- a/scripts/support/kubernetes/builtwithdark/editor-network-policy.yaml
+++ b/scripts/support/kubernetes/builtwithdark/editor-network-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: editor-network-policy
@@ -12,6 +12,7 @@ spec:
   egress:
     - to:
         - ipBlock:
+            # Allows all IPs
             cidr: 0.0.0.0/0
             except:
               # make sure to block link-local addresses,

--- a/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
+++ b/scripts/support/kubernetes/builtwithdark/honeycomb.yaml
@@ -155,7 +155,7 @@ data:
 
 # Daemonset
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -171,6 +171,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: honeycomb-agent # needs to be a label from template.metadata.labels
   template:
     metadata:
       labels:

--- a/scripts/support/kubernetes/certs/cert-manager.yaml
+++ b/scripts/support/kubernetes/certs/cert-manager.yaml
@@ -6517,6 +6517,7 @@ metadata:
     app.kubernetes.io/component: "cainjector"
     helm.sh/chart: cert-manager-v0.14.0
 spec:
+  revisionHistoryLimit: 10
   replicas: 1
   selector:
     matchLabels:
@@ -6564,6 +6565,7 @@ metadata:
     app.kubernetes.io/component: "controller"
     helm.sh/chart: cert-manager-v0.14.0
 spec:
+  revisionHistoryLimit: 10
   replicas: 1
   selector:
     matchLabels:
@@ -6622,6 +6624,7 @@ metadata:
     app.kubernetes.io/component: "webhook"
     helm.sh/chart: cert-manager-v0.14.0
 spec:
+  revisionHistoryLimit: 10
   replicas: 1
   selector:
     matchLabels:

--- a/scripts/support/kubernetes/certs/darkcustomdomain-ingress.yaml
+++ b/scripts/support/kubernetes/certs/darkcustomdomain-ingress.yaml
@@ -7,7 +7,7 @@
 # Handles darkcustomdomain, for which we (not google) do TLS termination
 #
 # See docs/custom-domains.md for more detail.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: darkcustomdomain-l4-ingress

--- a/scripts/support/kubernetes/certs/nginx-ingress-controller.yaml
+++ b/scripts/support/kubernetes/certs/nginx-ingress-controller.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
 spec:
+  revisionHistoryLimit: 10
   replicas: 1
   selector:
     matchLabels:

--- a/scripts/support/kubernetes/cronchecker/cc-network-policy.yaml
+++ b/scripts/support/kubernetes/cronchecker/cc-network-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: cc-network-policy
@@ -12,6 +12,7 @@ spec:
   egress:
     - to:
         - ipBlock:
+            # Allows all IPs
             cidr: 0.0.0.0/0
             except:
               # make sure to block link-local addresses,

--- a/scripts/support/kubernetes/cronchecker/cron-deployment.template.yaml
+++ b/scripts/support/kubernetes/cronchecker/cron-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cron-deployment

--- a/scripts/support/kubernetes/garbagecollector/garbagecollector-deployment.template.yaml
+++ b/scripts/support/kubernetes/garbagecollector/garbagecollector-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: garbagecollector-deployment

--- a/scripts/support/kubernetes/honeycomb-heapster.yaml
+++ b/scripts/support/kubernetes/honeycomb-heapster.yaml
@@ -2,12 +2,16 @@
 # honeycomb-agent pods so there will be new ones with the new config:
 # `kubectl delete pod --selector k8s-app=honeycomb-agent`
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-honeycomb
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: heapster
+  revisionHistoryLimit: 10
   replicas: 1
   template:
     metadata:

--- a/scripts/support/kubernetes/postgres-honeytail-deployment.template.yaml
+++ b/scripts/support/kubernetes/postgres-honeytail-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres-honeytail-deployment

--- a/scripts/support/kubernetes/queueworker/qw-deployment.template.yaml
+++ b/scripts/support/kubernetes/queueworker/qw-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qw-deployment

--- a/scripts/support/kubernetes/queueworker/qw-network-policy.yaml
+++ b/scripts/support/kubernetes/queueworker/qw-network-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: qw-network-policy
@@ -12,6 +12,7 @@ spec:
   egress:
     - to:
         - ipBlock:
+            # Allows all IPs
             cidr: 0.0.0.0/0
             # make sure to block link-local addresses,
             # since there's sensitive data in http://metadata

--- a/scripts/support/kubernetes/queueworker/scheduler-deployment.template.yaml
+++ b/scripts/support/kubernetes/queueworker/scheduler-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scheduler-deployment

--- a/scripts/support/kubernetes/tunnel/isolate-tunnel.yaml
+++ b/scripts/support/kubernetes/tunnel/isolate-tunnel.yaml
@@ -13,6 +13,7 @@ spec:
   egress:
     - to:
         - ipBlock:
+            # Allows all IPs
             cidr: 0.0.0.0/0
             except:
               # make sure to block link-local addresses,

--- a/scripts/support/kubernetes/tunnel/tunnel-deployment.template.yaml
+++ b/scripts/support/kubernetes/tunnel/tunnel-deployment.template.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       app: tunnel-app
+  revisionHistoryLimit: 10
   replicas: 1
   template:
     metadata:

--- a/scripts/support/kubernetes/tunnel/tunnel-deployment.template.yaml
+++ b/scripts/support/kubernetes/tunnel/tunnel-deployment.template.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tunnel-deployment

--- a/scripts/support/yamllinter
+++ b/scripts/support/yamllinter
@@ -6,8 +6,14 @@ set -euo pipefail
 function check {
   if [[ "$1" == *"kubernetes"* ]]; then
     echo "kubeval $1"
-    # not the production version
-    kubeval --skip-kinds=ManagedCertificate,Issuer,CustomResourceDefinition --kubernetes-version=1.15.7 "$1"
+    # production version is 1.16.13, this is the closest in that repo
+    kubeval \
+      --additional-schema-locations \
+        https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master,https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/746d95595310baddb59477bde49bfa7e6a4eecb7 \
+      --skip-kinds=ManagedCertificate,Issuer,CustomResourceDefinition \
+      --kubernetes-version=1.16.10 \
+      --force-color \
+      "$1"
   else
     echo "not kubernetes so no kubeval: $1"
   fi


### PR DESCRIPTION
Production is now k8s 1.16, but the deployment files were not updated. This led to this failure: https://app.circleci.com/pipelines/github/darklang/dark/420/workflows/9e2ba329-dc41-4746-9e66-ea2877d94437/jobs/3749

This update all the k8s files to 1.16 using the https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ and an updated kubeval