### PR TITLE
Update Wasm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:
           keys:
-            - v4-fsharp-backend-{{ checksum "../checksum" }}
+            - v5-fsharp-backend-{{ checksum "../checksum" }}
             # Fails often enough that it's better not to have a fallback
       - attach_workspace: { at: "." }
       - show-large-files-and-directories
@@ -307,7 +307,7 @@ jobs:
       - show-large-files-and-directories
       - save_cache:
           paths: [fsharp-backend/Build]
-          key: v4-fsharp-backend-{{ checksum "../checksum" }}
+          key: v5-fsharp-backend-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
       - notify-job-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:b9a1c40
+      - image: darklang/dark-base:4fb8b8b
   # Rust is so big we create a separate container for it and only use that
   # for rust builds
   in-rust-container:
@@ -29,7 +29,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-rust:b9a1c40
+      - image: darklang/dark-rust:4fb8b8b
 
 commands:
   show-large-files-and-directories:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
       - restore_cache:
           keys:
             - v4-fsharp-backend-{{ checksum "../checksum" }}
-            - v4-fsharp-backend
+            # Fails often enough that it's better not to have a fallback
       - attach_workspace: { at: "." }
       - show-large-files-and-directories
       # so the ocamltestserver will load

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:4fb8b8b
+      - image: darklang/dark-base:a53cf1d
   # Rust is so big we create a separate container for it and only use that
   # for rust builds
   in-rust-container:
@@ -29,7 +29,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-rust:4fb8b8b
+      - image: darklang/dark-rust:a53cf1d
 
 commands:
   show-large-files-and-directories:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
-    "ionide.ionide-fsharp@5.6.0",
+    "ionide.ionide-fsharp@5.7.3",
     "shuumatsu.vscode-ocamlformat",
     "esbenp.prettier-vscode",
     "ms-python.python",

--- a/Dockerfile
+++ b/Dockerfile
@@ -273,7 +273,7 @@ RUN sudo pip3 install -U --no-cache-dir -U crcmod \
 ############################
 RUN sudo pip3 install --no-cache-dir yq yamllint && echo 'PATH=~/.local/bin:$PATH' >> ~/.bashrc
 
-RUN pip3 install git+https://github.com/darklang/watchgod.git@5bf4f0f3b49bc64f435f59493b0e17e07a20da0d
+RUN pip3 install git+https://github.com/pbiggar/watchgod.git@b74cd7ec064ebc7b4263dc532c7c97e046002bef
 # Formatting
 
 RUN pip3 install yapf==0.31.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -420,7 +420,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-too
 
 # install Rust dev tools
 RUN rustup component add clippy-preview rustfmt-preview rls
-RUN cargo install cargo-cache --no-default-features --features ci-autoclean
+RUN cargo install cargo-cache --version 0.6.3 --no-default-features --features ci-autoclean
 USER dark
 
 # Once we have cargo and things installed in /usr/local/cargo and that added to PATH,

--- a/Dockerfile
+++ b/Dockerfile
@@ -328,7 +328,7 @@ RUN wget -q https://honeycomb.io/download/honeymarker/linux/honeymarker_1.9_amd6
 # (runtime-deps, runtime, and sdk), see
 # https://github.com/dotnet/dotnet-docker/blob/master/src
 
-ENV DOTNET_SDK_VERSION=6.0.100-rc.2.21505.57 \
+ENV DOTNET_SDK_VERSION=6.0.100 \
     # Skip extraction of XML docs - generally not useful within an
     # image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
@@ -342,7 +342,7 @@ ENV DOTNET_SDK_VERSION=6.0.100-rc.2.21505.57 \
     DOTNET_USE_POLLING_FILE_WATCHER=true
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='0a8f85a2757f61ca7f9b8c546af4554c2aac9cdb06f6d62879a60de6f2a3d37ea7136f48896c9c85828a2d55df354e7b9b5b4dc22896c927f0c6370a5ade1b9c' \
+    && dotnet_sha512='cb0d174a79d6294c302261b645dba6a479da8f7cf6c1fe15ae6998bc09c5e0baec810822f9e0104e84b0efd51fdc0333306cb2a0a6fcdbaf515a8ad8cf1af25b' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && sudo mkdir -p /usr/share/dotnet \
     && sudo tar -C /usr/share/dotnet -oxzf dotnet.tar.gz . \
@@ -351,10 +351,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && sudo ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     && dotnet help
 
-RUN sudo dotnet workload install \
-      -s https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json \
-      -s https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json \
-      wasm-tools
+RUN sudo dotnet workload install wasm-tools
 RUN dotnet tool install -g dotnet-sos
 # TODO: is this the right directory?
 RUN echo "plugin load /home/dark/.dotnet/tools/.store/dotnet-sos/5.0.160202/dotnet-sos/5.0.160202/tools/netcoreapp2.1/any/linux-x64/libsosplugin.so" > ~/.lldbinit

--- a/Dockerfile
+++ b/Dockerfile
@@ -358,7 +358,7 @@ RUN echo "plugin load /home/dark/.dotnet/tools/.store/dotnet-sos/5.0.160202/dotn
 
 # formatting
 ENV PATH "$PATH:/home/dark/bin"
-RUN dotnet tool install fantomas-tool --version 4.5.6 --tool-path ~/bin
+RUN dotnet tool install fantomas-tool --version 4.5.7 --tool-path ~/bin
 RUN curl https://raw.githubusercontent.com/darklang/build-files/main/ocamlformat --output ~/bin/ocamlformat && chmod +x ~/bin/ocamlformat
 
 #############

--- a/fsharp-backend/global.json
+++ b/fsharp-backend/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.2.21505.57",
+    "version": "6.0.100",
     "rollForward": "disable"
   }
 }

--- a/fsharp-backend/paket.dependencies
+++ b/fsharp-backend/paket.dependencies
@@ -7,43 +7,41 @@ storage: none
 // Basics
 nuget Newtonsoft.Json = 13.0.1
 nuget Ply = 0.3.1
-nuget FSharpPlus = 1.2.1
+nuget FSharpPlus = 1.2.2
 nuget FsRegEx = 0.7.2
-nuget FSharpx.Extras = 2.5.0
+nuget FSharpx.Extras = 3.0.0
 nuget FSharp.Core = 6.0.1
-nuget Faithlife.Utility = 0.11.2
+nuget Faithlife.Utility = 0.12.1
 
 // Tests
 nuget Expecto = 9.0.4
 nuget Expecto.FsCheck = 9.0.4
-nuget FsCheck = 2.16.0
+nuget FsCheck = 2.16.3
 nuget FSharp.Compiler.Service = 41.0.1
-nuget System.Runtime.CompilerServices.Unsafe = 6.0.0-preview.7.21377.19 // to resolve dependencies
 
 // Services
 nuget Giraffe = 5.0.0
-nuget Microsoft.AspNetCore.Mvc.NewtonsoftJson = 5.0.3
-nuget Lib.AspNetCore.ServerTiming = 4.1.0
+nuget Microsoft.AspNetCore.Mvc.NewtonsoftJson = 6.0.0
+nuget Lib.AspNetCore.ServerTiming = 4.2.0
 nuget PusherServer = 4.6.1
 nuget Rollbar = 4.0.3
 nuget Rollbar.NetCore.AspNet = 4.0.3
-nuget Microsoft.Extensions.Diagnostics.HealthChecks = 6.0.0-preview.7.21378.6
-nuget Microsoft.Extensions.Hosting.Abstractions = 6.0.0-preview.7.21377.19 // to resolve dependencies
-nuget AspNetCore.HealthChecks.Npgsql = 5.0.2
+nuget Microsoft.Extensions.Diagnostics.HealthChecks = 6.0.0
+nuget AspNetCore.HealthChecks.Npgsql = 6.0.1-rc1.2
 
 // Tracing
-nuget Honeycomb.OpenTelemetry = 0.12.0-beta
-nuget System.Diagnostics.DiagnosticSource = 6.0.0-preview.7.21377.19
-nuget OpenTelemetry = 1.2.0-alpha3
-nuget OpenTelemetry.Exporter.OpenTelemetryProtocol = 1.2.0-alpha3
-nuget OpenTelemetry.Exporter.Console = 1.2.0-alpha3
-nuget OpenTelemetry.Instrumentation.AspNetCore = 1.0.0-rc7
-nuget OpenTelemetry.Extensions.Hosting = 1.0.0-rc7
-nuget OpenTelemetry.Instrumentation.Http = 1.0.0-rc7
+nuget Honeycomb.OpenTelemetry = 0.13.0-beta
+nuget System.Diagnostics.DiagnosticSource = 6.0.0
+nuget OpenTelemetry = 1.2.0-beta1
+nuget OpenTelemetry.Exporter.OpenTelemetryProtocol = 1.2.0-beta1
+nuget OpenTelemetry.Exporter.Console = 1.2.0-beta1
+nuget OpenTelemetry.Instrumentation.AspNetCore = 1.0.0-rc8
+nuget OpenTelemetry.Extensions.Hosting = 1.0.0-rc8
+nuget OpenTelemetry.Instrumentation.Http = 1.0.0-rc8
 
 // LibBackend
-nuget Npgsql.FSharp = 4.0.0
-nuget Npgsql = 5.0.7
+nuget Npgsql.FSharp = 4.1.0
+nuget Npgsql = 6.0.0
 #git https://github.com/npgsql/npgsql
 nuget Sodium.Core = 1.2.3
 
@@ -54,4 +52,4 @@ nuget Argu = 6.1.1
 group Wasm
   source https://api.nuget.org/v3/index.json
   // Wasm - this is in its own group to avoid a clash with OpenTelemetry
-  nuget Microsoft.AspNetCore.Components.WebAssembly = 6.0.0-preview.7.21378.6
+  nuget Microsoft.AspNetCore.Components.WebAssembly = 6.0.0

--- a/fsharp-backend/paket.lock
+++ b/fsharp-backend/paket.lock
@@ -5,17 +5,17 @@ NUGET
     Argu (6.1.1)
       FSharp.Core (>= 4.3.2)
       System.Configuration.ConfigurationManager (>= 4.4)
-    AspNetCore.HealthChecks.NpgSql (5.0.2)
-      Microsoft.Extensions.Diagnostics.HealthChecks (>= 5.0.1)
-      Npgsql (>= 5.0.3)
+    AspNetCore.HealthChecks.NpgSql (6.0.1-rc1.2)
+      Microsoft.Extensions.Diagnostics.HealthChecks (>= 6.0.0-rc.2.21480.10)
+      Npgsql (>= 6.0.0-rc.2)
     Expecto (9.0.4)
       FSharp.Core (>= 4.6)
       Mono.Cecil (>= 0.11.3)
     Expecto.FsCheck (9.0.4)
       Expecto (>= 9.0.4)
       FsCheck (>= 2.14.3)
-    Faithlife.Utility (0.11.2)
-    FsCheck (2.16)
+    Faithlife.Utility (0.12.1)
+    FsCheck (2.16.3)
       FSharp.Core (>= 4.2.3)
     FSharp.Compiler.Service (41.0.1)
       FSharp.Core (6.0.1)
