### PR TITLE
Allow contributor builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ version: 2.1
 # scripts/build/_build-server. Generally, if you add something to this file,
 # there's an equivalent to be added in one of those files.
 
-orbs:
-  slack: circleci/slack@4.4.4
-
 executors:
   simple-executor:
     docker:
@@ -83,11 +80,46 @@ commands:
   ##########################
   # Slack
   ##########################
-  notify-job-failure:
+  slack-notify-failure:
     steps:
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
+      - run:
+          name: Slack failure notification
+          when: on_success
+          command: |
+            curl
+              -v
+              -X POST
+              -H 'Content-type: application/json'
+              -d '{ "success": true \
+                  , "branch": "$CIRCLE_BRANCH" \
+                  , "url": "$CIRCLE_BUILD_URL" \
+                  , "prs": "$CIRCLE_PULL_REQUESTS" \
+                  , "sha": "$CIRCLE_SHA1" \
+                  , "username": "$CIRCLE_USERNAME" \
+                  , "job": "$CIRCLE_JOB" \
+                  }'
+              https://ops-circleci.builtwithdark.com/notify-slack
+
+
+  slack-notify-success:
+    steps:
+      - run:
+          name: Slack failure notification
+          when: on_fail
+          command: |
+            curl
+              -v
+              -X POST
+              -H 'Content-type: application/json'
+              -d '{ "success": false \
+                  , "branch": "$CIRCLE_BRANCH" \
+                  , "url": "$CIRCLE_BUILD_URL" \
+                  , "prs": "$CIRCLE_PULL_REQUESTS" \
+                  , "sha": "$CIRCLE_SHA1" \
+                  , "username": "$CIRCLE_USERNAME" \
+                  , "job": "$CIRCLE_JOB" \
+                  }'
+              https://ops-circleci.builtwithdark.com/notify-slack
 
   ##########################
   # Rust
@@ -218,7 +250,7 @@ jobs:
       - store_artifacts: { path: rundir }
       - store_artifacts: { path: backend/static/etags.json }
       - store_test_results: { path: rundir/test_results }
-      - notify-job-failure
+      - slack-notify-failure
 
   build-backend:
     executor: in-container
