### PR TITLE
Improve exception metadata during execution

### DIFF
--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -144,12 +144,12 @@ let configureStaticContent (app : IApplicationBuilder) : IApplicationBuilder =
 
 let rollbarCtxToMetadata
   (ctx : HttpContext)
-  : (LibService.Rollbar.AspNet.Person * Metadata) =
+  : (LibService.Rollbar.Person * Metadata) =
   let person =
     try
       loadUserInfo ctx |> LibBackend.Account.userInfoToPerson
     with
-    | _ -> LibService.Rollbar.AspNet.emptyPerson
+    | _ -> LibService.Rollbar.emptyPerson
   let canvas =
     try
       string (loadCanvasInfo ctx).name

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -1090,11 +1090,11 @@ that's already taken, returns an error."
                 return DResult(Ok(DStr session.sessionKey))
               with
               | e ->
-                let attrs =
+                let metadata =
                   [ "username", username :> obj
-                    "fn", "DarkInternal::newSessionForUserName" ]
-                let e = InternalException("Failed to create session", attrs, e)
-                LibService.Rollbar.sendException state.executionID e
+                    "fn", "DarkInternal::newSessionForUserName"
+                    "error", "failed to create session" ]
+                state.reportException state metadata e
                 return DResult(Error(DStr "Failed to create session"))
             }
           | _ -> incorrectArgs ())
@@ -1127,11 +1127,11 @@ that's already taken, returns an error."
                   )
               with
               | e ->
-                let attrs =
+                let metadata =
                   [ "username", username :> obj
-                    "fn", "DarkInternal::newSessionForUserName" ]
-                let e = InternalException("Failed to create session", attrs, e)
-                LibService.Rollbar.sendException state.executionID e
+                    "fn", "DarkInternal::newSessionForUserName"
+                    "error", "failed to create session" ]
+                state.reportException state metadata e
                 return DResult(Error(DStr "Failed to create session"))
             }
           | _ -> incorrectArgs ())

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -8,6 +8,7 @@ open Prelude.Tablecloth
 open Tablecloth
 
 module Telemetry = LibService.Telemetry
+module Rollbar = LibService.Rollbar
 
 let shutdown = ref false
 
@@ -20,7 +21,7 @@ let run () : Task<unit> =
       with
       | e ->
         // If there's an exception, alert and continue
-        LibService.Rollbar.sendException (ExecutionID "cronchecker") [] e
+        Rollbar.sendException (ExecutionID "cronchecker") Rollbar.emptyPerson [] e
       do! Task.Delay LibBackend.Config.pauseBetweenCronsInMs
     return ()
   }

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -20,7 +20,7 @@ let run () : Task<unit> =
       with
       | e ->
         // If there's an exception, alert and continue
-        LibService.Rollbar.sendException (ExecutionID "cronchecker") e
+        LibService.Rollbar.sendException (ExecutionID "cronchecker") [] e
       do! Task.Delay LibBackend.Config.pauseBetweenCronsInMs
     return ()
   }

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -55,7 +55,7 @@ let triggerRollbar (executionID : ExecutionID) : unit =
 
   // Send async exception
   let e = new System.Exception($"{prefix} sendException exception")
-  Rollbar.sendException executionID e
+  Rollbar.sendException executionID tags e
 
 let triggerPagingRollbar () : int =
   // This one pages

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -55,7 +55,7 @@ let triggerRollbar (executionID : ExecutionID) : unit =
 
   // Send async exception
   let e = new System.Exception($"{prefix} sendException exception")
-  Rollbar.sendException executionID tags e
+  Rollbar.sendException executionID Rollbar.emptyPerson tags e
 
 let triggerPagingRollbar () : int =
   // This one pages

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -39,7 +39,7 @@ type UserInfoAndCreatedAt =
     id : UserID
     createdAt : NodaTime.Instant }
 
-let userInfoToPerson (ui : UserInfo) : LibService.Rollbar.AspNet.Person =
+let userInfoToPerson (ui : UserInfo) : LibService.Rollbar.Person =
   { id = Some ui.id; email = Some ui.email; username = Some ui.username }
 
 

