### PR TITLE
Fix trace garbage collection for function results

### DIFF
--- a/backend/libbackend/account.ml
+++ b/backend/libbackend/account.ml
@@ -460,48 +460,6 @@ let upsert_admins () : unit =
           "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkcEQxWXBLOG1aVStnUUJUYXdKZytkQSR3TWFXb1hHOER1UzVGd2NDYzRXQVc3RlZGN0VYdVpnMndvZEJ0QnY1bkdJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     ; email = "paul@darklang.com"
     ; name = "Paul Biggar" } ;
-  upsert_admin_exn
-    { username = "ellen"
-    ; password =
-        Password.from_hash
-          "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkcHcxNmRhelJaTGNrYXhZV1psLytXdyRpUHJ1V1NQV2xya1RDZjRDbGlwNTkyaC9tSlZvaTVWSTliRlp0c2xrVmg0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-    ; email = "ellen@darklang.com"
-    ; name = "Ellen Chisa" } ;
-  upsert_admin_exn
-    { username = "alice"
-    ; password =
-        Password.from_hash
-          "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkVGllNGtJT3kyMVFjL1dGUnhScC9PdyROMnp1ZVZnczhIcjl0ODZEREN2VFBYMVNHOE1Za1plSUZCSWFzck9aR1J3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-    ; email = "alice@darklang.com"
-    ; name = "Alice Wong" } ;
-  upsert_admin_exn
-    { username = "ismith"
-    ; password =
-        Password.from_hash
-          "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkbHlXamc0MHA3MWRBZ1kyTmFTTVhIZyRnaWZ1UGpsSnoxMFNUVDlZYWR5Tis1SVovRFVxSXdZeXVtL0Z2TkFOa1ZnAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-    ; email = "ismith@darklang.com"
-    ; name = "Ian Smith" } ;
-  upsert_admin_exn
-    { username = "sydney"
-    ; password =
-        Password.from_hash
-          "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkMDJYZzhSS1RQai9JOGppdzI5MTBEUSRJdE0yYnlIK29OL1RIdzFJbC9yNWZBT2RGR0xrUFc3V3MxaVpUUUVFKytjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-    ; email = "sydney@darklang.com"
-    ; name = "Sydney Noteboom" } ;
-  upsert_admin_exn
-    { username = "julian"
-    ; password =
-        Password.from_hash
-          "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkRmFQeGdPZXhaZTFZL2pSYkZ4azFNQSRFR0ZyNEkyeDVqaDIvL243UEIzeUhkcTIwaUZUUi91RXE1RDJkQ0o0eE5BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-    ; email = "julian@darklang.com"
-    ; name = "Julian Ceipek" } ;
-  upsert_admin_exn
-    { username = "dean"
-    ; password =
-        Password.from_hash
-          "JGFyZ29uMmkkdj0xOSRtPTMyNzY4LHQ9NCxwPTEkWjdFdjJlZ2ZmMnZRaFhjQWlpOWlPZyRrL2F1bGFEU0tra3BQMmNKTHF6S3NaU3d5WXdmWm1pNkQ4Yy96alJrT3YwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-    ; email = "dean@darklang.com"
-    ; name = "Dean Strelau" } ;
   ()
 
 

--- a/backend/libbackend/analysis.ml
+++ b/backend/libbackend/analysis.ml
@@ -166,6 +166,10 @@ let user_fn_trace (c : Canvas.canvas) (fn : RTT.user_fn) (trace_id : traceid) :
   (trace_id, Some {input = ivs; timestamp; function_results})
 
 
+let traceid_of_tlid (tlid : tlid) : Uuidm.t =
+  Uuidm.v5 Uuidm.nil (string_of_id tlid)
+
+
 let traceids_for_handler (c : Canvas.canvas) (h : RTT.HandlerT.handler) :
     traceid list =
   match Handler.event_desc_for h with
