### PR TITLE
Fix /api/packages requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ services/postgres-honeytail-deployment/postgres-honeytail-deployment.yaml
 services/qw-deployment/qw-deployment.yaml
 services/queueworker-deployment/queueworker-deployment.yaml
 services/scheduler-deployment/scheduler-deployment.yaml
-services/tunnel-deployment/tunnel-deployment.yaml
 services/tunnel2-deployment/tunnel2-deployment.yaml
 
 # Rust projects build into target/

--- a/backend/bin/legacy_serialization_server.ml
+++ b/backend/bin/legacy_serialization_server.ml
@@ -25,177 +25,181 @@ let shutdown = ref false
 let server () =
   let stop, stopper = Lwt.wait () in
   Libcommon.Telemetry.with_root "Serialization_server" (fun root ->
-    let callback (conn : S.conn) (req : CRequest.t) (req_body : Cl.Body.t) :
-        (CResponse.t * Cl.Body.t) Lwt.t =
-      Libcommon.Telemetry.with_span root "request" (fun span ->
-        let%lwt body_string = Cl.Body.to_string req_body in
-        let body_length = String.length body_string in
-        let ch, _ = conn in
-        let ip_address : string =
-          match Conduit_lwt_unix.endp_of_flow ch with
-          | `TCP (ip, port) ->
-              Ipaddr.to_string ip
-          | _ ->
-              assert false
-        in
-        let uri = CRequest.uri req in
-        let meth = CRequest.meth req in
-        let path =
-          uri
-          |> Uri.path
-          |> String.lstrip ~drop:(( = ) '/')
-          |> String.rstrip ~drop:(( = ) '/')
-          |> String.split ~on:'/'
-        in
-        Libcommon.Telemetry.Span.set_attrs
-          span
-          [ ("uri", `String (Uri.to_string uri))
-          ; ("path", `String (Uri.path uri))
-          ; ("method", `String (Cohttp.Code.string_of_method meth))
-          ; ("request_length", `Int body_length)
-          ; ("ip_address", `String ip_address)
-          ] ;
-        let headers = Header.of_list [] in
-        let fn =
-          match path with
-          | ["bs"; fnname] ->
-            ( match fnname with
-            | "user_fn_bin2json" ->
-                Some BS.user_fn_bin2json
-            | "user_tipe_bin2json" ->
-                Some BS.user_tipe_bin2json
-            | "handler_bin2json" ->
-                Some BS.handler_bin2json
-            | "db_bin2json" ->
-                Some BS.db_bin2json
-            | "oplist_bin2json" ->
-                Some BS.oplist_bin2json
-            | "pos_bin2json" ->
-                Some BS.pos_bin2json
-            | "expr_bin2json" ->
-                Some BS.expr_bin2json
-            | "expr_tlid_pair_bin2json" ->
-                Some BS.expr_tlid_pair_bin2json
-            | "toplevel_bin2json" ->
-                Some BS.toplevel_bin2json
-            | "user_fn_json2bin" ->
-                Some BS.user_fn_json2bin
-            | "user_tipe_json2bin" ->
-                Some BS.user_tipe_json2bin
-            | "handler_json2bin" ->
-                Some BS.handler_json2bin
-            | "db_json2bin" ->
-                Some BS.db_json2bin
-            | "oplist_json2bin" ->
-                Some BS.oplist_json2bin
-            | "pos_json2bin" ->
-                Some BS.pos_json2bin
-            | "expr_json2bin" ->
-                Some BS.expr_json2bin
-            | "expr_tlid_pair_json2bin" ->
-                Some BS.expr_tlid_pair_json2bin
-            | _ ->
-                None )
-          | _ ->
-              None
-        in
-        match (meth, fn) with
-        | `POST, Some fn ->
-          ( try
-              let result = body_string |> fn in
-              let length = String.length result in
-              let sub_length = min length 50 in
-              Libcommon.Telemetry.Span.set_attrs
-                span
-                [ ("response_length", `Int length)
-                ; ("success", `Bool true)
-                ; ("response", `String (String.sub ~pos:0 ~len:sub_length result))
-                ] ;
-              respond_json_ok result
-            with e ->
-              let headers = Header.init () in
-              let message = Libexecution.Exception.exn_to_string e in
-              Libcommon.Telemetry.Span.set_attrs
-                span
-                [ ("success", `Bool false)
-                ; ("message", `String message)
-                ] ;
-              Libcommon.Log.erroR
-                "Error in legacyserver call"
-                ~data:message
-                ~params:
-                  [ ("uri", Uri.to_string uri)
-                  ; ("path", Uri.path uri)
-                  ; ("method", Cohttp.Code.string_of_method meth)
-                  ; ("body", body_string) ] ;
-              S.respond_string ~status:`Bad_request ~body:message ~headers () )
-        | `GET, None ->
-          ( match path with
-          | ["k8s"; "livenessProbe"] ->
-              S.respond_string
-                ~status:`OK
-                ~body:"Hello internal overlord"
-                ~headers
-                ()
-          | ["k8s"; "readinessProbe"] ->
-              let checks = [] in
-              ( match checks with
-              | [] ->
-                  if !ready
-                  then
-                    S.respond_string
-                      ~status:`OK
-                      ~body:"Hello internal overlord"
-                      ~headers
-                      ()
-                  else (
-                    Libcommon.Log.infO "Service ready" ;
-                    ready := true ;
-                    S.respond_string
-                      ~status:`OK
-                      ~body:"Hello internal overlord"
-                      ~headers
-                      () )
+      let callback (conn : S.conn) (req : CRequest.t) (req_body : Cl.Body.t) :
+          (CResponse.t * Cl.Body.t) Lwt.t =
+        Libcommon.Telemetry.with_span root "request" (fun span ->
+            let%lwt body_string = Cl.Body.to_string req_body in
+            let body_length = String.length body_string in
+            let ch, _ = conn in
+            let ip_address : string =
+              match Conduit_lwt_unix.endp_of_flow ch with
+              | `TCP (ip, port) ->
+                  Ipaddr.to_string ip
               | _ ->
+                  assert false
+            in
+            let uri = CRequest.uri req in
+            let meth = CRequest.meth req in
+            let path =
+              uri
+              |> Uri.path
+              |> String.lstrip ~drop:(( = ) '/')
+              |> String.rstrip ~drop:(( = ) '/')
+              |> String.split ~on:'/'
+            in
+            Libcommon.Telemetry.Span.set_attrs
+              span
+              [ ("uri", `String (Uri.to_string uri))
+              ; ("path", `String (Uri.path uri))
+              ; ("method", `String (Cohttp.Code.string_of_method meth))
+              ; ("request_length", `Int body_length)
+              ; ("ip_address", `String ip_address) ] ;
+            let headers = Header.of_list [] in
+            let fn =
+              match path with
+              | ["bs"; fnname] ->
+                ( match fnname with
+                | "user_fn_bin2json" ->
+                    Some BS.user_fn_bin2json
+                | "user_tipe_bin2json" ->
+                    Some BS.user_tipe_bin2json
+                | "handler_bin2json" ->
+                    Some BS.handler_bin2json
+                | "db_bin2json" ->
+                    Some BS.db_bin2json
+                | "oplist_bin2json" ->
+                    Some BS.oplist_bin2json
+                | "pos_bin2json" ->
+                    Some BS.pos_bin2json
+                | "expr_bin2json" ->
+                    Some BS.expr_bin2json
+                | "expr_tlid_pair_bin2json" ->
+                    Some BS.expr_tlid_pair_bin2json
+                | "toplevel_bin2json" ->
+                    Some BS.toplevel_bin2json
+                | "user_fn_json2bin" ->
+                    Some BS.user_fn_json2bin
+                | "user_tipe_json2bin" ->
+                    Some BS.user_tipe_json2bin
+                | "handler_json2bin" ->
+                    Some BS.handler_json2bin
+                | "db_json2bin" ->
+                    Some BS.db_json2bin
+                | "oplist_json2bin" ->
+                    Some BS.oplist_json2bin
+                | "pos_json2bin" ->
+                    Some BS.pos_json2bin
+                | "expr_json2bin" ->
+                    Some BS.expr_json2bin
+                | "expr_tlid_pair_json2bin" ->
+                    Some BS.expr_tlid_pair_json2bin
+                | _ ->
+                    None )
+              | _ ->
+                  None
+            in
+            match (meth, fn) with
+            | `POST, Some fn ->
+              ( try
+                  let result = body_string |> fn in
+                  let length = String.length result in
+                  let sub_length = min length 50 in
+                  Libcommon.Telemetry.Span.set_attrs
+                    span
+                    [ ("response_length", `Int length)
+                    ; ("success", `Bool true)
+                    ; ( "response"
+                      , `String (String.sub ~pos:0 ~len:sub_length result) ) ] ;
+                  respond_json_ok result
+                with e ->
+                  let headers = Header.init () in
+                  let message = Libexecution.Exception.exn_to_string e in
+                  Libcommon.Telemetry.Span.set_attrs
+                    span
+                    [("success", `Bool false); ("message", `String message)] ;
                   Libcommon.Log.erroR
-                    "Failed readiness check"
-                    ~params:[("checks", String.concat ~sep:"," checks)] ;
+                    "Error in legacyserver call"
+                    ~data:message
+                    ~params:
+                      [ ("uri", Uri.to_string uri)
+                      ; ("path", Uri.path uri)
+                      ; ("method", Cohttp.Code.string_of_method meth)
+                      ; ("body", body_string) ] ;
                   S.respond_string
                     ~status:`Bad_request
-                    ~body:"Sorry internal overlord"
+                    ~body:message
                     ~headers
                     () )
-          (* For GKE graceful termination *)
-          | ["k8s"; "pkill"] ->
-              if not !shutdown (* note: this is a ref, not a boolean `not` *)
-              then (
-                shutdown := true ;
-                Libcommon.Log.infO
-                  "shutdown"
-                  ~data:"Received shutdown request - shutting down"
-                  ~params:[] ;
-                (* k8s gives us 30 seconds, so ballpark 2s for overhead *)
-                Lwt_unix.sleep 28.0
-                >>= fun _ ->
-                Lwt.wakeup stopper () ;
-                S.respond_string ~status:`OK ~body:"Terminated" ~headers () )
-              else (
-                Libcommon.Log.infO
-                  "shutdown"
-                  ~data:
-                    "Received redundant shutdown request - already shutting down" ;
-                S.respond_string ~status:`OK ~body:"Terminated" ~headers () )
-          | _ ->
-              let headers = Header.init () in
-              S.respond_string ~status:`Not_found ~body:"" ~headers () )
-        | _ ->
-            let headers = Header.init () in
-            S.respond_string ~status:`Not_found ~body:"" ~headers ())
-    in
-    S.create
-      ~stop
-      ~mode:(`TCP (`Port Libservice.Config.legacy_serialization_server_port))
-      (S.make ~callback ()))
+            | `GET, None ->
+              ( match path with
+              | ["k8s"; "livenessProbe"] ->
+                  S.respond_string
+                    ~status:`OK
+                    ~body:"Hello internal overlord"
+                    ~headers
+                    ()
+              | ["k8s"; "readinessProbe"] ->
+                  let checks = [] in
+                  ( match checks with
+                  | [] ->
+                      if !ready
+                      then
+                        S.respond_string
+                          ~status:`OK
+                          ~body:"Hello internal overlord"
+                          ~headers
+                          ()
+                      else (
+                        Libcommon.Log.infO "Service ready" ;
+                        ready := true ;
+                        S.respond_string
+                          ~status:`OK
+                          ~body:"Hello internal overlord"
+                          ~headers
+                          () )
+                  | _ ->
+                      Libcommon.Log.erroR
+                        "Failed readiness check"
+                        ~params:[("checks", String.concat ~sep:"," checks)] ;
+                      S.respond_string
+                        ~status:`Bad_request
+                        ~body:"Sorry internal overlord"
+                        ~headers
+                        () )
+              (* For GKE graceful termination *)
+              | ["k8s"; "pkill"] ->
+                  if not !shutdown
+                     (* note: this is a ref, not a boolean `not` *)
+                  then (
+                    shutdown := true ;
+                    Libcommon.Log.infO
+                      "shutdown"
+                      ~data:"Received shutdown request - shutting down"
+                      ~params:[] ;
+                    (* k8s gives us 30 seconds, so ballpark 2s for overhead *)
+                    Lwt_unix.sleep 28.0
+                    >>= fun _ ->
+                    Lwt.wakeup stopper () ;
+                    S.respond_string ~status:`OK ~body:"Terminated" ~headers ()
+                    )
+                  else (
+                    Libcommon.Log.infO
+                      "shutdown"
+                      ~data:
+                        "Received redundant shutdown request - already shutting down" ;
+                    S.respond_string ~status:`OK ~body:"Terminated" ~headers ()
+                    )
+              | _ ->
+                  let headers = Header.init () in
+                  S.respond_string ~status:`Not_found ~body:"" ~headers () )
+            | _ ->
+                let headers = Header.init () in
+                S.respond_string ~status:`Not_found ~body:"" ~headers ())
+      in
+      S.create
+        ~stop
+        ~mode:(`TCP (`Port Libservice.Config.legacy_serialization_server_port))
+        (S.make ~callback ()))
 
 
 let () =

--- a/backend/bin/legacy_serialization_server.ml
+++ b/backend/bin/legacy_serialization_server.ml
@@ -24,165 +24,178 @@ let shutdown = ref false
 
 let server () =
   let stop, stopper = Lwt.wait () in
-  let callback (conn : S.conn) (req : CRequest.t) (req_body : Cl.Body.t) :
-      (CResponse.t * Cl.Body.t) Lwt.t =
-    let%lwt body_string = Cl.Body.to_string req_body in
-    let ch, _ = conn in
-    let ip_address : string =
-      match Conduit_lwt_unix.endp_of_flow ch with
-      | `TCP (ip, port) ->
-          Ipaddr.to_string ip
-      | _ ->
-          assert false
-    in
-    let uri = CRequest.uri req in
-    let meth = CRequest.meth req in
-    let path =
-      uri
-      |> Uri.path
-      |> String.lstrip ~drop:(( = ) '/')
-      |> String.rstrip ~drop:(( = ) '/')
-      |> String.split ~on:'/'
-    in
-    let headers = Header.of_list [] in
-    let fn =
-      match path with
-      | ["bs"; fnname] ->
-        ( match fnname with
-        | "user_fn_bin2json" ->
-            Some BS.user_fn_bin2json
-        | "user_tipe_bin2json" ->
-            Some BS.user_tipe_bin2json
-        | "handler_bin2json" ->
-            Some BS.handler_bin2json
-        | "db_bin2json" ->
-            Some BS.db_bin2json
-        | "oplist_bin2json" ->
-            Some BS.oplist_bin2json
-        | "pos_bin2json" ->
-            Some BS.pos_bin2json
-        | "expr_bin2json" ->
-            Some BS.expr_bin2json
-        | "expr_tlid_pair_bin2json" ->
-            Some BS.expr_tlid_pair_bin2json
-        | "toplevel_bin2json" ->
-            Some BS.toplevel_bin2json
-        | "user_fn_json2bin" ->
-            Some BS.user_fn_json2bin
-        | "user_tipe_json2bin" ->
-            Some BS.user_tipe_json2bin
-        | "handler_json2bin" ->
-            Some BS.handler_json2bin
-        | "db_json2bin" ->
-            Some BS.db_json2bin
-        | "oplist_json2bin" ->
-            Some BS.oplist_json2bin
-        | "pos_json2bin" ->
-            Some BS.pos_json2bin
-        | "expr_json2bin" ->
-            Some BS.expr_json2bin
-        | "expr_tlid_pair_json2bin" ->
-            Some BS.expr_tlid_pair_json2bin
-        | _ ->
-            None )
-      | _ ->
-          None
-    in
-    match (meth, fn) with
-    | `POST, Some fn ->
-      ( try
-          let result = body_string |> fn in
-          let sub_length = min (String.length result) 50 in
-          Libcommon.Log.infO
-            "Successfully completed legacyserver call"
-            ~data:""
-            ~params:
-              [ ("uri", Uri.to_string uri)
-              ; ("path", Uri.path uri)
-              ; ("method", Cohttp.Code.string_of_method meth)
-              ; ("length", string_of_int (String.length result))
-              ; ("ip_address", ip_address)
-              ; ("result", String.sub ~pos:0 ~len:sub_length result) ] ;
-          respond_json_ok result
-        with e ->
-          let headers = Header.init () in
-          let message = Libexecution.Exception.exn_to_string e in
-          Libcommon.Log.erroR
-            "Error in legacyserver call"
-            ~data:message
-            ~params:
-              [ ("uri", Uri.to_string uri)
-              ; ("path", Uri.path uri)
-              ; ("method", Cohttp.Code.string_of_method meth)
-              ; ("body", body_string) ] ;
-          S.respond_string ~status:`Bad_request ~body:message ~headers () )
-    | `GET, None ->
-      ( match path with
-      | ["k8s"; "livenessProbe"] ->
-          S.respond_string
-            ~status:`OK
-            ~body:"Hello internal overlord"
-            ~headers
-            ()
-      | ["k8s"; "readinessProbe"] ->
-          let checks = [] in
-          ( match checks with
-          | [] ->
-              if !ready
-              then
-                S.respond_string
-                  ~status:`OK
-                  ~body:"Hello internal overlord"
-                  ~headers
-                  ()
-              else (
-                Libcommon.Log.infO "Service ready" ;
-                ready := true ;
-                S.respond_string
-                  ~status:`OK
-                  ~body:"Hello internal overlord"
-                  ~headers
-                  () )
+  Libcommon.Telemetry.with_root "Serialization_server" (fun root ->
+    let callback (conn : S.conn) (req : CRequest.t) (req_body : Cl.Body.t) :
+        (CResponse.t * Cl.Body.t) Lwt.t =
+      Libcommon.Telemetry.with_span root "request" (fun span ->
+        let%lwt body_string = Cl.Body.to_string req_body in
+        let body_length = String.length body_string in
+        let ch, _ = conn in
+        let ip_address : string =
+          match Conduit_lwt_unix.endp_of_flow ch with
+          | `TCP (ip, port) ->
+              Ipaddr.to_string ip
           | _ ->
+              assert false
+        in
+        let uri = CRequest.uri req in
+        let meth = CRequest.meth req in
+        let path =
+          uri
+          |> Uri.path
+          |> String.lstrip ~drop:(( = ) '/')
+          |> String.rstrip ~drop:(( = ) '/')
+          |> String.split ~on:'/'
+        in
+        Libcommon.Telemetry.Span.set_attrs
+          span
+          [ ("uri", `String (Uri.to_string uri))
+          ; ("path", `String (Uri.path uri))
+          ; ("method", `String (Cohttp.Code.string_of_method meth))
+          ; ("request_length", `Int body_length)
+          ; ("ip_address", `String ip_address)
+          ] ;
+        let headers = Header.of_list [] in
+        let fn =
+          match path with
+          | ["bs"; fnname] ->
+            ( match fnname with
+            | "user_fn_bin2json" ->
+                Some BS.user_fn_bin2json
+            | "user_tipe_bin2json" ->
+                Some BS.user_tipe_bin2json
+            | "handler_bin2json" ->
+                Some BS.handler_bin2json
+            | "db_bin2json" ->
+                Some BS.db_bin2json
+            | "oplist_bin2json" ->
+                Some BS.oplist_bin2json
+            | "pos_bin2json" ->
+                Some BS.pos_bin2json
+            | "expr_bin2json" ->
+                Some BS.expr_bin2json
+            | "expr_tlid_pair_bin2json" ->
+                Some BS.expr_tlid_pair_bin2json
+            | "toplevel_bin2json" ->
+                Some BS.toplevel_bin2json
+            | "user_fn_json2bin" ->
+                Some BS.user_fn_json2bin
+            | "user_tipe_json2bin" ->
+                Some BS.user_tipe_json2bin
+            | "handler_json2bin" ->
+                Some BS.handler_json2bin
+            | "db_json2bin" ->
+                Some BS.db_json2bin
+            | "oplist_json2bin" ->
+                Some BS.oplist_json2bin
+            | "pos_json2bin" ->
+                Some BS.pos_json2bin
+            | "expr_json2bin" ->
+                Some BS.expr_json2bin
+            | "expr_tlid_pair_json2bin" ->
+                Some BS.expr_tlid_pair_json2bin
+            | _ ->
+                None )
+          | _ ->
+              None
+        in
+        match (meth, fn) with
+        | `POST, Some fn ->
+          ( try
+              let result = body_string |> fn in
+              let length = String.length result in
+              let sub_length = min length 50 in
+              Libcommon.Telemetry.Span.set_attrs
+                span
+                [ ("response_length", `Int length)
+                ; ("success", `Bool true)
+                ; ("response", `String (String.sub ~pos:0 ~len:sub_length result))
+                ] ;
+              respond_json_ok result
+            with e ->
+              let headers = Header.init () in
+              let message = Libexecution.Exception.exn_to_string e in
+              Libcommon.Telemetry.Span.set_attrs
+                span
+                [ ("success", `Bool false)
+                ; ("message", `String message)
+                ] ;
               Libcommon.Log.erroR
