### PR TITLE
Match old interpreter

### DIFF
--- a/backend/liblegacy/fuzzing.ml
+++ b/backend/liblegacy/fuzzing.ml
@@ -218,6 +218,22 @@ let fns : Types.RuntimeT.fn list =
               Lib.fail args)
     ; preview_safety = Safe
     ; deprecated = false }
+  ; { prefix_names = ["Test::resetSideEffectCounter"]
+    ; infix_names = []
+    ; parameters = []
+    ; return_type = TNull
+    ; description =
+        "Resets the side effect counter to zero, to test real-world side-effects."
+    ; func =
+        InProcess
+          (function
+          | state, [] ->
+              sideEffectCount := 0 ;
+              DNull
+          | args ->
+              Lib.fail args)
+    ; preview_safety = Safe
+    ; deprecated = false }
   ; { prefix_names = ["Test::sideEffectCount"]
     ; infix_names = []
     ; parameters = []

--- a/fsharp-backend/src/ApiServer/Middleware.fs
+++ b/fsharp-backend/src/ApiServer/Middleware.fs
@@ -287,7 +287,7 @@ let executionIDMiddleware : HttpHandler =
       let executionID = gid ()
       let newCtx = saveExecutionID executionID ctx
       let headerValue = StringValues([| toString executionID |])
-      ctx.Response.Headers.Add("x-darklang-execution-id", headerValue)
+      ctx.Response.Headers.["x-darklang-execution-id"] <- headerValue
       return! next newCtx
     })
 

--- a/fsharp-backend/src/BwdServer/BwdServer.fs
+++ b/fsharp-backend/src/BwdServer/BwdServer.fs
@@ -42,11 +42,7 @@ module TI = LibBackend.TraceInputs
 // Headers
 // ---------------
 let setHeader (ctx : HttpContext) (name : string) (value : string) : unit =
-  // There's an exception thrown for duplicate test name. We just want the last
-  // header to win, especially since the user can add the same headers we add
-  let (_ : bool) = ctx.Response.Headers.Remove name
-
-  ctx.Response.Headers.Add(name, StringValues([| value |]))
+  ctx.Response.Headers.[name] <- StringValues([| value |])
 
 let getHeader (hs : IHeaderDictionary) (name : string) : string option =
   match hs.TryGetValue name with

--- a/fsharp-backend/src/LibExecution/Execution.fs
+++ b/fsharp-backend/src/LibExecution/Execution.fs
@@ -37,6 +37,7 @@ let createState
   { libraries = libraries
     tracing = tracing
     program = program
+    test = { sideEffectCount = 0 }
     tlid = tlid
     callstack = Set.empty
     onExecutionPath = true

--- a/fsharp-backend/src/LibExecution/Execution.fs
+++ b/fsharp-backend/src/LibExecution/Execution.fs
@@ -132,6 +132,7 @@ let traceDvals () : Dictionary<id, AT.ExecutionResult> * RT.TraceDval =
     let result =
       (if onExecutionPath then AT.ExecutedResult dval else AT.NonExecutedResult dval)
 
-    results.Add(id, result)
+    // Overwrites if present, which is what we want
+    results.[id] <- result
 
   (results, trace)

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -52,9 +52,9 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
       // return it instead of evaling the body
       | DErrorRail v -> return rhs
       | _ ->
-        let st = if lhs <> "" then st.Add(lhs, rhs) else st
-        return! (eval state st body)
-    | EString (_id, s) -> return (DStr(s.Normalize()))
+        let st = if lhs <> "" then Map.add lhs rhs st else st
+        return! eval state st body
+    | EString (_id, s) -> return DStr(s.Normalize())
     | EBool (_id, b) -> return DBool b
     | EInteger (_id, i) -> return DInt i
     | EFloat (_id, value) -> return DFloat value
@@ -194,7 +194,7 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
         // Since we return a DBlock, it's contents may never be
         // executed. So first we execute with no context to get some
         // live values.
-        let fakeST = st.Add("var", DIncomplete SourceNone)
+        let fakeST = Map.add "var" (DIncomplete SourceNone) st
         do! preview fakeST body
       let parameters =
         List.choose

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -157,7 +157,7 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
 
       return! Value result
     | EFeatureFlag (id, cond, oldcode, newcode) ->
-      // True gives newexpr, unlike in If statements
+      // True gives newcode, unlike in If statements
       //
       // In If statements, we use a false/null as false, and anything else is
       // true. But this won't work for feature flags. If statements are built
@@ -179,23 +179,13 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
         try
           eval state st cond
         with
-        | e -> Value(DBool false)
+        | _ -> Value(DBool false)
 
-      match cond with
-      | DBool true ->
-        // FSTODO
-        (* preview st oldcode *)
+      if cond = DBool true then
+        do! preview st oldcode
         return! eval state st newcode
-      // FSTODO
-      | DIncomplete _
-      | DErrorRail _
-      | DError _ ->
-        // FSTODO
-        (* preview st newcode *)
-        return! eval state st oldcode
-      | _ ->
-        // FSTODO
-        (* preview st newcode *)
+      else
+        do! preview st newcode
         return! eval state st oldcode
 
     // FSTODO

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -140,7 +140,8 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
             Map.tryFind field o |> Option.defaultValue DNull
         | DIncomplete _ -> obj
         | DErrorRail _ -> obj
-        | DError _ -> obj // differs from ocaml, but produces an Error either way
+        // CLEANUP: we should propagate DErrors too
+        // | DError _ -> obj // differs from ocaml, but produces an Error either way
         | x ->
           let actualType =
             match Dval.toType x with

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -369,11 +369,16 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
       | DNull ->
         do! preview st thenbody
         return! eval state st elsebody
+      | DError (src, _) ->
+        do! preview st thenbody
+        do! preview st elsebody
+        return DError(src, "Expected boolean, got error")
       | cond when Dval.isFake cond ->
         do! preview st thenbody
         do! preview st elsebody
         return cond
       // CLEANUP: I dont know why I made these always true
+      // This can't be cleaned up without a new language version
       | _ ->
         let! result = eval state st thenbody
         do! preview st elsebody

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -428,11 +428,14 @@ and applyFn
       | DFnVal fnVal, _ -> applyFnVal state id fnVal args isInPipe ster
       // Incompletes are allowed in pipes
       | DIncomplete _, InPipe _ -> Value(Option.defaultValue fn (List.tryHead args))
+      | other, InPipe _ ->
+        // CLEANUP: this matches the old pipe behaviour, no need to preserve that
+        Value(Option.defaultValue fn (List.tryHead args))
       | other, _ ->
         Value(
           Dval.errSStr
             sourceID
-            $"Expected a function value, got something else: {other}"
+            $"Expected a function value, got something else: {DvalRepr.toDeveloperReprV0 other}"
         )
 
   }

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -835,6 +835,9 @@ and Tracing =
     storeFnArguments : StoreFnArguments
     realOrPreview : RealOrPreview }
 
