### PR TITLE
Issue #2863

### DIFF
--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -2021,9 +2021,8 @@ let rec findAppropriateParentToWrap
     (oldExpr : FluidExpression.t) (ast : FluidAST.t) : FluidExpression.t option
     =
   let child = oldExpr in
-  Js.log2 "child" child ;
   let parent = FluidAST.findParent (E.toID oldExpr) ast in
-  Js.log2 "parent" parent ;
+
   match parent with
   | Some parent ->
     ( match parent with
@@ -2073,7 +2072,7 @@ let createPipe ~(findParent : bool) (id : ID.t) (astInfo : ASTInfo.t) :
   let action =
     Printf.sprintf "createPipe(id=%s findParent=%B)" (ID.toString id) findParent
   in
-  Js.log2 "createPipe id" id ;
+
   let astInfo = recordAction action astInfo in
   let exprToReplace =
     FluidAST.find id astInfo.ast
@@ -4169,17 +4168,11 @@ let rec updateKey
             if startPos = endPos
             then
               begin
-                Js.log "No selection" ;
                 let tokenAtLeft = getLeftTokenAt astInfo.state.newPos (ASTInfo.activeTokenInfos astInfo) in
                 match tokenAtLeft with
                 | Some current when T.isPipeable current.token ->
-                  Js.log "Pipeable Token at left " ;
-                  Some (T.tid current.token), false
-                | Some ({token = TPipe _; _} as current) ->
-                  Js.log "Pipe Token at left " ;
                   Some (T.tid current.token), false
                 | _ ->
-                  Js.log "Unmatched Token at left " ;
                   match topmostSelectionID with
                   | Some id -> Some (id), startPos = endPos;
                   | None -> Some (T.fakeid), startPos = endPos
@@ -4191,8 +4184,6 @@ let rec updateKey
                   | None -> Some (T.fakeid), startPos = endPos
               end
           in
-          Js.log2 "topmostID: " topmostID ;
-          Js.log2 "find Parent: " findParent ;
 
           Option.map topmostID ~f:(fun id ->
               let astInfo, blankId = createPipe ~findParent id astInfo in
@@ -5765,7 +5756,6 @@ let updateMsg'
   (* Js.log2 "ast" (show_ast newAST) ; *)
   (* Js.log2 "tokens" (eToStructure s newAST) ; *)
   astInfo
-
 
 let updateMsg
     (m : model)

--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -4162,26 +4162,32 @@ let rec updateKey
     | Keypress {key = K.ShiftEnter; _}, left, _ ->
         let doPipeline (astInfo : ASTInfo.t) : ASTInfo.t =
           let startPos, endPos = FluidUtil.getSelectionRange astInfo.state in
-          let topmostSelectionID = getTopmostSelectionID startPos endPos astInfo in
+          let topmostSelectionID =
+            getTopmostSelectionID startPos endPos astInfo
+          in
           let topmostID, findParent =
             if startPos = endPos
             then
-              begin
-                let tokenAtLeft = getLeftTokenAt astInfo.state.newPos (ASTInfo.activeTokenInfos astInfo) in
-                match tokenAtLeft with
-                | Some current when T.isPipeable current.token ->
-                  Some (T.tid current.token), false
-                | _ ->
-                  match topmostSelectionID with
-                  | Some id -> Some (id), startPos = endPos;
-                  | None -> Some (T.fakeid), startPos = endPos
-              end
+              let tokenAtLeft =
+                getLeftTokenAt
+                  astInfo.state.newPos
+                  (ASTInfo.activeTokenInfos astInfo)
+              in
+              match tokenAtLeft with
+              | Some current when T.isPipeable current.token ->
+                  (Some (T.tid current.token), false)
+              | _ ->
+                ( match topmostSelectionID with
+                | Some id ->
+                    (Some id, startPos = endPos)
+                | None ->
+                    (Some T.fakeid, startPos = endPos) )
             else
-              begin
-                match topmostSelectionID with
-                  | Some id -> Some (id), startPos = endPos;
-                  | None -> Some (T.fakeid), startPos = endPos
-              end
+              match topmostSelectionID with
+              | Some id ->
+                  (Some id, startPos = endPos)
+              | None ->
+                  (Some T.fakeid, startPos = endPos)
           in
 
           Option.map topmostID ~f:(fun id ->

--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -2022,7 +2022,6 @@ let rec findAppropriateParentToWrap
     =
   let child = oldExpr in
   let parent = FluidAST.findParent (E.toID oldExpr) ast in
-
   match parent with
   | Some parent ->
     ( match parent with
@@ -2072,7 +2071,6 @@ let createPipe ~(findParent : bool) (id : ID.t) (astInfo : ASTInfo.t) :
   let action =
     Printf.sprintf "createPipe(id=%s findParent=%B)" (ID.toString id) findParent
   in
-
   let astInfo = recordAction action astInfo in
   let exprToReplace =
     FluidAST.find id astInfo.ast
@@ -4061,6 +4059,7 @@ let maybeOpenCmd (m : Types.model) : Types.modification =
   in
   Option.withDefault mod' ~default:NoChange
 
+
 let rec updateKey
     ?(recursing = false) (inputEvent : fluidInputEvent) (astInfo : ASTInfo.t) =
   (* These might be the same token *)
@@ -5756,6 +5755,7 @@ let updateMsg'
   (* Js.log2 "ast" (show_ast newAST) ; *)
   (* Js.log2 "tokens" (eToStructure s newAST) ; *)
   astInfo
+
 
 let updateMsg
     (m : model)

--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -4165,6 +4165,13 @@ let rec updateKey
           let topmostSelectionID =
             getTopmostSelectionID startPos endPos astInfo
           in
+          let defaultTopmostSelection =
+            match topmostSelectionID with
+              | Some id ->
+                (Some id, startPos = endPos)
+              | None ->
+                (None, startPos = endPos);
+          in
           let topmostID, findParent =
             if startPos = endPos
             then
@@ -4173,21 +4180,14 @@ let rec updateKey
                   astInfo.state.newPos
                   (ASTInfo.activeTokenInfos astInfo)
               in
+
               match tokenAtLeft with
               | Some current when T.isPipeable current.token ->
                   (Some (T.tid current.token), false)
               | _ ->
-                ( match topmostSelectionID with
-                | Some id ->
-                    (Some id, startPos = endPos)
-                | None ->
-                    (None, startPos = endPos) )
+                defaultTopmostSelection
             else
-              match topmostSelectionID with
-              | Some id ->
-                  (Some id, startPos = endPos)
-              | None ->
-                  (None, startPos = endPos)
+              defaultTopmostSelection
           in
 
           Option.map topmostID ~f:(fun id ->

--- a/client/src/fluid/Fluid.ml
+++ b/client/src/fluid/Fluid.ml
@@ -4181,13 +4181,13 @@ let rec updateKey
                 | Some id ->
                     (Some id, startPos = endPos)
                 | None ->
-                    (Some T.fakeid, startPos = endPos) )
+                    (None, startPos = endPos) )
             else
               match topmostSelectionID with
               | Some id ->
                   (Some id, startPos = endPos)
               | None ->
-                  (Some T.fakeid, startPos = endPos)
+                  (None, startPos = endPos)
           in
 
           Option.map topmostID ~f:(fun id ->

--- a/client/src/fluid/FluidToken.ml
+++ b/client/src/fluid/FluidToken.ml
@@ -247,6 +247,73 @@ let isTextToken (t : t) : bool =
   | TFlagEnabledKeyword _ ->
       false
 
+let isPipeable (t : t) : bool =
+  match t with
+  | TInteger _
+  | TLetVarName _
+  | TListClose _
+  | TRecordClose _
+  | TFieldName _
+  | TVariable _
+  | TFnName _
+  | TString _
+  | TTrue _
+  | TFalse _
+  | TNullToken _
+  | TFloatWhole _
+  | TFloatPoint _
+  | TFloatFractional _
+  | TPatternInteger _
+  | TPatternVariable _
+  | TPatternConstructorName _
+  | TPatternBlank _
+  | TPatternString _
+  | TPatternTrue _
+  | TPatternFalse _
+  | TPatternNullToken _
+  | TPatternFloatWhole _
+  | TPatternFloatPoint _
+  | TPatternFloatFractional _ ->
+      true
+  | TFnVersion _
+  | TBlank _
+  | TPlaceholder _
+  | TPartial _
+  | TRightPartial _
+  | TLeftPartial _
+  | TPartialGhost _
+  | TRecordFieldname _
+  | TConstructorName _
+  | TBinOp _
+  | TLambdaVar _
+  | TStringMLStart _
+  | TStringMLMiddle _
+  | TStringMLEnd _
+  | TListOpen _
+  | TFieldPartial _
+  | TListComma (_, _)
+  | TSep _
+  | TLetKeyword _
+  | TRecordOpen _
+  | TRecordSep _
+  | TLetAssignment _
+  | TIfKeyword _
+  | TIfThenKeyword _
+  | TIfElseKeyword _
+  | TFieldOp _
+  | TNewline _
+  | TIndent _
+  | TLambdaSymbol _
+  | TLambdaComma _
+  | TMatchKeyword _
+  | TMatchBranchArrow _
+  | TPipe _
+  | TLambdaArrow _
+  | TParenOpen _
+  | TParenClose _
+  | TFlagWhenKeyword _
+  | TFlagEnabledKeyword _ ->
+      false
 
 let isStringToken t : bool =
   match t with

--- a/client/src/fluid/FluidToken.ml
+++ b/client/src/fluid/FluidToken.ml
@@ -247,6 +247,7 @@ let isTextToken (t : t) : bool =
   | TFlagEnabledKeyword _ ->
       false
 
+
 let isPipeable (t : t) : bool =
   match t with
   | TInteger _
@@ -314,6 +315,7 @@ let isPipeable (t : t) : bool =
   | TFlagWhenKeyword _
   | TFlagEnabledKeyword _ ->
       false
+
 
 let isStringToken t : bool =
   match t with

--- a/client/src/fluid/FluidToken.ml
+++ b/client/src/fluid/FluidToken.ml
@@ -273,10 +273,11 @@ let isPipeable (t : t) : bool =
   | TPatternNullToken _
   | TPatternFloatWhole _
   | TPatternFloatPoint _
-  | TPatternFloatFractional _ ->
+  | TPatternFloatFractional _
+  | TBlank _
+  | TPipe _ ->
       true
   | TFnVersion _
-  | TBlank _
   | TPlaceholder _
   | TPartial _
   | TRightPartial _
@@ -307,7 +308,6 @@ let isPipeable (t : t) : bool =
   | TLambdaComma _
   | TMatchKeyword _
   | TMatchBranchArrow _
-  | TPipe _
   | TLambdaArrow _
   | TParenOpen _
   | TParenClose _

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -3671,17 +3671,35 @@ let run () =
         enter
         "let a = []\n        |>List::append [5]\nlet *** = ___\n~5" ;
       t
+        "inserting a pipe into a list at a pipeble gives a new pipe from the list element"
+        (listFn [aList5])
+        ~pos:15
+        (key K.ShiftEnter)
+        "List::append [5\n              |>~___\n             ]" ;
+      t
+        "inserting a pipe into a list within a list gives a new pipe from the interior list element"
+        (listFn [list [five; list[six]]])
+        ~pos:18
+        (key K.ShiftEnter)
+        "List::append [5,[6\n                 |>~___\n                ]]" ;
+      t
+        "inserting a pipe at a blank element within a list gives a new pipe from the blank element"
+        (listFn [list [b; six]])
+        ~pos:15
+        (key K.ShiftEnter)
+        "List::append [___\n              |>~___\n             ,6]" ;
+      t
         "inserting a pipe into another pipe gives a single pipe1"
         (pipe five [listFn [rightPartial "|>" aList5]])
         ~pos:23
         enter
         "5\n|>List::append [5]\n|>~___\n" ;
       t
-        "inserting a pipe into another pipe gives a single pipe2"
+        "inserting a pipe into another pipe at a pipeable gives a new pipe"
         (pipe five [listFn [aList5]])
         ~pos:19
         (key K.ShiftEnter)
-        "5\n|>List::append [5]\n|>~___\n" ;
+        "5\n|>List::append [5\n                |>~___\n               ]\n" ;
       t
         "inserting a pipe into another pipe gives a single pipe3"
         five

--- a/client/test/fluid_test.ml
+++ b/client/test/fluid_test.ml
@@ -3678,7 +3678,7 @@ let run () =
         "List::append [5\n              |>~___\n             ]" ;
       t
         "inserting a pipe into a list within a list gives a new pipe from the interior list element"
-        (listFn [list [five; list[six]]])
+        (listFn [list [five; list [six]]])
         ~pos:18
         (key K.ShiftEnter)
         "List::append [5,[6\n                 |>~___\n                ]]" ;


### PR DESCRIPTION
## What is the problem/goal being addressed?
Elements within a list are not currently pipeable. The main problem is that when the cursor is at the end of a variable within a list (and nothing is selected), createPipe (in Fluid.ml) is given the id of the list and no other context to know if the cursor is inside the list or outside. The logic simply assumes that if nothing is selected it should find the top most element and pipe from there. 

## What is the solution to this problem?
Add a list of pipeable Fluid Tokens to check if the element being piped from is pipeable. So when nothing is selected the token to the left is checked and if it is pipeable a pipe is created from it.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*

With no token selected and pressing shift-enter:
Current behaviour:
![image](https://user-images.githubusercontent.com/5728611/106699719-40b57400-6598-11eb-8db5-99f551d9fbfd.png)

New behaviour:
![image](https://user-images.githubusercontent.com/5728611/106699930-a73a9200-6598-11eb-97f4-2be9609899b3.png)

## How are you sure this works/how was this tested?
Three new tests have been added and two have been updated to check the new behaviour.

## What is the reversion plan if this fails after shipping?
Back out the changes to Fluid.ml and fluid_test.ml

## Has this information been included in the comments?
No