### PR TITLE
Double the capacity of the queue

### DIFF
--- a/scripts/support/kubernetes/queueworker/qw-deployment.template.yaml
+++ b/scripts/support/kubernetes/queueworker/qw-deployment.template.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: qw-worker
-  replicas: 30
+  replicas: 60
   template:
     metadata:
       labels:


### PR DESCRIPTION
When we switch to 30, the queue gets overrun. This is part of the fix after the
outage at the weekend