### PR TITLE
Fully fix apiserver backendconfig

### DIFF
--- a/services/apiserver-deployment/apiserver-network-policy.yaml
+++ b/services/apiserver-deployment/apiserver-network-policy.yaml
@@ -15,3 +15,5 @@ spec:
     - ports:
         - protocol: TCP
           port: http-proxy-port
+        - protocol: TCP
+          port: 9002

--- a/services/apiserver-deployment/apiserver-service-backendconfig.yaml
+++ b/services/apiserver-deployment/apiserver-service-backendconfig.yaml
@@ -9,7 +9,7 @@ spec:
     # The default / returns a 301, so don't use that.
     requestPath: "/k8s/livenessProbe"
     type: HTTP
-    port: 30002 # the nodeport from apiserver-service
+    port: 30092 # the nodeport from apiserver-service
     # Host is not allowed here, but it has been manually set on this healthcheck so
     # that the server can recognize this is a healthcheck and not a granduser request
     # host: gce-ingress-healthcheck

--- a/services/apiserver-deployment/apiserver-service-backendconfig.yaml
+++ b/services/apiserver-deployment/apiserver-service-backendconfig.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: default
 spec:
   # A backendconfig allows us to configure how a load balancer talks to a service.
+  # There is one healthcheck per node (VM) to add it to the service.
   healthCheck:
-    # The default / returns a 301, so don't use that.
     requestPath: "/k8s/livenessProbe"
     type: HTTP
     port: 30092 # the nodeport from apiserver-service
     # Host is not allowed here, but it has been manually set on this healthcheck so
-    # that the server can recognize this is a healthcheck and not a granduser request
+    # that the server can recognize this is a healthcheck an API call
     # host: gce-ingress-healthcheck
     healthyThreshold: 1
     unhealthyThreshold: 1

--- a/services/apiserver-deployment/apiserver-service-backendconfig.yaml
+++ b/services/apiserver-deployment/apiserver-service-backendconfig.yaml
@@ -17,4 +17,4 @@ spec:
     # Changing this setting didn't seem to do anything - I needed to Edit it in the
     # GCP web console (or presumably using the gcloud command line utilily)
     # Note that only a change is status is logged.
-    enable: false
+    enable: true

--- a/services/apiserver-deployment/apiserver-service-backendconfig.yaml
+++ b/services/apiserver-deployment/apiserver-service-backendconfig.yaml
@@ -13,6 +13,8 @@ spec:
     # Host is not allowed here, but it has been manually set on this healthcheck so
     # that the server can recognize this is a healthcheck and not a granduser request
     # host: gce-ingress-healthcheck
+    healthyThreshold: 1
+    unhealthyThreshold: 1
   logging:
     # Changing this setting didn't seem to do anything - I needed to Edit it in the
     # GCP web console (or presumably using the gcloud command line utilily)

--- a/services/apiserver-deployment/apiserver-service.yaml
+++ b/services/apiserver-deployment/apiserver-service.yaml
@@ -19,4 +19,4 @@ spec:
       name: apiserver-healthcheck-port
       port: 9002
       targetPort: 9002
-      nodePort: 30002 # For the healthcheck in apiserver-service-backendconfig
+      nodePort: 30092 # For the healthcheck in apiserver-service-backendconfig

--- a/services/apiserver-deployment/nginx.conf
+++ b/services/apiserver-deployment/nginx.conf
@@ -47,28 +47,6 @@ server {
   listen 9000;
   server_name www.darklang.com;
 
-  # Healthcheck for the GCE ingress
-
-  # The GCE LB makes a request to www.darklang.com/k8s/livenessProbe to the regular
-  # port 80. All requests are made with the user agent GoogleHC/1.0.
-  # The load balancer sends this request on post 80 which comes to 9000 (I tried
-  # other ports but couldn't make it work pointing to port 9002).
-
-  # We don't serve regular traffic on www.darklang.com, just a redirect to
-  # darklang.com, so it's fine to make an exception for a route we're not using
-  # anyway. At the moment, users can't reach here anyway as the load balancer points
-  # this traffic to the editor-deployment.
-
-  # The GCE load balancer must pass before a node is added to the load balancer. This
-  # prevents pods on that node from being added when they're not live. Since the
-  # apiserver or other parts of the pod could have liveness issues (for example if
-  # they restarts) it makes sense to pass the check onto the apiserver container,
-  # rather than answering the liveness poll in nginx.
-  location /k8s/livenessProbe {
-    proxy_pass         http://localhost:9002;
-    proxy_http_version 1.1;
-  }
-
   # All other paths return a redirect
   location / {
     # tell clients to stop going to http://www.darklang.com

--- a/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
+++ b/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
@@ -9,7 +9,7 @@ spec:
     # Lets see how this goes for now
     requestPath: "/k8s/livenessProbe"
     type: HTTP
-    port: 31002 # the nodeport from bwdserver-service
+    port: 30112 # the nodeport from bwdserver-service
     # Host is not allowed here, but it has been manually set on this healthcheck so
     # that the server can recognize this is a healthcheck and not a granduser request
     # host: gce-ingress-healthcheck

--- a/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
+++ b/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: default
 spec:
   # A backendconfig allows us to configure how a load balancer talks to a service.
+  # There is one healthcheck per node (VM) to add it to the service.
   healthCheck:
-    # Lets see how this goes for now
     requestPath: "/k8s/livenessProbe"
     type: HTTP
     port: 30112 # the nodeport from bwdserver-service

--- a/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
+++ b/services/bwdserver-deployment/bwdserver-service-backendconfig.yaml
@@ -13,6 +13,8 @@ spec:
     # Host is not allowed here, but it has been manually set on this healthcheck so
     # that the server can recognize this is a healthcheck and not a granduser request
     # host: gce-ingress-healthcheck
+    healthyThreshold: 1
+    unhealthyThreshold: 1
   logging:
     # Changing this setting didn't seem to do anything - I needed to Edit it in the
     # GCP web console (or presumably using the gcloud command line utilily)

--- a/services/bwdserver-deployment/bwdserver-service.yaml
+++ b/services/bwdserver-deployment/bwdserver-service.yaml
@@ -19,4 +19,4 @@ spec:
       name: bwdserver-healthcheck-port
       port: 11002
       targetPort: 11002
-      nodePort: 31002 # For the healthcheck in bwdserver-service-backendconfig
+      nodePort: 30112 # For the healthcheck in bwdserver-service-backendconfig

--- a/services/editor-deployment/darklang-ingress.yaml
+++ b/services/editor-deployment/darklang-ingress.yaml
@@ -15,7 +15,7 @@ spec:
   rules:
     # See
     # https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress#creating_an_ingress
-    # These rules are intended to enable one user onto the new F# backend, while we
+    # These rules are intended to enable anyone to test out the F# backend, while we
     # see what works.
     - http:
         paths:


### PR DESCRIPTION
Finishing touches on making the apiserver healthcheck work the same as the bwdserver healthcheck.

It turns out the missing thing was the ingress rule to allow incoming traffic on 9002.

Also:
- fixed a lot of comments to reflect current reality.
- change to unhealthyThreshold of 1
- change to more consistent ports for the healthchecks
- remove unneeded nginx forwarding for the healthcheck

This config is already live in production.