### PR TITLE
Remove function_results_v2 code

### DIFF
--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -1566,30 +1566,11 @@ human-readable data."
         ; par "count" TInt ]
     ; return_type = TInt
     ; description =
-        "Copy the toplevel traces from function_results_v2 to function_results_v3"
+        "Doesn't exist anymore"
     ; func =
         internal_fn (function
             | _, [DUuid canvas_id; DStr tlid; DList traces; DInt count] ->
-                let tlid = tlid |> Unicode_string.to_string |> id_of_string in
-                let traces =
-                  traces
-                  |> List.map ~f:(function
-                         | DUuid uuid ->
-                             uuid
-                         | _ ->
-                             failwith "Not a Uuid")
-                  (* builtin trace *)
-                  |> List.cons (Analysis.traceid_of_tlid tlid)
-                in
-                let count = Dint.to_int_exn count in
-                let copied_count =
-                  Stored_function_result_v3_migration.copy_toplevel_traces
-                    ~canvas_id
-                    ~tlid
-                    ~traces
-                    count
-                in
-                Dval.dint copied_count
+                Dval.dint 0
             | args ->
                 fail args)
     ; preview_safety = Unsafe

--- a/backend/libbackend/libdarkinternal.ml
+++ b/backend/libbackend/libdarkinternal.ml
@@ -1565,8 +1565,7 @@ human-readable data."
         ; par "traces" TList
         ; par "count" TInt ]
     ; return_type = TInt
-    ; description =
-        "Doesn't exist anymore"
+    ; description = "Doesn't exist anymore"
     ; func =
         internal_fn (function
             | _, [DUuid canvas_id; DStr tlid; DList traces; DInt count] ->

--- a/backend/migrations/20220118_083627_drop-function-results-v2.sql
+++ b/backend/migrations/20220118_083627_drop-function-results-v2.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS function_results_v2 RESTRICT

--- a/backend/test/utils.ml
+++ b/backend/test/utils.ml
@@ -68,10 +68,6 @@ let clear_test_data () : unit =
   Db.run
     ~params:[List canvas_ids; String Db.array_separator]
     ~name:"clear_function_results_test_data"
-    "DELETE FROM function_results_v2 where canvas_id = ANY (string_to_array ($1, $2)::uuid[])" ;
-  Db.run
-    ~params:[List canvas_ids; String Db.array_separator]
-    ~name:"clear_function_results_test_data"
     "DELETE FROM function_results_v3 where canvas_id = ANY (string_to_array ($1, $2)::uuid[])" ;
   Db.run
     ~params:[List canvas_ids; String Db.array_separator]

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -52,12 +52,6 @@ let clearCanvasData (owner : UserID) (name : CanvasName.T) : Task<unit> =
       |> Sql.executeStatementAsync
       :> Task
 
-    let functionResultsV2 =
-      Sql.query "DELETE FROM function_results_v2 where canvas_id = @id::uuid"
-      |> Sql.parameters [ "id", Sql.uuid canvasID ]
-      |> Sql.executeStatementAsync
-      :> Task
-
     let functionResultsV3 =
       Sql.query "DELETE FROM function_results_v3 where canvas_id = @id::uuid"
       |> Sql.parameters [ "id", Sql.uuid canvasID ]
@@ -106,7 +100,6 @@ let clearCanvasData (owner : UserID) (name : CanvasName.T) : Task<unit> =
                       customDomains
                       events
                       functionArguments
-                      functionResultsV2
                       functionResultsV3
                       schedulingRules
                       secrets

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -1,4 +1,4 @@
-Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 23
+Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 22
 (List.length_v0 DarkInternal.allFunctions_v0 > 290) = true
 
 [tests.grants]

--- a/integration-tests/clear-db.sh
+++ b/integration-tests/clear-db.sh
@@ -19,7 +19,6 @@ SCRIPT=""
 for cid in $CANVASES; do
   SCRIPT+="DELETE FROM scheduling_rules WHERE canvas_id = '$cid';";
   SCRIPT+="DELETE FROM events WHERE canvas_id = '$cid';";
-  SCRIPT+="DELETE FROM function_results_v2 WHERE canvas_id = '$cid';";
   SCRIPT+="DELETE FROM function_results_v3 WHERE canvas_id = '$cid';";
   SCRIPT+="DELETE FROM stored_events_v2 WHERE canvas_id = '$cid';";
   SCRIPT+="DELETE FROM user_data WHERE canvas_id = '$cid';";


### PR DESCRIPTION
Add the migration to drop function_result_v2. This will be run in production, manually, after deploy.

Remove remaining code that references function_result_v2, mostly test code

Disable DarkInternal::copyToplevelTraces, as it's no longer useful 