--- a/fsharp-backend/src/LibExecution/Errors.fs
+++ b/fsharp-backend/src/LibExecution/Errors.fs
@@ -107,7 +107,7 @@ let incorrectArgsMsg (name : FQFnName.T) (p : Param) (actual : Dval) : string =
 
 // When a function has been removed (rarely happens but does happen occasionally)
 let removedFunction (state : ExecutionState) (fnName : string) : DvalTask =
-  state.notify state.executionID "function removed" [ "fnName", fnName ]
+  state.notify state "function removed" [ "fnName", fnName ]
   Ply(DError(SourceNone, $"{fnName} was removed from Dark"))
 
 // When you have a fakeval, you typically just want to return it.

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -727,7 +727,7 @@ and execFn
                 )
         with
         | Errors.FakeValFoundInQuery dv ->
-          state.notify state.executionID "fakeval found in query" [ "dval", dv ]
+          state.notify state "fakeval found in query" [ "dval", dv ]
           return dv
         | Errors.DBQueryException e ->
           return (Dval.errStr (Errors.queryCompilerErrorTemplate + e))
@@ -755,13 +755,18 @@ and execFn
               let msg = Errors.incorrectArgsMsg (fn.name) p actual
               return (Dval.errSStr sourceID msg)
         | Errors.StdlibException (Errors.FakeDvalFound dv) ->
-          state.notify state.executionID "fakedval found" [ "dval", dv ]
+          state.notify state "fakedval found" [ "dval", dv ]
           return dv
         | e ->
           // CLEANUP could we show the user the execution id here?
           state.reportException
-            state.executionID
-            (InternalException("An exception was caught in fncall", e))
+            state
+            [ "context", "An exception was caught in fncall"
+              "fn", fnDesc
+              "args", args
+              "callerID", id
+              "isInPipe", isInPipe ]
+            e
           // The GrandUser doesn't get to see DErrors, so it's safe to include this
           // value and show it to the Dark Developer
           return Dval.errSStr sourceID (Exception.toDeveloperMessage e)

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -861,9 +861,9 @@ and Libraries =
   { stdlib : Map<FQFnName.T, BuiltInFn>
     packageFns : Map<FQFnName.T, Package.Fn> }
 
-and ExceptionReporter = ExecutionID -> exn -> unit
+and ExceptionReporter = ExecutionState -> Metadata -> exn -> unit
 
-and Notifier = ExecutionID -> string -> Metadata -> unit
+and Notifier = ExecutionState -> string -> Metadata -> unit
 
 // All state used while running a program
 and ExecutionState =
@@ -890,14 +890,14 @@ and ExecutionState =
     onExecutionPath : bool }
 
 let consoleReporter : ExceptionReporter =
-  fun executionID (exn : exn) ->
+  fun state (metadata : Metadata) (exn : exn) ->
+    let metadata = metadata @ Exception.toMetadata exn
     print
-      $"An error was reported in the runtime ({executionID}):  \n  {exn.Message}\n{exn.StackTrace}\n  {Exception.toMetadata exn}\n\n"
+      $"An error was reported in the runtime ({state.executionID}):  \n  {exn.Message}\n{exn.StackTrace}\n  {metadata}\n\n"
 
 let consoleNotifier : Notifier =
-  fun executionID msg tags ->
-    print
-      $"A notification happened in the runtime ({executionID}):\n  {msg}\n  {tags}\n\n"
+  fun state msg tags ->
+    print $"A notification happened in the runtime ({state}):\n  {msg}\n  {tags}\n\n"
 
 let builtInFnToFn (fn : BuiltInFn) : Fn =
   { name = FQFnName.Stdlib fn.name

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -84,7 +84,9 @@ let createState
 
     let sendException (state : RT.ExecutionState) (metadata : Metadata) (exn : exn) =
       let metadata = extraMetadata state @ metadata
-      LibService.Rollbar.sendException state.executionID metadata exn
+      let person : LibService.Rollbar.Person =
+        { id = Some state.program.accountID; username = None; email = None }
+      LibService.Rollbar.sendException state.executionID person metadata exn
 
 
     return

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -68,8 +68,10 @@ let createState
 
     let! libraries = Lazy.force libraries
 
-    let metadataForState (state : RT.ExecutionState) : Metadata =
+    let extraMetadata (state : RT.ExecutionState) : Metadata =
       [ "tlid", tlid
+        "traceID", traceID
+        "touchedTLIDs", touchedTLIDs
         "executingFnName", state.executingFnName
         "callstack", state.callstack
         "canvas", state.program.canvasName
@@ -77,11 +79,11 @@ let createState
         "accountID", state.program.accountID ]
 
     let notify (state : RT.ExecutionState) (msg : string) (metadata : Metadata) =
-      let metadata = metadataForState state @ metadata
+      let metadata = extraMetadata state @ metadata
       LibService.Rollbar.notify state.executionID msg metadata
 
     let sendException (state : RT.ExecutionState) (metadata : Metadata) (exn : exn) =
-      let metadata = metadataForState state @ metadata
+      let metadata = extraMetadata state @ metadata
       LibService.Rollbar.sendException state.executionID metadata exn
 
 

--- a/fsharp-backend/src/LibService/FireAndForget.fs
+++ b/fsharp-backend/src/LibService/FireAndForget.fs
@@ -18,9 +18,7 @@ let fireAndForgetTask
       return ()
     with
     | e ->
-      Rollbar.sendException
-        executionID
-        (InternalException($"Fire and forget: {name} failed", [], e))
+      Rollbar.sendException executionID [ "fire-and-forget", name ] e
       return ()
   }
   |> ignore<Task<unit>>

