### PR TITLE
Enable RunAOTCompilation for Blazor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:42a94e2
+      - image: darklang/dark-base:6d4d7e1
   # Rust is so big we create a separate container for it and only use that
   # for rust builds
   in-rust-container:
@@ -24,7 +24,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-rust:42a94e2
+      - image: darklang/dark-rust:6d4d7e1
 
 commands:
   show-large-files-and-directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -343,6 +343,11 @@ RUN curl -SL --output dotnet.tar.gz https://storage.googleapis.com/dotnet6-rc1/d
     && sudo ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && dotnet help
 
+# Blazor RunAOTCompilation support
+RUN sudo dotnet workload install \
+      -s https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json \
+      -s https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json \
+      wasm-tools
 RUN dotnet tool install -g dotnet-sos
 # TODO: is this the right directory?
 RUN echo "plugin load /home/dark/.dotnet/tools/.store/dotnet-sos/5.0.160202/dotnet-sos/5.0.160202/tools/netcoreapp2.1/any/linux-x64/libsosplugin.so" > ~/.lldbinit

--- a/fsharp-backend/src/Wasm/Wasm.fsproj
+++ b/fsharp-backend/src/Wasm/Wasm.fsproj
@@ -4,12 +4,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>5.0</LangVersion>
     <!-- Publishing configuration -->
-    <!-- <RunAOTCompilation>true</RunAOTCompilation> -->
-    <!-- <SelfContained>true</SelfContained> -->
-    <!-- Disable from the publishing step for now, as it fails. Maybe when we're not
-         using super-alpha versions of everything this might work. -->
-    <IsPublishable>false</IsPublishable>
-    <!-- <IsTrimmable>false</IsTrimmable> -->
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <SelfContained>true</SelfContained>
+    <IsPublishable>true</IsPublishable>
+    <IsTrimmable>false</IsTrimmable>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>

--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -245,18 +245,7 @@ def fsharp_backend_full_build():
     && unbuffer dotnet {command} \
       --verbosity {verbosity} \
       --configuration {configuration}"
-  result = run_backend(start, build)
-
-  # When "Publish"ing, the wasm isn't built due to a bug. So we need to build it
-  # ourselves for now.
-  if result and in_ci:
-    build = f"cd fsharp-backend \
-      && unbuffer dotnet build \
-        --verbosity {verbosity} \
-        --configuration {configuration} \
-        src/Wasm/Wasm.fsproj"
-    result = run_backend(start, build)
-  return result
+  return run_backend(start, build)
 
 
 


### PR DESCRIPTION
Enables RunAOTCompilation for Blazor. This is a new feature of .NET6 where instead of compiling .NET to wasm and then interpreting Dark code, we compile Dark itself into wasm.

This is built without trimming as JSON serialization requires reflection at the moment, which doesn't work with trimming. It may be possible to not-trim Dark libraries but to trim other libraries, but this has not been attempted.

Unfortunately, it looks like there's a bug in the .NET build for Blazor.