@@ -48,14 +48,14 @@ NUGET
       FSharp.Core (>= 4.7.2)
       Microsoft.Bcl.AsyncInterfaces (>= 5.0)
     FSharp.Core (6.0.1)
-    FSharpPlus (1.2.1)
+    FSharpPlus (1.2.2)
       FSharp.Core (>= 4.6.2)
     FSharpx.Async (1.14.1)
       FSharp.Control.AsyncSeq (>= 2.0.21)
       FSharp.Core (>= 4.6.2)
     FSharpx.Collections (3.0.1)
       FSharp.Core (>= 4.3.4)
-    FSharpx.Extras (2.5)
+    FSharpx.Extras (3.0)
       FSharp.Core (>= 4.6.2)
       FSharpx.Async (>= 1.14.1)
       FSharpx.Collections (>= 2.1.2)
@@ -79,18 +79,17 @@ NUGET
       Microsoft.Extensions.Logging.Abstractions (>= 3.0.3)
     Grpc.Net.Common (2.40)
       Grpc.Core.Api (>= 2.40)
-    Honeycomb.OpenTelemetry (0.12.0-beta)
-      Microsoft.Extensions.Configuration.CommandLine (>= 5.0)
-      Microsoft.Extensions.Configuration.Json (>= 5.0)
+    Honeycomb.OpenTelemetry (0.13.0-beta)
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1)
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1)
       OpenTelemetry (>= 1.1)
       OpenTelemetry.Exporter.OpenTelemetryProtocol (>= 1.1)
       OpenTelemetry.Extensions.Hosting (>= 1.0.0-rc7)
       OpenTelemetry.Instrumentation.AspNetCore (>= 1.0.0-rc7)
-      OpenTelemetry.Instrumentation.GrpcNetClient (>= 1.0.0-rc7)
       OpenTelemetry.Instrumentation.Http (>= 1.0.0-rc7)
       OpenTelemetry.Instrumentation.SqlClient (>= 1.0.0-rc7)
       OpenTelemetry.Instrumentation.StackExchangeRedis (>= 1.0.0-rc7)
-    Lib.AspNetCore.ServerTiming (4.1)
+    Lib.AspNetCore.ServerTiming (4.2)
     libsodium (1.0.18.1)
     Microsoft.AspNetCore.Http (2.2.2)
       Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
@@ -104,12 +103,12 @@ NUGET
     Microsoft.AspNetCore.Http.Features (5.0.11)
       Microsoft.Extensions.Primitives (>= 5.0.1)
       System.IO.Pipelines (>= 5.0.1)
-    Microsoft.AspNetCore.JsonPatch (5.0.11)
+    Microsoft.AspNetCore.JsonPatch (6.0)
       Microsoft.CSharp (>= 4.7)
-      Newtonsoft.Json (>= 12.0.2)
-    Microsoft.AspNetCore.Mvc.NewtonsoftJson (5.0.3)
-      Microsoft.AspNetCore.JsonPatch (>= 5.0.3)
-      Newtonsoft.Json (>= 12.0.2)
+      Newtonsoft.Json (>= 13.0.1)
+    Microsoft.AspNetCore.Mvc.NewtonsoftJson (6.0)
+      Microsoft.AspNetCore.JsonPatch (>= 6.0)
+      Newtonsoft.Json (>= 13.0.1)
       Newtonsoft.Json.Bson (>= 1.0.2)
     Microsoft.AspNetCore.WebUtilities (2.2)
       Microsoft.Net.Http.Headers (>= 2.2)
@@ -142,8 +141,8 @@ NUGET
     Microsoft.Extensions.Configuration (5.0)
       Microsoft.Extensions.Configuration.Abstractions (>= 5.0)
       Microsoft.Extensions.Primitives (>= 5.0)
-    Microsoft.Extensions.Configuration.Abstractions (6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19)
+    Microsoft.Extensions.Configuration.Abstractions (6.0)
+      Microsoft.Extensions.Primitives (>= 6.0)
     Microsoft.Extensions.Configuration.Binder (5.0)
       Microsoft.Extensions.Configuration.Abstractions (>= 5.0)
     Microsoft.Extensions.Configuration.CommandLine (5.0)
@@ -162,32 +161,30 @@ NUGET
       Microsoft.Extensions.FileProviders.Abstractions (>= 5.0)
     Microsoft.Extensions.DependencyInjection (5.0.2)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 5.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (6.0.0-preview.7.21377.19)
-    Microsoft.Extensions.Diagnostics.HealthChecks (6.0.0-preview.7.21378.6)
-      Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (>= 6.0.0-preview.7.21378.6)
-      Microsoft.Extensions.Hosting.Abstractions (>= 6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.Logging.Abstractions (>= 6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.Options (>= 6.0.0-preview.7.21377.19)
-    Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (6.0.0-preview.7.21378.6)
-    Microsoft.Extensions.FileProviders.Abstractions (6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19)
+    Microsoft.Extensions.DependencyInjection.Abstractions (6.0)
+    Microsoft.Extensions.Diagnostics.HealthChecks (6.0)
+      Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (>= 6.0)
+      Microsoft.Extensions.Hosting.Abstractions (>= 6.0)
+      Microsoft.Extensions.Logging.Abstractions (>= 6.0)
+      Microsoft.Extensions.Options (>= 6.0)
+    Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (6.0)
+    Microsoft.Extensions.FileProviders.Abstractions (6.0)
+      Microsoft.Extensions.Primitives (>= 6.0)
     Microsoft.Extensions.FileProviders.Physical (5.0)
       Microsoft.Extensions.FileProviders.Abstractions (>= 5.0)
       Microsoft.Extensions.FileSystemGlobbing (>= 5.0)
       Microsoft.Extensions.Primitives (>= 5.0)
     Microsoft.Extensions.FileSystemGlobbing (5.0)
-    Microsoft.Extensions.Hosting.Abstractions (6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.Configuration.Abstractions (>= 6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0.0-preview.7.21377.19)
+    Microsoft.Extensions.Hosting.Abstractions (6.0)
+      Microsoft.Extensions.Configuration.Abstractions (>= 6.0)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0)
     Microsoft.Extensions.Logging (5.0)
       Microsoft.Extensions.DependencyInjection (>= 5.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 5.0)
       Microsoft.Extensions.Logging.Abstractions (>= 5.0)
       Microsoft.Extensions.Options (>= 5.0)
-    Microsoft.Extensions.Logging.Abstractions (6.0.0-preview.7.21377.19)
-      System.Buffers (>= 4.5.1)
-      System.Memory (>= 4.5.4)
+    Microsoft.Extensions.Logging.Abstractions (6.0)
     Microsoft.Extensions.Logging.Configuration (5.0)
       Microsoft.Extensions.Configuration (>= 5.0)
       Microsoft.Extensions.Configuration.Abstractions (>= 5.0)
@@ -198,17 +195,17 @@ NUGET
       Microsoft.Extensions.Options (>= 5.0)
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 5.0)
     Microsoft.Extensions.ObjectPool (5.0.11)
-    Microsoft.Extensions.Options (6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0.0-preview.7.21377.19)
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19)
+    Microsoft.Extensions.Options (6.0)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0)
+      Microsoft.Extensions.Primitives (>= 6.0)
     Microsoft.Extensions.Options.ConfigurationExtensions (5.0)
       Microsoft.Extensions.Configuration.Abstractions (>= 5.0)
       Microsoft.Extensions.Configuration.Binder (>= 5.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 5.0)
       Microsoft.Extensions.Options (>= 5.0)
       Microsoft.Extensions.Primitives (>= 5.0)
-    Microsoft.Extensions.Primitives (6.0.0-preview.7.21377.19)
-      System.Runtime.CompilerServices.Unsafe (>= 6.0.0-preview.7.21377.19)
+    Microsoft.Extensions.Primitives (6.0)
+      System.Runtime.CompilerServices.Unsafe (>= 6.0)
     Microsoft.IO.RecyclableMemoryStream (2.2)
     Microsoft.Net.Http.Headers (2.2.8)
       Microsoft.Extensions.Primitives (>= 2.2)
@@ -232,42 +229,40 @@ NUGET
     Newtonsoft.Json (13.0.1)
     Newtonsoft.Json.Bson (1.0.2)
       Newtonsoft.Json (>= 12.0.1)
-    Npgsql (5.0.7)
-      System.Runtime.CompilerServices.Unsafe (>= 4.6)
-    Npgsql.FSharp (4.0)
+    Npgsql (6.0)
+      System.Runtime.CompilerServices.Unsafe (>= 6.0)
+    Npgsql.FSharp (4.1)
       FSharp.Core (>= 4.7.2)
       Npgsql (>= 5.0.3)
       Ply (>= 0.3.1)
-    OpenTelemetry (1.2.0-alpha3)
+    OpenTelemetry (1.2.0-beta1)
       Microsoft.Extensions.Logging (>= 2.1)
       Microsoft.Extensions.Logging.Configuration (>= 2.1)
-      OpenTelemetry.Api (>= 1.2.0-alpha3)
+      OpenTelemetry.Api (>= 1.2.0-beta1)
       System.Collections.Immutable (>= 1.4)
       System.Reflection.Emit.Lightweight (>= 4.7)
-    OpenTelemetry.Api (1.2.0-alpha3)
-      System.Diagnostics.DiagnosticSource (>= 6.0.0-preview.6.21352.12)
+    OpenTelemetry.Api (1.2.0-beta1)
+      System.Diagnostics.DiagnosticSource (>= 6.0.0-rc.1.21451.13)
       System.Reflection.Emit.Lightweight (>= 4.7)
-    OpenTelemetry.Exporter.Console (1.2.0-alpha3)
-      OpenTelemetry (>= 1.2.0-alpha3)
-    OpenTelemetry.Exporter.OpenTelemetryProtocol (1.2.0-alpha3)
+    OpenTelemetry.Exporter.Console (1.2.0-beta1)
+      OpenTelemetry (>= 1.2.0-beta1)
+    OpenTelemetry.Exporter.OpenTelemetryProtocol (1.2.0-beta1)
       Google.Protobuf (>= 3.15.5 < 4.0)
       Grpc.Net.Client (>= 2.32 < 3.0)
-      OpenTelemetry (>= 1.2.0-alpha3)
-    OpenTelemetry.Extensions.Hosting (1.0.0-rc7)
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1 < 6.0)
-      OpenTelemetry (>= 1.1)
-    OpenTelemetry.Instrumentation.AspNetCore (1.0.0-rc7)
+      OpenTelemetry (>= 1.2.0-beta1)
+    OpenTelemetry.Extensions.Hosting (1.0.0-rc8)
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1)
+      OpenTelemetry (>= 1.2.0-beta1)
+    OpenTelemetry.Instrumentation.AspNetCore (1.0.0-rc8)
       Microsoft.AspNetCore.Http.Features (>= 2.1.1 < 6.0)
-      OpenTelemetry (>= 1.1)
-    OpenTelemetry.Instrumentation.GrpcNetClient (1.0.0-rc7)
-      OpenTelemetry (>= 1.1)
-    OpenTelemetry.Instrumentation.Http (1.0.0-rc7)
-      OpenTelemetry (>= 1.1)
+      OpenTelemetry (>= 1.2.0-beta1)
+    OpenTelemetry.Instrumentation.Http (1.0.0-rc8)
+      OpenTelemetry (>= 1.2.0-beta1)
     OpenTelemetry.Instrumentation.SqlClient (1.0.0-rc7)
       OpenTelemetry.Api (>= 1.1)
