### PR TITLE
Add tests around `emit` StdLib fn

### DIFF
--- a/backend/libbackend/event_queue.mli
+++ b/backend/libbackend/event_queue.mli
@@ -48,6 +48,8 @@ val put_back :
 
 val finish : transaction -> t -> unit
 
+val testing_get_queue : Uuidm.t -> string -> RuntimeT.dval list
+
 val schedule_all : unit -> unit
 
 module Scheduling_rule : sig

--- a/backend/liblegacyfuzzing/fuzzing.ml
+++ b/backend/liblegacyfuzzing/fuzzing.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Libexecution
 module Db = Libbackend_basics.Db
+module Event_queue = Libbackend_basics.Event_queue
 
 let of_internal_queryable_v0 (str : string) : string =
   let dval = Dval.of_internal_queryable_v0 str in
@@ -418,6 +419,23 @@ let fns : Types.RuntimeT.fn list =
                 "DELETE from ACCOUNTS WHERE username = $1"
                 ~params:[String (Unicode_string.to_string username)] ;
               DNull
+          | args ->
+              Lib.fail args)
+    ; preview_safety = Safe
+    ; deprecated = false }
+  ; { prefix_names = ["Test::getQueue"]
+    ; infix_names = []
+    ; parameters = [Lib.par "eventname" TStr]
+    ; return_type = TList
+    ; description = "Fetch a queue (test only)"
+    ; func =
+        InProcess
+          (function
+          | state, [DStr eventname] ->
+              Event_queue.testing_get_queue
+                state.canvas_id
+                (Unicode_string.to_string eventname)
+              |> DList
           | args ->
               Lib.fail args)
     ; preview_safety = Safe

--- a/fsharp-backend/src/LibBackend/EventQueue.fs
+++ b/fsharp-backend/src/LibBackend/EventQueue.fs
@@ -309,10 +309,28 @@ let dequeue () : Task<Option<T>> =
             name = name
             modifier = modifier
             delay = delay }
-
-
-
   }
