### PR TITLE
Fix deploy templates

### DIFF
--- a/containers/base-service-Dockerfile
+++ b/containers/base-service-Dockerfile
@@ -2,6 +2,11 @@
 
 FROM ubuntu:20.04
 
+# Our deploy runs this on CircleCI, and the default URLs can sometimes be slow to
+# download from. This switches to the closest mirror to CircleCI (recommended by
+# CircleCI support).
+RUN sh -c "sed -i 's|http://archive|http://us-east-1.ec2.archive|g' /etc/apt/sources.list"
+
 RUN apt-get update && \
     apt-get install \
       -y \

--- a/services/apiserver-deployment/apiserver-deployment.template.yaml
+++ b/services/apiserver-deployment/apiserver-deployment.template.yaml
@@ -186,7 +186,7 @@ spec:
         # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.25.0
+          image: "gcr.io/cloudsql-docker/gce-proxy:1.25.0"
           resources:
             requests:
               memory: "500Mi"

--- a/services/bwd-deployment/bwd-deployment.template.yaml
+++ b/services/bwd-deployment/bwd-deployment.template.yaml
@@ -98,7 +98,7 @@ spec:
         # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
               memory: "500Mi"

--- a/services/cron-deployment/cron-deployment.template.yaml
+++ b/services/cron-deployment/cron-deployment.template.yaml
@@ -67,7 +67,7 @@ spec:
         # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
               memory: "70Mi"

--- a/services/editor-deployment/editor-deployment.template.yaml
+++ b/services/editor-deployment/editor-deployment.template.yaml
@@ -97,7 +97,7 @@ spec:
         # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
               memory: "500Mi"

--- a/services/garbagecollector-deployment/garbagecollector-deployment.template.yaml
+++ b/services/garbagecollector-deployment/garbagecollector-deployment.template.yaml
@@ -63,7 +63,7 @@ spec:
         # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
               memory: "70Mi"

--- a/services/qw-deployment/qw-deployment.template.yaml
+++ b/services/qw-deployment/qw-deployment.template.yaml
@@ -65,7 +65,7 @@ spec:
         # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
               memory: "100Mi"

--- a/services/scheduler-deployment/scheduler-deployment.template.yaml
+++ b/services/scheduler-deployment/scheduler-deployment.template.yaml
@@ -65,7 +65,7 @@ spec:
         # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
               memory: "100Mi"

--- a/services/tunnel-deployment/tunnel-deployment.template.yaml
+++ b/services/tunnel-deployment/tunnel-deployment.template.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: tunnel-ctr
-          image: gcr.io/balmy-ground-195100/tunnel:{IMAGEID:tunnel}
+          image: "gcr.io/balmy-ground-195100/tunnel:{IMAGEID:tunnel}"
           # Resource limits + requests are intentionally the same, to ensure
           # this pod is a 'Guaranteed' pod, ref:
           #  https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6


### PR DESCRIPTION
Put quotes around yaml in the deploy templates, as sometimes k8s will think these strings are objects.

Also change ubuntu mirror to ec2 mirror to speed up deploys.