### PR TITLE
Update ApiServer to expect static blazor files to be hashed

### DIFF
--- a/fsharp-backend/src/ApiServer/Ui.fs
+++ b/fsharp-backend/src/ApiServer/Ui.fs
@@ -59,8 +59,7 @@ let prodHashReplacements : Lazy<Map<string, string>> =
      |> Map.remove "__date"
      |> Map.remove ".gitkeep"
      // Only hash our assets, not vendored assets
-     |> Map.filterWithIndex (fun k _ ->
-       not (String.includes "vendor/" k || String.includes "blazor/" k))
+     |> Map.filterWithIndex (fun k _ -> not (String.includes "vendor/" k))
      |> Map.toList
      |> List.map (fun (filename, hash) ->
        ($"/{filename}", hashedFilename filename hash))


### PR DESCRIPTION
Blazor assets that are stored in `backend/static/blazor` are hashed in prod, and the OCaml server expects them to be such, but the F# server doesn't.

This updates `ApiServer` to expect hashed `blazor` folder files.