### PR TITLE
Prelude functions rewrited

### DIFF
--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -443,55 +443,6 @@ module List =
       list
 
 module Map =
-  let map_s
-    (f : 'a -> TaskOrValue<'b>)
-    (dict : Map<'key, 'a>)
-    : TaskOrValue<Map<'key, 'b>> =
-    Map.fold
-      (fun (accum : TaskOrValue<Map<'key, 'b>>) (key : 'key) (arg : 'a) ->
-        taskv {
-          let! accum = accum
-          let! result = f arg
-          return Map.add key result accum
-        })
-      (Value(Map.empty))
-      dict
-
-  let filter_s
-    (f : 'key -> 'a -> TaskOrValue<bool>)
-    (dict : Map<'key, 'a>)
-    : TaskOrValue<Map<'key, 'a>> =
-    Map.fold
-      (fun (accum : TaskOrValue<Map<'key, 'a>>) (key : 'key) (arg : 'a) ->
-        taskv {
-          let! (accum : Map<'key, 'a>) = accum
-          let! keep = f key arg
-
-          return (if keep then (Map.add key arg accum) else accum)
-        })
-      (Value(Map.empty))
-      dict
-
-  let filter_map
-    (f : 'key -> 'a -> TaskOrValue<Option<'b>>)
-    (dict : Map<'key, 'a>)
-    : TaskOrValue<Map<'key, 'b>> =
-    Map.fold
-      (fun (accum : TaskOrValue<Map<'key, 'b>>) (key : 'key) (arg : 'a) ->
-        taskv {
-          let! (accum : Map<'key, 'b>) = accum
-          let! keep = f key arg
-
-          let result =
-            match keep with
-            | Some v -> Map.add key v accum
-            | None -> accum
-
-          return result
-        })
-      (Value(Map.empty))
-      dict
-
   let fold_s
     (f : 'state -> 'key -> 'a -> TaskOrValue<'state>)
     (initial : 'state)
@@ -505,6 +456,53 @@ module Map =
         })
       (Value(initial))
       dict
+
+  let map_s
+    (f : 'a -> TaskOrValue<'b>)
+    (dict : Map<'key, 'a>)
+    : TaskOrValue<Map<'key, 'b>> =
+    fold_s
+      (fun (accum : Map<'key, 'b>) (key : 'key) (arg : 'a) ->
+        taskv {
+          let! result = f arg
+          return Map.add key result accum
+        })
+      Map.empty
+      dict
+
+  let filter_s
+    (f : 'key -> 'a -> TaskOrValue<bool>)
+    (dict : Map<'key, 'a>)
+    : TaskOrValue<Map<'key, 'a>> =
+    fold_s
+      (fun (accum : Map<'key, 'a>) (key : 'key) (arg : 'a) ->
+        taskv {
+          let! keep = f key arg
+          return (if keep then (Map.add key arg accum) else accum)
+        })
+      Map.empty
+      dict
+
+  let filter_map
+    (f : 'key -> 'a -> TaskOrValue<Option<'b>>)
+    (dict : Map<'key, 'a>)
+    : TaskOrValue<Map<'key, 'b>> =
+    fold_s
+      (fun (accum : Map<'key, 'b>) (key : 'key) (arg : 'a) ->
+        taskv {
+          let! keep = f key arg
+
+          let result =
+            match keep with
+            | Some v -> Map.add key v accum
+            | None -> accum
+
+          return result
+        })
+      Map.empty
+      dict
+
+
 
 // ----------------------
 // Lazy utilities


### PR DESCRIPTION
## What is the problem/goal being addressed?
While working on the functions migration in `LibDict`, I needed to write a `fold_s` function to help with the code. So now I rewrite functions in Prelude to work with this new one.

## What is the solution to this problem?
Wrote `map_s`, `filter_s` and `filter_map` from Map module in `Prelude` using the new function `fold_s` to reuse code

## How are you sure this works/how was this tested?
I ran the tests again and they passed
