### PR TITLE
Match memory consumption to use

### DIFF
--- a/services/bwd-deployment/bwd-deployment.template.yaml
+++ b/services/bwd-deployment/bwd-deployment.template.yaml
@@ -23,8 +23,8 @@ spec:
           #  https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6
           resources:
             requests:
-              memory: "1000Mi"
-              cpu: "125m"
+              memory: "100Mi"
+              cpu: "10m"
             limits:
               memory: "1000Mi"
               cpu: "125m"
@@ -101,8 +101,8 @@ spec:
           image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "125m"
+              memory: "20Mi"
+              cpu: "10m"
             limits:
               memory: "500Mi"
               cpu: "125m"
@@ -122,8 +122,8 @@ spec:
           image: "gcr.io/balmy-ground-195100/stroller:{IMAGEID:stroller}"
           resources:
             requests:
-              memory: "250Mi"
-              cpu: "150m"
+              memory: "20Mi"
+              cpu: "10m"
             limits:
               memory: "250Mi"
               cpu: "150m"
@@ -174,8 +174,8 @@ spec:
           image: nginx:1.16.1
           resources:
             requests:
-              memory: "50Mi"
-              cpu: "100m"
+              memory: "20Mi"
+              cpu: "10m"
             limits:
               memory: "50Mi"
               cpu: "100m"

--- a/services/editor-deployment/editor-deployment.template.yaml
+++ b/services/editor-deployment/editor-deployment.template.yaml
@@ -23,8 +23,8 @@ spec:
           #  https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6
           resources:
             requests:
-              memory: "1000Mi"
-              cpu: "125m"
+              memory: "200Mi"
+              cpu: "50m"
             limits:
               memory: "1000Mi"
               cpu: "125m"
@@ -100,11 +100,11 @@ spec:
           image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "125m"
+              memory: "20Mi"
+              cpu: "10m"
             limits:
-              memory: "500Mi"
-              cpu: "125m"
+              memory: "200Mi"
+              cpu: "50m"
           # https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/128
           command: ["/bin/sh",
                     "-c",
@@ -121,8 +121,8 @@ spec:
           image: "gcr.io/balmy-ground-195100/stroller:{IMAGEID:stroller}"
           resources:
             requests:
-              memory: "250Mi"
-              cpu: "150m"
+              memory: "20Mi"
+              cpu: "30m"
             limits:
               memory: "250Mi"
               cpu: "150m"
@@ -173,8 +173,8 @@ spec:
           image: nginx:1.16.1
           resources:
             requests:
-              memory: "50Mi"
-              cpu: "100m"
+              memory: "20Mi"
+              cpu: "10m"
             limits:
               memory: "50Mi"
               cpu: "100m"

--- a/services/qw-deployment/qw-deployment.template.yaml
+++ b/services/qw-deployment/qw-deployment.template.yaml
@@ -26,7 +26,7 @@ spec:
               memory: "400Mi"
               cpu: "100m"
             limits:
-              memory: "800Mi"
+              memory: "1000Mi"
               cpu: "200m"
           envFrom:
             - configMapRef:
@@ -68,8 +68,8 @@ spec:
           image: "gcr.io/cloudsql-docker/gce-proxy:1.11"
           resources:
             requests:
-              memory: "100Mi"
-              cpu: "100m"
+              memory: "20Mi"
+              cpu: "10m"
             limits:
               memory: "500Mi"
               cpu: "150m"
@@ -88,8 +88,8 @@ spec:
           image: "gcr.io/balmy-ground-195100/stroller:{IMAGEID:stroller}"
           resources:
             requests:
-              memory: "50Mi"
-              cpu: "50m"
+              memory: "20Mi"
+              cpu: "10m"
             limits:
               memory: "250Mi"
               cpu: "75m"


### PR DESCRIPTION
Based on GCP/k8s numbers in production

This is to avoid warnings about being out of resources during a deploy, which makes cronchecker take longer to load.