### PR TITLE
Fix apiserver and bwdserver deployments

### DIFF
--- a/services/apiserver-deployment/apiserver-deployment.template.yaml
+++ b/services/apiserver-deployment/apiserver-deployment.template.yaml
@@ -178,6 +178,18 @@ spec:
                 secretKeyRef:
                   name: rollbar
                   key: post_token
+            # pusher
+            - name: DARK_CONFIG_PUSHER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: key
+            - name: DARK_CONFIG_PUSHER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: secret
+
         #########################
         # Postgres proxy config
         # To connect to postgres from kubernetes, we need to add a proxy. See

--- a/services/bwdserver-deployment/bwdserver-deployment.template.yaml
+++ b/services/bwdserver-deployment/bwdserver-deployment.template.yaml
@@ -172,6 +172,17 @@ spec:
                 secretKeyRef:
                   name: cloudsql-db-credentials
                   key: password
+            # pusher
+            - name: DARK_CONFIG_PUSHER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: key
+            - name: DARK_CONFIG_PUSHER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: secret
             # rollbar
             - name: DARK_CONFIG_ROLLBAR_POST_SERVER_ITEM
               valueFrom:

--- a/services/queueworker-deployment/queueworker-deployment.template.yaml
+++ b/services/queueworker-deployment/queueworker-deployment.template.yaml
@@ -168,6 +168,18 @@ spec:
                 secretKeyRef:
                   name: rollbar
                   key: post_token
+            # pusher
+            - name: DARK_CONFIG_PUSHER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: key
+            - name: DARK_CONFIG_PUSHER_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pusher-account-credentials
+                  key: secret
+
         #########################
         # Postgres proxy config
         # To connect to postgres from kubernetes, we need to add a proxy. See


### PR DESCRIPTION
apiserver and bwdserver aren't loading because of errors in legacyserver

The error is

```
Uncaught exception:

  (Failure
   "Sys.getenv_exn: environment variable DARK_CONFIG_PUSHER_KEY is not set")
```