+// Used for testing
+and TestContext = { mutable sideEffectCount : int }
+
 // Non-user-specific functionality needed to run code
 and Libraries =
   { stdlib : Map<FQFnName.T, BuiltInFn>
@@ -845,6 +848,7 @@ and ExecutionState =
   { libraries : Libraries
     tracing : Tracing
     program : ProgramContext
+    test : TestContext
     // TLID of the currently executing handler/fn
     tlid : tlid
     executingFnName : Option<FQFnName.T>

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -51,8 +51,8 @@ let send (executionID : id) (metadata : List<string * string>) (e : exn) : unit 
   try
     printfn "sending exception to rollbar"
     let (state : Dictionary.T<string, obj>) = Dictionary.empty ()
-    state.Add("message.honeycomb", honeycombLinkOfExecutionID executionID)
-    state.Add("execution_id", executionID)
+    state.["message.honeycomb"] <- honeycombLinkOfExecutionID executionID
+    state.["execution_id"] <- executionID
     List.iter (fun (k, v) -> Dictionary.add k (v :> obj) state |> ignore) metadata
 
     let (_ : Rollbar.ILogger) =

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -278,7 +278,7 @@ module Dictionary =
   let get = FSharpPlus.Dictionary.tryGetValue
 
   let add (k : 'k) (v : 'v) (d : T<'k, 'v>) : T<'k, 'v> =
-    d.Add(k, v)
+    d.[k] <- v
     d
 
   let empty () : T<'k, 'v> = System.Collections.Generic.Dictionary<'k, 'v>()
@@ -297,7 +297,7 @@ module Dictionary =
 
   let fromList (l : List<'k * 'v>) : T<'k, 'v> =
     let result = System.Collections.Generic.Dictionary<'k, 'v>()
-    List.iter (fun (k, v) -> result.Add(k, v)) l
+    List.iter (fun (k, v) -> result.[k] <- v) l
     result
 
 

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -275,7 +275,7 @@ module HashSet =
 
 module Dictionary =
   type T<'k, 'v> = System.Collections.Generic.Dictionary<'k, 'v>
-  let tryGetValue = FSharpPlus.Dictionary.tryGetValue
+  let get = FSharpPlus.Dictionary.tryGetValue
 
   let add (k : 'k) (v : 'v) (d : T<'k, 'v>) : T<'k, 'v> =
     d.Add(k, v)

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -80,6 +80,7 @@ let rec convertToExpr (ast : SynExpr) : PT.Expr =
     | SynPat.Const (SynConst.Char c, _) -> pChar c
     | SynPat.Const (SynConst.Bool b, _) -> pBool b
     | SynPat.Null _ -> pNull ()
+    | SynPat.Paren (pat, _) -> convertPattern pat
     | SynPat.Const (SynConst.Double d, _) ->
       let sign, whole, fraction = splitFloat d
       pFloat sign whole fraction

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -259,7 +259,9 @@ let rec convertToExpr (ast : SynExpr) : PT.Expr =
     |> List.map
          (function
          | ((LongIdentWithDots ([ name ], _), _), Some expr, _) ->
-           (name.idText, c expr)
+           // Allow empty fields in tests
+           let name = if name.idText = "___" then "" else name.idText
+           (name, c expr)
          | f -> failwith $"Not an expected field {f}")
     |> eRecord
   | SynExpr.Paren (expr, _, _, _) -> c expr // just unwrap

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -126,6 +126,7 @@ let rec convertToExpr (ast : SynExpr) : PT.Expr =
                  ("op_EqualsEquals", "==")
                  ("op_Equality", "==")
                  ("op_BangEquals", "!=")
+                 ("op_Inequality", "!=")
                  ("op_BooleanAnd", "&&")
                  ("op_BooleanOr", "||") ]
 

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -98,7 +98,8 @@ let rec convertToExpr (ast : SynExpr) : PT.Expr =
 
   let convertLambdaVar (var : SynSimplePat) : string =
     match var with
-    | SynSimplePat.Id (name, _, _, _, _, _) -> name.idText
+    | SynSimplePat.Id (name, _, _, _, _, _) ->
+      if name.idText = "___" then "" else name.idText
     | _ -> failwith $"unsupported lambdaVar {var}"
 
   // Add a pipetarget after creating it

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -105,7 +105,21 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
-
+    { name = fn "Test" "resetSideEffectCounter" 0
+      parameters = []
+      returnType = TNull
+      description =
+        "Reset the side effect counter to zero, to test real-world side-effects."
+      fn =
+        (function
+        | state, [ arg ] ->
+          // CLEANUP this function is no longer needed once we remove ocaml
+          state.test.sideEffectCount <- 0
+          Value(arg)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
     { name = fn "Test" "incrementSideEffectCounter" 0
       parameters =
         [ Param.make "passThru" (TVariable "a") "Value which will be returned" ]

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -17,9 +17,6 @@ let incorrectArgs = LibExecution.Errors.incorrectArgs
 let varA = TVariable "a"
 let varB = TVariable "b"
 
-// FSTODO: this is going cause race conditions - we should move this into state
-let sideEffectCount : int ref = ref 0
-
 let fns : List<BuiltInFn> =
   [ { name = fn "Test" "errorRailNothing" 0
       parameters = []
@@ -118,7 +115,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [ arg ] ->
-          sideEffectCount := !sideEffectCount + 1
+          state.test.sideEffectCount <- state.test.sideEffectCount + 1
           Value(arg)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
@@ -130,7 +127,7 @@ let fns : List<BuiltInFn> =
       description = "Return the value of the side-effect counter"
       fn =
         (function
-        | state, [] -> Value(Dval.int !sideEffectCount)
+        | state, [] -> Value(Dval.int state.test.sideEffectCount)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/tests/Tests/Execution.Tests.fs
+++ b/fsharp-backend/tests/Tests/Execution.Tests.fs
@@ -121,7 +121,7 @@ let testOtherDbQueryFunctionsHaveAnalysis : Test =
     let! _value = Exe.executeExpr state Map.empty ast
 
     Expect.equal
-      (Dictionary.tryGetValue varID results)
+      (Dictionary.get varID results)
       (Some(AT.ExecutedResult(DObj(Map.ofList [ "age", DIncomplete SourceNone ]))))
       "Has an age field"
   }
@@ -134,7 +134,7 @@ let testListLiterals : Test =
     let! (results : AT.AnalysisResults) = execSaveDvals [] [] ast
 
     return
-      match Dictionary.tryGetValue id results with
+      match Dictionary.get id results with
       | Some (AT.ExecutedResult (DIncomplete _)) -> Expect.isTrue true ""
       | _ -> Expect.isTrue false ""
   }
@@ -157,12 +157,12 @@ let testRecursionInEditor : Test =
     let! results = execSaveDvals [] [ recurse ] ast
 
     Expect.equal
-      (Dictionary.tryGetValue callerID results)
+      (Dictionary.get callerID results)
       (Some(AT.ExecutedResult(DInt 0I)))
       "result is there as expected"
 
     Expect.equal
-      (Dictionary.tryGetValue skippedCallerID results)
+      (Dictionary.get skippedCallerID results)
       (Some(
         AT.NonExecutedResult(DIncomplete(SourceID(recurse.tlid, skippedCallerID)))
       ))
@@ -170,7 +170,7 @@ let testRecursionInEditor : Test =
   }
 
 
-let testIfNotIsEvaluated : Test =
+let testIfPreview : Test =
   testTask "test if else case is evaluated" {
     let falseID = gid ()
     let trueID = gid ()
@@ -179,15 +179,14 @@ let testIfNotIsEvaluated : Test =
     let! results = execSaveDvals [] [] ast
 
     let check id expected msg =
-      Expect.equal (Dictionary.tryGetValue id results) (Some expected) msg
+      Expect.equal (Dictionary.get id results) (Some expected) msg
 
     check ifID (AT.ExecutedResult(DInt 5I)) "if is ok"
     check trueID (AT.ExecutedResult(DInt 5I)) "truebody is ok"
     check falseID (AT.NonExecutedResult(DInt 6I)) "falsebody is ok"
   }
 
-
-let testMatchEvaluation : Test =
+let testMatchPreview : Test =
   testTask "test match evaluation" {
     let mid = gid ()
     let pIntId = gid ()
@@ -253,7 +252,7 @@ let testMatchEvaluation : Test =
         List.iter
           (fun (id, name, value) ->
             Expect.equal
-              (Dictionary.tryGetValue id results)
+              (Dictionary.get id results)
               (Some value)
               $"{msg}: {id}, {name}")
           expected
@@ -278,7 +277,7 @@ let testMatchEvaluation : Test =
         |> List.iter
              (fun id ->
                if not (Set.contains id expectedIDs) then
-                 match Dictionary.tryGetValue id results with
+                 match Dictionary.get id results with
                  | Some (AT.ExecutedResult dv) ->
                    Expect.isTrue
                      false
@@ -390,8 +389,8 @@ let tests =
     "Execution"
     [ testListLiterals
       testRecursionInEditor
-      testIfNotIsEvaluated
-      testMatchEvaluation
+      testIfPreview
+      testMatchPreview
       testExecFunctionTLIDs
       testErrorRailUsedInAnalysis
       testOtherDbQueryFunctionsHaveAnalysis ]

--- a/fsharp-backend/tests/Tests/Execution.Tests.fs
+++ b/fsharp-backend/tests/Tests/Execution.Tests.fs
@@ -292,7 +292,7 @@ let testLambdaPreview : Test =
            )
          )
         ),
-        Some(AT.ExecutedResult(DStr "body")))) ]
+        Some(AT.NonExecutedResult(DStr "body")))) ]
 
 
 

