### PR TITLE
Enable crons in production

### DIFF
--- a/config/gke-builtwithdark
+++ b/config/gke-builtwithdark
@@ -49,7 +49,7 @@ DARK_CONFIG_ALLOW_TEST_ROUTES=n
 ## We set this to no as this is only used by F# workers at the moment and we don't
 ## want to run those in production just yet.
 DARK_CONFIG_TRIGGER_QUEUE_WORKERS=n
-DARK_CONFIG_TRIGGER_CRONS=n
+DARK_CONFIG_TRIGGER_CRONS=y
 DARK_CONFIG_CREATE_ACCOUNTS=n
 DARK_CONFIG_CHECK_TIER_ONE_HOSTS=y
 DARK_CONFIG_USE_HTTPS=y

--- a/fsharp-backend/src/LibBackend/Cron.fs
+++ b/fsharp-backend/src/LibBackend/Cron.fs
@@ -106,9 +106,6 @@ let checkAndScheduleWorkForCron (cron : CronScheduleData) : Task<bool> =
     if check.shouldExecute then
       use span = Telemetry.child "cron.enqueue" []
 
-      // FSTODO
-      // This is intended to not do the job, so that the OCaml one can keep doing it.
-      // I just want to check that the events look right
       if Config.triggerCrons then
         do!
           EventQueue.enqueue


### PR DESCRIPTION
Note this doesn't change the number of CronChecker (or cron_checker) pods, which will be done manually and checked.

The remaining steps:
- [ ] wait until it's in production
- [ ] open the cron.enqueue events graph
- [ ] scale down cron_checker to 0
  - kubectl scale deployment/cron-deployment  --replicas=0
- [ ] scale up CronChecker to 1
  - kubectl scale deployment/cronchecker-deployment  --replicas=1
- [ ] ensure graphs are as expected, with the same number of cron.enqueues (typically exactly 1 per handler/canvas per minute)
- [ ] merge PR setting the deployments correctly