### PR TITLE
Address blazor exceptions

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APIExecution.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIExecution.fs
@@ -99,7 +99,7 @@ module Handler =
       let! c = Canvas.loadTLIDsWithContext canvasInfo [ p.tlid ]
       let c = Result.unwrapUnsafe c
       let program = Canvas.toProgram c
-      let expr = c.handlers.[p.tlid].ast.toRuntimeType ()
+      let expr = c.handlers[ p.tlid ].ast.toRuntimeType ()
       t "load-canvas"
 
       let! state, touchedTLIDs = RealExe.createState p.trace_id p.tlid program

--- a/fsharp-backend/src/ApiServer/Middleware.fs
+++ b/fsharp-backend/src/ApiServer/Middleware.fs
@@ -172,10 +172,10 @@ type dataID =
 type ExecutionID = LibService.Telemetry.ExecutionID
 
 let save' (id : dataID) (value : 'a) (ctx : HttpContext) : HttpContext =
-  ctx.Items.[string id] <- value
+  ctx.Items[ string id ] <- value
   ctx
 
-let load'<'a> (id : dataID) (ctx : HttpContext) : 'a = ctx.Items.[$"{id}"] :?> 'a
+let load'<'a> (id : dataID) (ctx : HttpContext) : 'a = ctx.Items[$"{id}"] :?> 'a
 
 let loadSessionData (ctx : HttpContext) : Session.T =
   load'<Session.T> SessionData ctx
@@ -288,7 +288,7 @@ let executionIDMiddleware : HttpHandler =
       let executionID = LibService.Telemetry.executionID ()
       let newCtx = saveExecutionID executionID ctx
       let headerValue = StringValues([| string executionID |])
-      ctx.Response.Headers.["x-darklang-execution-id"] <- headerValue
+      ctx.Response.Headers[ "x-darklang-execution-id" ] <- headerValue
       return! next newCtx
     })
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
@@ -37,7 +37,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj value; DStr key; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! _id = UserDB.set state true db key value
             return DObj value
           }
@@ -55,7 +55,7 @@ let fns : List<BuiltInFn> =
         | state, [ DObj value; DDB dbname ] ->
           uply {
             let key = System.Guid.NewGuid() |> string
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! _id = UserDB.set state true db key value
             return DStr(key)
           }
@@ -71,7 +71,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr key; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! result = UserDB.getOption state db key
             return Dval.option result
           }
@@ -87,7 +87,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr key; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! result = UserDB.getOption state db key
             return Dval.option result
           }
@@ -104,7 +104,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList keys; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
 
             let skeys =
               List.map
@@ -130,7 +130,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList keys; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
 
             let skeys =
               List.map
@@ -155,7 +155,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList keys; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
 
             let skeys =
               List.map
@@ -184,7 +184,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList keys; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
 
             let skeys =
               List.map
@@ -209,7 +209,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList keys; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
 
             let skeys =
               List.map
@@ -235,7 +235,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList keys; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
 
             let skeys =
               List.map
@@ -259,7 +259,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr key; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! _result = UserDB.delete state db key
             return DNull
           }
@@ -275,7 +275,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! _result = UserDB.deleteAll state db
             return DNull
           }
@@ -293,7 +293,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
 
             return results |> List.map (fun (k, v) -> DList [ DStr k; v ]) |> DList
@@ -312,7 +312,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
             return results |> List.map snd |> Dval.list
           }
@@ -329,7 +329,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ (DObj fields); DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
             return results |> List.map snd |> Dval.list
           }
@@ -346,7 +346,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ (DObj fields); DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
             return results |> List.map (fun (k, v) -> v) |> Dval.list
           }
@@ -364,7 +364,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
 
             let! result = UserDB.queryExactFields state db fields
 
@@ -384,7 +384,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! result = UserDB.queryExactFields state db fields
             return result |> Map.ofList |> DObj
           }
@@ -402,7 +402,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! result = UserDB.queryExactFields state db fields
             return result |> Map.ofList |> DObj
           }
@@ -419,7 +419,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
 
             match results with
@@ -439,7 +439,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ (DObj fields); DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
 
             match results with
@@ -459,7 +459,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ (DObj fields); DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
 
             match results with
@@ -479,7 +479,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
 
             match results with
@@ -499,7 +499,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DObj fields; DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
 
             match results with
@@ -519,7 +519,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ (DObj fields); DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryExactFields state db fields
 
             match results with
