### PR TITLE
Finish libdarkinternal

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
@@ -8,6 +8,7 @@ open FSharp.Control.Tasks
 open System.Net.Http
 open System.IO.Compression
 open System.IO
+
 type AspHeaders = System.Net.Http.Headers.HttpHeaders
 
 open Prelude
@@ -169,7 +170,12 @@ let makeHttpCall
             // CLEANUP: OCaml doesn't send empty headers, but no reason not to
             ()
           elif String.equalsCaseInsensitive k "content-type" then
-            req.Content.Headers.ContentType <- Headers.MediaTypeHeaderValue.Parse(v)
+            try
+              req.Content.Headers.ContentType <-
+                Headers.MediaTypeHeaderValue.Parse(v)
+            with
+            | :? System.FormatException ->
+              Exception.raiseDeveloper "Invalid content-type header" []
           else
             // Dark headers can only be added once, as they use a Dict. Remove them
             // so they don't get added twice (eg via Authorization headers above)

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -672,9 +672,9 @@ that's already taken, returns an error."
             uply {
               try
                 let! meta = Canvas.getMeta (CanvasName.create host)
-                return DResult(Ok(DStr(string meta.id)))
+                return DOption(Some(DStr(string meta.id)))
               with
-              | e -> return DResult(Error(DStr e.Message))
+              | e -> return DOption None
             }
           | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -791,7 +791,7 @@ that's already taken, returns an error."
       deprecated = NotDeprecated }
     { name = fn "DarkInternal" "checkPermission" 0
       parameters = [ Param.make "username" TStr ""; Param.make "canvas" TStr "" ]
-      returnType = TBool
+      returnType = TStr
       description = "Check a user's permissions for a particular canvas."
       fn =
         internalFn (function

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -289,8 +289,8 @@ that's already taken, returns an error."
               match result with
               | Ok () ->
                 do Analytics.identifyUser state.executionID username
-                return DStr ""
-              | Error msg -> return Exception.raiseGrandUser msg
+                return DResult(Ok(DStr ""))
+              | Error msg -> return DResult(Error(DStr msg))
             }
           | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient5.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient5.fs
@@ -120,14 +120,11 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query =
-      DvalRepr.toQuery query
-      |> Tablecloth.Result.unwrapWith (fun msg -> Exception.raiseDeveloper msg [])
+    let query = DvalRepr.toQuery query |> Exception.unwrapResultDeveloper
 
     // Headers
     let encodedReqHeaders =
-      DvalRepr.toStringPairs reqHeaders
-      |> Tablecloth.Result.unwrapWith (fun msg -> Exception.raiseDeveloper msg [])
+      DvalRepr.toStringPairs reqHeaders |> Exception.unwrapResultDeveloper
     let contentType =
       HttpHeaders.get "content-type" encodedReqHeaders
       |> Option.defaultValue (guessContentType reqBody)

--- a/fsharp-backend/src/Benchmark/Benchmark.fs
+++ b/fsharp-backend/src/Benchmark/Benchmark.fs
@@ -19,7 +19,8 @@ module Canvas = LibBackend.Canvas
 
 let programContext () : Task<RT.ProgramContext> =
   task {
-    let! c = TestUtils.TestUtils.testCanvasInfo "benchmark"
+    let! owner = TestUtils.TestUtils.testOwner.Force()
+    let! c = TestUtils.TestUtils.testCanvasInfo owner "benchmark"
     return
       { canvasID = c.id
         canvasName = c.name

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -244,7 +244,10 @@ let userIDForUserName (username : UserName.T) : Task<UserID> =
        FROM accounts
        WHERE accounts.username = @username"
     |> Sql.parameters [ "username", Sql.string (string username) ]
-    |> Sql.executeRowAsync (fun read -> read.uuid "id")
+    |> Sql.executeRowOptionAsync (fun read -> read.uuid "id")
+    |> Task.map (function
+      | Some v -> v
+      | None -> Exception.raiseDeveloper "User not found")
 
 let usernameForUserID (userID : UserID) : Task<Option<UserName.T>> =
   Sql.query

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -404,7 +404,7 @@ let orgs (userID : UserID) : Task<List<OrgName.T>> =
     "SELECT org.username
      FROM access
      INNER JOIN accounts as org on access.organization_account = org.id
-     WHERE user_.username = @userID"
+     WHERE access.access_account = @userID"
   |> Sql.parameters [ "userID", Sql.uuid userID ]
   |> Sql.executeAsync (fun read -> read.string "username" |> OrgName.create)
   |> Task.map List.sort

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -108,7 +108,8 @@ let bannedUsernames : List<UserName.T> =
 let validateUserName (username : string) : Result<unit, string> =
   // rules: no uppercase, ascii only, must start with letter, other letters can
   // be numbers or underscores. 3-20 characters.
-  let reString = @"^[a-z][a-z0-9_]{2,19}$"
+  // CLEANUP should be 19
+  let reString = @"^[a-z][a-z0-9_]{2,20}$"
 
   if FsRegEx.isMatch reString username then
     Ok()

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -379,6 +379,7 @@ let ownedCanvases (userID : UserID) : Task<List<CanvasName.T>> =
      WHERE c.account_id = @userID"
   |> Sql.parameters [ "userID", Sql.uuid userID ]
   |> Sql.executeAsync (fun read -> read.string "name" |> CanvasName.create)
+  |> Task.map List.sort
 
 
 // NB: this returns canvases an account has access to via an organization, not
@@ -392,15 +393,17 @@ let accessibleCanvases (userID : UserID) : Task<List<CanvasName.T>> =
       WHERE access.access_account = @userID"
   |> Sql.parameters [ "userID", Sql.uuid userID ]
   |> Sql.executeAsync (fun read -> read.string "name" |> CanvasName.create)
+  |> Task.map List.sort
 
 let orgs (userID : UserID) : Task<List<OrgName.T>> =
   Sql.query
     "SELECT org.username
      FROM access
      INNER JOIN accounts as org on access.organization_account = org.id
-     WHERE access.access_account = @userID"
+     WHERE user_.username = @userID"
   |> Sql.parameters [ "userID", Sql.uuid userID ]
   |> Sql.executeAsync (fun read -> read.string "username" |> OrgName.create)
+  |> Task.map List.sort
 
 
 // **********************

--- a/fsharp-backend/src/LibBackend/Analytics.fs
+++ b/fsharp-backend/src/LibBackend/Analytics.fs
@@ -22,45 +22,43 @@ module FireAndForget = LibService.FireAndForget
 let identifyUser (executionID : ExecutionID) (username : UserName.T) : unit =
   FireAndForget.fireAndForgetTask "identify user" executionID (fun () ->
     task {
-      // FSTODO: check that analytics_metadata has been set correctly
       let! data = Account.getUserAndCreatedAtAndAnalyticsMetadata username
-      let (userInfoAndCreatedAt, heapioMetadata) = Option.unwrapUnsafe data
-      let! _organization =
-        task {
-          let! orgs = Authorization.orgsFor username
-          // A user's orgs for this purpose do not include orgs it has
-          // read-only access to
-          return
-            orgs
-            |> List.filter (function
-              | _, rw -> rw = Authorization.ReadWrite)
-            // If you have one org, that's your org! If you have no orgs, or
-            // more than one, then we just use your username. This is because
-            // Heap's properties/traits don't support lists.
-            |> (function
-            | [ (orgName, _) ] -> orgName
-            | _ -> username |> string |> OrgName.create)
-        }
-      // let payload =
-      // FSTODO
-      // let payload =
-      //   Assoc [ ("username", String user_info_and_created_at.username)
-      //           ("email", String user_info_and_created_at.email)
-      //           ("name", String user_info_and_created_at.name)
-      //           ("admin", Bool user_info_and_created_at.admin)
-      //           ("handle", String user_info_and_created_at.username)
-      //           ("organization", String organization) ]
-      // // We do zero checking of fields in heapio_metadata, but this is ok
-      // // because it's a field we control, going to a service only we see.
-      // // If we wanted to harden this later, we could List.filter the
-      // // heapio_metadata yojson *)
-      // Yojson.Safe.Util.combine payload heapio_metadata
-      // FSTODO
-      // do!
-      //   LibService.HeapAnalytics.heapioEvent
-      //     executionID
-      //     userInfoAndCreatedAt.id
-      //     Identify
-      //     payload
+      let (userInfoAndCreatedAt, heapioMetadataJson) = Option.unwrapUnsafe data
+      let! orgs = Authorization.orgsFor username
+      let organization =
+        // A user's orgs for this purpose do not include orgs it has
+        // read-only access to
+        orgs
+        |> List.filter (function
+          | _, rw -> rw = Authorization.ReadWrite)
+        // If you have one org, that's your org! If you have no orgs, or
+        // more than one, then we just use your username. This is because
+        // Heap's properties/traits don't support lists.
+        |> (function
+        | [ (orgName, _) ] -> orgName
+        | _ -> username |> string |> OrgName.create)
+
+      let heapioMetadata =
+        Json.Vanilla.deserialize<Map<string, string>> heapioMetadataJson
+
+      let payload =
+        [ ("username", string userInfoAndCreatedAt.username)
+          ("email", userInfoAndCreatedAt.email)
+          ("name", userInfoAndCreatedAt.name)
+          ("admin", string userInfoAndCreatedAt.admin)
+          ("handle", string userInfoAndCreatedAt.username)
+          ("organization", string organization) ]
+
+      // We do zero checking of fields in heapio_metadata, but this is ok
+      // because it's a field we control, going to a service only we see.
+      // If we wanted to harden this later, we could List.filter the
+      // heapio_metadata yojson *)
+      let payload = Map(payload @ Map.toList heapioMetadata)
+      LibService.HeapAnalytics.heapioEvent
+        executionID
+        userInfoAndCreatedAt.id
+        "identify-user"
+        LibService.HeapAnalytics.Identify
+        payload
       return ()
     })

--- a/fsharp-backend/src/LibBackend/Analytics.fs
+++ b/fsharp-backend/src/LibBackend/Analytics.fs
@@ -7,10 +7,6 @@ module Account = LibBackend.Account
 open System.Threading.Tasks
 open FSharp.Control.Tasks
 
-open Npgsql.FSharp
-open Npgsql
-open LibBackend.Db
-
 open Prelude
 open Tablecloth
 

--- a/fsharp-backend/src/LibBackend/Serialize.fs
+++ b/fsharp-backend/src/LibBackend/Serialize.fs
@@ -299,8 +299,6 @@ let currentHosts () : Task<string list> =
 //   ; "ellen-battery2"
 //   ; "julius-tokimeki-unfollow" ]
 
-
-
 type CronScheduleData =
   { canvasID : CanvasID
     ownerID : UserID
@@ -322,12 +320,12 @@ let fetchActiveCrons () : Task<List<CronScheduleData>> =
                   toplevel_oplists.name as handler_name,
                   toplevel_oplists.account_id,
                   canvases.name as canvas_name
-           FROM toplevel_oplists
-           JOIN canvases ON toplevel_oplists.canvas_id = canvases.id
-           WHERE module = 'CRON'
-             AND modifier IS NOT NULL
-             AND modifier <> ''
-             AND toplevel_oplists.name IS NOT NULL"
+       FROM toplevel_oplists
+       JOIN canvases ON toplevel_oplists.canvas_id = canvases.id
+      WHERE module = 'CRON'
+        AND modifier IS NOT NULL
+        AND modifier <> ''
+        AND toplevel_oplists.name IS NOT NULL"
   |> Sql.executeAsync (fun read ->
     { canvasID = read.uuid "canvas_id"
       ownerID = read.uuid "account_id"

--- a/fsharp-backend/src/LibBackend/SqlCompiler.fs
+++ b/fsharp-backend/src/LibBackend/SqlCompiler.fs
@@ -305,8 +305,8 @@ let partiallyEvaluate
     let exec (expr : Expr) : Ply.Ply<Expr> =
       uply {
         let newName = "dark_generated_" + randomString 8
-        let! value = LibExecution.Interpreter.eval state !symtable expr
-        symtable := Map.add newName value !symtable
+        let! value = LibExecution.Interpreter.eval state symtable.Value expr
+        symtable.Value <- Map.add newName value symtable.Value
         return (EVariable(gid (), newName))
       }
 
@@ -416,7 +416,7 @@ let partiallyEvaluate
       }
 
     let! result = postTraversal body
-    return (!symtable, result)
+    return (symtable.Value, result)
   }
 
 

--- a/fsharp-backend/src/LibBackend/TraceFunctionArguments.fs
+++ b/fsharp-backend/src/LibBackend/TraceFunctionArguments.fs
@@ -66,7 +66,8 @@ let loadForAnalysis
   |> Sql.executeRowOptionAsync (fun read ->
     (read.string "arguments_json"
      |> DvalRepr.ofInternalRoundtrippableV0
-     |> fun dv -> RT.Dval.toPairs dv, read.dateTime "timestamp"))
+     |> fun dv ->
+          RT.Dval.toPairs dv |> Result.unwrapUnsafe, read.dateTime "timestamp"))
 
 
 let loadTraceIDs (canvasID : CanvasID) (tlid : tlid) : Task<List<AT.TraceID>> =

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -971,11 +971,11 @@ let toStringPairsExn (dv : Dval) : (string * string) list =
       | (k, v) ->
         // CLEANUP: this is just to keep the error messages the same with OCaml. It's safe to change the error message
         // failwith $"Expected a string, but got: {toDeveloperReprV0 v}"
-        failwith "expecting str")
+        Exception.raiseLibrary "expecting str" [ "actual", toDeveloperReprV0 v ])
   | _ ->
     // CLEANUP As above
     // $"Expected a string, but got: {toDeveloperReprV0 dv}"
