### PR TITLE
Add support for bigints in test files (use the "I" suffix)

### DIFF
--- a/fsharp-backend/tests/Tests/FSharpToExpr.fs
+++ b/fsharp-backend/tests/Tests/FSharpToExpr.fs
@@ -62,6 +62,7 @@ let rec convertToExpr (ast : SynExpr) : D.Expr =
         pBlank ()
     | SynPat.Named (SynPat.Wild (_), name, _, _, _) -> pVar name.idText
     | SynPat.Const (SynConst.Int32 n, _) -> pInt n
+    | SynPat.Const (SynConst.UserNum (n, "I"), _) -> D.PInteger(gid (), n)
     | SynPat.Const (SynConst.Char c, _) -> pChar c
     | SynPat.Const (SynConst.Bool b, _) -> pBool b
     | SynPat.Null _ -> pNull ()
@@ -98,6 +99,7 @@ let rec convertToExpr (ast : SynExpr) : D.Expr =
 
   match ast with
   | SynExpr.Const (SynConst.Int32 n, _) -> eInt n
+  | SynExpr.Const (SynConst.UserNum (n, "I"), _) -> D.EInteger(gid (), n)
   | SynExpr.Null _ -> eNull ()
   | SynExpr.Const (SynConst.Char c, _) -> eChar c
   | SynExpr.Const (SynConst.Bool b, _) -> eBool b

--- a/fsharp-backend/tests/testfiles/int.tests
+++ b/fsharp-backend/tests/testfiles/int.tests
@@ -28,6 +28,7 @@ Int.remainder_v0 -15 6 = -3
 Int.mod_v0 15 5 = 0
 Int.mod_v0 15 6 = 3
 Int.mod_v0 0 15 = 0
+Int.mod_v0 9999999999999999999999999998I 3 = 2
 Int.power_v0 8 5 = 32768
 Int.power_v0 0 1 = 0
 Int.power_v0 1 0 = 1

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -131,6 +131,7 @@
 (match 2.0 with | 1.0 -> "fail" | 2.0 -> "pass" | var -> "fail") = "pass"
 (match null with | null -> "pass" | var -> "fail") = "pass"
 (match 2.0 with | blank -> "fail" | 2.0 -> "pass" | var -> "fail") = "pass"
+(match 999999999999999I with | 0 -> "fail" | 999999999999999I -> "pass") = "pass"
 
 [test.pipesimple]
 ([] |> List.push_v0 2) = [2]


### PR DESCRIPTION
## What is the problem/goal being addressed?
When we tried to test functions with large numbers, they weren't working.

## What is the solution to this problem?

It looks like the F# parser treats long integers as 0 instead of bigint. The documentation said that the "I" suffix allowed for bigint literals (eg `9999999999999999999I`). However, it still needed explicit test parser support.

## How are you sure this works/how was this tested?
Added tests for Int.mod_v0 and for matching.