--- a/fsharp-backend/src/LibService/FireAndForget.fs
+++ b/fsharp-backend/src/LibService/FireAndForget.fs
@@ -18,7 +18,11 @@ let fireAndForgetTask
       return ()
     with
     | e ->
-      Rollbar.sendException executionID [ "fire-and-forget", name ] e
+      Rollbar.sendException
+        executionID
+        Rollbar.emptyPerson
+        [ "fire-and-forget", name ]
+        e
       return ()
   }
   |> ignore<Task<unit>>

--- a/fsharp-backend/src/LibService/Kubernetes.fs
+++ b/fsharp-backend/src/LibService/Kubernetes.fs
@@ -142,7 +142,7 @@ let runKubernetesServer
   let app = builder.Build()
   Rollbar.AspNet.addRollbarToApp
     app
-    (fun _ -> Rollbar.AspNet.emptyPerson, [])
+    (fun _ -> Rollbar.emptyPerson, [])
     (Some startupPath)
 
   |> fun app -> app.UseRouting()

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -146,6 +146,10 @@ let init (serviceName : string) : unit =
   print " Configured rollbar"
   ()
 
+// -------------------------------
+// Honeycomb
+// -------------------------------
+
 // "https://ui.honeycomb.io/dark/datasets/kubernetes-bwd-ocaml?query={\"filters\":[{\"column\":\"rollbar\",\"op\":\"exists\"},{\"column\":\"execution_id\",\"op\":\"=\",\"value\":\"44602511168214071\"}],\"limit\":100,\"time_range\":604800}"
 type HoneycombFilter = { column : string; op : string; value : string }
 
@@ -170,8 +174,34 @@ let honeycombLinkOfExecutionID (executionID : ExecutionID) : string =
 
   string uri
 
+// -------------------------------
+// Include person data
+// -------------------------------
 
-let createState
+type Person =
+  { id : Option<UserID>
+    email : Option<string>
+    username : Option<UserName.T> }
+
+let emptyPerson = { id = None; email = None; username = None }
+
+/// Take a Person and an Exception and create a RollbarPackage that can be reported
+let createPackage (exn : exn) (person : Person) : Rollbar.IRollbarPackage =
+  let package : Rollbar.IRollbarPackage =
+    new Rollbar.ExceptionPackage(exn, exn.Message)
+  Rollbar.PersonPackageDecorator(
+    package,
+    person.id |> Option.map string |> Option.defaultValue null,
+    person.username |> Option.map string |> Option.defaultValue null,
+    person.email |> Option.defaultValue null
+  )
+
+
+
+// -------------------------------
+// Custom metadata
+// -------------------------------
+let createCustom
   (executionID : ExecutionID)
   (metadata : Metadata)
   : Dictionary.T<string, obj> =
@@ -186,7 +216,11 @@ let createState
     metadata
   custom
 
-// Not an error, let's just be aware a thing happened
+// -------------------------------
+// Reporting functions
+// -------------------------------
+
+/// Notify that a non-error happened
 let notify
   (executionID : ExecutionID)
   (message : string)
