### PR TITLE
Get the healthcheck to the bwdserver in a way it will respond to

### DIFF
--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -468,7 +468,8 @@ let webserver
   builder.WebHost
   |> fun wh -> wh.ConfigureLogging(loggerSetup)
   |> fun wh -> wh.UseKestrel(LibService.Kestrel.configureKestrel)
-  |> fun wh -> wh.UseUrls(hcUrl, $"http://*:{httpPort}")
+  |> fun wh ->
+       wh.UseUrls(hcUrl, $"http://*:{httpPort}", "http://bwdserver-healthcheck")
   |> ignore<IWebHostBuilder>
 
   let app = builder.Build()

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -468,8 +468,7 @@ let webserver
   builder.WebHost
   |> fun wh -> wh.ConfigureLogging(loggerSetup)
   |> fun wh -> wh.UseKestrel(LibService.Kestrel.configureKestrel)
-  |> fun wh ->
-       wh.UseUrls(hcUrl, $"http://*:{httpPort}", "http://bwdserver-healthcheck")
+  |> fun wh -> wh.UseUrls(hcUrl, $"http://*:{httpPort}")
   |> ignore<IWebHostBuilder>
 
   let app = builder.Build()

--- a/fsharp-backend/src/LibService/Kubernetes.fs
+++ b/fsharp-backend/src/LibService/Kubernetes.fs
@@ -67,6 +67,14 @@ let configureApp (port : int) (app : IApplicationBuilder) : IApplicationBuilder 
       let addHealthCheck (path : string) (tag : string) =
         endpoints.MapHealthChecks(path, taggedWith tag).RequireHost($"*:{port}")
         |> ignore<IEndpointConventionBuilder>
+        // The k8s healthcheck comes in on a port, but the google load balancer
+        // health check does not include the port in its request. We manually set the
+        // load balancer to set the host header to be "bwdserver-healthcheck" (adding
+        // a port was not supported)
+        endpoints
+          .MapHealthChecks(path, taggedWith tag)
+          .RequireHost($"bwdserver-healthcheck")
+        |> ignore<IEndpointConventionBuilder>
       addHealthCheck livenessPath livenessTag
       addHealthCheck startupPath startupTag
       addHealthCheck readinessPath readinessTag)

--- a/services/bwdserver-deployment/bwdserver-network-policy.yaml
+++ b/services/bwdserver-deployment/bwdserver-network-policy.yaml
@@ -15,3 +15,5 @@ spec:
     - ports:
         - protocol: TCP
           port: http-proxy-port
+        - protocol: TCP
+          port: 11002

--- a/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
+++ b/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
@@ -9,6 +9,10 @@ spec:
     # Lets see how this goes for now
     requestPath: "/k8s/livenessProbe"
     type: HTTP
+    port: 11002
+    # Host is not allowed here, but it has been manually set on this healthcheck so
+    # that the server can recognize this is a healthcheck and not a granduser request
+    # host: bwdserver-healthcheck
   logging:
     # Changing this setting didn't seem to do anything - I needed to Edit it in the
     # GCP web console (or presumably using the gcloud command line utilily)

--- a/services/bwdserver-deployment/bwdserver-service.yaml
+++ b/services/bwdserver-deployment/bwdserver-service.yaml
@@ -12,5 +12,10 @@ spec:
     app: bwdserver-app
   ports:
     - protocol: TCP
+      name: bwdserver-port
       port: 80
       targetPort: http-proxy-port
+    - protocol: TCP
+      name: bwdserver-healthcheck-port
+      port: 11002
+      targetPort: 11002


### PR DESCRIPTION
The Google load balancer (which is configured by a backend-config) needs to succeed for bwdserver to be reachable. However, the healthcheck as configured received a 302 response (this is because it hits the regular bwd codepath, returning a 302 https redirect).

We want it to hit the k8s endpoints instead. Alas, the default "host" http header does not include the port by default. As such, it needs instead to have a host provided (and it did not like having a port included on the host). So let's instead make a host that signals this, that customers can't accidentally hit.

Also, because the backend-config doesn't support the host header, I had to add this by manually.