-    failwith "expecting str"
+    Exception.raiseLibrary "expecting str" [ "actual", toDeveloperReprV0 dv ]
 
 // -------------------------
 // URLs and queryStrings

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -192,7 +192,8 @@ let rec typeToDeveloperReprV0 (t : DType) : string =
 let prettyTypename (dv : Dval) : string = dv |> Dval.toType |> typeToDeveloperReprV0
 
 // Backwards compatible version of `typeToDeveloperRepr`, should not be visible to
-// users but used by things like HttpClient (transitively)
+// users (except through LibDarkInternal) but used by things like HttpClient
+// (transitively)
 let rec typeToBCTypeName (t : DType) : string =
   match t with
   | TInt -> "int"

--- a/fsharp-backend/src/LibExecution/DvalRepr.fs
+++ b/fsharp-backend/src/LibExecution/DvalRepr.fs
@@ -842,7 +842,7 @@ let ofUnknownJsonV0 str =
   | _ -> failwith "Invalid json"
 
 
-let ofUnknownJsonV1 str =
+let ofUnknownJsonV1 str : Result<Dval, string> =
   // FSTODO: there doesn't seem to be a good reason that we use JSON.NET here,
   // might be better to switch to STJ
   let rec convert json =
@@ -861,14 +861,14 @@ let ofUnknownJsonV1 str =
     // disable all those so we fail if we see them. However, we might need to
     // just convert some of these into strings.
     | JNonStandard