--- a/fsharp-backend/tests/Tests/Execution.Tests.fs
+++ b/fsharp-backend/tests/Tests/Execution.Tests.fs
@@ -267,6 +267,34 @@ let testFeatureFlagPreview : Test =
         AT.ExecutedResult(DStr "old"),
         AT.NonExecutedResult(DStr "new"))) ]
 
+let testLambdaPreview : Test =
+  let f body =
+    task {
+      let lID = gid ()
+      let bodyID = Expr.toID body
+      let ast = ELambda(lID, [], body)
+      let! results = execSaveDvals [] [] ast
+
+      return (Dictionary.get lID results, Dictionary.get bodyID results)
+    }
+  testManyTask
+    "lambda preview"
+    f
+    [ (EString(65UL, "body"),
+       (Some(
+         AT.ExecutedResult(
+           DFnVal(
+             Lambda(
+               { parameters = []
+                 symtable = Map.empty
+                 body = EString(65UL, "body") }
+             )
+           )
+         )
+        ),
+        Some(AT.ExecutedResult(DStr "body")))) ]
+
+
 
 let testMatchPreview : Test =
   testTask "test match evaluation" {
@@ -472,6 +500,7 @@ let tests =
     [ testListLiterals
       testRecursionInEditor
       testIfPreview
+      testLambdaPreview
       testFeatureFlagPreview
       testMatchPreview
       testExecFunctionTLIDs

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -1,9 +1,77 @@
-(5 + 3) = 8 // binop
--55555555555555555555555555555.5 = -55555555555555555555555555555.5
+// ---------------------------
+// Basic interpreter execution
+// ---------------------------
 
-[test.lambda]
-(let y = (fun x -> x + 1) in
- List.map_v0 [1;2;3;4] y) = [ 2; 3; 4; 5 ]
+[tests.let]
+(let x = Test.errorRailNothing_v0 in 5) = Test.errorRailNothing_v0
+(let x = blank in 5) = 5
+(let x = Test.typeError_v0 "" in 5) = 5
+(let x = 5 in x) = 5
+
+
+[tests.list]
+[] = []
+[1] = [1]
+[ 5; blank; 0 ] = [5;0]
+[ 5; Int.add_v0 blank 5; 0 ] = [5;0]
+[ 5; Test.typeError_v0 "test"; 0 ] = [ 5; Test.typeError_v0 "test"; 0 ]
+[ 5; Test.errorRailNothing_v0; 0 ] = Test.errorRailNothing_v0
+
+
+[tests.records]
+{ col1 = 1 ; col1 = 2 } = Test.typeError_v0 "Duplicate key: col1"
+{ col1 = 1 ; col2 = 3 } = { col1 = 1 ; col2 = 3 }
+{ col1 = 2 ; col2 = blank } = { col1 = 2 }
+{ col1 = 2 ; col2 = Test.typeError_v0 "test" } = { col1 = 2; col2 = Test.typeError_v0 "test" }
+{ col1 = 2 ; col2 = Test.errorRailNothing_v0 } = Test.errorRailNothing_v0
+{ col1 = 2 ; ___ = 3 } = { col1 = 2 }
+(let _ = { col1 = 2 ; ___ = Test.incrementSideEffectCounter_v0 2 } in Test.sideEffectCount_v0) = 1
+
+
+[tests.fieldAccess]
+(let x = { col1 = 1 } in x.fieldName) = null
+
+
+[tests.variable]
+myvar = Test.typeError_v0 "There is no variable named: myvar"
+(let x = 5 in x) = 5
+
+
+[tests.fncall]
+(5 + 3) = 8
+Int.add_v0 5 3 = 8
+
+[tests.fqfnname]
+toString 5 = "5"
+
+
+[tests.if]
+(if true then "correct" else 0) = "correct")
+(if false then "" else "correct") = "correct")
+(if null then "" else "correct") = "correct")
+(if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "Expected boolean, got error")
+(if List.head_v1_ster [] then "" else "") = Test.errorRailNothing_v0)
+(if blank then "" else "") = blank
+(if 5 then "correct" else "") = "correct"
+
+
+[tests.featureflag]
+flag "test" true "old" "new" = "new"
+flag "test" false "old" "new" = "old"
+flag "" [true] "old" "new" = "old"
+// everything else is old
+flag "test" null "old" "new" = "old"
+flag "test" 5 "old" "new" = "old"
+flag "test" blank "old" "new" = "old"
+flag "test" (Test.typeError_v0 "test") "old" "new" = "old"
+flag "test" (List.head_v1_ster []) "old" "new" = "old"
+flag "test" {x = true} "old" "new" = "old"
+flag "test" [true] "old" "new" = "old"
+
+
+[tests.lambdas]
+List.push_v0 [] (fun x -> -4.611686018e+18) = [(fun x -> -4.611686018e+18)]
+(let y = (fun x -> x + 1) in List.map_v0 [1;2;3;4] y) = [ 2; 3; 4; 5 ]
 
 [test.lambda1]
 (let x = 5 in
@@ -17,8 +85,36 @@
     (String.toList_v1 "some string")
     (fun var -> String.toUppercase_v0 (String.fromChar_v1 var))) "") = "SOME STRING"
 
