### PR TITLE
Start moving to function_results_v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,6 +404,11 @@ jobs:
 
             echo $PATTERN > test-pattern
       - run:
+          name: DB migrations
+          command: |
+            cd fsharp-backend
+            ./Build/out/ExecHost/Release/net6.0/linux-x64/publish/ExecHost run-migrations
+      - run:
           name: Run integration tests
           command: |
             scripts/run-backend-server
@@ -434,7 +439,7 @@ jobs:
           command: |
             # Run the server long enough to ensure it runs the migrations
             cd fsharp-backend
-            ./Build/out/ExecHost/Release/net6.0/linux-x64/ExecHost run-migrations
+            ./Build/out/ExecHost/Release/net6.0/linux-x64/publish/ExecHost run-migrations
       - run:
           name: Run queue-scheduler tests
           command: scripts/run-rust-tests containers/queue-scheduler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,12 +430,11 @@ jobs:
       - attach_workspace: { at: "." }
       - show-large-files-and-directories
       - run:
-          name: Trigger migrations with runserver
+          name: Run DB migrations
           command: |
             # Run the server long enough to ensure it runs the migrations
-            scripts/build/_generate-etags
-            scripts/run-backend-server
-            scripts/devcontainer/_wait-until-server-ready
+            cd fsharp-backend
+            ./Build/out/ExecHost/Release/net6.0/linux-x64/ExecHost run-migrations
       - run:
           name: Run queue-scheduler tests
           command: scripts/run-rust-tests containers/queue-scheduler
@@ -529,6 +528,7 @@ workflows:
           context: Default
           requires:
             - build-backend
+            - build-fsharp-backend
             - build-client
             - build-queue-scheduler
       - integration-tests:

--- a/backend/bin/cron_checker.ml
+++ b/backend/bin/cron_checker.ml
@@ -28,7 +28,7 @@ let rec cron_checker (pid : int) () =
 
 
 let () =
