### PR TITLE
Paul/function results v3 c

### DIFF
--- a/backend/libbackend/dune
+++ b/backend/libbackend/dune
@@ -121,6 +121,7 @@
            stored_event
            stored_function_arguments
            stored_function_result
+           stored_function_result_v3_migration
            swagger
            undo
            webserver

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -1564,7 +1564,7 @@ human-readable data."
         ; par "tlid" TStr
         ; par "traces" TList
         ; par "count" TInt ]
-    ; return_type = TNull
+    ; return_type = TInt
     ; description =
         "Copy the toplevel traces from function_results_v2 to function_results_v3"
     ; func =
@@ -1582,12 +1582,12 @@ human-readable data."
                   |> List.cons (Analysis.traceid_of_tlid tlid)
                 in
                 let count = Dint.to_int_exn count in
-                Stored_function_result_v3_migration.copy_toplevel_traces
+                let copied_count = Stored_function_result_v3_migration.copy_toplevel_traces
                   ~canvas_id
                   ~tlid
                   ~traces
-                  count ;
-                DNull
+                  count in
+                Dval.dint copied_count
             | args ->
                 fail args)
     ; preview_safety = Unsafe

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -1582,11 +1582,13 @@ human-readable data."
                   |> List.cons (Analysis.traceid_of_tlid tlid)
                 in
                 let count = Dint.to_int_exn count in
-                let copied_count = Stored_function_result_v3_migration.copy_toplevel_traces
-                  ~canvas_id
-                  ~tlid
-                  ~traces
-                  count in
+                let copied_count =
+                  Stored_function_result_v3_migration.copy_toplevel_traces
+                    ~canvas_id
+                    ~tlid
+                    ~traces
+                    count
+                in
                 Dval.dint copied_count
             | args ->
                 fail args)

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -1518,18 +1518,12 @@ human-readable data."
     ; deprecated = false }
   ; { prefix_names = ["DarkInternal::getHandlerTraces"]
     ; infix_names = []
-    ; parameters =
-        [ par "canvas_id" TUuid
-        ; par "tlid" TStr
-        ; par "count" TInt ]
+    ; parameters = [par "canvas_id" TUuid; par "tlid" TStr; par "count" TInt]
     ; return_type = TList
     ; description = "Get the most recent [count] traces for the handler"
     ; func =
         internal_fn (function
-            | ( _
-              , [ DUuid canvas_id
-                ; DStr tlid
-                ; DInt count ] ) ->
+            | _, [DUuid canvas_id; DStr tlid; DInt count] ->
                 let count = Dint.to_int_exn count in
                 let host = Canvas.name_for_id canvas_id in
                 let tlid = tlid |> Unicode_string.to_string |> id_of_string in
@@ -1547,15 +1541,16 @@ human-readable data."
                 in
                 let result =
                   match Handler.event_desc_for handler with
-                  | Some(module_, path, modifier) ->
-                    Stored_function_result_v3_migration.get_handler_traces
-                      ~canvas_id
-                      ~module_
-                      ~path
-                      ~modifier
-                      ~tlid
-                      count
-                  | _ -> []
+                  | Some (module_, path, modifier) ->
+                      Stored_function_result_v3_migration.get_handler_traces
+                        ~canvas_id
+                        ~module_
+                        ~path
+                        ~modifier
+                        ~tlid
+                        count
+                  | _ ->
+                      []
                 in
                 List.map ~f:(fun uuid -> DUuid uuid) result |> DList
             | args ->

--- a/backend/libbackend/stored_function_result_v3_migration.ml
+++ b/backend/libbackend/stored_function_result_v3_migration.ml
@@ -25,8 +25,13 @@ let copy_toplevel_traces ~canvas_id ~tlid ~traces (count : int) : unit =
       ; Db.Int count ]
 
 
-let get_handler_traces ~canvas_id ~(tlid:tlid) ~(path:string) ~(module_:string) ~(modifier:string) (count : int) : Uuidm.t list
-    =
+let get_handler_traces
+    ~canvas_id
+    ~(tlid : tlid)
+    ~(path : string)
+    ~(module_ : string)
+    ~(modifier : string)
+    (count : int) : Uuidm.t list =
   let builtin_trace = Analysis.traceid_of_tlid tlid in
   Db.fetch
     ~name:"handler_valid_traces"
@@ -39,7 +44,11 @@ let get_handler_traces ~canvas_id ~(tlid:tlid) ~(path:string) ~(module_:string) 
      ORDER BY MAX(timestamp) DESC
      LIMIT $5"
     ~params:
-      [Db.Uuid canvas_id; Db.String module_; Db.String path; Db.String modifier; Db.Int count]
+      [ Db.Uuid canvas_id
+      ; Db.String module_
+      ; Db.String path
+      ; Db.String modifier
+      ; Db.Int count ]
   |> List.map ~f:(fun uuid ->
          uuid |> List.hd_exn |> Uuidm.of_string |> Option.value_exn)
   |> List.cons builtin_trace

--- a/backend/libbackend/stored_function_result_v3_migration.ml
+++ b/backend/libbackend/stored_function_result_v3_migration.ml
@@ -1,0 +1,45 @@
+open Core_kernel
+open Libexecution
+open Analysis_types
+open Types
+module RTT = Types.RuntimeT
+open Libcommon
+module Db = Libbackend_basics.Db
+
+let copy_toplevel_traces ~canvas_id ~tlid ~traces (count : int) : unit =
+  Db.run
+    ~name:"stored_function_result_v3_migration"
+    (* Chose the fields to match the idx_function_results_v2_most_recent index *)
+    "INSERT INTO function_results_v3
+        (SELECT * FROM function_results_v2
+          WHERE canvas_id = $1
+            AND (trace_id = ANY (string_to_array($3, $4)::uuid[])
+            AND tlid = $2)
+        ORDER BY timestamp DESC
+        LIMIT $5)"
+    ~params:
+      [ Db.Uuid canvas_id
+      ; Db.ID tlid
+      ; traces |> List.map ~f:(fun t -> Db.Uuid t) |> Db.List
+      ; String Db.array_separator
+      ; Db.Int count ]
+
+
+let get_handler_traces ~canvas_id ~(tlid:tlid) ~(path:string) ~(module_:string) ~(modifier:string) (count : int) : Uuidm.t list
+    =
+  let builtin_trace = Analysis.traceid_of_tlid tlid in
+  Db.fetch
+    ~name:"handler_valid_traces"
+    "SELECT trace_id from stored_events_v2
+      WHERE canvas_id = $1
+        AND module = $2
+        AND path = $3
+        AND modifier = $4
+     GROUP BY trace_id
+     ORDER BY MAX(timestamp) DESC
+     LIMIT $5"
+    ~params:
+      [Db.Uuid canvas_id; Db.String module_; Db.String path; Db.String modifier; Db.Int count]
+  |> List.map ~f:(fun uuid ->
+         uuid |> List.hd_exn |> Uuidm.of_string |> Option.value_exn)
+  |> List.cons builtin_trace

--- a/backend/libbackend/stored_function_result_v3_migration.ml
+++ b/backend/libbackend/stored_function_result_v3_migration.ml
@@ -6,23 +6,28 @@ module RTT = Types.RuntimeT
 open Libcommon
 module Db = Libbackend_basics.Db
 
-let copy_toplevel_traces ~canvas_id ~tlid ~traces (count : int) : unit =
-  Db.run
+let copy_toplevel_traces ~canvas_id ~tlid ~traces (count : int) : int =
+  Db.fetch_one
     ~name:"stored_function_result_v3_migration"
     (* Chose the fields to match the idx_function_results_v2_most_recent index *)
-    "INSERT INTO function_results_v3
+    "with rows as (
+      INSERT INTO function_results_v3
         (SELECT * FROM function_results_v2
           WHERE canvas_id = $1
             AND (trace_id = ANY (string_to_array($3, $4)::uuid[])
             AND tlid = $2)
         ORDER BY timestamp DESC
-        LIMIT $5)"
+        LIMIT $5)
+        RETURNING 1)
+      SELECT count(*) from rows"
     ~params:
       [ Db.Uuid canvas_id
       ; Db.ID tlid
       ; traces |> List.map ~f:(fun t -> Db.Uuid t) |> Db.List
       ; String Db.array_separator
       ; Db.Int count ]