-    | _ -> Exception.raiseInternal $"Invalid type in json" [ "json", json ]
+    | _ -> failwith "Invalid type in json"
 
   try
-    str |> parseJson |> convert
+    str |> parseJson |> convert |> Ok
   with
   | :? JsonReaderException as e ->
     let msg = if str = "" then "JSON string was empty" else e.Message
-    Exception.raiseInternal msg [ "str", str ]
+    Error msg
 
 
 // let rec show dv =

--- a/fsharp-backend/src/LibExecution/Execution.fs
+++ b/fsharp-backend/src/LibExecution/Execution.fs
@@ -29,6 +29,7 @@ let createState
   (executionID : ExecutionID)
   (libraries : RT.Libraries)
   (tracing : RT.Tracing)
+  (reportException : ExecutionID -> string -> exn -> List<string * obj> -> unit)
   (tlid : tlid)
   (program : RT.ProgramContext)
   : RT.ExecutionState =
@@ -36,6 +37,7 @@ let createState
     tracing = tracing
     program = program
     test = { sideEffectCount = 0 }
+    reportException = reportException
     executionID = executionID
     tlid = tlid
     callstack = Set.empty

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -758,8 +758,7 @@ and execFn
         | DarkException _ as e ->
           // The GrandUser doesn't get to see DErrors, so it's safe to include this
           // value and show it to the Dark Developer
-          return
-            (Dval.errSStr sourceID (Exception.toDeveloperMessage e |> Option.get))
+          return Dval.errSStr sourceID (Exception.toDeveloperMessage e)
         | e ->
           // We don't know what's happening here, so there could be sensitive
           // information in the message. Let's report the error and hide the message

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -755,12 +755,21 @@ and execFn
         | Errors.StdlibException Errors.FunctionRemoved ->
           return (Dval.errSStr sourceID $"{fn.name} was removed from Dark")
         | Errors.StdlibException (Errors.FakeDvalFound dv) -> return dv
-        // After the rethrow, this gets eventually caught then shown to the
-        // user as a Dark Internal Exception. It's an internal exception
-        // because we didn't anticipate the problem, give it a nice error
-        // message, etc. It'll appear in Rollbar as "Unknown Err". To remedy
-        // this, give it a nice exception via RT.error. *)
-        // FSTODO: the message above needs to be handled
-        | e -> return (Dval.errSStr sourceID e.Message)
+        | DarkException _ as e ->
+          // The GrandUser doesn't get to see DErrors, so it's safe to include this
+          // value and show it to the Dark Developer
+          return
+            (Dval.errSStr sourceID (Exception.toDeveloperMessage e |> Option.get))
+        | e ->
+          // We don't know what's happening here, so there could be sensitive
+          // information in the message. Let's report the error and hide the message
+          // from the user
+          // CLEANUP could we show the user the execution id here?
+          state.reportException
+            state.executionID
+            "An unknown exception was caught in the interpreter"
+            e
+            []
+          return (Dval.errSStr sourceID "An unknown error occured")
 
   }

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -437,10 +437,10 @@ module Dval =
     | DErrorRail dv -> dv
     | other -> other
 
-  let toPairs (dv : Dval) : (string * Dval) list =
+  let toPairs (dv : Dval) : Result<List<string * Dval>, string> =
     match dv with
-    | DObj obj -> Map.toList obj
-    | _ -> failwith "expecting str"
+    | DObj obj -> Ok(Map.toList obj)
+    | _ -> Error "expecting str"
 
   let rec toType (dv : Dval) : DType =
     let any = TVariable "a"

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -855,6 +855,7 @@ and ExecutionState =
     tracing : Tracing
     program : ProgramContext
     test : TestContext
+    reportException : ExecutionID -> string -> exn -> List<string * obj> -> unit
     // TLID of the currently executing handler/fn
     tlid : tlid
     executionID : ExecutionID

--- a/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
@@ -44,7 +44,10 @@ let fns : List<BuiltInFn> =
         "Parses a json string and returns its value. HTTPClient functions, and our request handler, automatically parse JSON into the `body` and `jsonbody` fields, so you probably won't need this. However, if you need to consume bad JSON, you can use string functions to fix the JSON and then use this function to parse it."
       fn =
         (function
-        | _, [ DStr json ] -> json |> DvalRepr.ofUnknownJsonV1 |> Ply
+        | _, [ DStr json ] ->
+          match DvalRepr.ofUnknownJsonV1 json with
+          | Ok dv -> Ply dv
+          | Error msg -> Ply(DError(SourceNone, msg))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -57,10 +60,9 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DStr json ] ->
-          try
-            json |> DvalRepr.ofUnknownJsonV1 |> Ply
-          with
-          | e -> Ply(DError(SourceNone, e.Message))
+          match DvalRepr.ofUnknownJsonV1 json with
+          | Ok dv -> Ply dv
+          | Error msg -> Ply(DError(SourceNone, msg))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -73,11 +75,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DStr json ] ->
-          (try
-            let dval = json |> DvalRepr.ofUnknownJsonV1
-            Ply(DResult(Ok dval))
-           with
-           | Failure e -> e |> string |> DStr |> Error |> DResult |> Ply)
+          json |> DvalRepr.ofUnknownJsonV1 |> Result.mapError DStr |> DResult |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -59,6 +59,9 @@ let createState
     let touchedTLIDs, traceTLIDFn = Exe.traceTLIDs ()
     HashSet.add tlid touchedTLIDs
 
+    let reportException executionID msg exn tags =
+      LibService.Rollbar.sendException msg executionID tags exn
+
     let tracing =
       { Exe.noTracing RT.Real with
           storeFnResult = TraceFunctionResults.store canvasID traceID
@@ -67,5 +70,7 @@ let createState
 
     let! libraries = Lazy.force libraries
 
-    return (Exe.createState executionID libraries tracing tlid program, touchedTLIDs)
+    return
+      (Exe.createState executionID libraries tracing reportException tlid program,
+       touchedTLIDs)
   }

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -989,6 +989,12 @@ module Json =
 // Functions we'll later add to Tablecloth
 // ----------------------
 module Tablecloth =
