### PR TITLE
Get better warnings in ExecHost

### DIFF
--- a/containers/gcp-exechost/prep.sh
+++ b/containers/gcp-exechost/prep.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 
 DIR=$(mktemp -d --suffix _gcp-exechost-builddir)
 
-cp -R backend/templates "$DIR/"
 cp -R scripts "$DIR/"
 
 mkdir -p "$DIR/app"

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -37,7 +37,8 @@ Domain = {LibBackend.Config.cookieDomain}
 let main args : int =
   try
     LibBackend.Init.init "execHost"
-  with e ->
+  with
+  | e ->
     // FSTODO rollbar
     raise e
 

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -37,6 +37,11 @@ Domain = {LibBackend.Config.cookieDomain}
 let main args : int =
   try
     LibBackend.Init.init "execHost"
+  with e ->
+    // FSTODO rollbar
+    raise e
+
+  try
     // FSTODO reportToRollbar commands
     match args with
     | [| "emergency-login"; username |] -> emergencyLogin username

--- a/scripts/production/connect-to-exec-host
+++ b/scripts/production/connect-to-exec-host
@@ -7,4 +7,4 @@ set -euo pipefail
 
 ./scripts/production/gcp-authorize-kubectl
 
-kubectl exec --stdin --tty gcp-exechost -- /bin/bash
+kubectl exec --stdin --tty deploy/exechost-deployment -c exechost-ctr -- /bin/bash


### PR DESCRIPTION
I can connect to the execHost, but the executable doesn't work. Let's find out what's wrong.