### PR TITLE
DvalRepr functions

### DIFF
--- a/backend/bin/libserialization.ml
+++ b/backend/bin/libserialization.ml
@@ -25,6 +25,8 @@ let () =
   Callback.register
     "to_internal_roundtrippable_v0"
     Fuzzing.to_internal_roundtrippable_v0 ;
+  Callback.register "of_internal_queryable_v0" Fuzzing.of_internal_queryable_v0 ;
+  Callback.register "of_internal_queryable_v1" Fuzzing.of_internal_queryable_v1 ;
   Callback.register "to_internal_queryable_v0" Fuzzing.to_internal_queryable_v0 ;
   Callback.register "to_internal_queryable_v1" Fuzzing.to_internal_queryable_v1 ;
   Callback.register "to_developer_repr_v0" Fuzzing.to_developer_repr_v0 ;

--- a/backend/libserialize/serialization_stubs.c
+++ b/backend/libserialize/serialization_stubs.c
@@ -35,6 +35,16 @@ void check_exception(const char* ctx1, const char* ctx2, const char* ctx3, value
   }
 }
 
+void check_null_closure(const char* ctx1, const char* ctx2, const char* ctx3, value *v) {
+  if (v == NULL) {
+    printf (
+      "WARNING: Closure not found (%s -> %s -> %s)\n",
+      ctx1, ctx2, ctx3);
+    fflush(stdout);
+    unlock();
+  }
+}
+
 void check_string(const char* ctx1, const char* ctx2, const char* ctx3, value v) {
   check_exception(ctx1, ctx2, ctx3, v);
   if (Tag_val(v) != String_tag) {
@@ -95,6 +105,7 @@ char* call_bin2json(const char* callback_name, void* bytes, int length) {
   value v = caml_alloc_initialized_string(length, bytes);
   check_string(callback_name, "call_bin2json", "caml_alloc_initialized_string", v);
   value* closure = caml_named_value(callback_name);
+  check_null_closure(callback_name, "call_bin2json", "", closure);
   check_exception(callback_name, "closure", "caml_named_value", *closure);
   value result = caml_callback_exn(*closure, v);
   check_exception(callback_name, "result", "caml_callback_exn", result);
@@ -136,6 +147,7 @@ extern char* expr_tlid_pair_bin2json(void* bytes, int length) {
 int call_json2bin(const char* callback_name, char* json, void** out_bytes) {
   lock();
   value* closure = caml_named_value(callback_name);
+  check_null_closure(callback_name, "call_json2bin", "", closure);
   check_exception(callback_name, "call_json2bin", "caml_named_value", *closure);
   value v = caml_copy_string(json);
   check_string(callback_name, "call_json2bin", "caml_copy_string", v);
@@ -177,6 +189,7 @@ extern int expr_tlid_pair_json2bin(char* json, void** out_bytes) {
 const char* string_to_string (const char* callback_name, const char* json) {
   lock();
   value* closure = caml_named_value(callback_name);
+  check_null_closure(callback_name, "string_to_string", "", closure);
   check_exception(callback_name, "string_to_string", "caml_named_value", *closure);
   value v = caml_copy_string(json);
   check_string(callback_name, "string_to_string", "copy_string", v);
@@ -249,6 +262,7 @@ extern const char* hash_v1 (const char* json) {
 extern char* digest () {
   lock();
   value* digest_value = caml_named_value("digest");
+  check_null_closure("digest", "", "", digest_value);
   char* result = copy_string_outside_runtime("digest", "caml_named_value", *digest_value);
   unlock();
   return result;

--- a/backend/libserialize/serialization_stubs.c
+++ b/backend/libserialize/serialization_stubs.c
@@ -149,7 +149,7 @@ int call_json2bin(const char* callback_name, char* json, void** out_bytes) {
   value* closure = caml_named_value(callback_name);
   check_null_closure(callback_name, "call_json2bin", "", closure);
   check_exception(callback_name, "call_json2bin", "caml_named_value", *closure);
-  value v = caml_copy_string(json);
+  value v = caml_copy_string(json); // has a strlen, think it's safe here
   check_string(callback_name, "call_json2bin", "caml_copy_string", v);
 
   value result = caml_callback_exn(*closure, v);
@@ -185,75 +185,78 @@ extern int expr_tlid_pair_json2bin(char* json, void** out_bytes) {
 
 /* --------------------
  * Dvals
+ * Strings can contain NULL bytes so we always use byte arrays and pass a length.
  * -------------------- */
-const char* string_to_string (const char* callback_name, const char* json) {
+const int string_to_string (const char* callback_name, char* bytesIn, int lengthIn, char** bytesOut) {
   lock();
   value* closure = caml_named_value(callback_name);
   check_null_closure(callback_name, "string_to_string", "", closure);
   check_exception(callback_name, "string_to_string", "caml_named_value", *closure);
-  value v = caml_copy_string(json);
+  value v = caml_alloc_initialized_string(lengthIn, bytesIn);
   check_string(callback_name, "string_to_string", "copy_string", v);
 
   value result = caml_callback_exn(*closure, v);
   char* retval = copy_string_outside_runtime(callback_name, "string_to_string", result);
+  *bytesOut = retval;
+  int lengthOut = caml_string_length(result);
   unlock();
-  return retval;
+  return lengthOut;
 }
 
-extern const char* to_internal_roundtrippable_v0 (const char* json) {
-  return string_to_string("to_internal_roundtrippable_v0", json);
+extern int to_internal_roundtrippable_v0 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_internal_roundtrippable_v0", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* of_internal_roundtrippable_v0 (const char* json) {
-  return string_to_string("of_internal_roundtrippable_v0", json);
+extern int of_internal_roundtrippable_v0 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("of_internal_roundtrippable_v0", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* to_internal_queryable_v0 (const char* json) {
-  return string_to_string("to_internal_queryable_v0", json);
+extern int to_internal_queryable_v0 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_internal_queryable_v0", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* to_internal_queryable_v1 (const char* json) {
-  return string_to_string("to_internal_queryable_v1", json);
+extern int to_internal_queryable_v1 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_internal_queryable_v1", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* of_internal_queryable_v0 (const char* json) {
-  return string_to_string("of_internal_queryable_v0", json);
+extern int of_internal_queryable_v0 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("of_internal_queryable_v0", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* of_internal_queryable_v1 (const char* json) {
-  return string_to_string("of_internal_queryable_v1", json);
+extern int of_internal_queryable_v1 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("of_internal_queryable_v1", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* to_developer_repr_v0 (const char* json) {
-  return string_to_string("to_developer_repr_v0", json);
+extern int to_developer_repr_v0 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_developer_repr_v0", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* to_enduser_readable_text_v0 (const char* json) {
-  return string_to_string("to_enduser_readable_text_v0", json);
+extern int to_enduser_readable_text_v0 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_enduser_readable_text_v0", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* to_pretty_machine_json_v1 (const char* json) {
-  return string_to_string("to_pretty_machine_json_v1", json);
+extern int to_pretty_machine_json_v1 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_pretty_machine_json_v1", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* to_url_string (const char* json) {
-  return string_to_string("to_url_string", json);
+extern int to_url_string (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_url_string", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* to_hashable_repr (const char* json) {
-  return string_to_string("to_hashable_repr", json);
+extern int to_hashable_repr (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("to_hashable_repr", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* of_unknown_json_v1 (const char* json) {
-  return string_to_string("of_unknown_json_v1", json);
+extern int of_unknown_json_v1 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("of_unknown_json_v1", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* hash_v0 (const char* json) {
-  return string_to_string("hash_v0", json);
+extern int hash_v0 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("hash_v0", bytesIn, lengthIn, bytesOut);
 }
 
-extern const char* hash_v1 (const char* json) {
-  return string_to_string("hash_v1", json);
+extern int hash_v1 (char* bytesIn, int lengthIn, char** bytesOut) {
+  return string_to_string("hash_v1", bytesIn, lengthIn, bytesOut);
 }
 
 /* --------------------

--- a/fsharp-backend/src/LibBackend/File.fs
+++ b/fsharp-backend/src/LibBackend/File.fs
@@ -74,6 +74,11 @@ let lsdir (root : Config.Root) (dir : string) : string list =
 let readfile (root : Config.Root) (f : string) : string =
   f |> checkFilename root Read |> System.IO.File.ReadAllText
 
+let readfileBytes (root : Config.Root) (f : string) : byte [] =
+  f |> checkFilename root Read |> System.IO.File.ReadAllBytes
+
+
+
 // let readfile_lwt root f : string Lwt.t =
 //   let f = check_filename root Read f in
 //   Lwt_io.with_file mode:Lwt_io.input f Lwt_io.read

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -133,7 +133,7 @@ module Binary =
 
     [<DllImport("./libserialization.so",
                 CallingConvention = CallingConvention.Cdecl,
-                EntryPoint = "to_developer_repr")>]
+                EntryPoint = "to_developer_repr_v0")>]
     extern string toDeveloperRepr(string str)
 
     [<DllImport("./libserialization.so",
@@ -143,7 +143,7 @@ module Binary =
 
     [<DllImport("./libserialization.so",
                 CallingConvention = CallingConvention.Cdecl,
-                EntryPoint = "to_pretty_machine_json")>]
+                EntryPoint = "to_pretty_machine_json_v1")>]
     extern string toPrettyMachineJsonV1(string str)
 
     [<DllImport("./libserialization.so",

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -148,6 +148,14 @@ let ocamlStringOfFloat (f : float) : string =
     if result.Contains "." then result else $"{result}."
 
 
+let ocamlBytesToString (bytes : byte []) =
+  // OCaml stops this at first zero, both otherwise jams the bytes into the
+  // string as is, without conversion.
+  bytes
+  |> Array.takeWhile (fun x -> x <> byte 0)
+  // CLEANUP: dumping these as ASCII isn't a great look
+  |> System.Text.Encoding.UTF8.GetString
+
 // -------------------------
 // Runtime Types
 // -------------------------
@@ -341,9 +349,7 @@ let toEnduserReadableTextV0 (dval : Dval) : string =
     | DResult (Error d) -> "Error: " + reprfn d
     | DOption (Some d) -> reprfn d
     | DOption None -> "Nothing"
-    | DBytes bytes ->
-        // Cleanup: dumping these as ASCII isn't a great look
-        bytes |> System.Text.Encoding.ASCII.GetChars |> System.String
+    | DBytes bytes -> ocamlBytesToString bytes
 
   reprfn dval
 

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -39,6 +39,17 @@ let writeJson (f : JsonWriter -> unit) : string =
   f w
   stream.ToString()
 
+let writePrettyJson (f : JsonWriter -> unit) : string =
+  let stream = new System.IO.StringWriter()
+  let w = new JsonTextWriter(stream)
+  // Match yojson
+  w.FloatFormatHandling <- FloatFormatHandling.Symbol
+  w.Formatting <- Formatting.Indented
+  f w
+  stream.ToString()
+
+
+
 let parseJson (s : string) : JToken =
   let reader = new JsonTextReader(new System.IO.StringReader(s))
   let jls = new JsonLoadSettings()
@@ -357,7 +368,7 @@ let rec toPrettyMachineJsonV1 (w : JsonWriter) (dv : Dval) : unit =
         (fun () ->
           w.WritePropertyName "Error"
           w.WriteValue msg)
-  | DHttpResponse (h, response) -> fstodo "httpresponse"
+  | DHttpResponse (h, response) -> writeDval response
   | DDB dbName -> w.WriteValue dbName
   | DDate date -> w.WriteValue(date.toIsoString ())
   // FSTODO
@@ -383,7 +394,7 @@ let rec toPrettyMachineJsonV1 (w : JsonWriter) (dv : Dval) : unit =
 
 
 let toPrettyMachineJsonStringV1 (dval : Dval) : string =
-  writeJson (fun w -> toPrettyMachineJsonV1 w dval)
+  writePrettyJson (fun w -> toPrettyMachineJsonV1 w dval)
 
 // This special format was originally the default OCaml (yojson-derived) format
 // for this.

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -149,12 +149,8 @@ let ocamlStringOfFloat (f : float) : string =
 
 
 let ocamlBytesToString (bytes : byte []) =
-  // OCaml stops this at first zero, both otherwise jams the bytes into the
-  // string as is, without conversion.
-  bytes
-  |> Array.takeWhile (fun x -> x <> byte 0)
   // CLEANUP: dumping these as ASCII isn't a great look
-  |> System.Text.Encoding.UTF8.GetString
+  System.Text.Encoding.UTF8.GetString bytes
 
 // -------------------------
 // Runtime Types

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -341,7 +341,9 @@ let toEnduserReadableTextV0 (dval : Dval) : string =
     | DResult (Error d) -> "Error: " + reprfn d
     | DOption (Some d) -> reprfn d
     | DOption None -> "Nothing"
-    | DBytes bytes -> System.BitConverter.ToString bytes
+    | DBytes bytes ->
+        // Cleanup: dumping these as ASCII isn't a great look
+        bytes |> System.Text.Encoding.ASCII.GetChars |> System.String
 
   reprfn dval
 

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -39,7 +39,7 @@ let rec eval (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
         return! (eval state st body)
     | EString (_id, s) -> return (DStr s)
     | EBool (_id, b) -> return DBool b
-    | EInteger (_id, i) -> return Dval.bigint i
+    | EInteger (_id, i) -> return DInt i
     | EFloat (_id, value) -> return DFloat value
     | ENull _id -> return DNull
     | ECharacter (_id, s) -> return DChar s
@@ -231,7 +231,7 @@ let rec eval (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
            * is ready to match. *)
           match pattern with
           | PInteger (pid, i) ->
-              let v = Dval.bigint i
+              let v = DInt i
 
               if v = dv then
                 executeMatch [] ((pid, v) :: builtUpTraces) st expr

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -57,12 +57,13 @@ module FQFnName =
   let modNamePat = @"^[A-Z][a-z0-9A-Z_]*$"
   let fnnamePat = @"^([a-z][a-z0-9A-Z_]*|[-+><&|!=^%/*]{1,2})$"
 
-  let packageName (owner : string)
-                  (package : string)
-                  (module_ : string)
-                  (function_ : string)
-                  (version : int)
-                  : T =
+  let packageName
+    (owner : string)
+    (package : string)
+    (module_ : string)
+    (function_ : string)
+    (version : int)
+    : T =
     assertRe "owner must match" namePat owner
     assertRe "package must match" namePat package
     if module_ <> "" then assertRe "modName name must match" modNamePat module_

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -355,10 +355,7 @@ module Dval =
     | DBytes _ -> TBytes
 
   let int (i : int) = DInt(bigint i)
-  let bigint (i : bigint) = DInt i
   let parseInt (i : string) = DInt(parseBigint i)
-
-  let float (value : double) : Dval = DFloat value
 
   let floatParts (sign : Sign, whole : bigint, fraction : bigint) : Dval =
     // FSTODO - add sourceID to errors

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -384,7 +384,7 @@ module Json =
       inherit JsonConverter<bigint>()
 
       override _.ReadJson(reader : JsonReader, _, _, _, s) : bigint =
-        reader.Value :?> string |> parseBigint
+        reader.Value.ToString() |> parseBigint
 
       override _.WriteJson
         (

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -70,7 +70,6 @@ module DarkFsCheck =
       let packageName = ownerName
       let modName : Gen<string> = nameGenerator [ 'A' .. 'Z' ] alphaNumeric
       let fnName : Gen<string> = nameGenerator [ 'a' .. 'z' ] alphaNumeric
-
       { new Arbitrary<PT.FQFnName.T>() with
           member x.Generator =
             gen {

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -74,7 +74,6 @@ module FQFnName =
       let packageName = ownerName
       let modName : Gen<string> = nameGenerator [ 'A' .. 'Z' ] alphaNumeric
       let fnName : Gen<string> = nameGenerator [ 'a' .. 'z' ] alphaNumeric
-
       { new Arbitrary<PT.FQFnName.T>() with
           member x.Generator =
             gen {
@@ -315,7 +314,8 @@ module EndUserReadable =
     static member SafeString() : Arbitrary<string> =
       Arb.Default.String() |> Arb.filter safeOCamlString
 
-    static member FQFnName() : Arbitrary<PT.FQFnName.T> = FQFnName.Generator.FQFnName ()
+    static member FQFnName() : Arbitrary<PT.FQFnName.T> =
+      FQFnName.Generator.FQFnName()
 
   // The format here is used to show users so it has to be exact
   let equalsOCaml (dv : RT.Dval) : bool =

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -315,6 +315,8 @@ module EndUserReadable =
     static member SafeString() : Arbitrary<string> =
       Arb.Default.String() |> Arb.filter safeOCamlString
 
+    static member FQFnName() : Arbitrary<PT.FQFnName.T> = FQFnName.Generator.FQFnName ()
+
   // The format here is used to show users so it has to be exact
   let equalsOCaml (dv : RT.Dval) : bool =
     DvalRepr.toEnduserReadableTextV0 dv .=. OCamlInterop.toEnduserReadableTextV0 dv

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -281,27 +281,28 @@ let interestingFloats : List<string * float> =
       "max 32 bit", -System.Math.Pow(2.0, 31.0)
       // interesting cause doubles support up to 53-bit ints
       "min 53 bit", System.Math.Pow(2.0, 52.0) - 1.0
-      "max 53 bit",  -System.Math.Pow(2.0, 52.0)
+      "max 53 bit", -System.Math.Pow(2.0, 52.0)
       // interesting cause OCaml uses 63 bit ints
-      "min 63 bit",    System.Math.Pow(2.0, 62.0) - 1.0
-      "max 63 bit",    -System.Math.Pow(2.0, 62.0)
+      "min 63 bit", System.Math.Pow(2.0, 62.0) - 1.0
+      "max 63 bit", -System.Math.Pow(2.0, 62.0)
       // interesting cause boundary of 64 bit ints
-      "min 64 bit",  System.Math.Pow(2.0, 63.0) - 1.0
-      "max 64 bit",  -System.Math.Pow(2.0, 63.0)
+      "min 64 bit", System.Math.Pow(2.0, 63.0) - 1.0
+      "max 64 bit", -System.Math.Pow(2.0, 63.0)
       // Interesting anyway
       "zero", 0.0
       "negative zero", -0.0
       "NaN", nan
       "infinity", infinity
-      "-infinity",  -infinity
-    ]
+      "-infinity", -infinity
+      // Mathy values
+      "e", System.Math.E
+      "pi", System.Math.PI
+      "tau", System.Math.Tau ]
+
   initial
-  |> List.flatMap (fun (doc, v) ->
-                     [
-                       ($"{doc} - 1", v - 1.0)
-                       ($"{doc} + 0",  v)
-                       ($"{doc} + 1", v + 1.0)
-                     ])
+  |> List.flatMap
+       (fun (doc, v) ->
+         [ ($"{doc} - 1", v - 1.0); ($"{doc} + 0", v); ($"{doc} + 1", v + 1.0) ])
 
 let sampleDvals : List<string * Dval> =
   [ ("int", Dval.int 5)
@@ -320,54 +321,56 @@ let sampleDvals : List<string * Dval> =
     // Special floats
     ("float zero", DFloat 0.0)
     ("float negative zero", DFloat -0.0)
-    ("float nan", DFloat nan) ] @ List.map (fun (doc, float) -> ($"float {doc}", DFloat float)) interestingFloats @ [
-    ("true", DBool true)
-    ("false", DBool false)
-    ("null", DNull)
-    ("datastore", DDB "Visitors")
-    ("string", DStr "incredibly this was broken")
-    // Json.NET has a habit of converting things automatically based on the type in the string
-    ("date string", DStr "2018-09-14T00:31:41Z")
-    ("int string", DStr "1039485")
-    ("int string2", DStr "-1039485")
-    ("int string3", DStr "0")
-    ("float string", DStr "5.6")
-    ("float string2", DStr "5.0")
-    ("float string3", DStr "-5.0")
-    ("uuid string", DStr "7d9e5495-b068-4364-a2cc-3633ab4d13e6")
-    ("list", DList [ Dval.int 4 ])
-    ("obj", DObj(Map.ofList [ "foo", Dval.int 5 ]))
-    ("obj2", DObj(Map.ofList [ ("type", DStr "weird"); ("value", DNull) ]))
-    ("obj3", DObj(Map.ofList [ ("type", DStr "weird"); ("value", DStr "x") ]))
-    // More Json.NET tests
-    ("obj4", DObj(Map.ofList [ "foo\\\\bar", Dval.int 5 ]))
-    ("obj5", DObj(Map.ofList [ "$type", Dval.int 5 ]))
-    ("incomplete", DIncomplete SourceNone)
-    ("error", DError(SourceNone, "some error string"))
-    ("block",
-     DFnVal(
-       Lambda
-         { body = RT.EBlank(id 1234)
-           symtable = Map.empty
-           parameters = [ (id 5678, "a") ] }
-     ))
-    ("errorrail", DErrorRail(Dval.int 5))
-    ("errorrail with float",
-     DErrorRail(DObj(Map.ofList ([ ("", DFloat nan); ("", DNull) ]))))
-    ("redirect", DHttpResponse(Redirect "/home", DNull))
-    ("httpresponse", DHttpResponse(Response(200, []), DStr "success"))
-    ("db", DDB "Visitors")
-    ("date", DDate(System.DateTime.ofIsoString "2018-09-14T00:31:41Z"))
-    // ; ("password", DPassword (PasswordBytes.of_string "somebytes"))
-    ("uuid", DUuid(System.Guid.Parse "7d9e5495-b068-4364-a2cc-3633ab4d13e6"))
-    ("option", DOption None)
-    ("option2", DOption(Some(Dval.int 15)))
-    ("option3", DOption(Some(DStr "a string")))
-    ("character", DChar "s")
-    ("result", DResult(Ok(Dval.int 15)))
-    ("result2", DResult(Error(DList [ DStr "dunno if really supported" ])))
-    ("result3", DResult(Ok(DStr "a string")))
-    ("bytes", "JyIoXCg=" |> System.Convert.FromBase64String |> DBytes) ]
+    ("float nan", DFloat nan) ]
+  @ (List.map (fun (doc, float) -> ($"float {doc}", DFloat float)) interestingFloats)
+    @ [ ("true", DBool true)
+        ("false", DBool false)
+        ("null", DNull)
+        ("datastore", DDB "Visitors")
+        ("string", DStr "incredibly this was broken")
+        // Json.NET has a habit of converting things automatically based on the type in the string
+        ("date string", DStr "2018-09-14T00:31:41Z")
+        ("int string", DStr "1039485")
+        ("int string2", DStr "-1039485")
+        ("int string3", DStr "0")
+        ("float string", DStr "5.6")
+        ("float string2", DStr "5.0")
+        ("float string3", DStr "-5.0")
+        ("uuid string", DStr "7d9e5495-b068-4364-a2cc-3633ab4d13e6")
+        ("list", DList [ Dval.int 4 ])
+        ("obj", DObj(Map.ofList [ "foo", Dval.int 5 ]))
+        ("obj2", DObj(Map.ofList [ ("type", DStr "weird"); ("value", DNull) ]))
+        ("obj3", DObj(Map.ofList [ ("type", DStr "weird"); ("value", DStr "x") ]))
+        // More Json.NET tests
+        ("obj4", DObj(Map.ofList [ "foo\\\\bar", Dval.int 5 ]))
+        ("obj5", DObj(Map.ofList [ "$type", Dval.int 5 ]))
+        ("incomplete", DIncomplete SourceNone)
+        ("error", DError(SourceNone, "some error string"))
+        ("block",
+         DFnVal(
+           Lambda
+             { body = RT.EBlank(id 1234)
+               symtable = Map.empty
+               parameters = [ (id 5678, "a") ] }
+         ))
+        ("errorrail", DErrorRail(Dval.int 5))
+        ("errorrail with float",
+         DErrorRail(DObj(Map.ofList ([ ("", DFloat nan); ("", DNull) ]))))
+        ("redirect", DHttpResponse(Redirect "/home", DNull))
+        ("httpresponse", DHttpResponse(Response(200, []), DStr "success"))
+        ("db", DDB "Visitors")
+        ("date", DDate(System.DateTime.ofIsoString "2018-09-14T00:31:41Z"))
+        // ; ("password", DPassword (PasswordBytes.of_string "somebytes"))
+        ("uuid", DUuid(System.Guid.Parse "7d9e5495-b068-4364-a2cc-3633ab4d13e6"))
+        ("uuid0", DUuid(System.Guid.Parse "00000000-0000-0000-0000-000000000000"))
+        ("option", DOption None)
+        ("option2", DOption(Some(Dval.int 15)))
+        ("option3", DOption(Some(DStr "a string")))
+        ("character", DChar "s")
+        ("result", DResult(Ok(Dval.int 15)))
+        ("result2", DResult(Error(DList [ DStr "dunno if really supported" ])))
+        ("result3", DResult(Ok(DStr "a string")))
+        ("bytes", "JyIoXCg=" |> System.Convert.FromBase64String |> DBytes) ]
 // FSTODO
 // ; ( "bytes2"
 // , DBytes

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -305,15 +305,16 @@ let interestingFloats : List<string * float> =
          [ ($"{doc} - 1", v - 1.0); ($"{doc} + 0", v); ($"{doc} + 1", v + 1.0) ])
 
 let sampleDvals : List<string * Dval> =
-  [ ("int", Dval.int 5)
-    ("int2", Dval.int (-1))
-    ("int_max_31_bits", RT.DInt 1073741824I)
-    ("int_above_31_bits", RT.DInt 1073741825I)
-    ("int_max_32_bits", RT.DInt 2147483647I)
-    ("int_above_32_bits", RT.DInt 2147483648I)
-    ("int_max_53_bits", RT.DInt 4503599627370496I)
-    ("int_above_53_bits", RT.DInt 4503599627370497I)
-    ("int_max_63_bits", RT.DInt 4611686018427387903I)
+  [ ("int0", Dval.int 0)
+    ("int-1", Dval.int (-1))
+    ("int5", Dval.int 5)
+    ("int_max_31_bits", DInt 1073741824I)
+    ("int_above_31_bits", DInt 1073741825I)
+    ("int_max_32_bits", DInt 2147483647I)
+    ("int_above_32_bits", DInt 2147483648I)
+    ("int_max_53_bits", DInt 4503599627370496I)
+    ("int_above_53_bits", DInt 4503599627370497I)
+    ("int_max_63_bits", DInt 4611686018427387903I)
     ("float", DFloat 7.2)
     ("float2", DFloat -7.2)
     ("float3", DFloat 15.0)
@@ -333,9 +334,6 @@ let sampleDvals : List<string * Dval> =
         ("int string", DStr "1039485")
         ("int string2", DStr "-1039485")
         ("int string3", DStr "0")
-        ("float string", DStr "5.6")
-        ("float string2", DStr "5.0")
-        ("float string3", DStr "-5.0")
         ("uuid string", DStr "7d9e5495-b068-4364-a2cc-3633ab4d13e6")
         ("list", DList [ Dval.int 4 ])
         ("obj", DObj(Map.ofList [ "foo", Dval.int 5 ]))
@@ -370,11 +368,13 @@ let sampleDvals : List<string * Dval> =
         ("result", DResult(Ok(Dval.int 15)))
         ("result2", DResult(Error(DList [ DStr "dunno if really supported" ])))
         ("result3", DResult(Ok(DStr "a string")))
-        ("bytes", "JyIoXCg=" |> System.Convert.FromBase64String |> DBytes) ]
-// FSTODO
-// ; ( "bytes2"
-// , DBytes
-//     (* use image bytes here to test for any weird bytes forms *)
-//     (File.readfile Testdata "sample_image_bytes.png"))
+        ("bytes", "JyIoXCg=" |> System.Convert.FromBase64String |> DBytes)
+        // use image bytes here to test for any weird bytes forms
+        ("bytes2",
+         DBytes(
+           LibBackend.File.readfileBytes
+             LibBackend.Config.Testdata
+             "sample_image_bytes.png"
+         )) ]
 
 // FSTODO: deeply nested data

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -271,6 +271,8 @@ let rec dvalEquality (left : Dval) (right : Dval) : bool =
   | DUuid _, _
   | DBytes _, _ -> left = right
 
+let dvalMapEquality (m1 : DvalMap) (m2 : DvalMap) = dvalEquality (DObj m1) (DObj m2)
+
 let interestingFloats : List<string * float> =
   let initial =
     // interesting cause OCaml uses 31 bit ints

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -271,6 +271,37 @@ let rec dvalEquality (left : Dval) (right : Dval) : bool =
   | DUuid _, _
   | DBytes _, _ -> left = right
 
+let interestingFloats : List<string * float> =
+  let initial =
+    // interesting cause OCaml uses 31 bit ints
+    [ "min 31 bit", System.Math.Pow(2.0, 30.0) - 1.0
+      "max 31 bit", -System.Math.Pow(2.0, 30.0)
+      // interesting cause boundary of 32 bit ints
+      "min 32 bit", System.Math.Pow(2.0, 31.0) - 1.0
+      "max 32 bit", -System.Math.Pow(2.0, 31.0)
+      // interesting cause doubles support up to 53-bit ints
+      "min 53 bit", System.Math.Pow(2.0, 52.0) - 1.0
+      "max 53 bit",  -System.Math.Pow(2.0, 52.0)
+      // interesting cause OCaml uses 63 bit ints
+      "min 63 bit",    System.Math.Pow(2.0, 62.0) - 1.0
+      "max 63 bit",    -System.Math.Pow(2.0, 62.0)
+      // interesting cause boundary of 64 bit ints
+      "min 64 bit",  System.Math.Pow(2.0, 63.0) - 1.0
+      "max 64 bit",  -System.Math.Pow(2.0, 63.0)
+      // Interesting anyway
+      "zero", 0.0
+      "negative zero", -0.0
+      "NaN", nan
+      "infinity", infinity
+      "-infinity",  -infinity
+    ]
+  initial
+  |> List.flatMap (fun (doc, v) ->
+                     [
+                       ($"{doc} - 1", v - 1.0)
+                       ($"{doc} + 0",  v)
+                       ($"{doc} + 1", v + 1.0)
+                     ])
 
 let sampleDvals : List<string * Dval> =
   [ ("int", Dval.int 5)
@@ -286,13 +317,10 @@ let sampleDvals : List<string * Dval> =
     ("float2", DFloat -7.2)
     ("float3", DFloat 15.0)
     ("float4", DFloat -15.0)
-    ("float5", DFloat -0.0)
-    ("float6", DFloat 0.0)
-    (* Long term, we shoudln't allow Infinity/NaNs, but since we do we should
-     * make sure they roundtrip OK. *)
-    ("nan", DFloat nan)
-    ("positive infinity", DFloat infinity)
-    ("negative infinity", DFloat -infinity)
+    // Special floats
+    ("float zero", DFloat 0.0)
+    ("float negative zero", DFloat -0.0)
+    ("float nan", DFloat nan) ] @ List.map (fun (doc, float) -> ($"float {doc}", DFloat float)) interestingFloats @ [
     ("true", DBool true)
     ("false", DBool false)
     ("null", DNull)

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -127,6 +127,17 @@ let testDvalUserDBV1Migration =
          Expect.equalDval dv (backwards dv) $"backwards"
        }
 
+let testToDeveloperRepr =
+  testMany
+    "toDeveloperRepr"
+    DvalRepr.toDeveloperReprV0
+    // Most of this is just the OCaml output and not really what the output should be
+    [ RT.DHttpResponse(RT.Response(0, []), RT.DNull), "0 {  }\nnull"
+      RT.DFloat(-0.0), "-0.0"
+      RT.DFloat(infinity), "Infinity"
+      RT.DObj(Map.ofList [ "", RT.DNull ]), "{ \n  : null\n}"
+      RT.DList [ RT.DNull ], "[ \n  null\n]" ]
+
 // let testDateMigrationHasCorrectFormats () =
 //   let str = "2019-03-08T08:26:14Z" in
 //   let date = RT.DDate(System.DateTime.ofIsoString str) in
@@ -241,4 +252,5 @@ let tests =
       testInternalRoundtrippableDoesntCareAboutOrder
       testDvalOptionQueryableSpecialCase
       testSpecialRoundtrips
+      testToDeveloperRepr
       testDvalUserDBV1Migration ]

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -138,6 +138,15 @@ let testToDeveloperRepr =
       RT.DObj(Map.ofList [ "", RT.DNull ]), "{ \n  : null\n}"
       RT.DList [ RT.DNull ], "[ \n  null\n]" ]
 
+let testToEnduserReadable =
+  testMany
+    "toEnduserReadable"
+    DvalRepr.toEnduserReadableTextV0
+    // Most of this is just the OCaml output and not really what the output should be
+    [ RT.DFloat(0.0), "0." // this one in particular is ridic
+      RT.DFloat(-0.0), "-0."
+      RT.DHttpResponse(RT.Response(0, []), RT.DNull), "0 {  }\nnull" ]
+
 // let testDateMigrationHasCorrectFormats () =
 //   let str = "2019-03-08T08:26:14Z" in
 //   let date = RT.DDate(System.DateTime.ofIsoString str) in
@@ -253,4 +262,5 @@ let tests =
       testDvalOptionQueryableSpecialCase
       testSpecialRoundtrips
       testToDeveloperRepr
+      testToEnduserReadable
       testDvalUserDBV1Migration ]

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -62,7 +62,7 @@ let testDvalRoundtrippableRoundtrips =
 let testSpecialRoundtrips =
   testMany
     "special roundtrippable dvals roundtrip"
-    FuzzTests.All.RoundtrippableDval.dvalReprInternalRoundtrippableV1Roundtrip
+    FuzzTests.All.RoundtrippableDval.dvalReprInternalRoundtrippableV0Roundtrip
     [ RT.DObj(
         Map.ofList [ ("", RT.DFloat 1.797693135e+308)
                      ("a", RT.DErrorRail(RT.DFloat nan)) ]

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -62,7 +62,7 @@ let testDvalRoundtrippableRoundtrips =
 let testSpecialRoundtrips =
   testMany
     "special roundtrippable dvals roundtrip"
-    FuzzTests.All.RoundtrippableDval.dvalReprInternalRoundtrippableV0Roundtrip
+    FuzzTests.All.RoundtrippableDval.roundtrip
     [ RT.DObj(
         Map.ofList [ ("", RT.DFloat 1.797693135e+308)
                      ("a", RT.DErrorRail(RT.DFloat nan)) ]

--- a/fsharp-backend/tests/Tests/OCamlInterop.Tests.fs
+++ b/fsharp-backend/tests/Tests/OCamlInterop.Tests.fs
@@ -12,7 +12,7 @@ open LibBackend.ProgramTypes
 let fuzzedTests =
   [ testListUsingProperty
       "OCamlInterop expr tests"
-      FuzzTests.All.ocamlInteropYojsonExprRoundtrip
+      FuzzTests.All.OCamlInterop.yojsonExprRoundtrip
       [ EFnCall(0UL, FQFnName.parse "b/k/C::r_v1", [], NoRail) // norail was copied wrong
         EBinOp(
           0UL,
@@ -29,29 +29,21 @@ let fuzzedTests =
         ) ]
     testListUsingProperty
       "OCamlInterop Yojson handler tests"
-      FuzzTests.All.ocamlInteropYojsonHandlerRoundtrip
+      FuzzTests.All.OCamlInterop.yojsonHandlerRoundtrip
       [ { tlid = 0UL
           ast = EFnCall(0UL, FQFnName.parse "o/t/F::e_v1", [], NoRail)
           pos = { x = 0; y = 0 }
           spec =
-            Handler.Worker(
-              "",
-              { moduleID = 0UL; nameID = 0UL; modifierID = 0UL }
-            ) }
+            Handler.Worker("", { moduleID = 0UL; nameID = 0UL; modifierID = 0UL }) }
 
         { tlid = 0UL
           pos = { x = 0; y = 0 }
           ast = EBool(0UL, false)
           spec =
-            Handler.Cron(
-              "",
-              "",
-              { moduleID = 0UL; nameID = 0UL; modifierID = 0UL }
-            ) } ]
+            Handler.Cron("", "", { moduleID = 0UL; nameID = 0UL; modifierID = 0UL }) } ]
     testListUsingProperty
       "OCamlInterop Binary handler tests"
-      FuzzTests.All.ocamlInteropBinaryHandlerRoundtrip
-      []
-  ]
+      FuzzTests.All.OCamlInterop.binaryHandlerRoundtrip
+      [] ]
 
 let tests = testList "ocamlInterop" fuzzedTests

--- a/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
@@ -11,13 +11,12 @@ let fuzzedTests =
     "Tests found by fuzzing"
     [ testListUsingProperty
         "FQFnName parse tests"
-        FuzzTests.All.fqFnNameRoundtrip
+        FuzzTests.All.FQFnName.roundtrip
 
         (List.map
           PT.FQFnName.parse
           [ "d6x3an030gugdr7t74k6k/s/F::pIi4tOCQujxl_v3"
             "uawmdntve/dolxb/X4Im::nsgKJGO_v1"
-            "gqs/ekupo0/AmOCq7bpK9xBftJX1F4s::nFTxmaoJ8wAeshW0E_v1" ])
-    ]
+            "gqs/ekupo0/AmOCq7bpK9xBftJX1F4s::nFTxmaoJ8wAeshW0E_v1" ]) ]
 
-let tests = testList "ProgramTypes" [fuzzedTests]
+let tests = testList "ProgramTypes" [ fuzzedTests ]

--- a/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
@@ -11,7 +11,7 @@ let fuzzedTests =
     "Tests found by fuzzing"
     [ testListUsingProperty
         "FQFnName parse tests"
-        FuzzTests.All.FQFnName.roundtrip
+        FuzzTests.All.FQFnName.ptRoundtrip
 
         (List.map
           PT.FQFnName.parse

--- a/scripts/dotnet-fsi
+++ b/scripts/dotnet-fsi
@@ -1,15 +1,3 @@
 #!/bin/bash
 
-# To generate main.group.fsx, you need to run:
-# $ rm paket-files/paket.restore.cached
-# $ dotnet restore
-# $ dotnet paket generate-load-scripts --framework net50
-
-dotnet fsi \
-  --load:"fsharp-backend/.paket/load/net50/main.group.fsx" \
-  --reference:"fsharp-backend/Build/out/Prelude.dll" \
-  --reference:"fsharp-backend/Build/out/LibExecution.dll" \
-  --reference:"fsharp-backend/Build/out/LibBackend.dll" \
-  --reference:"fsharp-backend/Build/out/ApiServer.dll" \
-  --reference:"fsharp-backend/Build/out/BwdServer.dll" \
-  "${@}"
+dotnet fsi --use:scripts/support/fsi-setup.fsx "${@}"

--- a/scripts/support/dotnet-regen-fsi
+++ b/scripts/support/dotnet-regen-fsi
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+. ./scripts/support/assert-in-container "$0" "$@"
+
+set -euo pipefail
+
+cd fsharp-backend
+rm paket-files/paket.restore.cached
+dotnet restore
+dotnet paket generate-load-scripts --framework net50

--- a/scripts/support/fsi-setup.fsx
+++ b/scripts/support/fsi-setup.fsx
@@ -1,0 +1,26 @@
+// This file is used to have a nice FSI setup
+
+// Load program code
+
+printfn "Loading program; if something wrong run ./scripts/support/dotnet-regen-fsi"
+
+#I "../../fsharp-backend" ;;
+#I "../../fsharp-backend/Build/out" ;;
+
+#load ".paket/load/net50/main.group.fsx" ;;
+#r "Prelude.dll" ;;
+#r "LibService.dll" ;;
+#r "LibExecution.dll" ;;
+#r "LibBackend.dll" ;;
+#r "ApiServer.dll" ;;
+#r "BwdServer.dll" ;;
+#r "Tests.dll" ;;
+#r "FuzzTests.dll" ;;
+
+// Convenience shortcuts
+module RT = LibExecution.RuntimeTypes ;;
+module PT = LibBackend.ProgramTypes ;;
+module DvalRepr = LibExecution.DvalRepr ;;
+module OCamlInterop = LibBackend.OCamlInterop ;;
+
+printfn "Loaded and ready to go"


### PR DESCRIPTION
This significantly improves most of the DvalRepr functions by fuzzing them, handling edge cases, adding them as tests, etc.

Funcrtions I know believe to be perfect:
- {to,of}InternalRoundtrippableV0 - 
- {to,of}InternalQueryableV0
- toDeveloperRepr
- toPrettyMachineJson
- toEnduserReadable

Also does:
- significantly improves error handling and display in serialization_stubs (used for OCaml interop)
- improves the dotnet-fsi script
- add lots of float tests
- removes some static methods of Dval that did nothing useful