### PR TITLE
Correct keyboard references link

### DIFF
--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -14,7 +14,7 @@ let docsURL = "https://docs.darklang.com"
 
 let functionRefsURL = "https://ops-documentation.builtwithdark.com/?pretty=1"
 
-let keyboardRefsURL = "https://docs.darklang.com/keyboard-mapping"
+let keyboardRefsURL = "https://docs.darklang.com/reference/keyboard-mapping"
 
 let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
   let tlid = TL.id(tl)


### PR DESCRIPTION
## What is the problem/goal being addressed?
The keyboard reference link seems to be broken, directing to https://docs.darklang.com/keyboard-mapping rather than https://docs.darklang.com/reference/keyboard-mapping

## What is the solution to this problem?
Update the link.


I'm guessing the non -reference link used to work, and now doesn't for some reason, but figured this would be an easier solution.