### PR TITLE
Final steps in CronChecker

### DIFF
--- a/fsharp-backend/src/LibBackend/Config.fs
+++ b/fsharp-backend/src/LibBackend/Config.fs
@@ -101,49 +101,7 @@ let createAccounts = bool "DARK_CONFIG_CREATE_ACCOUNTS"
 
 // Should we redirect insecure requests
 let useHttps = bool "DARK_CONFIG_USE_HTTPS"
-// -------------------------
-// Logs
-// -------------------------
-// let logFormat : [`Json | `DecoratedJson] =
-//   let asStr =
-//     stringChoice "DARK_CONFIG_LOGGING_FORMAT" ["json"; "decorated_json"]
-//   in
-//   match asStr with
-//   | "json" ->
-//       `Json
-//   | "decorated_json" ->
-//       `DecoratedJson
-//   | _ ->
-//       failwith $"Invalid logging format: {asStr}"
-//
 
-// let logLevel =
-//   let asStr =
-//     stringChoice
-//       "DARK_CONFIG_LOGLEVEL"
-//       [ "off"
-//         "inspect"
-//         "fatal"
-//         "error"
-//         "warn"
-//         "info"
-//         "success"
-//         "debug"
-//         "all" ]
-//
-//   match asStr with
-//   | "off" -> Off
-//   | "inspect" -> Inspect
-//   | "fatal" -> Fatal
-//   | "error" -> Error
-//   | "warn" -> Warn
-//   | "info" -> Info
-//   | "success" -> Success
-//   | "debug" -> Debug
-//   | "all" -> All
-//   | _ -> failwith $"Invalid level name: {asStr}"
-//
-// FSTODO
 let shouldWriteShapeData = bool "DARK_CONFIG_SAVE_SERIALIZATION_DIGEST"
 
 let showStacktrace = bool "DARK_CONFIG_SHOW_STACKTRACE"

--- a/fsharp-backend/src/LibBackend/init.ml.unported
+++ b/fsharp-backend/src/LibBackend/init.ml.unported
@@ -1,43 +1,14 @@
 open Core_kernel
 
-let has_inited : bool ref = ref false
-
 let init ~run_side_effects =
   try
     if not !has_inited
     then (
-      (* Ocaml runtime stuff *)
       Caml.print_endline "Libbackend Initialization Begins" ;
-      Printexc.record_backtrace true ;
-      Exn.initialize_module () ;
       (* libexecution *)
-      let non_client_fns =
-        Libdb.fns
-        @ Libdb2.fns
-        @ Libevent.fns
-        @ Libhttpclient.fns
-        @ Libcrypto.fns
-        @ Libtwilio.fns
-        @ Libdarkinternal.fns
-        @ Libstaticassets.fns
-        @ Libjwt.fns
-        @ Libx509.fns
-      in
-      Libexecution.Init.init Config.log_level Config.log_format non_client_fns ;
-      (* init the Random module, will be seeded from /dev/urandom on Linux *)
-      Random.self_init () ;
-      (* Dark-specific stuff *)
-      File.init () ;
-      Httpclient.init () ;
       if run_side_effects
       then (
-        Migrations.init () ;
         Account.init () ;
         Canvas.write_shape_data () ) ;
       if Config.check_tier_one_hosts then Canvas.check_tier_one_hosts () ;
-      Libcommon.Log.infO "Libbackend" ~data:"Initialization Complete" ;
       has_inited := true )
-  with e ->
-    let bt = Libexecution.Exception.get_backtrace () in
-    Rollbar.last_ditch e ~bt "backend initialization" "no execution id" ;
-    raise e

--- a/fsharp-backend/src/LibService/Config.fs
+++ b/fsharp-backend/src/LibService/Config.fs
@@ -41,15 +41,19 @@ let heapioId = string "DARK_CONFIG_HEAPIO_ID"
 // honeycomb
 // --------------------
 type TelemetryExporter =
-  | NoExporter
   | Honeycomb
   | Console
 
 // "Where do you send the logs?"
-let telemetryExporter : TelemetryExporter =
-  stringChoice
-    "DARK_CONFIG_TELEMETRY_EXPORTER"
-    [ ("none", NoExporter); ("honeycomb", Honeycomb); ("console", Console) ]
+let telemetryExporters : List<TelemetryExporter> =
+  "DARK_CONFIG_TELEMETRY_EXPORTER"
+  |> string
+  |> Tablecloth.String.split ","
+  |> Tablecloth.List.filterMap (function
+    | "honeycomb" -> Some Honeycomb
+    | "console" -> Some Console
+    | "none" -> None
+    | name -> failwith $"Unexpected Telemetry exporter {name}")
 
 let honeycombApiKey = string "DARK_CONFIG_HONEYCOMB_API_KEY"
 let honeycombDataset = string "DARK_CONFIG_HONEYCOMB_DATASET_NAME"

--- a/fsharp-backend/src/LibService/Telemetry.fs
+++ b/fsharp-backend/src/LibService/Telemetry.fs
@@ -263,10 +263,13 @@ let addTelemetry
   : TracerProviderBuilder =
   builder
   |> fun b ->
