### PR TITLE
Correct mimetype of WASM files in ApiServer

### DIFF
--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -20,6 +20,7 @@ open Tablecloth
 
 open Http
 open Middleware
+open Microsoft.AspNetCore.StaticFiles
 
 module Auth = LibBackend.Authorization
 module Config = LibBackend.Config
@@ -112,6 +113,10 @@ let addRoutes (app : IApplicationBuilder) : IApplicationBuilder =
 // --------------------
 let configureStaticContent (app : IApplicationBuilder) : IApplicationBuilder =
   if Config.apiServerServeStaticContent then
+    let contentTypeProvider = FileExtensionContentTypeProvider()
+    contentTypeProvider.Mappings[ ".dll" ] <- "application/wasm"
+    contentTypeProvider.Mappings[ ".wasm" ] <- "application/wasm"
+
     app.UseStaticFiles(
       StaticFileOptions(
         ServeUnknownFileTypes = true,
@@ -119,7 +124,8 @@ let configureStaticContent (app : IApplicationBuilder) : IApplicationBuilder =
         OnPrepareResponse =
           (fun ctx ->
             ctx.Context.Response.Headers[ "Access-Control-Allow-Origin" ] <-
-              StringValues([| "*" |]))
+              StringValues([| "*" |])),
+        ContentTypeProvider = contentTypeProvider
       )
     )
   else


### PR DESCRIPTION
## What is the problem/goal being addressed?
When loading Blazor assemblies (.dlls and .wasm files), console warnings indicate that they are being loaded with the incorrect MIME type. (application/octet-stream)

## What is the solution to this problem?
Ensures that `ApiServer` returns all statically-hosted `.dll` and `.wasm` files are returned with a MIME type of `application/wasm`

Use `FileExtensionContentTypeProvider` type exposed in `Microsoft.AspNetCore.StaticFiles` to configure the MIME types per file  extension

## How are you sure this works/how was this tested?
Tested locally; console warnings that existed previously no longer do.