-[test.lambdaFloat]
-List.push_v0 [] (fun x -> -4.611686018e+18) = [(fun x -> -4.611686018e+18)]
+
+
+[tests.pipes]
+([] |> List.push_v0 2) = [2]
+
+[test.pipes]
+([5]
+ |> List.head_v0
+ |> Int.add_v0 1
+ |> (+) 3
+ |> blank
+ |> (fun x -> if (x + 4) > 1 then x else (1 + x))) = 9
+
+[test.pipevariable FSHARPONLY - we didn't implement this in OCaml]
+(let x = fun a -> a + 1 in
+ (5
+ |> x
+ |> x
+ |> (+) 3
+ |> blank)) = 10
+
+
+[tests.match]
+(match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"
+(match "x" with | "y" -> "fail" | "x" -> "pass" | var -> "fail") = "pass"
+(match true with | false -> "fail" | true -> "pass" | var -> "fail") = "pass"
+(match 2.0 with | 1.0 -> "fail" | 2.0 -> "pass" | var -> "fail") = "pass"
+(match null with | null -> "pass" | var -> "fail") = "pass"
+(match 2.0 with | blank -> "fail" | 2.0 -> "pass" | var -> "fail") = "pass"
+(match 999999999999999I with | 0 -> "fail" | 999999999999999I -> "pass") = "pass"
 
 [test.matchInt]
 (match 5 with
@@ -128,39 +224,19 @@ List.push_v0 [] (fun x -> -4.611686018e+18) = [(fun x -> -4.611686018e+18)]
  | Nothing -> "constructor nothing"
  | name -> name ++ "var") = "not matched: var"
 
-[tests.match]
-(match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"
-(match "x" with | "y" -> "fail" | "x" -> "pass" | var -> "fail") = "pass"
-(match true with | false -> "fail" | true -> "pass" | var -> "fail") = "pass"
-(match 2.0 with | 1.0 -> "fail" | 2.0 -> "pass" | var -> "fail") = "pass"
-(match null with | null -> "pass" | var -> "fail") = "pass"
-(match 2.0 with | blank -> "fail" | 2.0 -> "pass" | var -> "fail") = "pass"
-(match 999999999999999I with | 0 -> "fail" | 999999999999999I -> "pass") = "pass"
-
-[test.pipesimple]
-([] |> List.push_v0 2) = [2]
-
-[test.pipes]
-([5]
- |> List.head_v0
- |> Int.add_v0 1
- |> (+) 3
- |> blank
- |> (fun x -> if (x + 4) > 1 then x else (1 + x))) = 9
-
-[test.pipevariable FSHARPONLY - we didn't implement this in OCaml]
-(let x = fun a -> a + 1 in
- (5
- |> x
- |> x
- |> (+) 3
- |> blank)) = 10
 
 [tests.constructors]
 Nothing = Nothing
 ((List.head_v1 []) == Nothing) = true
 
-[tests.incomplete_propagation]
+
+// ---------------------------
+// Fakeval propagation and handling
+// This should also should be tested above for all cases
+// No harm in repeating tests
+// ---------------------------
+
+[tests.incompletePropagation]
 List.head_v0 blank = blank
 (if blank then 5 else 6) = blank
 (List.head_v0 blank).field = blank
@@ -180,28 +256,34 @@ List.map_v0 [1;2;3;4;5] (fun x y -> x) = Test.typeError_v0 "Expected 2 arguments
 Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 "Option::map2 was called with the wrong type to parameter: option2" // OCAMLONLY
 Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 "Option::map2 was called with a String (\"not an option\"), but `option2` expected a Option." // FSHARPONLY
 
-[fn.errorRailFn arg]
-[] |> List.head_v1_ster |> (+) 3 |> (fun x -> if (x + 4) > 1 then x else (1 + x))
 
+
+[fn.errorRailFn arg]
+([] |> List.head_v1_ster |> (+) 3 |> (fun x -> if (x + 4) > 1 then x else (1 + x)))
 
 [tests.errorrail]
+
 Dict.get_v1 {} "i" = Nothing
 Dict.get_v1_ster {} "i" = Test.errorRailNothing_v0_ster
 ([5] |> List.head_v1_ster |> (+) 3 |> (fun x -> if (x + 4) > 1 then x else (1 + x))) = 8
 ([ ] |> List.head_v1_ster |> (+) 3 |> (fun x -> if (x + 4) > 1 then x else (1 + x))) = Test.errorRailNothing_v0
-(errorRailFn null) = Nothing
 (blank == Test.errorRailNothing_v0) = Test.errorRailNothing_v0
 (let x = Dict.get_v1_ster {} "i" in 1) = Test.errorRailNothing_v0
+(errorRailFn null) = Nothing
+
 
 [tests.errorrailPropagation]
-List.push_v0 [1;2;3;4] (List.head_v1_ster []) = Test.errorRailNothing_v0_ster
-// List.filter_v1 [1;2;3;4] (fun x -> List.head_v1_ster []) = Test.errorRailNothing_v0_ster
-List.map_v0 [1;2;3;4] (fun x -> List.head_v1_ster []) = Test.errorRailNothing_v0_ster
-List.fold_v0 [1;2;3;4] 1 (fun x y -> List.head_v1_ster []) = Test.errorRailNothing_v0_ster
+List.push_v0 [1;2;3;4] Test.errorRailNothing_v0 = Test.errorRailNothing_v0
+List.filter_v1 [1;2;3;4] (fun x -> Test.errorRailNothing_v0) = Test.errorRailNothing_v0
+List.map_v0 [1;2;3;4] (fun x -> Test.errorRailNothing_v0) = Test.errorRailNothing_v0
+List.fold_v0 [1;2;3;4] 1 (fun x y -> Test.errorRailNothing_v0) = Test.errorRailNothing_v0
 List.map_v0 [1;2;3;4] (fun x -> blank) = blank
-{ x = (List.head_v1_ster []) } = Test.errorRailNothing_v0_ster
-Error (List.head_v1_ster []) = Test.errorRailNothing_v0_ster
+{ x = Test.errorRailNothing_v0 } = Test.errorRailNothing_v0
+Error Test.errorRailNothing_v0 = Test.errorRailNothing_v0
 
+// ---------------------------
+// Shadowing
+// ---------------------------
 [tests.shadowing]
 (let x = 5 in let x = 6 in x) = 6
 (let x = 35 in (match 6 with | x -> x)) = 6
@@ -210,60 +292,18 @@ Error (List.head_v1_ster []) = Test.errorRailNothing_v0_ster
 (let x = 35 in (match Ok 6 with | Ok x -> (List.map_v0 [1; 2; 3; 4] (fun x -> x + 2)))) = [ 3; 4; 5; 6]
 (List.map_v0 [1;2;3;4] (fun x -> (let x = 35 in (match Ok 6 with | Ok x -> x + 2)))) = [ 8; 8; 8; 8 ]
 (List.map_v0 [1;2;3;4] (fun x -> (match Ok 6 with | Ok x -> let x = 9 in x + 2))) = [ 11; 11; 11; 11 ]
-
-[tests.records]
-{ col1 = 1 ; col1 = 2 } = Test.typeError_v0 "Duplicate key: col1"
-{ col1 = 1 ; col2 = 3 } = { col1 = 1 ; col2 = 3 }
-{ col1 = 2 ; col2 = blank } = { col1 = 2 }
-{ col1 = 2 ; col2 = Test.typeError_v0 "test" } = { col1 = 2; col2 = Test.typeError_v0 "test" }
-{ col1 = 2 ; col2 = Test.errorRailNothing_v0 } = Test.errorRailNothing_v0
-{ col1 = 2 ; ___ = 3 } = { col1 = 2 }
-(let _ = { col1 = 2 ; ___ = Test.incrementSideEffectCounter_v0 2 } in Test.sideEffectCount_v0) = 1
-
-[tests.fieldAccess]
-(let x = { col1 = 1 } in x.fieldName) = null
-
-[tests.list]
-[] = []
-[1] = [1]
-[ 5; blank; 0 ] = [5;0]
-[ 5; Int.add_v0 blank 5; 0 ] = [5;0]
-[ 5; Test.typeError_v0 "test"; 0 ] = [ 5; Test.typeError_v0 "test"; 0 ]
-[ 5; (List.head_v1_ster []); 0 ] = Test.errorRailNothing_v0
-
-[tests.variable]
-myvar = Test.typeError_v0 "There is no variable named: myvar"
-(let x = 5 in x) = 5
+(List.map_v0 [1;2;3;4] (fun x -> (match Ok (Ok 6) with | Ok (Ok x) -> let x = 9 in x + 2))) = [ 11; 11; 11; 11 ]
 
 
-[tests.featureflag]
-flag "test" true "old" "new" = "new" // show new for true
-flag "test" false "old" "new" = "old" // show old for false
-flag "test" blank "old" "new" = "old" // show old for incomplete condition
-flag "test" null "old" "new" = "old" // show old for null
-flag "test" (Test.typeError_v0 "test") "old" "new" = "old" // show old for error
-flag "test" (List.head_v1_ster []) "old" "new" = "old" // show old for errorrail
-flag "test" {x = true} "old" "new" = "old" // show old for object
-flag "test" [true] "old" "new" = "old" // show old for list
-
-[tests.if]
-(if true then "correct" else 0) = "correct")
-(if false then "" else "correct") = "correct")
-(if null then "" else "correct") = "correct")
-(if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "Expected boolean, got error")
-(if List.head_v1_ster [] then "" else "") = Test.errorRailNothing_v0)
-(if blank then "" else "") = blank
-(if 5 then "correct" else "") = "correct"
-
-
-[tests.fqfnname]
-toString 5 = "5"
-
+// ---------------------------
+// Equality
+// ---------------------------
 
 [tests.equality]
 (5 = 5) = true
 (5 <> 6) = true
 (5.6 = 5.6) = true