-    OpenTelemetry.Instrumentation.StackExchangeRedis (1.0.0-rc7)
-      Microsoft.Extensions.Options (>= 2.1 < 6.0)
-      OpenTelemetry.Api (>= 1.1)
+    OpenTelemetry.Instrumentation.StackExchangeRedis (1.0.0-rc8)
+      Microsoft.Extensions.Options (>= 2.1)
+      OpenTelemetry.Api (>= 1.2.0-beta1)
       StackExchange.Redis (>= 2.1.58 < 3.0)
     Pipelines.Sockets.Unofficial (2.2)
       System.IO.Pipelines (>= 5.0)
@@ -370,8 +365,8 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
       System.Runtime (>= 4.3)
-    System.Diagnostics.DiagnosticSource (6.0.0-preview.7.21377.19)
-      System.Runtime.CompilerServices.Unsafe (>= 6.0.0-preview.7.21377.19)
+    System.Diagnostics.DiagnosticSource (6.0)
+      System.Runtime.CompilerServices.Unsafe (>= 6.0)
     System.Diagnostics.PerformanceCounter (5.0.1)
       Microsoft.NETCore.Platforms (>= 5.0.1)
       Microsoft.Win32.Registry (>= 5.0)
@@ -600,7 +595,7 @@ NUGET
     System.Runtime (4.3.1)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    System.Runtime.CompilerServices.Unsafe (6.0.0-preview.7.21377.19)
+    System.Runtime.CompilerServices.Unsafe (6.0)
     System.Runtime.Extensions (4.3.1)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
