### PR TITLE
Fix APIServer tests

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APITraces.fs
+++ b/fsharp-backend/src/ApiServer/Api/APITraces.fs
@@ -51,7 +51,7 @@ module TraceData =
 
       t "load-canvas"
 
-      // TODO: we dont need the handlers or functions at all here, just for the sample
+      // CLEANUP: we dont need the handlers or functions at all here, just for the sample
       // values which we can do on the client instead
       let handler = c.handlers |> Map.get p.tlid
 
@@ -61,7 +61,7 @@ module TraceData =
         | None ->
           match c.userFunctions |> Map.get p.tlid with
           | Some u -> Traces.userfnTrace c.meta.id p.trace_id u |> Task.map Some
-          | None -> task { return None }
+          | None -> Task.FromResult None
 
       t "load-trace"
 

--- a/fsharp-backend/src/LibBackend/Traces.fs
+++ b/fsharp-backend/src/LibBackend/Traces.fs
@@ -60,10 +60,7 @@ let savedInputVars
     let withR = [ ("request", event) ] in
 
     let bound =
-      if route = "" then
-        []
-      else
-        (
+      if route <> "" then
         // Check the trace actually matches the route, if not the client
         // has made a mistake in matching the traceid to this handler, but
         // that might happen due to a race condition. If it does, carry
@@ -74,7 +71,9 @@ let savedInputVars
         if Routing.requestPathMatchesRoute route requestPath then
           Routing.routeInputVars route requestPath |> Option.unwrapUnsafe
         else
-          sampleRouteInputVars h)
+          sampleRouteInputVars h
+      else
+        []
 
     withR @ bound
   | PT.Handler.Worker _ -> [ ("event", event) ]

--- a/fsharp-backend/src/LibBackend/Traces.fs
+++ b/fsharp-backend/src/LibBackend/Traces.fs
@@ -16,13 +16,15 @@ module PT = LibExecution.ProgramTypes
 let incomplete = RT.DIncomplete RT.SourceNone
 
 let sampleRequest : RT.Dval =
-  RT.Dval.obj [ ("body", incomplete)
-                ("jsonBody", incomplete)
-                ("formBody", incomplete)
-                ("queryParams", incomplete)
-                ("headers", incomplete)
-                ("fullBody", incomplete)
-                ("url", incomplete) ]
+  ([ ("body", incomplete)
+     ("jsonBody", incomplete)
+     ("formBody", incomplete)
+     ("queryParams", incomplete)
+     ("headers", incomplete)
+     ("fullBody", incomplete)
+     ("url", incomplete) ])
+  |> Map
+  |> RT.Dval.DObj
 
 let sampleRequestInputVars : AT.InputVars = [ ("request", sampleRequest) ]
 

--- a/fsharp-backend/src/Tablecloth/TableclothList.fs
+++ b/fsharp-backend/src/Tablecloth/TableclothList.fs
@@ -34,7 +34,9 @@ let tail l =
 
 let cons element list = element :: list
 
-let take count t = List.take count t
+let take count t =
+  // List.take throws an exception
+  List.truncate count t
 
 let takeWhile (f : 'a -> bool) (l : 'a list) = List.takeWhile f l
 

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -39,7 +39,7 @@ type U = Lazy<Task<User>>
 
 let portFor (server : Server) : int =
   match server with
-  | OCaml -> 8000
+  | OCaml -> 8000 // nginx for the ocaml server is on port 8000
   | FSharp -> LibService.Config.apiServerNginxPort
 
 // login as test user and return the csrfToken (the cookies are stored in httpclient)

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -27,21 +27,31 @@ type AuthData = LibBackend.Session.AuthData
 
 open ApiServer
 
+type Server =
+  | FSharp
+  | OCaml
+
 let ident = Fun.identity
 
 type User = { client : HttpClient; csrf : string }
 
 type U = Lazy<Task<User>>
 
