### PR TITLE
Port AWS::urlencode to F#

### DIFF
--- a/fsharp-backend/src/LibExecution/StdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibNoModule.fs
@@ -146,7 +146,17 @@ let fns : List<BuiltInFn> =
       description = "Url encode a string per AWS' requirements"
       fn =
           (function
-          | _, [ DStr s ] -> 
+          | _, [ DStr s ] ->
+              (* Based on the original OCaml implementation which was slightly modified from
+               * https://github.com/mirage/ocaml-cohttp/pull/294/files (to use
+               * Buffer.add_string instead of add_bytes); see also
+               * https://github.com/mirage/ocaml-uri/issues/65. It's pretty much a straight
+               * up port from the Java example at
+               * https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html,
+               * which calls it UriEncode *)
+              (* Percent encode the path as s3 wants it. Uri doesn't
+                 encode $, or the other sep characters in a path.
+                 If upstream allows that we can nix this function *)
               let n = String.length s
               let sb = new Text.StringBuilder()
               let is_hex (ch: char) = 
@@ -157,6 +167,7 @@ let fns : List<BuiltInFn> =
                 if ((is_hex s.[i]) || (is_special s.[i])) then
                   sb.Append(s.[i]) |> ignore
                 elif (s.[i] = '%') then
+                  // We're expecting already escaped strings so ignore the escapes
                   if i + 2 < n then
                     if is_hex s.[i + 1] && is_hex s.[i + 2] then
                       sb.Append s.[i] |> ignore

--- a/fsharp-backend/src/LibExecution/StdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibNoModule.fs
@@ -140,22 +140,37 @@ let fns : List<BuiltInFn> =
 //   ; sqlSpec = NotYetImplementedTODO
 // ; previewable = Pure
 //   ; deprecated = ReplacedBy(fn "" "" 0) }
-// ; { name = fn "AWS" "urlencode" 0
-//   ; parameters = [Param.make "str" TStr ""]
-//   ; returnType = TStr
-//   ; description = "Url encode a string per AWS' requirements"
-//   ; fn =
-//         (function
-//         | _, [DStr str] ->
-//             str
-//             |> Unicode_string.to_string
-//             |> Stdlib_util.AWS.url_encode
-//             |> DStr
-//         | _ ->
-//             incorrectArgs ())
-//   ; sqlSpec = NotYetImplementedTODO
-// ; previewable = Pure
-//   ; deprecated = NotDeprecated }
+    { name = fn "AWS" "urlencode" 0
+      parameters = [Param.make "str" TStr ""]
+      returnType = TStr
+      description = "Url encode a string per AWS' requirements"
+      fn =
+          (function
+          | _, [ DStr s ] -> 
+              let n = String.length s
+              let sb = new Text.StringBuilder()
+              let is_hex (ch: char) = 
+                (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+              let is_special (ch: char) =
+                ch = '_' || ch = '-' || ch = '~' || ch = '.' || ch = '/'
+              for i in 0 .. n - 1 do
+                if ((is_hex s.[i]) || (is_special s.[i])) then
+                  sb.Append(s.[i]) |> ignore
+                elif (s.[i] = '%') then
+                  if i + 2 < n then
+                    if is_hex s.[i + 1] && is_hex s.[i + 2] then
+                      sb.Append s.[i] |> ignore
+                    else
+                      sb.Append "%25" |> ignore
+                else
+                  sb.Append (s.[i] |> int |> sprintf "%%%X") |> ignore
+              sb.ToString()
+              |> DStr 
+              |> Value
+          | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
     { name = fn "Twitter" "urlencode" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr

--- a/fsharp-backend/tests/testfiles/aws.tests
+++ b/fsharp-backend/tests/testfiles/aws.tests
@@ -1,0 +1,5 @@
+AWS.urlencode_v0 "https://google.com?q=left shark&l=en" = "https%3A//google.com%3Fq%3Dleft%20shark%26l%3Den" // Test fails without a comment here
+AWS.urlencode_v0 "%" = "" // Edge case bug(?) in OCaml implementation that F# needs to replicate
+AWS.urlencode_v0 "%%" = "" // Edge case bug(?) in OCaml implementation that F# needs to replicate
+AWS.urlencode_v0 "%A" = "A" // Edge case bug(?) in OCaml implementation that F# needs to replicate
+AWS.urlencode_v0 "%AA" = "%AA"


### PR DESCRIPTION
## What is the problem/goal being addressed?
Porting AWS::urlencode  to F#

## What is the solution to this problem?
Duplicate the behavior of the OCaml implementation, including some potential bugs.

## How are you sure this works/how was this tested?
Added aws.tests, including some tests showing that the potential bug in the OCaml implementation is also in the F# version
