### PR TITLE
More readonly API call fixes

### DIFF
--- a/fsharp-backend/src/LibBackend/Canvas.fs
+++ b/fsharp-backend/src/LibBackend/Canvas.fs
@@ -491,6 +491,13 @@ let loadAllDBs (meta : Meta) : Task<T> =
     return! loadFrom LiveToplevels meta tlids
   }
 
+/// Returns a best guess at all workers (excludes what it knows not to be a worker)
+let loadAllWorkers (meta : Meta) : Task<T> =
+  task {
+    let! tlids = Serialize.fetchTLIDsForAllWorkers meta.id
+    return! loadFrom LiveToplevels meta tlids
+  }
+
 let loadTLIDsWithDBs (meta : Meta) (tlids : List<tlid>) : Task<T> =
   task {
     let! dbTLIDs = Serialize.fetchTLIDsForAllDBs meta.id

--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -103,9 +103,6 @@ let legacyBytesReq (endpoint : string) (data : byte array) : Task<byte array> =
     return! content.ReadAsByteArrayAsync()
   }
 
-let serialize (v : 'a) : byte array =
-  v |> Json.OCamlCompatible.serialize |> UTF8.toBytes
-
 let stringToBytesReq (endpoint : string) (str : string) : Task<byte array> =
   str |> UTF8.toBytes |> legacyBytesReq endpoint
 
@@ -119,14 +116,22 @@ let stringToDvalReq (endpoint : string) (str : string) : Task<RT.Dval> =
   str
   |> UTF8.toBytes
   |> legacyStringReq endpoint
-  |> Task.map Json.OCamlCompatible.deserialize<OCamlTypes.RuntimeT.dval>
+  |> Task.map (Json.OCamlCompatible.legacyDeserialize<OCamlTypes.RuntimeT.dval>)
   |> Task.map Convert.ocamlDval2rt
 
 let dvalToStringReq (endpoint : string) (dv : RT.Dval) : Task<string> =
-  dv |> Convert.rt2ocamlDval |> serialize |> legacyStringReq endpoint
+  dv
+  |> Convert.rt2ocamlDval
+  |> Json.OCamlCompatible.legacySerialize
+  |> UTF8.toBytes
+  |> legacyStringReq endpoint
 
 let dvalListToStringReq (endpoint : string) (l : List<RT.Dval>) : Task<string> =
-  l |> List.map Convert.rt2ocamlDval |> serialize |> legacyStringReq endpoint
+  l
+  |> List.map Convert.rt2ocamlDval
+  |> Json.OCamlCompatible.legacySerialize
+  |> UTF8.toBytes
+  |> legacyStringReq endpoint
 
 
 // Binary deserialization functions

--- a/fsharp-backend/src/LibBackend/Serialize.fs
+++ b/fsharp-backend/src/LibBackend/Serialize.fs
@@ -236,6 +236,18 @@ let fetchTLIDsForAllDBs (canvasID : CanvasID) : Task<List<tlid>> =
   |> Sql.parameters [ "canvasID", Sql.uuid canvasID ]
   |> Sql.executeAsync (fun read -> read.tlid "tlid")
 
+let fetchTLIDsForAllWorkers (canvasID : CanvasID) : Task<List<tlid>> =
+  Sql.query
+    "SELECT tlid FROM toplevel_oplists
+     WHERE canvas_id = @canvasID
+       AND tipe = 'handler'::toplevel_type
+       AND module <> 'CRON'
+       AND module <> 'REPL'
+       AND module <> 'HTTP'"
+  |> Sql.parameters [ "canvasID", Sql.uuid canvasID ]
+  |> Sql.executeAsync (fun read -> read.tlid "tlid")
+
+
 let fetchAllTLIDs (canvasID : CanvasID) : Task<List<tlid>> =
   Sql.query
     "SELECT tlid FROM toplevel_oplists

--- a/fsharp-backend/src/LibBackend/Traces.fs
+++ b/fsharp-backend/src/LibBackend/Traces.fs
@@ -35,7 +35,7 @@ let sampleModuleInputVars (h : PT.Handler.T) : AT.InputVars =
   | PT.Handler.HTTP _ -> sampleRequestInputVars
   | PT.Handler.Cron _ -> []
   | PT.Handler.REPL _ -> []
-  | PT.Handler.UnknownHandler _ -> []
+  | PT.Handler.UnknownHandler _ -> sampleRequestInputVars @ sampleEventInputVars
   | PT.Handler.Worker _
   | PT.Handler.OldWorker _ -> sampleEventInputVars
 
@@ -79,11 +79,11 @@ let savedInputVars
         []
 
     withR @ bound
+  | PT.Handler.OldWorker _
   | PT.Handler.Worker _ -> [ ("event", event) ]
   | PT.Handler.Cron _ -> []
   | PT.Handler.UnknownHandler _ -> []
   | PT.Handler.REPL _ -> []
-  | PT.Handler.OldWorker _ -> []
 
 
 // -------------------------

--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -230,7 +230,7 @@ module RuntimeT =
     | DResp of (dhttp * dval)
     | DDB of string
     | DDate of RT.DDateTime.T
-    | DPassword of byte array // We dont use this path for testing, see DvalReprExternal.Tests
+    | DPassword of Password // We dont use this path for testing, see DvalReprExternal.Tests
     | DUuid of System.Guid
     | DOption of optionT
     | DCharacter of string
@@ -1037,7 +1037,7 @@ module Convert =
     | RT.DDate d -> ORT.DDate d
     | RT.DDB name -> ORT.DDB name
     | RT.DUuid uuid -> ORT.DUuid uuid
-    | RT.DPassword (Password bytes) -> ORT.DPassword bytes
+    | RT.DPassword pw -> ORT.DPassword pw
     | RT.DHttpResponse (RT.Redirect url) -> ORT.DResp(ORT.Redirect url, c RT.DNull)
     | RT.DHttpResponse (RT.Response (code, headers, hdv)) ->
       ORT.DResp(ORT.Response(int64 code, headers), c hdv)
@@ -1077,7 +1077,7 @@ module Convert =
     | ORT.DDate d -> RT.DDate d
     | ORT.DDB name -> RT.DDB name
     | ORT.DUuid uuid -> RT.DUuid uuid
-    | ORT.DPassword bytes -> RT.DPassword(Password bytes)
+    | ORT.DPassword pw -> RT.DPassword pw
     | ORT.DResp (ORT.Redirect url, _) -> RT.DHttpResponse(RT.Redirect url)
     | ORT.DResp (ORT.Response (code, headers), hdv) ->
       RT.DHttpResponse(RT.Response(code, headers, c hdv))

--- a/fsharp-backend/tests/DataTests/DataTests.fs
+++ b/fsharp-backend/tests/DataTests/DataTests.fs
@@ -40,11 +40,7 @@ let saveCheckpointData (tested : CheckpointData) : unit =
 /// Skip if it's something we verify is allowed
 let shouldRun (cd : CheckpointData) (canvasName : CanvasName.T) : bool =
   let cn = string canvasName
-  not (String.endsWith "-" cn)
-  && not (String.endsWith "_" cn)
-  && not (cn.Contains("--"))
-  && not (cn.Contains("__"))
-  && not (Set.contains cn cd.complete)
+  not (Set.contains cn cd.complete)
   && not (Set.contains cn cd.skipForNow)
   && not (Set.contains cn cd.broken)
 

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -496,15 +496,17 @@ let testTriggerHandler (client : C) (canvasName : CanvasName.T) =
 
 let testWorkerStats (client : C) (canvasName : CanvasName.T) : Task<unit> =
   task {
-    let! (initialLoad : InitialLoad.T) = getInitialLoad client canvasName
+    let! canvas = Canvas.getMeta canvasName
+
+    let! canvasWithJustWorkers = Canvas.loadAllWorkers canvas
 
     let! (_ : List<unit>) =
-      initialLoad.toplevels
-      |> Convert.ocamlToplevel2PT
-      |> Tuple2.first
+      canvasWithJustWorkers.handlers
+      |> Map.values
       |> List.filterMap (fun h ->
         match h.spec with
         | PT.Handler.Worker _ -> Some h.tlid
+        | PT.Handler.OldWorker _ -> Some h.tlid
         | _ -> None)
       |> List.map (fun tlid ->
         postApiTest

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -392,7 +392,9 @@ let testGetTraceData (client : C) (canvasName : CanvasName.T) =
             trace =
               t.trace
               |> Tuple2.mapSecond (fun td ->
-                { td with timestamp = td.timestamp.truncate () }) })
+                { td with
+                    timestamp = td.timestamp.truncate ()
+                    input = td.input |> List.sortBy (fun (k, v) -> k) }) })
 
     let! (_ : List<unit>) =
       body


### PR DESCRIPTION
Fixes #3542.

Expands the DataLoads testing framework to test all the read-only API calls in ApiServer for all users:
- remove call to initialLoad where it isn't needed
- structure all tests in APIServer.Tests in the same format to be easy to call
- allow running which tracking failures
- allow specifying a filename

Caught some errors:
- DPasswords were incorrect deserialized
- unknown handlers and old workers didn't get sample traces
- old worker handlers didn't get sample traces