+let portFor (server : Server) : int =
+  match server with
+  | OCaml -> 8000
+  | FSharp -> LibService.Config.apiServerNginxPort
+
 // login as test user and return the csrfToken (the cookies are stored in httpclient)
 let login (username : string) (password : string) : Task<User> =
   task {
     let client = new HttpClient()
+    let port = portFor OCaml
 
     use loginReq =
       new HttpRequestMessage(
         HttpMethod.Post,
-        $"http://darklang.localhost:8000/login"
+        $"http://darklang.localhost:{port}/login"
       )
 
     let body =
@@ -73,18 +83,31 @@ let loggedOutUser () =
 
 
 
-let getAsync (user : U) (url : string) : Task<HttpResponseMessage> =
+let getAsync
+  (server : Server)
+  (user : U)
+  (path : string)
+  : Task<HttpResponseMessage> =
   task {
     let! user = Lazy.force user
+    let port = portFor server
+    let url = $"http://darklang.localhost:{port}{path}"
     use message = new HttpRequestMessage(HttpMethod.Get, url)
     message.Headers.Add("X-CSRF-Token", user.csrf)
 
     return! user.client.SendAsync(message)
   }
 
-let postAsync (user : U) (url : string) (body : string) : Task<HttpResponseMessage> =
+let postAsync
+  (server : Server)
+  (user : U)
+  (path : string)
+  (body : string)
+  : Task<HttpResponseMessage> =
   task {
     let! user = Lazy.force user
+    let port = portFor server
+    let url = $"http://darklang.localhost:{port}{path}"
     use message = new HttpRequestMessage(HttpMethod.Post, url)
     message.Headers.Add("X-CSRF-Token", user.csrf)
 
@@ -105,7 +128,7 @@ let noBody () = ""
 let getInitialLoad (user : U) : Task<InitialLoad.T> =
   task {
     let! (o : HttpResponseMessage) =
-      postAsync user $"http://darklang.localhost:8000/api/test/initial_load" ""
+      postAsync OCaml user $"/api/test/initial_load" ""
 
     Expect.equal o.StatusCode System.Net.HttpStatusCode.OK ""
     let! body = o.Content.ReadAsStringAsync()
@@ -117,11 +140,8 @@ let getInitialLoad (user : U) : Task<InitialLoad.T> =
 let testUiReturnsTheSame =
   testTask "ui returns the same" {
 
-    let! (o : HttpResponseMessage) =
-      getAsync testUser "http://darklang.localhost:8000/a/test"
-
-    let! (f : HttpResponseMessage) =
-      getAsync testUser "http://darklang.localhost:9000/a/test"
+    let! (o : HttpResponseMessage) = getAsync OCaml testUser "/a/test"
+    let! (f : HttpResponseMessage) = getAsync FSharp testUser "/a/test"
 
     Expect.equal o.StatusCode f.StatusCode ""
 
@@ -144,20 +164,22 @@ let testUiReturnsTheSame =
     let oc, ocfns = parse oc
     let fc, fcfns = parse fc
 
+    let port = portFor OCaml
+
     let oc =
       oc
         // a couple of specific ones
         .Replace(
-          "static.darklang.localhost:8000",
+          $"static.darklang.localhost:{port}",
           $"static.darklang.localhost:{LibService.Config.apiServerNginxPort}"
         )
         .Replace(
-          "builtwithdark.localhost:8000",
+          $"builtwithdark.localhost:{port}",
           $"builtwithdark.localhost:{LibService.Config.bwdServerNginxPort}"
         )
         // get the rest
         .Replace(
-          "localhost:8000",
+          $"localhost:{port}",
           $"localhost:{LibService.Config.apiServerNginxPort}"
         )
 
@@ -209,10 +231,6 @@ let testUiReturnsTheSame =
       filteredOCamlFns
   }
 
-type Server =
-  | FSharp
-  | OCaml
-
 type ApiResponse<'a> = Task<'a * System.Net.HttpStatusCode * Map<string, string>>
 
 let postApiTestCase
@@ -223,13 +241,8 @@ let postApiTestCase
   (canonicalizeBody : 'a -> 'a)
   : ApiResponse<'a> =
   task {
-    let port =
-      match server with
-      | OCaml -> TestConfig.ocamlHttpPort
-      | FSharp -> LibService.Config.apiServerNginxPort
-
     let! (response : HttpResponseMessage) =
-      postAsync testUser $"http://darklang.localhost:{port}/api/test/{api}" body
+      postAsync server testUser $"/api/test/{api}" body
 
     let! content = response.Content.ReadAsStringAsync()
 
@@ -252,6 +265,7 @@ let postApiTestCase
       clear "Server-Timing"
       clear "x-darklang-execution-id"
       let (_ : bool) = h.Remove "Connection" // not useful, not in new API
+      let (_ : bool) = h.Remove "Strict-Transport-Security" // only in new API
 
       h
       |> Seq.toList
@@ -301,7 +315,7 @@ let testPostApi
 let testGetTraceData =
   testTask "get_trace is the same" {
     let! (o : HttpResponseMessage) =
-      postAsync testUser $"http://darklang.localhost:8000/api/test/all_traces" ""
+      postAsync OCaml testUser $"/api/test/all_traces" ""
 
     Expect.equal o.StatusCode System.Net.HttpStatusCode.OK ""
     let! body = o.Content.ReadAsStringAsync()
@@ -495,7 +509,7 @@ let testDelete404s =
     let get404s () : Task<List<TI.F404>> =
       task {
         let! (o : HttpResponseMessage) =
-          postAsync testUser $"http://darklang.localhost:8000/api/test/get_404s" ""
+          postAsync OCaml testUser $"/api/test/get_404s" ""
 
         Expect.equal o.StatusCode System.Net.HttpStatusCode.OK ""
         let! body = o.Content.ReadAsStringAsync()
@@ -530,8 +544,11 @@ let testDelete404s =
     let insert404 server : Task<unit> =
       task {
         // FSTODO switch test to use F#, which doesn't yet add traces
-        let url = $"http://test.builtwithdark.localhost:8000{path}"
-        let! result = getAsync testUser url
+        let! user = Lazy.force testUser
+        let port = portFor server
+        let url = $"http://test.builtwithdark.localhost:{port}/{path}"
+        use message = new HttpRequestMessage(HttpMethod.Get, url)
+        let! result = user.client.SendAsync(message)
         Expect.equal result.StatusCode System.Net.HttpStatusCode.NotFound "404s"
 
         // assert 404 added
@@ -547,10 +564,10 @@ let testDelete404s =
     let! f404 = get404 ()
     Expect.equal f404 None "initial"
 
-    do! insert404 ()
+    do! insert404 OCaml
     let! oResponse = delete404 OCaml
 
-    do! insert404 ()
+    do! insert404 FSharp
     let! fResponse = delete404 FSharp
 
     Expect.equal fResponse oResponse "compare responses"
@@ -625,14 +642,10 @@ let permissions =
     "check apiserver permissions"
     (fun (user : U) (username : string) ->
       task {
-        let! (uiResp : HttpResponseMessage) =
-          getAsync user $"http://darklang.localhost:9000/a/{username}"
+        let! (uiResp : HttpResponseMessage) = getAsync FSharp user $"/a/{username}"
 
         let! (apiResp : HttpResponseMessage) =
-          postAsync
-            user
-            $"http://darklang.localhost:9000/api/{username}/initial_load"
-            ""
+          postAsync FSharp user $"/api/{username}/initial_load" ""
 
         return (int uiResp.StatusCode, int apiResp.StatusCode)
       })

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -543,10 +543,12 @@ let testDelete404s =
 
     let insert404 server : Task<unit> =
       task {
-        // FSTODO switch test to use F#, which doesn't yet add traces
         let! user = Lazy.force testUser
-        let port = portFor server
-        let url = $"http://test.builtwithdark.localhost:{port}/{path}"
+        let port =
+          match server with
+          | OCaml -> 8000
+          | FSharp -> LibService.Config.bwdServerNginxPort
+        let url = $"http://test.builtwithdark.localhost:{port}{path}"
         use message = new HttpRequestMessage(HttpMethod.Get, url)
         let! result = user.client.SendAsync(message)
         Expect.equal result.StatusCode System.Net.HttpStatusCode.NotFound "404s"

--- a/fsharp-backend/tests/testfiles/list.tests
+++ b/fsharp-backend/tests/testfiles/list.tests
@@ -4,6 +4,8 @@
 
 List.append_v0 [1; 2; 3] [4; 5; 6] = [1; 2; 3; 4; 5; 6]
 List.append_v0 [3;4] [5;6] = [3;4;5;6]
+List.append_v0 [1] [2] = [1;2]
+List.append_v0 [] [] = []
 
 List.contains_v0 [1;2;3] 2 = true
 List.contains_v0 [1;2;3] 4 = false
@@ -20,6 +22,7 @@ List.drop_v0 [1;2;3;4] 5 = []
 List.drop_v0 [3; 3; 3] 0 = [3; 3; 3]
 List.drop_v0 [5; 4; 3; 2; 1]  5 = []
 List.drop_v0 [5] 4 = []
+List.drop_v0 [] 4 = []
 
 List.dropWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `-1`" // FSHARPONLY
 List.dropWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` passed to `List::dropWhile` to return a boolean value for every value in `list`. However, it returned `-1` for the input `1`." // OCAMLONLY
@@ -41,6 +44,7 @@ List.filter_v0 [1;2;3] (fun item -> 2) = Test.typeError_v0 "Expecting fn to retu
 List.filter_v0 [1;2;3] (fun item -> 2) = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `2`" // FSHARPONLY
 List.filter_v0 [true;false;true] (fun item -> "a") = Test.typeError_v0 "Expecting fn to return bool" // OCAMLONLY
 List.filter_v0 [true;false;true] (fun item -> "a") = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `\"a\"`" // FSHARPONLY
+List.filter_v0 [] (fun item -> "a") = []
 
 List.filter_v1 [-20; 5; 9;] (fun x -> x < 1) = [-20]
 List.filter_v1 [-20; 5; 9;] (fun x -> x > 20) = []
@@ -53,6 +57,7 @@ List.filter_v1 [1;2;3] (fun item -> "a") = Test.typeError_v0 "Expecting fn to re
 List.filter_v1 [1;2;3] (fun item -> "a") = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `\"a\"`" // FSHARPONLY
 List.filter_v1 [true;false;true] (fun item -> "a") = Test.typeError_v0 "Expecting fn to return bool" // OCAMLONLY
 List.filter_v1 [true;false;true] (fun item -> "a") = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `\"a\"`" // FSHARPONLY
+List.filter_v1 [] (fun item -> "a") = []
 
 List.filter_v2 [1;2;3] (fun item -> match item with | 1 -> Nothing | 2 -> false | 3 -> true) = Test.typeError_v0 "Expected the argument `f` passed to `List::filter_v2` to return `true` or `false` for every value in `list`. However, it returned `Nothing` for the input `1`." // OCAMLONLY
 List.filter_v2 [1;2;3] (fun item -> match item with | 1 -> Nothing | 2 -> false | 3 -> true) = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `Nothing`" // FSHARPONLY
@@ -62,6 +67,7 @@ List.filter_v2 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> blank | 3
 List.filter_v2 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> false | 3 -> true) = [ 1; 3 ]
 List.filter_v2 [] (fun item -> true) = []
 List.filter_v2 [-20; 5; 9;] (fun x -> x > 20) = []
+List.filter_v2 [] (fun item -> "a") = []
 
 List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then Nothing else (Just (item * 2))) = [ 2; 6 ]
 List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then blank else (Just (item * 2))) = blank
@@ -96,8 +102,10 @@ List.flatten_v0 [] = []
 
 List.fold_v0 ["a"; "b"; "c"; "d"] "x" (fun accum curr -> accum ++ curr) = "xabcd"
 List.fold_v0 [1;2;3;4;5] [] (fun accum curr -> List.pushBack_v0 accum (curr + 1)) = [2;3;4;5;6]
+List.fold_v0 [] [] (fun accum curr -> 5) = []
 
 List.foreach_v0 [1;2;3] (fun x -> x + 1) = [2;3;4]
+List.foreach_v0 [] (fun x -> x + 1) = []
 List.foreach_v0 [Test.typeError_v0 "test"] (fun x -> x) = [Test.typeError_v0 "test"]
 
 List.getAt_v0 ["a"; "b"; "c"; "d"] -1 = Nothing
@@ -105,10 +113,12 @@ List.getAt_v0 [1; 2; 3; 4] 4611686018427387902I = Nothing
 List.getAt_v0 [1;2;3;4] 0 = Just 1
 List.getAt_v0 [1;2;3;4] 4 = Nothing
 List.getAt_v0 [3; 3; 3] -5 = Nothing
+List.getAt_v0 [] 5 = Nothing
 List.getAt_v0 [3; 3; 3] 2147483648I = Nothing
 
 List.getAt_v1 ["a"; "b"; "c"; "d"] -1 = Nothing
 List.getAt_v1 [0] 1 = Nothing
+List.getAt_v1 [] 1 = Nothing
 List.getAt_v1 [1; 2; 3; 4] 4611686018427387902I = Nothing // FSHARPONLY
 List.getAt_v1 [1;2;3;4] 0 = Just 1
 List.getAt_v1 [3; 3; 3] -5 = Nothing
@@ -160,16 +170,21 @@ List.last_v2 [Test.typeError_v0 "test"] = Test.typeError_v0 "test"
 List.last_v2 [] = Nothing
 
 List.length_v0 [1;2;3] = 3
+List.length_v0 [] = 0
 
 List.map_v0 (List.range_v0 1 5) (fun x -> x + 1) = [2; 3; 4; 5; 6]
 List.map_v0 [1; 2; 3] (fun x -> Bool.and_v0 (Int.greaterThanOrEqualTo_v0 x 0) (Int.lessThanOrEqualTo_v0 x 4)) = [true; true; true]
 List.map_v0 [1; 2] (fun x -> x + 1) = [2; 3]
+List.map_v0 [] (fun x -> x + 1) = []
 
 List.map2_v0 [10;20;30] [1;2;3] (fun a b -> a - b) = Just [ 9; 18; 27 ]
 List.map2_v0 [10;20] [1;2;3] (fun a b -> a - b) = Nothing
+List.map2_v0 [] [] (fun a b -> a - b) = Just []
 
 List.map2shortest_v0 [10;20;30] [1;2;3] (fun a b -> a - b) = [ 9; 18; 27 ]
 List.map2shortest_v0 [10;20] [1;2;3] (fun a b -> a - b) = [ 9; 18 ]
+List.map2shortest_v0 [] [1;2;3] (fun a b -> a - b) = []
+List.map2shortest_v0 [1;2;3] [] (fun a b -> a - b) = []
 
 List.member_v0 [1;2;3] 2 = true
 List.member_v0 [1;2;3] 4 = false
@@ -203,14 +218,17 @@ List.repeat_v0 -4 "a" = Test.typeError_v0 "Expected the argument `times` to be p
 
 List.reverse_v0 ["a"; "b"; "c"; "d"] = ["d";"c";"b";"a"]
 List.reverse_v0 [5; 4; 3; 2; 1] = [1;2;3;4;5]
+List.reverse_v0 [] = []
 
 List.singleton_v0 1 = [ 1 ]
 List.singleton_v0 blank = blank
 
 List.sortBy_v0 [6;2;8;3] (fun x -> 0 - x) = [8;6;3;2]
+List.sortBy_v0 [] (fun x -> 0 - x) = []
 
 List.sort_v0 ["6";"2";"8";"3"] = ["2";"3";"6";"8"]
 List.sort_v0 [6;2;8;3] = [2;3;6;8]
+List.sort_v0 [] = []
 
 List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "`f` must return one of -1, 0, 1, but returned non-int: 0.1" // OCAMLONLY
 List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "`f` must return one of -1, 0, 1, but returned another int: 3" // OCAMLONLY
@@ -222,6 +240,7 @@ List.sortByComparator_v0 [Test.typeError "㧑༷釺";1;2;3] (fun a b -> 1) = Err
 List.sortByComparator_v0 [Test.typeError "㧑༷釺";1;2;3] (fun a b -> 1) = Error "Expected `f` to return -1, 0, 1, but it returned `<Error: 㧑༷釺>`" // FSHARPONLY
 
 List.sortByComparator_v0 [3;1;2] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [ 1; 2; 3 ]
+List.sortByComparator_v0 [] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok []
 List.sortByComparator_v0 [3;1;2;67;3;-1;6;3;5;6;2;5;63;2;3;5;-1;-1;-1] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [-1; -1; -1; -1; 1; 2; 2; 2; 3; 3; 3; 3; 5; 5; 5; 6; 6; 63; 67]
 
 List.tail_v0 [10; 20; 30; 40] = Just [20; 30; 40]
@@ -233,6 +252,7 @@ List.take_v0 ["a"; "b"; "c"; "d"] 3 = ["a"; "b"; "c"]
 List.take_v0 [3; 3; 3] 0 = []
 List.take_v0 [5; 4; 3; 2; 1]  5 = [5; 4; 3; 2; 1]
 List.take_v0 [5] 4 = [5]
+List.take_v0 [] 4 = []
 
 List.takeWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `-1`" // FSHARPONLY
 List.takeWhile_v0 [1;2;3;4] (fun item -> 0 - 1) = Test.typeError_v0 "Expected the argument `f` passed to `List::takeWhile` to return a boolean value for every value in `list`. However, it returned `-1` for the input `1`." // OCAMLONLY
@@ -247,6 +267,7 @@ List.uniqueBy_v0 [1;2;3;4] (fun x -> Int.divide_v0 x 2) = [ 1; 2; 4 ] // FSHARPO
 List.uniqueBy_v0 [1;2;3;4] (fun x -> x) = [ 1; 2; 3; 4 ]
 List.uniqueBy_v0 [1;1;1;1] (fun x -> x) = [ 1 ]
 List.uniqueBy_v0 [7;42;7;2;10] (fun x -> x) = [ 2; 7; 10; 42 ]
+List.uniqueBy_v0 [] (fun x -> x) = []
 
 List.unzip_v0 [[1;10];10;[3;30]] = Test.typeError_v0 "Expected every value within the `pairs` argument passed to `List::unzip` to be a list with exactly two values. However, that is not the case for the value at index 1: 10. It is of type `Int` instead of `List`." // OCAMLONLY
 List.unzip_v0 [[1;10];10;[3;30]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `10`. It is of type Int instead of `List`" // FSHARPONLY
@@ -260,6 +281,7 @@ List.unzip_v0 [[10;6]] = [[10],[6]]
 List.zipShortest_v0 [10;20;30] [1;2;3] = [ [ 10; 1 ]; [ 20; 2 ]; [ 30; 3 ] ]
 List.zipShortest_v0 [10;20] [1;2;3] = [ [ 10; 1 ]; [ 20; 2 ] ]
 List.zipShortest_v0 ["b";"v";"z"] [] = []
+List.zipShortest_v0 [] ["b";"v";"z"] = []
 List.zipShortest_v0 [Test.typeError_v0 ""] [Just ""] = Test.typeError_v0 ""
 
 List.zip_v0 [10;20;30] [1;2;3] = Just [ [ 10; 1 ]; [ 20; 2 ]; [ 30; 3 ] ]


### PR DESCRIPTION
The APIServer tests have been failing for a while (they're not run in CI). This makes them work again:

- Trim the HSTS server heading before comparing with the OCaml headers
- refactor APIserver tests to have the port handled automatically
- fix the sample header

Also added a bunch of tests for empty lists