+  module Result =
+    let unwrapWith (f : 'err -> 'ok) (t : Result<'ok, 'err>) : 'ok =
+      match t with
+      | Ok v -> v
+      | Error v -> f v
+
   module String =
     let take (count : int) (str : string) : string =
       if count >= str.Length then str else str.Substring(0, count)

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -79,6 +79,11 @@ module Exception =
     callExceptionCallback e "developer" msg []
     raise e
 
+  let unwrapResultDeveloper (r : Result<'ok, string>) : 'ok =
+    match r with
+    | Ok v -> v
+    | Error msg -> raiseDeveloper msg
+
   // An editor exception is one which is caused by an invalid action on the part of
   // the Dark editor. We are interested in these. The message may be shown to the
   // logged-in user, and should be suitable for this.
@@ -100,32 +105,34 @@ module Exception =
     callExceptionCallback e "library" msg tags
     raise e
 
-  let toGrandUserMessage (e : exn) : Option<string> =
+  let unknownErrorMessage = "Unknown error"
+
+  let toGrandUserMessage (e : exn) : string =
     match e with
     | DarkException (InternalError _)
     | DarkException (DeveloperError _)
     | DarkException (LibraryError _)
-    | DarkException (EditorError _) -> None
-    | DarkException (GrandUserError msg) -> Some msg
-    | _ -> None
+    | DarkException (EditorError _) -> unknownErrorMessage
+    | DarkException (GrandUserError msg) -> msg
+    | _ -> unknownErrorMessage
 
-  let toDeveloperMessage (e : exn) : Option<string> =
+  let toDeveloperMessage (e : exn) : string =
     match e with
-    | DarkException (InternalError _) -> None
+    | DarkException (InternalError _) -> unknownErrorMessage
     | DarkException (DeveloperError msg)
     | DarkException (LibraryError (msg, _))
     | DarkException (EditorError msg)
-    | DarkException (GrandUserError msg) -> Some msg
-    | _ -> None
+    | DarkException (GrandUserError msg) -> msg
+    | _ -> unknownErrorMessage
 
-  let toInternalMessage (e : exn) : Option<string * List<string * obj>> =
+  let toInternalMessage (e : exn) : string * List<string * obj> =
     match e with
     | DarkException (InternalError (msg, tags))
-    | DarkException (LibraryError (msg, tags)) -> Some(msg, tags)
+    | DarkException (LibraryError (msg, tags)) -> (msg, tags)
     | DarkException (DeveloperError msg)
     | DarkException (EditorError msg)
-    | DarkException (GrandUserError msg) -> Some(msg, [])
-    | e -> Some(e.Message, [])
+    | DarkException (GrandUserError msg) -> (msg, [])
+    | e -> (e.Message, [])
 
   // FSTODO
   let shouldPage (e : exn) : bool =

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -198,7 +198,11 @@ module Eval =
             loadFnResult = loadFromTrace functionResults }
 
       let executionID = ExecutionID "analysis"
-      let state = Exe.createState executionID libraries tracing tlid program
+      let reportError executionID msg (exn : exn) tags =
+        print
+          $"An error was reported in the runtime: {msg}\n  {exn.Message}, {exn.StackTrace}"
+      let state =
+        Exe.createState executionID libraries tracing reportError tlid program
 
       let ast = (expr |> OT.Convert.ocamlExpr2PT).toRuntimeType ()
       let inputVars = Map traceData.input

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -1128,6 +1128,7 @@ module ExecutePureFunctions =
   let equalsOCaml ((fn, args) : (PT.FQFnName.StdlibFnName * List<RT.Dval>)) : bool =
     let t =
       task {
+        let! owner = testOwner.Force()
         let args = List.mapi (fun i arg -> ($"v{i}", arg)) args
         let fnArgList = List.map (fun (name, _) -> eVar name) args
 
@@ -1140,7 +1141,7 @@ module ExecutePureFunctions =
 
         let! expected = OCamlInterop.execute ownerID canvasID ast st [] []
 
-        let! state = executionStateFor "executePure" Map.empty Map.empty
+        let! state = executionStateFor owner "executePure" Map.empty Map.empty
 
         let! actual =
           LibExecution.Execution.executeExpr state st (ast.toRuntimeType ())

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -437,11 +437,12 @@ module HttpClient =
   let dvalToUrlStringExn (l : List<string * RT.Dval>) : bool =
     let dv = RT.DObj(Map l)
 
-    DvalRepr.toUrlStringExn dv .=. (OCamlInterop.toUrlString dv).Result
+    DvalRepr.toUrlString dv .=. (OCamlInterop.toUrlString dv).Result
 
   let dvalToQuery (l : List<string * RT.Dval>) : bool =
     let dv = RT.DObj(Map l)
-    DvalRepr.toQuery dv .=. (OCamlInterop.dvalToQuery dv).Result
+    DvalRepr.toQuery dv |> Result.unwrapUnsafe
+    .=. (OCamlInterop.dvalToQuery dv).Result
 
   let dvalToFormEncoding (l : List<string * RT.Dval>) : bool =
     let dv = RT.DObj(Map l)

--- a/fsharp-backend/tests/TestUtils/FSI.fs
+++ b/fsharp-backend/tests/TestUtils/FSI.fs
@@ -18,7 +18,8 @@ open Prelude
 let execute (code : string) : RT.Dval =
   let t =
     task {
-      let! state = TestUtils.executionStateFor "fsi" Map.empty Map.empty
+      let! owner = TestUtils.testOwner.Force()
+      let! state = TestUtils.executionStateFor owner "fsi" Map.empty Map.empty
       let prog = FSharpToExpr.parseRTExpr code
       return! Exe.executeExpr state Map.empty prog
     }
@@ -29,8 +30,9 @@ let execute (code : string) : RT.Dval =
 let executeOCaml (code : string) : RT.Dval =
   let t =
     task {
+      let! owner = TestUtils.testOwner.Force()
       let prog = FSharpToExpr.parsePTExpr code
-      let! state = TestUtils.executionStateFor "fsi" Map.empty Map.empty
+      let! state = TestUtils.executionStateFor owner "fsi" Map.empty Map.empty
       let accountID = state.program.accountID
       let canvasID = state.program.canvasID
       return! OCamlInterop.execute accountID canvasID prog Map.empty [] []

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -167,12 +167,12 @@ let libraries : Lazy<RT.Libraries> =
        packageFns = Map.empty })
 
 let executionStateFor
+  (owner : Account.UserInfo)
   (name : string)
   (dbs : Map<string, RT.DB.T>)
   (userFunctions : Map<string, RT.UserFunction.T>)
   : Task<RT.ExecutionState> =
   task {
-    let! owner = testOwner.Force()
     let ownerID : UserID = (owner : Account.UserInfo).id
     let executionID = ExecutionID $"test-{name}"
 

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -205,11 +205,14 @@ let executionStateFor
         userTypes = Map.empty
         secrets = [] }
 
+    let reportError executionID msg exn tags = raise exn
+
     return
       Exe.createState
         executionID
         (Lazy.force libraries)
         (Exe.noTracing RT.Real)
+        reportError
         tlid
         program
 

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -11,6 +11,7 @@ open LibBackend.Db
 
 open Prelude
 open Tablecloth
