### PR TITLE
LibList functions migration

### DIFF
--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -442,6 +442,31 @@ module List =
       (Value None)
       list
 
+  let filter_map
+    (f : 'a -> TaskOrValue<Option<'b>>)
+    (list : List<'a>)
+    : TaskOrValue<List<'b>> =
+    taskv {
+      let! filtered =
+        List.fold
+          (fun (accum : TaskOrValue<List<'b>>) (arg : 'a) ->
+            taskv {
+              let! (accum : List<'b>) = accum
+              let! keep = f arg
+
+              let result =
+                match keep with
+                | Some v -> v :: accum
+                | None -> accum
+
+              return result
+            })
+          (Value [])
+          list
+
+      return List.rev filtered
+    }
+
 module Map =
   let map_s
     (f : 'a -> TaskOrValue<'b>)

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -21,11 +21,12 @@ List.drop_v0 [3; 3; 3] 0 = [3; 3; 3]
 List.drop_v0 [5; 4; 3; 2; 1]  5 = []
 List.drop_v0 [5] 4 = []
 
-//List.dropWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` passed to `List::takeWhile` to return a boolean value for every value in `list`. However, it returned `-1` for the input `1`."
-//List.dropWhile_v0 [1;2;3;4] (fun item -> item < 3) = [ 3, 4 ]
-//List.dropWhile_v0 [1;2;3;4] (fun item -> item >= 1) = []
-//List.dropWhile_v0 [1;5;2;2] (fun item -> item < 3) = [ 5, 2, 2 ]
-//List.dropWhile_v0 [] (fun item -> item < 3) = []
+List.dropWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` to be boolean value for every value in `list`, but it was `-1` for the input 1" // FSHARPONLY
+List.dropWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` passed to `List::dropWhile` to return a boolean value for every value in `list`. However, it returned `-1` for the input `1`." // OCAMLONLY
+List.dropWhile_v0 [1;2;3;4] (fun item -> item < 3) = [ 3, 4 ]
+List.dropWhile_v0 [1;2;3;4] (fun item -> item >= 1) = []
+List.dropWhile_v0 [1;5;2;2] (fun item -> item < 3) = [ 5, 2, 2 ]
+List.dropWhile_v0 [] (fun item -> item < 3) = []
 
 List.empty_v0 = []
 
@@ -62,10 +63,11 @@ List.filter_v2 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> false | 3
 List.filter_v2 [] (fun item -> true) = []
 List.filter_v2 [-20; 5; 9;] (fun x -> x > 20) = []
 
-//List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then Nothing else (Just (item * 2))) = [ 2, 6 ]
-//List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then blank else (Just (item * 2))) = blank
-//List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then false else (Just (item * 2))) = Test.typeError_v0 "Expected the argument `f` passed to `List::filterMap` to return `Just` or `Nothing` for every value in `list`"
-//List.filterMap_v0 [] (fun item -> 0) = []
+List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then Nothing else (Just (item * 2))) = [ 2, 6 ]
+List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then blank else (Just (item * 2))) = blank
+List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then false else (Just (item * 2))) = Test.typeError_v0 "Expected the argument `f` passed to `List::filterMap` to return `Just` or `Nothing` for every value in `list`. However, it returned `false` for the input `2`." // OCAMLONLY
+List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then false else (Just (item * 2))) = Test.typeError_v0 "Expected the argument `f` to be `Just` or `Nothing` for every value in `list`, but it was `false` for the input 2" // FSHARPONLY
+List.filterMap_v0 [] (fun item -> 0) = []
 
 List.findFirst_v0 [1;2;3] (fun x -> x > 5) = null
 List.findFirst_v0 [] (fun x -> x) = null
@@ -125,8 +127,9 @@ List.head_v2 [1, 2, 3] = Just 1
 List.head_v2 [Test.typeError_v0 "test"] = Test.typeError_v0 "test"
 List.head_v2 [] = Nothing
 
-//List.indexedMap_v0 [3;2;1] (fun i v -> v - i) = [ 3, 1, -1 ]
-//List.indexedMap_v0 [] (fun i v -> v - i) = []
+List.indexedMap_v0 [3;2;1] (fun i v -> v - i) = [ 3, 1, -1 ]
+List.indexedMap_v0 [] (fun i v -> v - i) = []
+List.indexedMap_v0 [3;2;1] (fun i v -> i) = [0, 1, 2]
 
 List.interleave_v0 [1;2;3] [4;5;6] = [ 1, 4, 2, 5, 3, 6 ]
 List.interleave_v0 [1;2;3] [4] = [ 1, 4, 2, 3 ]