@@ -540,7 +540,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.getAll state db
 
             return results |> List.map (fun (k, v) -> DList [ DStr k; v ]) |> DList
@@ -557,7 +557,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.getAll state db
             return results |> List.map snd |> DList
           }
@@ -573,7 +573,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.getAll state db
             return results |> List.map snd |> Dval.list
           }
@@ -591,7 +591,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! result = UserDB.getAll state db
 
             return result |> List.map (fun (k, v) -> DList [ DStr k; v ]) |> DList
@@ -609,7 +609,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! result = UserDB.getAll state db
             return result |> Map.ofList |> DObj
           }
@@ -625,7 +625,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! (count : int) = UserDB.count state db
             return count |> int64 |> DInt
           }
@@ -641,7 +641,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [ DDB dbname ] ->
-          let db = state.program.dbs.[dbname]
+          let db = state.program.dbs[dbname]
 
           db.cols
           |> List.filter (fun (k, v) -> k <> "")
@@ -660,7 +660,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [ DDB dbname ] ->
-          let db = state.program.dbs.[dbname]
+          let db = state.program.dbs[dbname]
 
           db.cols
           |> List.filter (fun (k, v) -> k <> "")
@@ -691,7 +691,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.getAllKeys state db
             return results |> List.map (fun k -> DStr k) |> DList
           }
@@ -708,7 +708,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname; DFnVal (Lambda b) ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.queryValues state db b
             return results |> Dval.list
           }
@@ -725,7 +725,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname; DFnVal (Lambda b) ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.query state db b
             return results |> Map.ofList |> DObj
           }
@@ -742,7 +742,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname; DFnVal (Lambda b) ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.query state db b
 
             match results with
@@ -762,7 +762,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname; DFnVal (Lambda b) ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.query state db b
 
             match results with
@@ -782,7 +782,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname; DFnVal (Lambda b) ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! results = UserDB.query state db b
 
             match results with
@@ -802,7 +802,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DDB dbname; DFnVal (Lambda b) ] ->
           uply {
-            let db = state.program.dbs.[dbname]
+            let db = state.program.dbs[dbname]
             let! result = UserDB.queryCount state db b
             return Dval.int result
           }

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -80,7 +80,7 @@ let getBody (ctx : HttpContext) : Task<byte array> =
 // Headers
 // ---------------
 let setHeader (ctx : HttpContext) (name : string) (value : string) : unit =
-  ctx.Response.Headers.[name] <- StringValues([| value |])
+  ctx.Response.Headers[ name ] <- StringValues([| value |])
 
 let getHeader (hs : IHeaderDictionary) (name : string) : string option =
   match hs.TryGetValue name with

--- a/fsharp-backend/src/LibBackend/EventQueue.fs
+++ b/fsharp-backend/src/LibBackend/EventQueue.fs
@@ -367,7 +367,8 @@ let getWorkerSchedules (canvasID : CanvasID) : Task<WorkerStates.T> =
            AND tipe = 'handler'
            AND module = 'WORKER'"
       |> Sql.parameters [ "canvasID", Sql.uuid canvasID ]
-      |> Sql.executeAsync (fun read -> (read.string "name", WorkerStates.Running))
+      |> Sql.executeAsync (fun read ->
+        (read.stringOrNone "name" |> Option.unwrap "", WorkerStates.Running))
 
     let states = Map.fromList states
 

--- a/fsharp-backend/src/LibBackend/Migrations.fs
+++ b/fsharp-backend/src/LibBackend/Migrations.fs
@@ -71,7 +71,7 @@ let runSystemMigration (name : string) (sql : string) : unit =
       |> Sql.executeTransaction [ sql, []
                                   recordMigrationStmt, [ recordMigrationParams ] ]
 
