### PR TITLE
Cronchecker exceptions

### DIFF
--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -18,13 +18,15 @@ let legacyServerCheck : LibService.Kubernetes.HealthCheck =
     checkFn =
       fun (_ : System.Threading.CancellationToken) ->
         task {
-          // Make sure we can load a canvas
-          // Loading all the tier one canvases takes way too long, so just pick a simple one
-          // do! Canvas.checkTierOneHosts ()
-          let host = CanvasName.create "ian-httpbin"
-          let! meta = Canvas.getMeta host
-          let! (_ : Canvas.T) = Canvas.loadAll meta
-          return HealthCheckResult.Healthy("It's fine")
+          try
+            // Make sure we can load a canvas
+            // Loading all the tier one canvases takes way too long, so just pick a simple one
+            let host = CanvasName.create "ian-httpbin"
+            let! meta = Canvas.getMeta host
+            let! (_ : Canvas.T) = Canvas.loadAll meta
+            return HealthCheckResult.Healthy("It's fine")
+          with
+          | e -> return HealthCheckResult.Unhealthy(e.Message)
         } }
 
 


### PR DESCRIPTION
Don't start up cronchecker until the DB is available.

This is to prevent the huge number of exceptions reported to rollbar during startup (now that events make it to rollbar).