### PR TITLE
Attempt to avoid bash during Remote Container bootstrap

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -89,7 +89,14 @@
   "updateRemoteUserUID": true,
 
   // `mounts` (above) expects some files to exist on the host, so create them.
-  "initializeCommand": "./scripts/support/initialize-vscode ${localEnv:USERPROFILE}${localEnv:HOME}",
+
+  // Note that we use an array here as when cloning directly into a new
+  // container, the bootstrap container used by the Remote Containers extension
+  // doesn't have bash, which is needed to interpolate string values here
+  "initializeCommand": [
+    "./scripts/support/initialize-vscode",
+    "${localEnv:USERPROFILE}${localEnv:HOME}"
+  ],
 
   // Run one build-server, and keep it running for the life of the
   // devcontainer. This is in postStart rather than postAttach as postAttach would


### PR DESCRIPTION
When using VSCode with the Remote Containers extension, the extension
bootstraps a container using a default alpine container. The alpine
container does not have bash.

When executing the `initializeCommand` script, the build fails when
trying to call bash. I speculate that it is trying to call bash because
there's a string in initializeCommand, but that it wouldn't if there was
instead an array - which doesn't need a shell to sort out.

