### PR TITLE
Add tests for Http.redirectTo and .responseWithHeaders

### DIFF
--- a/fsharp-backend/tests/testfiles/http.tests
+++ b/fsharp-backend/tests/testfiles/http.tests
@@ -77,3 +77,14 @@ Http.responseWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 45035996
 
 ((Http.response_v0 "" 4503599627370496I) |> toString) = "4503599627370496 {  }\n\"\""
 ((Http.respond_v0 "" 4503599627370496I) |> toString) = "4503599627370496 {  }\n\"\""
+
+(Http.redirectTo_v0 "") |> toString = "302 \nnull"
+(Http.redirectTo_v0 "bad url") |> toString = "302 bad url\nnull"
+(Http.redirectTo_v0 "http://someothersite.com/") |> toString = "302 http://someothersite.com/\nnull"
+(Http.redirectTo_v0 "/relativeUrl") |> toString = "302 /relativeUrl\nnull"
+
+Http.responseWithHeaders_v0 null {} 200 = Http.response_v0 null 200
+Http.responseWithHeaders_v0 "" {} 200 = Http.response_v0 "" 200
+Http.responseWithHeaders_v0 "value" {} 201 = Http.response_v0 "value" 201
+(Http.responseWithHeaders_v0 "value" { ``Server`` = "darklang" } 201) |> toString = "201 { Server: darklang }\n\"value\""
+(Http.responseWithHeaders_v0 4503599627370496I { ``Server`` = "darklang"; ``X-Secret-Key`` = "p@ssw0rd" } 200) |> toString = "200 { Server: darklang,X-Secret-Key: p@ssw0rd }\n4503599627370496"


### PR DESCRIPTION
## What is the problem/goal being addressed?
`http.tests` was missing tests around `Http.redirectTo_v0` and `Http.responseWithHeaders_v0`

## What is the solution to this problem?
Add tests