### PR TITLE
Remove duplicated stdlib functions that were just renamed

### DIFF
--- a/fsharp-backend/src/ApiServer/Functions.fs
+++ b/fsharp-backend/src/ApiServer/Functions.fs
@@ -11,7 +11,7 @@ open Tablecloth
 module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
 
-// FSCLEANUP
+// CLEANUP
 // These types are to match the existing OCaml serializations that the frontend
 // can read
 type ParamMetadata =
@@ -35,7 +35,49 @@ type FunctionMetadata =
     deprecated : bool
     is_supported_in_query : bool }
 
-let allFunctions = LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns
+let functionsWithoutRenames =
+  LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns
+
+// -------------------------
+// renamed fns
+// -------------------------
+
+// To cut down on the amount of code, when we rename a function and make no other
+// changes, we don't duplicate it. Instead, we rename it and add the rename to this
+// list. At startup, the renamed functions are created and added to the list.
+let renamed =
+  let fn = RT.FQFnName.stdlibFnName
+  // old name first, new name second. The new one should still be in the codebase,
+  // the old one should not. If a function is renamed multiple times, add the latest
+  // rename first.
+  [ fn "DB" "query" 3, fn "DB" "queryExactFields" 0
+    fn "DB" "query" 2, fn "DB" "query" 3 // don't know why
+    fn "DB" "queryWithKey" 2, fn "DB" "queryExactFieldsWithKey" 0
+    fn "DB" "get" 1, fn "DB" "get" 2
+    fn "DB" "queryOne" 2, fn "DB" "queryOneWithExactFields" 0
+    fn "DB" "queryOneWithKey" 2, fn "DB" "queryOneWithExactFieldsWithKey" 0 ]
+
+
+let renamedFunctions : List<RT.BuiltInFn> =
+  let existing = functionsWithoutRenames |> List.map (fun fn -> fn.name, fn) |> Map
+  renamed
+  |> List.fold Map.empty (fun renamedFns (oldName, newName) ->
+    debuG "old" oldName
+    debuG "new" newName
+    let newFn =
+      Map.tryFind newName (Map.mergeFavoringLeft renamedFns existing)
+      |> Exception.unwrapOptionInternal
+           $"all fns should exist {oldName} -> {newName}"
+           [ "oldName", oldName; "newName", newName ]
+    Map.add
+      oldName
+      { newFn with name = oldName; deprecated = RT.RenamedTo newName }
+      renamedFns)
+  |> Map.values
+
+
+let allFunctions = functionsWithoutRenames @ renamedFunctions
+
 
 // CLEANUP not needed anymore
 let fsharpOnlyFns : Lazy<Set<string>> =

--- a/fsharp-backend/src/ApiServer/Functions.fs
+++ b/fsharp-backend/src/ApiServer/Functions.fs
@@ -35,49 +35,6 @@ type FunctionMetadata =
     deprecated : bool
     is_supported_in_query : bool }
 
-let functionsWithoutRenames =
-  LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns
-
-// -------------------------
-// renamed fns
-// -------------------------
-
-// To cut down on the amount of code, when we rename a function and make no other
-// changes, we don't duplicate it. Instead, we rename it and add the rename to this
-// list. At startup, the renamed functions are created and added to the list.
-let renamed =
-  let fn = RT.FQFnName.stdlibFnName
-  // old name first, new name second. The new one should still be in the codebase,
-  // the old one should not. If a function is renamed multiple times, add the latest
-  // rename first.
-  [ fn "DB" "query" 3, fn "DB" "queryExactFields" 0
-    fn "DB" "query" 2, fn "DB" "query" 3 // don't know why
-    fn "DB" "queryWithKey" 2, fn "DB" "queryExactFieldsWithKey" 0
-    fn "DB" "get" 1, fn "DB" "get" 2
-    fn "DB" "queryOne" 2, fn "DB" "queryOneWithExactFields" 0
-    fn "DB" "queryOneWithKey" 2, fn "DB" "queryOneWithExactFieldsWithKey" 0 ]
-
-
-let renamedFunctions : List<RT.BuiltInFn> =
-  let existing = functionsWithoutRenames |> List.map (fun fn -> fn.name, fn) |> Map
-  renamed
-  |> List.fold Map.empty (fun renamedFns (oldName, newName) ->
-    debuG "old" oldName
-    debuG "new" newName
-    let newFn =
-      Map.tryFind newName (Map.mergeFavoringLeft renamedFns existing)
-      |> Exception.unwrapOptionInternal
-           $"all fns should exist {oldName} -> {newName}"
-           [ "oldName", oldName; "newName", newName ]
-    Map.add
-      oldName
-      { newFn with name = oldName; deprecated = RT.RenamedTo newName }
-      renamedFns)
-  |> Map.values
-
-
-let allFunctions = functionsWithoutRenames @ renamedFunctions
-
 
 // CLEANUP not needed anymore
 let fsharpOnlyFns : Lazy<Set<string>> =
@@ -156,11 +113,16 @@ let functionsToString (fns : RT.BuiltInFn list) : string =
   |> List.sortBy (fun fn -> fn.name)
   |> Json.Vanilla.prettySerialize
 
-let adminFunctions : Lazy<string> = lazy (allFunctions |> functionsToString)
+let adminFunctions : Lazy<string> =
+  lazy
+    (LibRealExecution.RealExecution.stdlibFns.Force()
+     |> Map.values
+     |> functionsToString)
 
 let nonAdminFunctions : Lazy<string> =
   lazy
-    (allFunctions
+    (LibRealExecution.RealExecution.stdlibFns.Force()
+     |> Map.values
      |> List.filter (function
        | { name = { module_ = "DarkInternal" } } -> false
        | _ -> true)

--- a/fsharp-backend/src/BackendOnlyStdLib/LibCrypto.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibCrypto.fs
@@ -30,6 +30,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = ImpurePreviewable
       deprecated = NotDeprecated }
+
+
     { name = fn "Crypto" "sha384" 0
       parameters = [ Param.make "data" TBytes "" ]
       returnType = TBytes
@@ -41,6 +43,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = ImpurePreviewable
       deprecated = NotDeprecated }
+
+
     { name = fn "Crypto" "md5" 0
       parameters = [ Param.make "data" TBytes "" ]
       returnType = TBytes
@@ -53,6 +57,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = ImpurePreviewable
       deprecated = NotDeprecated }
+
+
     { name = fn "Crypto" "sha256hmac" 0
       parameters = [ Param.make "key" TBytes ""; Param.make "data" TBytes "" ]
       returnType = TBytes
@@ -67,6 +73,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = ImpurePreviewable
       deprecated = NotDeprecated }
+
+
     { name = fn "Crypto" "sha1hmac" 0
       parameters = [ Param.make "key" TBytes ""; Param.make "data" TBytes "" ]
       returnType = TBytes

--- a/fsharp-backend/src/BackendOnlyStdLib/LibCrypto.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibCrypto.fs
@@ -12,11 +12,8 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
 let incorrectArgs = Errors.incorrectArgs
 
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Crypto" "sha256" 0

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDB.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDB.fs
@@ -27,6 +27,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "delete" 0
       parameters = [ Param.make "value" obj ""; Param.make "table" dbType "" ]
       returnType = TNull
@@ -38,6 +40,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "deleteAll" 0
       parameters = [ Param.make "table" dbType "" ]
       returnType = TNull
@@ -49,6 +53,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "update" 0
       parameters = [ Param.make "value" obj ""; Param.make "table" dbType "" ]
       returnType = TNull
@@ -60,6 +66,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "fetchBy" 0
       parameters =
         [ Param.make "value" varA ""
@@ -74,6 +82,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "fetchOneBy" 0
       parameters =
         [ Param.make "value" varA ""
@@ -88,6 +98,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "fetchByMany" 0
       parameters = [ Param.make "spec" obj ""; Param.make "table" dbType "" ]
       returnType = TList varA
@@ -100,6 +112,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "fetchOneByMany" 0
       parameters = [ Param.make "spec" obj ""; Param.make "table" dbType "" ]
       returnType = varA
@@ -112,6 +126,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "fetchAll" 0
       parameters = [ Param.make "table" dbType "" ]
       returnType = TList varA
@@ -123,6 +139,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "keys" 0
       parameters = [ Param.make "table" dbType "" ]
       returnType = TList varA
@@ -134,6 +152,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = DeprecatedBecause("Old DB functions have been removed") }
+
+
     { name = fn "DB" "schema" 0
       parameters = [ Param.make "table" dbType "" ]
       returnType = obj

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
@@ -9,9 +9,6 @@ module Db = LibBackend.Db
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
-let removedFunction = LibExecution.Errors.removedFunction
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"
@@ -19,12 +16,10 @@ let dbType = TDB varA
 
 // CLEANUP use varA for valParam
 let ocamlTObj = TDict(varA)
-let valParam = Param.make "val" varA ""
 let ocamlCompatibleValParam = Param.make "val" ocamlTObj ""
 let keyParam = Param.make "key" TStr ""
 let keysParam = Param.make "keys" (TList TStr) ""
 let tableParam = Param.make "table" dbType ""
-let specParam = Param.make "spec" varA ""
 let ocamlCompatibleSpecParam = Param.make "spec" ocamlTObj ""
 let queryParam = Param.makeWithArgs "filter" (TFn([ varA ], TBool)) "" [ "value" ]
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
@@ -45,6 +45,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "add" 0
       parameters = [ ocamlCompatibleValParam; tableParam ]
       returnType = TStr
@@ -63,6 +65,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "set" 1) }
+
+
     { name = fn "DB" "get" 2
       parameters = [ keyParam; tableParam ]
       returnType = TOption varA
@@ -79,6 +83,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "getMany" 1
       parameters = [ keysParam; tableParam ]
       returnType = TList varA
@@ -105,6 +111,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "getMany" 2) }
+
+
     { name = fn "DB" "getMany" 2
       parameters = [ keysParam; tableParam ]
       returnType = TList varA
@@ -130,6 +138,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "getMany" 3) }
+
+
     { name = fn "DB" "getMany" 3
       parameters = [ keysParam; tableParam ]
       returnType = TOption varA
@@ -159,6 +169,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "getExisting" 0
       parameters = [ keysParam; tableParam ]
       returnType = TList varA
@@ -184,6 +196,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "getManyWithKeys" 0
       parameters = [ keysParam; tableParam ]
       returnType = TList varA
@@ -210,6 +224,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "getManyWithKeys" 1) }
+
+
     { name = fn "DB" "getManyWithKeys" 1
       parameters = [ keysParam; tableParam ]
       returnType = TDict varA
@@ -235,6 +251,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "delete" 1
       parameters = [ keyParam; tableParam ]
       returnType = TNull
@@ -251,6 +269,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "deleteAll" 1
       parameters = [ tableParam ]
       returnType = TNull
@@ -267,6 +287,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "query" 1
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TList varA // heterogenous list
@@ -286,6 +308,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "query" 2) }
+
+
     { name = fn "DB" "queryExactFields" 0
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TList varA
@@ -303,6 +327,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "queryWithKey" 1
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TList varA
@@ -323,6 +349,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "queryExactFieldsWithKey" 0) }
+
+
     { name = fn "DB" "queryExactFieldsWithKey" 0
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = ocamlTObj
@@ -341,6 +369,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "queryOne" 1
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TOption varA
@@ -361,6 +391,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "queryOne" 2) }
+
+
     { name = fn "DB" "queryOneWithExactFields" 0
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TOption varA
@@ -381,6 +413,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "queryOneWithKey" 1
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TOption varA
@@ -401,6 +435,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "queryOneWithKey" 2) }
+
+
     { name = fn "DB" "queryOneWithExactFieldsWithKey" 0
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TOption varA
@@ -421,6 +457,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "getAll" 1
       parameters = [ tableParam ]
       returnType = TList varA
@@ -440,6 +478,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "getAll" 2) }
+
+
     { name = fn "DB" "getAll" 2
       parameters = [ tableParam ]
       returnType = TList varA
@@ -456,6 +496,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "getAll" 3) }
+
+
     { name = fn "DB" "getAll" 3
       parameters = [ tableParam ]
       returnType = TList varA
@@ -472,6 +514,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "getAllWithKeys" 1
       parameters = [ tableParam ]
       returnType = TList varA
@@ -491,6 +535,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "getAllWithKeys" 2) }
+
+
     { name = fn "DB" "getAllWithKeys" 2
       parameters = [ tableParam ]
       returnType = TDict(varA)
@@ -508,6 +554,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "count" 0
       parameters = [ tableParam ]
       returnType = TInt
@@ -525,6 +573,8 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated }
     // previously called `DB::keys`
