### PR TITLE
Fix what I hope are the remaining problems with events in CronChecker

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -804,6 +804,7 @@ that's already taken, returns an error."
         internalFn (function
           | _, [ DStr level; DStr name; DObj log as result ] ->
             let args =
+              // CLEANUP: possible these aren't being logged
               log
               |> Map.toList
               // We could just leave the dval vals as strings and use params, but

--- a/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
@@ -35,8 +35,9 @@ let fns : List<BuiltInFn> =
           uply {
             // See client/src/Entry.ml for the "_"
             let canvasID = state.program.canvasID
+            let canvasName = state.program.canvasName
             let accountID = state.program.accountID
-            do! EventQueue.enqueue canvasID accountID space name "_" data
+            do! EventQueue.enqueue canvasName canvasID accountID space name "_" data
             return data
           }
         | _ -> incorrectArgs ())
@@ -53,9 +54,11 @@ let fns : List<BuiltInFn> =
           uply {
             // See client/src/Entry.ml for the "_"
             let canvasID = state.program.canvasID
+            let canvasName = state.program.canvasName
             let accountID = state.program.accountID
 
-            do! EventQueue.enqueue canvasID accountID "WORKER" name "_" data
+            do!
+              EventQueue.enqueue canvasName canvasID accountID "WORKER" name "_" data
 
             return data
           }