-  Libbackend.Init.init ~run_side_effects:false ;
+  Libbackend.Init.init ~run_side_effects:false ~run_migrations:false ;
   (* If either thread sets the shutdown ref, the other will see it and
    * terminate; block until both have terminated. *)
   (* Three cases where we want to exit:

--- a/backend/bin/legacy_fuzzing_server.ml
+++ b/backend/bin/legacy_fuzzing_server.ml
@@ -120,7 +120,7 @@ let () =
     print_endline "Starting legacy fuzzing server" ;
     (* see https://github.com/mirage/ocaml-cohttp/issues/511 *)
     let () = Lwt.async_exception_hook := ignore in
-    Libbackend.Init.init ~run_side_effects:false ;
+    Libbackend.Init.init ~run_side_effects:false ~run_migrations:false ;
     Libexecution.Libs.init F.fns ;
     ignore (Lwt_main.run (Nocrypto_entropy_lwt.initialize () >>= server))
   with e ->

--- a/backend/bin/legacy_serialization_server.ml
+++ b/backend/bin/legacy_serialization_server.ml
@@ -170,7 +170,7 @@ let () =
   try
     Libcommon.Log.infO "Starting legacy server" ;
     (* We need this to ensure that infix is correct *)
-    Libbackend.Init.init ~run_side_effects:false ;
+    Libbackend.Init.init ~run_side_effects:false ~run_migrations:false ;
     (* see https://github.com/mirage/ocaml-cohttp/issues/511 *)
     let () = Lwt.async_exception_hook := ignore in
     ignore (Lwt_main.run (Nocrypto_entropy_lwt.initialize () >>= server))

--- a/backend/bin/queue_worker.ml
+++ b/backend/bin/queue_worker.ml
@@ -7,7 +7,7 @@ module Event_queue = Libbackend_basics.Event_queue
 let shutdown = ref false
 
 let queue_worker execution_id =
-  Libbackend.Init.init ~run_side_effects:false ;
+  Libbackend.Init.init ~run_side_effects:false ~run_migrations:false ;
   let rec queue_worker () =
     let result = Libbackend.Queue_worker.run execution_id in
     match result with

--- a/backend/bin/server.ml
+++ b/backend/bin/server.ml
@@ -5,7 +5,7 @@ let () =
     print_endline "Starting server" ;
     (* see https://github.com/mirage/ocaml-cohttp/issues/511 *)
     let () = Lwt.async_exception_hook := ignore in
-    Libbackend.Init.init ~run_side_effects:true ;
+    Libbackend.Init.init ~run_migrations:false ~run_side_effects:true ;
     Libbackend.Webserver.run ()
   with e ->
     let bt = Libexecution.Exception.get_backtrace () in

--- a/backend/libbackend/init.ml
+++ b/backend/libbackend/init.ml
@@ -4,7 +4,7 @@ module File = Libbackend_basics.File
 
 let has_inited : bool ref = ref false
 
-let init ~run_side_effects =
+let init ~run_side_effects ~run_migrations =
   try
     if not !has_inited
     then (
@@ -31,9 +31,10 @@ let init ~run_side_effects =
       (* Dark-specific stuff *)
       File.init () ;
       Httpclient.init () ;
+      if run_migrations
+      then Migrations.init () ;
       if run_side_effects
       then (
-        Migrations.init () ;
         Account.init () ;
         Canvas.write_shape_data () ) ;
       if Config.check_tier_one_hosts then Canvas.check_tier_one_hosts () ;

--- a/backend/libbackend/init.ml
+++ b/backend/libbackend/init.ml
@@ -31,8 +31,7 @@ let init ~run_side_effects ~run_migrations =
       (* Dark-specific stuff *)
       File.init () ;
       Httpclient.init () ;
-      if run_migrations
-      then Migrations.init () ;
+      if run_migrations then Migrations.init () ;
       if run_side_effects
       then (
         Account.init () ;

--- a/backend/libbackend/stored_function_result.ml
+++ b/backend/libbackend/stored_function_result.ml
@@ -30,6 +30,7 @@ let store_v2
         ; Int Dval.current_hash_version
         ; RoundtrippableDval result ]
 
+
 let store_v3
     ~canvas_id ~trace_id (tlid, fnname, id) (arglist : RTT.dval list) result =
   if canvas_id = Stored_event.throttled
@@ -49,6 +50,7 @@ let store_v3
         ; String (Dval.hash Dval.current_hash_version arglist)
         ; Int Dval.current_hash_version
         ; RoundtrippableDval result ]
+
 
 let store = store_v2
 
@@ -79,6 +81,7 @@ let load_v2 ~canvas_id ~trace_id tlid : function_result list =
              Exception.internal
                "Bad DB format for stored_functions_results.load")
 
+
 let load_v3 ~canvas_id ~trace_id tlid : function_result list =
   (* Right now, we don't allow the user to see multiple results when a function
    * is called in a loop. But, there's a lot of data when functions are called
@@ -105,6 +108,7 @@ let load_v3 ~canvas_id ~trace_id tlid : function_result list =
          | _ ->
              Exception.internal
                "Bad DB format for stored_functions_results.load")
+
 
 let load ~canvas_id ~trace_id tlid : function_result list =
   (* DISABLED FOR NOW UNTIL THE MIGRATION IS DONE *)

--- a/backend/libbackend/stored_function_result.ml
+++ b/backend/libbackend/stored_function_result.ml
@@ -10,7 +10,7 @@ module Db = Libbackend_basics.Db
 (* External *)
 (* ------------------------- *)
 
-let store
+let store_v2
     ~canvas_id ~trace_id (tlid, fnname, id) (arglist : RTT.dval list) result =
   if canvas_id = Stored_event.throttled
   then ()
@@ -30,8 +30,29 @@ let store
         ; Int Dval.current_hash_version
         ; RoundtrippableDval result ]
 
+let store_v3
+    ~canvas_id ~trace_id (tlid, fnname, id) (arglist : RTT.dval list) result =
+  if canvas_id = Stored_event.throttled
+  then ()
+  else
+    Db.run
+      ~name:"stored_function_result.store"
+      "INSERT INTO function_results_v3
+      (canvas_id, trace_id, tlid, fnname, id, hash, hash_version, timestamp, value)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP, $8)"
+      ~params:
+        [ Uuid canvas_id
+        ; Uuid trace_id
+        ; ID tlid
+        ; String fnname
+        ; ID id
+        ; String (Dval.hash Dval.current_hash_version arglist)
+        ; Int Dval.current_hash_version
+        ; RoundtrippableDval result ]
 
-let load ~canvas_id ~trace_id tlid : function_result list =
+let store = store_v2
+
+let load_v2 ~canvas_id ~trace_id tlid : function_result list =
   (* Right now, we don't allow the user to see multiple results when a function
    * is called in a loop. But, there's a lot of data when functions are called
    * in a loop, so avoid massive responses. *)
@@ -57,6 +78,38 @@ let load ~canvas_id ~trace_id tlid : function_result list =
          | _ ->
              Exception.internal
                "Bad DB format for stored_functions_results.load")
