### PR TITLE
Add List::sortByComparator

### DIFF
--- a/fsharp-backend/src/LibBackend/Routing.fs
+++ b/fsharp-backend/src/LibBackend/Routing.fs
@@ -78,9 +78,7 @@ let routeInputVars
   if splitRoute.Length > splitRequestPath.Length then
     // Can't match. Route *must* be the <= the length of path
     None
-  else
-
-  if splitRequestPath.Length = splitRoute.Length then
+  elif splitRequestPath.Length = splitRoute.Length then
     // If the route/path are the same length we can zip a binding down
     doBinding splitRoute splitRequestPath
   else

--- a/fsharp-backend/src/LibExecution/Errors.fs
+++ b/fsharp-backend/src/LibExecution/Errors.fs
@@ -39,6 +39,12 @@ let expectedLambdaType (typ : DType) (actual : Dval) : string =
   let typ = DvalRepr.typeToDeveloperReprV0 typ
   $"Expecting the function to return {typ}, but the result was {actual}"
 
+let expectedLambdaValue (expected : string) (actual : Dval) : string =
+  let actual = DvalRepr.toDeveloperReprV0 actual
+  $"Expecting the function to return {expected}, but the result was {actual}"
+
+
+
 // Used for values which are outside the range of expected values for some
 // reason. Really, any function using this should have a Result type instead.
 let argumentWasnt (expected : string) (paramName : string) (dv : Dval) : string =

--- a/fsharp-backend/src/LibExecution/StdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibList.fs
@@ -40,10 +40,11 @@ module Sort =
       let mutable leftHalfIndex = 0
       let mutable rightHalfIndex = index + halfLen
       let rightHalfEnd = index + length
+
+      // this whole thing is just a hacky for-loop with breaks
       let mutable i' = 0
       let mutable cont = true
 
-      // this whole thing is just a hacky for-loop with breaks
       while (cont && i' < length) do
         // Advance the array here to make sure we do it, but use `i` for the calculations
         let i = i'
@@ -52,15 +53,13 @@ module Sort =
         if (leftHalfIndex = halfLen) then
           // All of the remaining elements must be from the right half, and thus must already be in position
           cont <- false // break
-        else
-
-        if (rightHalfIndex = rightHalfEnd) then
+        elif rightHalfIndex = rightHalfEnd then
           // Copy remaining elements from the local copy
           copy
             localCopyofHalfOfArray
             leftHalfIndex
             arrayToSort
-            (index + 1)
+            (index + i)
             (length - i)
 
           cont <- false // break
@@ -69,16 +68,12 @@ module Sort =
           let v1 = arrayToSort.[rightHalfIndex]
           let! comparisonResult = comparer v0 v1
 
-          if comparisonResult = 0 then
-            // default(TCompareAsEqualAction).CompareAsEqual();
-            // This are already equal, so do nothing
-            ()
-          else if comparisonResult <= 0 then
+          if comparisonResult <= 0 then
+            arrayToSort.[i + index] <- v0
             leftHalfIndex <- leftHalfIndex + 1
-            arrayToSort.[i + index] <- localCopyofHalfOfArray.[leftHalfIndex]
           else
+            arrayToSort.[i + index] <- v1
             rightHalfIndex <- rightHalfIndex + 1
-            arrayToSort.[i + index] <- arrayToSort.[rightHalfIndex]
     }
 
   let rec mergeSortHelper
@@ -89,26 +84,23 @@ module Sort =
     (scratchSpace : Array)
     : TaskOrValue<unit> =
     taskv {
-      if length = 1 then
+      if length <= 1 then
         return ()
-      else
-
-      if length = 2 then
+      elif length = 2 then
         let v0 = arrayToSort.[index]
         let v1 = arrayToSort.[index + 1]
         let! result = comparer v0 v1
 
         if result > 0 then
-          do arrayToSort.[index] <- v1
-          do arrayToSort.[index + 1] <- v0
-        else
-          return ()
+          arrayToSort.[index] <- v1
+          arrayToSort.[index + 1] <- v0
+
       else
         let halfLen = length / 2
         do! mergeSortHelper arrayToSort index halfLen comparer scratchSpace
 
-        let nextIndex = (index + halfLen)
-        let nextLength = (length - halfLen)
+        let nextIndex = index + halfLen
+        let nextLength = length - halfLen
         do! mergeSortHelper arrayToSort nextIndex nextLength comparer scratchSpace
 
         copy arrayToSort index scratchSpace 0 halfLen

--- a/fsharp-backend/src/LibExecution/StdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecution/StdLib/LibList.fs
@@ -622,7 +622,8 @@ let fns : List<BuiltInFn> =
                 do! Sort.sort fn array
                 return array |> Array.toList |> DList |> Ok |> DResult
               }