-    assertEq "recorded migrations" 1 counts.[1]
+    assertEq "recorded migrations" 1 counts[1]
 
     ()
 

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -1052,7 +1052,7 @@ let parseQueryString (queryString : string) : List<string * List<string>> =
   |> Array.map (fun key ->
     let values = nvc.GetValues key
     let split =
-      values.[values.Length - 1] |> FSharpPlus.String.split [| "," |] |> Seq.toList
+      values[values.Length - 1] |> FSharpPlus.String.split [| "," |] |> Seq.toList
 
     if isNull key then
       // All the values with no key are by GetValues, so make each one a value

--- a/fsharp-backend/src/LibExecution/Execution.fs
+++ b/fsharp-backend/src/LibExecution/Execution.fs
@@ -94,6 +94,6 @@ let traceDvals () : Dictionary.T<id, AT.ExecutionResult> * RT.TraceDval =
       (if onExecutionPath then AT.ExecutedResult dval else AT.NonExecutedResult dval)
 
     // Overwrites if present, which is what we want
-    results.[id] <- result
+    results[id] <- result
 
   (results, trace)

--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -332,7 +332,7 @@ module Convert =
     | ORT.FPString fp -> PT.PString(fp.patternID, fp.str)
     | ORT.FPFloat (_, id, w, f) ->
       let whole = parseBigint w
-      let sign = if w.[0] = '-' then Negative else Positive
+      let sign = if w[0] = '-' then Negative else Positive
       PT.PFloat(id, sign, System.Numerics.BigInteger.Abs whole, parseBigint f)
     | ORT.FPNull (_, id) -> PT.PNull id
     | ORT.FPBlank (_, id) -> PT.PBlank id
@@ -351,7 +351,7 @@ module Convert =
     | ORT.EString (id, str) -> PT.EString(id, str)
     | ORT.EFloat (id, w, f) ->
       let whole = parseBigint w
-      let sign = if w.[0] = '-' then Negative else Positive
+      let sign = if w[0] = '-' then Negative else Positive
       PT.EFloat(id, sign, System.Numerics.BigInteger.Abs whole, parseBigint f)
     | ORT.EBool (id, b) -> PT.EBool(id, b)
     | ORT.ENull id -> PT.ENull id

--- a/fsharp-backend/src/LibExecution/VendoredTablecloth.fs
+++ b/fsharp-backend/src/LibExecution/VendoredTablecloth.fs
@@ -52,10 +52,10 @@ module String =
   let split (on : string) (s : string) : List<string> = s.Split(on) |> List.ofArray
 
   let trim (s : string) : string = s.Trim()
-  let dropLeft (count : int) (s : string) : string = s.[count..]
+  let dropLeft (count : int) (s : string) : string = s[count..]
 
   let dropRight (count : int) (s : string) : string =
-    s.[0 .. (s.Length - (count + 1))]
+    s[0 .. (s.Length - (count + 1))]
 
   let replace (old : string) (newStr : string) (s : string) : string =
     s.Replace(old, newStr)

--- a/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
@@ -38,11 +38,11 @@ let fns : List<BuiltInFn> =
           let buf = new StringBuilder(len * 2)
 
           for i = 0 to len - 1 do
-            let byte = bytes.[i] |> int
+            let byte = bytes[i] |> int
 
             buf
-              .Append(hexUppercaseLookup.[((byte >>> 4) &&& 0xF)])
-              .Append(hexUppercaseLookup.[(byte &&& 0xF)])
+              .Append(hexUppercaseLookup[((byte >>> 4) &&& 0xF)])
+              .Append(hexUppercaseLookup[(byte &&& 0xF)])
             |> ignore<StringBuilder>
 
           buf |> string |> DStr |> Ply

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -64,15 +64,15 @@ module Sort =
 
           cont <- false // break
         else
-          let v0 = localCopyofHalfOfArray.[leftHalfIndex]
-          let v1 = arrayToSort.[rightHalfIndex]
+          let v0 = localCopyofHalfOfArray[leftHalfIndex]
+          let v1 = arrayToSort[rightHalfIndex]
           let! comparisonResult = comparer v0 v1
 
           if comparisonResult <= 0 then
-            arrayToSort.[i + index] <- v0
+            arrayToSort[i + index] <- v0
             leftHalfIndex <- leftHalfIndex + 1
           else
-            arrayToSort.[i + index] <- v1
+            arrayToSort[i + index] <- v1
             rightHalfIndex <- rightHalfIndex + 1
     }
 
@@ -87,13 +87,13 @@ module Sort =
       if length <= 1 then
         return ()
       elif length = 2 then
-        let v0 = arrayToSort.[index]
-        let v1 = arrayToSort.[index + 1]
+        let v0 = arrayToSort[index]
+        let v1 = arrayToSort[index + 1]
         let! result = comparer v0 v1
 
         if result > 0 then
-          arrayToSort.[index] <- v1
-          arrayToSort.[index + 1] <- v0
+          arrayToSort[index] <- v1
+          arrayToSort[index + 1] <- v0
 
       else
         let halfLen = length / 2
@@ -1279,7 +1279,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList [] ] -> Ply(DOption None)
         | _, [ DList l ] ->
