### PR TITLE
LibFloat migration

### DIFF
--- a/fsharp-backend/src/LibExecution/StdLib/LibFloat.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibFloat.fs
@@ -290,4 +290,16 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
+      deprecated = NotDeprecated }
+    { name = fn "Float" "roundTowardsZero" 0
+      parameters = [ Param.make "a" TFloat "" ]
+      returnType = TInt
+      description =
+        "Discard the fractional portion of the float, rounding towards zero."
+      fn =
+        (function
+        | _, [ DFloat a ] -> bigint (Math.Truncate a) |> DInt |> Value
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
       deprecated = NotDeprecated } ]

--- a/fsharp-backend/tests/testfiles/float.tests
+++ b/fsharp-backend/tests/testfiles/float.tests
@@ -110,6 +110,12 @@ Float.multiply_v0 26.0 0.5 = 13.0
 Float.power_v0 4.0 -0.5 = 0.5
 Float.power_v0 4.0 0.5 = 2.0
 
+Float.roundTowardsZero -2367.9267 = -2367
+Float.roundTowardsZero 000000.9 = 0
+Float.roundTowardsZero -000000.9 = 0
+Float.roundTowardsZero 0.0 = 0
+Float.roundTowardsZero 2147483647.000009 = 2147483647
+
 Float.sqrt_v0 25.0 = 5.0
 Float.sqrt_v0 0.0 = 0.0
 //Float.sqrt_v0 111111111111111111111111111111111111111111.1 = 333333333333333400000 // Ocaml accepts this large number


### PR DESCRIPTION
## What is the problem/goal being addressed?
Continue with the migration of the functions written in OCaml to F#, in this case it was only added Float::roundTowardsZero_v0 function to LibFloat

## What is the solution to this problem?
Functions previously in OCaml, migrated to F#

## How are you sure this works/how was this tested?
Tests I added for the function passed

