### PR TITLE
Fix fuzz test json config file

### DIFF
--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -842,6 +842,11 @@ module Json =
     let deserialize<'a> (json : string) : 'a =
       JsonSerializer.Deserialize<'a>(json, _options)
 
+    let deserializeWithComments<'a> (json : string) : 'a =
+      let options = getOptions ()
+      options.ReadCommentHandling <- JsonCommentHandling.Skip
+      JsonSerializer.Deserialize<'a>(json, options)
+
     let prettySerialize (data : 'a) : string =
       let options = getOptions ()
       options.WriteIndented <- true

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -837,10 +837,10 @@ module ExecutePureFunctions =
 
   // Keep a list of allowed errors where we can edit it without recompiling
   let readAllowedErrors () =
-    use r = new System.IO.StreamReader "tests/allowedFuzzerErrors.json"
+    use r = new System.IO.StreamReader "tests/allowedFuzzerErrors.jsonc"
     let json = r.ReadToEnd()
 
-    Json.Vanilla.deserialize<AllowedFuzzerErrorFileStructure> json
+    Json.Vanilla.deserializeWithComments<AllowedFuzzerErrorFileStructure> json
 
   let allowedErrors = readAllowedErrors ()
 

--- a/fsharp-backend/tests/allowedFuzzerErrors.jsonc
+++ b/fsharp-backend/tests/allowedFuzzerErrors.jsonc
@@ -1,7 +1,7 @@
 {
-  // If None, test anything. If `Some fn`, only test fn
-  "functionToTest": ["None"],
-  //"functionToTest": ["Some", "String::base64Decode"],
+  // If null, test anything. If `"fn"`, only test fn
+  "functionToTest": null,
+  //"functionToTest": "String::base64Decode",
   "knownDifferingFunctions": [
     // These use a different sort order in OCaml
     "List::sort", // FSTODO


### PR DESCRIPTION
With these changes the fuzzers start up again.

- Use standard Option handling (null vs string)
- Allow comments
- Rename to jsonc so vscode/github highlight nicely

It broke because we changed how we parsed json, and we switched this to the "vanilla" parser which can't read comments.