--- a/fsharp-backend/src/Benchmark/Benchmark.fs
+++ b/fsharp-backend/src/Benchmark/Benchmark.fs
@@ -22,6 +22,7 @@ let programContext () : Task<RT.ProgramContext> =
     let! c = TestUtils.TestUtils.testCanvasInfo "benchmark"
     return
       { canvasID = c.id
+        canvasName = c.name
         accountID = c.owner
         dbs = Map.empty
         userFns = Map.empty

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -400,7 +400,7 @@ let orgs (userID : UserID) : Task<List<OrgName.T>> =
      INNER JOIN accounts as org on access.organization_account = org.id
      WHERE access.access_account = @userID"
   |> Sql.parameters [ "userID", Sql.uuid userID ]
-  |> Sql.executeAsync (fun read -> read.string "name" |> OrgName.create)
+  |> Sql.executeAsync (fun read -> read.string "username" |> OrgName.create)
 
 
 // **********************

--- a/fsharp-backend/src/LibBackend/Canvas.fs
+++ b/fsharp-backend/src/LibBackend/Canvas.fs
@@ -853,8 +853,6 @@ let loadAndResaveFromTestFile (meta : Meta) : Task<unit> =
 
 
 let toProgram (c : T) : RT.ProgramContext =
-  let ownerID = c.meta.owner
-  let canvasID = c.meta.id
 
   let dbs =
     c.dbs
@@ -877,6 +875,7 @@ let toProgram (c : T) : RT.ProgramContext =
   let secrets = (c.secrets |> Map.map (fun pt -> pt.toRuntimeType ()) |> Map.values)
 
   { accountID = c.meta.owner
+    canvasName = c.meta.name
     canvasID = c.meta.id
     userFns = userFns
     userTypes = userTypes

--- a/fsharp-backend/src/LibBackend/Cron.fs
+++ b/fsharp-backend/src/LibBackend/Cron.fs
@@ -112,6 +112,7 @@ let checkAndScheduleWorkForCron (cron : CronScheduleData) : Task<bool> =
       if Config.triggerCrons then
         do!
           EventQueue.enqueue
+            cron.canvasName
             cron.canvasID
             cron.ownerID
             "CRON"

--- a/fsharp-backend/src/LibBackend/Cron.fs
+++ b/fsharp-backend/src/LibBackend/Cron.fs
@@ -104,7 +104,7 @@ let checkAndScheduleWorkForCron (cron : CronScheduleData) : Task<bool> =
   task {
     let! check = executionCheck cron
     if check.shouldExecute then
-      Telemetry.addTags [ ("cron", true) ]
+      use span = Telemetry.child "cron.enqueue" []
 
       // FSTODO
       // This is intended to not do the job, so that the OCaml one can keep doing it.
@@ -153,7 +153,7 @@ let checkAndScheduleWorkForCron (cron : CronScheduleData) : Task<bool> =
           // consistency with http/worker logs
           ("method", string cron.interval) ]
         @ ([ delayLog; intervalLog; delayRatioLog ] |> List.filterMap (fun a -> a))
-      Telemetry.addEvent "cron.enqueue" attrs
+      Telemetry.addTags attrs
       return true
     else
       return false

--- a/fsharp-backend/src/LibBackend/EventQueue.fs
+++ b/fsharp-backend/src/LibBackend/EventQueue.fs
@@ -203,6 +203,7 @@ let logQueueSize
 
 
 let enqueue
+  (canvasName : CanvasName.T)
   (canvasID : CanvasID)
   (accountID : UserID)
   (space : string)
@@ -211,6 +212,13 @@ let enqueue
   (data : RT.Dval)
   : Task<unit> =
   task {
+    Telemetry.addEvent
+      "enqueue"
+      [ "canvasName", canvasName
+        "canvasID", canvasID
+        "space", space
+        "name", name
+        "modifier", modifier ]
     do! logQueueSize Enqueue None canvasID space name modifier
     return!
       Sql.query

--- a/fsharp-backend/src/LibBackend/EventQueue.fs
+++ b/fsharp-backend/src/LibBackend/EventQueue.fs
@@ -156,6 +156,7 @@ let logQueueSize
   : Task<unit> =
   task {
     // host is optional b/c we have it when we dequeue, but not enqueue.
+    use span = Telemetry.child "queue size" []
     let! host =
       match host with
       | Some host -> Task.FromResult(host)
@@ -186,18 +187,16 @@ let logQueueSize
                           "modifier", Sql.string modifier ]
       |> Sql.executeRowAsync (fun read -> read.int "count")
 
-    Telemetry.addEvent
-      "queue size"
-      [ ("canvas_queue_size", canvasQueueSize)
-        ("worker_queue_size", workerQueueSize)
-        // Prefixing all of these with queue so we don't overwrite - e.g., 'enqueue'
-        // from a handler that has a space, etc
-        ("queue_canvas_name", host)
-        ("queue_action", string queue_action)
-        ("queue_canvas_id", canvasID)
-        ("queue_event_space", space)
-        ("queue_event_name", name)
-        ("queue_event_modifier", modifier) ]
+    Telemetry.addTags [ ("canvas_queue_size", canvasQueueSize)
+                        ("worker_queue_size", workerQueueSize)
+                        // Prefixing all of these with queue so we don't overwrite - e.g., 'enqueue'
+                        // from a handler that has a space, etc
+                        ("queue_canvas_name", host)
+                        ("queue_action", string queue_action)
+                        ("queue_canvas_id", canvasID)
+                        ("queue_event_space", space)
+                        ("queue_event_name", name)
+                        ("queue_event_modifier", modifier) ]
   }
 
 
@@ -212,13 +211,14 @@ let enqueue
   (data : RT.Dval)
   : Task<unit> =
   task {
-    Telemetry.addEvent
-      "enqueue"
-      [ "canvas_name", canvasName
-        "canvas_id", canvasID
-        "space", space
-        "handler_name", name
-        "modifier", modifier ]
+    use span =
+      Telemetry.child
+        "enqueue"
+        [ "canvas_name", canvasName
+          "canvas_id", canvasID
+          "space", space
+          "handler_name", name
+          "modifier", modifier ]
     do! logQueueSize Enqueue None canvasID space name modifier
     return!
       Sql.query

--- a/fsharp-backend/src/LibBackend/EventQueue.fs
+++ b/fsharp-backend/src/LibBackend/EventQueue.fs
@@ -214,10 +214,10 @@ let enqueue
   task {
     Telemetry.addEvent
       "enqueue"
-      [ "canvasName", canvasName
-        "canvasID", canvasID
+      [ "canvas_name", canvasName
+        "canvas_id", canvasID
         "space", space
-        "name", name
+        "handler_name", name
         "modifier", modifier ]
     do! logQueueSize Enqueue None canvasID space name modifier
     return!

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -821,9 +821,10 @@ and LoadFnArguments = tlid -> List<DvalMap * System.DateTime>
 
 and StoreFnArguments = tlid -> DvalMap -> Task<unit>
 
-// Every part of a user's program except the actual code to run (types, fns, secrets, etc)
+// Every part of a user's program
 and ProgramContext =
   { canvasID : CanvasID
+    canvasName : CanvasName.T
     accountID : UserID
     dbs : Map<string, DB.T>
     userFns : Map<string, UserFunction.T>

--- a/fsharp-backend/src/LibService/Telemetry.fs
+++ b/fsharp-backend/src/LibService/Telemetry.fs
@@ -57,7 +57,13 @@ module Span =
     assert_
       "Telemetry must be initialized before creating root"
       (Internal._source <> null)
-    Internal._source.StartActivity(name)
+    // Deliberately created with no parent to make this a root
+    // From https://github.com/open-telemetry/opentelemetry-dotnet/issues/984
+    System.Diagnostics.Activity.Current <- null
+    let span =
+      Internal._source.CreateActivity(name, System.Diagnostics.ActivityKind.Internal)
+    span.Start()
+
 
   // Get the Span/Activity for this execution. It is thread and also async-local.
   // See https://twitter.com/ChetHusk/status/1466589986786971649 For the sake of
@@ -76,13 +82,15 @@ module Span =
     assert_
       "Telemetry must be initialized before creating root"
       (Internal._source <> null)
-    let result = Internal._source.StartActivity(name)
+    // Don't start it until the parent is set, or it won't work
+    let result =
+      Internal._source.CreateActivity(name, System.Diagnostics.ActivityKind.Internal)
     let result =
       if result <> null && parent <> null then
         result.SetParentId parent.Id
       else
         result
-    result
+    result.Start()
 
   let addTag (name : string) (value : obj) (span : T) : unit =
     span.AddTag(name, value) |> ignore<T>

--- a/fsharp-backend/src/LibService/Telemetry.fs
+++ b/fsharp-backend/src/LibService/Telemetry.fs
@@ -122,8 +122,11 @@ let addTags (tags : List<string * obj>) : unit = Span.addTags tags (Span.current
 
 let addEvent (name : string) (tags : List<string * obj>) : unit =
   let span = Span.current ()
-  let e = span.AddEvent(System.Diagnostics.ActivityEvent name)
-  Span.addTags tags e
+  let tagCollection = System.Diagnostics.ActivityTagsCollection()
+  List.iter (fun (k, v) -> tagCollection[k] <- v) tags
+  let event =
+    System.Diagnostics.ActivityEvent(name, System.DateTime.Now, tagCollection)
+  span.AddEvent(event) |> ignore<Span.T>
 
 let addError (name : string) (tags : List<string * obj>) : unit =
   addEvent name (("level", "error") :: tags)

--- a/fsharp-backend/src/Tablecloth/TableclothList.fs
+++ b/fsharp-backend/src/Tablecloth/TableclothList.fs
@@ -215,7 +215,7 @@ let sliding (step : int) (size : int) (l : 'a t) =
 
    loop l : 'a t t)
 
-let chunksOf size l = sliding size size l
+let chunksOf size l = List.chunkBySize size l
 
 let chunks_of size l = chunksOf size l
 

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -162,6 +162,7 @@ module Eval =
       let program : RT.ProgramContext =
         { accountID = System.Guid.NewGuid()
           canvasID = System.Guid.NewGuid()
+          canvasName = CanvasName.create "todo"
           userFns =
             userFns
             |> List.map OT.Convert.ocamlUserFunction2PT

--- a/fsharp-backend/tests/Tests/EventQueue.Tests.fs
+++ b/fsharp-backend/tests/Tests/EventQueue.Tests.fs
@@ -39,7 +39,7 @@ let testEventQueueRoundtrip =
     do!
       Canvas.saveTLIDs meta [ (h.tlid, oplists, PT.TLHandler h, Canvas.NotDeleted) ]
 
-    do! EQ.enqueue meta.id meta.owner "CRON" "test" "Daily" RT.DNull // I don't believe crons take inputs?
+    do! EQ.enqueue meta.name meta.id meta.owner "CRON" "test" "Daily" RT.DNull // I don't believe crons take inputs?
 
     do! EQ.testingScheduleAll ()
     let! result = QueueWorker.dequeueAndProcess ()
@@ -73,7 +73,7 @@ let testEventQueueIsFifo =
        |> Canvas.saveTLIDs meta)
 
     let enqueue (name : string) (i : int64) =
-      EQ.enqueue meta.id meta.owner "WORKER" name "_" (RT.DInt i)
+      EQ.enqueue meta.name meta.id meta.owner "WORKER" name "_" (RT.DInt i)
 
     do! enqueue "apple" 1L
     do! enqueue "apple" 2L

--- a/fsharp-backend/tests/Tests/Prelude.Tests.fs
+++ b/fsharp-backend/tests/Tests/Prelude.Tests.fs
@@ -80,6 +80,14 @@ let mapTests =
            Map.ofList [ (1, -1); (2, -2); (3, -3) ],
            Map.ofList [ (1, 1); (2, 2); (3, 3) ]) ] ]
 
+let listTests =
+  testList
+    "List"
+    [ testMany2
+        "List.chunksOf"
+        Tablecloth.List.chunksOf
+        [ (2, [ 1; 2; 3 ], [ [ 1; 2 ]; [ 3 ] ]) ] ]
 
 
-let tests = testList "prelude" [ canvasName; asyncTests; mapTests ]
+
+let tests = testList "prelude" [ canvasName; asyncTests; mapTests; listTests ]

--- a/fsharp-backend/tests/Tests/StdLib.Tests.fs
+++ b/fsharp-backend/tests/Tests/StdLib.Tests.fs
@@ -78,18 +78,18 @@ let oldFunctionsAreDeprecated =
       let key = string { fn.name with version = 0 }
 
       if fn.deprecated = RT.NotDeprecated then
-        counts
-        := Map.update
-             key
-             (fun count -> count |> Option.defaultValue 0 |> (+) 1 |> Some)
-             counts.Value
+        counts.Value <-
+          Map.update
+            key
+            (fun count -> count |> Option.defaultValue 0 |> (+) 1 |> Some)
+            counts.Value
 
       ())
 
     Map.iter
       (fun name count ->
         Expect.equal count 1 $"{name} has more than one undeprecated function")
-      !counts
+      counts.Value
   }
 
 let intInfixMatch =


### PR DESCRIPTION
Cronchecker wasn't running properly and when I fixed that it wasn't generating stuff in the right shape.

- trace Enqueue event (add canvasName to it)
- fix SQL bug when fetching orgs
- switch some events to spans, where appropriate
- fix root spans to not have a parent
- for child spans to properly connect to their parent
- fix attributes in events
- fix List.chunksOf, which was throwing away the crons we wanted to run
- fix some warnnings