-            with e -> Value(DResult(Error(DStr(string e))))
+            with Errors.StdlibException (Errors.StringError m) ->
+              Value(DResult(Error(DStr m)))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -1006,16 +1006,11 @@ module ExecutePureFunctions =
           debugFn ()
           debuG "ocaml (expected) is not normalized" (debugDval expected)
           return false
-        else
-
-        if not (Expect.isCanonical actual) then
+        elif not (Expect.isCanonical actual) then
           debugFn ()
           debuG "fsharp (actual) is not normalized" (debugDval actual)
           return false
-        else
-
-        if dvalEquality actual expected then
-
+        elif dvalEquality actual expected then
           return true
         else
           match actual, expected with

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -210,8 +210,12 @@ List.sortBy_v0 [6;2;8;3] (fun x -> 0 - x) = [8;6;3;2]
 List.sort_v0 ["6";"2";"8";"3"] = ["2";"3";"6";"8"]
 List.sort_v0 [6;2;8;3] = [2;3;6;8]
 
-//List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "`f` must return one of -1, 0, 1, but returned non-int: 0.1"
-//List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "`f` must return one of -1, 0, 1, but returned another int: 3"
+List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "`f` must return one of -1, 0, 1, but returned non-int: 0.1" // OCAMLONLY
+List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "`f` must return one of -1, 0, 1, but returned another int: 3" // OCAMLONLY
+
+List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "Expecting the function to return -1, 0, 1, but the result was 0.1" // FSHARPONLY
+List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "Expecting the function to return -1, 0, 1, but the result was 3" // FSHARPONLY
+
 List.sortByComparator_v0 [3;1;2] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [ 1, 2, 3 ]
 List.sortByComparator_v0 [3;1;2;67;3;-1;6;3;5;6;2;5;63;2;3;5;-1;-1;-1] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok[-1; -1; -1; -1; 1; 2; 2; 2; 3; 3; 3; 3; 5; 5; 5; 6; 6; 63; 67]
 

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -210,9 +210,9 @@ List.sortBy_v0 [6;2;8;3] (fun x -> 0 - x) = [8;6;3;2]
 List.sort_v0 ["6";"2";"8";"3"] = ["2";"3";"6";"8"]
 List.sort_v0 [6;2;8;3] = [2;3;6;8]
 
-//List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "`f` must return one of -1, 0, 1, but returned non-int: 0.1" // List.sortByComparator works
-//List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "`f` must return one of -1, 0, 1, but returned another int: 3" // List.sortByComparator works
-//List.sortByComparator_v0 [3;1;2] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [ 1, 2, 3 ] // List.sortByComparator works
+//List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "`f` must return one of -1, 0, 1, but returned non-int: 0.1"
+//List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "`f` must return one of -1, 0, 1, but returned another int: 3"
+List.sortByComparator_v0 [3;1;2] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [ 1, 2, 3 ]
 
 List.tail_v0 [10, 20, 30, 40] = Just [20, 30, 40]
 List.tail_v0 [] = Nothing

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -213,6 +213,7 @@ List.sort_v0 [6;2;8;3] = [2;3;6;8]
 //List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "`f` must return one of -1, 0, 1, but returned non-int: 0.1"
 //List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "`f` must return one of -1, 0, 1, but returned another int: 3"
 List.sortByComparator_v0 [3;1;2] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [ 1, 2, 3 ]
+List.sortByComparator_v0 [3;1;2;67;3;-1;6;3;5;6;2;5;63;2;3;5;-1;-1;-1] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok[-1; -1; -1; -1; 1; 2; 2; 2; 3; 3; 3; 3; 5; 5; 5; 6; 6; 63; 67]
 
 List.tail_v0 [10, 20, 30, 40] = Just [20, 30, 40]
 List.tail_v0 [] = Nothing


### PR DESCRIPTION
List::sortByComparator_v0 needs to sort with a callback. However, the existing sorting algorithms in .NET (also true of OCaml) can't be made to use async. 

## What is the solution to this problem?

We need a sorting algorithm that is async aware. I copied an existing C# merge sort algorithm and ported it to F# and used TaskOrValue to make it async.

Merge sort is a good candidate as it is very predictable, and doesn't have bad worst-case complexity like other `O(n log n)` sorting algorithms. There are probably more performant options (like using insertion sort for small arrays) but this seems fine.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
*Please include before/after screenshots/gifs if appropriate*

## How are you sure this works/how was this tested?

This could do with some fuzzing, actually.

## What is the reversion plan if this fails after shipping?

None.

## Has this information been included in the comments?
Yes