+
+/// Fetches (only) the values stored in a queue,
+/// only to be used for writing tests
+let testingGetQueue canvasID eventName =
+  task {
+    let! result =
+      Sql.query
+        "SELECT e.value
+      FROM events AS e
+      JOIN canvases AS c ON e.canvas_id = c.id
+      WHERE c.id = @canvasID
+        AND e.name = @eventName
+      ORDER BY e.id ASC"
+      |> Sql.parameters [ "canvasID", Sql.uuid canvasID
+                          "eventName", Sql.string eventName ]
+      |> Sql.executeAsync (fun read -> (read.string "value"))
+
+    return
+      result |> List.map (LibExecution.DvalReprInternal.ofInternalRoundtrippableV0)
+  }
+
 // schedule_all bypasses actual scheduling logic and is meant only for allowing
 // testing without running the queue-scheduler process
 let testingScheduleAll () : Task<unit> =

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -215,4 +215,20 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
+      deprecated = NotDeprecated }
+    { name = fn "Test" "getQueue" 0
+      parameters = [ Param.make "eventName" TStr "" ]
+      returnType = TList TStr
+      description = "Fetch a queue (test only)"
+      fn =
+        (function
+        | state, [ DStr eventName ] ->
+          uply {
+            let canvasID = state.program.canvasID
+            let! results = LibBackend.EventQueue.testingGetQueue canvasID eventName
+            return DList results
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
       deprecated = NotDeprecated } ]

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -37,18 +37,16 @@ let t
       try
         let! owner = owner
         let! meta =
-          let workersNeedSetUp = workers <> []
-
           // Little optimization to skip the DB sometimes
-          if initializeDB || workersNeedSetUp then
+          if initializeDB then
             initializeCanvasForOwner owner name
           else
             createCanvasForOwner owner name
 
-        let workersWithIds = workers |> List.map (fun w -> w, (gid ()))
+        let workersWithIDs = workers |> List.map (fun w -> w, (gid ()))
 
         let ops =
-          workersWithIds
+          workersWithIDs
           |> List.map (fun (worker, tlid) ->
             PT.SetHandler(
               tlid,
@@ -66,7 +64,7 @@ let t
         let c = Canvas.empty meta |> Canvas.addOps ops []
 
         let oplists =
-          workersWithIds
+          workersWithIDs
           |> List.map (fun (_w, tlid) ->
             tlid, ops, PT.TLHandler c.handlers[tlid], Canvas.NotDeleted)
 
@@ -205,7 +203,10 @@ let fileTests () : Test =
       if filename = "internal.tests" then testAdmin.Force() else testOwner.Force()
 
     let finish () =
-      let initializeDB = filename = "internal.tests" || currentTest.dbs <> []
+      let initializeDB =
+        filename = "internal.tests"
+        || currentTest.dbs <> []
+        || currentTest.workers <> []
       if currentTest.recording then
         let newTestCase =
           t

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -1,6 +1,7 @@
 module Tests.LibExecution
 
-// Create test cases from .tests files in the tests/stdlib dir
+// Create test cases from .tests files in the tests/testfiles dir
+// A readme in that same directory exists to explain usage.
 
 open Expecto
 
@@ -24,6 +25,7 @@ let t
   (code : string)
   (dbs : List<PT.DB.T>)
   (functions : Map<string, PT.UserFunction.T>)
+  (workers : List<string>)
   : Test =
   let name = $"{comment} ({code})"
 
@@ -34,11 +36,40 @@ let t
       try
         let! owner = owner
         let! meta =
+          let workersNeedSetUp = workers <> []
+
           // Little optimization to skip the DB sometimes
-          if initializeDB then
+          if initializeDB || workersNeedSetUp then
             initializeCanvasForOwner owner name
           else
             createCanvasForOwner owner name
+
+        let workersWithIds = workers |> List.map (fun w -> w, (gid ()))
+
+        let ops =
+          workersWithIds
+          |> List.map (fun (worker, tlid) ->
+            PT.SetHandler(
+              tlid,
+              testPos,
+              { tlid = tlid
+                pos = testPos
+                ast = PT.Expr.EBlank(gid ())
+                spec =
+                  PT.Handler.Worker(
+                    worker,
+                    { moduleID = gid (); nameID = gid (); modifierID = gid () }
+                  ) }
+            ))
+
+        let c = LibBackend.Canvas.empty meta |> LibBackend.Canvas.addOps ops []
+
+        let oplists =
+          workersWithIds
+          |> List.map (fun (_w, tlid) ->
+            tlid, ops, PT.TLHandler c.handlers[tlid], LibBackend.Canvas.NotDeleted)
+
+        do! LibBackend.Canvas.saveTLIDs meta oplists
 
         let rtDBs =
           (dbs |> List.map (fun db -> db.name, PT.DB.toRuntimeType db) |> Map.ofList)
@@ -118,7 +149,8 @@ type TestInfo =
   { name : string
     recording : bool
     code : string
-    dbs : List<PT.DB.T> }
+    dbs : List<PT.DB.T>
+    workers : List<string> }
 
 type TestGroup = { name : string; tests : List<Test>; dbs : List<PT.DB.T> }
 
@@ -151,7 +183,8 @@ let fileTests () : Test =
   |> Array.filter ((<>) ".gitattributes")
   |> Array.map (fun file ->
     let filename = System.IO.Path.GetFileName file
-    let emptyTest = { recording = false; name = ""; dbs = []; code = "" }
+    let emptyTest =
+      { recording = false; name = ""; dbs = []; code = ""; workers = [] }
 
     let emptyFn =
       { recording = false; name = ""; parameters = []; code = ""; tlid = id 7 }
@@ -181,6 +214,7 @@ let fileTests () : Test =
             currentTest.code
             currentTest.dbs
             functions
+            currentTest.workers
 
         allTests <- allTests @ [ newTestCase ]
 
@@ -227,6 +261,7 @@ let fileTests () : Test =
       | Regex @"^\[tests\.(.*)\]$" [ name ] ->
         finish ()
         currentGroup <- { currentGroup with name = name }
+
       // [db] declaration
       | Regex @"^\[db.(.*) (\{.*\})\]\s*$" [ name; definition ] ->
         finish ()
@@ -251,6 +286,8 @@ let fileTests () : Test =
               |> Map.values }
 
         dbs <- Map.add name db dbs
+
+
       // [function] declaration
       | Regex @"^\[fn\.(\S+) (.*)\]$" [ name; definition ] ->
         finish ()
@@ -271,6 +308,7 @@ let fileTests () : Test =
             name = name
             parameters = parameters
             code = "" }
+
       // [test] with DB indicator
       | Regex @"^\[test\.(.*)\] with DB (.*)$" [ name; dbName ] ->
         finish ()
@@ -281,6 +319,17 @@ let fileTests () : Test =
 
         currentTest <-
           { currentTest with name = $"{name} (line {i})"; recording = true }
+
+      // [test] with Worker indicator
+      | Regex @"^\[test\.(.*)\] with Worker (.*)$" [ name; workerName ] ->
+        finish ()
+
+        currentTest <-
+          { currentTest with
+              name = $"{name} (line {i})"
+              recording = true
+              workers = [ workerName ] }
+
       // [test] indicator (no DB)
       | Regex @"^\[test\.(.*)\]$" [ name ] ->
         finish ()
@@ -307,11 +356,20 @@ let fileTests () : Test =
             code
             currentGroup.dbs
             functions
+            currentTest.workers
 
         currentGroup <- { currentGroup with tests = currentGroup.tests @ [ test ] }
       | Regex @"^(.*)\s*$" [ code ] ->
         let initializeDB = filename = "internal.tests" || currentGroup.dbs <> []
-        let test = t owner initializeDB $"line {i}" code currentGroup.dbs functions
+        let test =
+          t
+            owner
+            initializeDB
+            $"line {i}"
+            code
+            currentGroup.dbs
+            functions
+            currentTest.workers
 
         currentGroup <- { currentGroup with tests = currentGroup.tests @ [ test ] }
 

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -15,6 +15,7 @@ open Tablecloth
 module RT = LibExecution.RuntimeTypes
 module PT = LibExecution.ProgramTypes
 module Exe = LibExecution.Execution
+module Canvas = LibBackend.Canvas
 
 open TestUtils.TestUtils
 
@@ -62,14 +63,14 @@ let t
                   ) }
             ))
 