-          Ply(Dval.optionJust l.[System.Random.Shared.Next l.Length])
+          Ply(Dval.optionJust l[System.Random.Shared.Next l.Length])
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Impure

--- a/fsharp-backend/src/LibExecutionStdLib/LibMiddleware.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibMiddleware.fs
@@ -106,7 +106,7 @@ let varB = TVariable "b"
 //                  let values = nvc.GetValues key
 
 //                  let value =
-//                    let split = values.[values.Length - 1] |> String.split ","
+//                    let split = values[values.Length - 1] |> String.split ","
 
 //                    match split with
 //                    | [] -> DNull
@@ -170,7 +170,7 @@ let varB = TVariable "b"
 //             "/?:@ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-~=,&"
 
 //            let mutable safe = (Array.init 256 (fun _ -> false))
-//            Array.iter (fun b -> safe.[int b] <- true) (UTF8.toBytes allowed)
+//            Array.iter (fun b -> safe[int b] <- true) (UTF8.toBytes allowed)
 //            safe)
 
 //         (function
@@ -182,7 +182,7 @@ let varB = TVariable "b"
 //           |> Array.iter
 //                (fun b ->
 //                  let (_ : System.Text.StringBuilder) =
-//                    if urlSafe.[int b] then
+//                    if urlSafe[int b] then
 //                      result.Append(char b)
 //                    else
 //                      result.AppendFormat("%{0:X2}", b)

--- a/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -169,14 +169,14 @@ let fns : List<BuiltInFn> =
 
 
           for i = 0 to n - 1 do
-            let (c : byte) = bytes.[i]
+            let (c : byte) = bytes[i]
 
             if ((is_hex c) || (is_special c)) then
               sb.Append(char c) |> ignore<Text.StringBuilder>
-            elif (bytes.[i] = byte '%') then
+            elif (bytes[i] = byte '%') then
               // We're expecting already escaped strings so ignore the escapes
               if i + 2 < n then
-                if is_hex bytes.[i + 1] && is_hex bytes.[i + 2] then
+                if is_hex bytes[i + 1] && is_hex bytes[i + 2] then
                   sb.Append(char c) |> ignore<Text.StringBuilder>
                 else
                   sb.Append "%25" |> ignore<Text.StringBuilder>

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -63,8 +63,8 @@ let send
   try
     print "sending exception to rollbar"
     let (state : Dictionary.T<string, obj>) = Dictionary.empty ()
-    state.["message.honeycomb"] <- honeycombLinkOfExecutionID executionID
-    state.["execution_id"] <- string executionID
+    state["message.honeycomb"] <- honeycombLinkOfExecutionID executionID
+    state["execution_id"] <- string executionID
     List.iter
       (fun (k, v) ->
         Dictionary.add k (v :> obj) state |> ignore<Dictionary.T<string, obj>>)

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -99,6 +99,8 @@ module AspNet =
         with
         | e ->
           send (Telemetry.executionID ()) [] e
+          print e.Message
+          print e.StackTrace
           raise e
       }
 

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -253,9 +253,9 @@ let readFloat (f : float) : (bigint * bigint) =
   let asStr = f.ToString("G53").Split "."
 
   if asStr.Length = 1 then
-    parseBigint asStr.[0], 0I
+    parseBigint asStr[0], 0I
   else
-    parseBigint asStr.[0], parseBigint asStr.[1]
+    parseBigint asStr[0], parseBigint asStr[1]
 
 
 let makeFloat (positiveSign : bool) (whole : bigint) (fraction : bigint) : float =
@@ -525,7 +525,7 @@ module Dictionary =
   let get = FSharpPlus.Dictionary.tryGetValue
 
   let add (k : 'k) (v : 'v) (d : T<'k, 'v>) : T<'k, 'v> =
-    d.[k] <- v
+    d[k] <- v
     d
 
   let empty () : T<'k, 'v> = System.Collections.Generic.Dictionary<'k, 'v>()
@@ -544,7 +544,7 @@ module Dictionary =
 
   let fromList (l : List<'k * 'v>) : T<'k, 'v> =
     let result = empty ()
-    List.iter (fun (k, v) -> result.[k] <- v) l
+    List.iter (fun (k, v) -> result[k] <- v) l
     result
 
 
@@ -612,7 +612,7 @@ module Json =
             match reader.TokenType with
             | JsonToken.EndArray -> acc
             | _ ->
-              let value = serializer.Deserialize(reader, fields.[index].PropertyType)
+              let value = serializer.Deserialize(reader, fields[index].PropertyType)
 
               reader.Read() |> ignore<bool>
               read (index + 1) (acc @ [ value ])