+(-55555555555555555555555555555.5 = -55555555555555555555555555555.5) = true
 (5.6 <> 5.7) = true
 (5.7 <> 6) = true
 (5.7 <> 5) = true
@@ -302,6 +342,6 @@ toString 5 = "5"
 ((fun x -> let y = 1 in y) <> (fun x -> let y = 1 in x)) = true
 
 [db.MyDB { "x" : "Str", "y": "Str" }]
-[test.db equality] with DB MyDB
-MyDB = MyDB
-MyDB <> 5
+[tests.db equality] with DB MyDB
+(MyDB = MyDB) = true
+(MyDB <> 5) = true

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -215,10 +215,11 @@ Error (List.head_v1_ster []) = Test.errorRailNothing_v0_ster
 { col1 = 1 ; col1 = 2 } = Test.typeError_v0 "Duplicate key: col1"
 { col1 = 1 ; col2 = 3 } = { col1 = 1 ; col2 = 3 }
 { col1 = 2 ; col2 = blank } = { col1 = 2 }
-//({ col1 = 2 ; ```` = blank }) = ({ col1 = 2 }) // todo: do unit test instead
 { col1 = 2 ; col2 = Test.typeError_v0 "test" } = { col1 = 2; col2 = Test.typeError_v0 "test" }
 { col1 = 2 ; col2 = (List.head_v1_ster []) } = Test.errorRailNothing_v0_ster
 (let x = { col1 = 1 } in x.fieldName) = null
