### PR TITLE
Use Task.mapWithConcurrency instead of chunking crons

### DIFF
--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -62,4 +62,4 @@ let main _ : int =
       Telemetry.addEvent "Pointing at prodclone; will not trigger crons" []
     0
   with
-  | e -> LibService.Rollbar.lastDitchBlockAndPage "Error starting cronchecker" e
+  | e -> Rollbar.lastDitchBlockAndPage "Error starting cronchecker" e

--- a/fsharp-backend/src/LibService/Config.fs
+++ b/fsharp-backend/src/LibService/Config.fs
@@ -96,7 +96,7 @@ type PostgresConfig =
     dbname : string
     user : string
     password : string
-    poolSize : string }
+    poolSize : int }
 
 let pgHost = string "DARK_CONFIG_DB_HOST"
 
@@ -106,7 +106,7 @@ let pgUser = string "DARK_CONFIG_DB_USER"
 
 let pgPassword = password "DARK_CONFIG_DB_PASSWORD"
 
-let pgPoolSize = password "DARK_CONFIG_DB_POOL_SIZE"
+let pgPoolSize = int "DARK_CONFIG_DB_POOL_SIZE"
 
 let postgresSettings : PostgresConfig =
   { host = pgHost


### PR DESCRIPTION
We run crons in parallel in chunks of 100. However, the DB connection pool is only max 30. That means that we might get 100 connections and then discard 70 of them.

I don't know if that's actually happening, but I'm seeing that a lot of DB time is spent on discarding sessions (calling the `discard all` command). That spiked when we increased the pool, which is weird. But, the only thing using the connection pool is this, so worth a try.

The code is copied from #3566, which is waiting on the migration before I can merge it.