@@ -638,7 +638,7 @@ module Json =
         serializer.Serialize(writer, list)
 
       override _.ReadJson(reader, t, _, serializer) =
-        let itemType = t.GetGenericArguments().[0]
+        let itemType = t.GetGenericArguments()[0]
 
         let collectionType =
           typedefof<System.Collections.Generic.IEnumerable<_>>.MakeGenericType
@@ -654,8 +654,8 @@ module Json =
 
         let rec make =
           function
-          | [] -> FSharpValue.MakeUnion(cases.[0], [||])
-          | head :: tail -> FSharpValue.MakeUnion(cases.[1], [| head; (make tail) |])
+          | [] -> FSharpValue.MakeUnion(cases[0], [||])
+          | head :: tail -> FSharpValue.MakeUnion(cases[1], [| head; (make tail) |])
 
         make (collection |> Seq.toList)
 
@@ -679,7 +679,7 @@ module Json =
             match reader.TokenType with
             | JsonToken.EndArray -> acc
             | _ ->
-              let value = deserialize (itemTypes.[index])
+              let value = deserialize (itemTypes[index])
               advance ()
               read (index + 1) (acc @ [ value ])
 
@@ -733,7 +733,7 @@ module Json =
             null
           else
             let _, fields = FSharpValue.GetUnionFields(value, value.GetType())
-            fields.[0]
+            fields[0]
 
         serializer.Serialize(writer, value)
 
@@ -747,9 +747,9 @@ module Json =
         let cases = FSharpType.GetUnionCases(t)
 
         if reader.TokenType = JsonToken.Null then
-          FSharpValue.MakeUnion(cases.[0], [||])
+          FSharpValue.MakeUnion(cases[0], [||])
         else
-          let innerType = t.GetGenericArguments().[0]
+          let innerType = t.GetGenericArguments()[0]
 
           let innerType =
             if innerType.IsValueType then
@@ -760,9 +760,9 @@ module Json =
           let value = serializer.Deserialize(reader, innerType)
 
           if value = null then
-            FSharpValue.MakeUnion(cases.[0], [||])
+            FSharpValue.MakeUnion(cases[0], [||])
           else
-            FSharpValue.MakeUnion(cases.[1], [| value |])
+            FSharpValue.MakeUnion(cases[1], [| value |])
 
     type OCamlFloatConverter() =
       inherit JsonConverter<double>()

--- a/fsharp-backend/src/Tablecloth/TableclothArray.fs
+++ b/fsharp-backend/src/Tablecloth/TableclothArray.fs
@@ -29,9 +29,9 @@ let isEmpty a = length a = 0
 
 let is_empty a = isEmpty a
 
-let first t = if length t < 1 then None else Some t.[0]
+let first t = if length t < 1 then None else Some t[0]
 
-let last t = if length t < 1 then None else Some t.[length t - 1]
+let last t = if length t < 1 then None else Some t[length t - 1]
 
 let get i a = Array.get a i
 