@@ -273,7 +305,7 @@ jobs:
           key: v9-backend-{{ checksum "esy.json" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
-      - notify-job-failure
+      - slack-notify-failure
 
   build-fsharp-backend:
     executor: in-container
@@ -313,7 +345,7 @@ jobs:
           key: v5-fsharp-backend-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
-      - notify-job-failure
+      - slack-notify-failure
 
   static-checks:
     executor: in-rust-container
@@ -324,7 +356,7 @@ jobs:
       - run: scripts/formatting/format check
       - run: scripts/build/compile-project shipit
       - run: scripts/deployment/shipit validate
-      - notify-job-failure
+      - slack-notify-failure
 
   predeployment-checks:
     executor: in-container
@@ -333,7 +365,7 @@ jobs:
       - auth-with-gcp: { background: false }
       - run: scripts/build/compile-project shipit
       - run: scripts/deployment/shipit manual diff > /dev/null 2>&1
-      - notify-job-failure
+      - slack-notify-failure
 
   build-stroller:
     executor: in-rust-container
@@ -343,7 +375,7 @@ jobs:
       - run: scripts/build/compile-project stroller --test
       - assert-clean-worktree
       - rust-finish: { project: "stroller", dir: "containers/stroller" }
-      - notify-job-failure
+      - slack-notify-failure
 
   build-queue-scheduler:
     executor: in-rust-container
@@ -354,7 +386,7 @@ jobs:
       - run: scripts/build/compile-project queue-scheduler
       - assert-clean-worktree
       - rust-finish: { project: "queue-scheduler", dir: "containers/queue-scheduler" }
-      - notify-job-failure
+      - slack-notify-failure
 
   build-postgres-honeytail:
     executor: simple-executor
@@ -362,7 +394,7 @@ jobs:
       - darkcheckout
       - prep-container-creation
       - run: cd containers/postgres-honeytail && docker build -t postgres-honeytail .
-      - notify-job-failure
+      - slack-notify-failure
 
   validate-honeycomb-config:
     executor: simple-executor
@@ -370,7 +402,7 @@ jobs:
       - darkcheckout
       - prep-container-creation
       - run: bash -c scripts/linting/test-honeycomb-config.sh
-      - notify-job-failure
+      - slack-notify-failure
 
   integration-tests:
     executor: in-container
@@ -424,7 +456,7 @@ jobs:
           name: "Save packagejson-specific cache"
           paths: ["integration-tests/node_modules", "/home/dark/.cache/ms-playwright"]
           key: v2-playwright-{{ checksum "integration-tests/package-lock.json" }}-{{ .Branch }}
-      - notify-job-failure
+      - slack-notify-failure
 
 
   rust-integration-tests:
@@ -445,7 +477,7 @@ jobs:
           command: scripts/run-rust-tests containers/queue-scheduler
       - assert-clean-worktree
       - store_artifacts: { path: rundir }
-      - notify-job-failure
+      - slack-notify-failure
 
   gcp-containers-test:
     executor: in-container
@@ -457,7 +489,7 @@ jobs:
       # This is needed because kubectl --dry-run uses it
       - auth-with-gcp: { background: false }
       - build-gcp-containers
-      - notify-job-failure
+      - slack-notify-failure
 
   push-to-gcp:
     executor: in-container
@@ -474,7 +506,7 @@ jobs:
           paths: ["gcr-image-ids.json"]
       - run: scripts/deployment/_push-assets-to-cdn
       - run: scripts/deployment/shipit containers push
-      - notify-job-failure
+      - slack-notify-failure
 
   deploy:
     executor: in-container
@@ -486,64 +518,45 @@ jobs:
       - attach_workspace: { at: "." }
       - show-large-files-and-directories
       - run: scripts/deployment/gke-deploy --manifest=gcr-image-ids.json
-      - notify-job-failure
-      - slack/notify:
-          event: pass
-          template: success_tagged_deploy_1
+      - slack-notify-failure
+      - slack-notify-success
 
   notify-non-deploy:
     executor: simple-executor
     steps:
-      - slack/notify:
-          event: pass
-          template: basic_success_1
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
+      - slack-notify-success
+      - slack-notify-failure
 
 workflows:
   version: 2
   build-and-deploy:
     jobs:
       # initial builds & tests
-      - static-checks:
-          context: Default
-      - predeployment-checks:
-          context: Default
-      - build-postgres-honeytail:
-          context: Default
-      - validate-honeycomb-config:
-          context: Default
-      - build-backend:
-          context: Default
-      - build-client:
-          context: Default
-      - build-stroller:
-          context: Default
-      - build-queue-scheduler:
-          context: Default
+      - static-checks
+      - predeployment-checks
+      - build-postgres-honeytail
+      - validate-honeycomb-config
+      - build-backend
+      - build-client
+      - build-stroller
+      - build-queue-scheduler
       - build-fsharp-backend:
-          context: Default
           requires:
             - build-backend
 
       # expensive tests
       - rust-integration-tests:
-          context: Default
           requires:
             - build-backend
             - build-fsharp-backend
             - build-client
             - build-queue-scheduler
       - integration-tests:
-          context: Default
           requires:
             - build-backend
             - build-client
             - build-fsharp-backend
       - gcp-containers-test:
-          context: Default
           requires:
             - build-client # to rebuild etags
             - build-backend
@@ -553,7 +566,6 @@ workflows:
 
       # pre-deploy, in parallel with integration-tests
       - push-to-gcp:
-          context: Default
           filters:
             branches:
               only: main
@@ -567,7 +579,6 @@ workflows:
 
       # actual deploy
       - deploy:
-          context: Default
           filters:
             branches:
               only: main
@@ -580,7 +591,6 @@ workflows:
             - predeployment-checks
 
       - notify-non-deploy:
-          context: Default
           filters:
             branches:
               ignore: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
           name: Slack notification
           when: on_success
           command: |
-            curl -X POST -H 'Content-type: application/json' -d "{ \"success\": true, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": [$CIRCLE_PULL_REQUESTS], \"sha\": \"$CIRCLE_SHA1\", \"username\": "$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
+            curl -X POST -H 'Content-type: application/json' -d "{ \"success\": true, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": [$CIRCLE_PULL_REQUESTS], \"sha\": \"$CIRCLE_SHA1\", \"username\": \"$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-job-failure:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,19 +88,7 @@ commands:
           name: Slack notification
           when: on_fail
           command: |
-            curl \
-              -X POST \
-              -H 'Content-type: application/json' \
-              -d "{ \"success\": false
-                  , \"buildType\": \"<<parameters.buildType>>\"
-                  , \"branch\": \"$CIRCLE_BRANCH\"
-                  , \"url\": \"$CIRCLE_BUILD_URL\"
-                  , \"prs\": [$CIRCLE_PULL_REQUESTS]
-                  , \"sha\": \"$CIRCLE_SHA1\"
-                  , \"username\": \"$CIRCLE_USERNAME\"
-                  , \"job\": \"$CIRCLE_JOB\"
-                  }" \
-              https://ops-circleci.builtwithdark.com/notify-slack
+            curl -X POST -H 'Content-type: application/json' -d "{ \"success\": false, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": [$CIRCLE_PULL_REQUESTS], \"sha\": \"$CIRCLE_SHA1\", \"username\": \"$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-success:
     parameters:
@@ -110,19 +98,7 @@ commands:
           name: Slack notification
           when: on_success
           command: |
-            curl \
-              -X POST \
-              -H 'Content-type: application/json' \
-              -d "{ \"success\": true
-                  , \"buildType\": \"<<parameters.buildType>>\"
-                  , \"branch\": \"$CIRCLE_BRANCH\"
-                  , \"url\": \"$CIRCLE_BUILD_URL\"
-                  , \"prs\": [$CIRCLE_PULL_REQUESTS]
-                  , \"sha\": \"$CIRCLE_SHA1\"
-                  , \"username\": "$CIRCLE_USERNAME\"
-                  , \"job\": \"$CIRCLE_JOB\"
-                  }" \
-              https://ops-circleci.builtwithdark.com/notify-slack
+            curl -X POST -H 'Content-type: application/json' -d "{ \"success\": true, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": [$CIRCLE_PULL_REQUESTS], \"sha\": \"$CIRCLE_SHA1\", \"username\": "$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-job-failure:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,14 +91,14 @@ commands:
             curl \
               -X POST \
               -H 'Content-type: application/json' \