+open LibService.Exception
 
 module RT = LibExecution.RuntimeTypes
 module PT = LibExecution.ProgramTypes
@@ -205,14 +206,18 @@ let executionStateFor
         userTypes = Map.empty
         secrets = [] }
 
-    let reportError executionID msg exn tags = raise exn
+    let reportException (executionID : ExecutionID) (msg : string) (exn : exn) tags =
+      // Don't rethrow exceptions as sometimes we want to test errors
+      print "Exception Thrown"
+      print exn.Message
+      print exn.StackTrace
 
     return
       Exe.createState
         executionID
         (Lazy.force libraries)
         (Exe.noTracing RT.Real)
-        reportError
+        reportException
         tlid
         program
 

--- a/fsharp-backend/tests/Tests/Account.Tests.fs
+++ b/fsharp-backend/tests/Tests/Account.Tests.fs
@@ -34,16 +34,16 @@ let testUsernameValidationWorks =
     "validateUsername"
     Account.validateUserName
     [ "Upper",
-      (Error "Invalid username 'Upper', must match /^[a-z][a-z0-9_]{2,19}$/")
+      (Error "Invalid username 'Upper', must match /^[a-z][a-z0-9_]{2,20}$/")
       "uPPer",
-      (Error "Invalid username 'uPPer', must match /^[a-z][a-z0-9_]{2,19}$/")
-      "a", (Error "Invalid username 'a', must match /^[a-z][a-z0-9_]{2,19}$/")
+      (Error "Invalid username 'uPPer', must match /^[a-z][a-z0-9_]{2,20}$/")
+      "a", (Error "Invalid username 'a', must match /^[a-z][a-z0-9_]{2,20}$/")
       "aaa❤️",
-      (Error "Invalid username 'aaa❤️', must match /^[a-z][a-z0-9_]{2,19}$/")
+      (Error "Invalid username 'aaa❤️', must match /^[a-z][a-z0-9_]{2,20}$/")
       "aaa-aaa",
-      (Error "Invalid username 'aaa-aaa', must match /^[a-z][a-z0-9_]{2,19}$/")
+      (Error "Invalid username 'aaa-aaa', must match /^[a-z][a-z0-9_]{2,20}$/")
       "aaa aaa",
-      (Error "Invalid username 'aaa aaa', must match /^[a-z][a-z0-9_]{2,19}$/")
+      (Error "Invalid username 'aaa aaa', must match /^[a-z][a-z0-9_]{2,20}$/")
       "aaa_aaa", Ok()
       "myusername09", Ok()
       "paul", Ok() ]

--- a/fsharp-backend/tests/Tests/BwdServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/BwdServer.Tests.fs
@@ -173,11 +173,12 @@ let replaceByteStrings
 
 let t filename =
   testTask $"Httpfiles: {filename}" {
+    let! owner = testOwner.Force()
     let skip = String.startsWith "_" filename
     let name = if skip then String.dropLeft 1 filename else filename
     let name = $"bwdserver-{name}"
     let testName = $"test-{name}"
-    do! clearCanvasData (CanvasName.create testName)
+    do! clearCanvasData owner (CanvasName.create testName)
 
     let filename = $"tests/httptestfiles/{filename}"
     let! contents = System.IO.File.ReadAllBytesAsync filename
@@ -206,7 +207,7 @@ let t filename =
          PT.TLHandler h,
          Canvas.NotDeleted))
 
-    let! (meta : Canvas.Meta) = testCanvasInfo testName
+    let! (meta : Canvas.Meta) = testCanvasInfo owner testName
     do! Canvas.saveTLIDs meta oplists
 
     // CORS