@@ -78,9 +78,9 @@ let count f a =
     a
 
 let swap (i : int) (j : int) (a : 'a array) =
-  let temp = a.[i]
-  a.[i] <- a.[j]
-  a.[j] <- temp
+  let temp = a[i]
+  a[i] <- a[j]
+  a[j] <- temp
   ()
 
 let find f a =
@@ -111,7 +111,7 @@ let map_with_index f a = mapWithIndex f a
 let map2 (f : 'a -> 'b -> 'c) (a : 'a array) (b : 'b array) =
   let minLength = min (length a) (length b) in
 
-  Array.init minLength (fun i -> f a.[i] b.[i])
+  Array.init minLength (fun i -> f a[i] b[i])
 
 
 let zip a b = map2 (fun left right -> (left, right)) a b
@@ -123,7 +123,7 @@ let map3
   (arrayC : 'c array)
   =
   let minLength = min (length arrayA) (min (length arrayC) (length arrayB))
-  Array.init minLength (fun i -> f arrayA.[i] arrayB.[i] arrayC.[i])
+  Array.init minLength (fun i -> f arrayA[i] arrayB[i] arrayC[i])
 
 
 let partition f a = Array.partition f a
@@ -204,7 +204,7 @@ let slice from ``to`` array =
   if sliceFrom >= sliceTo then
     [||]
   else
-    Array.init (sliceTo - sliceFrom) (fun i -> array.[i + sliceFrom])
+    Array.init (sliceTo - sliceFrom) (fun i -> array[i + sliceFrom])
 
 
 let sliding step size a =
@@ -214,7 +214,7 @@ let sliding step size a =
     [||]
   else
     initialize
-      (fun i -> initialize (fun j -> a.[(i * step) + j]) size)
+      (fun i -> initialize (fun j -> a[(i * step) + j]) size)
       (1 + ((n - size) / step))
 
 
@@ -271,7 +271,7 @@ let equal (f : 'a -> 'a -> bool) a b =
     true
   else
     let rec loop index =
-      if index = length a then true else f a.[index] b.[index] && loop (index + 1)
+      if index = length a then true else f a[index] b[index] && loop (index + 1)
 
     loop 0
 
@@ -285,7 +285,7 @@ let compare (f : 'a -> 'a -> int) a b =
         if index = length a then
           0
         else
-          match f a.[index] b.[index] with
+          match f a[index] b[index] with
           | 0 -> loop (index + 1)
           | result -> result
 

--- a/fsharp-backend/src/Tablecloth/TableclothMap.fs
+++ b/fsharp-backend/src/Tablecloth/TableclothMap.fs
@@ -87,7 +87,7 @@ let filter_with_index f m = filterWithIndex f m
 
 let partition f m = Map.partition f m
 
-let find f m = Map.tryFindKey f m |> Option.map (fun k -> (k, m.[k]))
+let find f m = Map.tryFindKey f m |> Option.map (fun k -> (k, m[k]))
 
 let any f m = Map.exists (fun _ v -> f v) m
 

--- a/fsharp-backend/src/Tablecloth/TableclothString.fs
+++ b/fsharp-backend/src/Tablecloth/TableclothString.fs
@@ -32,7 +32,7 @@ let isEmpty s = length s = 0
 
 let is_empty s = isEmpty s
 
-let get (i : int) (s : string) = s.[i]
+let get (i : int) (s : string) = s[i]
 
 let getAt index s =
   if index >= 0 && index < length s then Some(get index s) else None
@@ -44,13 +44,13 @@ let get_at index s = getAt index s
 let uncons (s : string) : (char * string) option =
   (match s with
    | "" -> None
-   | s -> Some(s.[0], s.[1 .. (String.length s - 1)]))
+   | s -> Some(s[0], s[1 .. (String.length s - 1)]))
 
-let dropLeft (count : int) (s : string) = s.[count..]
+let dropLeft (count : int) (s : string) = s[count..]
 
 let drop_left count s = dropLeft count s
 
-let dropRight (count : int) (s : string) = s.[0 .. (s.Length - (count + 1))]
+let dropRight (count : int) (s : string) = s[0 .. (s.Length - (count + 1))]
 
 let drop_right count s = dropRight count s
 
@@ -74,16 +74,16 @@ let to_uppercase s = toUppercase s
 
 let capitalize (s : string) =
   if s.Length = 0 then ""
-  else if s.Length = 1 then System.Char.ToUpper(s.[0]).ToString()
-  else System.Char.ToUpper(s.[0]).ToString() + s.[1..]
+  else if s.Length = 1 then System.Char.ToUpper(s[0]).ToString()
+  else System.Char.ToUpper(s[0]).ToString() + s[1..]
 
 let uncapitalize (s : string) =
   if s.Length = 0 then ""
-  else if s.Length = 1 then System.Char.ToLower(s.[0]).ToString()
-  else System.Char.ToLower(s.[0]).ToString() + s.[1..]
+  else if s.Length = 1 then System.Char.ToLower(s[0]).ToString()
+  else System.Char.ToLower(s[0]).ToString() + s[1..]
 
 let isCapitalized (s : string) =
-  if s.Length = 0 then false else System.Char.IsUpper(s.[0])
+  if s.Length = 0 then false else System.Char.IsUpper(s[0])
 
 let is_capitalized s = isCapitalized s
 
@@ -102,7 +102,7 @@ let reverse (s : string) =
 
   graphemes |> Seq.toList |> List.reverse |> String.concat ""
 
-let slice from ``to`` (str : string) = str.[from..``to``]
+let slice from ``to`` (str : string) = str[from..``to``]
 
 let indexOf (needle : string) (haystack : string) : int option =
   let result = haystack.IndexOf(needle) in if result = -1 then None else Some result

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -15,9 +15,11 @@ module ORT = LibExecution.OCamlTypes.RuntimeT
 module DvalRepr = LibExecution.DvalRepr
 
 module ClientInterop =
+  // -----------------------
+  // DB types
+  // -----------------------
   // CLEANUP There is a subtly different definition of DBs, which is that the
   // type should be a DType, but the client gives us a string instead.
-
   type client_col = string OT.or_blank * string OT.or_blank
 
   type client_db_migration =
@@ -35,6 +37,7 @@ module ClientInterop =
       version : int64
       old_migrations : client_db_migration list
       active_migration : client_db_migration option }
+
 
   let convert_col ((name, tipe) : client_col) : ORT.DbT.col =
     match tipe with
@@ -62,10 +65,35 @@ module ClientInterop =
       old_migrations = List.map convert_migration db.old_migrations
       active_migration = Option.map convert_migration db.active_migration }
 
