### PR TITLE
Don't set ASPNETCORE_URLS - we set it manually everywhere

### DIFF
--- a/containers/fsharp-service-Dockerfile
+++ b/containers/fsharp-service-Dockerfile
@@ -30,8 +30,6 @@ RUN sudo apt-get update \
     && sudo rm -rf /var/lib/apt/lists/*
 
 ENV \
-    # Configure web servers to bind to port 80 when present
-    ASPNETCORE_URLS=http://+:80 \
     DOTNET_SDK_VERSION=6.0.100 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_EnableDiagnostics=0


### PR DESCRIPTION
Hopefully this is the problem in production

Trying to fix the startup of all the F# pods in production, they all have a stack trace like this. For some reason it won't start the http servers. My working theory is that it's using the ASPNETCORE_URLS env var instead of the string provided (the port there being 80, which is restricted for non-root users, while the string provided is port 9001/11001/etc).

```
 $ kubectl logs queueworker-deployment-7f4d865ffb-lwv2k queueworker-ctr
Starting queueworker
Starting QueueWorker
Initing LibService in QueueWorker
Configuring rollbar
 Configured rollbar
Configuring Telemetry
 Configured Telemetry
 Inited LibService in QueueWorker
Initing LibExecution in QueueWorker
 Inited LibExecution in QueueWorker
Initing LibExecutionStdLib in QueueWorker
 Inited LibExecutionStdLib in QueueWorker
Initing LibBackend in QueueWorker
 Inited LibBackend in QueueWorker
Initing BackendOnlyStdLib in QueueWorker
Configuring HttpClient
 Inited BackendOnlyStdLib in QueueWorker
Initing LibRealExecution in QueueWorker
 Inited LibRealExecution in QueueWorker
last ditch rollbar: Error running CronChecker
Permission denied
   at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, String callerName)
   at System.Net.Sockets.Socket.DoBind(EndPoint endPointSnapshot, SocketAddress socketAddress)
   at System.Net.Sockets.Socket.Bind(EndPoint localEP)
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.CreateDefaultBoundListenSocket(EndPoint endpoint)
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketConnectionListener.Bind()
   at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.BindAsync(EndPoint endpoint, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.TransportManager.BindAsync(EndPoint endPoint, ConnectionDelegate connectionDelegate, EndpointConfig endpointConfig, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerImpl.<>c__DisplayClass30_0`1.<<StartAsync>g__OnBind|0>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindEndpointAsync(ListenOptions endpoint, AddressBindContext context, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.BindAsync(AddressBindContext context, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.AnyIPListenOptions.BindAsync(AddressBindContext context, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.AddressesStrategy.BindAsync(AddressBindContext context, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindAsync(IEnumerable`1 listenOptions, AddressBindContext context, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerImpl.BindAsync(CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerImpl.StartAsync[TContext](IHttpApplication`1 application, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.Run(IHost host)
   at Microsoft.AspNetCore.Builder.WebApplication.Run(String url)
   at LibService.Kubernetes.runKubernetesServer(String serviceName, Int32 port, FSharpFunc`2 shutdownCallback) in /home/dark/app/fsharp-backend/src/LibService/Kubernetes.fs:line 108
   at QueueWorker.main(String[] _arg1) in /home/dark/app/fsharp-backend/src/QueueWorker/QueueWorker.fs:line 190
Exception when calling rollbar
Posting a payload to the Rollbar API Service timed-out
   at Rollbar.RollbarLoggerBlockingWrapper.WaitAndCompleteReport(PayloadBundle payloadBundle, SemaphoreSlim signal)
   at Rollbar.RollbarLoggerBlockingWrapper.Report(Object dataObject, ErrorLevel level, IDictionary`2 custom)
   at Rollbar.RollbarLoggerBlockingWrapper.Log(ErrorLevel level, Object obj, IDictionary`2 custom)
   at Rollbar.RollbarLoggerBlockingWrapper.Error(Object obj, IDictionary`2 custom)
   at LibService.Rollbar.lastDitchBlocking(String message, ExecutionID executionID, FSharpList`1 metadata, Exception e) in /home/dark/app/fsharp-backend/src/LibService/Rollbar.fs:line 123
```