-              -d "{ 'success': false
-                  , 'buildType': <<parameters.buildType>>
-                  , 'branch': '$CIRCLE_BRANCH'
-                  , 'url': '$CIRCLE_BUILD_URL'
-                  , 'prs': '$CIRCLE_PULL_REQUESTS'
-                  , 'sha': '$CIRCLE_SHA1'
-                  , 'username': '$CIRCLE_USERNAME'
-                  , 'job': '$CIRCLE_JOB'
+              -d "{ \"success\": false
+                  , \"buildType\": \"<<parameters.buildType>>\"
+                  , \"branch\": \"$CIRCLE_BRANCH\"
+                  , \"url\": \"$CIRCLE_BUILD_URL\"
+                  , \"prs\": [$CIRCLE_PULL_REQUESTS]
+                  , \"sha\": \"$CIRCLE_SHA1\"
+                  , \"username\": \"$CIRCLE_USERNAME\"
+                  , \"job\": \"$CIRCLE_JOB\"
                   }" \
               https://ops-circleci.builtwithdark.com/notify-slack
 
@@ -113,14 +113,14 @@ commands:
             curl \
               -X POST \
               -H 'Content-type: application/json' \
-              -d "{ 'success': true
-                  , 'buildType': <<parameters.buildType>>
-                  , 'branch': '$CIRCLE_BRANCH'
-                  , 'url': '$CIRCLE_BUILD_URL'
-                  , 'prs': '$CIRCLE_PULL_REQUESTS'
-                  , 'sha': '$CIRCLE_SHA1'
-                  , 'username': "$CIRCLE_USERNAME'
-                  , 'job': '$CIRCLE_JOB'
+              -d "{ \"success\": true
+                  , \"buildType\": \"<<parameters.buildType>>\"
+                  , \"branch\": \"$CIRCLE_BRANCH\"
+                  , \"url\": \"$CIRCLE_BUILD_URL\"
+                  , \"prs\": [$CIRCLE_PULL_REQUESTS]
+                  , \"sha\": \"$CIRCLE_SHA1\"
+                  , \"username\": "$CIRCLE_USERNAME\"
+                  , \"job\": \"$CIRCLE_JOB\"
                   }" \
               https://ops-circleci.builtwithdark.com/notify-slack
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,15 +91,15 @@ commands:
             curl \
               -X POST \
               -H 'Content-type: application/json' \
