### PR TITLE
Push integration test results only when credentials present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,12 +485,6 @@ jobs:
       - darkcheckout
       - setup-app
       - attach_workspace: { at: "." }
-      # This is needed because kubectl --dry-run uses it
-      - auth-with-gcp:
-          background: false
-          filters:
-            branches:
-              ignore: /^(pull\/).*$/
       - build-gcp-containers
       - slack-notify-job-failure
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,11 @@ jobs:
       - setup-app
       - attach_workspace: { at: "." }
       # This is needed because kubectl --dry-run uses it
-      - auth-with-gcp: { background: false }
+      - auth-with-gcp:
+          background: false
+          filters:
+            branches:
+              ignore: /^(pull\/).*$/
       - build-gcp-containers
       - slack-notify-job-failure
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ commands:
       - run: scripts/deployment/shipit containers build --save-manifest=gcr-image-ids.json
       - run: cat gcr-image-ids.json
       # Test them
-      - run: scripts/deployment/shipit release push --dry-run=client --arg CHANGE_CAUSE="test" --manifest=gcr-image-ids.json
+      - run: scripts/deployment/shipit release prepare --dry-run=client --arg CHANGE_CAUSE="test" --manifest=gcr-image-ids.json
 
   ##########################
   # misc
@@ -530,7 +530,10 @@ workflows:
     jobs:
       # initial builds & tests
       - static-checks
-      - predeployment-checks
+      - predeployment-checks:
+          filters:
+            branches:
+              ignore: /^(pull\/).*$/
       - build-postgres-honeytail
       - validate-honeycomb-config
       - build-backend

--- a/integration-tests/_integration-test-results-to-honeycomb.sh
+++ b/integration-tests/_integration-test-results-to-honeycomb.sh
@@ -13,11 +13,13 @@ set -euo pipefail
 # accepts (despite docs specifying either RFC3339 or RFC3339 with nanoseconds)
 timestamp=$(date)
 
-cat rundir/test_results/integration_tests.json \
-    | integration-tests/_process-integration-test-results.sh \
-    | honeytail --parser=json \
-                --writekey="${BUILDEVENT_APIKEY}" \
-                --dataset="integration-tests" \
-                --add_field="timestamp=${timestamp}" \
-                --backfill \
-                --file=-
+if [[ -v BUILDEVENT_APIKEY ]]; then
+  cat rundir/test_results/integration_tests.json \
+      | integration-tests/_process-integration-test-results.sh \
+      | honeytail --parser=json \
+                  --writekey="${BUILDEVENT_APIKEY}" \
+                  --dataset="integration-tests" \
+                  --add_field="timestamp=${timestamp}" \
+                  --backfill \
+                  --file=-
+fi


### PR DESCRIPTION
## What is the problem/goal being addressed?
CI fails to post the results of integration tests to honeycomb, for PRs against a fork of Dark.

Example: https://app.circleci.com/pipelines/github/darklang/dark/2149/workflows/1877e29a-765c-49c1-b9c4-3bb46564c7bd/jobs/22397?invite=true#step-112-3

## What is the solution to this problem?
Only attempt push to honeycomb if credential `BUILDEVENT_APIKEY` is recent, in the appropriate shell script.
