### PR TITLE
Get analysis errors into rollbar and the error bar

### DIFF
--- a/client/workers/FSharpAnalysisWrapper.res
+++ b/client/workers/FSharpAnalysisWrapper.res
@@ -21,5 +21,12 @@ let stringifyInput = (event: event): response =>
     }
   }
 
-let decodeOutput = str =>
-  Decode.result(Decoders.analysisEnvelope, Decode.string, Json.parseOrRaise(str))
+let decodeOutput = str => {
+  let result = Decode.result(Decoders.analysisEnvelope, Decode.string, Json.parseOrRaise(str))
+  switch result {
+  | Belt.Result.Ok(msg) => Belt.Result.Ok(msg)
+  | Belt.Result.Error(msg) =>
+    Unshared.Rollbar.send(msg, None, Js.Json.null)
+    Belt.Result.Error(Types.AnalysisParseError(msg))
+  }
+}


### PR DESCRIPTION
Fixes the last part of #3272. This gets errors from Wasm analysis into Rollbar and the red error bar.