-              -d '{ "success": false
-                  , "buildType" <<parameters.buildType>>
-                  , "branch": "$CIRCLE_BRANCH"
-                  , "url": "$CIRCLE_BUILD_URL"
-                  , "prs": "$CIRCLE_PULL_REQUESTS"
-                  , "sha": "$CIRCLE_SHA1"
-                  , "username": "$CIRCLE_USERNAME"
-                  , "job": "$CIRCLE_JOB"
-                  }' \
+              -d "{ 'success': false
+                  , 'buildType': <<parameters.buildType>>
+                  , 'branch': '$CIRCLE_BRANCH'
+                  , 'url': '$CIRCLE_BUILD_URL'
+                  , 'prs': '$CIRCLE_PULL_REQUESTS'
+                  , 'sha': '$CIRCLE_SHA1'
+                  , 'username': '$CIRCLE_USERNAME'
+                  , 'job': '$CIRCLE_JOB'
+                  }" \
               https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-success:
@@ -113,15 +113,15 @@ commands:
             curl \
               -X POST \
               -H 'Content-type: application/json' \
-              -d '{ "success": true
-                  , "buildType" <<parameters.buildType>>
-                  , "branch": "$CIRCLE_BRANCH"
-                  , "url": "$CIRCLE_BUILD_URL"
-                  , "prs": "$CIRCLE_PULL_REQUESTS"
-                  , "sha": "$CIRCLE_SHA1"
-                  , "username": "$CIRCLE_USERNAME"
-                  , "job": "$CIRCLE_JOB"
-                  }' \
+              -d "{ 'success': true
+                  , 'buildType': <<parameters.buildType>>
+                  , 'branch': '$CIRCLE_BRANCH'
+                  , 'url': '$CIRCLE_BUILD_URL'
+                  , 'prs': '$CIRCLE_PULL_REQUESTS'
+                  , 'sha': '$CIRCLE_SHA1'
+                  , 'username': "$CIRCLE_USERNAME'
+                  , 'job': '$CIRCLE_JOB'
+                  }" \
               https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-job-failure:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,9 @@ commands:
           name: Slack notification
           when: on_fail
           command: |
-            curl
-              -v
-              -X POST
-              -H 'Content-type: application/json'
+            curl \
+              -X POST \
+              -H 'Content-type: application/json' \
               -d '{ "success": false \
                   , "buildType" <<parameters.buildType>> \
                   , "branch": "$CIRCLE_BRANCH" \
@@ -100,7 +99,7 @@ commands:
                   , "sha": "$CIRCLE_SHA1" \
                   , "username": "$CIRCLE_USERNAME" \
                   , "job": "$CIRCLE_JOB" \