+{ col1 = 2 ; ___ = 3 } = { col1 = 2 }
+(let _ = { col1 = 2 ; ___ = Test.incrementSideEffectCounter_v0 2 } in Test.sideEffectCount_v0) = 1
 
 [tests.list]
 [] = []

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -261,43 +261,45 @@ toString 5 = "5"
 
 
 [tests.equality]
-5 = 5
-5 <> 6
-5.6 = 5.6
-5.6 <> 5.7
-5.7 <> 6
-5.7 <> 5
-true = true
-false = false
-true <> false
-null = null
-null <> Nothing
-null <> false
-null <> 0
-null <> 0.0
-[ 1; 2; 3 ] = [ 1; 2; 3]
-[ 1; 2; 3 ] <> [ 3; 2; 1]
-{ x = 6; y = 7 } = { x = 6; y = 7 }
-{ x = 6; y = 7 } = { y = 7; x = 6 }
-{ x = 6; y = 7 } <> { x = 7; y = 6 }
-"asd" = "asd"
-"asd" <> "sad"
-(Date.parse_v2 "2019-07-28T22:42:36Z") = (Date.parse_v2 "2019-07-28T22:42:36Z")
-(Date.parse_v2 "2019-07-28T22:42:37Z") <> (Date.parse_v2 "2019-07-28T22:42:36Z")
-String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d" = String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
-String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2e" <> String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
-Nothing = Nothing
-Nothing <> Just Nothing
-Just 5 = Just 5
-Just 5 <> Just 6
-Just (Just 0) <> Just (Just 1)
-Just (Just 0) = Just (Just 0)
-Error 0 = Error 0
-Ok 0 = Ok 0
-Ok 0 <> Error 0
-(String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼") = (String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼")
+(5 = 5) = true
+(5 <> 6) = true
+(5.6 = 5.6) = true
+(5.6 <> 5.7) = true
+(5.7 <> 6) = true
+(5.7 <> 5) = true
+(blank = blank) = blank
+(Test.typeError_v0 "test" <> Test.typeError_v0 "different msg") = Test.typeError_v0 "Fn called with an error as an argument"
+(true = true) = true
+(false = false) = true
+(true <> false) = true
+(null = null) = true
+(null <> Nothing) = true
+(null <> false) = true
+(null <> 0) = true
+(null <> 0.0) = true
+([ 1; 2; 3 ] = [ 1; 2; 3 ]) = true
+([ 1; 2; 3 ] <> [ 3; 2; 1 ]) = true
+({ x = 6; y = 7 } = { x = 6; y = 7 }) = true
+({ x = 6; y = 7 } = { y = 7; x = 6 }) = true
+({ x = 6; y = 7 } <> { x = 7; y = 6 }) = true
+("asd" = "asd") = true
+("asd" <> "sad") = true
+((Date.parse_v2 "2019-07-28T22:42:36Z") = (Date.parse_v2 "2019-07-28T22:42:36Z")) = true
+((Date.parse_v2 "2019-07-28T22:42:37Z") <> (Date.parse_v2 "2019-07-28T22:42:36Z")) = true
+(String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d" = String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = true
+(String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2e" <> String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = true
+(Nothing = Nothing) = true
+(Nothing <> Just Nothing) = true
+(Just 5 = Just 5) = true
+(Just 5 <> Just 6) = true
+(Just (Just 0) <> Just (Just 1)) = true
+(Just (Just 0) = Just (Just 0)) = true
+(Error 0 = Error 0) = true
+(Ok 0 = Ok 0) = true
+(Ok 0 <> Error 0) = true
+((String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼") = (String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼")) = true
 //(fun x -> y) = (fun x -> y) // CLEANUP: they have different IDs so they're not equal
-(fun x -> let y = 1 in y) <> (fun x -> let y = 1 in x)
+((fun x -> let y = 1 in y) <> (fun x -> let y = 1 in x)) = true
 
 [db.MyDB { "x" : "Str", "y": "Str" }]
 [test.db equality] with DB MyDB

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -29,8 +29,14 @@
 
 
 [tests.fieldAccess]
+(let x = { col1 = 1 } in x.col1) = 1
+(let x = { col1 = 1 } in x.___) = blank
 (let x = { col1 = 1 } in x.fieldName) = null
-
+(let x = blank in x.fieldName) = blank
+(let x = Test.typeError_v0 "error" in x.fieldName) = Test.typeError_v0 "Attempting to access a field of something that isn't a record or dict, (it's a Error)."
+(let x = Test.errorRailNothing_v0 in x.fieldName) = Test.errorRailNothing_v0
+(let x = 6 in x.fieldName) = Test.typeError_v0 "Attempting to access a field of something that isn't a record or dict, (it's a Int)."
+(let x = { col1 = 1 } in x.fieldName) = null
 
 [tests.variable]
 myvar = Test.typeError_v0 "There is no variable named: myvar"

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -240,6 +240,15 @@ flag "test" (List.head_v1_ster []) "old" "new" = "old" // show old for errorrail
 flag "test" {x = true} "old" "new" = "old" // show old for object
 flag "test" [true] "old" "new" = "old" // show old for list
 
+[tests.if]
+(if true then "correct" else 0) = "correct")
+(if false then "" else "correct") = "correct")
+(if null then "" else "correct") = "correct")
+(if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "Expected boolean, got error")
+(if List.head_v1_ster [] then "" else "") = Test.errorRailNothing_v0)
+(if blank then "" else "") = blank
+(if 5 then "correct" else "") = "correct"
+
 
 [tests.fqfnname]
 toString 5 = "5"

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -264,6 +264,23 @@ Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 
 Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 "Option::map2 was called with a String (\"not an option\"), but `option2` expected a Option." // FSHARPONLY
 
 
