### PR TITLE
Optimize f# backend more

### DIFF
--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -2,5 +2,14 @@
 
 # F#
 
-- `ignore` should always use a type signature
+- `ignore` should always use a type signature (this should be enforced by the
+  compiler)
+
 - use `print` instead of `Console.WriteLine` or similar, the latter deadlocks
+
+- ensure that `try` do not have a `uply` in the body unless you know what you are
+  doing and provide a comment. Typically, the `uply` should be on the outside, which
+  causes the compiler to compile the `try` into a version which supports Tasks.
+  Otherwise, it won't catch an exception thrown within the `uply`.
+
+- you can only use Tasks (aka `Ply`) once. Using it a second time is undefined.

--- a/backend/bin/legacyserver.ml
+++ b/backend/bin/legacyserver.ml
@@ -33,6 +33,7 @@ let server () =
       |> String.rstrip ~drop:(( = ) '/')
       |> String.split ~on:'/'
     in
+    print_endline ("got request: " ^ Uri.path uri ^ " and body\n: " ^ body_string ) ;
     let fn =
       match path with
       | ["execute"] ->
@@ -57,6 +58,8 @@ let server () =
             Some BS.expr_bin2json
         | "expr_tlid_pair_bin2json" ->
             Some BS.expr_tlid_pair_bin2json
+        | "toplevel_bin2json" ->
+            Some BS.toplevel_bin2json
         | "user_fn_json2bin" ->
             Some BS.user_fn_json2bin
         | "user_tipe_json2bin" ->
@@ -117,16 +120,14 @@ let server () =
     | `POST, Some fn ->
       ( try
           let result = body_string |> fn in
-          print_endline ("success calling " ^ Uri.to_string uri) ;
           (* FSTODO reduce debugging info *)
-          print_endline ("body was: \n" ^ body_string) ;
-          print_endline ("result was: \n " ^ result) ;
+          print_endline ("\n\n") ;
           respond_json_ok result
         with e ->
           let headers = Header.init () in
           let message = Libexecution.Exception.exn_to_string e in
           print_endline
-            ("error while calling " ^ Uri.to_string uri ^ "\n" ^ message) ;
+            ("error while calling " ^ Uri.to_string uri ^ "\n" ^ message ^ "\n\n") ;
           S.respond_string ~status:`Bad_request ~body:message ~headers () )
     | _ ->
         let headers = Header.init () in

--- a/backend/bin/legacyserver.ml
+++ b/backend/bin/legacyserver.ml
@@ -33,7 +33,8 @@ let server () =
       |> String.rstrip ~drop:(( = ) '/')
       |> String.split ~on:'/'
     in
-    print_endline ("got request: " ^ Uri.path uri ^ " and body\n: " ^ body_string ) ;
+    print_endline
+      ("got request: " ^ Uri.path uri ^ " and body\n: " ^ body_string) ;
     let fn =
       match path with
       | ["execute"] ->