@@ -176,7 +180,7 @@ let traceids_for_handler (c : Canvas.canvas) (h : RTT.HandlerT.handler) :
              if String.Caseless.equal hmodule "HTTP"
              then
                (* Ensure we only return trace_ids that would bind to this handler
-              * if the trace was executed for real now *)
+                * if the trace was executed for real now *)
                c.handlers
                |> Toplevel.handlers
                (* Filter and order the handlers that would match the trace's path *)
@@ -188,7 +192,7 @@ let traceids_for_handler (c : Canvas.canvas) (h : RTT.HandlerT.handler) :
                (* Don't use HTTP filtering stack for non-HTTP traces *)
                Some trace_id)
       (* If there's no matching traces, add the default trace *)
-      |> (function [] -> [Uuidm.v5 Uuidm.nil (string_of_id h.tlid)] | x -> x)
+      |> (function [] -> [traceid_of_tlid h.tlid] | x -> x)
   | None ->
       (* If the event description isn't complete, add the default trace *)
       [Uuidm.v5 Uuidm.nil (string_of_id h.tlid)]

--- a/backend/libbackend/garbage_collection.ml
+++ b/backend/libbackend/garbage_collection.ml
@@ -86,36 +86,34 @@ let collect
               (`Int function_arguments_row_count) ;
             function_arguments_row_count)
       in
-      (* Temporarily disabled because causing operational problems *)
-      (* let function_results_v2_row_count = *)
-      (*   Telemetry.with_span *)
-      (*     span *)
-      (*     "garbage_collector_function_results_v2" *)
-      (*     (fun span -> *)
-      (*       let function_results_v2_row_count = *)
-      (*         canvas_ids_and_names *)
-      (*         |> List.map ~f:(fun (canvas_id, canvas_name) -> *)
-      (*                Thread.yield () ; *)
-      (*                Stored_function_result.trim_results_for_canvas *)
-      (*                  span *)
-      (*                  action *)
-      (*                  canvas_id *)
-      (*                  ~canvas_name *)
-      (*                  ~limit) *)
-      (*         |> Tc.List.sum *)
-      (*       in *)
-      (*       Telemetry.Span.set_attr *)
-      (*         span *)
-      (*         "function_results_v2_row_count" *)
-      (*         (`Int function_results_v2_row_count) ; *)
-      (*       function_arguments_row_count) *)
-      (* in *)
+      let function_results_v2_row_count =
+        Telemetry.with_span
+          span
+          "garbage_collector_function_results_v2"
+          (fun span ->
+            let function_results_v2_row_count =
+              canvas_ids_and_names
+              |> List.map ~f:(fun (canvas_id, canvas_name) ->
+                     Thread.yield () ;
+                     Stored_function_result.trim_results_for_canvas
+                       span
+                       action
+                       canvas_id
+                       ~canvas_name
+                       ~limit)
+              |> Tc.List.sum
+            in
+            Telemetry.Span.set_attr
+              span
+              "function_results_v2_row_count"
+              (`Int function_results_v2_row_count) ;
+            function_results_v2_row_count)
+      in
       Telemetry.Span.set_attrs
         span
         [ ("stored_events_v2_row_count", `Int stored_events_v2_row_count)
         ; ("function_arguments_row_count", `Int function_arguments_row_count)
-        ; ("function_results_v2_row_count", `Int 0)
-          (* ; ("function_results_v2_row_count", `Int function_results_v2_row_count) *)
+        ; ("function_results_v2_row_count", `Int function_results_v2_row_count)
         ] ;
       ())
   |> ignore

--- a/backend/libbackend/stored_event.mli
+++ b/backend/libbackend/stored_event.mli
@@ -10,7 +10,7 @@ type event_record =
 
 type four_oh_four = event_record [@@deriving show, yojson]
 
-val get_handlers_for_canvas : Uuidm.t -> event_desc list
+val get_handlers_for_canvas : Uuidm.t -> (Types.tlid * event_desc) list
 
 (* We store a set of events for each host. The events may or may not
  * belong to a toplevel. We provide a list in advance so that they can

--- a/backend/libbackend/stored_event.mli
+++ b/backend/libbackend/stored_event.mli
@@ -58,6 +58,13 @@ type trim_events_canvases =
   | All
   | JustOne of string
 
+val repeat_while_hitting_limit :
+     action:trim_events_action
+  -> span:Libcommon.Telemetry.Span.t
+  -> limit:int
+  -> f:(unit -> int)
+  -> int
+
 val trim_events_for_canvas :
      span:Libcommon.Telemetry.Span.t
   -> action:trim_events_action

--- a/backend/libbackend/stored_function_result.ml
+++ b/backend/libbackend/stored_function_result.ml
@@ -63,9 +63,10 @@ type trim_results_action = Stored_event.trim_events_action
 let trim_results_for_handler
     (span : Libcommon.Telemetry.Span.t)
     (action : trim_results_action)
+    ~(before : Time.t)
     ~(limit : int)
     ~(canvas_name : string)
-    ~(tlid : string)
+    ~(tlid : id)
     (canvas_id : Uuidm.t) : int =
   Telemetry.with_span span "trim_results_for_handler" (fun span ->
       let db_fn trim_events_action =
@@ -79,47 +80,208 @@ let trim_results_for_handler
         [ ("limit", `Int limit)
         ; ("canvas_id", `String (canvas_id |> Uuidm.to_string))
         ; ("canvas_name", `String canvas_name)
-        ; ("tlid", `String tlid)
+        ; ("type", `String "handler")
+        ; ("tlid", `String (string_of_id tlid))
         ; ("action", `String action_str) ] ;
+      let valid_traces =
+        Db.fetch
+          ~name:"valid_traces"
+          "SELECT DISTINCT trace_id
+           FROM stored_events_v2
+           WHERE canvas_id = $1
+             AND tlid = $2
+             AND timestamp < $3
+           LIMIT 1000"
+          ~params:[Db.Uuid canvas_id; Db.ID tlid; Db.Time before]
+        |> List.map ~f:(fun uuid ->
+               uuid |> List.hd_exn |> Uuidm.of_string |> Option.value_exn)
+      in
       let count =
-        try
+        (* Each handler should only have 10 traces newer than a week *)
+        if List.length valid_traces >= 1000
+        then (
+          Log.erroR "db error" ~params:[("err", "Too many traces")] ;
+          Telemetry.Span.set_attr span "too_many" (`Bool true) ;
+          0 )
+        else
           (db_fn action)
             ~name:"gc_function_results"
             (Printf.sprintf
-               "WITH last_ten AS (
-                  SELECT canvas_id, tlid, trace_id
-                  FROM function_results_v2
-                  WHERE canvas_id = $1
-                    AND tlid = $2
-                    AND timestamp < (NOW() - interval '1 week') LIMIT 10),
-              to_delete AS (
-                SELECT canvas_id, tlid, trace_id
-                  FROM function_results_v2
-                  WHERE canvas_id = $1
-                    AND tlid = $2
-                    AND timestamp < (NOW() - interval '1 week')
-                  LIMIT $3)
-              %s FROM function_results_v2
+               "%s FROM function_results_v2
                 WHERE canvas_id = $1
                   AND tlid = $2
-                  AND timestamp < (NOW() - interval '1 week')
-                  AND (canvas_id, tlid, trace_id) NOT IN (SELECT canvas_id, tlid, trace_id FROM last_ten)
-                  AND (canvas_id, tlid, trace_id) IN (SELECT canvas_id, tlid, trace_id FROM to_delete);"
+                  AND timestamp < $3
+                  AND trace_id NOT IN ($4)"
                action_str)
-            ~params:[Db.Uuid canvas_id; Db.String tlid; Db.Int limit]
-        with Exception.DarkException e ->
-          Log.erroR
-            "db error"
             ~params:
-              [ ( "err"
-                , e
-                  |> Exception.exception_data_to_yojson
-                  |> Yojson.Safe.to_string ) ] ;
-          Exception.reraise (Exception.DarkException e)
+              [ Db.Uuid canvas_id
+              ; Db.ID tlid
+              ; Db.Time before
+              ; valid_traces |> List.map ~f:(fun t -> Db.Uuid t) |> Db.List ]
       in
       Telemetry.Span.set_attr span "row_count" (`Int count) ;
       count)
 
+
+let trim_results_for_handlers
+    (span : Libcommon.Telemetry.Span.t)
+    (action : trim_results_action)
+    ~(before : Time.t)
+    ~(limit : int)
+    ~(canvas_name : string)
+    (canvas_id : Uuidm.t) : int * int =
+  let handlers =
+    Telemetry.with_span
+      span
+      "get_handlers_for_canvas"
+      ~attrs:[("canvas_name", `String canvas_name)]
+      (fun span ->
+        Db.fetch
+          ~name:"get_handlers_for_gc"
+          "SELECT tlid
+            FROM toplevel_oplists
+            WHERE canvas_id = $1
+            AND tipe = 'handler';"
+          ~params:[Db.Uuid canvas_id]
+        (* List.hd_exn - we're only returning one field from this query *)
+        |> List.map ~f:(fun tlid -> tlid |> List.hd_exn |> id_of_string))
+  in
+  let row_count =
+    handlers
+    |> List.map ~f:(fun tlid ->
+           trim_results_for_handler
+             span
+             action
+             ~before
+             ~tlid
+             ~canvas_name
+             ~limit
+             canvas_id)
+    |> Tc.List.sum
+  in
+  (List.length handlers, row_count)
+
+
+let trim_results_for_function
+    (span : Libcommon.Telemetry.Span.t)
+    (action : trim_results_action)
+    ~(before : Time.t)
+    ~(traces : Uuidm.t list)
+    ~(limit : int)
+    ~(canvas_name : string)
+    ~(tlid : id)
+    (canvas_id : Uuidm.t) : int =
+  Telemetry.with_span span "trim_results_for_function" (fun span ->
+      let db_fn trim_events_action =
+        match action with Count -> Db.fetch_count | Delete -> Db.delete
+      in
+      let action_str =
+        match action with Count -> "SELECT count(*)" | Delete -> "DELETE"
+      in
+      Telemetry.Span.set_attrs
+        span
+        [ ("limit", `Int limit)
+        ; ("canvas_id", `String (canvas_id |> Uuidm.to_string))
+        ; ("canvas_name", `String canvas_name)
+        ; ("tlid", `String (string_of_id tlid))
+        ; ("type", `String "function")
+        ; ("action", `String action_str) ] ;
+      let count =
+        (db_fn action)
+          ~name:"gc_function_results"
+          (Printf.sprintf
+             "%s FROM function_results_v2
+                WHERE canvas_id = $1
+                  AND tlid = $2
+                  AND timestamp < $3
+                  AND trace_id NOT IN ($4)"
+             action_str)
+          ~params:
+            [ Db.Uuid canvas_id
+            ; Db.ID tlid
+            ; Db.Time before
+            ; traces |> List.map ~f:(fun t -> Db.Uuid t) |> Db.List ]
+      in
+      Telemetry.Span.set_attr span "row_count" (`Int count) ;
+      count)
+
+
+let get_canvas_functions ~span ~canvas_name ~canvas_id () : tlid list =
+  Telemetry.with_span
+    span
+    "get_functions_for_canvas"
+    ~attrs:[("canvas_name", `String canvas_name)]
+    (fun span ->
+      Db.fetch
+        ~name:"get_functions_for_gc"
+        "SELECT tlid
+                FROM toplevel_oplists
+                WHERE canvas_id = $1
+                AND tipe = 'user_function';"
+        ~params:[Db.Uuid canvas_id]
+      |> List.map ~f:(fun tlid -> tlid |> List.hd_exn |> id_of_string))
+
+
+let get_all_handler_traces ~span ~canvas_name ~canvas_id ~before () :
+    Uuidm.t list =
+  Telemetry.with_span
+    span
+    "get_all_handler_traces"
+    ~attrs:[("canvas_name", `String canvas_name)]
+    (fun span ->
+      Db.fetch
+        ~name:"valid_traces"
+        "SELECT DISTINCT trace_id
+         FROM stored_events_v2
+         WHERE canvas_id = $1
+           AND timestamp < $2
+         LIMIT 1000"
+        ~params:[Db.Uuid canvas_id; Db.Time before]
+      |> List.map ~f:(fun uuid ->
+             uuid |> List.hd_exn |> Uuidm.of_string |> Option.value_exn))
+
+
+let trim_results_for_functions
+    (span : Libcommon.Telemetry.Span.t)
+    (action : trim_results_action)
+    ~(before : Time.t)
+    ~(limit : int)
+    ~(canvas_name : string)
+    (canvas_id : Uuidm.t) : int * int =
+  (* Unlike handlers, a function can have traces that it didn't create, as it
+   * can be called by both handlers and other functions' default traces. As a
+   * result, we need the global set of traces in the entire canvas to be able
+   * to trim this effectively. *)
+  (* We have a set of global traces, which we hope have already been trimmed to
+   * a reasonable size. *)
+  let handler_traces =
+    get_all_handler_traces ~span ~canvas_name ~canvas_id ~before ()
+  in
+  let all_functions = get_canvas_functions ~span ~canvas_name ~canvas_id () in
+  let all_function_traces =
+    let traceid_of_tlid (tlid : tlid) : Uuidm.t = (* Copied from analysis.ml *)
+      Uuidm.v5 Uuidm.nil (string_of_id tlid)
+    in
+    all_functions |> List.map ~f:traceid_of_tlid
+  in
+  let all_traces = handler_traces @ all_function_traces in
+  let row_count =
+    all_functions
+    |> List.map ~f:(fun tlid ->
+           trim_results_for_function
+             span
+             action
+             ~before
+             ~traces:all_traces
+             ~tlid
+             ~canvas_name
+             ~limit
+             canvas_id)
+    |> Tc.List.sum
+  in
+  (List.length all_functions, row_count)
+
+(* TODO one week vs 1 day? *)
 
 let trim_results_for_canvas
     (span : Libcommon.Telemetry.Span.t)
@@ -128,48 +290,46 @@ let trim_results_for_canvas
     ~(canvas_name : string)
     (canvas_id : Uuidm.t) : int =
   Telemetry.with_span span "trim_results_for_canvas" (fun span ->
-      let handlers =
-        Telemetry.with_span
+      try
+        (* We pick an exact time so that it's synced, and pick a time where we
+           can avoid being affected by current operations coming in. This could be
+           tuned better. *)
+        let before = Time.sub (Time.now ()) (Time.Span.of_day 7.0) in
+        let handler_count, handler_row_count =
+          trim_results_for_handlers
+            span
+            action
+            ~before
+            ~limit
+            ~canvas_name
+            canvas_id
+        in
+        let function_count, function_row_count =
+          trim_results_for_functions
+            span
+            action
+            ~before
+            ~limit
+            ~canvas_name
+            canvas_id
+        in
+        let row_count = function_row_count + handler_row_count in
+        Telemetry.Span.set_attrs
           span
-          "get_function_handlers_for_canvas"
-          ~attrs:[("canvas_name", `String canvas_name)]
-          (fun span ->
-            ( try
-                Db.fetch
-                  ~name:"get_function_handlers_for_gc"
-                  "SELECT tlid
-                   FROM toplevel_oplists
-                   WHERE canvas_id = $1
-                   AND tipe = 'user_function';"
-                  ~params:[Db.Uuid canvas_id]
-              with Exception.DarkException e ->
-                Log.erroR
-                  "db error"
-                  ~params:
-                    [ ( "err"
-                      , e
-                        |> Exception.exception_data_to_yojson
-                        |> Yojson.Safe.to_string ) ] ;
-                Exception.reraise (Exception.DarkException e) )
-            (* List.hd_exn - we're only returning one field from this query *)
-            |> List.map ~f:(fun tlid -> tlid |> List.hd_exn))
-      in
-      let row_count : int =
-        handlers
-        |> List.map ~f:(fun tlid ->
-               trim_results_for_handler
-                 span
-                 action
-                 ~tlid
-                 ~canvas_name
-                 ~limit
-                 canvas_id)
-        |> Tc.List.sum
-      in
-      Telemetry.Span.set_attrs
-        span
-        [ ("handler_count", `Int (handlers |> List.length))
-        ; ("row_count", `Int row_count)
-        ; ("canvas_name", `String canvas_name)
-        ; ("canvas_id", `String (canvas_id |> Uuidm.to_string)) ] ;
-      row_count)
+          [ ("handler_count", `Int handler_count)
+          ; ("function_count", `Int function_count)
+          ; ("function_row_count", `Int function_row_count)
+          ; ("handler_row_count", `Int handler_row_count)
+          ; ("row_count", `Int row_count)
+          ; ("canvas_name", `String canvas_name)
+          ; ("canvas_id", `String (canvas_id |> Uuidm.to_string)) ] ;
+        row_count
+      with Exception.DarkException e ->
+        Log.erroR
+          "error trimming stored_function_results"
+          ~params:
+            [ ("canvas_name", canvas_name)
+            ; ( "err"
+              , e |> Exception.exception_data_to_yojson |> Yojson.Safe.to_string
+              ) ] ;
+        Exception.reraise (Exception.DarkException e))

--- a/backend/libbackend/stored_function_result.ml
+++ b/backend/libbackend/stored_function_result.ml
@@ -95,10 +95,10 @@ let trim_results_for_handler
           "SELECT DISTINCT trace_id
            FROM stored_events_v2
            WHERE canvas_id = $1
-             AND module = $1
-             AND path LIKE $2
-             AND modifier = $3
-             AND timestamp < $3
+             AND module = $2
+             AND path LIKE $3
+             AND modifier = $4
+             AND timestamp < $5
            LIMIT 1000"
           ~params:
             [ Db.Uuid canvas_id

--- a/backend/libbackend/stored_function_result.mli
+++ b/backend/libbackend/stored_function_result.mli
@@ -27,11 +27,3 @@ val trim_results_for_canvas :
   -> Uuidm.t
   -> int
 
-val trim_results_for_handler :
-     Libcommon.Telemetry.Span.t
-  -> trim_results_action
-  -> limit:int
-  -> canvas_name:string
-  -> tlid:string
-  -> Uuidm.t
-  -> int

--- a/backend/libbackend/stored_function_result.mli
+++ b/backend/libbackend/stored_function_result.mli
@@ -26,4 +26,3 @@ val trim_results_for_canvas :
   -> canvas_name:string
   -> Uuidm.t
   -> int
-


### PR DESCRIPTION
The garbage collection didn't work for function results, and had performance issues so had to be disabled. This makes it work with a different algorithm (find valid traces in the app then delete others in small chunk; previously it tried to figure out invalid traces during the query).

Right now the DB is 1.4TB, this should drop it to 200GB of actual data (barring fragmentation).