### PR TITLE
LibDict functions migration to F#

### DIFF
--- a/fsharp-backend/tests/testfiles/dict.tests
+++ b/fsharp-backend/tests/testfiles/dict.tests
@@ -1,16 +1,33 @@
 Dict.empty_v0 = {}
 
-// Dict.filterMap_v0 {} (fun (key, value) -> 0) = {}
-// Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then Nothing else (Just (key ++ value))) = { c = "cz"; a = "ax"}
-// Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then blank else (Just (key ++ value))) = blank
-// Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then false else (Just (key ++ value))) = Test.typeError_v0 "Expected the argument `f` passed to `Dict::filterMap` to return `Just` or `Nothing` for every entry in `dict`"
+Dict.filterMap_v0 {} (fun (key, value) -> 0) = {}
+Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then Nothing else (Just (key ++ value))) = { c = "cz"; a = "ax"}
+Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then blank else (Just (key ++ value))) = blank
+Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then false else (Just (key ++ value))) = Test.typeError_v0 "Expected the argument `f` passed to `Dict::filterMap` to return `Just` or `Nothing` for every entry in `dict`. However, it returned `false` for the entry `b : \"y\"`." // OCAMLONLY
+Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then false else (Just (key ++ value))) = Test.typeError_v0 "Expected the argument `f` to be `Just` or `Nothing` for every entry in `dict`, but it was `false` for the entry b: \"y\"." // FSHARPONLY
 
-// Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> k == "key1") = { key1 = "val1"}
-// Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> k == blank) = blank
-// Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> v == "val1") = { key1 = "val1"}
-// Dict.filter_v1 { key1 = 1; key2 = blank; key3 = 3 }  (fun (k, v) -> v > 0) = { key3 = 3; key1 = 1}
+Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> k == "key1") = { key1 = "val1"}
+Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> k == blank) = blank
+Dict.filter_v1 { key1 = 1; key2 = 3 }  (fun (k, v) -> v < 2) = { key1 = 1 }
+Dict.filter_v1 { key1 = 1; key2 = blank; key3 = 3 }  (fun (k, v) -> v > 0) = { key3 = 3; key1 = 1}
+Dict.filter_v1 {} (fun (k, v) -> 0) = {}
+Dict.filter_v1 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Fn returned incorrect type" // OCAMLONLY
+Dict.filter_v1 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expecting the function to return Bool, but the result was 2" // FSHARPONLY
 
-// Dict.foreach_v0 { key1 = "val1"; key2 = "val2" } (fun x -> x ++ "_append") = { key2 = "val2_append"; key1 = "val1_append"}
+Dict.filter_v0 { key1 = 1; key2 = 3 }  (fun (k, v) -> v < 2) = { key1 = 1 }
+Dict.filter_v0 { a = 1; b = 9; c = -20 } (fun (k, v) -> v >= 1) = { b = 9; a = 1 }
+Dict.filter_v0 { a = 1; b = 2; c = 3 } (fun (k, v) -> match v with | 1 -> true | 2 -> false | 3 -> true) = { c = 3; a = 1 }
+Dict.filter_v0 { a = 1; b = -1; c = -2; d = -3; e = 2; f = 3 } (fun (k, v) -> (match v with | v -> if v > -2 then true else false)) = { f = 3; e = 2; b = -1; a = 1 }
+Dict.filter_v0 {} (fun (k, v) -> 0) = {}
+Dict.filter_v0 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expecting fn to return bool" // OCAMLONLY
+Dict.filter_v0 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expecting the function to return Bool, but the result was 2" // FSHARPONLY
+Dict.filter_v0 { a = true; b = false; c = true } (fun (k, v) -> "a") = Test.typeError_v0 "Expecting fn to return bool" // OCAMLONLY
+Dict.filter_v0 { a = true; b = false; c = true } (fun (k, v) -> "a") = Test.typeError_v0 "Expecting the function to return Bool, but the result was \"a\"" // FSHARPONLY
+
+Dict.foreach_v0 { key1 = "val1"; key2 = "val2" } (fun x -> x ++ "_append") = { key2 = "val2_append"; key1 = "val1_append"}
+Dict.foreach_v0 { key1 = 1; key2 = 2 } (fun x -> x + 1) = { key2 = 3; key1 = 2 }
+Dict.foreach_v0 {} (fun (key, value) -> 0) = {}
+Dict.foreach_v0 { a = "1"; b = "2" } (fun x -> x ++ "0") = { b = "20"; a = "10"}
 
 Dict.fromListOverwritingDuplicates_v0 [["a";1];["b";2];["a";3]] = { b = 2 ; a = 3 }
 Dict.fromListOverwritingDuplicates_v0 [["a";1];["b";2];["c";3]] = { c = 3 ; b = 2 ; a= 1 }
