### PR TITLE
Add debugging to legacyserver

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Attach to ApiServer",
       "type": "coreclr",
       "request": "attach",
-      "program": "/home/dark/app/fsharp-backend/Build/out/ApiServer/Debug/net6.0/linux-x64/ApiServer2",
+      "program": "/home/dark/app/fsharp-backend/Build/out/ApiServer/Debug/net6.0/linux-x64/ApiServer",
       "stopAtEntry": true
     },
     {

--- a/backend/bin/legacy_serialization_server.ml
+++ b/backend/bin/legacy_serialization_server.ml
@@ -92,6 +92,7 @@ let server () =
     | `POST, Some fn ->
       ( try
           let result = body_string |> fn in
+          let sub_length = min (String.length result) 50 in
           Libcommon.Log.infO
             "Successfully completed legacyserver call"
             ~data:""
@@ -101,7 +102,7 @@ let server () =
               ; ("method", Cohttp.Code.string_of_method meth)
               ; ("length", string_of_int (String.length result))
               ; ("ip_address", ip_address)
-              ; ("result", String.sub ~pos:0 ~len:50 result) ] ;
+              ; ("result", String.sub ~pos:0 ~len:sub_length result) ] ;
           respond_json_ok result
         with e ->
           let headers = Header.init () in

--- a/fsharp-backend/src/LibService/Telemetry.fs
+++ b/fsharp-backend/src/LibService/Telemetry.fs
@@ -298,7 +298,11 @@ let addTelemetry
   |> fun b ->
        b.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName))
   |> fun b -> b.AddAspNetCoreInstrumentation(configureAspNetCore)
-  |> fun b -> b.AddHttpClientInstrumentation()
+  |> fun b ->
+       b.AddHttpClientInstrumentation (fun options ->
+         options.SetHttpFlavor <- true // Record HTTP version
+         options.RecordException <- true
+         ())
   |> fun b ->
        match traceDBQueries with
        | TraceDBQueries -> b.AddNpgsql()

--- a/scripts/production/connect-to-production-container
+++ b/scripts/production/connect-to-production-container
@@ -5,10 +5,6 @@
 
 set -euo pipefail
 
-pod=$1 # a deployment name is also allowed
-container=$2
-namespace="${3:-darklang}"
-
 ./scripts/production/gcp-authorize-kubectl
 
-kubectl exec --stdin --tty $pod -c $container --namespace $namespace -- /bin/bash
+kubectl exec --stdin --tty "$@" -- /bin/bash


### PR DESCRIPTION
I cant figure out why the legacyserver isn't being reached by the ApiServer, so this adds some instrumentation on both ends to see if we can get some answers.

Also some minor fixed to VSCode launching, and connecting to production containers.