### PR TITLE
Port More List functions

### DIFF
--- a/fsharp-backend/src/LibExecution/StdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibList.fs
@@ -325,12 +325,12 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DList l ] ->
-          let f a b =
-            match (a, b) with
-            | DList a, DList b -> DList (List.append a b)
+          let f acc i =
+            match i with
+            | DList l -> List.append acc l
             | _ -> Errors.throw "Flattening non-lists"
           in
-          Value(List.fold f (DList []) l)
+          List.fold f [] l |> DList |> Value
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecution/StdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibList.fs
@@ -318,27 +318,23 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
-    //   ; { name = fn "List" "flatten" 0
-//     ; parameters = [Param.make "list" TList ""]
-//     ; returnType = TList
-//     ; description =
-//         "Returns a single list containing the values of every list directly in `list` (does not recursively flatten nested lists)."
-//     ; fn =
-//           (function
-//           | _, [DList l] ->
-//               let f a b =
-//                 match (a, b) with
-//                 | DList a, DList b ->
-//                     DList (List.append a b)
-//                 | _ ->
-//                     RT.error (DList [a; b]) "Flattening non-lists"
-//               in
-//               List.fold (DList []) ~f l
-//           | _ ->
-//               incorrectArgs ())
-//     ; sqlSpec = NotYetImplementedTODO
-//     ; previewable = Pure
-//     ; deprecated = NotDeprecated }
+    { name = fn "List" "flatten" 0
+      parameters = [Param.make "list" (TList (TList varA)) ""]
+      returnType = TList varA
+      description = "Returns a single list containing the values of every list directly in `list` (does not recursively flatten nested lists)."
+      fn =
+        (function
+        | _, [ DList l ] ->
+          let f a b =
+            match (a, b) with
+            | DList a, DList b -> DList (List.append a b)
+            | _ -> Errors.throw "Flattening non-lists"
+          in
+          Value(List.fold f (DList []) l)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
 //   ; { name = fn "List" "interpose" 0
 //     ; parameters = [Param.make "list" TList ""; Param.make "sep" varA ""]
 //     ; returnType = TList

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -5,6 +5,13 @@ List.contains_v0 [1;2;3] 2 = true
 List.contains_v0 [1;2;3] 4 = false
 List.contains_v0 [] 1 = false
 
+List.drop_v0 [1;2;3;4] 2 = [ 3, 4 ]
+List.drop_v0 [1;2;3;4] 4 = []
+List.drop_v0 [1;2;3;4] 5 = []
+List.drop_v0 [1;2;3;4] 0 = [ 1, 2, 3, 4 ]
+List.drop_v0 [1;2;3;4] -1 = [ 1, 2, 3, 4 ]
+//List.drop_v0 [1;2;3;4] 118446744073709551616I = [] //FSHARPONLY
+
 //List.dropWhile_v0 [1;2;3;4] (fun item -> item < 3) = [ 3, 4 ]
 //List.dropWhile_v0 [1;2;3;4] (fun item -> item >= 1) = []
 //List.dropWhile_v0 [1;5;2;2] (fun item -> item < 3) = [ 5, 2, 2 ]
@@ -33,11 +40,12 @@ List.filter_v0 [-20; 5; 9;] (fun x -> x < 1) = [-20]
 List.foreach_v0 [1;2;3] (fun x -> x + 1) = [2;3;4]
 List.foreach_v0 [Test.typeError_v0 "test"] (fun x -> x) = [Test.typeError_v0 "test"]
 
-//List.flatten_v0 [[1];[2];[3]] = [ 1, 2, 3 ]
-//List.flatten_v0 [[1];[[2;3]]] = [ 1, [ 2, 3 ] ]
-//List.flatten_v0 [[[]]] = [ [] ]
-//List.flatten_v0 [[]] = []
-//List.flatten_v0 [] = []
+List.flatten_v0 [[1];[2];[3]] = [ 1, 2, 3 ]
+List.flatten_v0 [[1];[[2;3]]] = [ 1, [ 2, 3 ] ]
+List.flatten_v0 [[[]]] = [ [] ]
+List.flatten_v0 [[]] = []
+List.flatten_v0 [] = []
+List.flatten_v0 [1;2;3] = Test.typeError_v0 "Flattening non-lists"
 
 List.getAt_v0 [1;2;3;4] 0 = Just 1
 List.getAt_v0 [1;2;3;4] 4 = Nothing
@@ -69,6 +77,13 @@ List.member_v0 [] 1 = false
 List.member_v0 [1;2;3] 2 = true
 List.member_v0 [1;2;3] 4 = false
 List.member_v0 [] 1 = false
+
+List.repeat_v0 0 1 = []
+List.repeat_v0 1 1 = [1]
+List.repeat_v0 1 "a" = ["a"]
+List.repeat_v0 3 1 = [1, 1, 1]
+//List.repeat_v0 -118446744073709551616I 1 = [] //FSHARPONLY
+//List.repeat_v0 118446744073709551616I 1 = Error "Expected the argument `times` to be less than 2147483647, but it was `118446744073709551616`" //FSHARPONLY
 
 List.randomElement_v0 [1] = Just 1
 List.randomElement_v0 [] = Nothing


### PR DESCRIPTION
## What is the problem/goal being addressed?
Porting stdlib List functions to F# backend

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
Ported `List::repeat_v0`, `List::drop_v0` and `List::flatten_v0`

`List::repeat_v0` raised an interesting choice: since Dark ints are now infinite precision, should we allow functions like this to create truly massive lists or should we just expose some sort of limit (the most obvious being F#'s own limit of Int32). 
I chose the latter option because materializing extremely large lists is a very good way to undermine the stability of a shared runtime. 
I noticed other list functions have similar problems (eg. `List::take`, which I ran out of time to finish, has no efficient way to take more than `Int32.MaxValue` items), which suggests to me that a lazy list implementation might be a better pairing with infinite precision integers.

## How are you sure this works/how was this tested?
Added test cases and iterated with `scripts/builder --compile --watch --test`

I can't figure out how to get VSCode to format this for me, so I expect that will probably fail in CI