### PR TITLE
Fix converting newlines to spaces when add secrets

### DIFF
--- a/client/src/components/InsertSecret.res
+++ b/client/src/components/InsertSecret.res
@@ -157,7 +157,7 @@ let view = (m: ST.insertModal): Html.html<Types.msg> =>
               },
               list{},
             ),
-            Html.input'(
+            Html.textarea(
               list{
                 Attr.placeholder("secret value"),
                 Attr.name("secret-value"),

--- a/client/src/components/InsertSecret.res
+++ b/client/src/components/InsertSecret.res
@@ -162,7 +162,7 @@ let view = (m: ST.insertModal): Html.html<Types.msg> =>
                 Attr.placeholder("secret value"),
                 Attr.name("secret-value"),
                 Attr.value(m.newSecretValue),
-                Html.classList(list{("modal-form-input", true), ("error", !m.isValueValid)}),
+                Html.classList(list{("modal-form-textarea", true), ("error", !m.isValueValid)}),
                 Events.onInput(str => Types.SecretMsg(OnUpdateValue(str))),
               },
               list{},

--- a/client/src/components/InsertSecret.res
+++ b/client/src/components/InsertSecret.res
@@ -162,7 +162,7 @@ let view = (m: ST.insertModal): Html.html<Types.msg> =>
                 Attr.placeholder("secret value"),
                 Attr.name("secret-value"),
                 Attr.value(m.newSecretValue),
-                Html.classList(list{("modal-form-textarea", true), ("error", !m.isValueValid)}),
+                Html.classList(list{("modal-form-input", true), ("error", !m.isValueValid)}),
                 Events.onInput(str => Types.SecretMsg(OnUpdateValue(str))),
               },
               list{},

--- a/client/styles/_modal.scss
+++ b/client/styles/_modal.scss
@@ -8,6 +8,7 @@ $light-grey: $grey2;
   background-color: $black3;
   min-height: 35px;
   height: 35px;
+  min-width: 35ch;
   width: 35ch;
   padding: 0px 10px;
   caret-color: $grey3;

--- a/client/styles/_modal.scss
+++ b/client/styles/_modal.scss
@@ -6,6 +6,7 @@ $light-grey: $grey2;
 
 .modal-form-input {
   background-color: $black3;
+  min-height: 35px;
   height: 35px;
   width: 35ch;
   padding: 0px 10px;

--- a/client/styles/_modal.scss
+++ b/client/styles/_modal.scss
@@ -6,20 +6,10 @@ $light-grey: $grey2;
 
 .modal-form-input {
   background-color: $black3;
+  min-height: 35px;
   height: 35px;
   width: 35ch;
   padding: 0px 10px;
-  caret-color: $grey3;
-  color: $white1;
-}
-
-.modal-form-textarea {
-  background-color: $black3;
-  min-height: 35px;
-  height: 35px;
-  min-width: 35ch;
-  width: 35ch;
-  padding: 7px 10px;
   caret-color: $grey3;
   color: $white1;
 }

--- a/client/styles/_modal.scss
+++ b/client/styles/_modal.scss
@@ -6,10 +6,20 @@ $light-grey: $grey2;
 
 .modal-form-input {
   background-color: $black3;
-  min-height: 35px;
   height: 35px;
   width: 35ch;
   padding: 0px 10px;
+  caret-color: $grey3;
+  color: $white1;
+}
+
+.modal-form-textarea {
+  background-color: $black3;
+  min-height: 35px;
+  height: 35px;
+  min-width: 35ch;
+  width: 35ch;
+  padding: 7px 10px;
   caret-color: $grey3;
   color: $white1;
 }

--- a/client/styles/_secrets.scss
+++ b/client/styles/_secrets.scss
@@ -6,7 +6,6 @@
   margin-top: 20px;
   display: flex;
 
-  // for narrow views
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
@@ -30,11 +29,6 @@
     &::placeholder {
       text-transform: none;
     }
-  }
-
-  textarea {
-    resize: vertical;
-    padding: 7px 10px;
   }
 }
 

--- a/client/styles/_secrets.scss
+++ b/client/styles/_secrets.scss
@@ -12,7 +12,8 @@
   align-items: center;
 
   input,
-  button {
+  button,
+  textarea {
     margin: 5px;
 
     &::placeholder {
@@ -30,17 +31,14 @@
       text-transform: none;
     }
   }
+
+  textarea {
+    resize: vertical;
+    padding: 7px 10px;
+  }
 }
 
 .form-error {
   color: lighten($red, 15%);
   text-align: center;
-}
-
-@media only screen and (min-width: 900px) {
-  .insert-secret-form {
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-  }
 }

--- a/client/styles/_secrets.scss
+++ b/client/styles/_secrets.scss
@@ -6,6 +6,7 @@
   margin-top: 20px;
   display: flex;
 
+  // for narrow views
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
@@ -29,6 +30,11 @@
     &::placeholder {
       text-transform: none;
     }
+  }
+
+  textarea {
+    resize: vertical;
+    padding: 7px 10px;
   }
 }
 

--- a/client/styles/_secrets.scss
+++ b/client/styles/_secrets.scss
@@ -6,7 +6,6 @@
   margin-top: 20px;
   display: flex;
 
-  // for narrow views
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
@@ -33,7 +32,6 @@
   }
 
   textarea {
-    resize: vertical;
     padding: 7px 10px;
   }
 }


### PR DESCRIPTION
## What is the problem/goal being addressed?

Fix #2861

## What is the solution to this problem?

Switch from an `input` to a `textarea`, and change some corresponding styles

## What are the changes here? How do they solve the problem and what other product impacts do they cause?

I have changed the horizontal layout direction to vertical, because textarea is resizeable.

## How are you sure this works/how was this tested?

![image](https://user-images.githubusercontent.com/19646569/130363158-2a2b7570-6f0d-4bec-adcf-6b78a54d5692.png)
![image](https://user-images.githubusercontent.com/19646569/130363166-cb217b20-4f69-4d52-a239-0e905f31e925.png)
![image](https://user-images.githubusercontent.com/19646569/130363179-77404e85-3071-4b93-bdf6-d706e27cf847.png)
![image](https://user-images.githubusercontent.com/19646569/130363187-067c259d-0cc5-43cc-8357-55134d2782ea.png)

## What is the reversion plan if this fails after shipping?

🤷‍♂️

## Has this information been included in the comments?

No.