@@ -121,13 +122,17 @@ let server () =
       ( try
           let result = body_string |> fn in
           (* FSTODO reduce debugging info *)
-          print_endline ("\n\n") ;
+          print_endline "\n\n" ;
           respond_json_ok result
         with e ->
           let headers = Header.init () in
           let message = Libexecution.Exception.exn_to_string e in
           print_endline
-            ("error while calling " ^ Uri.to_string uri ^ "\n" ^ message ^ "\n\n") ;
+            ( "error while calling "
+            ^ Uri.to_string uri
+            ^ "\n"
+            ^ message
+            ^ "\n\n" ) ;
           S.respond_string ~status:`Bad_request ~body:message ~headers () )
     | _ ->
         let headers = Header.init () in

--- a/backend/liblegacy/serialization.ml
+++ b/backend/liblegacy/serialization.ml
@@ -46,6 +46,8 @@ let expr_bin2json (str : string) : string =
 let expr_tlid_pair_bin2json (str : string) : string =
   bin2json BS.expr_tlid_pair_of_binary_string BS.expr_tlid_pair_to_yojson str
 
+let toplevel_bin2json (str : string) : string =
+  bin2json BS.toplevel_of_binary_string BS.toplevel_to_yojson str
 
 (* ----------------------- *)
 (* Convert JSON to binary for F# *)

--- a/backend/liblegacy/serialization.ml
+++ b/backend/liblegacy/serialization.ml
@@ -46,8 +46,10 @@ let expr_bin2json (str : string) : string =
 let expr_tlid_pair_bin2json (str : string) : string =
   bin2json BS.expr_tlid_pair_of_binary_string BS.expr_tlid_pair_to_yojson str
 
+
 let toplevel_bin2json (str : string) : string =
   bin2json BS.toplevel_of_binary_string BS.toplevel_to_yojson str
+
 
 (* ----------------------- *)
 (* Convert JSON to binary for F# *)

--- a/backend/libserialize/binary_serialization.ml
+++ b/backend/libserialize/binary_serialization.ml
@@ -84,6 +84,29 @@ let user_tipe_to_binary_string (ut : Types.RuntimeT.user_tipe) : string =
   |> Core_extended.Bin_io_utils.to_line SF.RuntimeT.bin_user_tipe
   |> Bigstring.to_string
 
+(* Move this here to avoid 4 separate HTTP calls to legacyserver *)
+type toplevel =
+  | Handler of Types.RuntimeT.HandlerT.handler
+  | DB of Types.RuntimeT.DbT.db
+  | UserType of Types.RuntimeT.user_tipe
+  | UserFn of Types.RuntimeT.user_fn
+  [@@deriving yojson]
+
+let toplevel_of_binary_string (str : string) : toplevel =
+  try
+    handler_of_binary_string str |> Handler
+  with e1 ->
+    try
+      db_of_binary_string str |> DB
+    with e2 ->
+      try
+        user_fn_of_binary_string str |> UserFn
+      with e3 ->
+        try
+          user_tipe_of_binary_string str |> UserType
+        with e4 ->
+          failwith ("could not parse binary toplevel")
+
 
 let oplist_to_binary_string (ops : Types.oplist) : string =
   ops

--- a/backend/libserialize/binary_serialization.ml
+++ b/backend/libserialize/binary_serialization.ml
@@ -84,28 +84,24 @@ let user_tipe_to_binary_string (ut : Types.RuntimeT.user_tipe) : string =
   |> Core_extended.Bin_io_utils.to_line SF.RuntimeT.bin_user_tipe
   |> Bigstring.to_string
 
+
 (* Move this here to avoid 4 separate HTTP calls to legacyserver *)
 type toplevel =
   | Handler of Types.RuntimeT.HandlerT.handler
   | DB of Types.RuntimeT.DbT.db
   | UserType of Types.RuntimeT.user_tipe
   | UserFn of Types.RuntimeT.user_fn
-  [@@deriving yojson]
+[@@deriving yojson]
 
 let toplevel_of_binary_string (str : string) : toplevel =
-  try
-    handler_of_binary_string str |> Handler
+  try handler_of_binary_string str |> Handler
   with e1 ->
-    try
-      db_of_binary_string str |> DB
-    with e2 ->
-      try
-        user_fn_of_binary_string str |> UserFn
-      with e3 ->
-        try
-          user_tipe_of_binary_string str |> UserType
-        with e4 ->
-          failwith ("could not parse binary toplevel")
+    ( try db_of_binary_string str |> DB
+      with e2 ->
+        ( try user_fn_of_binary_string str |> UserFn
+          with e3 ->
+            ( try user_tipe_of_binary_string str |> UserType
+              with e4 -> failwith "could not parse binary toplevel" ) ) )
 
 
 let oplist_to_binary_string (ops : Types.oplist) : string =

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,21 @@
+# Some notes on benchmarking
+
+## General
+
+- Benchmarking in a VSCode container doesn't work - VSCode seems to do something to each request
+- the F# server will happily spread out to lots of cores and it's hard to siturate it. At `--cpus 2` it's easier to watch
+- ensure you optimize by passing the `--optimize` flag to `scripts/builder` or `scripts/build-server`
+
+## Profiling .NET
+- dotnet tool install dotnet-trace
+- dotnet trace ps # get id of BwdServer
+- dotnet trace collect --format SpeedScope -p ID
+- upload the file to https://speedscope.app for a flame graph
+
+
+## Using ab
+
+- sudo apt install apache2-utils # install
+- ab -n 2000 -c 50 URL # good settings
+
+

--- a/fsharp-backend/src/LibBackend/Serialize.fs
+++ b/fsharp-backend/src/LibBackend/Serialize.fs
@@ -110,7 +110,7 @@ let loadOnlyRenderedTLIDs
        (fun read -> (read.bytea "rendered_oplist_cache", read.stringOrNone "pos"))
   |> Task.bind
        (fun list ->
-         list |> List.map OCamlInterop.toplevelOfCachedBinary |> Task.flatten)
+         list |> List.map OCamlInterop.toplevelBin2Json |> Task.flatten)
 
 
 

--- a/fsharp-backend/src/LibBackend/Serialize.fs
+++ b/fsharp-backend/src/LibBackend/Serialize.fs
@@ -109,8 +109,7 @@ let loadOnlyRenderedTLIDs
   |> Sql.executeAsync
        (fun read -> (read.bytea "rendered_oplist_cache", read.stringOrNone "pos"))
   |> Task.bind
-       (fun list ->
-         list |> List.map OCamlInterop.toplevelBin2Json |> Task.flatten)
+       (fun list -> list |> List.map OCamlInterop.toplevelBin2Json |> Task.flatten)
 
 
 

--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -576,6 +576,21 @@ module Convert =
            | ORT.Handler h -> (hs @ [ ocamlHandler2PT tl.pos h ], dbs)
            | ORT.DB db -> (hs, dbs @ [ ocamlDB2PT tl.pos db ]))
 
+  module BSTypes =
+    type tl =
+      | Handler of ORT.HandlerT.handler<ORT.fluidExpr>
+      | DB of ORT.DbT.db<ORT.fluidExpr>
+      | UserType of ORT.user_tipe
+      | UserFn of ORT.user_fn<ORT.fluidExpr>
+
+
+  let ocamlBinarySerializationToplevel2PT (pos : pos) (tl : BSTypes.tl) : PT.Toplevel =
+    match tl with
+    | BSTypes.Handler h -> PT.TLHandler (ocamlHandler2PT pos h)
+    | BSTypes.DB db -> PT.TLDB (ocamlDB2PT pos db)
+    | BSTypes.UserType ut -> PT.TLType (ocamlUserType2PT ut)
+    | BSTypes.UserFn uf -> PT.TLFunction (ocamlUserFunction2PT uf)
+
 
 
   // ----------------

--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -584,12 +584,15 @@ module Convert =
       | UserFn of ORT.user_fn<ORT.fluidExpr>
 
 
-  let ocamlBinarySerializationToplevel2PT (pos : pos) (tl : BSTypes.tl) : PT.Toplevel =
+  let ocamlBinarySerializationToplevel2PT
+    (pos : pos)
+    (tl : BSTypes.tl)
+    : PT.Toplevel =
     match tl with
-    | BSTypes.Handler h -> PT.TLHandler (ocamlHandler2PT pos h)
-    | BSTypes.DB db -> PT.TLDB (ocamlDB2PT pos db)
-    | BSTypes.UserType ut -> PT.TLType (ocamlUserType2PT ut)
-    | BSTypes.UserFn uf -> PT.TLFunction (ocamlUserFunction2PT uf)
+    | BSTypes.Handler h -> PT.TLHandler(ocamlHandler2PT pos h)
+    | BSTypes.DB db -> PT.TLDB(ocamlDB2PT pos db)
+    | BSTypes.UserType ut -> PT.TLType(ocamlUserType2PT ut)
+    | BSTypes.UserFn uf -> PT.TLFunction(ocamlUserFunction2PT uf)
 
 
 

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -265,7 +265,7 @@ module OCamlInterop =
     |> toplevelToCachedBinary
     |> result
     |> (fun bin -> bin, None)
-    |> toplevelOfCachedBinary
+    |> toplevelBin2Json
     |> result
     .=. h
 

--- a/scripts/support/build-server
+++ b/scripts/support/build-server
@@ -12,6 +12,10 @@ import signal
 
 run_tests = False
 
+# When compiling code, use the optimized version of the build. This causes
+# --optimize to be passed to the compile script.
+optimize = False
+
 # Make io unbuffered
 def flush(fn):
   def newfn(x):
@@ -38,10 +42,11 @@ def compile_project(name):
 
 def compile(files):
   global run_tests
+  test = ""
   if run_tests:
-    test = "--test "
-  else:
-    test = ""
+    test += " --test"
+  if optimize:
+    test += " --optimize "
   fileStr = " ".join(files)
   try:
     return run(f"scripts/support/compile {test} {fileStr}")
@@ -77,6 +82,7 @@ def main():
   # like --watch does.
   should_serve = False
 
+
   for f in sys.argv[1:]:
     if f == "--compile":
       should_compile = True
@@ -87,6 +93,9 @@ def main():
     elif f == "--serve":
       should_serve = True
       should_compile = True
+    elif f == "--optimize":
+      global optimize
+      optimize = True
     elif f == "--test":
       global should_run_tests
       should_run_tests = True

--- a/scripts/support/build-server
+++ b/scripts/support/build-server
@@ -16,6 +16,16 @@ run_tests = False
 # --optimize to be passed to the compile script.
 optimize = False
 
+def getFlags():
+  global run_tests
+  global optimize
+  flags = ""
+  if run_tests:
+    flags += " --test"
+  if optimize:
+    flags += " --optimize "
+  return flags
+
 # Make io unbuffered
 def flush(fn):
   def newfn(x):
@@ -38,21 +48,18 @@ def run(bash):
   return proc.returncode == 0
 
 def compile_project(name):
-  return run(f"scripts/support/compile-project {name}")
+  flags = getFlags()
+  return run(f"scripts/support/compile-project {name} {flags}")
+
 
 def compile(files):
-  global run_tests
-  test = ""
-  if run_tests:
-    test += " --test"
-  if optimize:
-    test += " --optimize "
   fileStr = " ".join(files)
+  flags = getFlags()
   try:
-    return run(f"scripts/support/compile {test} {fileStr}")
+    return run(f"scripts/support/compile {flags} {fileStr}")
   except:
     print(f"Tried to compile too many files. Length was {len(fileStr)}")
-    return compile_project(f"all {test}")
+    return compile_project("all")
 
 def run_server():
   exit = compile(["scripts/support/runserver"])

--- a/scripts/support/compile
+++ b/scripts/support/compile
@@ -8,7 +8,8 @@ import os
 from pathlib import Path
 
 run_tests = False
-in_ci = os.environ.get("CI")
+in_ci = os.getenv("CI") == "true"
+optimize = in_ci
 
 # Make io unbuffered
 def flush(fn):
@@ -85,7 +86,7 @@ def copy_static():
 def copy_fsharp_static():
   start = time.time()
   blazor = run_backend(start, "cp -f fsharp-backend/src/Wasm/static/BlazorWorker.js backend/static/")
-  if in_ci:
+  if optimize:
     wwwroot = run_backend(start, "rsync -a fsharp-backend/Build/out/Wasm/Release/net6.0/wwwroot/_framework/ backend/static/blazor/")
   else:
     wwwroot = run_backend(start, "rsync -a fsharp-backend/Build/out/Wasm/Debug/net6.0/wwwroot/_framework/ backend/static/blazor/")
@@ -145,7 +146,7 @@ def backend_build():
   exes = [ rename(x) for x in os.listdir("backend/bin") if x.endswith(".ml") ]
   exes.append("@analysis.js")
   exes = " ".join(exes)
-  if in_ci:
+  if optimize:
     compilation_profile = "release"
   else:
     compilation_profile = "dev"
@@ -175,7 +176,7 @@ def backend_test():
 def fsharp_backend_test():
   start = time.time()
   ci = "--verbosity detailed" if in_ci else "--verbosity normal"
-  if in_ci:
+  if optimize:
     configuration = " --published"
   else:
     configuration = ""
@@ -220,18 +221,27 @@ def fsharp_paket_restore():
 # there but I'm not sure what.
 def fsharp_backend_quick_build():
   start = time.time()
+  if optimize:
+    configuration = "Release"
+    verbosity = "minimal"
+    command = "publish"
+  else:
+    configuration = "Debug"
+    verbosity = "minimal"
+    command = "build"
+
   build = f"cd fsharp-backend \
-    && unbuffer dotnet build \
+    && unbuffer dotnet {command} \
       -graphBuild:true \
       --no-restore \
-      --verbosity minimal \
-      --configuration Debug"
+      --verbosity {verbosity} \
+      --configuration {configuration}"
   return run_backend(start, build)
 
 
 def fsharp_backend_full_build():
   start = time.time()
-  if in_ci:
+  if optimize:
     configuration = "Release"
     verbosity = "minimal"
     command = "publish"
@@ -249,7 +259,7 @@ def fsharp_backend_full_build():
 
   # When "Publish"ing, the wasm isn't built due to a bug. So we need to build it
   # ourselves for now.
-  if result and in_ci:
+  if result and optimize:
     build = f"cd fsharp-backend \
       && unbuffer dotnet build \
         --verbosity {verbosity} \
@@ -262,7 +272,7 @@ def fsharp_backend_full_build():
 
 
 def rust_build(dir):
-  if in_ci:
+  if optimize:
     build_flags = " --release"
   else:
     build_flags = ""
@@ -313,7 +323,7 @@ def reload_server():
 
 def reload_fsharp_server():
   start = time.time()
-  if in_ci:
+  if optimize:
     configuration = " --published"
   else:
     configuration = ""
@@ -677,6 +687,9 @@ def main():
     if f == "--test":
       global run_tests
       run_tests = True
+    elif f == "--optimize":
+      global optimize
+      optimize = True
     else:
       f = os.path.abspath(f) # the ignore patterns rely on absolute dirs
       if not ignore(f):

--- a/scripts/support/compile-project
+++ b/scripts/support/compile-project
@@ -22,6 +22,7 @@ for v in "${files[@]}"; do
 done
 
 test=""
+optimize=""
 testfiles=""
 
 for cmd in "$@"; do
@@ -31,6 +32,9 @@ for cmd in "$@"; do
       ;;
     --test )
       test="--test"
+      ;;
+    --optimize )
+      optimize="--optimize"
       ;;
     -h | --help )
       usage
@@ -43,4 +47,4 @@ for cmd in "$@"; do
   esac
 done
 
-./scripts/support/compile $testfiles $test
+./scripts/support/compile $testfiles $test $optimize


### PR DESCRIPTION
I need to compare the actual running time of the F# backend to the existing OCaml one, to ensure things at least stay the same.

The first step was to ensure the ocaml and f# were built with the optimization settings turned on.

Also adds an optimization where we only ask legacyserver to decode toplevels once per toplevel. This increases throughput by 20%.