@@ -19,7 +36,7 @@ Dict.fromListOverwritingDuplicates_v0 [["a";1];["b";2];["c";3;3]] = Test.typeErr
 Dict.fromListOverwritingDuplicates_v0 [["a";1];["b";2];["c";3;3]] = Test.typeError_v0 "All list items must be `[key, value]`" // FSHARPONLY
 Dict.fromListOverwritingDuplicates_v0 [[1;1]] = Test.typeError_v0 "Expected every value within the `entries` argument passed to `Dict::fromListOverwritingDuplicates` to be a `[key, value]` list. However, that is not the case for the value at index 0: `[ \n  1, 1\n]`. Keys must be `String`s but the type of `1` is `Int`." // OCAMLONLY
 Dict.fromListOverwritingDuplicates_v0 [[1;1]] = Test.typeError_v0 "Expected the argument `key` to be a string, but it was `1`" // FSHARPONLY
-Dict.fromListOverwritingDuplicates_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "Expected every value within the `entries` argument passed to `Dict::fromListOverwritingDuplicates` to be a `[key, value]` list. However, that is not the case for the value at index 1: `2`. It is of type `Int` instead of `List`."" // OCAMLONLY
+Dict.fromListOverwritingDuplicates_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "Expected every value within the `entries` argument passed to `Dict::fromListOverwritingDuplicates` to be a `[key, value]` list. However, that is not the case for the value at index 1: `2`. It is of type `Int` instead of `List`." // OCAMLONLY
 Dict.fromListOverwritingDuplicates_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "All list items must be `[key, value]`" // FSHARPONLY
 
 Dict.fromList_v0 [["a";1];["b";2];["a";3]] = Nothing // duplicate key
@@ -44,7 +61,10 @@ Dict.isEmpty_v0 {} = true
 
 Dict.keys_v0 { key1 = "val1" } = [ "key1"]
 
-// Dict.map_v0  { key1 = "val1"; key2 = "val2";  } (fun (k, x) -> k ++ x) = { key2 = "key2val2"; key1 = "key1val1" }
+Dict.map_v0 { key1 = "val1"; key2 = "val2"; } (fun (k, x) -> k ++ x) = { key2 = "key2val2"; key1 = "key1val1" }
+Dict.map_v0 { key1 = 5; key2 = 3; key3 = 3; } (fun (k, x) -> Bool.and_v0 (Int.greaterThanOrEqualTo_v0 x 1) (Int.lessThanOrEqualTo_v0 x 4)) = { key3 = true; key2 = true; key1 = false; }
+Dict.map_v0 { a = 1; b = 2; } (fun (k, x) -> x + 1) = { b = 3; a = 2 }
+Dict.map_v0 {} (fun (key, value) -> 0) = {}
 
 Dict.member_v0 { otherKey = 5; someKey = 5 } "someKey" = true
 Dict.member_v0 { otherKey = 5 } "someKey" = false


### PR DESCRIPTION
## What is the problem/goal being addressed?
Continue with the migration of the functions written in OCaml to F#, in this case those of the LibDict.fs class. I added some functions to Prelude too to help

## What is the solution to this problem?
Functions previously in OCaml, migrated to F#

## How are you sure this works/how was this tested?
Tests passed and I added some aditional tests to try different results.
