### PR TITLE
LibDate function migration

### DIFF
--- a/fsharp-backend/src/LibExecution/StdLib/LibDate.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibDate.fs
@@ -234,64 +234,61 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
-    //   { name = fn "Date" "toHumanReadable" 0
-//
-//     parameters = [ Param.make "date" TDate ]
-//     returnType = TStr
-//     description = "Turn a Date into a human readable format"
-//     fn =
-//
-//       (function
-//       | _, [ DDate date ] ->
-//           let time = date |> Time.to_span_since_epoch |> Time.Span.to_sec in
-//           let msPerMinute = 60.0 *. 1000.0 in
-//           let msPerHour = msPerMinute *. 60.0 in
-//           let msPerDay = msPerHour *. 24.0 in
-//           let msPerMonth = msPerDay *. 30.0 in
-//           let msPerYear = msPerDay *. 365.0 in
-//
-//           let rec f time =
-//             if time /. msPerYear > 1.0 then
-//               let suffix = if time /. msPerYear > 2.0 then "years" else "year"
-//
-//               ((time /. msPerYear |> int_of_float |> string_of_int)
-//                ^ " " ^ suffix ^ ", ")
-//               ^ f (Float.mod_float time msPerYear)
-//             else if time /. msPerMonth > 1.0 then
-//               let suffix = if time /. msPerMonth > 2.0 then "months" else "month"
-//
-//               ((time /. msPerMonth |> int_of_float |> string_of_int)
-//                ^ " " ^ suffix ^ ", ")
-//               ^ f (Float.mod_float time msPerMonth)
-//             else if time /. msPerDay > 1.0 then
-//               let suffix = if time /. msPerDay > 2.0 then "days" else "day"
-//
-//               ((time /. msPerDay |> int_of_float |> string_of_int)
-//                ^ " " ^ suffix ^ ", ")
-//               ^ f (Float.mod_float time msPerDay)
-//             else if time /. msPerHour > 1.0 then
-//               let suffix = if time /. msPerHour > 2.0 then "hours" else "hour"
-//
-//               ((time /. msPerHour |> int_of_float |> string_of_int)
-//                ^ " " ^ suffix ^ ", ")
-//               ^ f (Float.mod_float time msPerHour)
-//             else if time /. msPerMinute > 1.0 then
-//               let suffix =
-//                 if time /. msPerMinute > 2.0 then "minutes" else "minute"
-//
-//               ((time /. msPerMinute |> int_of_float |> string_of_int)
-//                ^ " " ^ suffix)
-//               ^ f (Float.mod_float time msPerMinute)
-//             else
-//               ""
-//
-//           let diff = f time in
-//           let diff = if diff = "" then "less than a minute" else diff in
-//           DStr diff
-//       | _ -> incorrectArgs ())
-//     sqlSpec = NotQueryable
-//     previewable = Pure
-//     deprecated = ReplacedBy(fn "" "" 0) (* This doesn't mean anything *)  }
+    { name = fn "Date" "toHumanReadable" 0
+      parameters = [ Param.make "date" TDate "" ]
+      returnType = TStr
+      description = "Turn a Date into a human readable format"
+      fn =
+        (function
+        | _, [ DDate date ] ->
+            let time =
+              date
+              |> System.DateTimeOffset
+              |> (fun dto -> dto.ToUnixTimeSeconds())
+              |> float
+
+            let msPerMinute = 60.0 * 1000.0
+            let msPerHour = msPerMinute * 60.0
+            let msPerDay = msPerHour * 24.0
+            let msPerMonth = msPerDay * 30.0
+            let msPerYear = msPerDay * 365.0
+
+            let rec f time =
+              if time / msPerYear > 1.0 then
+                let suffix = if time / msPerYear > 2.0 then "years" else "year"
+
+                ((time / msPerYear |> int |> string) + " " + suffix + ", ")
+                + f (time % msPerYear)
+              else if time / msPerMonth > 1.0 then
+                let suffix = if time / msPerMonth > 2.0 then "months" else "month"
+
+                ((time / msPerMonth |> int |> string) + " " + suffix + ", ")
+                + f (time % msPerMonth)
+              else if time / msPerDay > 1.0 then
+                let suffix = if time / msPerDay > 2.0 then "days" else "day"
+
+                ((time / msPerDay |> int |> string) + " " + suffix + ", ")
+                + f (time % msPerDay)
+              else if time / msPerHour > 1.0 then
+                let suffix = if time / msPerHour > 2.0 then "hours" else "hour"
+
+                ((time / msPerHour |> int |> string) + " " + suffix + ", ")
+                + f (time % msPerHour)
+              else if time / msPerMinute > 1.0 then
+                let suffix = if time / msPerMinute > 2.0 then "minutes" else "minute"
+
+                ((time / msPerMinute |> int |> string) + " " + suffix)
+                + f (time % msPerMinute)
+              else
+                ""
+
+            let diff = f time
+            let result = if diff = "" then "less than a minute" else diff
+            Value(DStr result)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = DeprecatedBecause "This function doesn't work" }
     { name = fn "Date" "year" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt

--- a/fsharp-backend/tests/testfiles/date.tests
+++ b/fsharp-backend/tests/testfiles/date.tests
@@ -82,3 +82,7 @@ Date.toStringISO8601BasicDate_v0 (d "1069-07-28T22:42:36Z") = "10690728"
 1095379198 |> Date.fromSeconds_v0 |> Date.toSeconds_v0 = 1095379198
 // d "2019-07-28T22:42:36Z" |> Date.toSeconds_v0 |> Date.fromSeconds_v0 |> toString_v0 = "2019-07-28T22:42:36Z"
 // Date.today_v0 |> toString_v0 = "2020-10-17T00:00:00Z" // todo, how can we test this
+
+[tests.date human readable don't work]
+Date.toHumanReadable_v0 (d "2021-07-02T17:42:36Z") = "18 days, 19 hours, 27 minutes"
+Date.toHumanReadable_v0 (d "1970-01-01T00:00:00Z") = "less than a minute"


### PR DESCRIPTION
## What is the problem/goal being addressed?
Continue with the migration of the functions written in OCaml to F#.

## What is the solution to this problem?
There were only one function left to migrate in `LibDate.fs`, `Date::toHumanReadable`

## How are you sure this works/how was this tested?
It is a function that has been deprecated because it doesn't work but I added some tests just in case we ever use it again.