+[tests.errorPropagation]
+List.head_v0 (Test.typeError_v0 "test") = Test.typeError_v0 "Fn called with an error as an argument"
+(if Test.typeError_v0 "test" then 5 else 6) = Test.typeError_v0 "Expected boolean, got error"
+(List.head_v0 (Test.typeError_v0 "test")).field = Test.typeError_v0 "Attempting to access a field of something that isn't a record or dict, (it's a Error)."
+[ 5; 6; List.head_v0 (Test.typeError_v0 "test") ] = [5;6; Test.typeError_v0 "Fn called with an error as an argument"]
+[ 5; 6; Test.typeError_v0 "test"] = [ 5; 6; Test.typeError_v0 "test"]
+{ i = Test.typeError_v0 "test"; m = 5; j = List.head_v0 (Test.typeError_v0 "test"); n = 6 } = { n = 6; m = 5 ; j = Test.typeError_v0 "Fn called with an error as an argument"; i = Test.typeError_v0 "test" }
+5 |> (Test.typeError_v0 "test") |> (+) 3 = Test.typeError_v0 "Fn called with an error as an argument"
+5 |> (+) (Test.typeError_v0 "test") |> (+) 3564 = Test.typeError_v0 "Fn called with an error as an argument"
+5 |> (+) (Test.typeError_v0 "test") = Test.typeError_v0 "Fn called with an error as an argument"
+(let x = Test.typeError_v0 "test" in (5 |> x)) = 5
+Just (Test.typeError_v0 "test") = (Test.typeError_v0 "test")
+Error (Test.typeError_v0 "test") = (Test.typeError_v0 "test")
+Ok (Test.typeError_v0 "test") = (Test.typeError_v0 "test")
+
+
+
 
 [fn.errorRailFn arg]
 ([] |> List.head_v1_ster |> (+) 3 |> (fun x -> if (x + 4) > 1 then x else (1 + x)))

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -7,6 +7,7 @@
 (let x = blank in 5) = 5
 (let x = Test.typeError_v0 "" in 5) = 5
 (let x = 5 in x) = 5