-        let c = LibBackend.Canvas.empty meta |> LibBackend.Canvas.addOps ops []
+        let c = Canvas.empty meta |> Canvas.addOps ops []
 
         let oplists =
           workersWithIds
           |> List.map (fun (_w, tlid) ->
-            tlid, ops, PT.TLHandler c.handlers[tlid], LibBackend.Canvas.NotDeleted)
+            tlid, ops, PT.TLHandler c.handlers[tlid], Canvas.NotDeleted)
 
-        do! LibBackend.Canvas.saveTLIDs meta oplists
+        do! Canvas.saveTLIDs meta oplists
 
         let rtDBs =
           (dbs |> List.map (fun db -> db.name, PT.DB.toRuntimeType db) |> Map.ofList)

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -51,7 +51,7 @@ let setUpWorkers meta workers =
 
 let t
   (owner : Task<LibBackend.Account.UserInfo>)
-  (initializeDB : bool)
+  (initializeCanvas : bool)
   (comment : string)
   (code : string)
   (dbs : List<PT.DB.T>)
@@ -68,7 +68,7 @@ let t
         let! owner = owner
         let! meta =
           // Little optimization to skip the DB sometimes
-          if initializeDB then
+          if initializeCanvas then
             initializeCanvasForOwner owner name
           else
             createCanvasForOwner owner name
