### PR TITLE
Include metadata in F# Wasm exceptions

### DIFF
--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -62,7 +62,9 @@ let inline isNull (x : ^T when ^T : not struct) = obj.ReferenceEquals(x, null)
 
 type Metadata = List<string * obj>
 
-// Do not show to anyone, we need to rollbar this and address it
+/// An error within Dark itself - we need to rollbar this and address it.
+///
+/// Do not show to anyone, unless within a WASM request.
 type InternalException(message : string, metadata : Metadata, inner : exn) =
   inherit System.Exception(message, inner)
   member _.metadata = metadata
@@ -70,14 +72,14 @@ type InternalException(message : string, metadata : Metadata, inner : exn) =
   new(msg : string, metadata : Metadata) = InternalException(msg, metadata, null)
   new(msg : string, inner : exn) = InternalException(msg, [], inner)
 
-// An error caused by the grand user making the request, show the error to the
-// requester no matter who they are
+/// An error caused by the grand user making the request, show the error to the
+/// requester no matter who they are
 type GrandUserException(message : string, inner : exn) =
   inherit System.Exception(message, inner)
   new(msg : string) = GrandUserException(msg, null)
 
-// An error caused by how the developer wrote the code, such as calling a function
-// with the wrong type
+/// An error caused by how the developer wrote the code, such as calling a function
+/// with the wrong type
 type DeveloperException(message : string, inner : exn) =
   inherit System.Exception(message, inner)
   new(msg : string) = DeveloperException(msg, null)

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -313,7 +313,9 @@ type EvalWorker =
           let metadata = Exception.toMetadata e
           System.Console.WriteLine("Error parsing analysis in Blazor")
           System.Console.WriteLine($"called with message: {message}")
-          System.Console.WriteLine($"caught exception: \"{e.Message}\" \"{metadata}\"")
+          System.Console.WriteLine(
+            $"caught exception: \"{e.Message}\" \"{metadata}\""
+          )
           Error($"exception: {e.Message}, metdata: {metadata}")
 
       match args with
@@ -327,7 +329,9 @@ type EvalWorker =
           let metadata = Exception.toMetadata e
           System.Console.WriteLine("Error running analysis in Blazor")
           System.Console.WriteLine($"called with message: {message}")
-          System.Console.WriteLine($"caught exception: \"{e.Message}\" \"{metadata}\"")
+          System.Console.WriteLine(
+            $"caught exception: \"{e.Message}\" \"{metadata}\""
+          )
           return Error($"exception: {e.Message}, metadata: {metadata}")
     }
     |> Task.map Json.OCamlCompatible.serialize

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -310,10 +310,11 @@ type EvalWorker =
           )
         with
         | e ->
+          let metadata = Exception.toMetadata e
           System.Console.WriteLine("Error parsing analysis in Blazor")
           System.Console.WriteLine($"called with message: {message}")
-          System.Console.WriteLine($"caught exception: \"{e.Message}\"")
-          Error(e.Message)
+          System.Console.WriteLine($"caught exception: \"{e.Message}\" \"{metadata}\"")
+          Error($"exception: {e.Message}, metdata: {metadata}")
 
       match args with
       | Error e -> return Error e
@@ -323,10 +324,11 @@ type EvalWorker =
           return Ok result
         with
         | e ->
+          let metadata = Exception.toMetadata e
           System.Console.WriteLine("Error running analysis in Blazor")
           System.Console.WriteLine($"called with message: {message}")
-          System.Console.WriteLine($"caught exception: \"{e.Message}\"")
-          return Error(e.Message)
+          System.Console.WriteLine($"caught exception: \"{e.Message}\" \"{metadata}\"")
+          return Error($"exception: {e.Message}, metadata: {metadata}")
     }
     |> Task.map Json.OCamlCompatible.serialize
     |> Task.map EvalWorker.postMessage


### PR DESCRIPTION
Aimed to resolve #3577.

Tested locally by updating `src/LibExecution/OCamlTypes.fs` locally, commenting out the handling of `EIntegers` from `rt2ocamlExpr`, and running an analysis on something that returned an Int.
![image](https://user-images.githubusercontent.com/906686/158647613-410fc90c-6a9d-45c8-8507-28b5e4857b9c.png)

If I try to change the shape of the Error returned (e.g. by returning an anonymous record of `{ message: string, metadata: ...}` , I get issues in decoding the error on the client. So, I shoe-horned both into the string - happy to take recommendations there.