### PR TITLE
Port Twitter::urlencode function

### DIFF
--- a/fsharp-backend/src/LibExecution/StdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibNoModule.fs
@@ -1,6 +1,7 @@
 module LibExecution.StdLib.LibNoModule
 
 open Prelude
+open System
 
 module DvalRepr = LibExecution.DvalRepr
 open LibExecution.RuntimeTypes
@@ -64,8 +65,8 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<>"
       previewable = Pure
-      deprecated = NotDeprecated } ]
-// ; { name = fn "" "assoc" 0
+      deprecated = NotDeprecated }
+    // ; { name = fn "" "assoc" 0
 //   ; parameters = [Param.make "obj" TObj ""; Param.make "key" TStr ""; Param.make "val" varA ""]
 //   ; returnType = TObj
 //   ; description = "Return a copy of `obj` with the `key` set to `val`."
@@ -157,19 +158,14 @@ let fns : List<BuiltInFn> =
 //   ; sqlSpec = NotYetImplementedTODO
 // ; previewable = Pure
 //   ; deprecated = NotDeprecated }
-// ; { name = fn "Twitter" "urlencode" 0
-//   ; parameters = [Param.make "s" TStr ""]
-//   ; returnType = TStr
-//   ; description = "Url encode a string per Twitter's requirements"
-//   ; fn =
-//         (function
-//         | _, [DStr s] ->
-//             s
-//             |> Unicode_string.to_string
-//             |> Uri.pct_encode `Userinfo
-//             |> DStr
-//         | _ ->
-//             incorrectArgs ())
-//   ; sqlSpec = NotYetImplementedTODO
-// ; previewable = Pure
-//   ; deprecated = NotDeprecated }
+    { name = fn "Twitter" "urlencode" 0
+      parameters = [ Param.make "s" TStr "" ]
+      returnType = TStr
+      description = "Url encode a string per Twitter's requirements"
+      fn =
+        (function
+        | _, [ DStr s ] -> s |> Uri.EscapeDataString |> DStr |> Value
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated } ]

--- a/fsharp-backend/tests/testfiles/twitter.tests
+++ b/fsharp-backend/tests/testfiles/twitter.tests
@@ -1,1 +1,1 @@
-// Twitter.urlencode_v0 "https://google.com?q=left shark&l=en" = "https%3A%2F%2Fgoogle.com%3Fq%3Dleft%20shark%26l%3Den" // URL percent encoding
+Twitter.urlencode_v0 "https://google.com?q=left shark&l=en" = "https%3A%2F%2Fgoogle.com%3Fq%3Dleft%20shark%26l%3Den" // URL percent encoding


### PR DESCRIPTION
## What is the problem/goal being addressed?
This PR ports over the Twitter::urlencode function from OCaml to F#. 

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
The main change is removing the use of the previous OCaml unicode library, and use the built in `Uri.EscapeDataString` method from .NET. 

## How are you sure this works/how was this tested?
The existing twitter.tests unit test passes, I also tested it out against the [examples on the Twitter documentation](https://developer.twitter.com/en/docs/authentication/oauth-1-0a/percent-encoding-parameters) and the output was correct. 