### PR TITLE
For integration tests, fixes BWD URL

### DIFF
--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -233,7 +233,7 @@ test.describe.parallel("Integration Tests", async () => {
 
   function bwdUrl(testInfo: TestInfo, path: string) {
     return (
-      "http://test-" + testInfo.title + ".builtwithdark.lvh.me:8000" + path
+      "http://test-" + testInfo.title + ".builtwithdark.localhost:8000" + path
     );
   }
 


### PR DESCRIPTION
## What is the problem/goal being addressed?
When running integration tests locally, the BWD urls of test canvases was broken as-is, yielding several failing tests locally.

Prior to this commit, 
```
function bwdUrl(testInfo: TestInfo, path: string) {
  return (
    "http://test-" + testInfo.title + ".builtwithdark.lvh.me:8000" + path
  );
}
```

## What is the solution to this problem?
Adjusts the URL to
```
function bwdUrl(testInfo: TestInfo, path: string) {
  return (
   "http://test-" + testInfo.title + ".builtwithdark.localhost:8000" + path
  );
}
```
, which works for me


@pbiggar _should_ the lvh.me URL work? if so, any ideas what could be wrong?
Also, what does "lvh" stand for?