+
+let load_v3 ~canvas_id ~trace_id tlid : function_result list =
+  (* Right now, we don't allow the user to see multiple results when a function
+   * is called in a loop. But, there's a lot of data when functions are called
+   * in a loop, so avoid massive responses. *)
+  Db.fetch
+    ~name:"sfr_load"
+    "SELECT
+       DISTINCT ON (fnname, id, hash, hash_version)
+       fnname, id, hash, hash_version, value, timestamp
+     FROM function_results_v3
+     WHERE canvas_id = $1
+       AND trace_id = $2
+       AND tlid = $3
+     ORDER BY fnname, id, hash, hash_version, timestamp DESC"
+    ~params:[Db.Uuid canvas_id; Db.Uuid trace_id; Db.ID tlid]
+  |> List.map ~f:(function
+         | [fnname; id; hash; hash_version; dval; ts] ->
+             ( fnname
+             , id_of_string id
+             , hash
+               (* hash_version is nullable, nulls come back as empty string *)
+             , (match hash_version with "" -> 0 | hv -> hv |> int_of_string)
+             , Dval.of_internal_roundtrippable_v0 dval )
+         | _ ->
+             Exception.internal
+               "Bad DB format for stored_functions_results.load")
+
+let load ~canvas_id ~trace_id tlid : function_result list =
+  let v3_results = load_v3 ~canvas_id ~trace_id tlid in
+  if List.length v3_results >= 10 then v3_results else
+  load_v2 ~canvas_id ~trace_id tlid
 
 
 (** trim_results_for_canvas is like trim_results but for a single canvas.

--- a/backend/libbackend/stored_function_result.ml
+++ b/backend/libbackend/stored_function_result.ml
@@ -107,8 +107,9 @@ let load_v3 ~canvas_id ~trace_id tlid : function_result list =
                "Bad DB format for stored_functions_results.load")
 
 let load ~canvas_id ~trace_id tlid : function_result list =
-  let v3_results = load_v3 ~canvas_id ~trace_id tlid in
-  if List.length v3_results >= 10 then v3_results else
+  (* DISABLED FOR NOW UNTIL THE MIGRATION IS DONE *)
+  (* let v3_results = load_v3 ~canvas_id ~trace_id tlid in *)
+  (* if List.length v3_results >= 10 then v3_results else *)
   load_v2 ~canvas_id ~trace_id tlid
 
 

--- a/backend/migrations/20220116_234036_add-function_results_v3.sql
+++ b/backend/migrations/20220116_234036_add-function_results_v3.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS
+function_results_v3
+( canvas_id UUID REFERENCES canvases(id) NOT NULL
+, tlid BIGINT NOT NULL
+, fnname TEXT NOT NULL
+, id BIGINT NOT NULL
+, hash TEXT NOT NULL
+, timestamp TIMESTAMPTZ NOT NULL
+, value TEXT NOT NULL
+, trace_id UUID NOT NULL
+, hash_version INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS
+idx_function_results_v3_most_recent
+ON function_results_v3
+(canvas_id, trace_id, tlid, timestamp DESC)

--- a/backend/test/test.ml
+++ b/backend/test/test.ml
@@ -23,7 +23,7 @@ let () =
     ; ("garbage_collection", Test_garbage_collection.suite)
     ; ("event-queue", Test_event_queue.suite) ]
   in