-       match Config.telemetryExporter with
-       | Config.Honeycomb -> b.AddHoneycomb(honeycombOptions).AddConsoleExporter()
-       | Config.NoExporter -> b
-       | Config.Console -> b.AddConsoleExporter()
+       List.fold
+         b
+         (fun b exporter ->
+           match exporter with
+           | Config.Honeycomb -> b.AddHoneycomb(honeycombOptions)
+           | Config.Console -> b.AddConsoleExporter())
+         Config.telemetryExporters
   |> fun b ->
        b.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName))
   |> fun b -> b.AddAspNetCoreInstrumentation(configureAspNetCore)

--- a/services/cronchecker-deployment/cronchecker-deployment.template.yaml
+++ b/services/cronchecker-deployment/cronchecker-deployment.template.yaml
@@ -28,12 +28,14 @@ spec:
           # this pod is a 'Burstable' pod, ref:
           #  https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6
           resources:
+            # Observed in practice using 100m and 80Mi
+            # FSTODO: this was not when they were running in parallel, so I doubled it
             requests:
-              memory: "200Mi"
-              cpu: "125m"
+              memory: "240Mi"
+              cpu: "300m"
             limits:
-              memory: "400Mi"
-              cpu: "250m"
+              memory: "600Mi"
+              cpu: "600m"
           # lifecycle:
           #   preStop:
           #     We implement the SIGTERM handler instead (even if we used preStop we'd
@@ -115,11 +117,12 @@ spec:
           image: "gcr.io/cloudsql-docker/gce-proxy:1.25.0"
           resources:
             requests:
-              memory: "250Mi"
-              cpu: "125m"
+              # Observed in practice using 60m and 10Mi when going full-tilt
+              memory: "20Mi"
+              cpu: "100m"
             limits:
-              memory: "500Mi"
-              cpu: "125m"
+              memory: "100Mi"
+              cpu: "200m"
           command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances={BUILTIN:CLOUDSQL_INSTANCE_NAME}=tcp:5432", "-credential_file=/secrets/cloudsql/credentials.json"]
           volumeMounts:
             - name: cloudsql-instance-credentials

--- a/services/cronchecker-deployment/cronchecker-deployment.template.yaml
+++ b/services/cronchecker-deployment/cronchecker-deployment.template.yaml
@@ -12,6 +12,9 @@ spec:
   # there should only be one of these right now, as there's no locking on checking
   # if we should enqueue or not
   replicas: 1
+  strategy:
+    # Limit to max 1, removing the old one first, then adding the new one
+    type: Recreate
   template:
     metadata:
       labels:

--- a/services/exechost-deployment/exechost-deployment.template.yaml
+++ b/services/exechost-deployment/exechost-deployment.template.yaml
@@ -11,9 +11,8 @@ spec:
       app: exechost
   replicas: 1
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
+    # No need for more than one of these
+    type: Recreate
   template:
     metadata:
       labels:

--- a/services/exechost-deployment/exechost-deployment.template.yaml
+++ b/services/exechost-deployment/exechost-deployment.template.yaml
@@ -21,16 +21,15 @@ spec:
       containers:
         - name: exechost-ctr
           image: "gcr.io/balmy-ground-195100/gcp-exechost:{IMAGEID:gcp-exechost}"
-          # Resource limits + requests are intentionally the same, to ensure
-          # this pod is a 'Guaranteed' pod, ref:
-          #  https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6
           resources:
             requests:
-              memory: "1000Mi"
-              cpu: "125m"
+              # This is basically off all the time
+              memory: "10Mi"
+              cpu: "10m"
             limits:
-              memory: "1000Mi"
-              cpu: "125m"
+              # Allow generous limits in case it needs it when we're actually doing something
+              memory: "200Mi"
+              cpu: "250m"
           envFrom:
             - configMapRef:
                 name: "{VERSIONED-CONFIGMAP:app-config}"
@@ -79,23 +78,20 @@ spec:
                   name: honeycomb
                   key: api-key
 
-
         #########################
         # Postgres proxy config
-        # To connect to postgres from kubernetes, we need to add a proxy. See
         # https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine.
-        # Note in particular that we needed to create a service account and a
-        # set of GKE secrets, listed below, to manage this.
         #########################
         - name: cloudsql-proxy
           image: "gcr.io/cloudsql-docker/gce-proxy:1.25.0"
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "125m"
+              # This is basically off all the time
+              memory: "10Mi"
+              cpu: "10m"
             limits:
-              memory: "500Mi"
-              cpu: "125m"
+              memory: "20Mi"
+              cpu: "20m"
           command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances={BUILTIN:CLOUDSQL_INSTANCE_NAME}=tcp:5432", "-credential_file=/secrets/cloudsql/credentials.json"]
           volumeMounts:
             - name: cloudsql-instance-credentials


### PR DESCRIPTION
- remove some dead code
- allow mulitple telemetry exporters (and so disable the console exporter in prod)
- change the k8s deployment strategy for cronchecker to be just one at a time
- change CPU limits for cronchecker and exechost

This also enables the last PR (parallel cronchecker) which was deployed in the wrong order.