-                  }'
+                  }' \
               https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-success:
@@ -111,10 +110,9 @@ commands:
           name: Slack notification
           when: on_success
           command: |
-            curl
-              -v
-              -X POST
-              -H 'Content-type: application/json'
+            curl \
+              -X POST \
+              -H 'Content-type: application/json' \
               -d '{ "success": true \
                   , "buildType" <<parameters.buildType>> \
                   , "branch": "$CIRCLE_BRANCH" \
@@ -123,7 +121,7 @@ commands:
                   , "sha": "$CIRCLE_SHA1" \
                   , "username": "$CIRCLE_USERNAME" \
                   , "job": "$CIRCLE_JOB" \
-                  }'
+                  }' \
               https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-job-failure:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ commands:
                   , "sha": "$CIRCLE_SHA1"
                   , "username": "$CIRCLE_USERNAME"
                   , "job": "$CIRCLE_JOB"
-                  }'
+                  }' \
               https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-success:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,15 +91,15 @@ commands:
             curl \
               -X POST \
               -H 'Content-type: application/json' \
-              -d '{ "success": false \
-                  , "buildType" <<parameters.buildType>> \
-                  , "branch": "$CIRCLE_BRANCH" \
-                  , "url": "$CIRCLE_BUILD_URL" \
-                  , "prs": "$CIRCLE_PULL_REQUESTS" \
-                  , "sha": "$CIRCLE_SHA1" \
-                  , "username": "$CIRCLE_USERNAME" \
-                  , "job": "$CIRCLE_JOB" \
-                  }' \
+              -d '{ "success": false
+                  , "buildType" <<parameters.buildType>>
+                  , "branch": "$CIRCLE_BRANCH"
+                  , "url": "$CIRCLE_BUILD_URL"
+                  , "prs": "$CIRCLE_PULL_REQUESTS"
+                  , "sha": "$CIRCLE_SHA1"
+                  , "username": "$CIRCLE_USERNAME"
+                  , "job": "$CIRCLE_JOB"
+                  }'
               https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-success:
@@ -113,14 +113,14 @@ commands:
             curl \
               -X POST \
               -H 'Content-type: application/json' \
-              -d '{ "success": true \
-                  , "buildType" <<parameters.buildType>> \
-                  , "branch": "$CIRCLE_BRANCH" \
-                  , "url": "$CIRCLE_BUILD_URL" \
-                  , "prs": "$CIRCLE_PULL_REQUESTS" \
-                  , "sha": "$CIRCLE_SHA1" \
-                  , "username": "$CIRCLE_USERNAME" \
-                  , "job": "$CIRCLE_JOB" \
+              -d '{ "success": true
+                  , "buildType" <<parameters.buildType>>
+                  , "branch": "$CIRCLE_BRANCH"
+                  , "url": "$CIRCLE_BUILD_URL"
+                  , "prs": "$CIRCLE_PULL_REQUESTS"
+                  , "sha": "$CIRCLE_SHA1"
+                  , "username": "$CIRCLE_USERNAME"
+                  , "job": "$CIRCLE_JOB"
                   }' \
               https://ops-circleci.builtwithdark.com/notify-slack
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,30 +81,11 @@ commands:
   # Slack
   ##########################
   slack-notify-failure:
+    parameters:
+      buildType: { type: string } # build or deploy
     steps:
       - run:
