### PR TITLE
Reduce events in cronchecker

### DIFF
--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -144,7 +144,9 @@ let configureApp (appBuilder : WebApplication) =
 let configureServices (services : IServiceCollection) : unit =
   services
   |> LibService.Rollbar.AspNet.addRollbarToServices
-  |> LibService.Telemetry.AspNet.addTelemetryToServices "ApiServer"
+  |> LibService.Telemetry.AspNet.addTelemetryToServices
+       "ApiServer"
+       LibService.Telemetry.TraceDBQueries
   |> LibService.Kubernetes.configureServices
   |> fun s -> s.AddServerTiming()
   |> ignore<IServiceCollection>

--- a/fsharp-backend/src/ApiServer/Http.fs
+++ b/fsharp-backend/src/ApiServer/Http.fs
@@ -43,7 +43,7 @@ type TraceTimer =
 // Call [t.stop()] at the end, or the final span duration will be incorrect.
 let startTimer (initialName : string) (ctx : HttpContext) : TraceTimer =
   let parent = Span.current ()
-  let mutable child = Span.child initialName parent
+  let mutable child = Span.child initialName parent []
   let st =
     ctx.RequestServices.GetService<Lib.AspNetCore.ServerTiming.IServerTiming>()
   let stop () : unit =
@@ -57,7 +57,7 @@ let startTimer (initialName : string) (ctx : HttpContext) : TraceTimer =
   { next =
       fun name ->
         stop ()
-        child <- Span.child name parent
+        child <- Span.child name parent []
     span = fun () -> child
     stop = fun () -> stop () }
 

--- a/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
@@ -8,18 +8,15 @@ open FSharp.Control.Tasks
 open System.Net.Http
 open System.IO.Compression
 open System.IO
+type AspHeaders = System.Net.Http.Headers.HttpHeaders
 
 open Prelude
 open LibExecution
 open LibBackend
 open VendoredTablecloth
 
-type AspHeaders = System.Net.Http.Headers.HttpHeaders
 
 module RT = RuntimeTypes
-
-type KeyValuePair<'k, 'v> = System.Collections.Generic.KeyValuePair<'k, 'v>
-type StringValues = Microsoft.Extensions.Primitives.StringValues
 
 type HttpHeaders = List<string * string>
 
@@ -92,8 +89,8 @@ let httpClient : HttpClient =
 // Convert .NET HttpHeaders into Dark-style headers
 let convertHeaders (headers : AspHeaders) : HttpHeaders =
   headers
-  |> Seq.map (fun (kvp : KeyValuePair<string, seq<string>>) ->
-    (kvp.Key, kvp.Value |> Seq.toList |> String.concat ","))
+  |> Seq.map Tuple2.fromKeyValuePair
+  |> Seq.map (fun (k, v) -> (k, v |> Seq.toList |> String.concat ","))
   |> Seq.toList
 
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -963,7 +963,7 @@ that's already taken, returns an error."
               with
               | e ->
                 let attrs = [ "username", username :> obj ]
-                Telemetry.addError "DarkInternal::newSessionForUserName" attrs
+                Telemetry.addException "DarkInternal::newSessionForUserName" e attrs
                 LibService.Rollbar.sendException
                   "Failed to create session"
                   state.executionID
@@ -1000,7 +1000,6 @@ that's already taken, returns an error."
               with
               | e ->
                 let attrs = [ "username", username :> obj ]
-                Telemetry.addError "DarkInternal::newSessionForUserName_v1" attrs
                 LibService.Rollbar.sendException
                   "Failed to create session"
                   state.executionID

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -445,7 +445,9 @@ let configureServices (services : IServiceCollection) : unit =
   services
   |> LibService.Kubernetes.configureServices
   |> LibService.Rollbar.AspNet.addRollbarToServices
-  |> LibService.Telemetry.AspNet.addTelemetryToServices "BwdServer"
+  |> LibService.Telemetry.AspNet.addTelemetryToServices
+       "BwdServer"
+       LibService.Telemetry.TraceDBQueries
   |> ignore<IServiceCollection>
 
 

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -18,7 +18,6 @@ open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.DependencyInjection
 
-type KeyValuePair<'k, 'v> = System.Collections.Generic.KeyValuePair<'k, 'v>
 type StringValues = Microsoft.Extensions.Primitives.StringValues
 
 open Prelude
@@ -42,19 +41,20 @@ module FireAndForget = LibService.FireAndForget
 // ---------------
 let getHeaders (ctx : HttpContext) : List<string * string> =
   ctx.Request.Headers
