### PR TITLE
Dont set an ACL that's no longer used

### DIFF
--- a/scripts/push-assets-to-cdn
+++ b/scripts/push-assets-to-cdn
@@ -29,10 +29,11 @@ done
   cd gzipped_assets
   # -m parallelizes upload
   # -n no-clobber - we don't need upload assets already there
+  # -r recursive
   gsutil -m \
       -h 'Content-Encoding: gzip' \
       -h 'Cache-Control:public' \
-      cp -a public-read -n -r . gs://darklang-static-assets
+      cp -n -r . gs://darklang-static-assets
 )
 
 rm -r gzipped_assets


### PR DESCRIPTION
## What is the problem/goal being addressed?

On GCP, I recently set the access control for the darklang-static-assets bucket to use "Uniform ACLs".

On a [recent deploy](https://app.circleci.com/pipelines/github/darklang/dark/1370/workflows/af460aa6-1dee-474f-900c-1d50605aa648/jobs/13366), there were HTTP 400 errors when pushing to the bucket:

```
BadRequestException: 400 Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access
```

## What is the solution to this problem?

It looks like we should just avoid setting them ACL, which is no longer necessary.