-          name: Slack failure notification
-          when: on_success
-          command: |
-            curl
-              -v
-              -X POST
-              -H 'Content-type: application/json'
-              -d '{ "success": true \
-                  , "branch": "$CIRCLE_BRANCH" \
-                  , "url": "$CIRCLE_BUILD_URL" \
-                  , "prs": "$CIRCLE_PULL_REQUESTS" \
-                  , "sha": "$CIRCLE_SHA1" \
-                  , "username": "$CIRCLE_USERNAME" \
-                  , "job": "$CIRCLE_JOB" \
-                  }'
-              https://ops-circleci.builtwithdark.com/notify-slack
-
-
-  slack-notify-success:
-    steps:
-      - run:
-          name: Slack failure notification
+          name: Slack notification
           when: on_fail
           command: |
             curl
@@ -112,6 +93,7 @@ commands:
               -X POST
               -H 'Content-type: application/json'
               -d '{ "success": false \
+                  , "buildType" <<parameters.buildType>> \
                   , "branch": "$CIRCLE_BRANCH" \
                   , "url": "$CIRCLE_BUILD_URL" \
                   , "prs": "$CIRCLE_PULL_REQUESTS" \
@@ -120,6 +102,49 @@ commands:
                   , "job": "$CIRCLE_JOB" \
                   }'
               https://ops-circleci.builtwithdark.com/notify-slack
+
+  slack-notify-success:
+    parameters:
+      buildType: { type: string } # build or deploy
+    steps:
+      - run:
+          name: Slack notification
+          when: on_success
+          command: |
+            curl
+              -v
+              -X POST
+              -H 'Content-type: application/json'
+              -d '{ "success": true \
+                  , "buildType" <<parameters.buildType>> \
+                  , "branch": "$CIRCLE_BRANCH" \
+                  , "url": "$CIRCLE_BUILD_URL" \
+                  , "prs": "$CIRCLE_PULL_REQUESTS" \
+                  , "sha": "$CIRCLE_SHA1" \
+                  , "username": "$CIRCLE_USERNAME" \
+                  , "job": "$CIRCLE_JOB" \
+                  }'
+              https://ops-circleci.builtwithdark.com/notify-slack
+
+  slack-notify-job-failure:
+    steps:
+      - slack-notify-failure:
+          buildType: "job"
+  slack-notify-deploy:
+    steps:
+      - slack-notify-failure:
+          buildType: "deploy"
+      - slack-notify-success:
+          buildType: "deploy"
+  slack-notify-build:
+    steps:
+      - slack-notify-failure:
+          buildType: "build"
+      - slack-notify-success:
+          buildType: "build"
+
+
+
 
   ##########################
   # Rust
@@ -250,7 +275,7 @@ jobs:
       - store_artifacts: { path: rundir }
       - store_artifacts: { path: backend/static/etags.json }
       - store_test_results: { path: rundir/test_results }
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   build-backend:
     executor: in-container
