### PR TITLE
LibDB2 functions migration

### DIFF
--- a/fsharp-backend/src/LibBackend/StdLib/LibDB2.fs
+++ b/fsharp-backend/src/LibBackend/StdLib/LibDB2.fs
@@ -251,39 +251,38 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
-    // ; { name = fn "DB" "delete" 1
-//   ; parameters = [keyParam; tableParam]
-//   ; returnType = TNull
-//   ; description = "Delete `key` from `table`"
-//   ; fn =
-//          (function
-//         | state, [DStr key; DDB dbname] -> taskv {
-//             let db = state.program.dbs.[dbname]
-//             let key = Unicode_string.to_string key in
-//             UserDB.delete state db key ;
-//             DNull
-//           }
-//         | _ ->
-//             incorrectArgs ())
-//   ; sqlSpec = NotQueryable
-//   ; previewable = Impure
-//   ; deprecated = NotDeprecated }
-// ; { name = fn "DB" "deleteAll" 1
-//   ; parameters = [tableParam]
-//   ; returnType = TNull
-//   ; description = "Delete everything from `table`"
-//   ; fn =
-//          (function
-//         | state, [DDB dbname] -> taskv {
-//             let db = state.program.dbs.[dbname]
-//             UserDB.delete_all state db ;
-//             DNull
-//           }
-//         | _ ->
-//             incorrectArgs ())
-//   ; sqlSpec = NotQueryable
-//   ; previewable = Impure
-//   ; deprecated = NotDeprecated }
+    { name = fn "DB" "delete" 1
+      parameters = [ keyParam; tableParam ]
+      returnType = TNull
+      description = "Delete `key` from `table`"
+      fn =
+        (function
+        | state, [ DStr key; DDB dbname ] ->
+            taskv {
+              let db = state.program.dbs.[dbname]
+              let! _result = UserDB.delete state db key
+              return DNull
+            }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+    { name = fn "DB" "deleteAll" 1
+      parameters = [ tableParam ]
+      returnType = TNull
+      description = "Delete everything from `table`"
+      fn =
+        (function
+        | state, [ DDB dbname ] ->
+            taskv {
+              let db = state.program.dbs.[dbname]
+              let! _result = UserDB.deleteAll state db
+              return DNull
+            }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
     { name = fn "DB" "query" 1
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TList varA // heterogenous list

--- a/fsharp-backend/tests/testfiles/db.tests
+++ b/fsharp-backend/tests/testfiles/db.tests
@@ -219,6 +219,38 @@
  let two = DB.set_v1 { x = "foo" } "two" X in
  DB.queryOneWithKey_v2 { x = "foo" } X) = Nothing
 
+// DB.delete
+[test.db.delete_v1 does delete] with DB X
+(let one = DB.set_v1 { x = "foo"} "one" X in
+ let delete = DB.delete_v1 "one" X in
+ DB.getAllWithKeys_v1 X) = []
+
+[test.db.delete_v1 deletes nothing] with DB X
+(let one = DB.set_v1 { x = "foo"} "one" X in
+ let delete = DB.delete_v1 "two" X in
+ DB.getAllWithKeys_v1 X) = [["one"; { x = "foo"}]]
+
+[test.db.delete_v1 deletes only one] with DB X
+(let one = DB.set_v1 { x = "foo"} "one" X in
+ let two = DB.set_v1 { x = "bar" } "two" X in
+ let delete = DB.delete_v1 "one" X in
+ DB.getAllWithKeys_v1 X) = [["two"; { x = "bar"}]]
+
+// // DB.deleteAll
+[test.db.deleteAll_v1 works] with DB X
+(let one = DB.set_v1 { x = "foo"} "one" X in
+ let delete = DB.deleteAll_v1 X in
+ DB.getAll_v1 X) = []
+
+[test.db.deleteAll_v1 delete all] with DB X
+(let one = DB.set_v1 { x = "foo"} "one" X in
+ let two = DB.set_v1 { x = "bar" } "two" X in
+ let delete = DB.deleteAll_v1 X in
+ DB.getAll_v1 X) = []
+
+[test.db.deleteAll_v1 works] with DB X
+(let delete = DB.deleteAll_v1 X in
+ DB.getAll_v1 X) = []
 
 // ------------
 // SqlCompiler queries


### PR DESCRIPTION
## What is the problem/goal being addressed?
Continue with the migration of the functions written in OCaml to F#, in this case were missing only DB2::delete_v1 and DB2::deleteAll_v1 from LibDB2.

## What is the solution to this problem?
Functions previously in OCaml, migrated to F#

## How are you sure this works/how was this tested?
Tests passed and I added some aditional tests to try different results.
