### PR TITLE
Enable apiserver access

### DIFF
--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -8,7 +8,12 @@ let apiCallNoParams = (
   ~callback: Tea.Result.t<'resulttype, Tea.Http.error<string>> => msg,
   endpoint: string,
 ): Tea.Cmd.t<msg> => {
-  let url = "/api/" ++ (Tea.Http.encodeUri(m.canvasName) ++ endpoint)
+  let root = if VariantTesting.useFSharpBackend(m) {
+    "/api-testing-fsharp/"
+  } else {
+    "/api/"
+  }
+  let url = root ++ (Tea.Http.encodeUri(m.canvasName) ++ endpoint)
   let request = Tea.Http.request({
     method': "POST",
     headers: list{

--- a/client/src/app/VariantTesting.res
+++ b/client/src/app/VariantTesting.res
@@ -10,6 +10,7 @@ let toVariantTest = (s: string): option<variantTest> =>
   | "stub" => Some(StubVariant)
   | "localhost-assets" => Some(NgrokVariant)
   | "lpartial" => Some(LeftPartialVariant)
+  | "fsharp-backend" => Some(FsharpBackend)
   | _ => None
   }
 
@@ -19,6 +20,7 @@ let nameOf = (vt: variantTest): string =>
   | StubVariant => "stub"
   | NgrokVariant => "localhost-assets"
   | LeftPartialVariant => "lpartial"
+  | FsharpBackend => "fsharp-backend"
   }
 
 let toCSSClass = (vt: variantTest): string => nameOf(vt) ++ "-variant"
@@ -27,6 +29,8 @@ let availableAdminVariants: list<variantTest> = list{NgrokVariant}
 
 let activeCSSClasses = (m: model): string =>
   m.tests |> List.map(~f=toCSSClass) |> String.join(~sep=" ")
+
+let useFSharpBackend = (m: model): bool => List.member(~value=FsharpBackend, m.tests)
 
 let enabledVariantTests = (isAdmin: bool): list<variantTest> => {
   /* admins have these enabled by default, but can opt-out via query param */

--- a/client/src/core/Types.res
+++ b/client/src/core/Types.res
@@ -1472,6 +1472,8 @@ and variantTest =
   StubVariant
   | NgrokVariant
   | LeftPartialVariant
+  // CLEANUP remove after F# migration
+  | FsharpBackend
 
 /* ----------------------------- */
 /* FeatureFlags */

--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -67,11 +67,17 @@ let addRoutes (app : IApplicationBuilder) : IApplicationBuilder =
     let handler = jsonHandler f
     let route = $"/api/{{canvasName}}/{name}"
     addRoute "POST" route std perm handler
+    // CLEANUP remove - these are for testing only
+    let testingRoute = $"/api-testing-fsharp/{{canvasName}}/{name}"
+    addRoute "POST" testingRoute std perm handler
 
   let apiOption name perm f =
     let handler = (jsonOptionHandler f)
     let route = $"/api/{{canvasName}}/{name}"
     addRoute "POST" route std perm handler
+    // CLEANUP remove - these are for testing only
+    let testingRoute = $"/api-testing-fsharp/{{canvasName}}/{name}"
+    addRoute "POST" testingRoute std perm handler
 
   addRoute "GET" "/login" html None Login.loginPage
   addRoute "POST" "/login" html None Login.loginHandler
@@ -82,13 +88,18 @@ let addRoutes (app : IApplicationBuilder) : IApplicationBuilder =
   builder.MapGet("/check-apiserver", checkApiserver) |> ignore<IRouteBuilder>
 
   addRoute "GET" "/a/{canvasName}" html R (htmlHandler Ui.uiHandler)
+  // CLEANUP remove - this are for testing only
+  addRoute "GET" "/a-testing-fsharp/{canvasName}" html R (htmlHandler Ui.uiHandler)
 
   // For internal testing - please don't test this out, it might page me
-  addRoute "GET" "/a/{canvasName}/trigger-exception" std R (fun ctx ->
+  let exceptionFn (ctx : HttpContext) =
     let userInfo = loadUserInfo ctx
-    Exception.raiseInternal "triggered test exception" [ "user", userInfo.username ])
-  api "add_op" RW AddOps.addOp
+    Exception.raiseInternal "triggered test exception" [ "user", userInfo.username ]
+  addRoute "GET" "/a/{canvasName}/trigger-exception" std R exceptionFn
+  // CLEANUP remove - this are for testing only
+  addRoute "GET" "/a-testing-fsharp/{canvasName}/trigger-exception" std R exceptionFn
 
+  api "add_op" RW AddOps.addOp
   api "all_traces" R Traces.AllTraces.fetchAll
   api "delete_404" RW F404s.Delete.delete
   api "delete_secret" RW Secrets.Delete.delete

--- a/services/apiserver-deployment/nginx.conf
+++ b/services/apiserver-deployment/nginx.conf
@@ -106,7 +106,7 @@ server {
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
   # These prefixes are handled by the backend.
-  location ~ (/a/|/api/|/login|/logout|/check-apiserver) {
+  location ~ (/a/|/a-testing-fsharp/|/api/|/api-testing-fsharp/|/login|/logout|/check-apiserver) {
     # https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/linux-nginx?view=aspnetcore-6.0#configure-nginx
     proxy_pass         http://localhost:9001;
     proxy_http_version 1.1;

--- a/services/editor-deployment/darklang-ingress.yaml
+++ b/services/editor-deployment/darklang-ingress.yaml
@@ -19,24 +19,17 @@ spec:
     # see what works.
     - http:
         paths:
-          # No slash at the end
-          - path: /a/trydarkfsharp
+          # Testing so that any user can use these
+          - path: /a-testing-fsharp/*
             pathType: ImplementationSpecific
             backend:
               service:
                 name: apiserver-service
                 port:
                   number: 80
-          # Slash at the end and things after it
-          - path: /a/trydarkfsharp/*
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: apiserver-service
-                port:
-                  number: 80
-          # Api
-          - path: /api/trydarkfsharp/*
+
+          # Api - CLEANUP remove
+          - path: /api-testing-fsharp/*
             pathType: ImplementationSpecific
             backend:
               service:


### PR DESCRIPTION
Part of https://github.com/darklang/dark/issues/3508

This allows users to test out the new backend in the editor by going to

`https://darklang/a/canvasname?fsharp-backend=true`

At also allows them to test loading the editor by going to 

`https://darklang.com/a-testing-fsharp/canvasname`

Or to get both:

`https://darklang.com/a-testing-fsharp/canvasname?fsharp-backend=true`

