### PR TITLE
Ensure Blazor failures get to Rollbar

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -268,6 +268,9 @@ window.Dark = {
 
       window.Dark.analysis.lastRun = new Date();
     },
+    errorCallback: function (error) {
+      window.onerror("Blazor worker failure", error);
+    },
     initialized: false,
     requestAnalysis: function (params) {
       const analysis = window.Dark.fsharpAnalysis;
@@ -309,7 +312,11 @@ window.Dark = {
       };
       // Only load when asked for
       if (window.Dark.analysis.useBlazor) {
-        window.BlazorWorker.initWorker(initializedCallback, analysis.callback);
+        window.BlazorWorker.initWorker(
+          initializedCallback,
+          analysis.callback,
+          analysis.errorCallback,
+        );
       }
     },
   },


### PR DESCRIPTION
## What is the problem/goal being addressed?
Errors that occur in Blazor-compiled F# backend are lost inside of BlazorWorker.js

## What is the solution to this problem?
Pass an on-error callback to the blazor worker initializer, and adjust BlazorWorker to ensure such errors get there