### PR TITLE
Update cert-manager for static.darklang.com

### DIFF
--- a/services/editor-deployment/darklang.com-tls.yaml
+++ b/services/editor-deployment/darklang.com-tls.yaml
@@ -8,6 +8,6 @@ spec:
   dnsNames:
     # We don't need a wildcard for darklang.com, as we get specific certs for the subdomains we use
     - darklang.com
-    - www.darklang.com
+    - '*.darklang.com'
   issuerRef:
     name: letsencrypt-prod-wildcards

--- a/services/editor-deployment/static.darklang.com-tls.yaml
+++ b/services/editor-deployment/static.darklang.com-tls.yaml
@@ -1,3 +1,5 @@
+# Note this is not actually used, we are currently using *.darklang.com
+# instead, as k8s certs cannot be added to storage buckets at the moment.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:


### PR DESCRIPTION
static.darklang.com has a cert, but cert-manager can't automatically update it because it's not a k8s service with a k8s ingres in front of it.

Instead, add *.darklang.com to the existing darklang cert and use that for the static.darklang.com load balancer.

I think this won't work long term (that is, I think when the cert renews the static.darklang.com load balancer will not automatically update to the new cert because it's not a k8s ingress):

config-connector is supposed to handle this, but GCP has not enabled it:
- https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/485
- https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/517
- https://issuetracker.google.com/issues/182815525

I've added a calendar entry to check what happens when the cert updates. Note, if this cert doesn't update, we have a sectigo cert for *.darklang.com that doesn't expire until June, so we can switch to that.