### PR TITLE
Don't run multiple build-servers in the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -88,6 +88,14 @@
   "containerUser": "dark",
   "updateRemoteUserUID": true,
 
+  // `mounts` (above) expects some files to exist on the host, so create them.
   "initializeCommand": "bash ./scripts/support/initialize-vscode",
-  "postAttachCommand": "./scripts/support/build-server --compile --watch | tee rundir/logs/build-server.txt"
+
+  // Run one build-server, and keep it running for the life of the
+  // devcontainer. This is in postStart rather than postAttach as postAttach would
+  // add a new build-server each time and we only want one.
+  "postStartCommand": "nohup ./scripts/support/build-server --compile --watch > rundir/logs/build-server.txt &",
+
+  // Show the build-server output in a terminal
+  "postAttachCommand": "tail -n 1000 -f rundir/logs/build-server.txt"
 }


### PR DESCRIPTION
Fix some problems in the vscode. By having the build-server as a postAttachCommand, we run one build-server every time we reload vscode (which is a lot, because ionide is fickle). But we really only want one build-server to run because otherwise it will run multiple build jobs, and that will confuse dotnet, causing it to hang (and probably other side effects too).

So really, build-server needs to be a postStartCommand, and we can just show the output in the postAttachCommand.

Reference: https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_lifecycle-scripts