### PR TITLE
Actually stop processing

### DIFF
--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -96,7 +96,6 @@ let dequeue_and_process execution_id :
                          * will just sit in the queue, being processed forever.
                          * Instead, let's drop it after a week. *)
                         let expired = Event_queue.has_expired event in
-                        (* event.delay < 604800000.0 *)
                         Span.set_attrs
                           parent
                           [ ("host", `String host)

--- a/backend/libbackend/queue_worker.ml
+++ b/backend/libbackend/queue_worker.ml
@@ -109,8 +109,9 @@ let dequeue_and_process execution_id :
                           ~execution_id
                           ~canvas_id
                           (space, name, modifier, event_timestamp, trace_id) ;
-                        if not expired
-                        then Event_queue.put_back transaction event `Incomplete ;
+                        if expired
+                        then Event_queue.finish transaction event
+                        else Event_queue.put_back transaction event `Incomplete ;
                         Ok None
                     | Some h ->
                         Span.set_attrs


### PR DESCRIPTION
When you don't do anything after a dequeue, it stays scheduled and something else will pick it up after. The actual thing I want to do so that events stop being processed is to "finish" it.