### PR TITLE
More fuzzing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,8 +260,8 @@ jobs:
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:
           keys:
-            - v1-fsharp-backend-{{ checksum "../checksum" }}
-            - v1-fsharp-backend
+            - v2-fsharp-backend-{{ checksum "../checksum" }}
+            - v2-fsharp-backend
       - attach_workspace: { at: "." }
       - show-large-files-and-directories
       # so the ocamltestserver will load
@@ -279,7 +279,7 @@ jobs:
       - show-large-files-and-directories
       - save_cache:
           paths: [fsharp-backend/Build]
-          key: v1-fsharp-backend-{{ checksum "../checksum" }}
+          key: v2-fsharp-backend-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
 

--- a/backend/bin/legacyserver.ml
+++ b/backend/bin/legacyserver.ml
@@ -112,9 +112,12 @@ let server () =
     match (meth, fn) with
     | `POST, Some fn ->
       ( try
-          let result = body_string |> fn |> respond_json_ok in
+          let result = body_string |> fn in
           print_endline ("success calling " ^ Uri.to_string uri) ;
-          result
+          // FSTODO reduce debugging info
+          print_endline ("body was: \n" ^ body_string) ;
+          print_endline ("result was: \n " ^ result) ;
+          respond_json_ok result
         with e ->
           let headers = Header.init () in
           let message =

--- a/backend/bin/legacyserver.ml
+++ b/backend/bin/legacyserver.ml
@@ -118,14 +118,11 @@ let server () =
         with e ->
           let headers = Header.init () in
           let message =
-            "failed to run function at: "
-            ^ Uri.to_string uri
-            ^ "\n"
-            ^ Libexecution.Exception.to_string e
+            Libexecution.Exception.to_string e
           in
-          print_endline message ;
+          print_endline ("error while calling " ^ Uri.to_string uri ^ "\n" ^ message) ;
           S.respond_string
-            ~status:`Internal_server_error
+            ~status:`Bad_request
             ~body:message
             ~headers
             () )

--- a/backend/bin/legacyserver.ml
+++ b/backend/bin/legacyserver.ml
@@ -118,7 +118,7 @@ let server () =
         with e ->
           let headers = Header.init () in
           let message =
-            Libexecution.Exception.to_string e
+            Libexecution.Exception.exn_to_string e
           in
           print_endline ("error while calling " ^ Uri.to_string uri ^ "\n" ^ message) ;
           S.respond_string

--- a/backend/bin/legacyserver.ml
+++ b/backend/bin/legacyserver.ml
@@ -114,7 +114,7 @@ let server () =
       ( try
           let result = body_string |> fn in
           print_endline ("success calling " ^ Uri.to_string uri) ;
-          // FSTODO reduce debugging info
+          (* FSTODO reduce debugging info *)
           print_endline ("body was: \n" ^ body_string) ;
           print_endline ("result was: \n " ^ result) ;
           respond_json_ok result

--- a/backend/bin/legacyserver.ml
+++ b/backend/bin/legacyserver.ml
@@ -120,15 +120,10 @@ let server () =
           respond_json_ok result
         with e ->
           let headers = Header.init () in
-          let message =
-            Libexecution.Exception.exn_to_string e
-          in
-          print_endline ("error while calling " ^ Uri.to_string uri ^ "\n" ^ message) ;
-          S.respond_string
-            ~status:`Bad_request
-            ~body:message
-            ~headers
-            () )
+          let message = Libexecution.Exception.exn_to_string e in
+          print_endline
+            ("error while calling " ^ Uri.to_string uri ^ "\n" ^ message) ;
+          S.respond_string ~status:`Bad_request ~body:message ~headers () )
     | _ ->
         let headers = Header.init () in
         S.respond_string ~status:`Not_found ~body:"" ~headers ()

--- a/backend/liblegacy/fuzzing.ml
+++ b/backend/liblegacy/fuzzing.ml
@@ -260,6 +260,36 @@ let fns : Types.RuntimeT.fn list =
               Lib.fail args)
     ; preview_safety = Safe
     ; deprecated = false }
+  ; { prefix_names = ["Test::okWithTypeError"]
+    ; infix_names = []
+    ; parameters = [Lib.par "msg" TStr]
+    ; return_type = TResult
+    ; description = "Returns a DError in an Ok"
+    ; func =
+        InProcess
+          (function
+          | state, [DStr msg] ->
+              let msg = Unicode_string.to_string msg in
+              DOption(OptJust(DError(SourceNone, msg)))
+          | args ->
+              Lib.fail args)
+    ; preview_safety = Safe
+    ; deprecated = false }
+  ; { prefix_names = ["Test::errorWithTypeError"]
+    ; infix_names = []
+    ; parameters = [Lib.par "msg" TStr]
+    ; return_type = TOption
+    ; description = "Returns a DError in a Just"
+    ; func =
+        InProcess
+          (function
+          | state, [DStr msg] ->
+              let msg = Unicode_string.to_string msg in
+              DOption(OptJust(DError(SourceNone, msg)))
+          | args ->
+              Lib.fail args)
+    ; preview_safety = Safe
+    ; deprecated = false }
   ]
 
 

--- a/backend/liblegacy/fuzzing.ml
+++ b/backend/liblegacy/fuzzing.ml
@@ -245,7 +245,7 @@ let fns : Types.RuntimeT.fn list =
               Lib.fail args)
     ; preview_safety = Safe
     ; deprecated = false }
-  ; { prefix_names = ["Test::"]
+  ; { prefix_names = ["Test::justWithTypeError"]
     ; infix_names = []
     ; parameters = [Lib.par "msg" TStr]
     ; return_type = TOption

--- a/backend/liblegacy/fuzzing.ml
+++ b/backend/liblegacy/fuzzing.ml
@@ -244,7 +244,23 @@ let fns : Types.RuntimeT.fn list =
           | args ->
               Lib.fail args)
     ; preview_safety = Safe
-    ; deprecated = false } ]
+    ; deprecated = false }
+  ; { prefix_names = ["Test::"]
+    ; infix_names = []
+    ; parameters = [Lib.par "msg" TStr]
+    ; return_type = TOption
+    ; description = "Returns a DError in a Just"
+    ; func =
+        InProcess
+          (function
+          | state, [DStr msg] ->
+              let msg = Unicode_string.to_string msg in
+              DOption(OptJust(DError(SourceNone, msg)))
+          | args ->
+              Lib.fail args)
+    ; preview_safety = Safe
+    ; deprecated = false }
+  ]
 
 
 let exec_state : Types.RuntimeT.exec_state =

--- a/backend/liblegacy/fuzzing.ml
+++ b/backend/liblegacy/fuzzing.ml
@@ -255,7 +255,7 @@ let fns : Types.RuntimeT.fn list =
           (function
           | state, [DStr msg] ->
               let msg = Unicode_string.to_string msg in
-              DOption(OptJust(DError(SourceNone, msg)))
+              DOption (OptJust (DError (SourceNone, msg)))
           | args ->
               Lib.fail args)
     ; preview_safety = Safe
@@ -270,7 +270,7 @@ let fns : Types.RuntimeT.fn list =
           (function
           | state, [DStr msg] ->
               let msg = Unicode_string.to_string msg in
-              DOption(OptJust(DError(SourceNone, msg)))
+              DOption (OptJust (DError (SourceNone, msg)))
           | args ->
               Lib.fail args)
     ; preview_safety = Safe
@@ -285,12 +285,11 @@ let fns : Types.RuntimeT.fn list =
           (function
           | state, [DStr msg] ->
               let msg = Unicode_string.to_string msg in
-              DOption(OptJust(DError(SourceNone, msg)))
+              DOption (OptJust (DError (SourceNone, msg)))
           | args ->
               Lib.fail args)
     ; preview_safety = Safe
-    ; deprecated = false }
-  ]
+    ; deprecated = false } ]
 
 
 let exec_state : Types.RuntimeT.exec_state =

--- a/docs/unittests.md
+++ b/docs/unittests.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Unit tests run automatically on the client and backend, as part of
-the compile script. Run it with --test to run tests.
+the builder script. Run it with `--test` to run tests.
 
 ## Backend
 
@@ -23,12 +23,20 @@ line using:
 
 `scripts/run-fsharp-tests`
 
+Run `scripts/run-fsharp-tests --help` for options. In particular, to run only tests with XXX in their names:
+
+`scripts/run-fsharp-tests --filter-test-case XXX`
+
+Or to run only testlists with XXX in their names:
+
+`scripts/run-fsharp-tests --filter-test-list XXX`
+
 Tests are _not_ automatically discovered; they must be added to Tests.fs.
 
 ## Client-side
 
 To run tests, run `scripts/run-client-tests` or `npm run test` (slower).
-Run `scripts/runtests --help` for options.
+Run `scripts/run-client-tests --help` for options.
 
 Tests are _not_ automatically discovered; they must be added to
 `run` in the file in question to run automatically, and new files

--- a/fsharp-backend/paket.dependencies
+++ b/fsharp-backend/paket.dependencies
@@ -10,7 +10,7 @@ nuget FSharp.Core 5.0.0
 //github haf/expecto:8fb043f1de5c847979c4ccb2fa7c14696bfafe55
 nuget Expecto 9.0.2
 nuget Expecto.FsCheck 9.0.2
-nuget FsCheck = 2.15.1
+nuget FsCheck = 2.15.3
 nuget FSharp.Compiler.Service = 38.0.2
 
 // Services

--- a/fsharp-backend/paket.lock
+++ b/fsharp-backend/paket.lock
@@ -12,7 +12,7 @@ NUGET
       Expecto (>= 9.0.2)
       FsCheck (>= 2.14.2)
     Faithlife.Utility (0.11.2)
-    FsCheck (2.15.1)
+    FsCheck (2.15.3)
       FSharp.Core (>= 4.2.3)
     FSharp.Compiler.Service (38.0.2)
       FSharp.Core (5.0)

--- a/fsharp-backend/src/BwdServer/BwdServer.fs
+++ b/fsharp-backend/src/BwdServer/BwdServer.fs
@@ -346,7 +346,7 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
                     ctx.Response.Redirect(url, false)
                     return ctx
                 | RT.DHttpResponse (RT.Response (status, headers, RT.DBytes body)) ->
-                    ctx.Response.StatusCode <- status
+                    ctx.Response.StatusCode <- truncateToInt32 status
                     // FSTODO content type of application/json for dobj and dlist
                     List.iter (fun (k, v) -> setHeader ctx k v) headers
                     do! ctx.Response.Body.WriteAsync(body, 0, body.Length)

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -67,7 +67,7 @@ module OCamlTypes =
     | TErrorRail
     | TCharacter
     | TResult