@@ -305,7 +330,7 @@ jobs:
           key: v9-backend-{{ checksum "esy.json" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   build-fsharp-backend:
     executor: in-container
@@ -345,7 +370,7 @@ jobs:
           key: v5-fsharp-backend-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   static-checks:
     executor: in-rust-container
@@ -356,7 +381,7 @@ jobs:
       - run: scripts/formatting/format check
       - run: scripts/build/compile-project shipit
       - run: scripts/deployment/shipit validate
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   predeployment-checks:
     executor: in-container
@@ -365,7 +390,7 @@ jobs:
       - auth-with-gcp: { background: false }
       - run: scripts/build/compile-project shipit
       - run: scripts/deployment/shipit manual diff > /dev/null 2>&1
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   build-stroller:
     executor: in-rust-container
@@ -375,7 +400,7 @@ jobs:
       - run: scripts/build/compile-project stroller --test
       - assert-clean-worktree
       - rust-finish: { project: "stroller", dir: "containers/stroller" }
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   build-queue-scheduler:
     executor: in-rust-container
@@ -386,7 +411,7 @@ jobs:
       - run: scripts/build/compile-project queue-scheduler
       - assert-clean-worktree
       - rust-finish: { project: "queue-scheduler", dir: "containers/queue-scheduler" }
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   build-postgres-honeytail:
     executor: simple-executor
@@ -394,7 +419,7 @@ jobs:
       - darkcheckout
       - prep-container-creation
       - run: cd containers/postgres-honeytail && docker build -t postgres-honeytail .
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   validate-honeycomb-config:
     executor: simple-executor
@@ -402,7 +427,7 @@ jobs:
       - darkcheckout
       - prep-container-creation
       - run: bash -c scripts/linting/test-honeycomb-config.sh
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   integration-tests:
     executor: in-container
@@ -456,7 +481,7 @@ jobs:
           name: "Save packagejson-specific cache"
           paths: ["integration-tests/node_modules", "/home/dark/.cache/ms-playwright"]
           key: v2-playwright-{{ checksum "integration-tests/package-lock.json" }}-{{ .Branch }}
-      - slack-notify-failure
+      - slack-notify-job-failure
 
 
   rust-integration-tests:
@@ -477,7 +502,7 @@ jobs:
           command: scripts/run-rust-tests containers/queue-scheduler
       - assert-clean-worktree
       - store_artifacts: { path: rundir }
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   gcp-containers-test:
     executor: in-container
@@ -489,7 +514,7 @@ jobs:
       # This is needed because kubectl --dry-run uses it
       - auth-with-gcp: { background: false }
       - build-gcp-containers
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   push-to-gcp:
     executor: in-container
@@ -506,7 +531,7 @@ jobs:
           paths: ["gcr-image-ids.json"]
       - run: scripts/deployment/_push-assets-to-cdn
       - run: scripts/deployment/shipit containers push
-      - slack-notify-failure
+      - slack-notify-job-failure
 
   deploy:
     executor: in-container
@@ -518,14 +543,12 @@ jobs:
       - attach_workspace: { at: "." }
       - show-large-files-and-directories
       - run: scripts/deployment/gke-deploy --manifest=gcr-image-ids.json
-      - slack-notify-failure
-      - slack-notify-success
+      - slack-notify-deploy
 
   notify-non-deploy:
     executor: simple-executor
     steps:
-      - slack-notify-success
-      - slack-notify-failure
+      - slack-notify-build
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ commands:
           name: Slack notification
           when: on_fail
           command: |
-            curl -X POST -H 'Content-type: application/json' -d "{ \"success\": false, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": [$CIRCLE_PULL_REQUESTS], \"sha\": \"$CIRCLE_SHA1\", \"username\": \"$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
+            curl -v -X POST -H 'Content-type: application/json' -d "{ \"success\": false, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": \"$CIRCLE_PULL_REQUESTS\", \"sha\": \"$CIRCLE_SHA1\", \"username\": \"$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-success:
     parameters:
@@ -98,7 +98,7 @@ commands:
           name: Slack notification
           when: on_success
           command: |
-            curl -X POST -H 'Content-type: application/json' -d "{ \"success\": true, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": [$CIRCLE_PULL_REQUESTS], \"sha\": \"$CIRCLE_SHA1\", \"username\": \"$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
+            curl -v -X POST -H 'Content-type: application/json' -d "{ \"success\": true, \"buildType\": \"<<parameters.buildType>>\", \"branch\": \"$CIRCLE_BRANCH\", \"url\": \"$CIRCLE_BUILD_URL\", \"prs\": \"$CIRCLE_PULL_REQUESTS\", \"sha\": \"$CIRCLE_SHA1\", \"username\": \"$CIRCLE_USERNAME\", \"job\": \"$CIRCLE_JOB\" }" https://ops-circleci.builtwithdark.com/notify-slack
 
   slack-notify-job-failure:
     steps:


### PR DESCRIPTION
CircleCI was blocking contributor builds because we used a "Context" (a collection of secrets) and if it can't share those (because we don't enable sharing secrets) it fails the builds as unauthorized.

The secrets were slack keys, so the obvious thing is to move the slack notification to a darklang canvas (where the secret is hidden away) and remove the context from the build.