-  |> Seq.map (fun (kvp : KeyValuePair<string, StringValues>) ->
-    (kvp.Key, kvp.Value.ToArray() |> Array.toList |> String.concat ","))
+  |> Seq.map Tuple2.fromKeyValuePair
+  |> Seq.map (fun (k, v) -> (k, v.ToArray() |> Array.toList |> String.concat ","))
   |> Seq.toList
 
 let getQuery (ctx : HttpContext) : List<string * List<string>> =
   ctx.Request.Query
-  |> Seq.map (fun (kvp : KeyValuePair<string, StringValues>) ->
-    (kvp.Key,
+  |> Seq.map Tuple2.fromKeyValuePair
+  |> Seq.map (fun (k, v) ->
+    (k,
      // If there are duplicates, .NET puts them in the same StringValues.
      // However, it doesn't parse commas. We want a list if there are commas,
      // but we want to overwrite if there are two of the same headers.
      // CLEANUP this isn't to say that this is good behaviour
-     kvp.Value.ToArray()
+     v.ToArray()
      |> Array.toList
      |> List.tryLast
      |> Option.defaultValue ""

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -32,7 +32,7 @@ let main _ : int =
     BackendOnlyStdLib.Init.init "CronChecker"
     LibRealExecution.Init.init "CronChecker"
 
-    Telemetry.Console.loadTelemetry "CronChecker"
+    Telemetry.Console.loadTelemetry "CronChecker" Telemetry.DontTraceDBQueries
     // we need to stop running if we're told to stop by k8s
     LibService.Kubernetes.runKubernetesServer
       "CronChecker"

--- a/fsharp-backend/src/LibBackend/Canvas.fs
+++ b/fsharp-backend/src/LibBackend/Canvas.fs
@@ -10,6 +10,7 @@ open LibBackend.Db
 
 open Prelude
 open Tablecloth
+open LibService.Exception
 
 module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
@@ -248,10 +249,11 @@ let applyOp (isNew : bool) (op : PT.Op) (c : T) : T =
   with
   | e ->
     // Log here so we have context, but then re-raise
-    Telemetry.addError
+    Telemetry.addException
       "apply_op failure"
-      [ ("host", c.meta.name); ("op", string op); ("exn", string e) ]
-    reraise ()
+      e
+      [ ("host", c.meta.name); ("op", string op) ]
+    e.Reraise()
 
 
 // NOTE: If you add a new verification here, please ensure all places that

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -375,7 +375,6 @@ module UTF8 =
   let ofBytesWithReplacement (input : byte array) : string =
     System.Text.Encoding.UTF8.GetString input
 
-
 // Base64 comes in various flavors, typically URLsafe (has '-' and '_' with no
 // padding) or regular (has + and / and has '=' padding at the end)
 module Base64 =
@@ -500,6 +499,12 @@ module Uuid =
 
   let uuidV5 (data : string) (nameSpace : System.Guid) : System.Guid =
     Faithlife.Utility.GuidUtility.Create(nilNamespace, data, 5)
+
+module Tuple2 =
+  let fromKeyValuePair
+    (kvp : System.Collections.Generic.KeyValuePair<'a, 'b>)
+    : ('a * 'b) =
+    kvp.Key, kvp.Value
 
 type System.DateTime with
 

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -506,6 +506,12 @@ module Tuple2 =
     : ('a * 'b) =
     kvp.Key, kvp.Value
 
+  let toKeyValuePair
+    ((k, v) : 'a * 'b)
+    : (System.Collections.Generic.KeyValuePair<'a, 'b>) =
+    System.Collections.Generic.KeyValuePair<'a, 'b>(k, v)
+
+
 type System.DateTime with
 
   member this.toIsoString() : string =

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -53,12 +53,12 @@ exception DarkException of DarkExceptionData
 
 // This is for tracing
 let mutable exceptionCallback =
-  (fun (typ : string) (msg : string) (tags : List<string * obj>) -> ())
+  (fun (e : exn) (typ : string) (msg : string) (tags : List<string * obj>) -> ())
 
 module Exception =
-  let callExceptionCallback typ msg tags =
+  let callExceptionCallback e typ msg tags =
     try
-      exceptionCallback typ msg tags
+      exceptionCallback e typ msg tags
     with
     | _ ->
       // We're completely screwed at this point
@@ -68,32 +68,37 @@ module Exception =
   // msg is suitable to show to the grand user. We don't care about grandUser
   // exceptions, they're normal.
   let raiseGrandUser (msg : string) =
-    callExceptionCallback "grand" msg []
-    raise (DarkException(GrandUserError(msg)))
+    let e = DarkException(GrandUserError(msg))
+    callExceptionCallback e "grand" msg []
+    raise e
 
   // A developer exception is one caused by the incorrect actions of our
   // user/developer. The msg is suitable to show to the user.
   let raiseDeveloper (msg : string) =
-    callExceptionCallback "developer" msg []
-    raise (DarkException(DeveloperError(msg)))
+    let e = DarkException(DeveloperError(msg))
+    callExceptionCallback e "developer" msg []
+    raise e
 
   // An editor exception is one which is caused by an invalid action on the part of
   // the Dark editor. We are interested in these. The message may be shown to the
   // logged-in user, and should be suitable for this.
   let raiseEditor (msg : string) =
-    callExceptionCallback "editor" msg []
-    raise (DarkException(EditorError(msg)))
+    let e = DarkException(EditorError(msg))
+    callExceptionCallback e "editor" msg []
+    raise e
 
   // An internal error. Should be rollbarred, and should not be shown to users.
   let raiseInternal (msg : string) (tags : List<string * obj>) =
-    callExceptionCallback "internal" msg tags
-    raise (DarkException(InternalError(msg, tags)))
+    let e = DarkException(InternalError(msg, tags))
+    callExceptionCallback e "internal" msg tags
+    raise e
 
   // An error in library code - should not be shown to grand users. May be shown to
   // logged-in developers (most typically in a DError or a Result).
   let raiseLibrary (msg : string) (tags : List<string * obj>) =
-    callExceptionCallback "library" msg tags
-    raise (DarkException(LibraryError(msg, tags)))
+    let e = DarkException(LibraryError(msg, tags))
+    callExceptionCallback e "library" msg tags
+    raise e
 
   let toGrandUserMessage (e : exn) : Option<string> =
     match e with

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -182,7 +182,7 @@ let main _ : int =
   try
     print "Starting QueueWorker"
     LibService.Init.init "QueueWorker"
-    Telemetry.Console.loadTelemetry "QueueWorker"
+    Telemetry.Console.loadTelemetry "QueueWorker" Telemetry.DontTraceDBQueries
     LibExecution.Init.init "QueueWorker"
     LibExecutionStdLib.Init.init "QueueWorker"
     LibBackend.Init.init "QueueWorker"

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -8,8 +8,6 @@ open Expecto
 open System.Net.Http
 open Microsoft.AspNetCore.Http
 
-type KeyValuePair<'k, 'v> = System.Collections.Generic.KeyValuePair<'k, 'v>
-
 open Tablecloth
 open Prelude
 open Prelude.Tablecloth
@@ -58,8 +56,8 @@ let login (username : string) (password : string) : Task<User> =
       )
 
     let body =
-      [ KeyValuePair<string, string>("username", username)
-        KeyValuePair<string, string>("password", password) ]
+      [ ("username", username); ("password", password) ]
+      |> List.map Tuple2.toKeyValuePair
 
     loginReq.Content <- new FormUrlEncodedContent(body)
 
@@ -697,8 +695,8 @@ let cookies =
         match creds with
         | Some (username, password) ->
           let body =
-            [ KeyValuePair<string, string>("username", username)
-              KeyValuePair<string, string>("password", password) ]
+            [ ("username", username); ("password", password) ]
+            |> List.map Tuple2.toKeyValuePair
 
           req.Content <- new FormUrlEncodedContent(body)
         | None -> ()

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -9,7 +9,6 @@ open System.Net.Http
 open Microsoft.AspNetCore.Http
 
 type KeyValuePair<'k, 'v> = System.Collections.Generic.KeyValuePair<'k, 'v>
-type StringValues = Microsoft.Extensions.Primitives.StringValues
 
 open Tablecloth
 open Prelude

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -5,6 +5,8 @@ module Tests.All
 open Expecto
 open System.Threading.Tasks
 
+module Telemetry = LibService.Telemetry
+
 [<EntryPoint>]
 let main (args : string array) : int =
   LibService.Init.init "Tests"
@@ -21,7 +23,7 @@ let main (args : string array) : int =
   // CLEANUP For now, migrations are run by the ocaml process in run-fsharp-tests
   // LibBackend.Migrations.init ()
   let httpClientTestsTask = Tests.HttpClient.init cancelationTokenSource.Token
-  LibService.Telemetry.Console.loadTelemetry "tests"
+  Telemetry.Console.loadTelemetry "tests" Telemetry.TraceDBQueries
   (LibBackend.Account.initTestAccounts ()).Wait()
 
   let tests =


### PR DESCRIPTION
CronChecker in production had way too many events - 1 per DB query - which blew our budget for events. This disables Npgsql events in CronChecker and QueueWorker - hopefully this should keep them in check.