@@ -200,12 +234,12 @@ let notify
   let stacktraceMetadata = ("stacktrace", System.Environment.StackTrace :> obj)
   let metadata = stacktraceMetadata :: metadata
   Telemetry.notify message metadata
-  let custom = createState executionID metadata
+  let custom = createCustom executionID metadata
   Rollbar.RollbarLocator.RollbarInstance.Info(message, custom)
   |> ignore<Rollbar.ILogger>
 
 
-// An error but not an exception
+/// Notify that an error (but not an exception) happened
 let sendError
   (executionID : ExecutionID)
   (message : string)
@@ -218,7 +252,7 @@ let sendError
   | _ -> ()
   print System.Environment.StackTrace
   Telemetry.addEvent message metadata
-  let custom = createState executionID (("message", message :> obj) :: metadata)
+  let custom = createCustom executionID (("message", message :> obj) :: metadata)
   Rollbar.RollbarLocator.RollbarInstance.Error(message, custom)
   |> ignore<Rollbar.ILogger>
 
@@ -295,6 +329,7 @@ let exceptionWhileProcessingException
 /// it's better to keep the existing exception and add extra context via metadata.
 let sendException
   (executionID : ExecutionID)
+  (person : Person)
   (metadata : Metadata)
   (e : exn)
   : unit =
@@ -304,17 +339,18 @@ let sendException
     let metadata = Exception.toMetadata e @ metadata
     printMetadata metadata
     Telemetry.addException e
-    let custom = createState executionID metadata
-    Rollbar.RollbarLocator.RollbarInstance.Error(e, custom)
+    let custom = createCustom executionID metadata
+    let package = createPackage e person
+    Rollbar.RollbarLocator.RollbarInstance.Error(package, custom)
     |> ignore<Rollbar.ILogger>
   with
   | processingException -> exceptionWhileProcessingException e processingException
 
 
-// Wraps the exception in a PageableException, then sends in to rollbar in a blocking
-// call to make sure this exception gets sent. Use for startup and other places where
-// the process is intended to end after this call. Do not use this in general code,
-// as it blocks. Returns an int as the process will exit immediately after.
+/// Wraps the exception in a PageableException, then sends in to rollbar in a blocking
+/// call to make sure this exception gets sent. Use for startup and other places where
+/// the process is intended to end after this call. Do not use this in general code,
+/// as it blocks. Returns an int as the process will exit immediately after.
 let lastDitchBlockAndPage (msg : string) (inner : exn) : int =
   try
     let e = PageableException(msg, inner)
@@ -324,7 +360,7 @@ let lastDitchBlockAndPage (msg : string) (inner : exn) : int =
     // FSTODO: handle SystemInitializationException with a .Inner
     let metadata = Exception.toMetadata e
     Telemetry.addException e
-    let custom = createState (ExecutionID "last ditch") metadata
+    let custom = createCustom (ExecutionID "last ditch") metadata
     Rollbar
       .RollbarLocator
       .RollbarInstance
@@ -344,15 +380,6 @@ module AspNet =
   open Microsoft.Extensions.DependencyInjection
   open Rollbar.NetCore.AspNet
   open Microsoft.AspNetCore.Builder
-
-
-  type Person =
-    { id : Option<UserID>
-      email : Option<string>
-      username : Option<UserName.T> }
-
-  let emptyPerson = { id = None; email = None; username = None }
-
 
   // Setup parameters for rollbar middleware
   type RollbarContext =
@@ -400,21 +427,10 @@ module AspNet =
                 with
                 | _ -> emptyPerson, [ "exception calling ctxMetadataFn", true ]
               let metadata = metadata @ Exception.toMetadata e
-              let custom = createState executionID metadata
-
-              let package : Rollbar.IRollbarPackage =
-                new Rollbar.ExceptionPackage(e, e.Message)
-              // decorate the http info
+              let custom = createCustom executionID metadata
+              let package = createPackage e person
               let package = HttpRequestPackageDecorator(package, ctx.Request, true)
-              let package =
-                new HttpResponsePackageDecorator(package, ctx.Response, true)
-              let package =
-                Rollbar.PersonPackageDecorator(
-                  package,
-                  person.id |> Option.map string |> Option.defaultValue null,
-                  person.username |> Option.map string |> Option.defaultValue null,
-                  person.email |> Option.defaultValue null
-                )
+              let package = HttpResponsePackageDecorator(package, ctx.Response, true)
               Rollbar.RollbarLocator.RollbarInstance.Error(package, custom)
               |> ignore<Rollbar.ILogger>
               print "Rollbar exception sent"