-  Init.init ~run_side_effects:true ;
+  Init.init ~run_migrations:true ~run_side_effects:true ;
   Log.set_level `All ;
   Account.init_testing () ;
   let wrapped_suites =

--- a/fsharp-backend/src/LibBackend/Migrations.fs
+++ b/fsharp-backend/src/LibBackend/Migrations.fs
@@ -32,13 +32,11 @@ let initializeMigrationsTable () : unit =
      , sql TEXT NOT NULL)"
   |> Sql.executeStatementSync
 
-let isAlreadyRun (name : string) : bool =
-  Sql.query
-    "SELECT TRUE from system_migrations
-     WHERE name = @name"
-  |> Sql.parameters [ "name", Sql.string name ]
-  |> Sql.executeExistsSync
 
+let getExistingMigrations () : List<string> =
+  Sql.query
+    "SELECT name from system_migrations"
+  |> Sql.execute (fun read -> read.string "name")
 
 let runSystemMigration (name : string) (sql : string) : unit =
 
@@ -46,10 +44,9 @@ let runSystemMigration (name : string) (sql : string) : unit =
   // On conflict, do nothing because another starting process might be running this migration as well.
   let recordMigrationStmt =
     "INSERT INTO system_migrations
-                             (name, execution_date, sql)
-                             VALUES
-                             (@name, CURRENT_TIMESTAMP, @sql)
-                             ON CONFLICT DO NOTHING"
+       (name, execution_date, sql)
+       VALUES (@name, CURRENT_TIMESTAMP, @sql)
+       ON CONFLICT DO NOTHING"
 
   let recordMigrationParams = [ "name", Sql.string name; "sql", Sql.string sql ]
 
@@ -88,12 +85,13 @@ let run () : unit =
   if (not (isInitialized ())) then initializeMigrationsTable ()
 
   let migrations = names ()
-  print $"migrations: \n"
+  print "migrations: "
   List.iter (fun m -> print $" - {m}") migrations
+  let existingMigrations = getExistingMigrations () |> Set
 
   List.iter
     (fun name ->
-      if isAlreadyRun name then
+      if Set.contains name existingMigrations then
         print $"migration already run: {name}"
         Telemetry.addEvent "migration already run" [ "data", name ]
       else

--- a/fsharp-backend/src/LibBackend/Migrations.fs
+++ b/fsharp-backend/src/LibBackend/Migrations.fs
@@ -34,8 +34,7 @@ let initializeMigrationsTable () : unit =
 
 
 let getExistingMigrations () : List<string> =
-  Sql.query
-    "SELECT name from system_migrations"
+  Sql.query "SELECT name from system_migrations"
   |> Sql.execute (fun read -> read.string "name")
 
 let runSystemMigration (name : string) (sql : string) : unit =

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -65,6 +65,10 @@ let login (username : string) (password : string) : Task<User> =
     let! loginResp = client.SendAsync(loginReq)
     let! loginContent = loginResp.Content.ReadAsStringAsync()
 
+    if loginResp.StatusCode <> System.Net.HttpStatusCode.OK then
+      debuG "loginContent" loginContent
+      Expect.equal loginResp.StatusCode System.Net.HttpStatusCode.OK ""
+
     let csrfToken =
       match loginContent with
       | Regex "const csrfToken = \"(.*?)\";" [ token ] -> token

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -1,4 +1,4 @@
-Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 22
+Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 23
 (List.length_v0 DarkInternal.allFunctions_v0 > 290) = true
 
 [tests.grants]

--- a/scripts/devcontainer/_wait-until-server-ready
+++ b/scripts/devcontainer/_wait-until-server-ready
@@ -8,7 +8,7 @@ function wait_for {
   count=0
   until curl --output /dev/null --silent --show-error --head --fail "${test_url}"; do
       ((count++)) && ((count==60)) && exit 1
-      printf "waiting for %s\n" "$1"
+      printf "waiting for %s at %s\n" "$1" "$test_url"
       sleep 1
   done
 }

--- a/scripts/run-fsharp-tests
+++ b/scripts/run-fsharp-tests
@@ -30,11 +30,31 @@ done
 sudo killall legacy_serializtion_server.exe || true
 sudo killall legacy_fuzzing_server.exe || true
 sudo killall ocamltestserver.exe || true
+sudo killall server.exe || true
 killall -9 Tests || true
+
+if [[ "$PUBLISHED" == "true" ]]; then
+  EXE=Build/out/Tests/Release/net6.0/linux-x64/Tests
+  EXECHOST=Build/out/ExecHost/Release/net6.0/linux-x64/ExecHost
+else
+  EXE=Build/out/Tests/Debug/net6.0/linux-x64/Tests
+  EXECHOST=Build/out/ExecHost/Debug/net6.0/linux-x64/ExecHost
+fi
+
 
 ./scripts/devcontainer/_wait-for-background-services postgresql
 dropdb --if-exists testdb
 createdb testdb
+
+# Run the migrations before the other servers start
+cd fsharp-backend && \
+  DARK_CONFIG_TELEMETRY_EXPORTER=none \
+  DARK_CONFIG_DB_HOST=localhost \
+  DARK_CONFIG_DB_DBNAME=testdb \
+  DARK_CONFIG_DB_USER=dark \
+  DARK_CONFIG_DB_PASSWORD=darklang \
+  DARK_CONFIG_ROLLBAR_ENABLED=n \
+  time "${EXECHOST}" run-migrations && cd ..
 
 # These scripts run in the docker container. When this script is run from in the
 # container, these scripts and the spawned processes stay running. this is helpful if
@@ -48,12 +68,6 @@ createdb testdb
 
 # CLEANUP This is where the migrations are run for testdb at the moment
 DARK_CONFIG_STATIC_HOST="static.darklang.localhost:${DARK_CONFIG_TEST_OCAMLSERVER_NGINX_PORT}" ./scripts/devcontainer/_wait-until-server-ready
-
-if [[ "$PUBLISHED" == "true" ]]; then
-  EXE=Build/out/Tests/Release/net6.0/linux-x64/Tests
-else
-  EXE=Build/out/Tests/Debug/net6.0/linux-x64/Tests
-fi
 
 # Expecto has a number of async bugs causing it to hang. It appears to be due
 # to the test framework though it's hard to tell. It's solved by disabling the


### PR DESCRIPTION
This is the first deploy of #3379, simply adding a DB migration to add the table.

It also adds code to read from function_results_v3 as well as v2, but that code is disabled for now.

Another major change is removing DB migrations from running when the server starts up - now migrations are run after a deploy by hand using ExecHost, not automatically. So I've removed migrations from the OCaml backend, and replaced them with calling ExecHost for tests as well.