+  // -----------------------
+  // Analysis types
+  // -----------------------
+  // Cleanup: Dvals are different, and there are dvals in analysis results
+  type InputVars = List<string * ORT.dval>
+
+  type FunctionResult =
+    AT.FnName * id * AT.FunctionArgHash * AT.HashVersion * ORT.dval
+
+  type TraceData =
+    { input : InputVars
+      timestamp : System.DateTime
+      function_results : List<FunctionResult> }
+
+  let convert_trace_data (td : TraceData) : AT.TraceData =
+    { input = List.map (fun (s, dv) -> (s, OT.Convert.ocamlDval2rt dv)) td.input
+      timestamp = td.timestamp
+      function_results =
+        List.map
+          (fun (a, b, c, d, dv) -> (a, b, c, d, OT.Convert.ocamlDval2rt dv))
+          td.function_results }
+
+  // -----------------------
+  // High-level defs
+  // -----------------------
   type handler_analysis_param =
     { handler : ORT.fluidExpr ORT.HandlerT.handler
       trace_id : AT.TraceID
-      trace_data : AT.TraceData
+      trace_data : TraceData
       (* dont use a trace as this isn't optional *)
       dbs : client_db list
       user_fns : ORT.fluidExpr ORT.user_fn list
@@ -75,7 +103,7 @@ module ClientInterop =
   type function_analysis_param =
     { func : ORT.fluidExpr ORT.user_fn
       trace_id : AT.TraceID
-      trace_data : AT.TraceData
+      trace_data : TraceData
       (* dont use a trace as this isn't optional *)
       dbs : client_db list
       user_fns : ORT.fluidExpr ORT.user_fn list
@@ -198,7 +226,7 @@ module Eval =
       runAnalysis
         ah.handler.tlid
         ah.trace_id
-        ah.trace_data
+        (ClientInterop.convert_trace_data ah.trace_data)
         ah.user_fns
         ah.user_tipes
         (List.map ClientInterop.convert_db ah.dbs)
@@ -207,7 +235,7 @@ module Eval =
       runAnalysis
         af.func.tlid
         af.trace_id
-        af.trace_data
+        (ClientInterop.convert_trace_data af.trace_data)
         af.user_fns
         af.user_tipes
         (List.map ClientInterop.convert_db af.dbs)

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -268,6 +268,8 @@ type EvalWorker =
       with
       | e ->
         System.Console.WriteLine("Error running analysis in Blazor")
+        System.Console.WriteLine($"with message: {message}")
+        System.Console.WriteLine($"and error:\n")
         System.Console.WriteLine(e)
         return Error(string e)
     }

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -978,8 +978,8 @@ module ExecutePureFunctions =
                     false)
 
               let! fnIndex = Gen.choose (0, List.length fns - 1)
-              let name = fns.[fnIndex].name
-              let signature = fns.[fnIndex].parameters
+              let name = fns[fnIndex].name
+              let signature = fns[fnIndex].parameters
 
               let unifiesWith (typ : RT.DType) =
                 (fun dv ->
@@ -1031,7 +1031,7 @@ module ExecutePureFunctions =
                     | "String::padEnd", 1 ->
                       let! v = Generators.char ()
                       return RT.DStr v
-                    | _ -> return! genDval signature.[i].typ
+                    | _ -> return! genDval signature[i].typ
                   }
                 // Still throw in random data occasionally test errors, edge-cases, etc.
                 let randomValue =
@@ -1194,9 +1194,9 @@ module ExecutePureFunctions =
                 if sameGroups && actualMatch.Groups.Count > 1 then
                   // start at 1, because 0 is the whole match
                   for i = 1 to actualMatch.Groups.Count - 1 do
-                    let group = actualMatch.Groups.[i]
+                    let group = actualMatch.Groups[i]
                     actualGroupMatches.Add(group.Name, group.Value)
-                    let group = expectedMatch.Groups.[i]
+                    let group = expectedMatch.Groups[i]
                     expectedGroupMatches.Add(group.Name, group.Value)
 
                 let dToL d = Dictionary.toList d |> List.sortBy Tuple2.first

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -169,7 +169,7 @@ let rec convertToExpr (ast : SynExpr) : PT.Expr =
 
   // Note to self: LongIdent = Ident list
   | SynExpr.LongIdent (_, LongIdentWithDots ([ modName; fnName ], _), _, _) when
-    System.Char.IsUpper(modName.idText.[0])
+    System.Char.IsUpper(modName.idText[0])
     ->
     let module_ = modName.idText
 

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -84,7 +84,7 @@ let fns : List<BuiltInFn> =
           let chars = String.toEgcSeq s
 
           if Seq.length chars = 1 then
-            chars |> Seq.toList |> fun l -> l.[0] |> DChar |> Some |> DOption |> Ply
+            chars |> Seq.toList |> fun l -> l[0] |> DChar |> Some |> DOption |> Ply
           else
             Ply(DOption None)
         | _ -> incorrectArgs ())

--- a/fsharp-backend/tests/Tests/BwdServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/BwdServer.Tests.fs
@@ -63,7 +63,7 @@ let findIndex (pattern : 'a list) (list : 'a list) : int option =
       let mutable matches = true
       let mutable j = 0
       while matches && j < pattern.Length do
-        if list.[i + j] <> pattern.[j] then
+        if list[i + j] <> pattern[j] then
           matches <- false
           j <- pattern.Length // stop early
         else
@@ -147,7 +147,7 @@ let replaceByteStrings
       let mutable matches = true
       let mutable j = 0
       while j < pattern.Length do
-        if bytes.[i + j] <> patternBytes.[j] then
+        if bytes[i + j] <> patternBytes[j] then
           matches <- false
           j <- pattern.Length // stop early
         else
@@ -158,11 +158,11 @@ let replaceByteStrings
         i <- i + pattern.Length
       else
         // not matched, char is in result, look at next char
-        result <- bytes.[i] :: result
+        result <- bytes[i] :: result
         i <- i + 1
     // Add the final ones we skipped above
     for i = i to bytes.Length - 1 do
-      result <- bytes.[i] :: result
+      result <- bytes[i] :: result
     // bytes are added in reverse, so one more reverse needed
     result |> List.reverse |> List.toArray
 

--- a/fsharp-backend/tests/Tests/HttpClient.Tests.fs
+++ b/fsharp-backend/tests/Tests/HttpClient.Tests.fs
@@ -83,7 +83,7 @@ let t filename =
     if not m.Success then failwith $"incorrect format in {name}"
     let g = m.Groups
 
-    (g.[2].Value, g.[3].Value, g.[4].Value)
+    (g[2].Value, g[3].Value, g[4].Value)
 
   let expected =
     expectedRequest |> UTF8.toBytes |> Http.setHeadersToCRLF |> Http.split
@@ -99,7 +99,7 @@ let t filename =
         headers = normalizeHeaders newResponseBody response.headers
         body = newResponseBody }
 
-  testCases.[name] <- { expected = expected; result = response }
+  testCases[name] <- { expected = expected; result = response }
 
 
   // Load the testcases first so that redirection works
@@ -209,7 +209,7 @@ let runTestHandler (ctx : HttpContext) : Task<HttpContext> =
       let testName =
         let segment = System.Uri(ctx.Request.Path.Value).Segments.[1]
         if String.endsWith "/" segment then String.dropRight 1 segment else segment
-      let testCase = testCases.[testName]
+      let testCase = testCases[testName]
 
       let actualHeaders =
         BwdServer.Server.getHeaders ctx

--- a/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
@@ -62,7 +62,7 @@ let matchSql
     (fun g ->
       match g.Count with // implicit full match counts for 1
       | 1 -> true
-      | 2 -> Map.find g.[1].Value args = expected.[0]
+      | 2 -> Map.find g[1].Value args = expected[0]
       | _ -> failwith "not supported yet")
     "compare sql"
 


### PR DESCRIPTION
In the client, the execution engine was failing to parse DErrors. It turns out it was trying to read using the Dval serializers, when it should have been using the ORT.Dval serializer.

Also add more debugging, and address error reading from WorkerSchedule.