@@ -777,91 +772,80 @@ NUGET
 GROUP Wasm
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Microsoft.AspNetCore.Authorization (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.AspNetCore.Metadata (>= 6.0.0-preview.7.21378.6) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Logging.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Options (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Components (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.AspNetCore.Authorization (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.AspNetCore.Components.Analyzers (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-    Microsoft.AspNetCore.Components.Analyzers (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-    Microsoft.AspNetCore.Components.Forms (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.AspNetCore.Components (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-    Microsoft.AspNetCore.Components.Web (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.AspNetCore.Components (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.AspNetCore.Components.Forms (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.Extensions.DependencyInjection (>= 6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.JSInterop (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      System.IO.Pipelines (>= 6.0.0-preview.7.21377.19) - restriction: >= net6.0
-    Microsoft.AspNetCore.Components.WebAssembly (6.0.0-preview.7.21378.6)
-      Microsoft.AspNetCore.Components.Web (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.Extensions.Configuration.Binder (>= 6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Configuration.Json (>= 6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Logging (>= 6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.JSInterop.WebAssembly (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-    Microsoft.AspNetCore.Metadata (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-    Microsoft.Bcl.AsyncInterfaces (6.0.0-preview.7.21377.19) - restriction: || (&& (>= monoandroid) (>= net6.0) (< netstandard2.0)) (&& (< monoandroid) (>= net6.0) (< netcoreapp2.1)) (&& (< monoandroid) (>= net6.0) (< netcoreapp3.1)) (&& (>= monotouch) (>= net6.0)) (&& (>= net461) (>= net6.0)) (&& (>= net6.0) (< netcoreapp2.0)) (&& (>= net6.0) (>= uap10.1)) (&& (>= net6.0) (>= xamarinios)) (&& (>= net6.0) (>= xamarinmac)) (&& (>= net6.0) (>= xamarintvos)) (&& (>= net6.0) (>= xamarinwatchos))
-    Microsoft.Extensions.Configuration (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.Configuration.Abstractions (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.Configuration.Binder (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.Configuration.FileExtensions (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Configuration (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Configuration.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileProviders.Physical (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.Configuration.Json (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Configuration (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Configuration.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Configuration.FileExtensions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Text.Json (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-    Microsoft.Extensions.FileProviders.Abstractions (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileProviders.Physical (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileSystemGlobbing (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.FileSystemGlobbing (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-    Microsoft.Extensions.Logging (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.DependencyInjection (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Logging.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Options (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Diagnostics.DiagnosticSource (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.Logging.Abstractions (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      System.Buffers (>= 4.5.1) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.Options (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Primitives (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.Primitives (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      System.Runtime.CompilerServices.Unsafe (>= 6.0.0-preview.7.21377.19) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.JSInterop (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-    Microsoft.JSInterop.WebAssembly (6.0.0-preview.7.21378.6) - restriction: >= net6.0
-      Microsoft.JSInterop (>= 6.0.0-preview.7.21378.6) - restriction: >= net6.0
-    System.Buffers (4.5.1) - restriction: >= net6.0
-    System.Diagnostics.DiagnosticSource (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      System.Runtime.CompilerServices.Unsafe (>= 6.0.0-preview.7.21377.19) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= monotouch) (>= net461) (>= net5.0) (&& (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netcoreapp2.1) (>= xamarinios)) (&& (< netcoreapp2.1) (>= xamarinmac)) (&& (< netstandard2.0) (>= xamarintvos)) (&& (< netstandard2.0) (>= xamarinwatchos))
-    System.IO.Pipelines (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    System.Memory (4.5.4) - restriction: >= net6.0
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    System.Runtime.CompilerServices.Unsafe (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-    System.Text.Encodings.Web (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Runtime.CompilerServices.Unsafe (>= 6.0.0-preview.7.21377.19) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (>= netcoreapp2.1)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= netcoreapp3.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    System.Text.Json (6.0.0-preview.7.21377.19) - restriction: >= net6.0
-      Microsoft.Bcl.AsyncInterfaces (>= 6.0.0-preview.7.21377.19) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (>= netcoreapp2.1) (< netcoreapp3.1)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Runtime.CompilerServices.Unsafe (>= 6.0.0-preview.7.21377.19) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (>= netcoreapp2.1)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= netcoreapp3.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Text.Encodings.Web (>= 6.0.0-preview.7.21377.19) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid) (>= netcoreapp2.1)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= netcoreapp3.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+    Microsoft.AspNetCore.Authorization (6.0) - restriction: >= net6.0
+      Microsoft.AspNetCore.Metadata (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Logging.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Options (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.AspNetCore.Components (6.0) - restriction: >= net6.0
+      Microsoft.AspNetCore.Authorization (>= 6.0) - restriction: >= net6.0
+      Microsoft.AspNetCore.Components.Analyzers (>= 6.0) - restriction: >= net6.0
+    Microsoft.AspNetCore.Components.Analyzers (6.0) - restriction: >= net6.0
+    Microsoft.AspNetCore.Components.Forms (6.0) - restriction: >= net6.0
+      Microsoft.AspNetCore.Components (>= 6.0) - restriction: >= net6.0
+    Microsoft.AspNetCore.Components.Web (6.0) - restriction: >= net6.0
+      Microsoft.AspNetCore.Components (>= 6.0) - restriction: >= net6.0
+      Microsoft.AspNetCore.Components.Forms (>= 6.0) - restriction: >= net6.0
+      Microsoft.Extensions.DependencyInjection (>= 6.0) - restriction: >= net6.0
+      Microsoft.JSInterop (>= 6.0) - restriction: >= net6.0
+      System.IO.Pipelines (>= 6.0) - restriction: >= net6.0
+    Microsoft.AspNetCore.Components.WebAssembly (6.0)
+      Microsoft.AspNetCore.Components.Web (>= 6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Configuration.Binder (>= 6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Configuration.Json (>= 6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Logging (>= 6.0) - restriction: >= net6.0
+      Microsoft.JSInterop.WebAssembly (>= 6.0) - restriction: >= net6.0
+    Microsoft.AspNetCore.Metadata (6.0) - restriction: >= net6.0
+    Microsoft.Extensions.Configuration (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Primitives (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.Configuration.Abstractions (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Primitives (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.Configuration.Binder (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.Configuration.FileExtensions (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Configuration (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Configuration.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.FileProviders.Physical (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Primitives (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.Configuration.Json (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Configuration (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Configuration.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Configuration.FileExtensions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Text.Json (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.DependencyInjection (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.DependencyInjection.Abstractions (6.0) - restriction: >= net6.0
+    Microsoft.Extensions.FileProviders.Abstractions (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.Primitives (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.FileProviders.Physical (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.FileSystemGlobbing (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Primitives (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.FileSystemGlobbing (6.0) - restriction: >= net6.0
+    Microsoft.Extensions.Logging (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.DependencyInjection (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Logging.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Options (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Diagnostics.DiagnosticSource (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.Logging.Abstractions (6.0) - restriction: >= net6.0
+    Microsoft.Extensions.Options (6.0) - restriction: >= net6.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.Primitives (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.Primitives (6.0) - restriction: >= net6.0
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.JSInterop (6.0) - restriction: >= net6.0
+    Microsoft.JSInterop.WebAssembly (6.0) - restriction: >= net6.0
+      Microsoft.JSInterop (>= 6.0) - restriction: >= net6.0
+    System.Diagnostics.DiagnosticSource (6.0) - restriction: >= net6.0
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    System.IO.Pipelines (6.0) - restriction: >= net6.0
+    System.Runtime.CompilerServices.Unsafe (6.0) - restriction: >= net6.0
+    System.Text.Encodings.Web (6.0) - restriction: >= net6.0
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    System.Text.Json (6.0) - restriction: >= net6.0
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Text.Encodings.Web (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)

--- a/fsharp-backend/src/LibService/Telemetry.fs
+++ b/fsharp-backend/src/LibService/Telemetry.fs
@@ -103,7 +103,7 @@ let addTelemetry (builder : TracerProviderBuilder) : TracerProviderBuilder =
       builder
       |> fun b ->
            match Config.telemetryExporter with
-           | Config.Honeycomb -> b.UseHoneycomb(honeycombOptions)
+           | Config.Honeycomb -> b.AddHoneycomb(honeycombOptions)
            | Config.NoExporter -> b
            | Config.Console -> b.AddConsoleExporter()
       |> fun b -> b.AddAspNetCoreInstrumentation()

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -105,6 +105,11 @@ let matches (pattern : string) (input : string) : bool =
   m.Success
 
 // ----------------------
+// Runtime info
+// ----------------------
+let isBlazor = System.OperatingSystem.IsBrowser()
+
+// ----------------------
 // Debugging
 // ----------------------
 
@@ -136,14 +141,17 @@ type NonBlockingConsole() =
           System.Console.WriteLine(
             $"Exception in blocking queue thread: {e.Message}"
           )
-    let thread = System.Threading.Thread(f)
-    do
-      thread.IsBackground <- true
-      thread.Name <- "Prelude.NonBlockingConsole printer"
-      thread.Start()
+    // Background threads aren't supported in Blazor
+    if not isBlazor then
+      let thread = System.Threading.Thread(f)
+      do
+        thread.IsBackground <- true
+        thread.Name <- "Prelude.NonBlockingConsole printer"
+        thread.Start()
 
 
-  static member WriteLine(value : string) : unit = mQueue.Add(value)
+  static member WriteLine(value : string) : unit =
+    if isBlazor then System.Console.WriteLine value else mQueue.Add(value)
 
 
 let debuG (msg : string) (a : 'a) : unit =

--- a/fsharp-backend/src/Wasm/Wasm.fsproj
+++ b/fsharp-backend/src/Wasm/Wasm.fsproj
@@ -4,7 +4,10 @@
     <!-- <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings> -->
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>6.0</LangVersion>
-    <!-- <RunAOTCompilation>true</RunAOTCompilation> -->
+    <!-- in the compile script, we compile this in debug mode anyway, so changing
+    this doesn't change what we actually deliver. However, it does change how long it
+    takes to compile, so disable until we can actually ship AOT builds -->
+    <RunAOTCompilation>false</RunAOTCompilation>
     <!-- <PublishTrimmed>false</PublishTrimmed> -->
     <!-- <EmccCompileOptimizationFlag>-O0 -s ASSERTIONS=2 -s STACK_OVERFLOW_CHECK=2 -s SAFE_HEAP=1</EmccCompileOptimizationFlag> -->
     <!-- <EmccLinkOptimizationFlag>-O0 -s ASSERTIONS=2 -s STACK_OVERFLOW_CHECK=2 -s SAFE_HEAP=1</EmccLinkOptimizationFlag> -->

--- a/fsharp-backend/src/Wasm/Wasm.fsproj
+++ b/fsharp-backend/src/Wasm/Wasm.fsproj
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <PropertyGroup>
+    <!-- <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings> -->
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>6.0</LangVersion>
-    <!-- Publishing configuration -->
     <!-- <RunAOTCompilation>true</RunAOTCompilation> -->
-    <!-- <SelfContained>true</SelfContained> -->
-    <!-- Disable from the publishing step for now, as it fails. Maybe when we're not
-         using super-alpha versions of everything this might work. -->
-    <IsPublishable>false</IsPublishable>
-    <!-- <IsTrimmable>false</IsTrimmable> -->
-    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <!-- <PublishTrimmed>false</PublishTrimmed> -->
+    <!-- <EmccCompileOptimizationFlag>-O0 -s ASSERTIONS=2 -s STACK_OVERFLOW_CHECK=2 -s SAFE_HEAP=1</EmccCompileOptimizationFlag> -->
+    <!-- <EmccLinkOptimizationFlag>-O0 -s ASSERTIONS=2 -s STACK_OVERFLOW_CHECK=2 -s SAFE_HEAP=1</EmccLinkOptimizationFlag> -->
+    <!-- <BlazorEnableCompression>false</BlazorEnableCompression> -->
+    <!-- <WasmNativeStrip>false</WasmNativeStrip> -->
+    <!-- <WasmLinkIcalls>true</WasmLinkIcalls> -->
+    <!-- <WasmDebugLevel>1</WasmDebugLevel> -->
+    <!-- <WasmDedup>false</WasmDedup> -->
+    <!-- <WasmNativeDebugSymbols>true</WasmNativeDebugSymbols> -->
+    <!-- <EmccVerbose>true</EmccVerbose> -->
+    <!-- <RuntimeIdentifier>browser-wasm</RuntimeIdentifier> -->
+    <!-- should optimize the download slightly -->
+    <!-- <BlazorEnableTimeZoneSupport>false</BlazorEnableTimeZoneSupport> -->
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../LibExecution/LibExecution.fsproj" />

--- a/fsharp-backend/src/Wasm/static/BlazorWorker.js
+++ b/fsharp-backend/src/Wasm/static/BlazorWorker.js
@@ -551,8 +551,9 @@ D-REMOVED */
           const appBinDirName = "appBinDir"; // D-MOVED from global scope
           load_runtime(appBinDirName, hasDebuggingEnabled() ? -1 : 0);
           MONO.mono_wasm_runtime_ready();
+          // D-REMOVED
           // TODO: this might be a better to way to invoke things than what we have hacked in
-          attachInteropInvoker();
+          // attachInteropInvoker();
           onReady();
         });
 

--- a/fsharp-backend/src/Wasm/static/BlazorWorker.js
+++ b/fsharp-backend/src/Wasm/static/BlazorWorker.js
@@ -588,13 +588,16 @@ D-REMOVED */
         }
       }
 
-      /* D-REMOVED
-      const anchorTagForAbsoluteUrlConversions = document.createElement('a');
+      // D-REMOVED
+      // const anchorTagForAbsoluteUrlConversions = document.createElement("a");
       function toAbsoluteUrl(possiblyRelativeUrl) {
-        anchorTagForAbsoluteUrlConversions.href = possiblyRelativeUrl;
-        return anchorTagForAbsoluteUrlConversions.href;
+        return new URL(possiblyRelativeUrl).href;
+        // D-CHANGED - not supported in a web worker
+        // anchorTagForAbsoluteUrlConversions.href = possiblyRelativeUrl;
+        // return anchorTagForAbsoluteUrlConversions.href;
       }
 
+      /* D-REMOVED
       function getArrayDataPointer(array){
         return array + 12; // First byte from here is length, then following bytes are entries
       }

--- a/fsharp-backend/src/Wasm/static/BlazorWorker.js
+++ b/fsharp-backend/src/Wasm/static/BlazorWorker.js
@@ -369,9 +369,9 @@ D-REMOVED */
             // Use invariant culture if the app does not carry icu data.
             MONO.mono_wasm_setenv("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1");
           }
-        };
+          // }; // D-CHANGED
 
-        module.preRun.push(() => {
+          // module.preRun.push(() => {
           // By now, emscripten should be initialised enough that we can capture these methods for later use
           mono_wasm_add_assembly = cwrap("mono_wasm_add_assembly", null, [
             "string",
@@ -499,7 +499,7 @@ D-REMOVED */
             }));
           };
           D-REMOVED */
-        });
+        };
         module.postRun.push(() => {
           if (
             resourceLoader.bootConfig.debugBuild &&

--- a/fsharp-backend/src/Wasm/static/BlazorWorker.js
+++ b/fsharp-backend/src/Wasm/static/BlazorWorker.js
@@ -820,6 +820,7 @@ D-REMOVED */
       return {
         loadResources: loadResources,
         loadResource: loadResource,
+        logToConsole: () => {},
         bootConfig: bootConfig,
         startOptions: startOptions,
         purgeUnusedCacheEntriesAsync: () => Promise.resolve(),

--- a/fsharp-backend/src/Wasm/static/BlazorWorker.js
+++ b/fsharp-backend/src/Wasm/static/BlazorWorker.js
@@ -1,21 +1,865 @@
-// This file adapted taken from https://github.com/Tewr/BlazorWorker/blob/073c7b01e79319119947b427674b91804b784632/src/BlazorWorker/BlazorWorker.js
-// It seems this was the original source: https://github.com/dotnet/aspnetcore/blob/main/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
-
+// Adapted from github/dotnet/aspnetcore/src/Components/Web.JS/src/Platform
+// https://github.com/dotnet/aspnetcore/tree/504c502b6b783cf3ebc48623e2099f09fe1af74d/src/Components/Web.JS/src/Platform
 // MIT license
-// Copyright (c) 2019-2020 Tor
-// https://github.com/Tewr/BlazorWorker/blob/073c7b01e79319119947b427674b91804b784632/LICENSE
+
+// This file copied a number of Blazor files to adapt them for a non-blazor world. The primary differences are:
+// - no Blazor object
+// - no Window object (as this is run in a web worker)
+// - not typescript
+
+// The files adapted are:
+// - MonoPlatform.ts - does nearly all of the platform loading and initialization
+// - WebAssemblyConfigLoader.ts - to load/cache config from the server
+// - WebAssemblyResourceLoader.ts - to load/cache resouces (assemblies and such) from the server
+// - BootConfig.ts - utility class around blazor.boot.json
+
+// I've made a number of notes to discuss when I changed thing:
+// D-REMOVED: explains why something was removed
+// D-ADDED: explains why something was added
+// D-CHANGED:  explains why something was changed
+// Note that I didn't make notes when typescript types were removed
+
+// =======================
+// MonoPlatform.ts
+// =======================
+// https://github.com/dotnet/aspnetcore/blob/9b1de73ab6a18cbb3efbcb129a0ef911da3c4b5b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
 
 // This file loads .NET in a webWorker, including the Dark LibExecution WASM.
 // It creates and initializes the webworker, which then downloads all the
 // WASM/Blazor code needed from the server.
 
+/* D-REMOVED
+import { DotNet } from '@microsoft/dotnet-js-interop';
+import { attachDebuggerHotkey, hasDebuggingEnabled } from './MonoDebugger';
+import { showErrorNotification } from '../../BootErrors';
+import { WebAssemblyResourceLoader, LoadingResource } from '../WebAssemblyResourceLoader';
+import { Platform, System_Array, Pointer, System_Object, System_String, HeapLock } from '../Platform';
+import { WebAssemblyBootResourceType } from '../WebAssemblyStartOptions';
+import { BootJsonData, ICUDataMode } from '../BootConfig';
+import { Blazor } from '../../GlobalExports';
+
+declare let Module: EmscriptenModule;
+
+let mono_wasm_add_assembly: (name: string, heapAddress: number, length: number) => void;
+D-REMOVED */
+// D-MOVED: to inside monoPlatform
+// const appBinDirName = "appBinDir";
+/* D-REMOVED
+const uint64HighOrderShift = Math.pow(2, 32);
+const maxSafeNumberHighPart = Math.pow(2, 21) - 1; // The high-order int32 from Number.MAX_SAFE_INTEGER
+
+let currentHeapLock: MonoHeapLock | null = null;
+
+// Memory access helpers
+// The implementations are exactly equivalent to what the global getValue(addr, type) function does,
+// except without having to parse the 'type' parameter, and with less risk of mistakes at the call site
+function getValueI16(ptr: number) {
+  return Module.HEAP16[ptr >> 1];
+}
+function getValueI32(ptr: number) {
+  return Module.HEAP32[ptr >> 2];
+}
+function getValueFloat(ptr: number) {
+  return Module.HEAPF32[ptr >> 2];
+}
+function getValueU64(ptr: number) {
+  // There is no Module.HEAPU64, and Module.getValue(..., 'i64') doesn't work because the implementation
+  // treats 'i64' as being the same as 'i32'. Also we must take care to read both halves as unsigned.
+  const heapU32Index = ptr >> 2;
+  const highPart = Module.HEAPU32[heapU32Index + 1];
+  if (highPart > maxSafeNumberHighPart) {
+    throw new Error(`Cannot read uint64 with high order part ${highPart}, because the result would exceed Number.MAX_SAFE_INTEGER.`);
+  }
+
+  return (highPart * uint64HighOrderShift) + Module.HEAPU32[heapU32Index];
+}
+D-REMOVED */
+// D-CHANGED: turned into a function to serialize better to be passed to a webworker
+// const monoPlatform = () => {
 window.BlazorWorker = (function () {
-  let worker;
-  const workerDef = function (appRoot, hashReplacements) {
+  function workerDef() {
+    // D-ADDED: from BootConfig
+    // export enum ICUDataMode {
+    //   Sharded,
+    //   All,
+    //   Invariant
+    // }
+    const ICUDataMode = {
+      Sharded: 0,
+      All: 1,
+      Invariant: 2,
+    };
+    /* D-REMOVED
+  start: function start(resourceLoader: WebAssemblyResourceLoader) {
+    return new Promise<void>((resolve, reject) => {
+      attachDebuggerHotkey(resourceLoader);
+
+      // dotnet.js assumes the existence of this
+      window['Browser'] = {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        init: () => { },
+      };
+
+      // Emscripten works by expecting the module config to be a global
+      // For compatibility with macOS Catalina, we have to assign a temporary value to window.Module
+      // before we start loading the WebAssembly files
+      addGlobalModuleScriptTagsToDocument(() => {
+        window['Module'] = createEmscriptenModuleInstance(resourceLoader, resolve, reject);
+        addScriptTagsToDocument(resourceLoader);
+      });
+    });
+  },
+
+  callEntryPoint: async function callEntryPoint(assemblyName: string) : Promise<any> {
+    const emptyArray = [[]];
+
+    try {
+      await BINDING.call_assembly_entry_point(assemblyName, emptyArray, 'm');
+    } catch (error) {
+      console.error(error);
+      showErrorNotification();
+    }
+  },
+
+  toUint8Array: function toUint8Array(array: System_Array<any>): Uint8Array {
+    const dataPtr = getArrayDataPointer(array);
+    const length = getValueI32(dataPtr);
+    const uint8Array = new Uint8Array(length);
+    uint8Array.set(Module.HEAPU8.subarray(dataPtr + 4, dataPtr + 4 + length));
+    return uint8Array;
+  },
+
+  getArrayLength: function getArrayLength(array: System_Array<any>): number {
+    return getValueI32(getArrayDataPointer(array));
+  },
+
+  getArrayEntryPtr: function getArrayEntryPtr<TPtr extends Pointer>(array: System_Array<TPtr>, index: number, itemSize: number): TPtr {
+    // First byte is array length, followed by entries
+    const address = getArrayDataPointer(array) + 4 + index * itemSize;
+    return address as any as TPtr;
+  },
+
+  getObjectFieldsBaseAddress: function getObjectFieldsBaseAddress(referenceTypedObject: System_Object): Pointer {
+    // The first two int32 values are internal Mono data
+    return (referenceTypedObject as any as number + 8) as any as Pointer;
+  },
+
+  readInt16Field: function readHeapInt16(baseAddress: Pointer, fieldOffset?: number): number {
+    return getValueI16((baseAddress as any as number) + (fieldOffset || 0));
+  },
+
+  readInt32Field: function readHeapInt32(baseAddress: Pointer, fieldOffset?: number): number {
+    return getValueI32((baseAddress as any as number) + (fieldOffset || 0));
+  },
+
+  readUint64Field: function readHeapUint64(baseAddress: Pointer, fieldOffset?: number): number {
+    return getValueU64((baseAddress as any as number) + (fieldOffset || 0));
+  },
+
+  readFloatField: function readHeapFloat(baseAddress: Pointer, fieldOffset?: number): number {
+    return getValueFloat((baseAddress as any as number) + (fieldOffset || 0));
+  },
+
+  readObjectField: function readHeapObject<T extends System_Object>(baseAddress: Pointer, fieldOffset?: number): T {
+    return getValueI32((baseAddress as any as number) + (fieldOffset || 0)) as any as T;
+  },
+
+  readStringField: function readHeapObject(baseAddress: Pointer, fieldOffset?: number, readBoolValueAsString?: boolean): string | null {
+    const fieldValue = getValueI32((baseAddress as any as number) + (fieldOffset || 0));
+    if (fieldValue === 0) {
+      return null;
+    }
+
+    if (readBoolValueAsString) {
+      // Some fields are stored as a union of bool | string | null values, but need to read as a string.
+      // If the stored value is a bool, the behavior we want is empty string ('') for true, or null for false.
+      const unboxedValue = BINDING.unbox_mono_obj(fieldValue as any as System_Object);
+      if (typeof (unboxedValue) === 'boolean') {
+        return unboxedValue ? '' : null;
+      }
+      return unboxedValue;
+    }
+
+    let decodedString: string | null | undefined;
+    if (currentHeapLock) {
+      decodedString = currentHeapLock.stringCache.get(fieldValue);
+      if (decodedString === undefined) {
+        decodedString = BINDING.conv_string(fieldValue as any as System_String);
+        currentHeapLock.stringCache.set(fieldValue, decodedString);
+      }
+    } else {
+      decodedString = BINDING.conv_string(fieldValue as any as System_String);
+    }
+
+    return decodedString;
+  },
+
+  readStructField: function readStructField<T extends Pointer>(baseAddress: Pointer, fieldOffset?: number): T {
+    return ((baseAddress as any as number) + (fieldOffset || 0)) as any as T;
+  },
+
+  beginHeapLock: function() {
+    assertHeapIsNotLocked();
+    currentHeapLock = new MonoHeapLock();
+    return currentHeapLock;
+  },
+
+  invokeWhenHeapUnlocked: function(callback) {
+    // This is somewhat like a sync context. If we're not locked, just pass through the call directly.
+    if (!currentHeapLock) {
+      callback();
+    } else {
+      currentHeapLock.enqueuePostReleaseAction(callback);
+    }
+  },
+
+function addScriptTagsToDocument(resourceLoader: WebAssemblyResourceLoader) {
+  const browserSupportsNativeWebAssembly = typeof WebAssembly !== 'undefined' && WebAssembly.validate;
+  if (!browserSupportsNativeWebAssembly) {
+    throw new Error('This browser does not support WebAssembly.');
+  }
+
+  // The dotnet.*.js file has a version or hash in its name as a form of cache-busting. This is needed
+  // because it's the only part of the loading process that can't use cache:'no-cache' (because it's
+  // not a 'fetch') and isn't controllable by the developer (so they can't put in their own cache-busting
+  // querystring). So, to find out the exact URL we have to search the boot manifest.
+  const dotnetJsResourceName = Object
+    .keys(resourceLoader.bootConfig.resources.runtime)
+    .filter(n => n.startsWith('dotnet.') && n.endsWith('.js'))[0];
+  const dotnetJsContentHash = resourceLoader.bootConfig.resources.runtime[dotnetJsResourceName];
+  const scriptElem = document.createElement('script');
+  scriptElem.src = `_framework/${dotnetJsResourceName}`;
+  scriptElem.defer = true;
+
+  // For consistency with WebAssemblyResourceLoader, we only enforce SRI if caching is allowed
+  if (resourceLoader.bootConfig.cacheBootResources) {
+    scriptElem.integrity = dotnetJsContentHash;
+    scriptElem.crossOrigin = 'anonymous';
+  }
+
+  // Allow overriding the URI from which the dotnet.*.js file is loaded
+  if (resourceLoader.startOptions.loadBootResource) {
+    const resourceType: WebAssemblyBootResourceType = 'dotnetjs';
+    const customSrc = resourceLoader.startOptions.loadBootResource(resourceType, dotnetJsResourceName, scriptElem.src, dotnetJsContentHash);
+    if (typeof (customSrc) === 'string') {
+      scriptElem.src = customSrc;
+    } else if (customSrc) {
+      // Since we must load this via a <script> tag, it's only valid to supply a URI (and not a Request, say)
+      throw new Error(`For a ${resourceType} resource, custom loaders must supply a URI string.`);
+    }
+  }
+
+  document.body.appendChild(scriptElem);
+}
+
+// Due to a strange behavior in macOS Catalina, we have to delay loading the WebAssembly files
+// until after it finishes evaluating a <script> element that assigns a value to window.Module.
+// This may be fixed in a later version of macOS/iOS, or even if not it may be possible to reduce
+// this to a smaller workaround.
+function addGlobalModuleScriptTagsToDocument(callback: () => void) {
+  const scriptElem = document.createElement('script');
+
+  // This pollutes global but is needed so it can be called from the script.
+  // The callback is put in the global scope so that it can be run after the script is loaded.
+  // onload cannot be used in this case for non-file scripts.
+  window['__wasmmodulecallback__'] = callback;
+
+  // Note: Any updates to the following script will require updating the inline script hash if using CSP
+  scriptElem.text = 'var Module; window.__wasmmodulecallback__(); delete window.__wasmmodulecallback__;';
+
+  document.body.appendChild(scriptElem);
+}
+D-REMOVED */
+
+    function createEmscriptenModuleInstance(resourceLoader, onReady, onError) {
+      const resources = resourceLoader.bootConfig.resources;
+      const module = {};
+      const suppressMessages = ["DEBUGGING ENABLED"];
+
+      module.print = line =>
+        suppressMessages.indexOf(line) < 0 && console.log(line);
+
+      module.printErr = line => {
+        // If anything writes to stderr, treat it as a critical exception. The underlying runtime writes
+        // to stderr if a truly critical problem occurs outside .NET code. Note that .NET unhandled
+        // exceptions also reach this, but via a different code path - see dotNetCriticalError below.
+        // FSTODO: add rollbar to error handler
+        console.error(line);
+        // D-REMOVED: blazor thing
+        // showErrorNotification();
+      };
+
+      module.preRun = module.preRun || [];
+      module.postRun = module.postRun || [];
+      module.preloadPlugins = [];
+
+      const dotnetWasmResourceName = "dotnet.wasm";
+      const assembliesBeingLoaded = resourceLoader.loadResources(
+        resources.assembly,
+        filename => `_framework/${filename}`,
+        "assembly",
+      );
+      const pdbsBeingLoaded = resourceLoader.loadResources(
+        resources.pdb || {},
+        filename => `_framework/${filename}`,
+        "pdb",
+      );
+      const wasmBeingLoaded = resourceLoader.loadResource(
+        /* name */ dotnetWasmResourceName,
+        /* url */ `_framework/${dotnetWasmResourceName}`,
+        /* hash */ resourceLoader.bootConfig.resources.runtime[
+          dotnetWasmResourceName
+        ],
+        /* type */ "dotnetwasm",
+      );
+
+      const dotnetTimeZoneResourceName = "dotnet.timezones.blat";
+      let timeZoneResource = undefined;
+      if (
+        resourceLoader.bootConfig.resources.runtime.hasOwnProperty(
+          dotnetTimeZoneResourceName,
+        )
+      ) {
+        timeZoneResource = resourceLoader.loadResource(
+          dotnetTimeZoneResourceName,
+          `_framework/${dotnetTimeZoneResourceName}`,
+          resourceLoader.bootConfig.resources.runtime[
+            dotnetTimeZoneResourceName
+          ],
+          "globalization",
+        );
+      }
+
+      let icuDataResource = undefined;
+      if (resourceLoader.bootConfig.icuDataMode !== ICUDataMode.Invariant) {
+        const applicationCulture =
+          resourceLoader.startOptions.applicationCulture ||
+          (navigator.languages && navigator.languages[0]);
+        const icuDataResourceName = getICUResourceName(
+          resourceLoader.bootConfig,
+          applicationCulture,
+        );
+        icuDataResource = resourceLoader.loadResource(
+          icuDataResourceName,
+          `_framework/${icuDataResourceName}`,
+          resourceLoader.bootConfig.resources.runtime[icuDataResourceName],
+          "globalization",
+        );
+
+        module.instantiateWasm = (imports, successCallback) => {
+          (async () => {
+            let compiledInstance;
+            try {
+              const dotnetWasmResource = await wasmBeingLoaded;
+              compiledInstance = await compileWasmModule(
+                dotnetWasmResource,
+                imports,
+              );
+            } catch (ex) {
+              module.printErr(ex.toString());
+              throw ex;
+            }
+            successCallback(compiledInstance);
+          })();
+          return []; // No exports
+        };
+
+        module.onRuntimeInitialized = () => {
+          if (!icuDataResource) {
+            // Use invariant culture if the app does not carry icu data.
+            MONO.mono_wasm_setenv("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1");
+          }
+        };
+
+        module.preRun.push(() => {
+          // By now, emscripten should be initialised enough that we can capture these methods for later use
+          mono_wasm_add_assembly = cwrap("mono_wasm_add_assembly", null, [
+            "string",
+            "number",
+            "number",
+          ]);
+          MONO.loaded_files = [];
+
+          if (timeZoneResource) {
+            loadTimezone(timeZoneResource);
+          }
+
+          if (icuDataResource) {
+            loadICUData(icuDataResource);
+          }
+
+          // Fetch the assemblies and PDBs in the background, telling Mono to wait until they are loaded
+          // Mono requires the assembly filenames to have a '.dll' extension, so supply such names regardless
+          // of the extensions in the URLs. This allows loading assemblies with arbitrary filenames.
+          assembliesBeingLoaded.forEach(r =>
+            addResourceAsAssembly(r, changeExtension(r.name, ".dll")),
+          );
+          pdbsBeingLoaded.forEach(r => addResourceAsAssembly(r, r.name));
+
+          /* D-REMOVED: we don't have a blazor object
+          Blazor._internal.dotNetCriticalError = (message) => {
+            module.printErr(BINDING.conv_string(message) || '(null)');
+          };
+          D-REMOVED */
+
+          /* D-REMOVED: we don't have a blazor object. But we might need satelite
+             assemblies so possibly we might need to come back to this.
+          Wire-up callbacks for satellite assemblies. Blazor will call these as part of the application
+          startup sequence to load satellite assemblies for the application's culture.
+          Blazor._internal.getSatelliteAssemblies = (culturesToLoadDotNetArray) => {
+            const culturesToLoad = BINDING.mono_array_to_js_array(culturesToLoadDotNetArray);
+            const satelliteResources = resourceLoader.bootConfig.resources.satelliteResources;
+            if (satelliteResources) {
+              const resourcePromises = Promise.all(culturesToLoad
+                .filter(culture => satelliteResources.hasOwnProperty(culture))
+                .map(culture => resourceLoader.loadResources(satelliteResources[culture], fileName => `_framework/${fileName}`, 'assembly'))
+                .reduce((previous, next) => previous.concat(next), new Array())
+                .map(async resource => (await resource.response).arrayBuffer()));
+              return BINDING.js_to_mono_obj(resourcePromises.then(resourcesToLoad => {
+                if (resourcesToLoad.length) {
+                  Blazor._internal.readSatelliteAssemblies = () => {
+                    const array = BINDING.mono_obj_array_new(resourcesToLoad.length);
+                    for (let i = 0; i < resourcesToLoad.length; i++) {
+                      BINDING.mono_obj_array_set(array, i, BINDING.js_typed_array_to_array(new Uint8Array(resourcesToLoad[i])));
+                    }
+                    return array;
+                  };
+                }
+                return resourcesToLoad.length;
+              }));
+            }
+            return BINDING.js_to_mono_obj(Promise.resolve(0));
+          };
+          D-REMOVED */
+
+          /* D-REMOVED: we don't have a blazor object. But we probably need lazy assemblies so come back to this
+          const lazyResources = {};
+          Blazor._internal.getLazyAssemblies = (assembliesToLoadDotNetArray) => {
+            const assembliesToLoad = BINDING.mono_array_to_js_array(assembliesToLoadDotNetArray);
+            const lazyAssemblies = resourceLoader.bootConfig.resources.lazyAssembly;
+
+            if (!lazyAssemblies) {
+              throw new Error("No assemblies have been marked as lazy-loadable. Use the 'BlazorWebAssemblyLazyLoad' item group in your project file to enable lazy loading an assembly.");
+            }
+
+            const assembliesMarkedAsLazy = assembliesToLoad.filter(assembly => lazyAssemblies.hasOwnProperty(assembly));
+
+            if (assembliesMarkedAsLazy.length !== assembliesToLoad.length) {
+              const notMarked = assembliesToLoad.filter(assembly => !assembliesMarkedAsLazy.includes(assembly));
+              throw new Error(`${notMarked.join()} must be marked with 'BlazorWebAssemblyLazyLoad' item group in your project file to allow lazy-loading.`);
+            }
+
+            let pdbPromises;
+            if (hasDebuggingEnabled()) {
+              const pdbs = resourceLoader.bootConfig.resources.pdb;
+              const pdbsToLoad = assembliesMarkedAsLazy.map(a => changeExtension(a, '.pdb'));
+              if (pdbs) {
+                pdbPromises = Promise.all(pdbsToLoad
+                  .map(pdb => lazyAssemblies.hasOwnProperty(pdb) ? resourceLoader.loadResource(pdb, `_framework/${pdb}`, lazyAssemblies[pdb], 'pdb') : null)
+                  .map(async resource => resource ? (await resource.response).arrayBuffer() : null));
+              }
+            }
+
+            const resourcePromises = Promise.all(assembliesMarkedAsLazy
+              .map(assembly => resourceLoader.loadResource(assembly, `_framework/${assembly}`, lazyAssemblies[assembly], 'assembly'))
+              .map(async resource => (await resource.response).arrayBuffer()));
+
+            return BINDING.js_to_mono_obj(Promise.all([resourcePromises, pdbPromises]).then(values => {
+              lazyResources['assemblies'] = values[0];
+              lazyResources['pdbs'] = values[1];
+              if (lazyResources['assemblies'].length) {
+                Blazor._internal.readLazyAssemblies = () => {
+                  const { assemblies } = lazyResources;
+                  if (!assemblies) {
+                    return BINDING.mono_obj_array_new(0);
+                  }
+                  const assemblyBytes = BINDING.mono_obj_array_new(assemblies.length);
+                  for (let i = 0; i < assemblies.length; i++) {
+                    const assembly = assemblies[i];
+                    BINDING.mono_obj_array_set(assemblyBytes, i, BINDING.js_typed_array_to_array(new Uint8Array(assembly)));
+                  }
+                  return assemblyBytes;
+                };
+
+                Blazor._internal.readLazyPdbs = () => {
+                  const { assemblies, pdbs } = lazyResources;
+                  if (!assemblies) {
+                    return BINDING.mono_obj_array_new(0);
+                  }
+                  const pdbBytes = BINDING.mono_obj_array_new(assemblies.length);
+                  for (let i = 0; i < assemblies.length; i++) {
+                    const pdb = pdbs && pdbs[i] ? new Uint8Array(pdbs[i]) : new Uint8Array();
+                    BINDING.mono_obj_array_set(pdbBytes, i, BINDING.js_typed_array_to_array(pdb));
+                  }
+                  return pdbBytes;
+                };
+              }
+
+              return lazyResources['assemblies'].length;
+            }));
+          };
+          D-REMOVED */
+        });
+        module.postRun.push(() => {
+          if (
+            resourceLoader.bootConfig.debugBuild &&
+            resourceLoader.bootConfig.cacheBootResources
+          ) {
+            resourceLoader.logToConsole();
+          }
+          resourceLoader.purgeUnusedCacheEntriesAsync(); // Don't await - it's fine to run in background
+
+          if (resourceLoader.bootConfig.icuDataMode === ICUDataMode.Sharded) {
+            MONO.mono_wasm_setenv("__BLAZOR_SHARDED_ICU", "1");
+
+            if (resourceLoader.startOptions.applicationCulture) {
+              // If a culture is specified via start options use that to initialize the Emscripten \  .NET culture.
+              MONO.mono_wasm_setenv(
+                "LANG",
+                `${resourceLoader.startOptions.applicationCulture}.UTF-8`,
+              );
+            }
+          }
+          let timeZone = "UTC";
+          try {
+            timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            // eslint-disable-next-line no-empty
+          } catch {}
+          MONO.mono_wasm_setenv("TZ", timeZone || "UTC");
+          if (resourceLoader.bootConfig.modifiableAssemblies) {
+            // Configure the app to enable hot reload in Development.
+            MONO.mono_wasm_setenv(
+              "DOTNET_MODIFIABLE_ASSEMBLIES",
+              resourceLoader.bootConfig.modifiableAssemblies,
+            );
+          }
+
+          if (resourceLoader.bootConfig.aspnetCoreBrowserTools) {
+            // See https://github.com/dotnet/aspnetcore/issues/37357#issuecomment-941237000
+            MONO.mono_wasm_setenv(
+              "__ASPNETCORE_BROWSER_TOOLS",
+              resourceLoader.bootConfig.aspnetCoreBrowserTools,
+            );
+          }
+
+          const load_runtime = cwrap("mono_wasm_load_runtime", null, [
+            "string",
+            "number",
+          ]);
+          // -1 enables debugging with logging disabled. 0 disables debugging entirely.
+
+          const appBinDirName = "appBinDir"; // D-MOVED from global scope
+          load_runtime(appBinDirName, hasDebuggingEnabled() ? -1 : 0);
+          MONO.mono_wasm_runtime_ready();
+          // TODO: this might be a better to way to invoke things than what we have hacked in
+          attachInteropInvoker();
+          onReady();
+        });
+
+        return module;
+
+        async function addResourceAsAssembly(dependency, loadAsName) {
+          const runDependencyId = `blazor:${dependency.name}`;
+          addRunDependency(runDependencyId);
+
+          try {
+            // Wait for the data to be loaded and verified
+            const dataBuffer = await dependency.response.then(r =>
+              r.arrayBuffer(),
+            );
+
+            // Load it into the Mono runtime
+            const data = new Uint8Array(dataBuffer);
+            const heapAddress = Module._malloc(data.length);
+            const heapMemory = new Uint8Array(
+              Module.HEAPU8.buffer,
+              heapAddress,
+              data.length,
+            );
+            heapMemory.set(data);
+            mono_wasm_add_assembly(loadAsName, heapAddress, data.length);
+            MONO.loaded_files.push(toAbsoluteUrl(dependency.url));
+          } catch (errorInfo) {
+            onError(errorInfo);
+            return;
+          }
+
+          removeRunDependency(runDependencyId);
+        }
+      }
+
+      /* D-REMOVED
+      const anchorTagForAbsoluteUrlConversions = document.createElement('a');
+      function toAbsoluteUrl(possiblyRelativeUrl) {
+        anchorTagForAbsoluteUrlConversions.href = possiblyRelativeUrl;
+        return anchorTagForAbsoluteUrlConversions.href;
+      }
+
+      function getArrayDataPointer(array){
+        return array + 12; // First byte from here is length, then following bytes are entries
+      }
+
+      function bindStaticMethod(assembly, typeName, method) {
+        // Fully qualified name looks like this: "[debugger-test] Math:IntAdd"
+        const fqn = `[${assembly}] ${typeName}:${method}`;
+        return BINDING.bind_static_method(fqn);
+      }
+
+      export let byteArrayBeingTransferred = null;
+      function attachInteropInvoker() {
+        const dotNetDispatcherInvokeMethodHandle = bindStaticMethod('Microsoft.AspNetCore.Components.WebAssembly', 'Microsoft.AspNetCore.Components.WebAssembly.Services.DefaultWebAssemblyJSRuntime', 'InvokeDotNet');
+        const dotNetDispatcherBeginInvokeMethodHandle = bindStaticMethod('Microsoft.AspNetCore.Components.WebAssembly', 'Microsoft.AspNetCore.Components.WebAssembly.Services.DefaultWebAssemblyJSRuntime', 'BeginInvokeDotNet');
+        const dotNetDispatcherEndInvokeJSMethodHandle = bindStaticMethod('Microsoft.AspNetCore.Components.WebAssembly', 'Microsoft.AspNetCore.Components.WebAssembly.Services.DefaultWebAssemblyJSRuntime', 'EndInvokeJS');
+        const dotNetDispatcherNotifyByteArrayAvailableMethodHandle = bindStaticMethod('Microsoft.AspNetCore.Components.WebAssembly', 'Microsoft.AspNetCore.Components.WebAssembly.Services.DefaultWebAssemblyJSRuntime', 'NotifyByteArrayAvailable');
+
+        DotNet.attachDispatcher({
+          beginInvokeDotNetFromJS: (callId , assemblyName , methodIdentifier, dotNetObjectId , argsJson ) => {
+            assertHeapIsNotLocked();
+            if (!dotNetObjectId && !assemblyName) {
+              throw new Error('Either assemblyName or dotNetObjectId must have a non null value.');
+            }
+            // As a current limitation, we can only pass 4 args. Fortunately we only need one of
+            // 'assemblyName' or 'dotNetObjectId', so overload them in a single slot
+            const assemblyNameOrDotNetObjectId = dotNetObjectId
+              ? dotNetObjectId.toString()
+              : assemblyName;
+
+            dotNetDispatcherBeginInvokeMethodHandle(
+              callId ? callId.toString() : null,
+              assemblyNameOrDotNetObjectId,
+              methodIdentifier,
+              argsJson,
+            );
+          },
+          endInvokeJSFromDotNet: (asyncHandle, succeeded, serializedArgs) => {
+            dotNetDispatcherEndInvokeJSMethodHandle(serializedArgs);
+          },
+          sendByteArray: (id , data ) => {
+            byteArrayBeingTransferred = data;
+            dotNetDispatcherNotifyByteArrayAvailableMethodHandle(id);
+          },
+          invokeDotNetFromJS: (assemblyName, methodIdentifier, dotNetObjectId, argsJson) => {
+            assertHeapIsNotLocked();
+            return dotNetDispatcherInvokeMethodHandle(
+              assemblyName ? assemblyName : null,
+              methodIdentifier,
+              dotNetObjectId ? dotNetObjectId.toString() : null,
+              argsJson,
+            );
+          },
+        });
+      }
+      D-REMOVED */
+
+      async function loadTimezone(timeZoneResource) {
+        const runDependencyId = "blazor:timezonedata";
+        addRunDependency(runDependencyId);
+
+        const request = await timeZoneResource.response;
+        const arrayBuffer = await request.arrayBuffer();
+
+        Module["FS_createPath"]("/", "usr", true, true);
+        Module["FS_createPath"]("/usr/", "share", true, true);
+        Module["FS_createPath"]("/usr/share/", "zoneinfo", true, true);
+        MONO.mono_wasm_load_data_archive(
+          new Uint8Array(arrayBuffer),
+          "/usr/share/zoneinfo/",
+        );
+
+        removeRunDependency(runDependencyId);
+      }
+
+      function getICUResourceName(bootConfig, culture) {
+        const combinedICUResourceName = "icudt.dat";
+        if (!culture || bootConfig.icuDataMode === ICUDataMode.All) {
+          return combinedICUResourceName;
+        }
+
+        const prefix = culture.split("-")[0];
+        if (["en", "fr", "it", "de", "es"].includes(prefix)) {
+          return "icudt_EFIGS.dat";
+        } else if (["zh", "ko", "ja"].includes(prefix)) {
+          return "icudt_CJK.dat";
+        } else {
+          return "icudt_no_CJK.dat";
+        }
+      }
+
+      async function loadICUData(icuDataResource) {
+        const runDependencyId = "blazor:icudata";
+        addRunDependency(runDependencyId);
+
+        const request = await icuDataResource.response;
+        const array = new Uint8Array(await request.arrayBuffer());
+
+        const offset = MONO.mono_wasm_load_bytes_into_heap(array);
+        if (!MONO.mono_wasm_load_icu_data(offset)) {
+          throw new Error("Error loading ICU asset.");
+        }
+        removeRunDependency(runDependencyId);
+      }
+
+      async function compileWasmModule(wasmResource, imports) {
+        // This is the same logic as used in emscripten's generated js. We can't use emscripten's js because
+        // it doesn't provide any method for supplying a custom response provider, and we want to integrate
+        // with our resource loader cache.
+
+        if (typeof WebAssembly["instantiateStreaming"] === "function") {
+          try {
+            const streamingResult = await WebAssembly["instantiateStreaming"](
+              wasmResource.response,
+              imports,
+            );
+            return streamingResult.instance;
+          } catch (ex) {
+            console.info(
+              "Streaming compilation failed. Falling back to ArrayBuffer instantiation. ",
+              ex,
+            );
+          }
+        }
+
+        // If that's not available or fails (e.g., due to incorrect content-type header),
+        // fall back to ArrayBuffer instantiation
+        const arrayBuffer = await wasmResource.response.then(r =>
+          r.arrayBuffer(),
+        );
+        const arrayBufferResult = await WebAssembly.instantiate(
+          arrayBuffer,
+          imports,
+        );
+        return arrayBufferResult.instance;
+      }
+
+      function changeExtension(filename, newExtensionWithLeadingDot) {
+        const lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex < 0) {
+          throw new Error(`No extension to replace in '${filename}'`);
+        }
+
+        return filename.substr(0, lastDotIndex) + newExtensionWithLeadingDot;
+      }
+
+      /* D-REMOVED
+      function assertHeapIsNotLocked() {
+        if (currentHeapLock) {
+          throw new Error("Assertion failed - heap is currently locked");
+        }
+      }
+
+      class MonoHeapLock implements HeapLock {
+        // Within a given heap lock, it's safe to cache decoded strings since the memory can't change
+        stringCache = new Map<number, string | null>();
+
+        private postReleaseActions?: Function[];
+
+        enqueuePostReleaseAction(callback: Function) {
+          if (!this.postReleaseActions) {
+            this.postReleaseActions = [];
+          }
+
+          this.postReleaseActions.push(callback);
+        }
+
+        release() {
+          if (currentHeapLock !== this) {
+            throw new Error('Trying to release a lock which isn\'t current');
+          }
+
+          currentHeapLock = null;
+
+          while (this.postReleaseActions?.length) {
+            const nextQueuedAction = this.postReleaseActions.shift()!;
+
+            // It's possible that the action we invoke here might itself take a succession of heap locks,
+            // but since heap locks must be released synchronously, by the time we get back to this stack
+            // frame, we know the heap should no longer be locked.
+            nextQueuedAction();
+            assertHeapIsNotLocked();
+          }
+        }
+      }
+      D-REMOVED */
+    }
+
+    // =======================
+    // WebAssemblyStartOptions.ts
+    // =======================
+    let startOptions = {
+      environment: "development",
+      applicationCulture: "en-US",
+      loadBootResource: (type, name, defaultUri, integrity) => null,
+    };
+    // =======================
+    // WebAssemblyResourceLoader.ts
+    // =======================
+    const resourceLoader = bootConfig => {
+      // export interface LoadingResource {
+      //   name: string;
+      //   url: string;
+      //   response: Promise<Response>;
+      // }
+      // export type ResourceList = { [name: string]: string };
+      const loadResources = (resources, urlFn, resourceType) => {
+        return Object.keys(resources).map(name =>
+          loadResource(name, urlFn(name), resources[name], resourceType),
+        );
+      };
+      // This corresponds to loadResourceWithoutCaching. In the future we should add caching.
+      const loadResource = (name, url, contentHash, resourceType) => {
+        url = toDarklangSetupUri(url);
+        let response = fetch(url, {
+          cache: "no-cache",
+          integrity: bootConfig.cacheBootResources ? contentHash : undefined,
+        });
+        return { name, url, response };
+      };
+      return {
+        loadResources: loadResources,
+        loadResource: loadResource,
+        bootConfig: bootConfig,
+        startOptions: startOptions,
+      };
+    };
+
+    // =======================
+    // BootConfig.ts
+    // =======================
+    const onError = err => {
+      // FSTODO: add rollbar to error handler
+      console.error(err);
+    };
+
+    function bootConfig(onReady) {
+      return fetch(toDarklangSetupUri("blazor.boot.json"))
+        .then(response => response.json())
+        .then(blazorBoot => {
+          let loader = resourceLoader(blazorBoot);
+          self.Module = createEmscriptenModuleInstance(
+            loader,
+            onReady,
+            onError,
+          );
+
+          // Start loading scripts
+          let runtimeResources = Object.keys(blazorBoot.resources.runtime);
+          let dotnetjsfilename = runtimeResources.find(
+            p => p.startsWith("dotnet.") && p.endsWith(".js"),
+          );
+          if (dotnetjsfilename === "") {
+            throw "BlazorWorker: Unable to locate dotnetjs file in blazor boot config.";
+          }
+          self.importScripts(toDarklangSetupUri(dotnetjsfilename));
+        })
+        .catch(onError);
+    }
+
+    // =======================
+    // Glue it together with our setup
+    // =======================
     hashReplacements = JSON.parse(hashReplacements);
-    const nonExistingDlls = [];
-    let blazorBootManifest;
-    const fileToUrl = file => {
+    function toDarklangSetupUri(file) {
+      file = file.replace(/_framework\//, "");
       let hashed = hashReplacements["/" + file];
       if (hashed) {
         // Remove the starting slash
@@ -23,10 +867,15 @@ window.BlazorWorker = (function () {
       } else {
         hashed = file;
       }
-      return appRoot + "/" + hashed;
-    };
+      return `${appRoot}/blazor/${hashed}`;
+    }
+
+    // =======================
+    // Initialize
+    // =======================
 
     const onReady = () => {
+      console.log("Calling onReady");
       // Setup the onmessage handler to call F#
       const messageHandler = Module.mono_bind_static_method(
         "[Wasm]Wasm.EvalWorker:OnMessage",
@@ -38,147 +887,17 @@ window.BlazorWorker = (function () {
       self.postMessage("darkWebWorkerInitializedMessage");
     };
 
-    const onError = err => {
-      // FSTODO: add rollbar to error handler
-      console.error(err);
-    };
+    bootConfig(onReady);
+    // doesn't return anything
+  }
 
-    function asyncLoad(url, reponseType) {
-      return new Promise((resolve, reject) => {
-        const xhr = new XMLHttpRequest();
-        const arrayBufferType = "arraybuffer";
-        xhr.open("GET", url, /* async: */ true);
-        xhr.responseType = reponseType || arrayBufferType;
-        xhr.onload = function xhr_onload() {
-          if (xhr.status == 200 || (xhr.status == 0 && xhr.response)) {
-            if (this.responseType === arrayBufferType) {
-              const asm = new Uint8Array(xhr.response);
-              resolve(asm);
-            } else {
-              resolve(xhr.response);
-            }
-          } else {
-            reject(xhr);
-          }
-        };
-        xhr.onerror = reject;
-        xhr.send(undefined);
-      });
-    }
-
-    // This module is part of Emscripten, and the functions are used to set up
-    // the Wasm-compiled version of .NET
-    var Module = {};
-
-    Module.print = line => console.log(`WASM-WORKER: ${line}`);
-
-    Module.preRun = [];
-    Module.postRun = [];
-
-    Module.locateFile = fileName => {
-      switch (fileName) {
-        case "dotnet.wasm":
-          return fileToUrl("blazor/dotnet.wasm");
-        default:
-          return fileToUrl(fileName);
-      }
-    };
-
-    Module.preRun.push(() => {
-      const mono_wasm_add_assembly = Module.cwrap(
-        "mono_wasm_add_assembly",
-        null,
-        ["string", "number", "number"],
-      );
-
-      mono_string_get_utf8 = Module.cwrap(
-        "mono_wasm_string_get_utf8",
-        "number",
-        ["number"],
-      );
-
-      MONO.loaded_files = [];
-
-      Object.keys(blazorBootManifest.resources.assembly).forEach(url => {
-        if (!blazorBootManifest.resources.assembly.hasOwnProperty(url)) {
-          // Do not attempt to load a dll which is not present anyway
-          nonExistingDlls.push(url);
-          return;
-        }
-
-        const runDependencyId = `blazor:${url}`;
-        addRunDependency(runDependencyId);
-
-        asyncLoad(fileToUrl(`blazor/${url}`)).then(
-          data => {
-            const heapAddress = Module._malloc(data.length);
-            const heapMemory = new Uint8Array(
-              Module.HEAPU8.buffer,
-              heapAddress,
-              data.length,
-            );
-            heapMemory.set(data);
-            mono_wasm_add_assembly(url, heapAddress, data.length);
-            MONO.loaded_files.push(url);
-            removeRunDependency(runDependencyId);
-          },
-          errorInfo => {
-            const isPdb404 =
-              errorInfo instanceof XMLHttpRequest &&
-              errorInfo.status === 404 &&
-              url.match(/\.pdb$/);
-            if (!isPdb404) {
-              onError(errorInfo);
-            }
-            removeRunDependency(runDependencyId);
-          },
-        );
-      });
-    });
-
-    Module.postRun.push(() => {
-      MONO.mono_wasm_setenv("MONO_URI_DOTNETRELATIVEORABSOLUTE", "true");
-      const load_runtime = Module.cwrap("mono_wasm_load_runtime", null, [
-        "string",
-        "number",
-      ]);
-      load_runtime("appBinDir", 0); // why appBinDir? Dunno
-      MONO.mono_wasm_runtime_is_ready = true;
-      onReady();
-      if (nonExistingDlls.length > 0) {
-        console.warn(
-          `BlazorWorker: Module.postRun: ${nonExistingDlls.length} assemblies was specified as a dependency for the worker but was not present in the bootloader. This may be normal if trimmming is used. To remove this warning, either configure the linker not to trim the specified assemblies if they were removed in error, or conditionally remove the specified dependencies for builds that uses trimming. If trimming is not used, make sure that the assembly is included in the build.`,
-          nonExistingDlls,
-        );
-      }
-    });
-
-    self.Module = Module;
-
-    //TODO: This call could/should be session cached. But will the built-in blazor fetch service worker override
-    // (PWA et al) do this already if configured ?
-    asyncLoad(fileToUrl("blazor/blazor.boot.json"), "json").then(
-      blazorboot => {
-        // Save this for loading other scripts later
-        blazorBootManifest = blazorboot;
-
-        // Start loading scripts
-        let runtimeResources = Object.keys(blazorboot.resources.runtime);
-        let dotnetjsfilename = runtimeResources.find(
-          p => p.startsWith("dotnet.") && p.endsWith(".js"),
-        );
-        if (dotnetjsfilename === "") {
-          throw "BlazorWorker: Unable to locate dotnetjs file in blazor boot config.";
-        }
-        self.importScripts(fileToUrl(`blazor/${dotnetjsfilename}`));
-      },
-      errorInfo => onError(errorInfo),
-    );
-  };
-
+  // ===========================
   // Initialize the worker
-  let hashes = JSON.stringify(hashReplacements);
-  const inlineWorker = `self.onmessage = ${workerDef}("${window.location.protocol}//${staticUrl}", '${hashes}')`;
+  // ===========================
+  const inlineWorker = `
+    let appRoot = "${window.location.protocol}//${staticUrl}";
+    let hashReplacements = '${JSON.stringify(hashReplacements)}';
+    self.onmessage = (${workerDef})(appRoot, hashReplacements)`;
 
   const initWorker = function (initCallback, onMessageCallback) {
     const blob = new Blob([inlineWorker], {

--- a/fsharp-backend/src/Wasm/static/BlazorWorker.js
+++ b/fsharp-backend/src/Wasm/static/BlazorWorker.js
@@ -369,9 +369,9 @@ D-REMOVED */
             // Use invariant culture if the app does not carry icu data.
             MONO.mono_wasm_setenv("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1");
           }
-          // }; // D-CHANGED
+        }; // D-CHANGED
 
-          // module.preRun.push(() => {
+        module.preRun.push(() => {
           // By now, emscripten should be initialised enough that we can capture these methods for later use
           mono_wasm_add_assembly = cwrap("mono_wasm_add_assembly", null, [
             "string",
@@ -499,7 +499,7 @@ D-REMOVED */
             }));
           };
           D-REMOVED */
-        };
+        });
         module.postRun.push(() => {
           if (
             resourceLoader.bootConfig.debugBuild &&

--- a/fsharp-backend/src/Wasm/static/BlazorWorker.js
+++ b/fsharp-backend/src/Wasm/static/BlazorWorker.js
@@ -819,8 +819,15 @@ D-REMOVED */
         loadResource: loadResource,
         bootConfig: bootConfig,
         startOptions: startOptions,
+        purgeUnusedCacheEntriesAsync: () => Promise.resolve(),
       };
     };
+    // =======================
+    // MonoDebugger.ts
+    // =======================
+    function hasDebuggingEnabled() {
+      return true;
+    }
 
     // =======================
     // BootConfig.ts

--- a/scripts/build/compile
+++ b/scripts/build/compile
@@ -93,6 +93,8 @@ def copy_fsharp_static():
     wwwroot = run_backend(
         start,
         "rsync -a fsharp-backend/Build/out/Wasm/Release/net6.0/wwwroot/_framework/ backend/static/blazor/"
+        # For now, use the non-published version, which actually works
+        # "rsync -a fsharp-backend/Build/out/Wasm/Release/net6.0/publish/wwwroot/_framework/ backend/static/blazor/"
     )
   else:
     wwwroot = run_backend(
@@ -309,8 +311,7 @@ def fsharp_backend_full_build():
   result = run_backend(start, build)
 
   start = time.time()
-  # When "Publish"ing, the wasm isn't built due to a bug. So we need to build it
-  # ourselves for now.
+  # Publishing the Wasm leads to an assertion failure while initializing .net via BlazorWorker
   if result and optimize:
     build = f"cd fsharp-backend \
       && unbuffer dotnet build \

--- a/scripts/build/compile
+++ b/scripts/build/compile
@@ -275,6 +275,17 @@ def fsharp_backend_quick_build():
       --verbosity {verbosity} \
       --configuration {configuration}"
 
+  result = run_backend(start, build)
+
+  start = time.time()
+  # Publishing the Wasm leads to an assertion failure while initializing .net via BlazorWorker
+  if result and optimize:
+    build = f"cd fsharp-backend \
+      && unbuffer dotnet build \
+        --verbosity {verbosity} \
+        --configuration {configuration} \
+        src/Wasm/Wasm.fsproj"
+
   return run_backend(start, build)
 
 
@@ -297,6 +308,7 @@ def fsharp_backend_full_build():
 
   result = run_backend(start, build)
 
+  start = time.time()
   # When "Publish"ing, the wasm isn't built due to a bug. So we need to build it
   # ourselves for now.
   if result and optimize:

--- a/scripts/run-fsharp-server
+++ b/scripts/run-fsharp-server
@@ -34,6 +34,8 @@ TUNNEL_DAEMON_EXE="containers/tunnel/tunnel-daemon"
 echo "Stopping servers"
 #sudo pkill -f nginx || true # FSTODO
 #FSTODO
+sudo pkill -f "ApiServer" || true
+sudo pkill -f "BwdServer" || true
 sudo pkill -f "ApiServer2" || true
 sudo pkill -f "BwdServer2" || true
 
@@ -89,8 +91,13 @@ if [[ -f "${API_SERVER_EXE}" && -f "${BWD_SERVER_EXE}" ]]; then
   # cp "${BINPATH}/BwdServer.runtimeconfig.json" "${BINPATH}/BwdServer2.runtimeconfig.json"
   # cp "${BINPATH}/BwdServer.xml" "${BINPATH}/BwdServer2.xml"
   echo "Running server"
-  "${API_SERVER_EXE}2" > "$LOGS/fsharp-apiserver.log" 2>&1 &
-  "${BWD_SERVER_EXE}2" > "$LOGS/fsharp-bwdserver.log" 2>&1 &
+  if [[ "$PUBLISHED" == "true" ]]; then
+    "${API_SERVER_EXE}" > "$LOGS/fsharp-apiserver.log" 2>&1 &
+    "${BWD_SERVER_EXE}" > "$LOGS/fsharp-bwdserver.log" 2>&1 &
+  else
+    "${API_SERVER_EXE}2" > "$LOGS/fsharp-apiserver.log" 2>&1 &
+    "${BWD_SERVER_EXE}2" > "$LOGS/fsharp-bwdserver.log" 2>&1 &
+  fi
   #FSTODO
   # "${QW_EXE}" --no-health-check > "$LOGS/queue_worker.log" 2>&1 &
   # "${CRON_EXE}" --no-health-check > "$LOGS/cron.log" 2>&1 &


### PR DESCRIPTION
Move to .NET 6 and try to get AOT compilation working for Blazor.

The main change was rewriting Blazor worker off the original, to try and minimize the changes and hope that that solves things. Unfortunately, it's still hits the same problems, but now I know it's not me.

This leaves the AOT in roughly the same place as before. I noticed it was broken in production and maybe this fixes it.

Also:
- Upgrade to watchgod with a fix in it so it doesn't stop compiling as soon as it has a bad symlink
- Fix the latest working version of fantomas
- update all the dependencies to the latest versions
- fix the cargo-cache version to avoid build breakage

