### PR TITLE
Fix production configs

### DIFF
--- a/fsharp-backend/src/LibService/Kubernetes.fs
+++ b/fsharp-backend/src/LibService/Kubernetes.fs
@@ -73,7 +73,7 @@ let configureApp (port : int) (app : IApplicationBuilder) : IApplicationBuilder 
         // a port was not supported)
         endpoints
           .MapHealthChecks(path, taggedWith tag)
-          .RequireHost($"bwdserver-healthcheck")
+          .RequireHost($"gce-ingress-healthcheck")
         |> ignore<IEndpointConventionBuilder>
       addHealthCheck livenessPath livenessTag
       addHealthCheck startupPath startupTag

--- a/services/apiserver-deployment/apiserver-service-backendconfig.yaml
+++ b/services/apiserver-deployment/apiserver-service-backendconfig.yaml
@@ -9,7 +9,12 @@ spec:
     # The default / returns a 301, so don't use that.
     requestPath: "/k8s/livenessProbe"
     type: HTTP
+    port: 30002 # the nodeport from apiserver-service
+    # Host is not allowed here, but it has been manually set on this healthcheck so
+    # that the server can recognize this is a healthcheck and not a granduser request
+    # host: gce-ingress-healthcheck
   logging:
     # Changing this setting didn't seem to do anything - I needed to Edit it in the
     # GCP web console (or presumably using the gcloud command line utilily)
+    # Note that only a change is status is logged.
     enable: false

--- a/services/apiserver-deployment/apiserver-service.yaml
+++ b/services/apiserver-deployment/apiserver-service.yaml
@@ -12,5 +12,11 @@ spec:
     app: apiserver-app
   ports:
     - protocol: TCP
+      name: apiserver-port
       port: 80
       targetPort: http-proxy-port
+    - protocol: TCP
+      name: apiserver-healthcheck-port
+      port: 9002
+      targetPort: 9002
+      nodePort: 30002 # For the healthcheck in apiserver-service-backendconfig

--- a/services/bwd-deployment/bwd-ingress.yaml
+++ b/services/bwd-deployment/bwd-ingress.yaml
@@ -19,7 +19,7 @@ spec:
     - host: trydarkfsharp.builtwithdark.com
       http:
         paths:
-          - path: /first-only-one-very-specific-path-to-ensure-this-doesnt-go-wrong
+          - path: /*
             pathType: ImplementationSpecific
             backend:
               service:

--- a/services/bwdserver-deployment/bwdserver-deployment.template.yaml
+++ b/services/bwdserver-deployment/bwdserver-deployment.template.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   revisionHistoryLimit: 10
-  replicas: 4
+  replicas: 3
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
+++ b/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
@@ -16,4 +16,5 @@ spec:
   logging:
     # Changing this setting didn't seem to do anything - I needed to Edit it in the
     # GCP web console (or presumably using the gcloud command line utilily)
+    # Note that only a change is status is logged.
     enable: true

--- a/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
+++ b/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
@@ -9,7 +9,7 @@ spec:
     # Lets see how this goes for now
     requestPath: "/k8s/livenessProbe"
     type: HTTP
-    port: 11002
+    port: 31002 # the nodeport from bwdserver-service
     # Host is not allowed here, but it has been manually set on this healthcheck so
     # that the server can recognize this is a healthcheck and not a granduser request
     # host: bwdserver-healthcheck

--- a/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
+++ b/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
@@ -12,7 +12,7 @@ spec:
     port: 31002 # the nodeport from bwdserver-service
     # Host is not allowed here, but it has been manually set on this healthcheck so
     # that the server can recognize this is a healthcheck and not a granduser request
-    # host: bwdserver-healthcheck
+    # host: gce-ingress-healthcheck
   logging:
     # Changing this setting didn't seem to do anything - I needed to Edit it in the
     # GCP web console (or presumably using the gcloud command line utilily)

--- a/services/bwdserver-deployment/bwdserver-service.yaml
+++ b/services/bwdserver-deployment/bwdserver-service.yaml
@@ -19,3 +19,4 @@ spec:
       name: bwdserver-healthcheck-port
       port: 11002
       targetPort: 11002
+      nodePort: 31002 # For the healthcheck in bwdserver-service-backendconfig


### PR DESCRIPTION
Allow the bwdserver to join the load balancer:
- Fix the configuration settings to get the healthcheck to the bwdserver. The missing configuration was the nodeport. 
- Copy the bwdserver settings to apiserver.
- Change the host in the healthchecks to gce-ingress-healthcheck
- add note about logging
- turn on logging in apiserver
- Fix infinite redirects (it's the header that indicates https, not actually https on the server, as TLS is terminated at the load balancer)
- support the rest of the tryfsharpdark paths on bwdserver
- reduce bwdserver replicas to 3 (from 4)


