### PR TITLE
Make starting build-server in the vscode container work

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -94,8 +94,9 @@
   // Run one build-server, and keep it running for the life of the
   // devcontainer. This is in postStart rather than postAttach as postAttach would
   // add a new build-server each time and we only want one.
-  "postStartCommand": "nohup ./scripts/support/build-server --compile --watch > rundir/logs/build-server.txt &",
+  "postStartCommand": "./scripts/support/vscode-post-start-command",
 
   // Show the build-server output in a terminal
-  "postAttachCommand": "tail -n 1000 -f rundir/logs/build-server.txt"
+  // Use -F as it the build-server might not have output by the time this starts
+  "postAttachCommand": "tail -n 1000 -F rundir/logs/build-server.txt"
 }

--- a/scripts/support/vscode-post-start-command
+++ b/scripts/support/vscode-post-start-command
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Starting build server"
+
+nohup ./scripts/support/build-server --compile --watch > /home/dark/app/rundir/logs/build-server.txt &
+
+# It seems that if we don't sleep here, the server does not start properly in all cases
+sleep 2
+
+echo "Build server started"


### PR DESCRIPTION
Unclear why nohup wasn't working, but it does now