@@ -162,11 +165,11 @@ List.map_v0 (List.range_v0 1 5) (fun x -> x + 1) = [2; 3; 4; 5; 6]
 List.map_v0 [1, 2, 3] (fun x -> Bool.and_v0 (Int.greaterThanOrEqualTo_v0 x 0) (Int.lessThanOrEqualTo_v0 x 4)) = [true; true; true]
 List.map_v0 [1, 2] (fun x -> x + 1) = [2, 3]
 
-//List.map2_v0 [10;20;30] [1;2;3] (fun a b -> a - b) = Just [ 9, 18, 27 ]
-//List.map2_v0 [10;20] [1;2;3] (fun a b -> a - b) = Nothing
+List.map2_v0 [10;20;30] [1;2;3] (fun a b -> a - b) = Just [ 9, 18, 27 ]
+List.map2_v0 [10;20] [1;2;3] (fun a b -> a - b) = Nothing
 
-//List.map2shortest_v0 [10;20;30] [1;2;3] (fun a b -> a - b) = [ 9, 18, 27 ]
-//List.map2shortest_v0 [10;20] [1;2;3] (fun a b -> a - b) = [ 9, 18 ]
+List.map2shortest_v0 [10;20;30] [1;2;3] (fun a b -> a - b) = [ 9, 18, 27 ]
+List.map2shortest_v0 [10;20] [1;2;3] (fun a b -> a - b) = [ 9, 18 ]
 
 List.member_v0 [1;2;3] 2 = true
 List.member_v0 [1;2;3] 4 = false
@@ -221,14 +224,19 @@ List.take_v0 [3; 3; 3] 0 = []
 List.take_v0 [5; 4; 3; 2; 1]  5 = [5; 4; 3; 2; 1]
 List.take_v0 [5] 4 = [5]
 
-//List.takeWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` passed to `List::takeWhile` to return a boolean value for every value in `list`. However, it returned `-1` for the input `1`."
-//List.takeWhile_v0 [1;2;3;4] (fun item -> item < 1) = []
-//List.takeWhile_v0 [1;2;3;4] (fun item -> item < 3) = [ 1, 2 ]
-//List.takeWhile_v0 [1;5;2;2] (fun item -> item < 3) = [ 1 ]
-//List.takeWhile_v0 [] (fun item -> item < 3) = []
+List.takeWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` to be boolean value for every value in `list`, but it was `-1` for the input 1" // FSHARPONLY
+List.takeWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` passed to `List::takeWhile` to return a boolean value for every value in `list`. However, it returned `-1` for the input `1`." // OCAMLONLY
+List.takeWhile_v0 [1;2;3;4] (fun item -> item < 1) = []
+List.takeWhile_v0 [1;2;3;4] (fun item -> item < 3) = [ 1, 2 ]
+List.takeWhile_v0 [1;5;2;2] (fun item -> item < 3) = [ 1 ]
+List.takeWhile_v0 [] (fun item -> item < 3) = []
 
-//List.uniqueBy_v0 [1;2;3;4] (fun x -> Int.divide_v0 x 2) = [ 1, 3, 4 ]
-//List.uniqueBy_v0 [1;2;3;4] (fun x -> x) = [ 1, 2, 3, 4 ]
+//it isn't specified which is the right value to keep when there are duplicates
+List.uniqueBy_v0 [1;2;3;4] (fun x -> Int.divide_v0 x 2) = [ 1, 3, 4 ] // OCAMLONLY
+List.uniqueBy_v0 [1;2;3;4] (fun x -> Int.divide_v0 x 2) = [ 1, 2, 4 ] // FSHARPONLY
+List.uniqueBy_v0 [1;2;3;4] (fun x -> x) = [ 1, 2, 3, 4 ]
+List.uniqueBy_v0 [1;1;1;1] (fun x -> x) = [ 1 ]
+List.uniqueBy_v0 [7;42;7;2;10] (fun x -> x) = [ 2, 7, 10, 42 ]
 
 List.unzip_v0 [[1;10];10;[3;30]] = Test.typeError_v0 "Expected every value within the `pairs` argument passed to `List::unzip` to be a list with exactly two values. However, that is not the case for the value at index 1: 10. It is of type `Int` instead of `List`." // OCAMLONLY
 List.unzip_v0 [[1;10];10;[3;30]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `10`It is of type Int instead of `List`" // FSHARPONLY


### PR DESCRIPTION
## What is the problem/goal being addressed?
Continue with the migration of the functions written in OCaml to F#.

## What is the solution to this problem?
Rewrite LibList.fs functions to F#. I also added a new function to Prelude (`List.filter_map`), to help with the code.

## How are you sure this works/how was this tested?
Tests passed and I added some more tests to check
