### PR TITLE
Build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -215,8 +215,7 @@ RUN /etc/init.d/postgresql start && \
 # Adjust PostgreSQL configuration so that remote connections to the
 # database are possible.
 RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.6/main/pg_hba.conf
-
-# RUN echo "listen_addresses='*'" >> /etc/postgresql/10/main/postgresql.conf
+RUN echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
 
 USER dark
 # Add VOLUMEs to allow backup of config, logs and databases

--- a/scripts/run-fsharp-tests
+++ b/scripts/run-fsharp-tests
@@ -33,6 +33,9 @@ createdb testdb
 ./scripts/support/runlegacyserver
 ./scripts/support/run-ocaml-test-server
 
+# CLEANUP This is where the migrations are run for testdb at the moment
+DARK_CONFIG_STATIC_HOST=static.darklang.localhost:8001 ./scripts/wait-until-server-ready
+
 # Expecto has a number of async bugs causing it to hang. It appears to be due
 # to the test framework though it's hard to tell. It's solved by disabling the
 # spinner and not running the tests in parallel.

--- a/scripts/wait-until-server-ready
+++ b/scripts/wait-until-server-ready
@@ -14,7 +14,4 @@ function wait_for {
 }
 
 wait_for analysis.js
-wait_for app.js
-wait_for appsupport.js
-wait_for app.css
 


### PR DESCRIPTION
## What is the problem/goal being addressed?
1. I could not access the postgres db using pgAdmin (pgAdmin installed windows side with container running in wsl2)
2. I was encountering an error during run-fsharp-tests saying that one of the databases did not exist yet. Turns out the migrations were not completing from the ocaml server before the fsharp server started writing tests.

## What is the solution to this problem?
1. Manually edited postgreql.conf and saw that worked to allow pgAdmin to connect, so I uncommented the line which was already in the dockerfile, but adjusted the postgres version number to be correct
2. Fix provided by @pbiggar 