@@ -426,7 +442,6 @@ module AspNet =
       }
 
 
-
   let addRollbarToServices (services : IServiceCollection) : IServiceCollection =
     // Nothing to do here, as rollbar is initialized above
     services
@@ -434,8 +449,8 @@ module AspNet =
   let addRollbarToApp
     (app : IApplicationBuilder)
     (ctxMetadataFn : HttpContext -> Person * Metadata)
-    (ignoreStatupPath : Option<string>)
+    (ignoreStartupPath : Option<string>)
     : IApplicationBuilder =
     app.UseMiddleware<DarkRollbarMiddleware>(
-      { ctxMetadataFn = ctxMetadataFn; ignoreStartupPath = ignoreStatupPath }
+      { ctxMetadataFn = ctxMetadataFn; ignoreStartupPath = ignoreStartupPath }
     )

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -290,11 +290,18 @@ let exceptionWhileProcessingException
       | _ -> ()
 
 
-let sendException (executionID : ExecutionID) (e : exn) : unit =
+/// Sends exception to Rollbar and also to Telemetry (honeycomb). The error is titled
+/// after the exception message - to change it wrap it in another exception. However,
+/// it's better to keep the existing exception and add extra context via metadata.
+let sendException
+  (executionID : ExecutionID)
+  (metadata : Metadata)
+  (e : exn)
+  : unit =
   try
     print $"rollbar: {e.Message}"
     print e.StackTrace
-    let metadata = Exception.toMetadata e
+    let metadata = Exception.toMetadata e @ metadata
     printMetadata metadata
     Telemetry.addException e
     let custom = createState executionID metadata

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -170,6 +170,7 @@ let run () : Task<unit> =
         | Error (e) ->
           LibService.Rollbar.sendException
             (Telemetry.executionID ())
+            []
             (PageableException("Unhandled exception bubbled to queue worker", e))
       with
       | e ->
@@ -177,6 +178,7 @@ let run () : Task<unit> =
         // continue
         LibService.Rollbar.sendException
           (Telemetry.executionID ())
+          []
           (PageableException("Unhandled exception bubbled to run", e))
 
   }

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -18,6 +18,7 @@ module RealExecution = LibRealExecution.RealExecution
 module Canvas = LibBackend.Canvas
 
 module Telemetry = LibService.Telemetry
+module Rollbar = LibService.Rollbar
 
 let dequeueAndProcess () : Task<Result<Option<RT.Dval>, exn>> =
   task {
@@ -168,16 +169,18 @@ let run () : Task<unit> =
         | Ok None -> do! Task.Delay 1000
         | Ok (Some _) -> return ()
         | Error (e) ->
-          LibService.Rollbar.sendException
+          Rollbar.sendException
             (Telemetry.executionID ())
+            Rollbar.emptyPerson
             []
             (PageableException("Unhandled exception bubbled to queue worker", e))
       with
       | e ->
         // No matter where else we catch it, this is essential or else the loop won't
         // continue
-        LibService.Rollbar.sendException
+        Rollbar.sendException
           (Telemetry.executionID ())
+          Rollbar.emptyPerson
           []
           (PageableException("Unhandled exception bubbled to run", e))
 

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -301,12 +301,12 @@ let executionStateFor
     // catch them much closer to where they happen (usually in the function
     // definition)
     let rec exceptionReporter : RT.ExceptionReporter =
-      fun executionID (exn : exn) ->
+      fun (state : RT.ExecutionState) metadata (exn : exn) ->
         let message = exn.Message
         let stackTrace = exn.StackTrace
-        let metadata = Exception.toMetadata exn
+        let metadata = Exception.toMetadata exn @ metadata
         let inner = exn.InnerException
-        if inner <> null then (exceptionReporter executionID inner) else ()
+        if inner <> null then (exceptionReporter state metadata inner) else ()
         testContext.exceptionReports <-
           (executionID, message, stackTrace, metadata)
           :: testContext.exceptionReports


### PR DESCRIPTION
I'm trying to debug some exceptions and don't have enough metadata to make it easy. This adds more for program execution.