-    | TUserType of string * int
+    | TUserType of string * int64
     | TBytes
 
 
@@ -133,8 +133,8 @@ module OCamlTypes =
         | DBMigrationInitialized
 
       type 'expr_type db_migration =
-        { starting_version : int
-          version : int
+        { starting_version : int64
+          version : int64
           state : db_migration_state
           rollforward : 'expr_type
           rollback : 'expr_type
@@ -144,12 +144,12 @@ module OCamlTypes =
         { tlid : tlid
           name : string or_blank
           cols : col list
-          version : int
+          version : int64
           old_migrations : 'expr_type db_migration list
           active_migration : 'expr_type db_migration option }
 
     module HandlerT =
-      type dtdeprecated = int or_blank
+      type dtdeprecated = int64 or_blank
 
       type spec_types = { input : dtdeprecated; output : dtdeprecated }
 
@@ -187,7 +187,7 @@ module OCamlTypes =
     type user_tipe =
       { tlid : tlid
         name : string or_blank
-        version : int
+        version : int64
         definition : user_tipe_definition }
 
     type tldata =
@@ -202,7 +202,7 @@ module OCamlTypes =
 
     and dhttp =
       | Redirect of string
-      | Response of int * (string * string) list
+      | Response of int64 * (string * string) list
 
     and optionT =
       | OptJust of dval
@@ -456,7 +456,7 @@ module Convert =
     | OT.TErrorRail -> PT.TErrorRail
     | OT.TCharacter -> PT.TChar
     | OT.TResult -> PT.TResult(any, any)
-    | OT.TUserType (name, version) -> PT.TUserType(name, version)
+    | OT.TUserType (name, version) -> PT.TUserType(name, int version)
     | OT.TBytes -> PT.TBytes
 
   let ocamlDBCol2PT ((name, tipe) : ORT.DbT.col) : PT.DB.Col =
@@ -471,13 +471,13 @@ module Convert =
       nameID = bo2ID o.name
       pos = pos
       cols = List.map ocamlDBCol2PT o.cols
-      version = o.version }
+      version = int o.version }
 
   let ocamlUserType2PT (o : ORT.user_tipe) : PT.UserType.T =
     { tlid = o.tlid
       name = o.name |> bo2String
       nameID = bo2ID o.name
-      version = o.version
+      version = int o.version
       definition =
         match o.definition with
         | ORT.UTRecord fields ->
@@ -819,7 +819,7 @@ module Convert =
     | PT.TErrorRail -> OT.TErrorRail
     | PT.TChar -> OT.TCharacter
     | PT.TResult _ -> OT.TResult
-    | PT.TUserType (name, version) -> OT.TUserType(name, version)
+    | PT.TUserType (name, version) -> OT.TUserType(name, int64 version)
     | PT.TBytes -> OT.TBytes
 
   let pt2ocamlDBCol (p : PT.DB.Col) : ORT.DbT.col =
@@ -829,7 +829,7 @@ module Convert =
     { tlid = p.tlid
       name = string2bo p.nameID p.name
       cols = List.map pt2ocamlDBCol p.cols
-      version = p.version
+      version = int64 p.version
       old_migrations = []
       active_migration = None }
 
@@ -837,7 +837,7 @@ module Convert =
   let pt2ocamlUserType (p : PT.UserType.T) : ORT.user_tipe =
     { tlid = p.tlid
       name = p.name |> string2bo p.nameID
-      version = p.version
+      version = int64 p.version
       definition =
         match p.definition with
         | PT.UserType.Record fields ->
@@ -1019,7 +1019,7 @@ module Convert =
     | RT.DPassword (Password bytes) -> ORT.DPassword bytes
     | RT.DHttpResponse (RT.Redirect url) -> ORT.DResp(ORT.Redirect url, c RT.DNull)
     | RT.DHttpResponse (RT.Response (code, headers, hdv)) ->
-        ORT.DResp(ORT.Response(code, headers), c hdv)
+        ORT.DResp(ORT.Response(int64 code, headers), c hdv)
     | RT.DList l -> ORT.DList(List.map c l)
     | RT.DObj o -> ORT.DObj(Map.map c o)
     | RT.DOption None -> ORT.DOption ORT.OptNothing
@@ -1059,7 +1059,7 @@ module Convert =
     | ORT.DPassword bytes -> RT.DPassword(Password bytes)
     | ORT.DResp (ORT.Redirect url, _) -> RT.DHttpResponse(RT.Redirect url)
     | ORT.DResp (ORT.Response (code, headers), hdv) ->
-        RT.DHttpResponse(RT.Response(code, headers, c hdv))
+        RT.DHttpResponse(RT.Response(bigint code, headers, c hdv))
     | ORT.DList l -> RT.DList(List.map c l)
     | ORT.DObj o -> RT.DObj(Map.map c o)
     | ORT.DOption ORT.OptNothing -> RT.DOption None

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -628,8 +628,8 @@ module Convert =
     | RT.PBool (id, b) -> ORT.FPBool(mid, id, b)
     | RT.PString (id, s) -> ORT.FPString { matchID = mid; patternID = id; str = s }
     | RT.PFloat (id, d) ->
-        let asStr = d.ToString().Split "."
-        ORT.FPFloat(mid, id, asStr.[0], asStr.[1])
+        let w, f = readFloat d
+        ORT.FPFloat(mid, id, string w, string f)
     | RT.PNull (id) -> ORT.FPNull(mid, id)
     | RT.PBlank (id) -> ORT.FPBlank(mid, id)
 
@@ -655,8 +655,8 @@ module Convert =
     | PT.EInteger (id, num) -> ORT.EInteger(id, num.ToString())
     | PT.ECharacter (id, num) -> failwith "Characters not supported"
     | PT.EString (id, str) -> ORT.EString(id, str)
-    | PT.EFloat (id, Positive, w, f) -> ORT.EFloat(id, w.ToString(), f.ToString())
-    | PT.EFloat (id, Negative, w, f) -> ORT.EFloat(id, $"-{w}", f.ToString())
+    | PT.EFloat (id, Positive, w, f) -> ORT.EFloat(id, string w, string f)
+    | PT.EFloat (id, Negative, w, f) -> ORT.EFloat(id, $"-{w}", string f)
     | PT.EBool (id, b) -> ORT.EBool(id, b)
     | PT.ENull id -> ORT.ENull id
     | PT.EVariable (id, var) -> ORT.EVariable(id, var)
@@ -712,12 +712,8 @@ module Convert =
     | RT.ECharacter (id, num) -> failwith "Characters not supported"
     | RT.EString (id, str) -> ORT.EString(id, str)
     | RT.EFloat (id, d) ->
-        let asStr = d.ToString().Split "."
-
-        if asStr.Length = 1 then
-          ORT.EFloat(id, asStr.[0], "0")
-        else
-          ORT.EFloat(id, asStr.[0], asStr.[1])
+        let (w, f) = readFloat d
+        ORT.EFloat(id, string w, string f)
     | RT.EBool (id, b) -> ORT.EBool(id, b)
     | RT.ENull id -> ORT.ENull id
     | RT.EVariable (id, var) -> ORT.EVariable(id, var)

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -713,7 +713,11 @@ module Convert =
     | RT.EString (id, str) -> ORT.EString(id, str)
     | RT.EFloat (id, d) ->
         let asStr = d.ToString().Split "."
-        ORT.EFloat(id, asStr.[0], asStr.[1])
+
+        if asStr.Length = 1 then
+          ORT.EFloat(id, asStr.[0], "0")
+        else
+          ORT.EFloat(id, asStr.[0], asStr.[1])
     | RT.EBool (id, b) -> ORT.EBool(id, b)
     | RT.ENull id -> ORT.ENull id
     | RT.EVariable (id, var) -> ORT.EVariable(id, var)

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -1091,11 +1091,15 @@ let legacyReq
 
     let! response = client.SendAsync(message)
 
-    if response.StatusCode <> System.Net.HttpStatusCode.OK then
+    if response.StatusCode = System.Net.HttpStatusCode.OK then
+      ()
+    else if response.StatusCode = System.Net.HttpStatusCode.BadRequest then
+      // This is how errors are reported
+      let! content = response.Content.ReadAsStringAsync()
+      failwith content
+    else
       let! content = response.Content.ReadAsStringAsync()
       failwith $"not a 200 response to {endpoint}: {response.StatusCode}, {content}"
-    else
-      ()
 
     return response.Content
   }

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -1332,4 +1332,9 @@ let execute
   let str =
     Json.OCamlCompatible.serialize ((ownerID, canvasID, program, args, dbs, fns))
 
-  stringToDvalReq "execute" str
+  task {
+    try
+      let! result = stringToDvalReq "execute" str
+      return result
+    with e -> return (RT.DError(RT.SourceNone, e.Message))
+  }

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -345,7 +345,7 @@ let responseOfJson (dv : Dval) (j : JToken) : DHTTP =
              | JList [ JString k; JString v ] -> (k, v)
              | _ -> failwith "Invalid DHttpResponse headers")
 
-      Response(int code, headers, dv)
+      Response(bigint code, headers, dv)
   | _ -> failwith "invalid response json"
 
 #nowarn "104" // ignore warnings about enums out of range

--- a/fsharp-backend/src/LibExecution/Execution.fs
+++ b/fsharp-backend/src/LibExecution/Execution.fs
@@ -57,7 +57,7 @@ let extractHttpErrorRail (result : RT.Dval) : RT.Dval =
       // CLEANUP: result should become a 500 error
       (RT.DHttpResponse(
         RT.Response(
-          404,
+          404I,
           [ "Content-Length", "9"
             "Server", "darklang"
             "Content-Type", "text/plain; charset=utf-8" ],
@@ -67,7 +67,7 @@ let extractHttpErrorRail (result : RT.Dval) : RT.Dval =
   | RT.DErrorRail _ ->
       (RT.DHttpResponse(
         RT.Response(
-          500,
+          500I,
           [ "Content-Length", "33"
             "Server", "darklang"
             "Content-Type", "text/plain; charset=utf-8" ],

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -205,7 +205,7 @@ and FnValImpl =
 
 and DHTTP =
   | Redirect of string
-  | Response of int * List<string * string> * Dval
+  | Response of bigint * List<string * string> * Dval
 
 and Dval =
   | DInt of bigint

--- a/fsharp-backend/src/LibExecution/StdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibDict.fs
@@ -125,13 +125,13 @@ let fns : List<BuiltInFn> =
               match acc, e with
               | Some acc, DList [ DStr k; value ] when Map.containsKey k acc -> None
               | Some acc, DList [ DStr k; value ] -> Some(Map.add k value acc)
-              | Some _, DList [ k; _ ] ->
-                  Errors.throw (Errors.argumentWasnt "a string" "key" k)
-              | Some _, _ -> Errors.throw "All list items must be `[key, value]`"
               | _,
                 ((DIncomplete _
                 | DErrorRail _
                 | DError _) as dv) -> Errors.foundFakeDval dv
+              | Some _, DList [ k; _ ] ->
+                  Errors.throw (Errors.argumentWasnt "a string" "key" k)
+              | Some _, _ -> Errors.throw "All list items must be `[key, value]`"
               | None, _ -> None
 
             let result = List.fold f (Some Map.empty) l

--- a/fsharp-backend/src/LibExecution/StdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibDict.fs
@@ -398,6 +398,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DObj o ] ->
+            // CLEANUP: this prints invalid JSON for infinity and NaN
             DObj o |> DvalRepr.toPrettyMachineJsonStringV1 |> DStr |> Value
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO

--- a/fsharp-backend/src/LibExecution/StdLib/LibHttp.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibHttp.fs
@@ -29,7 +29,7 @@ let fns : List<BuiltInFn> =
         "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body."
       fn =
         (function
-        | _, [ dv; DInt code ] -> Value(DHttpResponse(Response(int code, [], dv)))
+        | _, [ dv; DInt code ] -> Value(DHttpResponse(Response(code, [], dv)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -41,7 +41,7 @@ let fns : List<BuiltInFn> =
         "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body."
       fn =
         (function
-        | _, [ dv; DInt code ] -> Value(DHttpResponse(Response(int code, [], dv)))
+        | _, [ dv; DInt code ] -> Value(DHttpResponse(Response(code, [], dv)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -69,7 +69,7 @@ let fns : List<BuiltInFn> =
                      | k, v ->
                          Errors.throw (Errors.argumentWasnt "a string" "value" v))
 
-            Value(DHttpResponse(Response(int code, pairs, dv)))
+            Value(DHttpResponse(Response(code, pairs, dv)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -94,7 +94,7 @@ let fns : List<BuiltInFn> =
                      | k, v ->
                          Errors.throw (Errors.argumentWasnt "a string" "value" v))
 
-            Value(DHttpResponse(Response(int code, pairs, dv)))
+            Value(DHttpResponse(Response(code, pairs, dv)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -106,7 +106,7 @@ let fns : List<BuiltInFn> =
         "Returns a Response that can be returned from an HTTP handler to respond with HTTP status 200 and `response` body."
       fn =
         (function
-        | _, [ dv ] -> Value(DHttpResponse(Response(200, [], dv)))
+        | _, [ dv ] -> Value(DHttpResponse(Response(200I, [], dv)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -120,9 +120,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ dv; DInt code ] ->
             Value(
-              DHttpResponse(
-                Response(int code, [ ("Content-Type", "text/html") ], dv)
-              )
+              DHttpResponse(Response(code, [ ("Content-Type", "text/html") ], dv))
             )
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
@@ -137,9 +135,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ dv; DInt code ] ->
             Value(
-              DHttpResponse(
-                Response(int code, [ ("Content-Type", "text/html") ], dv)
-              )
+              DHttpResponse(Response(code, [ ("Content-Type", "text/html") ], dv))
             )
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
@@ -154,9 +150,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ dv; DInt code ] ->
             Value(
-              DHttpResponse(
-                Response(int code, [ ("Content-Type", "text/plain") ], dv)
-              )
+              DHttpResponse(Response(code, [ ("Content-Type", "text/plain") ], dv))
             )
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
@@ -171,9 +165,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ dv; DInt code ] ->
             Value(
-              DHttpResponse(
-                Response(int code, [ ("Content-Type", "text/plain") ], dv)
-              )
+              DHttpResponse(Response(code, [ ("Content-Type", "text/plain") ], dv))
             )
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
@@ -189,7 +181,7 @@ let fns : List<BuiltInFn> =
         | _, [ dv; DInt code ] ->
             Value(
               DHttpResponse(
-                Response(int code, [ ("Content-Type", "application/json") ], dv)
+                Response(code, [ ("Content-Type", "application/json") ], dv)
               )
             )
         | _ -> incorrectArgs ())
@@ -206,7 +198,7 @@ let fns : List<BuiltInFn> =
         | _, [ dv; DInt code ] ->
             Value(
               DHttpResponse(
-                Response(int code, [ ("Content-Type", "application/json") ], dv)
+                Response(code, [ ("Content-Type", "application/json") ], dv)
               )
             )
         | _ -> incorrectArgs ())
@@ -232,7 +224,7 @@ let fns : List<BuiltInFn> =
         "Returns a Response that can be returned from an HTTP handler to respond with a 400 status and string `error` message."
       fn =
         (function
-        | _, [ msg ] -> Value(DHttpResponse(Response(400, [], msg)))
+        | _, [ msg ] -> Value(DHttpResponse(Response(400I, [], msg)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -244,7 +236,7 @@ let fns : List<BuiltInFn> =
         "Returns a Response that can be returned from an HTTP handler to respond with 404 Not Found."
       fn =
         (function
-        | _, [] -> Value(DHttpResponse(Response(404, [], DNull)))
+        | _, [] -> Value(DHttpResponse(Response(404I, [], DNull)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -256,7 +248,7 @@ let fns : List<BuiltInFn> =
         "Returns a Response that can be returned from an HTTP handler to respond with 401 Unauthorized."
       fn =
         (function
-        | _, [] -> Value(DHttpResponse(Response(401, [], DNull)))
+        | _, [] -> Value(DHttpResponse(Response(401I, [], DNull)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -268,7 +260,7 @@ let fns : List<BuiltInFn> =
         "Returns a Response that can be returned from an HTTP handler to respond with 403 Forbidden."
       fn =
         (function
-        | _, [] -> Value(DHttpResponse(Response(403, [], DNull)))
+        | _, [] -> Value(DHttpResponse(Response(403I, [], DNull)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecution/StdLib/LibJson.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibJson.fs
@@ -56,7 +56,10 @@ let fns : List<BuiltInFn> =
         "Parses a json string and returns its value. HTTPClient functions, and our request handler, automatically parse JSON into the `body` and `jsonbody` fields, so you probably won't need this. However, if you need to consume bad JSON, you can use string functions to fix the JSON and then use this function to parse it."
       fn =
         (function
-        | _, [ DStr json ] -> json |> DvalRepr.ofUnknownJsonV1 |> Value
+        | _, [ DStr json ] ->
+            try
+              json |> DvalRepr.ofUnknownJsonV1 |> Value
+            with e -> Value(DError(SourceNone, e.Message))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecution/StdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibList.fs
@@ -1030,8 +1030,8 @@ let fns : List<BuiltInFn> =
             let l2 = List.take (int len) l2
 
             List.zip l1 l2
-            |> List.map (fun (val1, val2) -> DList [ val1; val2 ])
-            |> DList
+            |> List.map (fun (val1, val2) -> Dval.list [ val1; val2 ])
+            |> Dval.list
             |> Value
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
@@ -1052,8 +1052,8 @@ let fns : List<BuiltInFn> =
               Value(DOption None)
             else
               List.zip l1 l2
-              |> List.map (fun (val1, val2) -> DList [ val1; val2 ])
-              |> DList
+              |> List.map (fun (val1, val2) -> Dval.list [ val1; val2 ])
+              |> Dval.list
               |> Some
               |> DOption
               |> Value

--- a/fsharp-backend/src/LibExecution/StdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibList.fs
@@ -167,7 +167,8 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "f" (TFn([ varA ], TBool)) "" [ "val" ] ]
       returnType = varA
       description =
-        "Returns the first value of `list` for which `f val` returns `true`. Returns `null` if no such value exists."
+        // CLEANUP: returns null, not Nothing
+        "Returns the first value of `list` for which `f val` returns `true`. Returns `Nothing` if no such value exists."
       fn =
         (function
         | state, [ DList l; DFnVal fn ] ->

--- a/fsharp-backend/src/LibExecution/StdLib/LibMiddleware.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibMiddleware.fs
@@ -490,7 +490,7 @@ let fns : List<BuiltInFn> =
                   response |> DvalRepr.toPrettyMachineJsonStringV1 |> toBytes
 
                 let headers = [ "content-type", inferContentType response ]
-                Value(DHttpResponse(Response(200, headers, DBytes bytes)))
+                Value(DHttpResponse(Response(200I, headers, DBytes bytes)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecution/StdLib/LibResult.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibResult.fs
@@ -219,7 +219,7 @@ let fns : List<BuiltInFn> =
                       NotInPipe
                       NoRail
 
-                  return DResult(Ok result)
+                  return DResult(Ok result) //FSTODO
             }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -46,6 +46,12 @@ let debug (msg : string) (a : 'a) : 'a =
   debuG msg a
   a
 
+// Print the value of s, alongside with length and the bytes in the string
+let debugString (msg : string) (s : string) : string =
+  let bytes = s |> System.Text.Encoding.UTF8.GetBytes |> System.BitConverter.ToString
+  printfn $"DEBUG: {msg} ('{s}': (len {s.Length}, {bytes})"
+  s
+
 // Print the value of `a`. Note that since this is wrapped in a task, it must
 // resolve the task before it can print, which could lead to different ordering
 // of operations.
@@ -113,6 +119,7 @@ let parseFloat (whole : string) (fraction : string) : float =
 // Given a float, read it correctly into two ints: whole number and fraction
 let readFloat (f : float) : (bigint * bigint) =
   let asStr = f.ToString("G53").Split "."
+
   if asStr.Length = 1 then
     parseBigint asStr.[0], 0I
   else

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -151,6 +151,21 @@ let sha1digest (input : string) : byte [] =
 
 let toString (v : 'a) : string = v.ToString()
 
+let truncateToInt32 (v : bigint) : int32 =
+  try
+    int32 v
+  with :? System.OverflowException ->
+    if v > 0I then System.Int32.MaxValue else System.Int32.MinValue
+
+let truncateToInt64 (v : bigint) : int64 =
+  try
+    int64 v
+  with :? System.OverflowException ->
+    if v > 0I then System.Int64.MaxValue else System.Int64.MinValue
+
+
+
+
 
 module Uuid =
   let nilNamespace : System.Guid = System.Guid "00000000-0000-0000-0000-000000000000"

--- a/fsharp-backend/src/Prelude/TableclothList.fs
+++ b/fsharp-backend/src/Prelude/TableclothList.fs
@@ -210,12 +210,6 @@ let sliding (step : int) (size : int) (l : 'a t) =
        let sample = takeAllOrEmpty t size ([], 0) in
        if isEmpty sample then [] else sample :: loop (List.skip step l)
 
-
-
-
-
-
-
    loop l : 'a t t)
 
 let chunksOf size l = sliding size size l

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -962,13 +962,25 @@ module ExecutePureFunctions =
                 "Expected a string representation of an IEEE float"
           | _ -> false
 
+        let debugFn () =
+          debuG "fn" fn
+          debuG "args" (List.map (fun (_, v) -> debugDval v) args)
+
+        if not (Expect.isCanonical expected) then
+          debugFn ()
+          debuG "ocaml (expected) is not normalized" (debugDval expected)
+          return false
+        else
+
+        if not (Expect.isCanonical actual) then
+          debugFn ()
+          debuG "fsharp (actual) is not normalized" (debugDval actual)
+          return false
+        else
+
         if dvalEquality actual expected then
           return true
         else
-          let debugFn () =
-            debuG "fn" fn
-            debuG "args" (List.map (fun (_, v) -> debugDval v) args)
-
           match actual, expected with
           | RT.DError (_, msg1), RT.DError (_, msg2) ->
               let allowed = errorAllowed msg1 msg2
@@ -989,8 +1001,9 @@ module ExecutePureFunctions =
               // FSTODO make false
               return true
           | _ ->
-              debuG "ocaml (expected)" expected
-              debuG "fsharp (actual) " actual
+              debugFn ()
+              debuG "ocaml (expected)" (debugDval expected)
+              debuG "fsharp (actual) " (debugDval actual)
               return false
       }
 

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -861,7 +861,7 @@ module ExecutePureFunctions =
                        | 1, RT.DInt i, [ RT.DInt e ], "", "+", 0
                        | 1, RT.DInt i, [ RT.DInt e ], "Int", "add", 0 ->
                            isValidOCamlInt (e + i)
-                       | 0, RT.DList l, [ RT.DInt e ], "Int", "sum", 0 ->
+                       | 0, RT.DList l, _, "Int", "sum", 0 ->
                            l
                            |> List.map
                                 (function

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -727,10 +727,16 @@ module ExecutePureFunctions =
                            (ApiServer.Functions.fsharpOnlyFns.Force())
                        ))
                 |> List.filter
+                     // FSTODO: all these differences should be removed
                      (function
-                     // FSTODO: These use a different sort order in OCaml
-                     | { name = { module_ = "List"; function_ = "sort" } } -> false
-                     | { name = { module_ = "List"; function_ = "sortBy" } } -> false
+                     | { name = { module_ = "List"; function_ = "sort" } }
+                     | { name = { module_ = "List"; function_ = "sortBy" } } ->
+                         // FSTODO: These use a different sort order in OCaml
+                         false
+                     | { name = { module_ = "Object"; function_ = "toJSON" } }
+                     | { name = { module_ = "Dict"; function_ = "toJSON" } } ->
+                         // Known formatting differences
+                         false
                      | { name = { module_ = "String"; function_ = "base64Decode" } } ->
                          // Don't know what the bug is
                          false

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -638,7 +638,14 @@ module ExecutePureFunctions =
                 let naughty =
                   naughtyStrings |> Lazy.force |> List.map Gen.constant |> Gen.oneof
 
-                let! v = Gen.frequency [ (7, naughty); (3, Arb.generate<string>) ]
+                let! v =
+                  Gen.frequency [ (7, naughty)
+                                  (3,
+                                   Arb.generate<UnicodeString>
+                                   |> Gen.map
+                                        (function
+                                        | UnicodeString s -> s)) ]
+
                 return RT.DStr v
             | RT.TVariable _ -> return! Arb.generate<RT.Dval>
             | RT.TFloat ->

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -513,7 +513,7 @@ module ExecutePureFunctions =
   let ocamlIntLowerLimit = -4611686018427387904I
 
   let isValidOCamlInt (i : bigint) : bool =
-    i < ocamlIntUpperLimit && i > ocamlIntLowerLimit
+    i <= ocamlIntUpperLimit && i >= ocamlIntLowerLimit
 
 
   type Generator =
@@ -577,12 +577,12 @@ module ExecutePureFunctions =
                 let! v = Arb.generate<bigint>
                 return RT.EInteger(gid (), v)
             | RT.TStr ->
-                let! v = Arb.generate<string>
+                let! v = Generators.string ()
                 return RT.EString(gid (), v)
             | RT.TChar ->
                 // We don't have a construct for characters, so create code to generate the character
                 let! str =
-                  Arb.generate<string> |> Gen.resize 1 |> Gen.filter ((<>) "")
+                  Generators.string () |> Gen.resize 1 |> Gen.filter ((<>) "")
 
                 return call "String" "toChar" 0 [ RT.EString(gid (), str) ]
             // Don't generate a random value as some random values are invalid
@@ -605,7 +605,7 @@ module ExecutePureFunctions =
                     (fun l -> RT.ERecord(gid (), l))
                     (Gen.listOfLength
                       s
-                      (Gen.zip Arb.generate<string> (genExpr' typ (s / 2))))
+                      (Gen.zip (Generators.string ()) (genExpr' typ (s / 2))))
             | RT.TOption typ ->
                 match! Gen.optionOf (genExpr' typ s) with
                 | Some v -> return RT.EConstructor(gid (), "Just", [ v ])
@@ -653,7 +653,7 @@ module ExecutePureFunctions =
                 let! v = Arb.generate<bigint>
                 return RT.DInt v
             | RT.TStr ->
-                let! v = Arb.generate<string>
+                let! v = Generators.string ()
                 return RT.DStr v
             | RT.TVariable _ ->
                 let rec supportedType =
@@ -690,7 +690,7 @@ module ExecutePureFunctions =
                     (fun l -> RT.DObj(Map.ofList l))
                     (Gen.listOfLength
                       s
-                      (Gen.zip Arb.generate<string> (genDval' typ (s / 2))))
+                      (Gen.zip (Generators.string ()) (genDval' typ (s / 2))))
             // | RT.TIncomplete -> return! Gen.map RT.TIncomplete Arb.generate<incomplete>
             // | RT.TError -> return! Gen.map RT.TError Arb.generate<error>
             // | RT.THttpResponse of DType -> return! Gen.map RT.THttpResponse  Arb.generate<httpresponse >

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -91,12 +91,7 @@ module Generators =
        |> List.filter (String.startsWith "#" >> not))
 
   let char () : Gen<string> =
-    string ()
-    |> Gen.map (debug "generated string")
-    |> Gen.map (String.take 1)
-    |> Gen.map (debug "resized string")
-    |> Gen.filter ((<>) "")
-    |> Gen.map (debug "filtered string")
+    string () |> Gen.map (String.take 1) |> Gen.filter ((<>) "")
 
 
 module G = Generators
@@ -709,10 +704,7 @@ module ExecutePureFunctions =
                       RT.DDate dt)
                     Arb.generate<System.DateTime>
             | RT.TChar ->
-                debuG "generating a dval" ""
-
                 let! v = G.char ()
-                debuG "generated a dval" v
                 return RT.DChar v
             // | RT.TPassword -> return! Gen.map RT.TPassword Arb.generate<password>
             | RT.TUuid -> return! Gen.map RT.DUuid Arb.generate<System.Guid>

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -929,6 +929,10 @@ module ExecutePureFunctions =
           | "Char::toASCIICode"
           | "Char::toASCIIChar"
           | "String::foreach" -> true
+          // Known acceptable difference
+          | "Object::toJSON"
+          | "Object::toJSON_v1"
+          | "Dict::toJSON" -> true
           // Messages are close-enough
           | "%"
           | "Int::mod" ->

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -158,4 +158,26 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
+      deprecated = NotDeprecated }
+    { name = fn "Test" "okWithTypeError" 0
+      parameters = [ Param.make "msg" TStr "" ]
+      returnType = TOption varA
+      description = "Returns a DError in an OK"
+      fn =
+        (function
+        | _, [ DStr msg ] -> Value(DResult(Ok(DError(SourceNone, msg))))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+    { name = fn "Test" "errorWithTypeError" 0
+      parameters = [ Param.make "msg" TStr "" ]
+      returnType = TOption varA
+      description = "Returns a DError in a Result.error"
+      fn =
+        (function
+        | _, [ DStr msg ] -> Value(DResult(Ok(DError(SourceNone, msg))))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
       deprecated = NotDeprecated } ]

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -147,4 +147,15 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
+      deprecated = NotDeprecated }
+    { name = fn "Test" "justWithTypeError" 0
+      parameters = [ Param.make "msg" TStr "" ]
+      returnType = TOption varA
+      description = "Returns a DError in a Just"
+      fn =
+        (function
+        | _, [ DStr msg ] -> Value(DOption(Some(DError(SourceNone, msg))))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
       deprecated = NotDeprecated } ]

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -671,7 +671,7 @@ let sampleDvals : List<string * Dval> =
          DErrorRail(DObj(Map.ofList ([ ("", DFloat nan); ("", DNull) ]))))
         ("redirect", DHttpResponse(Redirect "/home"))
         ("httpresponse",
-         DHttpResponse(Response(200, [ "content-length", "9" ], DStr "success")))
+         DHttpResponse(Response(200I, [ "content-length", "9" ], DStr "success")))
         ("db", DDB "Visitors")
         ("date", DDate(System.DateTime.ofIsoString "2018-09-14T00:31:41Z"))
         ("password", DPassword(Password(toBytes "somebytes")))

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -556,7 +556,8 @@ module Expect =
         check (msg1.Replace("_v0", "")) (msg2.Replace("_v0", ""))
     | DErrorRail l, DErrorRail r -> de l r
     | DFnVal (Lambda l1), DFnVal (Lambda l2) ->
-        check l1.parameters l2.parameters
+        let vals l = List.map Tuple2.second l
+        check (vals l1.parameters) (vals l2.parameters)
         check l1.symtable l2.symtable // TODO: use dvalEquality
         exprEqualityBaseFn false l1.body l2.body errorFn
 

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -57,7 +57,7 @@ let testToDeveloperRepr =
         "toDeveloperRepr string"
         DvalRepr.toDeveloperReprV0
         // Most of this is just the OCaml output and not really what the output should be
-        [ RT.DHttpResponse(RT.Response(0, [], RT.DNull)), "0 {  }\nnull"
+        [ RT.DHttpResponse(RT.Response(0I, [], RT.DNull)), "0 {  }\nnull"
           RT.DFloat(-0.0), "-0."
           RT.DFloat(infinity), "inf"
           RT.DObj(Map.ofList [ "", RT.DNull ]), "{ \n  : null\n}"
@@ -76,7 +76,7 @@ let testToEnduserReadable =
       RT.DFloat(-5.1), "-5.1"
       RT.DError(RT.SourceNone, "Some message"), "Error: Some message"
       RT.DHttpResponse(RT.Redirect("some url")), "302 some url\nnull"
-      RT.DHttpResponse(RT.Response(0, [ "a header", "something" ], RT.DNull)),
+      RT.DHttpResponse(RT.Response(0I, [ "a header", "something" ], RT.DNull)),
       "0 { a header: something }\nnull" ]
 
 module ToHashableRepr =
@@ -118,7 +118,7 @@ module ToHashableRepr =
         t
           (DList [ DUuid(System.Guid.Parse "3e64631e-f455-5d61-30f7-2be5794ebb19")
                    DStr "6"
-                   DResult(Ok(DHttpResponse(Response(0, [], DChar "")))) ])
+                   DResult(Ok(DHttpResponse(Response(0I, [], DChar "")))) ])
           "[ \n  <uuid: 3e64631e-f455-5d61-30f7-2be5794ebb19>, \"6\", ResultOk 0 {  }\n    ''\n]"
 
         t

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -54,16 +54,13 @@ let t
 
         if testOCaml then
           let! ocamlActual =
-            try
-              LibBackend.OCamlInterop.execute
-                state.program.accountID
-                state.program.canvasID
-                actualProg
-                Map.empty
-                dbs
-                (Map.values functions)
-            with e ->
-              failwith "When calling OCaml code, OCaml server failed: {msg}, {e}"
+            LibBackend.OCamlInterop.execute
+              state.program.accountID
+              state.program.canvasID
+              actualProg
+              Map.empty
+              dbs
+              (Map.values functions)
 
           if shouldEqual then
             Expect.equalDval

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -62,6 +62,8 @@ let t
               dbs
               (Map.values functions)
 
+          Expect.isTrue (Expect.isCanonical ocamlActual) "actual is normalized"
+
           if shouldEqual then
             Expect.equalDval
               (normalizeDvalResult ocamlActual)
@@ -78,6 +80,8 @@ let t
             Exe.executeExpr state Map.empty (actualProg.toRuntimeType ())
 
           let fsharpActual = normalizeDvalResult fsharpActual
+
+          Expect.isTrue (Expect.isCanonical fsharpActual) "expected is normalized"
 
           if shouldEqual then
             Expect.equalDval fsharpActual expected $"FSharp: {msg}"

--- a/fsharp-backend/tests/Tests/StdLib.Tests.fs
+++ b/fsharp-backend/tests/Tests/StdLib.Tests.fs
@@ -29,7 +29,40 @@ let equalsOCaml =
           RT.DFnVal(
             RT.Lambda { parameters = []; symtable = Map.empty; body = RT.EBlank 1UL }
           ) ]),
-       true) ]
+       true)
+      ((RT.FQFnName.stdlibFnName "Result" "fromOption" 0,
+        [ RT.DOption(
+            Some(
+              RT.DFnVal(
+                RT.Lambda
+                  { parameters = []
+                    symtable = Map.empty
+                    body = RT.EFloat(84932785UL, -9.223372037e+18) }
+              )
+            )
+          )
+          RT.DStr "s" ]),
+       true)
+      ((RT.FQFnName.stdlibFnName "Result" "fromOption" 0,
+        [ RT.DOption(
+            Some(
+              RT.DFnVal(
+                RT.Lambda
+                  { parameters = []
+                    symtable = Map.empty
+                    body =
+                      RT.EMatch(
+                        gid (),
+                        RT.ENull(gid ()),
+                        [ (RT.PFloat(gid (), -9.223372037e+18), RT.ENull(gid ())) ]
+                      ) }
+              )
+            )
+          )
+          RT.DStr "s" ]),
+       true)
+
+      ]
 
 let oldFunctionsAreDeprecated =
   test "old functions are deprecated" {

--- a/fsharp-backend/tests/testfiles/dict.tests
+++ b/fsharp-backend/tests/testfiles/dict.tests
@@ -32,6 +32,7 @@ Dict.fromList_v0 [[1;1]] = Test.typeError_v0 "Expected the argument `key` to be 
 Dict.fromList_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "Expected every value within the `entries` argument passed to `Dict::fromList` to be a `[key, value]` list. However, that is not the case for the value at index 1: `2`. It is of type `Int` instead of `List`." // OCAMLONLY
 Dict.fromList_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "All list items must be `[key, value]`" // FSHARPONLY
 Dict.fromList_v0 [] = Just {}
+Dict.fromList_v0 [Test.typeError_v0 ""] = Test.typeError_v0 ""
 
 Dict.get_v0 { key1 = "val1" } "key1" = "val1"
 

--- a/fsharp-backend/tests/testfiles/dict.tests
+++ b/fsharp-backend/tests/testfiles/dict.tests
@@ -68,6 +68,12 @@ Dict.size_v0 {} = 0
 
 Dict.toJSON_v0 { key1 = "val1"; key2 = "val2"; } = "{ \"key1\": \"val1\", \"key2\": \"val2\" }" // OCAMLONLY
 Dict.toJSON_v0 { key1 = "val1"; key2 = "val2"; } = "{\n  \"key1\": \"val1\",\n  \"key2\": \"val2\"\n}" //FSHARPONLY
+Dict.toJSON_v0 { key1 = Test.infinity_v0 } = "{ \"key1\": Infinity }" // OCAMLONLY
+Dict.toJSON_v0 { key1 = Test.infinity_v0 } = "{\n  \"key1\": Infinity\n}" // FSHARPONLY
+Dict.toJSON_v0 { key1 = Test.negativeInfinity_v0 } = "{ \"key1\": -Infinity }" // OCAMLONLY
+Dict.toJSON_v0 { key1 = Test.negativeInfinity_v0 } = "{\n  \"key1\": -Infinity\n}" // FSHARPONLY
+Dict.toJSON_v0 { key1 = Test.nan_v0 } = "{ \"key1\": NaN }" // OCAMLONLY
+Dict.toJSON_v0 { key1 = Test.nan_v0 } = "{\n  \"key1\": NaN\n}" // FSHARPONLY
 
 Dict.toList_v0 { a = 1; b = 2; c = 3 } = [ [ "a"; 1 ], [ "b"; 2 ], [ "c"; 3 ]]
 Dict.toList_v0 {} = []

--- a/fsharp-backend/tests/testfiles/dict.tests
+++ b/fsharp-backend/tests/testfiles/dict.tests
@@ -21,6 +21,7 @@ Dict.fromListOverwritingDuplicates_v0 [[1;1]] = Test.typeError_v0 "Expected ever
 Dict.fromListOverwritingDuplicates_v0 [[1;1]] = Test.typeError_v0 "Expected the argument `key` to be a string, but it was `1`" // FSHARPONLY
 Dict.fromListOverwritingDuplicates_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "Expected every value within the `entries` argument passed to `Dict::fromListOverwritingDuplicates` to be a `[key, value]` list. However, that is not the case for the value at index 1: `2`. It is of type `Int` instead of `List`."" // OCAMLONLY
 Dict.fromListOverwritingDuplicates_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "All list items must be `[key, value]`" // FSHARPONLY
+Dict.fromListOverwritingDuplicates_v0 [Test.typeError_v0 ""] = Test.typeError_v0 ""
 
 Dict.fromList_v0 [["a";1];["b";2];["a";3]] = Nothing // duplicate key
 Dict.fromList_v0 [["a";1];["b";2];["c";3]] = Just { c = 3; b = 2; a = 1 }

--- a/fsharp-backend/tests/testfiles/http.tests
+++ b/fsharp-backend/tests/testfiles/http.tests
@@ -49,18 +49,28 @@ Http.success_v0 {``Content-Length`` = 0; Server = "darklang"} = Http.response_v0
 
 Http.respondWithHtml_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/html"} 200
 Http.respondWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/html"} 200
+Http.respondWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/html"} 4503599627370496I
 
 Http.responseWithHtml_v0 {test = "test1"}  200 = Http.responseWithHeaders_v0 {test = "test1"}  {``Content-Type`` = "text/html"} 200
 Http.responseWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/html"} 200
+Http.responseWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/html"} 4503599627370496I
 
+Http.respondWithText_v0 "value" 200 = Http.responseWithHeaders_v0 "value" {``Content-Type`` = "text/plain"} 200
 Http.respondWithText_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/plain"} 200
 Http.respondWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 200
+Http.respondWithText_v0 "" 4503599627370496I = Http.responseWithHeaders_v0 "" {``Content-Type`` = "text/plain"} 4503599627370496I
 
 Http.responseWithText_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/plain"} 200
 Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 200
+Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 4503599627370496I
 
 Http.respondWithJson_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "application/json"} 200
 Http.respondWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "application/json"} 200
+Http.respondWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "application/json"} 4503599627370496I
 
 Http.responseWithJson_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "application/json"} 200
 Http.responseWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "application/json"} 200
+Http.responseWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "application/json"} 4503599627370496I
+
+((Http.response_v0 "" 4503599627370496I) |> toString) = "4503599627370496 {  }\n\"\""
+((Http.respond_v0 "" 4503599627370496I) |> toString) = "4503599627370496 {  }\n\"\""

--- a/fsharp-backend/tests/testfiles/http.tests
+++ b/fsharp-backend/tests/testfiles/http.tests
@@ -59,7 +59,7 @@ Http.respondWithText_v0 "value" 200 = Http.responseWithHeaders_v0 "value" {``Con
 Http.respondWithText_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/plain"} 200
 Http.respondWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 200
 Http.respondWithText_v0 "" 4503599627370496I = Http.responseWithHeaders_v0 "" {``Content-Type`` = "text/plain"} 4503599627370496I
-Http.respondWithText_v0 null -1 = Http.responseWithHeaders_v0 {``Content-Type`: "text/plain"} -1 null
+Http.respondWithText_v0 "value" (-1) = Http.responseWithHeaders_v0 "value" {``Content-Type`` = "text/plain"} (-1)
 
 Http.responseWithText_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/plain"} 200
 Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 200

--- a/fsharp-backend/tests/testfiles/http.tests
+++ b/fsharp-backend/tests/testfiles/http.tests
@@ -59,6 +59,7 @@ Http.respondWithText_v0 "value" 200 = Http.responseWithHeaders_v0 "value" {``Con
 Http.respondWithText_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/plain"} 200
 Http.respondWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 200
 Http.respondWithText_v0 "" 4503599627370496I = Http.responseWithHeaders_v0 "" {``Content-Type`` = "text/plain"} 4503599627370496I
+Http.respondWithText_v0 null -1 = Http.responseWithHeaders_v0 {``Content-Type`: "text/plain"} -1 null
 
 Http.responseWithText_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/plain"} 200
 Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromList_ster ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 200

--- a/fsharp-backend/tests/testfiles/json.tests
+++ b/fsharp-backend/tests/testfiles/json.tests
@@ -25,6 +25,8 @@ JSON.parse_v0 "{Id : 1.}" = {Id = 1.0} // FSHARPONLY
 JSON.parse_v0 "[ {date : \"2013-11-05\", locations : {Japan: 3, Germany: 1}} ]" = [ {date = "2013-11-05"; locations = {Japan = 3; Germany = 1}} ]
 JSON.parse_v0 "{id : 555, edition : \"First\", author : \"Dennis Ritchie\"}" = {id = 555; edition = "First"; author = "Dennis Ritchie"}
 JSON.parse_v0 "\"\"" = ""
+JSON.parse_v0 "" = Test.typeError_v0 "Json Err: Blank input data" // OCAMLONLY
+JSON.parse_v0 "" = Test.typeError_v0 "Invalid type in json: " // FSHARPONLY
 
 JSON.parse_v1 "[97, 2, 30, 4]" = Ok [97, 2, 30, 4]
 JSON.parse_v1 "[97, 2, 30, 4,]" = Error "Json Err: Line 1, bytes 14-15:\nInvalid token ']'" // OCAMLONLY

--- a/fsharp-backend/tests/testfiles/json.tests
+++ b/fsharp-backend/tests/testfiles/json.tests
@@ -9,33 +9,48 @@ JSON.read_v0 "{id : 555, edition : \"First\", author : \"Dennis Ritchie\"}" = {i
 JSON.read_v0 "({id : 555, edition : \"First\", author : \"Dennis Ritchie\"})" = null
 JSON.read_v0 "" = null
 JSON.read_v0 "\"\"" = ""
+JSON.read_v0 "1,0/0,0" = null // OCAMLONLY
+JSON.read_v0 "1" = 1 // FSHARPONLY
 
 JSON.read_v1 "[97, 2, 30, 4]" = [97, 2, 30, 4]
+JSON.read_v1 "[97, 2, 30, 4,]" = Test.typeError "Json Err: Line 1, bytes 14-15:\nInvalid token ']'" // OCAMLONLY
 JSON.read_v1 "[97, 2, 30, 4,]" = [97, 2, 30, 4] // FSHARPONLY
 JSON.read_v1 "{Id : 1.0}" = {Id = 1.0}
+JSON.read_v1 "{Id : 1.}" = Test.typeError "Json Err: Line 1, bytes 7-9:\nExpected ',' or '}' but found '.}'" // OCAMLONLY
 JSON.read_v1 "{Id : 1.}" = {Id = 1.0} // FSHARPONLY
 JSON.read_v1 "[ {date : \"2013-11-05\", locations : {Japan: 3, Germany: 1}} ]" = [ {date = "2013-11-05"; locations = {Japan = 3; Germany = 1}} ]
 JSON.read_v1 "{id : 555, edition : \"First\", author : \"Dennis Ritchie\"}" = {id = 555; edition = "First"; author = "Dennis Ritchie"}
 JSON.read_v1 "\"\"" = ""
 
 JSON.parse_v0 "[97, 2, 30, 4]" = [97, 2, 30, 4]
+JSON.parse_v0 "[97, 2, 30, 4,]" = Test.typeError "Json Err: Line 1, bytes 14-15:\nInvalid token ']'" // OCAMLONLY
 JSON.parse_v0 "[97, 2, 30, 4,]" = [97, 2, 30, 4] // FSHARPONLY
 JSON.parse_v0 "{Id : 1.0}" = {Id = 1.0}
+JSON.parse_v0 "{Id : 1.}" = Test.typeError_v0 "Json Err: Line 1, bytes 7-9:\nExpected ',' or '}' but found '.}'" // OCAMLONLY // OCAMLONLY
 JSON.parse_v0 "{Id : 1.}" = {Id = 1.0} // FSHARPONLY
 JSON.parse_v0 "[ {date : \"2013-11-05\", locations : {Japan: 3, Germany: 1}} ]" = [ {date = "2013-11-05"; locations = {Japan = 3; Germany = 1}} ]
 JSON.parse_v0 "{id : 555, edition : \"First\", author : \"Dennis Ritchie\"}" = {id = 555; edition = "First"; author = "Dennis Ritchie"}
 JSON.parse_v0 "\"\"" = ""
+JSON.parse_v0 "''" = Test.typeError_v0 "Json Err: Line 1, bytes 0-2:\nInvalid token ''''" // OCAMLONLY
+JSON.parse_v0 "''" = "" // FSHARPONLY
 JSON.parse_v0 "" = Test.typeError_v0 "Json Err: Blank input data" // OCAMLONLY
 JSON.parse_v0 "" = Test.typeError_v0 "Invalid type in json: " // FSHARPONLY
 
+// FSTODO all of these weird things that JSON.net allows are ridiculous, we shouldn't expose them.
 JSON.parse_v1 "[97, 2, 30, 4]" = Ok [97, 2, 30, 4]
 JSON.parse_v1 "[97, 2, 30, 4,]" = Error "Json Err: Line 1, bytes 14-15:\nInvalid token ']'" // OCAMLONLY
 JSON.parse_v1 "[97, 2, 30, 4,]" = Ok [97, 2, 30, 4] // FSHARPONLY
-JSON.parse_v1 "{Id : 1.0}" = Ok {Id = 1.0}
+JSON.parse_v1 "{Id : 1.0}" = Ok { Id = 1.0 }
+JSON.parse_v1 "{Id : true}" = Ok { Id = true }
+JSON.parse_v1 "{Id : Infinity }" = Ok { Id = Test.infinity_v0 }
+JSON.parse_v1 "{Id : -Infinity }" = Ok { Id = Test.negativeInfinity_v0 }
+JSON.parse_v1 "{Id : NaN }" = Ok { Id = Test.nan_v0 }
 JSON.parse_v1 "{Id : 1.}" = Error "Json Err: Line 1, bytes 7-9:\nExpected ',' or '}' but found '.}'" // OCAMLONLY
 JSON.parse_v1 "{Id : 1.}" = Ok {Id = 1.0} // FSHARPONLY
 JSON.parse_v1 "[ {date : \"2013-11-05\", locations : {Japan: 3, Germany: 1}} ]" = Ok [ {date = "2013-11-05"; locations = {Japan = 3; Germany = 1}} ]
 JSON.parse_v1 "{id : 555, edition : \"First\", author : \"Dennis Ritchie\"}" = Ok {id = 555; edition = "First"; author = "Dennis Ritchie"}
+JSON.parse_v1 "{id : 555, edition : 'First' }" = Error "Json Err: Line 1, bytes 21-30:\nInvalid token ''First' }'" // OCAMLONLY
+JSON.parse_v1 "{id : 555, edition : 'First' }" = Ok {id = 555; edition = "First"} // FSHARPONLY
 JSON.parse_v1 "({id : 555, edition : \"First\", author : \"Dennis Ritchie\"})" = Error "Dark Exception.DarkInternal Err: We dont use tuples" // OCAMLONLY
 JSON.parse_v1 "({id : 555, edition : \"First\", author : \"Dennis Ritchie\"})" = Error "Invalid type in json: ({id : 555, edition : \"First\", author : \"Dennis Ritchie\"})" // FSHARPONLY
 JSON.parse_v1 "\"\"" = Ok ""

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -17,6 +17,9 @@
     (String.toList_v1 "some string")
     (fun var -> String.toUppercase_v0 (String.fromChar_v1 var))) "") = "SOME STRING"
 
+[test.lambdaFloat]
+List.push_v0 [] (fun x -> -4.611686018e+18) = [(fun x -> -4.611686018e+18)]
+
 [test.matchInt]
 (match 5 with
 | 5 -> "int"

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -242,9 +242,9 @@ List.unzip_v0 [[10;6]] = [[10],[6]]
 List.zipShortest_v0 [10;20;30] [1;2;3] = [ [ 10, 1 ], [ 20, 2 ], [ 30, 3 ] ]
 List.zipShortest_v0 [10;20] [1;2;3] = [ [ 10, 1 ], [ 20, 2 ] ]
 List.zipShortest_v0 ["b";"v";"z"] [] = []
-List.zipShortest_v0 [Test.typeError_v0 ""] [Just ""] = Test.typeError ""
+List.zipShortest_v0 [Test.typeError_v0 ""] [Just ""] = Test.typeError_v0 ""
 
 List.zip_v0 [10;20;30] [1;2;3] = Just [ [ 10, 1 ], [ 20, 2 ], [ 30, 3 ] ]
 List.zip_v0 [10;20] [1;2;3] = Nothing
 List.zip_v0 [] [] = Just []
-List.zip_v0 [Test.typeError_v0 ""] [Just ""] = (Test.justWithTypeError "")
+List.zip_v0 [Test.typeError_v0 ""] [Just ""] = Test.justWithTypeError_v0 ""

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -242,7 +242,9 @@ List.unzip_v0 [[10;6]] = [[10],[6]]
 List.zipShortest_v0 [10;20;30] [1;2;3] = [ [ 10, 1 ], [ 20, 2 ], [ 30, 3 ] ]
 List.zipShortest_v0 [10;20] [1;2;3] = [ [ 10, 1 ], [ 20, 2 ] ]
 List.zipShortest_v0 ["b";"v";"z"] [] = []
+List.zipShortest_v0 [Test.typeError_v0 ""] [Just ""] = Test.typeError ""
 
 List.zip_v0 [10;20;30] [1;2;3] = Just [ [ 10, 1 ], [ 20, 2 ], [ 30, 3 ] ]
 List.zip_v0 [10;20] [1;2;3] = Nothing
 List.zip_v0 [] [] = Just []
+List.zip_v0 [Test.typeError_v0 ""] [Just ""] = (Test.justWithTypeError "")

--- a/fsharp-backend/tests/testfiles/object.tests
+++ b/fsharp-backend/tests/testfiles/object.tests
@@ -7,6 +7,18 @@ Object.merge_v0 {} {} = {}
 
 Object.toJSON_v0 { key1 = "val1"; key2 = "val2"; } = "{ \"key1\": \"val1\", \"key2\": \"val2\" }" // OCAMLONLY
 Object.toJSON_v0 { key1 = "val1"; key2 = "val2"; } = "{\n  \"key1\": \"val1\",\n  \"key2\": \"val2\"\n}" //FSHARPONLY
+Object.toJSON_v0 { key1 = Test.infinity_v0 } = "{ \"key1\": Infinity }" // OCAMLONLY
+Object.toJSON_v0 { key1 = Test.infinity_v0 } = "{\n  \"key1\": Infinity\n}" // FSHARPONLY
+Object.toJSON_v0 { key1 = Test.negativeInfinity_v0 } = "{ \"key1\": -Infinity }" // OCAMLONLY
+Object.toJSON_v0 { key1 = Test.negativeInfinity_v0 } = "{\n  \"key1\": -Infinity\n}" // FSHARPONLY
+Object.toJSON_v0 { key1 = Test.nan_v0 } = "{ \"key1\": NaN }" // OCAMLONLY
+Object.toJSON_v0 { key1 = Test.nan_v0 } = "{\n  \"key1\": NaN\n}" // FSHARPONLY
 
 Object.toJSON_v1 { key1 = "val1"; key2 = "val2"; } = "{ \"key1\": \"val1\", \"key2\": \"val2\" }" // OCAMLONLY
 Object.toJSON_v1 { key1 = "val1"; key2 = "val2"; } = "{\n  \"key1\": \"val1\",\n  \"key2\": \"val2\"\n}" //FSHARPONLY
+Object.toJSON_v1 { key1 = Test.infinity_v0 } = "{ \"key1\": Infinity }" // OCAMLONLY
+Object.toJSON_v1 { key1 = Test.infinity_v0 } = "{\n  \"key1\": Infinity\n}" // FSHARPONLY
+Object.toJSON_v1 { key1 = Test.negativeInfinity_v0 } = "{ \"key1\": -Infinity }" // OCAMLONLY
+Object.toJSON_v1 { key1 = Test.negativeInfinity_v0 } = "{\n  \"key1\": -Infinity\n}" // FSHARPONLY
+Object.toJSON_v1 { key1 = Test.nan_v0 } = "{ \"key1\": NaN }" // OCAMLONLY
+Object.toJSON_v1 { key1 = Test.nan_v0 } = "{\n  \"key1\": NaN\n}" // FSHARPONLY

--- a/fsharp-backend/tests/testfiles/result.tests
+++ b/fsharp-backend/tests/testfiles/result.tests
@@ -20,6 +20,8 @@ Result.fromOption_v1 (Just 6) "test" = Ok 6
 Result.fromOption_v1 Nothing "test" = Error "test"
 Result.fromOption_v1 (Just (Error "test")) "test" = Ok (Error "test")
 Result.fromOption_v1 blank "test" = blank
+Result.fromOption_v1 (Test.justWithTypeError_v0 "err") "msg" = Test.typeError_v0 "err"
+
 
 Result.map2_v0 (Error "error1") (Error "error2") (fun (a, b) -> a - b) = Error "error1"
 Result.map2_v0 (Error "error1") (Ok 1) (fun (a, b) -> a - b) = Error "error1"

--- a/fsharp-backend/tests/testfiles/result.tests
+++ b/fsharp-backend/tests/testfiles/result.tests
@@ -44,9 +44,13 @@ Result.map_v1 blank (fun x -> Int.divide_v0 x 2) = blank
 
 Result.toOption_v0 (Error "test") = Nothing
 Result.toOption_v0 (Ok 6) = Just 6
+Result.toOption_v0 (Error Test.errorRailNothing_v0) = Test.errorrailNothing_v0
+Result.toOption_v0 (Ok Test.errorRailNothing_v0) = Test.errorRailNothing_v0
 
 Result.toOption_v1 (Error "test") = Nothing
 Result.toOption_v1 blank = blank
+Result.toOption_v1 (Error Test.errorRailNothing_v0) = Test.errorRailNothing_v0
+Result.toOption_v1 (Ok Test.errorRailNothing_v0) = Test.errorRailNothing_v0
 
 Result.withDefault_v0 (Error "test") 5 = 5
 Result.withDefault_v0 (Ok 6) 5 = 6

--- a/fsharp-backend/tests/testfiles/result.tests
+++ b/fsharp-backend/tests/testfiles/result.tests
@@ -44,7 +44,7 @@ Result.map_v1 blank (fun x -> Int.divide_v0 x 2) = blank
 
 Result.toOption_v0 (Error "test") = Nothing
 Result.toOption_v0 (Ok 6) = Just 6
-Result.toOption_v0 (Error Test.errorRailNothing_v0) = Test.errorrailNothing_v0
+Result.toOption_v0 (Error Test.errorRailNothing_v0) = Test.errorRailNothing_v0
 Result.toOption_v0 (Ok Test.errorRailNothing_v0) = Test.errorRailNothing_v0
 
 Result.toOption_v1 (Error "test") = Nothing

--- a/fsharp-backend/tests/testfiles/result.tests
+++ b/fsharp-backend/tests/testfiles/result.tests
@@ -27,6 +27,7 @@ Result.map2_v0 (Error "error1") (Error "error2") (fun (a, b) -> a - b) = Error "
 Result.map2_v0 (Error "error1") (Ok 1) (fun (a, b) -> a - b) = Error "error1"
 Result.map2_v0 (Ok 10) (Error "error2") (fun (a, b) -> a - b) = Error "error2"
 Result.map2_v0 (Ok 10) (Ok 1) (fun (a, b) -> a - b) = Ok 9
+Result.map2_v0 (Ok (Test.typeError_v0 "")) (Ok 1) (fun (a, b) -> a - b) = Test.typeError_v0 ""
 
 Result.mapError_v0 (Error "test") (fun x -> String.append_v0 x "-appended") = Error "test-appended"
 Result.mapError_v0 (Ok 4) (fun x -> Int.divide_v0 x 2) = Ok 4

--- a/fsharp-backend/tests/testfiles/result.tests
+++ b/fsharp-backend/tests/testfiles/result.tests
@@ -27,7 +27,7 @@ Result.map2_v0 (Error "error1") (Error "error2") (fun (a, b) -> a - b) = Error "
 Result.map2_v0 (Error "error1") (Ok 1) (fun (a, b) -> a - b) = Error "error1"
 Result.map2_v0 (Ok 10) (Error "error2") (fun (a, b) -> a - b) = Error "error2"
 Result.map2_v0 (Ok 10) (Ok 1) (fun (a, b) -> a - b) = Ok 9
-Result.map2_v0 (Ok (Test.typeError_v0 "")) (Ok 1) (fun (a, b) -> a - b) = Test.typeError_v0 ""
+Result.map2_v0 (Ok (Test.typeError_v0 "")) (Ok 1) (fun (a, b) -> a - b) = Test.typeError_v0 "Fn called with an error as an argument"
 
 Result.mapError_v0 (Error "test") (fun x -> String.append_v0 x "-appended") = Error "test-appended"
 Result.mapError_v0 (Ok 4) (fun x -> Int.divide_v0 x 2) = Ok 4

--- a/fsharp-backend/tests/testfiles/result.tests
+++ b/fsharp-backend/tests/testfiles/result.tests
@@ -12,28 +12,38 @@ Result.andThen_v1 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expected
 Result.andThen_v1 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expecting the function to return Result, but the result was 4" // FSHARPONLY
 Result.andThen_v1 (Ok 5) (fun x -> [blank]) = Test.typeError_v0 "Expected `f` to return a result" // OCAMLONLY
 Result.andThen_v1 (Ok 5) (fun x -> [blank]) = Test.typeError_v0 "Expecting the function to return Result, but the result was []" // FSHARPONLY
+
 Result.fromOption_v0 (Just 6) "test" = Ok 6
 Result.fromOption_v0 Nothing "test" = Error "test"
+
 Result.fromOption_v1 (Just 6) "test" = Ok 6
 Result.fromOption_v1 Nothing "test" = Error "test"
 Result.fromOption_v1 (Just (Error "test")) "test" = Ok (Error "test")
 Result.fromOption_v1 blank "test" = blank
+
 Result.map2_v0 (Error "error1") (Error "error2") (fun (a, b) -> a - b) = Error "error1"
 Result.map2_v0 (Error "error1") (Ok 1) (fun (a, b) -> a - b) = Error "error1"
 Result.map2_v0 (Ok 10) (Error "error2") (fun (a, b) -> a - b) = Error "error2"
 Result.map2_v0 (Ok 10) (Ok 1) (fun (a, b) -> a - b) = Ok 9
+
 Result.mapError_v0 (Error "test") (fun x -> String.append_v0 x "-appended") = Error "test-appended"
 Result.mapError_v0 (Ok 4) (fun x -> Int.divide_v0 x 2) = Ok 4
+
 Result.mapError_v1 (Error "test") (fun x -> String.append_v0 x "-appended") = Error "test-appended"
 Result.mapError_v1 (Ok 4) (fun x -> Int.divide_v0 x 2) = Ok 4
+
 Result.map_v0 (Error "test") (fun x -> Int.divide_v0 x 2) = Error "test"
 Result.map_v0 (Ok 4) (fun x -> Int.divide_v0 x 2) = Ok 2
+
 Result.map_v1 (Error "test") (fun x -> Int.divide_v0 x 2) = Error "test"
 Result.map_v1 (Ok 4) (fun x -> Int.divide_v0 x 2) = Ok 2
 Result.map_v1 blank (fun x -> Int.divide_v0 x 2) = blank
+
 Result.toOption_v0 (Error "test") = Nothing
 Result.toOption_v0 (Ok 6) = Just 6
+
 Result.toOption_v1 (Error "test") = Nothing
 Result.toOption_v1 blank = blank
+
 Result.withDefault_v0 (Error "test") 5 = 5
 Result.withDefault_v0 (Ok 6) 5 = 6

--- a/fsharp-backend/tests/testfiles/string.tests
+++ b/fsharp-backend/tests/testfiles/string.tests
@@ -466,12 +466,12 @@ String.toUppercase_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿" = "👱👱
 String.toUppercase_v0 "🧟‍♀️🧟‍♂️" = "🧟‍♀️🧟‍♂️"
 String.toUppercase_v0 "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
 String.toUppercase_v0 "żółw🧑🏽‍🦰🧑🏻‍🍼✋✋🏻✋🏿" = "żółW🧑🏽‍🦰🧑🏻‍🍼✋✋🏻✋🏿"
+String.toUppercase_v0 "`⁄€‹›ﬁﬂ‡°·‚—±" = "`⁄€‹›ﬁﬂ‡°·‚—±"
 String.toUppercase_v0 "ჾ" = "ჾ"
 
 String.toUppercase_v0 "z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇" = "Z̤͔ͧ̑̓ä͖̭̈̇Lͮ̒ͫǧ̗͚̚O̙̔ͮ̇͐̇"
 
 String.toUppercase_v0 "H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕" = "H̬̤̗̤͝E͜ ̜̥̝̻͍̟́W̕H̖̯͓O̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭A̺̪͍į͈͕̭͙̯̜T̶̼̮S̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅE̵H̵̬͇̫͙I̹͓̳̳̮͎̫̕N͟D̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢H͏͓̮̻E̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅA͏͓͔̹̼̣L̴͔̰̤̟͔ḽ̫.͕"
-
 
 
 String.toUppercase_v1 "" = ""
@@ -489,6 +489,7 @@ String.toUppercase_v1 "🧟‍♀️🧟‍♂️" = "🧟‍♀️🧟‍♂️
 String.toUppercase_v1 "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
 String.toUppercase_v1 "żółw🧑🏽‍🦰🧑🏻‍🍼✋✋🏻✋🏿" = "ŻÓŁW🧑🏽‍🦰🧑🏻‍🍼✋✋🏻✋🏿"
 String.toUppercase_v1 "ჾ" = "Ჾ"
+//String.toUppercase_v1 "`⁄€‹›ﬁﬂ‡°·‚—±" = "`⁄€‹›FIFL‡°·‚—±"
 
 String.toUppercase_v1 "z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇" = "Z̤͔ͧ̑̓Ä͖̭̈̇Lͮ̒ͫǦ̗͚̚O̙̔ͮ̇͐̇"
 

--- a/fsharp-backend/tests/testfiles/string.tests
+++ b/fsharp-backend/tests/testfiles/string.tests
@@ -549,6 +549,8 @@ String.trim_v0 " 👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍�
 String.trim_v0 "          żółw🧑🏽‍🦰🧑🏻‍🍼✋✋🏻✋🏿" = "żółw🧑🏽‍🦰🧑🏻‍🍼✋✋🏻✋🏿"
 String.trim_v0 " \xe2\x80\x83foo\xe2\x80\x83bar\xe2\x80\x83 " = "\xe2\x80\x83foo\xe2\x80\x83bar\xe2\x80\x83"
 String.trim_v0 " \xf0\x9f\x98\x84foobar\xf0\x9f\x98\x84 " = "\xf0\x9f\x98\x84foobar\xf0\x9f\x98\x84"
+String.trim_v0 "쉆ꥨ逴皪巌䖑ⱝዓ淋" = "쉆ꥨ逴皪巌䖑ⱝዓ淋" // FSHARPONLY - this one is correct
+String.trim_v0 "쉆ꥨ逴皪巌䖑ⱝዓ淋" = "ꥨ쉆逴皪巌䖑ⱝዓ淋" // OCAMLONLY -- CLEANUP
 
 String.reverse_v0 "abcde" = "edcba"
 String.reverse_v0 "0abcde" = "edcba0"

--- a/scripts/format
+++ b/scripts/format
@@ -97,91 +97,102 @@ is_allowed() {
 }
 
 all_prettier_files() {
-  find "$1" -type f \
+  find "$1" \
+    \( -path ".git" \
+    -o -path "_build" \
+    -o -path "./_build" \
+    -o -path "node_modules" \
+    -o -path "./node_modules" \
+    -o -path "_esy" \
+    -o -path "./_esy" \
+    -o -path "/home/dark/.esy" \
+    -o -path "esy.lock" \
+    -o -path "fsharp-backend" \
+    -o -path "backend/static" \
+    -o -path "./backend/static" \
+    -o -path "client/static/vendor" \
+    -o -path "./client/static/vendor" \
+    -o -path "lib" \
+    -o -path "./lib" \
+    -o -path "fsharp-backend/.paket" \
+    -o -path "./fsharp-backend/.paket" \
+    -o -path "fsharp-backend/Build" \
+    -o -path "./fsharp-backend/Build" \
+    \) -prune -false \
+    \
+    -o -type f \
     \( -name "*.css" \
     -o -name "*.scss" \
     -o -name "*.js" \
-    -o -name "*.html" \) -print0 \
-    -o -path ".git" -prune \
-    -o -path "_build" -prune \
-    -o -path "./_build" -prune \
-    -o -path "node_modules" -prune \
-    -o -path "./node_modules" -prune \
-    -o -path "backend/static" -prune \
-    -o -path "./backend/static" -prune \
-    -o -path "client/static/vendor" -prune \
-    -o -path "./client/static/vendor" -prune \
-    -o -path "_esy" -prune \
-    -o -path "./_esy" -prune \
-    -o -path "/home/dark/.esy" -prune \
-    -o -path "lib" -prune \
-    -o -path "./lib" -prune \
-    -o -path "fsharp-backend/.paket" -prune \
-    -o -path "./fsharp-backend/.paket" -prune \
-    -o -path "fsharp-backend/Build" -prune \
-    -o -path "./fsharp-backend/Build" -prune \
-  | grep --null-data --invert-match reset-normalize
+    -o -name "*.html" \
+    \) -print0 \
+    | grep --null-data --invert-match reset-normalize
 }
 
 all_ocaml_files() {
-  find "$1" -type f \
+  find "$1" \
+    \( -path ".git" \
+    -o -path "_build" \
+    -o -path "./_build" \
+    -o -path "node_modules" \
+    -o -path "./node_modules" \
+    -o -path "_esy" \
+    -o -path "./_esy" \
+    -o -path "/home/dark/.esy" \
+    -o -path "esy.lock" \
+    -o -path "fsharp-backend" \
+    \) -prune -false \
+    \
+    -o -type f \
     \( -name "*.ml" \
-    -o -name "*.mli" \) -print0 \
-    -o -path ".git" -prune \
-    -o -path "_build" -prune \
-    -o -path "./_build" -prune \
-    -o -path "node_modules" -prune \
-    -o -path "./node_modules" -prune \
-    -o -path "_esy" -prune \
-    -o -path "./_esy" -prune \
-    -o -path "/home/dark/.esy" -prune \
-    -o -path "esy.lock" -prune \
-    -o -path "./esy.lock" -prune \
-    -o -path "fsharp-backend" -prune
+    -o -name "*.mli" \
+    \) -print0
 }
 
 all_fsharp_files() {
-  find "$1" -type f \
+  find "$1" \
+    \( -path ".git" \
+    -o -path "_build" \
+    -o -path "./_build" \
+    -o -path "node_modules" \
+    -o -path "./node_modules" \
+    -o -path "_esy" \
+    -o -path "./_esy" \
+    -o -path "/home/dark/.esy" \
+    -o -path "esy.lock" \
+    -o -path "fsharp-backend" \
+    -o -path "fsharp-backend/.paket" \
+    -o -path "./fsharp-backend/.paket" \
+    -o -path "fsharp-backend/Build" \
+    \) -prune -false \
+    \
+    -o -type f \
     \( -name "*.fs" \
-    -o -name "*.fsi" \) -print \
-    -o -path ".git" -prune \
-    -o -path "_build" -prune \
-    -o -path "./_build" -prune \
-    -o -path "node_modules" -prune \
-    -o -path "./node_modules" -prune \
-    -o -path "_esy" -prune \
-    -o -path "./_esy" -prune \
-    -o -path "/home/dark/.esy" -prune \
-    -o -path "esy.lock" -prune \
-    -o -path "./esy.lock" -prune \
-    -o -path "fsharp-backend/.paket" -prune \
-    -o -path "./fsharp-backend/.paket" -prune \
-    -o -path "fsharp-backend/Build" -prune \
-    -o -path "./fsharp-backend/Build" -prune
+    -o -name "*.fsi" \
+    \) -print
 }
 
 all_rust_files() {
-  find "$1" -type f \
+  find "$1" \
+    \( -path ".git" \
+    -o -path "_build" \
+    -o -path "./_build" \
+    -o -path "node_modules" \
+    -o -path "./node_modules" \
+    -o -path "_esy" \
+    -o -path "./_esy" \
+    -o -path "/home/dark/.esy" \
+    -o -path "esy.lock" \
+    -o -path "fsharp-backend" \
+    -o -path "containers/stroller/target" \
+    -o -path "./containers/stroller/target" \
+    -o -path "containers/queue-scheduler/target" \
+    -o -path "./containers/queue-scheduler/target" \
+    \) -prune -false \
+    \
+    -o -type f \
     -name "*.rs" \
-    -print0 \
-    -o -path ".git" -prune \
-    -o -path "_build" -prune \
-    -o -path "./_build" -prune \
-    -o -path "node_modules" -prune \
-    -o -path "./node_modules" -prune \
-    -o -path "containers/stroller/target" -prune \
-    -o -path "./containers/stroller/target" -prune \
-    -o -path "containers/queue-scheduler/target" -prune \
-    -o -path "./containers/queue-scheduler/target" -prune \
-    -o -path "_esy" -prune \
-    -o -path "./_esy" -prune \
-    -o -path "/home/dark/.esy" -prune \
-    -o -path "esy.lock" -prune \
-    -o -path "./esy.lock" -prune \
-    -o -path "fsharp-backend/.paket" -prune \
-    -o -path "./fsharp-backend/.paket" -prune \
-    -o -path "fsharp-backend/Build" -prune \
-    -o -path "./fsharp-backend/Build" -prune
+    -print0
 }
 
 check_ocamlformat() {


### PR DESCRIPTION
I started fuzzing again, and I've now gotten to a point where we can run through the fuzzer from quite some time without coming up with a new error.

This updates the fuzzer with the logic to allow that:
- check that results are in expected format (mostly checking that they're normalized)
- use unicode strings in tests
- add test functions to allow incompletes in results
- get better errors from the ocaml legacyserver
- stop fuzzing JSON functions, we know the limitations
- merge the logic from Expect.equalDval and dvalEquality into a reusable function
- ignore Int::sum better
- ignore Int::subtract when overflowing

Fix bugs in:
- List.zipShortest
- Http functions - start to use a BigInt to represent the http status code (and an int64 for ocaml)
- fakeval handing in Dict.fromList
- sending floats with `e` in them to ocaml and back

Add tests for:
- fake vals in results (Result::fromOption, Result.map2)
- infinity/NaN in JSON
- errors when json parsing
- lots of edge cases in JSON parsing
- Dict.fromListOverwritingDuplicates_v0

Also:
- improve the unittests readme
- remove InternalException as it hides error messages