### PR TITLE
Fix startup

### DIFF
--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -18,7 +18,10 @@ let init (serviceName : string) (runSideEffects : bool) : Task<unit> =
 
     if runSideEffects then do! Account.init serviceName
 
-    do! Canvas.checkTierOneHosts ()
+    // FSTODO: disabled for now as prevents startup. I _think_ this doesn't work
+    // because the legacyserver isn't ready, but I'm not sure. It's unclear why we're
+    // not seeing logs or exceptions associated with this - it seems to just hang.
+    // do! Canvas.checkTierOneHosts ()
 
     print $" Inited LibBackend in {serviceName}"
   }

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -33,7 +33,10 @@ let digest () = "0e91e490041f06fae012f850231eb6ab"
 let client =
   // In .NET 6, this is fine without having to do anything about socket exhaustion or
   // DNS.
-  new System.Net.Http.HttpClient()
+  let client = new System.Net.Http.HttpClient()
+  // We prefer that this raise than hang
+  client.Timeout <- System.TimeSpan.FromSeconds 5
+  client
 
 let legacyReq
   (endpoint : string)


### PR DESCRIPTION
The F# containers are not starting up correctly, due to the new checkTierOne canvas check. Let's disable this for now.