### PR TITLE
Cleanup Rollbar and ExecutionID

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APIOps.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIOps.fs
@@ -135,7 +135,7 @@ let addOp (ctx : HttpContext) : Task<T> =
          | _ -> true)
     |> List.iter
          (fun op ->
-           LibBackend.HeapAnalytics.track
+           LibService.HeapAnalytics.track
              executionID
              canvasInfo.id
              canvasInfo.name

--- a/fsharp-backend/src/ApiServer/Ui.fs
+++ b/fsharp-backend/src/ApiServer/Ui.fs
@@ -29,7 +29,7 @@ let adminUiTemplate : Lazy<string> =
      uiHtml
        .Replace("{{ENVIRONMENT_NAME}}", LibService.Config.envDisplayName)
        .Replace("{{LIVERELOADJS}}", liveReloadJs)
-       .Replace("{{HEAPIO_ID}}", Config.heapioId)
+       .Replace("{{HEAPIO_ID}}", LibService.Config.heapioId)
        .Replace("{{ROLLBARCONFIG}}", Config.rollbarJs)
        .Replace("{{PUSHERCONFIG}}", LibBackend.Pusher.jsConfigString)
        .Replace("{{USER_CONTENT_HOST}}", Config.bwdServerContentHost)

--- a/fsharp-backend/src/BwdServer/BwdServer.fs
+++ b/fsharp-backend/src/BwdServer/BwdServer.fs
@@ -261,6 +261,8 @@ let runHttp
 let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
   task {
     setHeader ctx "Server" "Darklang"
+    let executionID = LibService.Telemetry.executionID ()
+    setHeader ctx "x-darklang-execution-id" (string executionID)
 
     let msg (code : int) (msg : string) =
       task {
@@ -279,8 +281,6 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
     match! Routing.canvasNameFromHost ctx.Request.Host.Host with
     | Some canvasName ->
       // CLEANUP: move execution ID header up
-      let executionID = gid ()
-      setHeader ctx "x-darklang-execution-id" (toString executionID)
       let ownerName = Account.ownerNameFromCanvasName canvasName
       let ownerUsername = UserName.create (toString ownerName)
 

--- a/fsharp-backend/src/BwdServer/BwdServer.fs
+++ b/fsharp-backend/src/BwdServer/BwdServer.fs
@@ -371,7 +371,6 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
     | None -> return! canvasNotFoundResponse ctx
   }
 
-
 // ---------------
 // Configure Kestrel/ASP.NET
 // ---------------
@@ -386,7 +385,7 @@ let configureApp (healthCheckPort : int) (app : IApplicationBuilder) =
           return! runDarkHandler ctx
       with
       | LoadException (msg, code) ->
-        // FSTODO log/honeycomb, rollbar
+        // FSTODO log/honeycomb
         let bytes = System.Text.Encoding.UTF8.GetBytes msg
         ctx.Response.StatusCode <- code
         if bytes.Length > 0 then ctx.Response.ContentType <- "text/plain"

--- a/fsharp-backend/src/LibBackend/Config.fs
+++ b/fsharp-backend/src/LibBackend/Config.fs
@@ -50,7 +50,7 @@ let cookieDomain = string "DARK_CONFIG_COOKIE_DOMAIN"
 let bwdServerContentHost = string "DARK_CONFIG_BWDSERVER_HOST"
 
 // -------------------------
-// Kubernetes *)
+// Kubernetes
 // -------------------------
 
 let curlTunnelUrl = string "DARK_CONFIG_CURL_TUNNEL_URL"
@@ -155,18 +155,14 @@ let rollbarClientAccessToken =
   | item -> Some item
 
 
-let rollbarEnabled = LibService.Config.rollbarEnabled
-
-let rollbarEnvironment = LibService.Config.rollbarEnvironment
-
 let rollbarJs =
   match rollbarClientAccessToken with
   | Some token ->
     Printf.sprintf
       "{captureUncaught:true,verbose:true,enabled:%s,accessToken:'%s',payload:{environment: '%s'}}"
-      (if rollbarEnabled then "true" else "false")
+      (if LibService.Config.rollbarEnabled then "true" else "false")
       token
-      rollbarEnvironment
+      LibService.Config.rollbarEnvironment
   | _ -> "{enabled:false}"
 
 

--- a/fsharp-backend/src/LibBackend/Config.fs
+++ b/fsharp-backend/src/LibBackend/Config.fs
@@ -184,12 +184,6 @@ let pusherCluster = string "DARK_CONFIG_PUSHER_CLUSTER"
 
 
 // -------------------------
-// Heap
-// -------------------------
-let heapioId = string "DARK_CONFIG_HEAPIO_ID"
-
-
-// -------------------------
 // Infra
 // -------------------------
 let publicDomain = string "DARK_CONFIG_PUBLIC_DOMAIN"

--- a/fsharp-backend/src/LibBackend/LibBackend.fsproj
+++ b/fsharp-backend/src/LibBackend/LibBackend.fsproj
@@ -24,7 +24,6 @@
     <Compile Include="Account.fs" />
     <Compile Include="Authorization.fs" />
     <Compile Include="Session.fs" />
-    <Compile Include="HeapAnalytics.fs" />
     <Compile Include="OCamlInterop.fs" />
     <Compile Include="Routing.fs" />
     <Compile Include="SqlCompiler.fs" />

--- a/fsharp-backend/src/LibBackend/Pusher.fs
+++ b/fsharp-backend/src/LibBackend/Pusher.fs
@@ -3,6 +3,8 @@ module LibBackend.Pusher
 open System.Threading.Tasks
 open FSharp.Control.Tasks
 
+type ExecutionID = LibService.Telemetry.ExecutionID
+
 open Prelude
 open Tablecloth
 
@@ -31,7 +33,7 @@ let pusherClient : Lazy<PusherServer.Pusher> =
 // Send an event to pusher. Note: this is fired in the backgroup, and does not
 // take any time from the current thread. You cannot wait for it, by design.
 let push
-  (executionID : id)
+  (executionID : ExecutionID)
   (canvasID : CanvasID)
   (eventName : string)
   (payload : 'x)
@@ -69,7 +71,7 @@ let push
 
 
 let pushNewTraceID
-  (executionID : id)
+  (executionID : ExecutionID)
   (canvasID : CanvasID)
   (traceID : AT.TraceID)
   (tlids : tlid list)
@@ -77,12 +79,16 @@ let pushNewTraceID
   push executionID canvasID "new_trace" (traceID, tlids)
 
 
-let pushNew404 (executionID : id) (canvasID : CanvasID) (f404 : TraceInputs.F404) =
+let pushNew404
+  (executionID : ExecutionID)
+  (canvasID : CanvasID)
+  (f404 : TraceInputs.F404)
+  =
   push executionID canvasID "new_404" f404
 
 
 let pushNewStaticDeploy
-  (executionID : id)
+  (executionID : ExecutionID)
   (canvasID : CanvasID)
   (asset : StaticAssets.StaticDeploy)
   =
@@ -90,11 +96,15 @@ let pushNewStaticDeploy
 
 
 // For exposure as a DarkInternal function
-let pushAddOpEvent (executionID : id) (canvasID : CanvasID) (event : Op.AddOpEvent) =
+let pushAddOpEvent
+  (executionID : ExecutionID)
+  (canvasID : CanvasID)
+  (event : Op.AddOpEvent)
+  =
   push executionID canvasID "add_op" event
 
 let pushWorkerStates
-  (executionID : id)
+  (executionID : ExecutionID)
   (canvasID : CanvasID)
   (ws : EventQueue.WorkerStates.T)
   : unit =

--- a/fsharp-backend/src/LibService/Config.fs
+++ b/fsharp-backend/src/LibService/Config.fs
@@ -26,6 +26,11 @@ let rollbarEnabled = bool "DARK_CONFIG_ROLLBAR_ENABLED"
 
 let rollbarEnvironment = string "DARK_CONFIG_ROLLBAR_ENVIRONMENT"
 
+// -------------------------
+// Heap
+// -------------------------
+let heapioId = string "DARK_CONFIG_HEAPIO_ID"
+
 
 // --------------------
 // honeycomb

--- a/fsharp-backend/src/LibService/HeapAnalytics.fs
+++ b/fsharp-backend/src/LibService/HeapAnalytics.fs
@@ -1,4 +1,4 @@
-module LibBackend.HeapAnalytics
+module LibService.HeapAnalytics
 
 open System.Threading.Tasks
 open FSharp.Control.Tasks
@@ -9,6 +9,8 @@ open System.Net.Http.Headers
 
 open Prelude
 open Tablecloth
+
+type ExecutionID = Telemetry.ExecutionID
 
 type IdentifyPayload =
   { identity : string
@@ -28,7 +30,7 @@ type Type =
 
 
 let _payloadForEvent
-  (executionID : id)
+  (executionID : ExecutionID)
   (canvasName : CanvasName.T)
   (canvasID : CanvasID)
   (event : string)
@@ -72,7 +74,7 @@ let httpClient () : HttpClient = new HttpClient(_socketsHandler)
 
 
 let heapioEvent
-  (executionID : id)
+  (executionID : ExecutionID)
   (canvasID : CanvasID)
   (canvasName : CanvasName.T)
   (owner : System.Guid)
@@ -131,7 +133,7 @@ let heapioEvent
 
 // CLEANUP do bulk track
 let track
-  (executionID : id)
+  (executionID : ExecutionID)
   (canvasID : CanvasID)
   (canvasName : CanvasName.T)
   (owner : System.Guid)

--- a/fsharp-backend/src/LibService/LibService.fsproj
+++ b/fsharp-backend/src/LibService/LibService.fsproj
@@ -13,11 +13,12 @@
     <None Include="paket.references" />
     <Compile Include="ConfigDsl.fs" />
     <Compile Include="Config.fs" />
+    <Compile Include="Telemetry.fs" />
     <Compile Include="Rollbar.fs" />
     <Compile Include="DBConnection.fs" />
     <Compile Include="HealthCheck.fs" />
+    <Compile Include="HeapAnalytics.fs" />
     <Compile Include="Kestrel.fs" />
-    <Compile Include="Telemetry.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Prelude/Prelude.fsproj" />

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -20,7 +20,9 @@ open LibService.Telemetry
 
 type Activity = System.Diagnostics.Activity
 
-let dequeueAndProcess (executionID : id) : Task<Result<Option<RT.Dval>, exn>> =
+let dequeueAndProcess
+  (executionID : ExecutionID)
+  : Task<Result<Option<RT.Dval>, exn>> =
   use root = Span.root "dequeue_and_process"
   root.AddTag("meta.process_id", toString executionID) |> ignore<Activity>
 
@@ -158,7 +160,8 @@ let dequeueAndProcess (executionID : id) : Task<Result<Option<RT.Dval>, exn>> =
         | Error e -> return Error e
       })
 
-let run (executionID : id) : Task<Result<Option<RT.Dval>, exn>> =
+let run (executionID : ExecutionID) : Task<Result<Option<RT.Dval>, exn>> =
+  // CLEANUP put in its own config item
   if String.toLowercase LibService.Config.postgresSettings.dbname = "prodclone" then
     use (span : Span.T) = Span.root "Pointing at prodclone; will not dequeue"
     Task.FromResult(Ok None)

--- a/fsharp-backend/tests/Tests/EventQueue.Tests.fs
+++ b/fsharp-backend/tests/Tests/EventQueue.Tests.fs
@@ -32,7 +32,6 @@ let testEventQueueRoundtrip =
     let name = "test-event_queue"
     do! clearCanvasData (CanvasName.create name)
     let! (meta : Canvas.Meta) = testCanvasInfo name
-    let executionID = gid ()
 
     let h = testCron "test" PT.Handler.EveryDay (p "let data = Date.now_v0 in 123")
     let oplists = [ hop h ]
@@ -43,7 +42,7 @@ let testEventQueueRoundtrip =
     do! EQ.enqueue meta.id meta.owner "CRON" "test" "Daily" RT.DNull // I don't believe crons take inputs?
 
     do! EQ.testingScheduleAll ()
-    let! result = QueueWorker.run executionID
+    let! result = QueueWorker.run (LibService.Telemetry.ExecutionID "traceID")
 
     match result with
     | Ok (Some resultDval) ->


### PR DESCRIPTION
This started as an attempt to improve the performance of the Rollbar middleware, though it didn't improve the performance, it's better to use this as it doesn't add a thing that has known poor performance.

This also abstracts ExecutionID, using the current OpenTelemetry trace id as the execution id.

Also some slight refactoring of heap and rollbar.