+
+
     { name = fn "DB" "schemaFields" 1
       parameters = [ tableParam ]
       returnType = TList varA
@@ -543,6 +593,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "schema" 1
       parameters = [ tableParam ]
       returnType = ocamlTObj
@@ -562,6 +614,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "generateKey" 0
       parameters = []
       returnType = TStr
@@ -573,6 +627,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "keys" 1
       parameters = [ tableParam ]
       returnType = TList varA
@@ -590,6 +646,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "query" 4
       parameters = [ tableParam; queryParam ]
       returnType = TList varA
@@ -607,6 +665,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = QueryFunction
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "queryWithKey" 3
       parameters = [ tableParam; queryParam ]
       returnType = TDict(varA)
@@ -624,6 +684,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = QueryFunction
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "queryOne" 3
       parameters = [ tableParam; queryParam ]
       returnType = TList varA
@@ -644,6 +706,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "queryOne" 4) }
+
+
     { name = fn "DB" "queryOne" 4
       parameters = [ tableParam; queryParam ]
       returnType = TOption varA
@@ -664,6 +728,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = QueryFunction
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "queryOneWithKey" 3
       parameters = [ tableParam; queryParam ]
       returnType = TOption varA
@@ -684,6 +750,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DB" "queryCount" 0
       parameters = [ tableParam; queryParam ]
       returnType = TInt

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
@@ -63,22 +63,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "set" 1) }
-    { name = fn "DB" "get" 1
-      parameters = [ keyParam; tableParam ]
-      returnType = TOption varA
-      description = "Finds a value in `table` by `key"
-      fn =
-        (function
-        | state, [ DStr key; DDB dbname ] ->
-          uply {
-            let db = state.program.dbs[dbname]
-            let! result = UserDB.getOption state db key
-            return Dval.option result
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DB" "get" 2) }
     { name = fn "DB" "get" 2
       parameters = [ keyParam; tableParam ]
       returnType = TOption varA
@@ -302,41 +286,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "query" 2) }
-    { name = fn "DB" "query" 2
-
-      parameters = [ ocamlCompatibleSpecParam; tableParam ]
-      returnType = TList varA
-      description =
-        "Fetch all the values from `table` which have the same fields and values that `spec` has, returning a list of values"
-      fn =
-        (function
-        | state, [ DObj fields; DDB dbname ] ->
-          uply {
-            let db = state.program.dbs[dbname]
-            let! results = UserDB.queryExactFields state db fields
-            return results |> List.map snd |> Dval.list
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DB" "query" 3) }
-    { name = fn "DB" "query" 3
-      parameters = [ ocamlCompatibleSpecParam; tableParam ]
-      returnType = TList varA
-      description =
-        "Fetch all the values from `table` which have the same fields and values that `spec` has, returning a list of values"
-      fn =
-        (function
-        | state, [ (DObj fields); DDB dbname ] ->
-          uply {
-            let db = state.program.dbs[dbname]
-            let! results = UserDB.queryExactFields state db fields
-            return results |> List.map snd |> Dval.list
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DB" "queryExactFields" 0) }
     { name = fn "DB" "queryExactFields" 0
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TList varA
@@ -369,24 +318,6 @@ let fns : List<BuiltInFn> =
             let! result = UserDB.queryExactFields state db fields
 
             return result |> List.map (fun (k, v) -> DList [ DStr k; v ]) |> DList
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DB" "queryExactFieldsWithKey" 0) }
-    { name = fn "DB" "queryWithKey" 2
-      parameters = [ ocamlCompatibleSpecParam; tableParam ]
-      returnType = ocamlTObj
-      description =
-        "Fetch all the values from `table` which have the same fields and values that `spec` has
-          , returning {key : value} as an object"
-      fn =
-        (function
-        | state, [ DObj fields; DDB dbname ] ->
-          uply {
-            let db = state.program.dbs[dbname]
-            let! result = UserDB.queryExactFields state db fields
-            return result |> Map.ofList |> DObj
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -430,26 +361,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "queryOne" 2) }
-    { name = fn "DB" "queryOne" 2
-      parameters = [ ocamlCompatibleSpecParam; tableParam ]
-      returnType = TOption varA
-      description =
-        "Fetch exactly one value from `table` which have the same fields and values that `spec` has. If there is exactly one value, it returns Just value and if there is none or more than 1 found, it returns Nothing"
-      fn =
-        (function
-        | state, [ (DObj fields); DDB dbname ] ->
-          uply {
-            let db = state.program.dbs[dbname]
-            let! results = UserDB.queryExactFields state db fields
-
-            match results with
-            | [ (_, v) ] -> return DOption(Some v)
-            | _ -> return DOption None
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DB" "queryOneWithExactFields" 0) }
     { name = fn "DB" "queryOneWithExactFields" 0
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TOption varA
@@ -490,26 +401,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "DB" "queryOneWithKey" 2) }
-    { name = fn "DB" "queryOneWithKey" 2
-      parameters = [ ocamlCompatibleSpecParam; tableParam ]
-      returnType = TOption varA
-      description =
-        "Fetch exactly one value from `table` which have the same fields and values that `spec` has. If there is exactly one key/value pair, it returns Just {key: value} and if there is none or more than 1 found, it returns Nothing"
-      fn =
-        (function
-        | state, [ DObj fields; DDB dbname ] ->
-          uply {
-            let db = state.program.dbs[dbname]
-            let! results = UserDB.queryExactFields state db fields
-
-            match results with
-            | [ (k, v) ] -> return DOption(Some(DObj(Map.ofList [ (k, v) ])))
-            | _ -> return DOption None
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DB" "queryOneExactFieldsWithKey" 0) }
     { name = fn "DB" "queryOneWithExactFieldsWithKey" 0
       parameters = [ ocamlCompatibleSpecParam; tableParam ]
       returnType = TOption varA

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -76,6 +76,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "endUsers" 0
       parameters = []
       returnType = TList varA
@@ -96,6 +98,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "checkAllCanvases" 0
       parameters = []
       returnType = TNull
@@ -104,6 +108,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = DeprecatedBecause "oldinternal" }
+
+
     { name = fn "DarkInternal" "migrateAllCanvases" 0
       parameters = []
       returnType = TNull
@@ -112,6 +118,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = DeprecatedBecause "oldinternal" }
+
+
     { name = fn "DarkInternal" "cleanupOldTraces" 0
       parameters = []
       returnType = TNull
@@ -120,6 +128,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "DarkInternal" "cleanupOldTraces" 0) }
+
+
     { name = fn "DarkInternal" "cleanupOldTraces" 1
       parameters = []
       returnType = TFloat
@@ -131,6 +141,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "DarkInternal" "cleanupOldTracesForCanvas" 1) }
+
+
     { name = fn "DarkInternal" "cleanupOldTracesForCanvas" 1
       parameters = [ Param.make "canvas_id" TUuid "" ]
       returnType = TFloat
@@ -143,6 +155,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = DeprecatedBecause "old internal" }
+
+
     { name = fn "DarkInternal" "checkCanvas" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TBool
@@ -159,6 +173,8 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       // CLEANUP should be marked deprecated
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "migrateCanvas" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TResult(varA, TStr)
@@ -175,6 +191,8 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated }
     // deprecated = DeprecatedBecause "old internal" } CLEANUP
+
+
     { name = fn "DarkInternal" "upsertUser" 0
       parameters =
         [ Param.make "username" TStr ""
@@ -204,6 +222,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "DarkInternal" "upsertUser" 1) }
+
+
     { name = fn "DarkInternal" "insertUser" 1
       parameters =
         [ Param.make "username" TStr ""
@@ -230,6 +250,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "DarkInternal" "insertUser" 2) }
+
+
     { name = fn "DarkInternal" "insertUser" 2
       parameters =
         [ Param.make "username" TStr ""
@@ -268,6 +290,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "upsertUser" 1
       parameters =
         [ Param.make "username" TStr ""
@@ -300,6 +324,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getUser" 0
       parameters = [ Param.make "username" TStr "" ]
       returnType = TOption varA
@@ -321,6 +347,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "DarkInternal" "getUser" 1) }
+
+
     { name = fn "DarkInternal" "getUser" 1
       parameters = [ Param.make "username" TStr "" ]
       returnType = TOption varA
@@ -343,6 +371,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getUserByEmail" 0
       parameters = [ Param.make "email" TStr "" ]
       returnType = TOption varA
@@ -365,6 +395,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "setAdmin" 0
       parameters = [ Param.make "username" TStr ""; Param.make "admin" TBool "" ]
       returnType = TNull
@@ -383,6 +415,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getUsers" 0
       parameters = []
       returnType = TList TStr
@@ -398,6 +432,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getAllCanvases" 0
       parameters = []
       returnType = TList TStr
@@ -412,6 +448,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "canvasesFor" 0
       parameters = [ Param.make "account" TStr "" ]
       returnType = TList TStr
@@ -430,6 +468,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "schema" 0
       parameters = [ Param.make "host" TStr ""; Param.make "dbid" TStr "" ]
       returnType = TDict TStr
@@ -442,6 +482,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "canvasAsText" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TStr
@@ -455,6 +497,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "handlers" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TList varA
@@ -475,6 +519,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "functions" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TList varA
@@ -494,6 +540,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "canLoadTraces" 0
       parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
       returnType = TBool
@@ -506,6 +554,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getCORSSetting" 0
       parameters = [ Param.make "canvas" TStr "" ]
       returnType = TOption(varA)
@@ -529,6 +579,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "setCORSSetting" 0
       parameters =
         [ Param.make "canvas" TStr ""; Param.make "origins" (TOption varA) "" ]
@@ -575,6 +627,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "dbs" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TList TStr
@@ -597,6 +651,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "oplistInfo" 0
       parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
       returnType = TDict TStr
@@ -610,6 +666,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "storedEvents" 0
       parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
       returnType = TOption varA
@@ -619,6 +677,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "pushStrollerEvent" 0
       parameters =
         [ Param.make "canvas_id" TStr ""
@@ -631,6 +691,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "DarkInternal" "pushStrollerEvent" 1) }
+
+
     { name = fn "DarkInternal" "pushStrollerEvent" 1
       parameters =
         [ Param.make "canvas_id" TStr ""
@@ -654,6 +716,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "sessionKeyToUsername" 0
       parameters = [ Param.make "sessionKey" TStr "" ]
       returnType = TOption varA
@@ -670,6 +734,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "canvasIdOfCanvasName" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TOption varA
@@ -688,6 +754,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "usernameToUserInfo" 0
       parameters = [ Param.make "username" TStr "" ]
       returnType = TOption varA
@@ -715,6 +783,8 @@ that's already taken, returns an error."
       deprecated = NotDeprecated
 
     }
+
+
     { name = fn "DarkInternal" "grant" 0
       parameters =
         [ Param.make "username" TStr ""
@@ -756,6 +826,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "grantsFor" 0
       parameters = [ Param.make "org" TStr "" ]
       returnType = TDict(varA)
@@ -778,6 +850,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "orgsFor" 0
       parameters = [ Param.make "username" TStr "" ]
       returnType = TDict TStr
@@ -799,6 +873,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "checkPermission" 0
       parameters = [ Param.make "username" TStr ""; Param.make "canvas" TStr "" ]
       // CLEANUP: should be TStr
@@ -817,6 +893,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "log" 0
       parameters =
         [ Param.make "level" TStr ""
@@ -845,6 +923,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "fnsUsed" 0
       parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
       returnType = TList varA
@@ -857,6 +937,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "fieldNamesUsed" 0
       parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
       returnType = TList varA
@@ -869,6 +951,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "fnMetadata" 0
       parameters = [ Param.make "name" TStr "" ]
       returnType = TResult(varA, TStr)
@@ -881,6 +965,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "allFunctions" 0
       parameters = []
       returnType = TList varA
@@ -912,6 +998,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "clearStaticAssets" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TNull
@@ -924,6 +1012,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getAllSchedulingRules" 0
       parameters = []
       returnType = TList varA
@@ -939,6 +1029,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getSchedulingRulesForCanvas" 0
       parameters = [ Param.make "canvas_id" TUuid "" ]
       returnType = TList varA
@@ -956,6 +1048,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "addWorkerSchedulingBlock" 0
       parameters =
         [ Param.make "canvas_id" TUuid ""; Param.make "handler_name" TStr "" ]
@@ -966,6 +1060,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "removeWorkerSchedulingBlock" 0
       parameters =
         [ Param.make "canvas_id" TUuid ""; Param.make "handler_name" TStr "" ]
@@ -976,6 +1072,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "newSessionForUsername" 0
       parameters = [ Param.make "username" TStr "" ]
       returnType = TResult(TStr, TStr)
@@ -1004,6 +1102,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "DarkInternal" "newSessionForUsername" 1) }
+
+
     { name = fn "DarkInternal" "newSessionForUsername" 1
       parameters = [ Param.make "username" TStr "" ]
       returnType = TResult(TStr, TStr)
@@ -1040,6 +1140,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "deleteSession" 0
       parameters = [ Param.make "session_key" TStr "" ]
       returnType = TInt
@@ -1059,6 +1161,8 @@ that's already taken, returns an error."
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "DarkInternal" "getAndLogTableSizes" 0
       parameters = []
       returnType = TDict(varA)

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -21,8 +21,6 @@ open LibBackend
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"

--- a/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
@@ -12,12 +12,9 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "" "emit" 0

--- a/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
@@ -44,6 +44,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "" "emit" 0) }
+
+
     { name = fn "" "emit" 1
       parameters = [ Param.make "event" varA ""; Param.make "Name" TStr "" ]
       returnType = varA

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient5.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient5.fs
@@ -19,7 +19,6 @@ let err (str : string) = Ply(Dval.errStr str)
 let incorrectArgs = Errors.incorrectArgs
 
 let varA = TVariable "a"
-let varB = TVariable "b"
 let returnTypeOk = TVariable "result"
 let returnTypeErr = TVariable "error" // FSTODO
 let returnType = TResult(returnTypeOk, returnTypeErr)

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient5.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient5.fs
@@ -192,6 +192,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "put" 5
       parameters = parameters
       returnType = returnType
@@ -201,6 +203,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "get" 5
       parameters = parametersNoBody
       returnType = returnType
@@ -210,6 +214,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "delete" 5
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE the spec
       // says it may have a body
@@ -221,6 +227,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "options" 5
       parameters = parametersNoBody
       returnType = returnType
@@ -230,6 +238,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "head" 5
       parameters = parametersNoBody
       returnType = returnType
@@ -239,6 +249,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "patch" 5
       parameters = parameters
       returnType = returnType

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
@@ -12,12 +12,7 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
-
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 // This is deprecated in favor of [encodeBasicAuth u p] due to using non-unicode append
 let encodeBasicAuthBroken (u : string) (p : string) : string =

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
@@ -59,6 +59,8 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       sqlSpec = NotYetImplementedTODO
       deprecated = ReplacedBy(fn "HttpClient" "basicAuth" 1) }
+
+
     { name = fn "HttpClient" "basicAuth" 1
       parameters = [ Param.make "username" TStr ""; Param.make "password" TStr "" ]
       returnType = TDict TStr

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -384,6 +384,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "JWT" "signAndEncode" 1) }
+
+
     { name = fn "JWT" "signAndEncodeWithHeaders" 0
       parameters =
         [ Param.make "pemPrivKey" TStr ""
@@ -400,6 +402,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "JWT" "signAndEncodeWithHeaders" 1) }
+
+
     { name = fn "JWT" "signAndEncode" 1
       parameters = [ Param.make "pemPrivKey" TStr ""; Param.make "payload" varA "" ]
       returnType = TResult(varB, varErr)
@@ -416,6 +420,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "JWT" "signAndEncodeWithHeaders" 1
       parameters =
         [ Param.make "pemPrivKey" TStr ""
@@ -435,6 +441,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "JWT" "verifyAndExtract" 0
       parameters = [ Param.make "pemPubKey" TStr ""; Param.make "token" TStr "" ]
       returnType = TOption varA
@@ -468,6 +476,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "JWT" "verifyAndExtract" 1) }
+
+
     { name = fn "JWT" "verifyAndExtract" 1
       parameters = [ Param.make "pemPubKey" TStr ""; Param.make "token" TStr "" ]
       returnType = TResult(varA, varErr)

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -12,8 +12,6 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"

--- a/fsharp-backend/src/BackendOnlyStdLib/LibPassword.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibPassword.fs
@@ -13,11 +13,8 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
 let incorrectArgs = Errors.incorrectArgs
 
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Password" "hash" 0

--- a/fsharp-backend/src/BackendOnlyStdLib/LibPassword.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibPassword.fs
@@ -52,6 +52,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "Password" "check" 0
       parameters =
         [ Param.make "existingpwr" TPassword ""; Param.make "rawpw" TStr "" ]

--- a/fsharp-backend/src/BackendOnlyStdLib/StdLib.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/StdLib.fs
@@ -9,6 +9,17 @@ open Prelude
 
 module RT = LibExecution.RuntimeTypes
 
+let fn = RT.FQFnName.stdlibFnName
+
+let renames =
+  [ fn "DB" "query" 3, fn "DB" "queryExactFields" 0
+    fn "DB" "query" 2, fn "DB" "query" 3 // don't know why these are the same
+    fn "DB" "queryWithKey" 2, fn "DB" "queryExactFieldsWithKey" 0
+    fn "DB" "get" 1, fn "DB" "get" 2 // don't know why these are the same
+    fn "DB" "queryOne" 2, fn "DB" "queryOneWithExactFields" 0
+    fn "DB" "queryOneWithKey" 2, fn "DB" "queryOneWithExactFieldsWithKey" 0 ]
+
+
 let fns : List<RT.BuiltInFn> =
   List.concat [ LibDB.fns
                 LibCrypto.fns
@@ -27,3 +38,4 @@ let fns : List<RT.BuiltInFn> =
                 LibTwilio.fns
                 LibX509.fns
                 LibDB2.fns ]
+  |> RT.renameFunctions renames

--- a/fsharp-backend/src/BackendOnlyStdLib/StdLib.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/StdLib.fs
@@ -20,22 +20,24 @@ let renames =
     fn "DB" "queryOneWithKey" 2, fn "DB" "queryOneWithExactFieldsWithKey" 0 ]
 
 
-let fns : List<RT.BuiltInFn> =
-  List.concat [ LibDB.fns
-                LibCrypto.fns
-                LibDarkInternal.fns
-                LibEvent.fns
-                LibHttpClient0.fns
-                LibHttpClient1.fns
-                LibHttpClient2.fns
-                LibHttpClient3.fns
-                LibHttpClient4.fns
-                LibHttpClient5.fns
-                LibHttpClientAuth.fns
-                LibJwt.fns
-                LibPassword.fns
-                LibStaticAssets.fns
-                LibTwilio.fns
-                LibX509.fns
-                LibDB2.fns ]
-  |> RT.renameFunctions renames
+let fns : Lazy<List<RT.BuiltInFn>> =
+  lazy
+    ([ LibDB.fns
+       LibCrypto.fns
+       LibDarkInternal.fns
+       LibEvent.fns
+       LibHttpClient0.fns
+       LibHttpClient1.fns
+       LibHttpClient2.fns
+       LibHttpClient3.fns
+       LibHttpClient4.fns
+       LibHttpClient5.fns
+       LibHttpClientAuth.fns
+       LibJwt.fns
+       LibPassword.fns
+       LibStaticAssets.fns
+       LibTwilio.fns
+       LibX509.fns
+       LibDB2.fns ]
+     |> List.concat
+     |> RT.renameFunctions renames)

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -896,3 +896,34 @@ let packageFnToFn (fn : Package.Fn) : Fn =
         NotDeprecated
     sqlSpec = NotQueryable
     fn = PackageFunction(fn.tlid, fn.body) }
+
+// -------------------------
+// renamed fns
+// -------------------------
+
+// To cut down on the amount of code, when we rename a function and make no other
+// changes, we don't duplicate it. Instead, we rename it and add the rename to this
+// list. At startup, the renamed functions are created and added to the list.
+
+// Renames is old name first, new name second. The new one should still be in the
+// codebase, the old one should not. If a function is renamed multiple times, add the
+// latest rename first.
+let renameFunctions
+  (renames : List<FQFnName.StdlibFnName * FQFnName.StdlibFnName>)
+  (existing : List<BuiltInFn>)
+  : List<BuiltInFn> =
+  let existingMap = existing |> List.map (fun fn -> fn.name, fn) |> Map
+  let newFns =
+    renames
+    |> List.fold Map.empty (fun renamedFns (oldName, newName) ->
+      let newFn =
+        Map.tryFind newName (Map.mergeFavoringLeft renamedFns existingMap)
+        |> Exception.unwrapOptionInternal
+             $"all fns should exist {oldName} -> {newName}"
+             [ "oldName", oldName; "newName", newName ]
+      Map.add
+        oldName
+        { newFn with name = oldName; deprecated = RenamedTo newName }
+        renamedFns)
+    |> Map.values
+  existing @ newFns

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -715,6 +715,8 @@ type Previewable =
 
 type Deprecation =
   | NotDeprecated
+  // The exact same function is available under a new, preferred name
+  | RenamedTo of FQFnName.StdlibFnName
   // This has been deprecated and has a replacement we can suggest
   | ReplacedBy of FQFnName.StdlibFnName
   // This has been deprecated and not replaced, provide a message for the user

--- a/fsharp-backend/src/LibExecutionStdLib/LibBool.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibBool.fs
@@ -25,6 +25,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "not"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Bool" "and" 0
       parameters = [ Param.make "a" TBool ""; Param.make "b" TBool "" ]
       returnType = TBool
@@ -36,6 +38,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "AND"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Bool" "or" 0
       parameters = [ Param.make "a" TBool ""; Param.make "b" TBool "" ]
       returnType = TBool
@@ -47,6 +51,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "OR"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Bool" "xor" 0
       parameters = [ Param.make "a" TBool ""; Param.make "b" TBool "" ]
       returnType = TBool
@@ -59,6 +65,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Bool" "isNull" 0
       parameters = [ Param.make "check" varA "" ]
       returnType = TBool
@@ -75,6 +83,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Bool" "isError" 0
       parameters = [ Param.make "check" varA "" ]
       returnType = TBool

--- a/fsharp-backend/src/LibExecutionStdLib/LibBool.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibBool.fs
@@ -10,7 +10,6 @@ let fn = FQFnName.stdlibFnName
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Bool" "not" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
@@ -24,6 +24,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Bytes" "hexEncode" 0
 
       parameters = [ Param.make "bytes" TBytes "" ]
@@ -50,6 +52,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Bytes" "length" 0
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TInt

--- a/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
@@ -31,6 +31,8 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated =
         DeprecatedBecause("used an old Character type that no longer exists") }
+
+
     { name = fn "Char" "toASCIIChar" 0
       parameters = [ Param.make "i" TInt "" ]
       returnType = TChar
@@ -43,6 +45,8 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated =
         DeprecatedBecause("used an old Character type that no longer exists") }
+
+
     { name = fn "Char" "toLowercase" 0
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar
@@ -55,6 +59,8 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated =
         DeprecatedBecause("used an old Character type that no longer exists") }
+
+
     { name = fn "Char" "toUppercase" 0
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar

--- a/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
@@ -11,12 +11,8 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Char" "toASCIICode" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
@@ -30,6 +30,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "Date" "parse" 1) }
+
+
     { name = fn "Date" "parse" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TDate, TStr)
@@ -46,6 +48,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "Date" "parse" 2) }
+
+
     { name = fn "Date" "parse" 2
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TDate, TStr)
@@ -62,6 +66,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "toString" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
@@ -74,6 +80,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "toStringISO8601BasicDateTime" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
@@ -86,6 +94,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "toStringISO8601BasicDate" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
@@ -97,6 +107,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "now" 0
       parameters = []
       returnType = TDate
@@ -108,6 +120,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "today" 0
       parameters = []
       returnType = TDate
@@ -121,6 +135,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "add" 0
       parameters = [ Param.make "d" TDate ""; Param.make "seconds" TInt "" ]
       returnType = TDate
@@ -132,6 +148,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "+"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "sub" 0
       parameters = [ Param.make "d" TDate ""; Param.make "seconds" TInt "" ]
       returnType = TDate
@@ -143,6 +161,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable // As the OCaml one wasn't
       previewable = Pure
       deprecated = ReplacedBy(fn "Date" "subtract" 0) }
+
+
     { name = fn "Date" "subtract" 0
       parameters = [ Param.make "d" TDate ""; Param.make "seconds" TInt "" ]
       returnType = TDate
@@ -154,6 +174,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "-"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "greaterThan" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
@@ -165,6 +187,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp ">"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "lessThan" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
@@ -176,6 +200,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp("<")
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "greaterThanOrEqualTo" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
@@ -187,6 +213,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp(">=")
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "lessThanOrEqualTo" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
@@ -198,6 +226,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp("<=")
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "toSeconds" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -215,6 +245,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "fromSeconds" 0
 
       parameters = [ Param.make "seconds" TInt "" ]
@@ -235,6 +267,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "toHumanReadable" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
@@ -290,6 +324,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = DeprecatedBecause "This function doesn't work" }
+
+
     { name = fn "Date" "year" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -301,6 +337,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'year'" ])
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "month" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -313,6 +351,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'month'" ])
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "day" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -324,6 +364,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'day'" ])
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "weekday" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -339,6 +381,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "hour" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -355,6 +399,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "Date" "hour" 1) }
+
+
     { name = fn "Date" "hour" 1
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -369,6 +415,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'hour'" ])
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "minute" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -388,6 +436,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'minute'" ])
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "second" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -402,6 +452,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'second'" ])
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Date" "atStartOfDay" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TDate

--- a/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
@@ -9,8 +9,6 @@ let fn = FQFnName.stdlibFnName
 
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Date" "parse" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
@@ -32,6 +32,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "size" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TInt
@@ -44,6 +46,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "keys" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = (TList TStr)
@@ -61,6 +65,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "values" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = (TList varA)
@@ -72,6 +78,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "toList" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = (TList varA)
@@ -88,6 +96,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "fromListOverwritingDuplicates" 0
       parameters = [ Param.make "entries" (TList varA) "" ]
       returnType = TDict varA
@@ -115,6 +125,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "fromList" 0
       parameters = [ Param.make "entries" (TList varA) "" ]
       returnType = TOption(TDict varA)
@@ -148,6 +160,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "get" 0
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = varA
@@ -163,6 +177,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "get" 1) }
+
+
     { name = fn "Dict" "get" 1
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TOption varA
@@ -174,6 +190,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "get" 2) }
+
+
     { name = fn "Dict" "get" 2
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TOption varA
@@ -186,6 +204,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "member" 0
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TBool
@@ -198,6 +218,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "foreach" 0
       parameters =
         [ Param.make "dict" (TDict varA) ""
@@ -221,6 +243,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "map" 0) }
+
+
     { name = fn "Dict" "map" 0
       parameters =
         [ Param.make "dict" (TDict varA) ""
@@ -253,6 +277,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "filter" 0
       parameters =
         [ Param.make "dict" (TDict varA) ""
@@ -296,6 +322,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "filter" 1) }
+
+
     { name = fn "Dict" "filter" 1
       parameters =
         [ Param.make "dict" (TDict varA) ""
@@ -345,6 +373,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "filterMap" 0
       parameters =
         [ Param.make "dict" (TDict varA) ""
@@ -406,6 +436,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "empty" 0
       parameters = []
       returnType = TDict varA
@@ -417,6 +449,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "isEmpty" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TBool
@@ -428,6 +462,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "merge" 0
       parameters =
         [ Param.make "left" (TDict varA) ""; Param.make "right" (TDict varA) "" ]
@@ -441,6 +477,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "toJSON" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TStr
@@ -453,6 +491,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "set" 0
       parameters =
         [ Param.make "dict" (TDict(TVariable "a")) ""
@@ -467,6 +507,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Dict" "remove" 0
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TDict varA

--- a/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
@@ -33,6 +33,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "roundUp" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
@@ -44,6 +46,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "floor" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
@@ -56,6 +60,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "roundDown" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
@@ -68,6 +74,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "round" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
@@ -79,6 +87,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "truncate" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
@@ -91,6 +101,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "absoluteValue" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TFloat
@@ -103,6 +115,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "negate" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TFloat
@@ -114,6 +128,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "sqrt" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TFloat
@@ -125,6 +141,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "power" 0
       parameters = [ Param.make "base" TFloat ""; Param.make "exponent" TFloat "" ]
       returnType = TFloat
@@ -136,6 +154,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "^"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "divide" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
@@ -147,6 +167,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "/"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "add" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
@@ -158,6 +180,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "+"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "multiply" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
@@ -169,6 +193,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "*"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "subtract" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
@@ -180,6 +206,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "-"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "greaterThan" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TBool
@@ -191,6 +219,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp ">"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "greaterThanOrEqualTo" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TBool
@@ -202,6 +232,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp ">="
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "lessThan" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TBool
@@ -213,6 +245,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "<"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "lessThanOrEqualTo" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TBool
@@ -224,6 +258,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "<="
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "sum" 0
       parameters = [ Param.make "a" (TList TFloat) "" ]
       returnType = TFloat
@@ -245,6 +281,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "min" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
@@ -256,6 +294,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "max" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
@@ -267,6 +307,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "clamp" 0
       parameters =
         [ Param.make "value" TFloat ""
@@ -289,6 +331,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Float" "roundTowardsZero" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt

--- a/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
@@ -10,17 +10,6 @@ let fn = FQFnName.stdlibFnName
 
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
-(* type coerces one list to another using a function *)
-// let list_coerce ~(f : dval -> 'a option) (l : dval list) :
-//     ('a list, dval list * dval) Result.t =
-//   l
-//   |> List.map (fun dv ->
-//          match f dv with Some v -> Result.Ok v | None -> Result.Error (l, dv))
-//   |> Result.all
-
-
-// let ( >>| ) = Result.( >>| )
-
 let fns : List<BuiltInFn> =
   [ { name = fn "Float" "ceiling" 0
       parameters = [ Param.make "a" TFloat "" ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
@@ -34,6 +34,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "response" 0) }
+
+
     { name = fn "Http" "response" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -49,6 +51,8 @@ let fns : List<BuiltInFn> =
     // TODO(ian): merge Http::respond with Http::respond_with_headers
     //  -- need to figure out how to deprecate functions w/o breaking
     //  user code
+
+
     { name = fn "Http" "respondWithHeaders" 0
       parameters =
         [ Param.make "response" varA ""
@@ -72,6 +76,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "responseWithHeaders" 0) }
+
+
     { name = fn "Http" "responseWithHeaders" 0
       parameters =
         [ Param.make "response" varA ""
@@ -95,6 +101,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "success" 0
       parameters = [ Param.make "response" varA "" ]
       returnType = THttpResponse varA
@@ -107,6 +115,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "respondWithHtml" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -120,6 +130,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "responseWithHtml" 0) }
+
+
     { name = fn "Http" "responseWithHtml" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -133,6 +145,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "respondWithText" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -146,6 +160,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "responseWithText" 0) }
+
+
     { name = fn "Http" "responseWithText" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -159,6 +175,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "respondWithJson" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -176,6 +194,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "responseWithJson" 0) }
+
+
     { name = fn "Http" "responseWithJson" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -193,6 +213,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "redirectTo" 0
       parameters = [ Param.make "url" TStr "" ]
       returnType = THttpResponse varA
@@ -205,6 +227,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "badRequest" 0
       parameters = [ Param.make "error" TStr "" ]
       returnType = THttpResponse varA
@@ -217,6 +241,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "notFound" 0
       parameters = []
       returnType = THttpResponse varA
@@ -229,6 +255,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "unauthorized" 0
       parameters = []
       returnType = THttpResponse varA
@@ -241,6 +269,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "forbidden" 0
       parameters = []
       returnType = THttpResponse varA
@@ -253,6 +283,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Http" "setCookie" 0
       parameters =
         [ Param.make "name" TStr ""
@@ -297,6 +329,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "setCookie" 1) }
+
+
     { name = fn "Http" "setCookie" 1
       parameters =
         [ Param.make "name" TStr ""
@@ -348,6 +382,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "setCookie" 2) }
+
+
     { name = fn "Http" "setCookie" 2
       parameters =
         [ Param.make "name" TStr ""

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
@@ -19,21 +19,7 @@ let incorrectArgs = LibExecution.Errors.incorrectArgs
 let varA = TVariable "a"
 
 let fns : List<BuiltInFn> =
-  [ { name = fn "Http" "respond" 0
-      parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
-      returnType = THttpResponse varA
-      description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body."
-      fn =
-        (function
-        | _, [ dv; DInt code ] -> Ply(DHttpResponse(Response(code, [], dv)))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Http" "response" 0) }
-
-
-    { name = fn "Http" "response" 0
+  [ { name = fn "Http" "response" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
       description =
@@ -45,34 +31,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
-    // TODO(ian): merge Http::respond with Http::respond_with_headers
-    //  -- need to figure out how to deprecate functions w/o breaking
-    //  user code
-
-
-    { name = fn "Http" "respondWithHeaders" 0
-      parameters =
-        [ Param.make "response" varA ""
-          Param.make "headers" (TDict varA) ""
-          Param.make "code" TInt "" ]
-      returnType = THttpResponse varA
-      description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code`, `response` body, and `headers`."
-      fn =
-        (function
-        | _, [ dv; DObj o; DInt code ] ->
-          let pairs =
-            Map.toList o
-            |> List.map (fun (k, v) ->
-              match k, v with
-              | k, DStr v -> k, v
-              | k, v -> Errors.throw (Errors.argumentWasnt "a string" "value" v))
-
-          Ply(DHttpResponse(Response(code, pairs, dv)))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Http" "responseWithHeaders" 0) }
 
 
     { name = fn "Http" "responseWithHeaders" 0
@@ -114,21 +72,6 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "Http" "respondWithHtml" 0
-      parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
-      returnType = THttpResponse varA
-      description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"text/html\"."
-      fn =
-        (function
-        | _, [ dv; DInt code ] ->
-          Ply(DHttpResponse(Response(code, [ ("Content-Type", "text/html") ], dv)))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Http" "responseWithHtml" 0) }
-
-
     { name = fn "Http" "responseWithHtml" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -144,21 +87,6 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "Http" "respondWithText" 0
-      parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
-      returnType = THttpResponse varA
-      description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"text/plain\"."
-      fn =
-        (function
-        | _, [ dv; DInt code ] ->
-          Ply(DHttpResponse(Response(code, [ ("Content-Type", "text/plain") ], dv)))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Http" "responseWithText" 0) }
-
-
     { name = fn "Http" "responseWithText" 0
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
@@ -172,25 +100,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
-
-
-    { name = fn "Http" "respondWithJson" 0
-      parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
-      returnType = THttpResponse varA
-      description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"application/json\""
-      fn =
-        (function
-        | _, [ dv; DInt code ] ->
-          Ply(
-            DHttpResponse(
-              Response(code, [ ("Content-Type", "application/json") ], dv)
-            )
-          )
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Http" "responseWithJson" 0) }
 
 
     { name = fn "Http" "responseWithJson" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
@@ -14,12 +14,9 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Http" "respond" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
@@ -15,8 +15,6 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "HttpClient" "formContentType" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
@@ -37,6 +37,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "jsonContentType" 0
       parameters = []
       returnType = TDict TStr
@@ -53,6 +55,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "plainTextContentType" 0
       parameters = []
       returnType = TDict TStr
@@ -65,6 +69,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "htmlContentType" 0
       parameters = []
       returnType = TDict TStr
@@ -77,6 +83,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "HttpClient" "bearerToken" 0
       parameters = [ Param.make "token" TStr "" ]
       returnType = TDict TStr
@@ -90,6 +98,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "HttpClient" "bearerToken" 1) }
+
+
     { name = fn "HttpClient" "bearerToken" 1
       parameters = [ Param.make "token" TStr "" ]
       returnType = TDict TStr

--- a/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
@@ -72,6 +72,8 @@ let fns : List<BuiltInFn> =
     ; sqlSpec = NotYetImplementedTODO
     ; previewable = Pure
     ; deprecated = NotDeprecated } *)
+
+
     { name = fn "Int" "remainder" 0
       parameters = [ Param.make "value" TInt ""; Param.make "divisor" TInt "" ]
       returnType = TResult(TInt, TStr)
@@ -96,6 +98,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "add" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TInt
@@ -107,6 +111,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "+"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "subtract" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TInt
@@ -118,6 +124,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "-"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "multiply" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TInt
@@ -129,6 +137,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "*"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "power" 0
       parameters = [ Param.make "base" TInt ""; Param.make "exponent" TInt "" ]
       returnType = TInt
@@ -157,6 +167,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "^"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "divide" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TInt
@@ -169,6 +181,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "/"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "absoluteValue" 0
       parameters = [ Param.make "a" TInt "" ]
       returnType = TInt
@@ -181,6 +195,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "negate" 0
       parameters = [ Param.make "a" TInt "" ]
       returnType = TInt
@@ -192,6 +208,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "greaterThan" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TBool
@@ -203,6 +221,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp ">"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "greaterThanOrEqualTo" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TBool
@@ -214,6 +234,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp ">="
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "lessThan" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TBool
@@ -225,6 +247,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "<"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "lessThanOrEqualTo" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TBool
@@ -236,6 +260,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "<="
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "random" 0
       parameters = [ Param.make "start" TInt ""; Param.make "end" TInt "" ]
       returnType = TInt
@@ -248,6 +274,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "Int" "random" 1) }
+
+
     { name = fn "Int" "random" 1
       parameters = [ Param.make "start" TInt ""; Param.make "end" TInt "" ]
       returnType = TInt
@@ -262,6 +290,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "sqrt" 0
       parameters = [ Param.make "a" TInt "" ]
       returnType = TFloat
@@ -273,6 +303,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "toFloat" 0
       parameters = [ Param.make "a" TInt "" ]
       returnType = TFloat
@@ -284,6 +316,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "sum" 0
       parameters = [ Param.make "a" (TList TInt) "" ]
       returnType = TInt
@@ -305,6 +339,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "max" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TInt
@@ -316,6 +352,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "min" 0
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TInt
@@ -327,6 +365,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Int" "clamp" 0
       parameters =
         [ Param.make "value" TInt ""

--- a/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
@@ -15,8 +15,6 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Int" "mod" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
@@ -37,6 +37,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "JSON" "read" 1) }
+
+
     { name = fn "JSON" "read" 1
       parameters = [ Param.make "json" TStr "" ]
       returnType = varA
@@ -52,6 +54,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "JSON" "parse" 0) }
+
+
     { name = fn "JSON" "parse" 0
       parameters = [ Param.make "json" TStr "" ]
       returnType = varA
@@ -67,6 +71,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "JSON" "parse" 1) }
+
+
     { name = fn "JSON" "parse" 1
       parameters = [ Param.make "json" TStr "" ]
       returnType = TResult(varA, varErr)

--- a/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
@@ -36,23 +36,6 @@ let fns : List<BuiltInFn> =
       deprecated = ReplacedBy(fn "JSON" "read" 1) }
 
 
-    { name = fn "JSON" "read" 1
-      parameters = [ Param.make "json" TStr "" ]
-      returnType = varA
-      description =
-        "Parses a json string and returns its value. HTTPClient functions, and our request handler, automatically parse JSON into the `body` and `jsonbody` fields, so you probably won't need this. However, if you need to consume bad JSON, you can use string functions to fix the JSON and then use this function to parse it."
-      fn =
-        (function
-        | _, [ DStr json ] ->
-          match DvalReprExternal.ofUnknownJsonV1 json with
-          | Ok dv -> Ply dv
-          | Error msg -> Ply(DError(SourceNone, msg))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "JSON" "parse" 0) }
-
-
     { name = fn "JSON" "parse" 0
       parameters = [ Param.make "json" TStr "" ]
       returnType = varA

--- a/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
@@ -12,13 +12,10 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varErr = TVariable "err"
 let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "JSON" "read" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -138,6 +138,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "head" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = varA
@@ -150,6 +152,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "head" 1) }
+
+
     { name = fn "List" "head" 1
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
@@ -161,6 +165,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "head" 2) }
+
+
     { name = fn "List" "head" 2
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
@@ -173,6 +179,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "tail" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption(TList varA)
@@ -189,6 +197,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "empty" 0
       parameters = []
       returnType = TList varA
@@ -200,6 +210,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "push" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
       returnType = TList varA
@@ -212,6 +224,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "pushBack" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
       returnType = TList varA
@@ -223,6 +237,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "last" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = varA
@@ -235,6 +251,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "last" 1) }
+
+
     { name = fn "List" "last" 1
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
@@ -247,6 +265,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "last" 2) }
+
+
     { name = fn "List" "last" 2
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
@@ -259,6 +279,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "reverse" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TList varA
@@ -270,6 +292,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "findFirst" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -297,6 +321,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "findFirst" 1) }
+
+
     { name = fn "List" "findFirst" 1
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -323,6 +349,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "findFirst" 2) }
+
+
     { name = fn "List" "findFirst" 2
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -349,6 +377,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "contains" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
       returnType = TBool
@@ -361,6 +391,8 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       // Deprecated in favor of List::member for consistency with Elm's naming
       deprecated = ReplacedBy(fn "List" "member" 0) }
+
+
     { name = fn "List" "member" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
       returnType = TBool
@@ -372,6 +404,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "repeat" 0
       parameters = [ Param.make "times" TInt ""; Param.make "val" varA "" ]
       returnType = TList varA
@@ -389,6 +423,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "length" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TInt
@@ -400,6 +436,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "range" 0
       parameters =
         [ Param.make "lowest" TInt "First, smallest number in the list"
@@ -415,6 +453,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "fold" 0
       parameters =
         [ Param.make "list" (TList varA) "" // CLEANUP add description "The list of items to process one at a time"
@@ -450,6 +490,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "flatten" 0
       parameters = [ Param.make "list" (TList(TList varA)) "" ]
       returnType = TList varA
@@ -468,6 +510,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "interpose" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "sep" varA "" ]
       returnType = TList varA
@@ -489,6 +533,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "interleave" 0
       parameters =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varB) "" ]
@@ -511,6 +557,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "uniqueBy" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -541,6 +589,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "isEmpty" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TBool
@@ -552,6 +602,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "sort" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TList varA
@@ -565,6 +617,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "sortBy" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -594,6 +648,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "sortByComparator" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -633,6 +689,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "append" 0
       parameters =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varA) "" ]
@@ -647,6 +705,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "filter" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -730,6 +790,8 @@ let fns : List<BuiltInFn> =
     //   sqlSpec = NotYetImplementedTODO
     //   previewable = Pure
     //   deprecated = NotDeprecated }
+
+
     { name = fn "List" "filter" 1
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -774,6 +836,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "filter" 2) }
+
+
     { name = fn "List" "filter" 2
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -819,6 +883,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "filterMap" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -869,6 +935,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "drop" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "count" TInt "" ]
       returnType = TList varA
@@ -883,6 +951,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "dropWhile" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -931,6 +1001,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "take" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "count" TInt "" ]
       returnType = TList varA
@@ -945,6 +1017,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "takeWhile" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -995,6 +1069,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "foreach" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -1020,6 +1096,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "map" 0) }
+
+
     { name = fn "List" "map" 0
       parameters =
         [ Param.make "list" (TList varA) "" // CLEANUP "The list to be operated on"
@@ -1044,6 +1122,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "indexedMap" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -1076,6 +1156,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "map2shortest" 0
       parameters =
         [ Param.make "as" (TList varA) ""
@@ -1109,6 +1191,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "map2" 0
       parameters =
         [ Param.make "as" (TList varA) ""
@@ -1147,6 +1231,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "zipShortest" 0
       parameters =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varB) "" ]
@@ -1174,6 +1260,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "zip" 0
       parameters =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varB) "" ]
@@ -1199,6 +1287,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "unzip" 0
       parameters = [ Param.make "pairs" (TList(TList varA)) "" ]
       returnType = TList(TList varA)
@@ -1237,6 +1327,8 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       // CLEANUP deprecate and replace with tuples
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "getAt" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "index" TInt "" ]
       returnType = TOption varA
@@ -1253,6 +1345,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "getAt" 1) }
+
+
     { name = fn "List" "getAt" 1
       parameters = [ Param.make "list" (TList varA) ""; Param.make "index" TInt "" ]
       returnType = TOption varA
@@ -1269,6 +1363,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "List" "randomElement" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA

--- a/fsharp-backend/src/LibExecutionStdLib/LibMath.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibMath.fs
@@ -11,12 +11,9 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Math" "pi" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibMath.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibMath.fs
@@ -31,6 +31,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "tau" 0
       parameters = []
       returnType = TFloat
@@ -43,6 +45,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "degrees" 0
       parameters = [ Param.make "angleInDegrees" TFloat "" ]
       returnType = TFloat
@@ -56,6 +60,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "turns" 0
       parameters = [ Param.make "angleInTurns" TFloat "" ]
       returnType = TFloat
@@ -69,6 +75,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "radians" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
@@ -82,6 +90,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "cos" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
@@ -95,6 +105,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "sin" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
@@ -108,6 +120,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "tan" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
@@ -121,6 +135,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "acos" 0
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TOption varA
@@ -142,6 +158,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "asin" 0
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TOption varA
@@ -163,6 +181,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "atan" 0
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TFloat
@@ -176,6 +196,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "atan2" 0
       parameters = [ Param.make "y" TFloat ""; Param.make "x" TFloat "" ]
       returnType = TFloat
@@ -189,6 +211,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "cosh" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
@@ -200,6 +224,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "sinh" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
@@ -211,6 +237,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Math" "tanh" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat

--- a/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -72,35 +72,6 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "" "assoc" 0
-      parameters =
-        [ Param.make "obj" (TDict varA) ""
-          Param.make "key" TStr ""
-          Param.make "val" varA "" ]
-      returnType = TDict varA
-      description = "Return a copy of `obj` with the `key` set to `val`."
-      fn =
-        (function
-        | _, [ DObj o; DStr k; v ] -> Ply(DObj(Map.add k v o))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Dict" "set" 0) }
-
-
-    { name = fn "" "dissoc" 0
-      parameters = [ Param.make "obj" (TDict varA) ""; Param.make "key" TStr "" ]
-      returnType = TDict varA
-      description = "Return a copy of `obj` with `key` unset."
-      fn =
-        (function
-        | _, [ DObj o; DStr k ] -> Ply(DObj(Map.remove k o))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Dict" "remove" 0) }
-
-
     { name = fn "" "toForm" 0
       parameters = [ Param.make "obj" (TDict varA) ""; Param.make "submit" TStr "" ]
       returnType = TStr

--- a/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -8,8 +8,6 @@ open LibExecution.RuntimeTypes
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"

--- a/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -30,6 +30,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "" "toRepr" 0
       parameters = [ Param.make "v" varA "" ]
       returnType = TStr
@@ -42,6 +44,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = DeprecatedBecause "Not intended for external use" }
+
+
     { name = fn "" "equals" 0
       parameters = [ Param.make "a" varA ""; Param.make "b" varA "" ]
       returnType = TBool
@@ -55,6 +59,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "="
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "" "notEquals" 0
       parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
       returnType = TBool
@@ -66,6 +72,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlBinOp "<>"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "" "assoc" 0
       parameters =
         [ Param.make "obj" (TDict varA) ""
@@ -80,6 +88,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "set" 0) }
+
+
     { name = fn "" "dissoc" 0
       parameters = [ Param.make "obj" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TDict varA
@@ -91,6 +101,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "remove" 0) }
+
+
     { name = fn "" "toForm" 0
       parameters = [ Param.make "obj" (TDict varA) ""; Param.make "submit" TStr "" ]
       returnType = TStr
@@ -121,6 +133,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = DeprecatedBecause "It is just a demo function" }
+
+
     { name = fn "Error" "toString" 0 // CLEANUP can’t actually call this
       parameters = [ Param.make "err" TError "" ]
       returnType = TStr
@@ -133,6 +147,8 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated =
         DeprecatedBecause "It is no longer allowed to use errors as arguments" }
+
+
     { name = fn "AWS" "urlencode" 0
       parameters = [ Param.make "str" TStr "" ]
       returnType = TStr
@@ -189,6 +205,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Twitter" "urlencode" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr

--- a/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
@@ -165,6 +165,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "empty" 0) }
+
+
     { name = fn "Object" "merge" 0
       parameters =
         [ Param.make "left" (TDict varA) ""; Param.make "right" (TDict varA) "" ]
@@ -178,6 +180,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "merge" 0) }
+
+
     { name = fn "Object" "toJSON" 0
       parameters = [ Param.make "obj" (TDict varA) "" ]
       returnType = TStr
@@ -190,6 +194,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Object" "toJSON" 1) }
+
+
     { name = fn "Object" "toJSON" 1
       parameters = [ Param.make "obj" (TDict varA) "" ]
       returnType = TStr

--- a/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
@@ -151,35 +151,7 @@ module PrettyResponseJsonV0 =
 
 
 let fns : List<BuiltInFn> =
-  [ { name = fn "Object" "empty" 0
-      parameters = []
-      returnType = TDict varA
-      description = "Return an empty object"
-      fn =
-        (function
-        | _, [] -> Ply(DObj(Map.empty))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Dict" "empty" 0) }
-
-
-    { name = fn "Object" "merge" 0
-      parameters =
-        [ Param.make "left" (TDict varA) ""; Param.make "right" (TDict varA) "" ]
-      returnType = TDict varA
-      description =
-        "Return a combined object with both objects' keys and values. If the same key exists in both `left` and `right`, then use the value from `right`"
-      fn =
-        (function
-        | _, [ DObj l; DObj r ] -> Ply(DObj(Map.mergeFavoringRight l r))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Dict" "merge" 0) }
-
-
-    { name = fn "Object" "toJSON" 0
+  [ { name = fn "Object" "toJSON" 0
       parameters = [ Param.make "obj" (TDict varA) "" ]
       returnType = TStr
       description = "Dumps `obj` to a JSON string"
@@ -190,18 +162,4 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = ReplacedBy(fn "Object" "toJSON" 1) }
-
-
-    { name = fn "Object" "toJSON" 1
-      parameters = [ Param.make "obj" (TDict varA) "" ]
-      returnType = TStr
-      description = "Dumps `obj` to a JSON string"
-      fn =
-        (function
-        | _, [ DObj o ] ->
-          DObj o |> DvalReprExternal.toPrettyMachineJsonStringV1 |> DStr |> Ply
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = ReplacedBy(fn "Dict" "toJSON" 0) } ]
+      deprecated = ReplacedBy(fn "Object" "toJSON" 1) } ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
@@ -16,12 +16,9 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 
 let fn = FQFnName.stdlibFnName
 
-let err (str : string) = Ply(Dval.errStr str)
-
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"
-let varB = TVariable "b"
 
 module PrettyResponseJsonV0 =
 

--- a/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
@@ -46,6 +46,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Option" "map" 1) }
+
+
     { name = fn "Option" "map" 1
       parameters = [ optionA; fnAToB ]
       returnType = TOption varB
@@ -67,6 +69,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Option" "map2" 0
       parameters =
         [ Param.make "option1" (TOption varA) ""
@@ -92,6 +96,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Option" "andThen" 0
       parameters =
         [ optionA
@@ -119,6 +125,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Option" "withDefault" 0
       parameters = [ optionA; Param.make "default" varA "" ]
       returnType = varA

--- a/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
@@ -47,6 +47,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "map" 1) }
+
+
     { name = fn "Result" "map" 1
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
@@ -70,6 +72,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Result" "mapError" 0
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
@@ -93,6 +97,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "mapError" 1) }
+
+
     { name = fn "Result" "mapError" 1
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
@@ -116,6 +122,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Result" "withDefault" 0
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
@@ -133,6 +141,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Result" "fromOption" 0
       parameters =
         [ Param.make "option" (TOption(varOk)) ""; Param.make "error" TStr "" ]
@@ -149,6 +159,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "fromOption" 1) }
+
+
     { name = fn "Result" "fromOption" 1
       parameters =
         [ Param.make "option" (TOption(varOk)) ""; Param.make "error" TStr "" ]
@@ -165,6 +177,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Result" "toOption" 0
       parameters = [ Param.make "result" (TResult(varOk, varErr)) "" ]
       returnType = TOption varB
@@ -179,6 +193,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "toOption" 1) }
+
+
     { name = fn "Result" "toOption" 1
       parameters = [ Param.make "result" (TResult(varOk, varErr)) "" ]
       returnType = TOption varB
@@ -193,6 +209,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Result" "map2" 0
       parameters =
         [ Param.make "result1" (TResult(varA, varErr)) ""
@@ -218,6 +236,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Result" "andThen" 0
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
@@ -247,6 +267,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "andThen" 1) }
+
+
     { name = fn "Result" "andThen" 1
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""

--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -23,8 +23,6 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
-let varA = TVariable "a"
-let varB = TVariable "b"
 
 let fns : List<BuiltInFn> =
   [ { name = fn "String" "isEmpty" 0

--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -38,6 +38,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "foreach" 0
       parameters =
         [ Param.make "s" TStr "" // CLEANUP "string to iterate over"
@@ -54,6 +56,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "foreach" 1) }
+
+
     { name = fn "String" "foreach" 1
       parameters =
         [ Param.make "s" TStr ""
@@ -96,6 +100,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "newline" 0
       parameters = []
       returnType = TStr
@@ -107,6 +113,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "toList" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TList TChar
@@ -118,6 +126,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toList" 1) }
+
+
     { name = fn "String" "toList" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TList TChar
@@ -135,6 +145,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "replaceAll" 0
       parameters =
         [ Param.make "s" TStr "" // CLEANUP "The string to operate on"
@@ -163,6 +175,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "replace"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "toInt" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TInt
@@ -185,6 +199,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toInt" 1) }
+
+
     { name = fn "String" "toInt" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TInt, TStr)
@@ -214,6 +230,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "toFloat" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TFloat
@@ -232,6 +250,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toFloat" 1) }
+
+
     { name = fn "String" "toFloat" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TFloat, TStr)
@@ -252,6 +272,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "toUppercase" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -271,6 +293,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "upper"
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toUppercase" 1) }
+
+
     { name = fn "String" "toUppercase" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -282,6 +306,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "upper"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "toLowercase" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -301,6 +327,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "lower"
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toLowercase" 1) }
+
+
     { name = fn "String" "toLowercase" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -312,6 +340,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "lower"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "length" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TInt
@@ -324,6 +354,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "length"
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "length" 1) }
+
+
     { name = fn "String" "length" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TInt
@@ -335,6 +367,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO // there isn't a unicode version of length
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "append" 0
       (* This used to provide "++" as an infix op.
        * It was moved to [String::append_v1] instead,
@@ -364,6 +398,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "append" 1) }
+
+
     { name = fn "String" "append" 1
       parameters = [ Param.make "s1" TStr ""; Param.make "s2" TStr "" ]
       returnType = TStr
@@ -377,6 +413,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "prepend" 0
       parameters = [ Param.make "s1" TStr ""; Param.make "s2" TStr "" ]
       returnType = TStr
@@ -389,6 +427,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "slugify" 0
       parameters = [ Param.make "string" TStr "" ]
       returnType = TStr
@@ -415,6 +455,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "slugify" 1) }
+
+
     { name = fn "String" "slugify" 1
       parameters = [ Param.make "string" TStr "" ]
       returnType = TStr
@@ -440,6 +482,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "slugify" 2) }
+
+
     { name = fn "String" "slugify" 2
       parameters = [ Param.make "string" TStr "" ]
       returnType = TStr
@@ -467,6 +511,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "reverse" 0
       parameters = [ Param.make "string" TStr "" ]
       returnType = TStr
@@ -479,6 +525,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "reverse"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "split" 0
       parameters = [ Param.make "s" TStr ""; Param.make "separator" TStr "" ]
       returnType = TList TStr
@@ -515,6 +563,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "join" 0
       parameters = [ Param.make "l" (TList TStr) ""; Param.make "separator" TStr "" ]
       returnType = TStr
@@ -536,6 +586,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "fromList" 0
       parameters = [ Param.make "l" (TList TChar) "" ]
       returnType = TStr
@@ -547,6 +599,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "fromList" 1) }
+
+
     { name = fn "String" "fromList" 1
       parameters = [ Param.make "l" (TList TChar) "" ]
       returnType = TStr
@@ -566,6 +620,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "fromChar" 0
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar
@@ -577,6 +633,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "fromChar" 1) }
+
+
     { name = fn "String" "fromChar" 1
       parameters = [ Param.make "c" TChar "" ]
       returnType = TStr
@@ -588,6 +646,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "base64Encode" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -605,6 +665,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "base64Decode" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -644,6 +706,8 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       // CLEANUP: this shouldnt return a string and should be deprecated
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "digest" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -665,6 +729,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "sha384" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -685,6 +751,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Crypto" "sha384" 0) }
+
+
     { name = fn "String" "sha256" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
@@ -705,6 +773,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "Crypto" "sha256" 0) }
+
+
     { name = fn "String" "random" 0
       parameters = [ Param.make "length" TInt "" ]
       returnType = TStr
@@ -733,6 +803,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "String" "random" 1) }
+
+
     { name = fn "String" "random" 1
       parameters = [ Param.make "length" TInt "" ]
       returnType = TResult(TStr, TStr)
@@ -761,6 +833,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = ReplacedBy(fn "String" "random" 1) }
+
+
     { name = fn "String" "random" 2
       parameters = [ Param.make "length" TInt "" ]
       returnType = TResult(TStr, TStr)
@@ -794,6 +868,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "htmlEscape" 0
       parameters = [ Param.make "html" TStr "" ]
       returnType = TStr
@@ -824,6 +900,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Impure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "toUUID" 0
       parameters = [ Param.make "uuid" TStr "" ]
       returnType = TUuid
@@ -843,6 +921,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toUUID" 1) }
+
+
     { name = fn "String" "toUUID" 1
       parameters = [ Param.make "uuid" TStr "" ]
       returnType = TResult(TUuid, TStr)
@@ -863,6 +943,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "isSubstring" 0
       parameters =
         [ Param.make "searchingFor" TStr ""; Param.make "lookingIn" TStr "" ]
@@ -875,6 +957,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "isSubstring" 1) }
+
+
     { name = fn "String" "isSubstring" 1
       parameters =
         [ Param.make "lookingIn" TStr ""; Param.make "searchingFor" TStr "" ]
@@ -890,6 +974,8 @@ let fns : List<BuiltInFn> =
           $"(strpos({lookingIn}, {searchingFor}) > 0)")
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "contains" 0) }
+
+
     { name = fn "String" "contains" 0
       parameters =
         [ Param.make "lookingIn" TStr ""; Param.make "searchingFor" TStr "" ]
@@ -905,6 +991,8 @@ let fns : List<BuiltInFn> =
           $"strpos({lookingIn}, {searchingFor}) > 0")
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "slice" 0
       parameters =
         [ Param.make "string" TStr ""
@@ -944,6 +1032,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "first" 0
       parameters =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
@@ -968,6 +1058,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "last" 0
       parameters =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
@@ -1014,6 +1106,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "dropLast" 0
       parameters =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
@@ -1058,6 +1152,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "dropFirst" 0
       parameters =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
@@ -1095,6 +1191,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "padStart" 0
       parameters =
         [ Param.make "string" TStr ""
@@ -1126,6 +1224,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "padEnd" 0
       parameters =
         [ Param.make "string" TStr ""
@@ -1157,6 +1257,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "trim" 0
       parameters = [ Param.make "str" TStr "" ]
       returnType = TStr
@@ -1169,6 +1271,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "trim"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "trimStart" 0
       parameters = [ Param.make "str" TStr "" ]
       returnType = TStr
@@ -1181,6 +1285,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "ltrim"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "trimEnd" 0
       parameters = [ Param.make "str" TStr "" ]
       returnType = TStr
@@ -1193,6 +1299,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = SqlFunction "rtrim"
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "toBytes" 0
       parameters = [ Param.make "str" TStr "" ]
       returnType = TBytes
@@ -1207,6 +1315,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "startsWith" 0
       parameters = [ Param.make "subject" TStr ""; Param.make "prefix" TStr "" ]
       returnType = TBool
@@ -1219,6 +1329,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "String" "endsWith" 0
       parameters =
         [ Param.make "subject" TStr "" // CLEANUP "String to test"

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -5,8 +5,6 @@ open LibExecution.RuntimeTypes
 
 module DvalReprExternal = LibExecution.DvalReprExternal
 
-let incorrectArgs = LibExecution.Errors.incorrectArgs
-
 let prefixFns : List<BuiltInFn> =
   List.concat [ LibBool.fns
                 LibBytes.fns
@@ -27,6 +25,10 @@ let prefixFns : List<BuiltInFn> =
                 LibOption.fns
                 LibResult.fns
                 LibString.fns ]
+
+// -------------------------
+// Infix fns
+// -------------------------
 
 // Map of prefix names to their infix versions
 let infixFnMapping =
@@ -71,4 +73,29 @@ let infixFns : List<BuiltInFn> =
   assertEq "All infixes are parsed" fns.Length infixFnMapping.Count // make sure we got them all
   fns
 
-let fns = infixFns @ prefixFns
+
+// -------------------------
+// renamed fns
+// -------------------------
+
+// To cut down on the amount of code, when we rename a function and make no other
+// changes, we don't duplicate it. Instead, we rename it and add the rename to this
+// list. At startup, the renamed functions are created and added to the list.
+let renamed =
+  let fn = FQFnName.stdlibFnName
+  // old name first, new name second. The new one should still be in the codebase
+  [ fn "DB" "query" 3, fn "DB" "queryExactFields" 0
+    fn "DB" "query" 2, fn "DB" "queryExactFields" 3 // don't know why
+    fn "DB" "queryWithKey" 2, fn "DB" "queryExactFieldsWithKey" 0
+    fn "DB" "get" 1, fn "DB" "get" 2
+    fn "DB" "queryOne" 2, fn "DB" "queryOneWithExactFields" 0
+    fn "DB" "queryOneWithKey" 2, fn "DB" "queryOneExactFieldsWithKey" 0
+    fn "x" "x" 0, fn "x" "x" 0 ]
+
+let renamedFunctions = []
+
+
+// -------------------------
+// All fns
+// -------------------------
+let fns = infixFns @ prefixFns @ renamedFunctions

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -21,27 +21,29 @@ let renames =
     fn "Object" "toJSON" 1, fn "Dict" "toJSON" 0 ]
 
 
-let prefixFns : List<BuiltInFn> =
-  List.concat [ LibBool.fns
-                LibBytes.fns
-                LibChar.fns
-                LibDate.fns
-                LibDict.fns
-                LibFloat.fns
-                LibHttp.fns
-                LibHttpClient.fns
-                LibJson.fns
-                LibMath.fns
-                LibObject.fns
-                LibUuid.fns
-                LibInt.fns
-                LibList.fns
-                // LibMiddleware.fns
-                LibNoModule.fns
-                LibOption.fns
-                LibResult.fns
-                LibString.fns ]
-  |> renameFunctions renames
+let prefixFns : Lazy<List<BuiltInFn>> =
+  lazy
+    ([ LibBool.fns
+       LibBytes.fns
+       LibChar.fns
+       LibDate.fns
+       LibDict.fns
+       LibFloat.fns
+       LibHttp.fns
+       LibHttpClient.fns
+       LibJson.fns
+       LibMath.fns
+       LibObject.fns
+       LibUuid.fns
+       LibInt.fns
+       LibList.fns
+       // LibMiddleware.fns
+       LibNoModule.fns
+       LibOption.fns
+       LibResult.fns
+       LibString.fns ]
+     |> List.concat
+     |> renameFunctions renames)
 
 // -------------------------
 // Infix fns
@@ -79,20 +81,21 @@ let infixFnNames =
 // Is this the name of an infix function?
 let isInfixName (name : FQFnName.StdlibFnName) = infixFnNames.Contains name
 
-let infixFns : List<BuiltInFn> =
-  let fns =
-    List.choose
-      (fun (builtin : BuiltInFn) ->
+let infixFns : Lazy<List<BuiltInFn>> =
+  lazy
+    (let fns =
+      prefixFns
+      |> Lazy.force
+      |> List.choose (fun (builtin : BuiltInFn) ->
         let opName = infixFnMapping.TryFind builtin.name
         Option.map (fun newName -> { builtin with name = newName }) opName)
-      prefixFns
 
-  assertEq "All infixes are parsed" fns.Length infixFnMapping.Count // make sure we got them all
-  fns
+     assertEq "All infixes are parsed" fns.Length infixFnMapping.Count // make sure we got them all
+     fns)
 
 
 
 // -------------------------
 // All fns
 // -------------------------
-let fns = infixFns @ prefixFns
+let fns = lazy (Lazy.force infixFns @ Lazy.force prefixFns)

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -74,28 +74,8 @@ let infixFns : List<BuiltInFn> =
   fns
 
 
-// -------------------------
-// renamed fns
-// -------------------------
-
-// To cut down on the amount of code, when we rename a function and make no other
-// changes, we don't duplicate it. Instead, we rename it and add the rename to this
-// list. At startup, the renamed functions are created and added to the list.
-let renamed =
-  let fn = FQFnName.stdlibFnName
-  // old name first, new name second. The new one should still be in the codebase
-  [ fn "DB" "query" 3, fn "DB" "queryExactFields" 0
-    fn "DB" "query" 2, fn "DB" "queryExactFields" 3 // don't know why
-    fn "DB" "queryWithKey" 2, fn "DB" "queryExactFieldsWithKey" 0
-    fn "DB" "get" 1, fn "DB" "get" 2
-    fn "DB" "queryOne" 2, fn "DB" "queryOneWithExactFields" 0
-    fn "DB" "queryOneWithKey" 2, fn "DB" "queryOneExactFieldsWithKey" 0
-    fn "x" "x" 0, fn "x" "x" 0 ]
-
-let renamedFunctions = []
-
 
 // -------------------------
 // All fns
 // -------------------------
-let fns = infixFns @ prefixFns @ renamedFunctions
+let fns = infixFns @ prefixFns

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -5,6 +5,22 @@ open LibExecution.RuntimeTypes
 
 module DvalReprExternal = LibExecution.DvalReprExternal
 
+let fn = FQFnName.stdlibFnName
+
+let renames =
+  [ fn "Http" "respond" 0, fn "Http" "response" 0
+    fn "Http" "respondWithHtml" 0, fn "Http" "responseWithHtml" 0
+    fn "Http" "respondWithText" 0, fn "Http" "responseWithText" 0
+    fn "Http" "respondWithJson" 0, fn "Http" "responseWithJson" 0
+    fn "Http" "respondWithHeaders" 0, fn "Http" "responseWithHeaders" 0
+    fn "" "assoc" 0, fn "Dict" "add" 0
+    fn "" "dissoc" 0, fn "Dict" "remove" 0
+    fn "JSON" "read" 1, fn "JSON" "parse" 0
+    fn "Object" "empty" 0, fn "Dict" "empty" 0
+    fn "Object" "merge" 0, fn "Dict" "merge" 0
+    fn "Object" "toJSON" 1, fn "Dict" "toJSON" 0 ]
+
+
 let prefixFns : List<BuiltInFn> =
   List.concat [ LibBool.fns
                 LibBytes.fns
@@ -25,6 +41,7 @@ let prefixFns : List<BuiltInFn> =
                 LibOption.fns
                 LibResult.fns
                 LibString.fns ]
+  |> renameFunctions renames
 
 // -------------------------
 // Infix fns

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -13,7 +13,7 @@ let renames =
     fn "Http" "respondWithText" 0, fn "Http" "responseWithText" 0
     fn "Http" "respondWithJson" 0, fn "Http" "responseWithJson" 0
     fn "Http" "respondWithHeaders" 0, fn "Http" "responseWithHeaders" 0
-    fn "" "assoc" 0, fn "Dict" "add" 0
+    fn "" "assoc" 0, fn "Dict" "set" 0
     fn "" "dissoc" 0, fn "Dict" "remove" 0
     fn "JSON" "read" 1, fn "JSON" "parse" 0
     fn "Object" "empty" 0, fn "Dict" "empty" 0

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -19,7 +19,8 @@ open LibBackend
 
 let stdlibFns : Lazy<Map<RT.FQFnName.T, RT.BuiltInFn>> =
   lazy
-    (LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns
+    (Lazy.force LibExecutionStdLib.StdLib.fns
+     @ Lazy.force BackendOnlyStdLib.StdLib.fns
      |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name))
 
 let packageFns : Lazy<Task<Map<RT.FQFnName.T, RT.Package.Fn>>> =

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -100,10 +100,10 @@ let sendAlert
   Rollbar.RollbarLocator.RollbarInstance.Log(level, message, custom)
   |> ignore<Rollbar.ILogger>
 
-let tagsFromDarkException (e : exn) =
+let exceptionMetadata (e : exn) =
   try
     match e with
-    | :? DarkException as e -> e.tags ()
+    | :? DarkException as e -> Exception.toMetadata e
     | _ -> []
   with
   | _ -> []
@@ -126,7 +126,7 @@ let sendException
     print $"rollbar: {message}"
     print e.Message
     print e.StackTrace
-    let metadata = metadata @ tagsFromDarkException e @ pageableMetadata e
+    let metadata = metadata @ exceptionMetadata e @ pageableMetadata e
     printMetadata metadata
     Telemetry.addException message e metadata
     let custom = createState message executionID metadata
@@ -152,7 +152,7 @@ let lastDitchBlocking
     print $"last ditch rollbar: {message}"
     print e.Message
     print e.StackTrace
-    let metadata = metadata @ tagsFromDarkException e @ pageableMetadata e
+    let metadata = metadata @ exceptionMetadata e @ pageableMetadata e
     Telemetry.addException message e metadata
     let custom = createState message executionID metadata
     Rollbar
@@ -219,7 +219,7 @@ module AspNet =
                 ctxMetadataFn ctx
               with
               | _ -> emptyPerson, [ "exception calling ctxMetadataFn", true ]
-            let metadata = metadata @ tagsFromDarkException e @ pageableMetadata e
+            let metadata = metadata @ exceptionMetadata e @ pageableMetadata e
             let custom = createState "http" executionID metadata
 
             let package : Rollbar.IRollbarPackage =

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -93,14 +93,6 @@ exception DarkException of data : DarkExceptionData with
     | LibraryError (msg, _) -> msg
     | GrandUserError msg -> msg
 
-  member this.tags() : List<string * obj> =
-    match this.data with
-    | InternalError (_, tags)
-    | LibraryError (_, tags) -> tags
-    | DeveloperError _
-    | EditorError _
-    | GrandUserError _ -> []
-
 
 exception PageableException of inner : System.Exception with
   override this.Message = this.inner.Message

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -189,6 +189,7 @@ module Eval =
 
       let stdlib =
         LibExecutionStdLib.StdLib.fns
+        |> Lazy.force
         |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
 
       // FSTODO: get packages from caller

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -1179,7 +1179,9 @@ module ExecutePureFunctions =
           member x.Generator =
             gen {
               let fns =
-                (LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns)
+                LibRealExecution.RealExecution.stdlibFns
+                |> Lazy.force
+                |> Map.values
                 |> List.filter (fun fn ->
                   let name = string fn.name
                   let has set = Set.contains name set

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -252,11 +252,11 @@ let testDB (name : string) (cols : List<PT.DB.Col>) : PT.DB.T =
 
 let libraries : Lazy<RT.Libraries> =
   lazy
-    ({ stdlib =
-         (LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns @ LibTest.fns
-          |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name))
-
-       packageFns = Map.empty })
+    (let testFns =
+      LibTest.fns
+      |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
+      |> Map.mergeFavoringLeft (Lazy.force LibRealExecution.RealExecution.stdlibFns)
+     { stdlib = testFns; packageFns = Map.empty })
 
 let executionStateFor
   (meta : Canvas.Meta)

--- a/fsharp-backend/tests/TestUtils/TestUtils.fsproj
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fsproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="../../src/Prelude/Prelude.fsproj" />
     <ProjectReference Include="../../src/LibExecution/LibExecution.fsproj" />
     <ProjectReference Include="../../src/LibExecutionStdLib/LibExecutionStdLib.fsproj" />
+    <ProjectReference Include="../../src/LibRealExecution/LibRealExecution.fsproj" />
     <ProjectReference Include="../../src/LibBackend/LibBackend.fsproj" />
     <ProjectReference Include="../../src/BackendOnlyStdLib/BackendOnlyStdLib.fsproj" />
   </ItemGroup>

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -216,8 +216,11 @@ let testUiReturnsTheSame =
 
     Expect.equal fc oc ""
 
+    let fns = LibRealExecution.RealExecution.stdlibFns |> Lazy.force
+
     let builtins =
-      Functions.allFunctions
+      fns
+      |> Map.values
       |> List.filter (fun fn ->
         Functions.fsharpOnlyFns |> Lazy.force |> Set.contains (string fn.name) |> not)
       |> List.map (fun fn -> RT.FQFnName.Stdlib fn.name)
@@ -244,7 +247,7 @@ let testUiReturnsTheSame =
     // all.
     let filteredOCamlFns = filtered ocfns
 
-    print $"Implemented fns  : {List.length Functions.allFunctions}"
+    print $"Implemented fns  : {Map.count fns}"
     print $"Excluding F#-only: {Set.length builtins}"
     print $"Fns in OCaml api : {List.length ocfns}"
     print $"Fns in F# api    : {List.length fcfns}"

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -172,11 +172,60 @@ let testUiReturnsTheSame =
 
     let port = portFor OCaml
 
-    // There have been some tiny changes, let's work around them
+    // There have been some tiny changes, let's work around them. The values here are the NEW values
     let ocfns =
       List.map
         (fun (fn : Functions.FunctionMetadata) ->
           match string fn.name with
+          | "assoc" ->
+            { fn with
+                description = "Returns a copy of `dict` with the `key` set to `val`."
+                parameters =
+                  [ { name = "dict"
+                      tipe = "Dict"
+                      block_args = []
+                      optional = false
+                      description = "" }
+                    { name = "key"
+                      tipe = "Str"
+                      block_args = []
+                      optional = false
+                      description = "" }
+                    { name = "val"
+                      tipe = "Any"
+                      block_args = []
+                      optional = false
+                      description = "" } ] }
+          | "dissoc" ->
+            { fn with
+                parameters =
+                  [ { name = "dict"
+                      tipe = "Dict"
+                      block_args = []
+                      optional = false
+                      description = "" }
+                    { name = "key"
+                      tipe = "Str"
+                      block_args = []
+                      optional = false
+                      description = "" } ]
+                description =
+                  "If the `dict` contains `key`, returns a copy of `dict` with `key` and its associated value removed. Otherwise, returns `dict` unchanged." }
+          | "Object::empty" ->
+            { fn with description = "Returns an empty dictionary." }
+          | "Object::merge" ->
+            { fn with
+                description =
+                  "Returns a combined dictionary with both dictionaries' entries. If the same key exists in both `left` and `right`, it will have the value from `right`." }
+          | "Object::toJSON_v1" ->
+            { fn with
+                description = "Returns `dict` as a JSON string."
+                parameters =
+                  [ { name = "dict"
+                      tipe = "Dict"
+                      block_args = []
+                      optional = false
+                      description = "" } ] }
           | "DB::queryOneWithKey_v2" ->
             { fn with
                 description =

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -172,6 +172,31 @@ let testUiReturnsTheSame =
 
     let port = portFor OCaml
 
+    // There have been some tiny changes, let's work around them
+    let ocfns =
+      List.map
+        (fun (fn : Functions.FunctionMetadata) ->
+          match string fn.name with
+          | "DB::queryOneWithKey_v2" ->
+            { fn with
+                description =
+                  fn.description + ". Previously called DB::queryOnewithKey_v2" }
+          | "DB::queryWithKey_v2" ->
+            { fn with
+                description =
+                  fn.description + ". Previous called DB::queryWithKey_v2" }
+          | "DB::query_v3" ->
+            { fn with
+                description = fn.description + ". Previously called DB::query_v3" }
+          | "DB::query_v2" ->
+            { fn with
+                description = fn.description + ". Previously called DB::query_v3" }
+          | "DB::queryOne_v2" ->
+            { fn with
+                description = fn.description + ". Previously called DB::queryOne_v2" }
+          | _ -> fn)
+        ocfns
+
     let oc =
       oc
         // a couple of specific ones
@@ -191,10 +216,8 @@ let testUiReturnsTheSame =
 
     Expect.equal fc oc ""
 
-    let allBuiltins = (LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns)
-
     let builtins =
-      allBuiltins
+      Functions.allFunctions
       |> List.filter (fun fn ->
         Functions.fsharpOnlyFns |> Lazy.force |> Set.contains (string fn.name) |> not)
       |> List.map (fun fn -> RT.FQFnName.Stdlib fn.name)
@@ -221,7 +244,7 @@ let testUiReturnsTheSame =
     // all.
     let filteredOCamlFns = filtered ocfns
 
-    print $"Implemented fns  : {List.length allBuiltins}"
+    print $"Implemented fns  : {List.length Functions.allFunctions}"
     print $"Excluding F#-only: {Set.length builtins}"
     print $"Fns in OCaml api : {List.length ocfns}"
     print $"Fns in F# api    : {List.length fcfns}"

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -113,10 +113,10 @@ let t
       | :? DarkException as e ->
         let metadata = Exception.toMetadata e
         print $"Exception thrown in test: {string e}\n{metadata}"
-        return (Expect.equal "Exception thrown in test" (string e) "")
+        return Expect.equal ("Exception thrown in test", []) (string e, metadata) ""
       | e ->
         print $"Exception thrown in test: {e}"
-        return (Expect.equal "Exception thrown in test" (string e) "")
+        return Expect.equal "Exception thrown in test" (string e) ""
     }
 
 

--- a/fsharp-backend/tests/Tests/StdLib.Tests.fs
+++ b/fsharp-backend/tests/Tests/StdLib.Tests.fs
@@ -69,9 +69,7 @@ let oldFunctionsAreDeprecated =
 
     let counts = ref Map.empty
 
-    let fns =
-      TestUtils.LibTest.fns
-      @ LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns
+    let fns = libraries.Force().stdlib |> Map.values
 
     fns
     |> List.iter (fun fn ->


### PR DESCRIPTION
A reasonable number of functions were just copied with a new name. This removes the extra code and adds a rename facility.

It took a while to find the right place for this in the code but I think we got it.

This also adds two spaces between all stdlib functions, making them much much much much much much much easier to read.

Also removes some unused vars from stdlib headers

Also makes function definitions lazy.