+  |> List.hd_exn
+  |> int_of_string
 
 
 let get_handler_traces

--- a/scripts/formatting/format
+++ b/scripts/formatting/format
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-CHECK=0 # (0 mean check, 1 means format)
+CHECK=255 # (0 mean check, 1 means format, 255 means error)
 OCAML=0 # (0 means check ocaml files, 1 means don't)
 PRETTIER=0 # (0 means check prettier files, 1 means don't)
 RUST=0 # (0 means check rust files, 1 means don't)
@@ -65,6 +65,11 @@ for val in "${@}"; do
       ;;
   esac
 done
+
+if [[ 255 -eq "$CHECK" ]]; then
+  echo -e "usage:\n  ./scripts/formatting/format check [files]\n  ./scripts/formatting/format format [files]"
+  exit 255
+fi
 
 #######################
 # Parse rest of arguments


### PR DESCRIPTION
Part of #3379.

This adds functions to LibDarkInternal to allow building part of the migration in Dark. Using this, I'll build a dark canvas to migrate function_results from the v2 table to the v3 table.

The code I prototyped to do this is:

```elm
let canvasID = "paul"
               |>DarkInternal::canvasIdOfCanvasName
               |>String::toUUIDv1
let traces = DarkInternal::handlers "paul"
             |>List::map \tlid -> let traces = DarkInternal::getHandlerTraces canvasID tlid 10
                                  traces
             |>List::flatten
let traces = List::sort traces
let fns = DarkInternal::functions "paul"
List::map fns \tlid -> DarkInternal::copyToplevelTraces canvasID tlid traces 10
```

Once this is merged I can built out and watch a slow migration.