@@ -208,7 +208,7 @@ let fileTests () : Test =
       if filename = "internal.tests" then testAdmin.Force() else testOwner.Force()
 
     let finish () =
-      let initializeDB =
+      let initializeCanvas =
         filename = "internal.tests"
         || currentTest.dbs <> []
         || currentTest.workers <> []
@@ -216,7 +216,7 @@ let fileTests () : Test =
         let newTestCase =
           t
             owner
-            initializeDB
+            initializeCanvas
             currentTest.name
             currentTest.code
             currentTest.dbs
@@ -354,11 +354,11 @@ let fileTests () : Test =
         currentFn <- { currentFn with code = currentFn.code + "\n" + line }
       // 1-line test
       | Regex @"^(.*)\s+//\s+(.*)$" [ code; comment ] ->
-        let initializeDB = filename = "internal.tests" || currentGroup.dbs <> []
+        let initializeCanvas = filename = "internal.tests" || currentGroup.dbs <> []
         let test =
           t
             owner
-            initializeDB
+            initializeCanvas
             $"{comment} (line {i})"
             code
             currentGroup.dbs
@@ -367,11 +367,11 @@ let fileTests () : Test =
 
         currentGroup <- { currentGroup with tests = currentGroup.tests @ [ test ] }
       | Regex @"^(.*)\s*$" [ code ] ->
-        let initializeDB = filename = "internal.tests" || currentGroup.dbs <> []
+        let initializeCanvas = filename = "internal.tests" || currentGroup.dbs <> []
         let test =
           t
             owner
-            initializeDB
+            initializeCanvas
             $"line {i}"
             code
             currentGroup.dbs

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -73,8 +73,7 @@ let t
           else
             createCanvasForOwner owner name
 
-        if workers <> [] then
-          do! setUpWorkers meta workers
+        if workers <> [] then do! setUpWorkers meta workers
 
         let rtDBs =
           (dbs |> List.map (fun db -> db.name, PT.DB.toRuntimeType db) |> Map.ofList)

--- a/fsharp-backend/tests/testfiles/README.md
+++ b/fsharp-backend/tests/testfiles/README.md
@@ -55,6 +55,12 @@ that these tests need to be isolated and that's much slower)
 `[test.name] with DB MyDB` indicates that the following lines, up until
 the next test indicator, are all a single test named "name", and should be
 parsed as one. The DB previously defined as MyDB is available to the test.