+(let x = 5 in let x = 6 in x) = 6
 
 
 [tests.list]

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -72,6 +72,7 @@ flag "test" [true] "old" "new" = "old"
 [tests.lambdas]
 List.push_v0 [] (fun x -> -4.611686018e+18) = [(fun x -> -4.611686018e+18)]
 (let y = (fun x -> x + 1) in List.map_v0 [1;2;3;4] y) = [ 2; 3; 4; 5 ]
+(let y = (fun x ___ -> x + 1) in List.map_v0 [1;2;3;4] y) = [ 2; 3; 4; 5 ]
 
 [test.lambda1]
 (let x = 5 in

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -216,10 +216,12 @@ Error (List.head_v1_ster []) = Test.errorRailNothing_v0_ster
 { col1 = 1 ; col2 = 3 } = { col1 = 1 ; col2 = 3 }
 { col1 = 2 ; col2 = blank } = { col1 = 2 }
 { col1 = 2 ; col2 = Test.typeError_v0 "test" } = { col1 = 2; col2 = Test.typeError_v0 "test" }
-{ col1 = 2 ; col2 = (List.head_v1_ster []) } = Test.errorRailNothing_v0_ster
-(let x = { col1 = 1 } in x.fieldName) = null
+{ col1 = 2 ; col2 = Test.errorRailNothing_v0 } = Test.errorRailNothing_v0
 { col1 = 2 ; ___ = 3 } = { col1 = 2 }
 (let _ = { col1 = 2 ; ___ = Test.incrementSideEffectCounter_v0 2 } in Test.sideEffectCount_v0) = 1
+
+[tests.fieldAccess]
+(let x = { col1 = 1 } in x.fieldName) = null
 
 [tests.list]
 [] = []
@@ -228,6 +230,10 @@ Error (List.head_v1_ster []) = Test.errorRailNothing_v0_ster
 [ 5; Int.add_v0 blank 5; 0 ] = [5;0]
 [ 5; Test.typeError_v0 "test"; 0 ] = [ 5; Test.typeError_v0 "test"; 0 ]
 [ 5; (List.head_v1_ster []); 0 ] = Test.errorRailNothing_v0
+
+[tests.variable]
+myvar = Test.typeError_v0 "There is no variable named: myvar"
+(let x = 5 in x) = 5
 
 
 [tests.featureflag]

--- a/fsharp-backend/tests/testfiles/string.tests
+++ b/fsharp-backend/tests/testfiles/string.tests
@@ -786,6 +786,8 @@ String.isSubstring_v1 "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳�
 
 [test.stringForeach]
 // Check that foreach executes the right number of times
-(let _ = String.foreach_v1 "a string" (fun x -> Test.incrementSideEffectCounter_v0 false) in
+// CLEANUP only needed for OCaml
+(let _ = Test.resetSideEffectCounter_v0 in
+ let _ = String.foreach_v1 "a string" (fun x -> Test.incrementSideEffectCounter_v0 false) in
  Test.sideEffectCount_v0) = 8
 


### PR DESCRIPTION
Go through the remaining cases where the old and new interpreter differ and make sure they're tested and correct.

- Make the interpreter work the same, including supporting previews for:
  - records
  - feature flags
- Fix race conditions with side effect counter in tests
- Use `.[]` instead of .Add to add to collections to avoid exceptions
- Support an edge case in `if` with `DError`
- Support an edge case piping into errors
- Support more things in the parser
- Reorganize and expand language tests
- fix equality tests