-                "Failed readiness check"
-                ~params:[("checks", String.concat ~sep:"," checks)] ;
+                "Error in legacyserver call"
+                ~data:message
+                ~params:
+                  [ ("uri", Uri.to_string uri)
+                  ; ("path", Uri.path uri)
+                  ; ("method", Cohttp.Code.string_of_method meth)
+                  ; ("body", body_string) ] ;
+              S.respond_string ~status:`Bad_request ~body:message ~headers () )
+        | `GET, None ->
+          ( match path with
+          | ["k8s"; "livenessProbe"] ->
               S.respond_string
-                ~status:`Bad_request
-                ~body:"Sorry internal overlord"
+                ~status:`OK
+                ~body:"Hello internal overlord"
                 ~headers
-                () )
-      (* For GKE graceful termination *)
-      | ["k8s"; "pkill"] ->
-          if not !shutdown (* note: this is a ref, not a boolean `not` *)
-          then (
-            shutdown := true ;
-            Libcommon.Log.infO
-              "shutdown"
-              ~data:"Received shutdown request - shutting down"
-              ~params:[] ;
-            (* k8s gives us 30 seconds, so ballpark 2s for overhead *)
-            Lwt_unix.sleep 28.0
-            >>= fun _ ->
-            Lwt.wakeup stopper () ;
-            S.respond_string ~status:`OK ~body:"Terminated" ~headers () )
-          else (
-            Libcommon.Log.infO
-              "shutdown"
-              ~data:
-                "Received redundant shutdown request - already shutting down" ;
-            S.respond_string ~status:`OK ~body:"Terminated" ~headers () )
-      | _ ->
-          let headers = Header.init () in
-          S.respond_string ~status:`Not_found ~body:"" ~headers () )
-    | _ ->
-        let headers = Header.init () in
-        S.respond_string ~status:`Not_found ~body:"" ~headers ()
-  in
-  S.create
-    ~stop
-    ~mode:(`TCP (`Port Libservice.Config.legacy_serialization_server_port))
-    (S.make ~callback ())
+                ()
+          | ["k8s"; "readinessProbe"] ->
+              let checks = [] in
+              ( match checks with
+              | [] ->
+                  if !ready
+                  then
+                    S.respond_string
+                      ~status:`OK
+                      ~body:"Hello internal overlord"
+                      ~headers
+                      ()
+                  else (
+                    Libcommon.Log.infO "Service ready" ;
+                    ready := true ;
+                    S.respond_string
+                      ~status:`OK
+                      ~body:"Hello internal overlord"
+                      ~headers
+                      () )
+              | _ ->
+                  Libcommon.Log.erroR
+                    "Failed readiness check"
+                    ~params:[("checks", String.concat ~sep:"," checks)] ;
+                  S.respond_string
+                    ~status:`Bad_request
+                    ~body:"Sorry internal overlord"
+                    ~headers
+                    () )
+          (* For GKE graceful termination *)
+          | ["k8s"; "pkill"] ->
+              if not !shutdown (* note: this is a ref, not a boolean `not` *)
+              then (
+                shutdown := true ;
+                Libcommon.Log.infO
+                  "shutdown"
+                  ~data:"Received shutdown request - shutting down"
+                  ~params:[] ;
+                (* k8s gives us 30 seconds, so ballpark 2s for overhead *)
+                Lwt_unix.sleep 28.0
+                >>= fun _ ->
+                Lwt.wakeup stopper () ;
+                S.respond_string ~status:`OK ~body:"Terminated" ~headers () )
+              else (
+                Libcommon.Log.infO
+                  "shutdown"
+                  ~data:
+                    "Received redundant shutdown request - already shutting down" ;
+                S.respond_string ~status:`OK ~body:"Terminated" ~headers () )
+          | _ ->
+              let headers = Header.init () in
+              S.respond_string ~status:`Not_found ~body:"" ~headers () )
+        | _ ->
+            let headers = Header.init () in
+            S.respond_string ~status:`Not_found ~body:"" ~headers ())
+    in
+    S.create
+      ~stop
+      ~mode:(`TCP (`Port Libservice.Config.legacy_serialization_server_port))
+      (S.make ~callback ()))
 
 
 let () =
@@ -205,4 +218,4 @@ let () =
     ignore (Lwt_main.run (Nocrypto_entropy_lwt.initialize () >>= server))
   with e ->
     let bt = Libexecution.Exception.get_backtrace () in
-    Libservice.Rollbar.last_ditch e ~bt "server" "no execution id"
+    Libservice.Rollbar.last_ditch e ~bt "serialization-server" "no execution id"

--- a/fsharp-backend/src/LibBackend/PackageManager.fs
+++ b/fsharp-backend/src/LibBackend/PackageManager.fs
@@ -324,15 +324,18 @@ let allFunctions () : Task<List<PT.Package.Fn>> =
             deprecated,
             tlid) ->
         task {
+          let name : PT.FQFnName.PackageFnName =
+            { owner = username
+              package = package
+              module_ = module_
+              function_ = fnname
+              version = version }
+          use _span =
+            LibService.Telemetry.child "decode package binary" [ "fn", string name ]
           let! (expr, _) = OCamlInterop.exprTLIDPairOfCachedBinary body
 
           return
-            ({ name =
-                 { owner = username
-                   package = package
-                   module_ = module_
-                   function_ = fnname
-                   version = version }
+            ({ name = name
                body = expr
                returnType =
                  PT.DType.parse returnType

--- a/services/apiserver-deployment/apiserver-deployment.template.yaml
+++ b/services/apiserver-deployment/apiserver-deployment.template.yaml
@@ -75,11 +75,11 @@ spec:
           # https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6
           resources:
             requests:
-              memory: "1000Mi"
-              cpu: "125m"
+              memory: "2000Mi"
+              cpu: "3"
             limits:
-              memory: "1000Mi"
-              cpu: "125m"
+              memory: "2000Mi"
+              cpu: "3"
 
           # ---------------------
           # Lifecycles probes

--- a/services/apiserver-deployment/apiserver-deployment.template.yaml
+++ b/services/apiserver-deployment/apiserver-deployment.template.yaml
@@ -78,8 +78,8 @@ spec:
               memory: "2000Mi"
               cpu: "3"
             limits:
-              memory: "2000Mi"
-              cpu: "3"
+              memory: "3000Mi"
+              cpu: "4"
 
           # ---------------------
           # Lifecycles probes

--- a/services/bwdserver-deployment/bwdserver-deployment.template.yaml
+++ b/services/bwdserver-deployment/bwdserver-deployment.template.yaml
@@ -75,11 +75,11 @@ spec:
           # https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6
           resources:
             requests:
-              memory: "1000Mi"
-              cpu: "125m"
+              memory: "2000Mi"
+              cpu: "3"
             limits:
-              memory: "1000Mi"
-              cpu: "125m"
+              memory: "2000Mi"
+              cpu: "3"
 
           # ---------------------
           # Lifecycles probes

--- a/services/bwdserver-deployment/bwdserver-deployment.template.yaml
+++ b/services/bwdserver-deployment/bwdserver-deployment.template.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   revisionHistoryLimit: 10
-  replicas: 2 # FSTODO - probably 4, depends on load supported
+  replicas: 4
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -78,8 +78,8 @@ spec:
               memory: "2000Mi"
               cpu: "3"
             limits:
-              memory: "2000Mi"
-              cpu: "3"
+              memory: "3000Mi"
+              cpu: "4"
 
           # ---------------------
           # Lifecycles probes


### PR DESCRIPTION
Adds enough telemetry to figure out the problem with calling the /packages route. What was happening was that the requests were happening quickly, but the JSON decoding was attrociously slow. Each decode was taking 200ms, even though the request was happing in fractions of a second.

The decode is slow because it's using Json.NET, but also because the server is underpowered. I fixed it by setting the servers to have 3 CPUs and 2GB memory. We're doing more of a beefy server than millions of underpowered servers like we were with OCaml (though that itself was async dodge).

We'll remove the JSON.net stuff at some point in the future, but it's fine for now. Given we'll remove all this stuff in the future, it isn't a huge problem.