+Cannot be used with `with Worker MyWorker` syntax.
+
+`[test.name] with Worker MyWorker` indicates that the following lines, up
+until the next test indicator, are all a single test named "name", and should
+be parsed as one. The Worker MyWorker is available to the test, without
+prior setup required. Cannot be used with `with DB MyDb` syntax.
 
 `[fn.name argnames]` creates a function which is available to all subsequent
 tests. The following lines are part of the function body (until we hit

--- a/fsharp-backend/tests/testfiles/events.tests
+++ b/fsharp-backend/tests/testfiles/events.tests
@@ -1,0 +1,26 @@
+[test.getQueue works FSHARPONLY] with Worker TestWorker
+Test.getQueue_v0 "TestWorker" = [] // FSHARPONLY
+
+[test.emit_v0 works FSHARPONLY] with Worker TestWorker
+(let _ = emit_v0 "value" "_" "TestWorker" in
+ let queue = Test.getQueue_v0 "TestWorker" in
+ queue) = ["value"]
+
+[test.emit_v1 works FSHARPONLY] with Worker TestWorker
+(let _ = emit_v1 "value" "TestWorker" in
+ let queue = Test.getQueue_v0 "TestWorker" in
+ queue) = ["value"]
+
+[test.emit_v0 works with mixed values FSHARPONLY] with Worker TestWorker
+(let _ = emit_v0 "value" "_" "TestWorker" in
+ let _ = emit_v0 1 "_" "TestWorker" in
+ let _ = emit_v0 {``Fruits`` = ["apple", "banana"] } "_" "TestWorker" in
+ let queue = Test.getQueue_v0 "TestWorker" in
+ queue) = ["value", 1, { ``Fruits`` = ["apple", "banana"] }]
+
+[test.emit_v1 works with mixed values FSHARPONLY] with Worker TestWorker
+(let _ = emit_v1 "value" "TestWorker" in
+ let _ = emit_v1 1 "TestWorker" in
+ let _ = emit_v1 {``Fruits`` = ["apple", "banana"] } "TestWorker" in
+ let queue = Test.getQueue_v0 "TestWorker" in
+ queue) = ["value", 1, { ``Fruits`` = ["apple", "banana"] }]

--- a/fsharp-backend/tests/testfiles/events.tests
+++ b/fsharp-backend/tests/testfiles/events.tests
@@ -1,5 +1,5 @@
 [test.getQueue works FSHARPONLY] with Worker TestWorker
-Test.getQueue_v0 "TestWorker" = [] // FSHARPONLY
+Test.getQueue_v0 "TestWorker" = []
 
 [test.emit_v0 works FSHARPONLY] with Worker TestWorker
 (let _ = emit_v0 "value" "_" "TestWorker" in

--- a/fsharp-backend/tests/testfiles/events.tests
+++ b/fsharp-backend/tests/testfiles/events.tests
@@ -1,24 +1,24 @@
-[test.getQueue works FSHARPONLY] with Worker TestWorker
+[test.getQueue works] with Worker TestWorker
 Test.getQueue_v0 "TestWorker" = []
 
-[test.emit_v0 works FSHARPONLY] with Worker TestWorker
+[test.emit_v0 works] with Worker TestWorker
 (let _ = emit_v0 "value" "_" "TestWorker" in
  let queue = Test.getQueue_v0 "TestWorker" in
  queue) = ["value"]
 
-[test.emit_v1 works FSHARPONLY] with Worker TestWorker
+[test.emit_v1 works] with Worker TestWorker
 (let _ = emit_v1 "value" "TestWorker" in
  let queue = Test.getQueue_v0 "TestWorker" in
  queue) = ["value"]
 
-[test.emit_v0 works with mixed values FSHARPONLY] with Worker TestWorker
+[test.emit_v0 works with mixed values] with Worker TestWorker
 (let _ = emit_v0 "value" "_" "TestWorker" in
  let _ = emit_v0 1 "_" "TestWorker" in
  let _ = emit_v0 {``Fruits`` = ["apple", "banana"] } "_" "TestWorker" in
  let queue = Test.getQueue_v0 "TestWorker" in
  queue) = ["value", 1, { ``Fruits`` = ["apple", "banana"] }]
 
-[test.emit_v1 works with mixed values FSHARPONLY] with Worker TestWorker
+[test.emit_v1 works with mixed values] with Worker TestWorker
 (let _ = emit_v1 "value" "TestWorker" in
  let _ = emit_v1 1 "TestWorker" in
  let _ = emit_v1 {``Fruits`` = ["apple", "banana"] } "TestWorker" in


### PR DESCRIPTION
## What is the problem/goal being addressed?
`emit_v0` and `emit_v1` are untested.

## What is the solution to this problem?
Add a `events.tests` file with tests - and generally allow for testing of `emit` within testfiles.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
- in `EventQueue.fs`, add fn `testingGetQueue` for test purposes, to fetch all events on a queue
- add a Test-only lib fn `getQueue` that uses `testingGetQueue`
- adjust `LibExecution.Test.fs`
  - to allow for the parsing of `[test.name] with Worker MyWorker` tests
  - to add the handlers to test programs when relevant, using `Canvas.addOps` (if there's a better way to do this, please let me know)
- update the relevant README.md
- add tests around `emit`

## How are you sure this works/how was this tested?

## What is the reversion plan if this fails after shipping?

## Has this information been included in the comments?