--- a/fsharp-backend/tests/Tests/Cron.Tests.fs
+++ b/fsharp-backend/tests/Tests/Cron.Tests.fs
@@ -37,8 +37,9 @@ let testCronFetchActiveCrons =
 let testCronSanity =
   testTask "cron sanity" {
     let name = "cron-sanity"
-    do! clearCanvasData (CanvasName.create name)
-    let! meta = testCanvasInfo name
+    let! owner = testOwner.Force()
+    do! clearCanvasData owner (CanvasName.create name)
+    let! meta = testCanvasInfo owner name
 
     let h = testCron "test" PT.Handler.EveryDay (p " 5 + 3")
     let oplists = [ hop h ]
@@ -62,8 +63,10 @@ let testCronSanity =
 let testCronJustRan =
   testTask "test cron just ran" {
     let name = "cron-just-ran"
-    do! clearCanvasData (CanvasName.create name)
-    let! meta = testCanvasInfo name
+
+    let! owner = testOwner.Force()
+    do! clearCanvasData owner (CanvasName.create name)
+    let! meta = testCanvasInfo owner name
 
     let h = testCron "test" PT.Handler.EveryDay (p "5 + 3")
 

--- a/fsharp-backend/tests/Tests/EventQueue.Tests.fs
+++ b/fsharp-backend/tests/Tests/EventQueue.Tests.fs
@@ -29,9 +29,10 @@ let p (code : string) = FSharpToExpr.parsePTExpr code
 
 let testEventQueueRoundtrip =
   testTask "event queue roundtrip" {
+    let! owner = testOwner.Force()
     let name = "test-event_queue"
-    do! clearCanvasData (CanvasName.create name)
-    let! (meta : Canvas.Meta) = testCanvasInfo name
+    do! clearCanvasData owner (CanvasName.create name)
+    let! (meta : Canvas.Meta) = testCanvasInfo owner name
 
     let h = testCron "test" PT.Handler.EveryDay (p "let data = Date.now_v0 in 123")
     let oplists = [ hop h ]
@@ -61,9 +62,10 @@ let testEventQueueRoundtrip =
 
 let testEventQueueIsFifo =
   testTask "event queue is fifo" {
+    let! owner = testOwner.Force()
     let name = "fifo"
-    do! clearCanvasData (CanvasName.create name)
-    let! meta = testCanvasInfo name
+    do! clearCanvasData owner (CanvasName.create name)
+    let! meta = testCanvasInfo owner name
     let apple = testWorker "apple" (p "event")
     let banana = testWorker "banana" (p "event")
 
@@ -108,8 +110,9 @@ let testEventQueueIsFifo =
 let testGetWorkerSchedulesForCanvas =
   testTask "worker schedules for canvas" {
     let name = "worker-schedules"
-    do! clearCanvasData (CanvasName.create name)
-    let! meta = testCanvasInfo name
+    let! owner = testOwner.Force()
+    do! clearCanvasData owner (CanvasName.create name)
+    let! meta = testCanvasInfo owner name
 
     let apple = testWorker "apple" (p "1")
     let banana = testWorker "banana" (p "1")

--- a/fsharp-backend/tests/Tests/HttpClient.Tests.fs
+++ b/fsharp-backend/tests/Tests/HttpClient.Tests.fs
@@ -104,6 +104,7 @@ let t filename =
 
   // Load the testcases first so that redirection works
   testTask $"HttpClient files: {filename}" {
+    let! owner = testOwner.Force()
     let testOCaml, testFSharp =
       if String.includes "FSHARPONLY" code then (false, true)
       else if String.includes "OCAMLONLY" code then (true, false)
@@ -126,7 +127,8 @@ let t filename =
         |> FSharpToExpr.parse
         |> FSharpToExpr.convertToTest
 
-      let! state = executionStateFor "test-httpclient-${name}" Map.empty Map.empty
+      let! state =
+        executionStateFor owner "test-httpclient-${name}" Map.empty Map.empty
 
       let! expected =
         Exe.executeExpr state Map.empty (expectedResult.toRuntimeType ())

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -30,12 +30,13 @@ let t
   else
     testTask name {
       try
+        let! owner = testOwner.Force()
         let rtDBs =
           (dbs |> List.map (fun db -> db.name, PT.DB.toRuntimeType db) |> Map.ofList)
 
         let rtFunctions = functions |> Map.map PT.UserFunction.toRuntimeType
 
-        let! state = executionStateFor name rtDBs rtFunctions
+        let! state = executionStateFor owner name rtDBs rtFunctions
 
         let source = FSharpToExpr.parse code
 

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -18,6 +18,7 @@ module Exe = LibExecution.Execution
 open TestUtils.TestUtils
 
 let t
+  (owner : Task<LibBackend.Account.UserInfo>)
   (comment : string)
   (code : string)
   (dbs : List<PT.DB.T>)
@@ -30,7 +31,7 @@ let t
   else
     testTask name {
       try
-        let! owner = testOwner.Force()
+        let! owner = owner
         let rtDBs =
           (dbs |> List.map (fun db -> db.name, PT.DB.toRuntimeType db) |> Map.ofList)
 
@@ -142,11 +143,13 @@ let fileTests () : Test =
     let mutable allTests = []
     let mutable functions : Map<string, PT.UserFunction.T> = Map.empty
     let mutable dbs : Map<string, PT.DB.T> = Map.empty
+    let owner =
+      if filename = "internal.tests" then testAdmin.Force() else testOwner.Force()
 
     let finish () =
       if currentTest.recording then
         let newTestCase =
-          t currentTest.name currentTest.code currentTest.dbs functions
+          t owner currentTest.name currentTest.code currentTest.dbs functions
 
         allTests <- allTests @ [ newTestCase ]
 
@@ -261,11 +264,11 @@ let fileTests () : Test =
         currentFn <- { currentFn with code = currentFn.code + "\n" + line }
       // 1-line test
       | Regex @"^(.*)\s+//\s+(.*)$" [ code; comment ] ->
-        let test = t $"{comment} (line {i})" code currentGroup.dbs functions
+        let test = t owner $"{comment} (line {i})" code currentGroup.dbs functions
 
         currentGroup <- { currentGroup with tests = currentGroup.tests @ [ test ] }
       | Regex @"^(.*)\s*$" [ code ] ->
-        let test = t $"line {i}" code currentGroup.dbs functions
+        let test = t owner $"line {i}" code currentGroup.dbs functions
 
         currentGroup <- { currentGroup with tests = currentGroup.tests @ [ test ] }
 

--- a/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
@@ -36,7 +36,8 @@ let compile
   (expr : Expr)
   : Task<string * Map<string, SqlValue>> =
   task {
-    let! state = executionStateFor "test" Map.empty Map.empty
+    let! owner = testOwner.Force()
+    let! state = executionStateFor owner "test" Map.empty Map.empty
 
     try
       let! sql, args =

--- a/fsharp-backend/tests/Tests/Traces.Tests.fs
+++ b/fsharp-backend/tests/Tests/Traces.Tests.fs
@@ -35,10 +35,11 @@ let testTraceIDsOfTlidsMatch : Test =
 
 let testFilterSlash : Test =
   testTask "test that a request which doesnt match doesnt end up in the traces" {
-    do! clearCanvasData (CanvasName.create "test-filter_slash")
+    let! owner = testOwner.Force()
+    do! clearCanvasData owner (CanvasName.create "test-filter_slash")
     let route = "/:rest"
     let handler = testHttpRouteHandler route "GET" (PT.EBlank 0UL)
-    let! meta = testCanvasInfo "test-filter_slash"
+    let! meta = testCanvasInfo owner "test-filter_slash"
     let! (c : Canvas.T) = canvasForTLs meta [ PT.TLHandler handler ]
 
     let t1 = System.Guid.NewGuid()
@@ -54,13 +55,14 @@ let testFilterSlash : Test =
 let testRouteVariablesWorkWithStoredEvents : Test =
   testTask "route variables work with stored events" {
 
+    let! owner = testOwner.Force()
     let canvasName = "test-route_variables_works"
-    do! clearCanvasData (CanvasName.create canvasName)
+    do! clearCanvasData owner (CanvasName.create canvasName)
 
     // set up test
     let httpRoute = "/some/:vars/:and/such"
     let handler = testHttpRouteHandler httpRoute "GET" (PT.EBlank 0UL)
-    let! meta = testCanvasInfo canvasName
+    let! meta = testCanvasInfo owner canvasName
     let! (c : Canvas.T) = canvasForTLs meta [ PT.TLHandler handler ]
 
     // store an event and check it comes out
@@ -89,7 +91,8 @@ let testRouteVariablesWorkWithStoredEvents : Test =
 let testRouteVariablesWorkWithTraceInputsAndWildcards : Test =
   testTask "route variables work with trace inputs and wildcards" {
     let canvasName = "test-route_variables_works_with_withcards"
-    do! clearCanvasData (CanvasName.create canvasName)
+    let! owner = testOwner.Force()
+    do! clearCanvasData owner (CanvasName.create canvasName)
 
     // note hyphen vs undeerscore
     let route = "/api/create_token"
@@ -97,7 +100,7 @@ let testRouteVariablesWorkWithTraceInputsAndWildcards : Test =
 
     // set up test
     let handler = testHttpRouteHandler route "GET" (PT.EBlank 0UL)
-    let! meta = testCanvasInfo canvasName
+    let! meta = testCanvasInfo owner canvasName
     let! (c : Canvas.T) = canvasForTLs meta [ PT.TLHandler handler ]
 
     // store an event and check it comes out

--- a/fsharp-backend/tests/Tests/TypeChecker.Tests.fs
+++ b/fsharp-backend/tests/Tests/TypeChecker.Tests.fs
@@ -52,8 +52,9 @@ let testBasicTypecheckWorks : Test =
 let testErrorNotWrappedByErrorRail =
   testTask "error not wrapped by errorRail" {
     let expr = FSharpToExpr.parseRTExpr "Dict.get_v1 (List.empty_v0 []) \"hello\""
+    let! owner = testOwner.Force()
 
-    let! state = executionStateFor "error" Map.empty Map.empty
+    let! state = executionStateFor owner "error" Map.empty Map.empty
 
     let! result = Exe.executeExpr state Map.empty expr
 
@@ -76,10 +77,11 @@ let testArguments : Test =
           description = ""
           infix = false
           body = body }
+      let! owner = testOwner.Force()
 
       let expr = S.eApply (S.eUserFnVal name) []
       let fns = Map.ofList [ name, userFn ]
-      let! state = executionStateFor "error" Map.empty fns
+      let! state = executionStateFor owner "error" Map.empty fns
       let! result = Exe.executeExpr state Map.empty expr
       return normalizeDvalResult result
     }

--- a/fsharp-backend/tests/Tests/Undo.Tests.fs
+++ b/fsharp-backend/tests/Tests/Undo.Tests.fs
@@ -47,7 +47,7 @@ let testUndo : Test =
       task {
         let! meta = testCanvasInfo owner "test-undo"
         let c = Canvas.fromOplist meta [] ops |> Result.unwrapUnsafe
-        let! state = executionStateFor "test-undo" Map.empty Map.empty
+        let! state = executionStateFor owner "test-undo" Map.empty Map.empty
         let h = Map.get tlid c.handlers |> Option.unwrapUnsafe
         return! Exe.executeExpr state Map.empty (h.ast.toRuntimeType ())
       }

--- a/fsharp-backend/tests/Tests/Undo.Tests.fs
+++ b/fsharp-backend/tests/Tests/Undo.Tests.fs
@@ -34,7 +34,8 @@ let testUndoFns : Test =
 
 let testUndo : Test =
   testTask "test undo" {
-    do! clearCanvasData (CanvasName.create "test-undo")
+    let! owner = testOwner.Force()
+    do! clearCanvasData owner (CanvasName.create "test-undo")
     let tlid = 7UL
     let ha code = hop ({ handler code with tlid = tlid })
     let sp = PT.TLSavepoint tlid
@@ -44,7 +45,7 @@ let testUndo : Test =
 
     let exe (ops : PT.Oplist) =
       task {
-        let! meta = testCanvasInfo "test-undo"
+        let! meta = testCanvasInfo owner "test-undo"
         let c = Canvas.fromOplist meta [] ops |> Result.unwrapUnsafe
         let! state = executionStateFor "test-undo" Map.empty Map.empty
         let h = Map.get tlid c.handlers |> Option.unwrapUnsafe
@@ -80,7 +81,8 @@ let testCanvasVerificationUndoRenameDupedName : Test =
     let dbID2 = gid ()
     let nameID2 = gid ()
     let pos = { x = 0; y = 0 }
-    let! meta = testCanvasInfo "test-undo-verification"
+    let! owner = testOwner.Force()
+    let! meta = testCanvasInfo owner "test-undo-verification"
 
     let ops1 =
       [ PT.CreateDBWithBlankOr(dbID, pos, nameID, "Books")

--- a/fsharp-backend/tests/Tests/UserDB.Tests.fs
+++ b/fsharp-backend/tests/Tests/UserDB.Tests.fs
@@ -17,8 +17,9 @@ let p = FSharpToExpr.parseRTExpr
 
 let nullsAddedToMissingColumn =
   testTask "test for the hack that columns get null in all rows to start" {
+    let! owner = testOwner.Force()
     let name = "null_added_to_column"
-    do! clearCanvasData (CanvasName.create name)
+    do! clearCanvasData owner (CanvasName.create name)
 
     // Add DB with 1 col, add value
     let db1 : RT.DB.T =

--- a/fsharp-backend/tests/Tests/UserDB.Tests.fs
+++ b/fsharp-backend/tests/Tests/UserDB.Tests.fs
@@ -25,7 +25,7 @@ let nullsAddedToMissingColumn =
     let db1 : RT.DB.T =
       { tlid = gid (); name = "MyDB"; version = 0; cols = [ "x", RT.TStr ] }
 
-    let! state = executionStateFor name (Map [ "MyDB", db1 ]) Map.empty
+    let! state = executionStateFor owner name (Map [ "MyDB", db1 ]) Map.empty
     let expr = p @"DB.set_v1 { x = ""v"" } ""i"" MyDB"
     let! (result : RT.Dval) = Exe.executeExpr state Map.empty expr
     Expect.equal (RT.DObj(Map [ "x", RT.DStr "v" ])) result "no nulls"

--- a/fsharp-backend/tests/httpclienttestfiles/request-content-type-invalid-fsharp
+++ b/fsharp-backend/tests/httpclienttestfiles/request-content-type-invalid-fsharp
@@ -18,4 +18,4 @@ Content-Length: LENGTH
 (let reqHeaders = { ``Content-Type`` = "just an invalid string" } in
  let response = HttpClient.get_v5_ster "http://URL" {} reqHeaders in
  response) =
-   Test.typeError_v0 "The format of value 'just an invalid string' is invalid."
+   Test.typeError_v0 "Invalid content-type header"

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -1,7 +1,43 @@
-DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
+Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 22
+(List.length_v0 DarkInternal.allFunctions_v0 > 290) = true
 
-(Dict.size_v0 DarkInternal.getAndLogTableSizes_v0) > 0 = true
-
+[tests.grants]
 DarkInternal.orgsFor "test" = {}
 
+[test.grants and orgs]
+(let _ = DarkInternal.grant "test" "dark" "rw" in
+ DarkInternal.orgsFor "test") = { dark = "rw" }
+
+[test.grants and grants]
+(let _ = DarkInternal.grant "test" "dark" "rw" in
+ DarkInternal.grantsFor "dark") = { test = "rw" }
+
+[tests.sessions]
+
+// It allows these, just puts them in the DB
+// [test.newSessionForUsername_v0 invalid user]
+// (DarkInternal.newSessionForUsername_v0 "not a user") = Error "No user 'not a user'"
+
+// It allows these, just puts them in the DB
+// [test.newSessionForUsername_v1 invalid user]
+// (DarkInternal.newSessionForUsername_v1 "not a user") = Error "No user 'not a user'"
+
+[test.newSessionForUsername_v0 real user]
+(let session = DarkInternal.newSessionForUsername_v0_ster "test" in
+ DarkInternal.sessionKeyToUsername_v0 session) = Ok "test"
+
+[test.newSessionForUsername_v1 real user]
+(let session = DarkInternal.newSessionForUsername_v1_ster "test" in
+ DarkInternal.sessionKeyToUsername session.sessionKey) = Ok "test"
+
+[test.deleteSession]
+(let session1 = DarkInternal.newSessionForUsername_v1_ster "test" in
+ DarkInternal.deleteSession_v0 session1.sessionKey) = 1
+
+[tests.users]
 DarkInternal.getUser_v1 "test" = Just { admin = false; email = "test@darklang.com"; name = "Dark OCaml Tests"; username = "test"}
+DarkInternal.getUserByEmail_v0 "test@darklang.com" = Just { admin = false; email = "test@darklang.com"; name = "Dark OCaml Tests"; username = "test"}
+DarkInternal.usernameToUserInfo_v0 "test" = Just { admin = false; email = "test@darklang.com"; name = "Dark OCaml Tests"; username = "test"}
+DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
+
+[tests.canvases]

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -43,3 +43,25 @@ DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentaluserna
 [tests.canvases]
 DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "Unknown Err: \"No owner found for host not-a-canvas\"" // OCAMLONLY
 DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "User not found" // FSHARPONLY
+
+DarkInternal.getCORSSetting_v0 "test" = Nothing
+
+[test.roundtrip cors just empty]
+(let _ = DarkInternal.setCORSSetting_v0 "test" (Just []) in
+ DarkInternal.getCORSSetting_v0 "test") = Just []
+
+[test.roundtrip cors just list]
+(let _ = DarkInternal.setCORSSetting_v0 "test" (Just ["localhost:8000"]) in
+ DarkInternal.getCORSSetting_v0 "test") = Just ["localhost:8000"]
+
+[test.roundtrip cors just number]
+(let _ = DarkInternal.setCORSSetting_v0 "test" (Just 5) in
+ DarkInternal.getCORSSetting_v0 "test") = Just []
+
+[test.roundtrip cors just number list]
+(let _ = DarkInternal.setCORSSetting_v0 "test" (Just [5]) in
+ DarkInternal.getCORSSetting_v0 "test") = Just []
+
+[test.roundtrip cors just star]
+(let _ = DarkInternal.setCORSSetting_v0 "test" (Just "*") in
+ DarkInternal.getCORSSetting_v0 "test") = Just "*"

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -41,3 +41,5 @@ DarkInternal.usernameToUserInfo_v0 "test" = Just { admin = false; email = "test@
 DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
 
 [tests.canvases]
+DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "Unknown Err: \"No owner found for host not-a-canvas\"" // OCAMLONLY
+DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "User not found" // FSHARPONLY

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -48,6 +48,9 @@ DarkInternal.getCORSSetting_v0 "test-cors1" = Nothing
 DarkInternal.canvasIdOfCanvasName_v0 "not-a-canvas" = Nothing
 (DarkInternal.canvasIdOfCanvasName_v0 "test") |> Option.map_v1 (fun x -> String.length_v1 x) = Just 36
 
+DarkInternal.checkPermission_v0 "test" "dark" = ""
+DarkInternal.checkPermission_v0 "dark" "test" = "rw"
+
 [test.roundtrip cors just empty]
 (let _ = DarkInternal.setCORSSetting_v0 "test-cors2" (Just []) in
  DarkInternal.getCORSSetting_v0 "test-cors2") = Just []

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -10,7 +10,9 @@ DarkInternal.orgsFor "test" = {}
 
 [test.grants and grants]
 (let _ = DarkInternal.grant "test" "dark" "rw" in
- DarkInternal.grantsFor "dark") = { test = "rw" }
+ let result = DarkInternal.grantsFor "dark"
+ let _ = DarkInternal.grant "test" "dark" "" in
+ result) = { test = "rw" }
 
 [tests.sessions]
 

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -1,3 +1,3 @@
 DarkInternal.upsertUser_v1 "Name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'Name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
-(Dict::length DarkInternal::getAndLogTableSizes) > 0 = true
-DarkInternal.orgsFor "test" = ["test"]
+(Dict.size_v0 DarkInternal.getAndLogTableSizes_v0) > 0 = true
+DarkInternal.orgsFor "test" = {}

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -1,2 +1,3 @@
-// DarkInternal.upsertUser_v1 "Name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'Name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
-//(Dict::length DarkInternal::getAndLogTableSizes) > 0 = true
+DarkInternal.upsertUser_v1 "Name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'Name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
+(Dict::length DarkInternal::getAndLogTableSizes) > 0 = true
+DarkInternal.orgsFor "test" = ["test"]

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -1,3 +1,7 @@
 DarkInternal.upsertUser_v1 "Name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'Name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
+
 (Dict.size_v0 DarkInternal.getAndLogTableSizes_v0) > 0 = true
+
 DarkInternal.orgsFor "test" = {}
+
+DarkInternal.getUser_v1 "test" = Just { admin = false; email = "test@darklang.com"; name = "Dark OCaml Tests"; username = "test"}

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -44,24 +44,24 @@ DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentaluserna
 DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "Unknown Err: \"No owner found for host not-a-canvas\"" // OCAMLONLY
 DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "User not found" // FSHARPONLY
 
-DarkInternal.getCORSSetting_v0 "test" = Nothing
+DarkInternal.getCORSSetting_v0 "test-cors1" = Nothing
 
 [test.roundtrip cors just empty]
-(let _ = DarkInternal.setCORSSetting_v0 "test" (Just []) in
- DarkInternal.getCORSSetting_v0 "test") = Just []
+(let _ = DarkInternal.setCORSSetting_v0 "test-cors2" (Just []) in
+ DarkInternal.getCORSSetting_v0 "test-cors2") = Just []
 
 [test.roundtrip cors just list]
-(let _ = DarkInternal.setCORSSetting_v0 "test" (Just ["localhost:8000"]) in
- DarkInternal.getCORSSetting_v0 "test") = Just ["localhost:8000"]
+(let _ = DarkInternal.setCORSSetting_v0 "test-cors3" (Just ["localhost:8000"]) in
+ DarkInternal.getCORSSetting_v0 "test-cors3") = Just ["localhost:8000"]
 
 [test.roundtrip cors just number]
-(let _ = DarkInternal.setCORSSetting_v0 "test" (Just 5) in
- DarkInternal.getCORSSetting_v0 "test") = Just []
+(let _ = DarkInternal.setCORSSetting_v0 "test-cors4" (Just 5) in
+ DarkInternal.getCORSSetting_v0 "test-cors4") = Nothing
 
 [test.roundtrip cors just number list]
-(let _ = DarkInternal.setCORSSetting_v0 "test" (Just [5]) in
- DarkInternal.getCORSSetting_v0 "test") = Just []
+(let _ = DarkInternal.setCORSSetting_v0 "test-cors5" (Just [5]) in
+ DarkInternal.getCORSSetting_v0 "test-cors5") = Nothing
 
 [test.roundtrip cors just star]
-(let _ = DarkInternal.setCORSSetting_v0 "test" (Just "*") in
- DarkInternal.getCORSSetting_v0 "test") = Just "*"
+(let _ = DarkInternal.setCORSSetting_v0 "test-cors6" (Just "*") in
+ DarkInternal.getCORSSetting_v0 "test-cors6") = Just "*"

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -43,8 +43,10 @@ DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentaluserna
 [tests.canvases]
 DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "Unknown Err: \"No owner found for host not-a-canvas\"" // OCAMLONLY
 DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "User not found" // FSHARPONLY
-
 DarkInternal.getCORSSetting_v0 "test-cors1" = Nothing
+
+DarkInternal.canvasIdOfCanvasName_v0 "not-a-canvas" = Nothing
+(DarkInternal.canvasIdOfCanvasName_v0 "test") |> Option.map_v1 (fun x -> String.length_v1 x) = Just 36
 
 [test.roundtrip cors just empty]
 (let _ = DarkInternal.setCORSSetting_v0 "test-cors2" (Just []) in

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -1,4 +1,4 @@
-DarkInternal.upsertUser_v1 "Name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'Name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
+DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'name with space', must match /^[a-z][a-z0-9_]{2,20}$/"
 
 (Dict.size_v0 DarkInternal.getAndLogTableSizes_v0) > 0 = true
 


### PR DESCRIPTION
A collection of fixes to test DarkInternal libraries.


Stuff that was needed to do this:
- support admin users in tests for internal.tests
- fix remainder of analytics
- add telemetry on exceptions
- fix username validation
- improve errors when user not found
- replace some failwiths