### PR TITLE
Add migration

### DIFF
--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -41,6 +41,16 @@
 
 - you can only use Tasks (aka `Ply`) once. Using it a second time is undefined.
 
+- use `///` for function comments
+
+- For file header comments, use `///` and add them to the first line of the file
+  before the module declaration
+
+## SQL
+
+- add `set statement_timeout = '1s'` or `set lock_timeout = '1s'` to the first line
+  of your script, so that it fails instead of taking the service down.
+
 ### Creating types
 
 When creating a type:

--- a/backend/migrations/20220316_174259_add-extra-events-index.sql
+++ b/backend/migrations/20220316_174259_add-extra-events-index.sql
@@ -1,1 +1,3 @@
+--#[no_tx]
+set statement_timeout = '1s';
 create index concurrently if not exists idx_events_for_dequeue2 on events (status, id) where status = 'scheduled'

--- a/backend/migrations/20220316_174259_add-extra-events-index.sql
+++ b/backend/migrations/20220316_174259_add-extra-events-index.sql
@@ -1,3 +1,2 @@
 --#[no_tx]
-set statement_timeout = '1s';
 create index concurrently if not exists idx_events_for_dequeue2 on events (status, id) where status = 'scheduled'

--- a/backend/migrations/20220316_174259_add-extra-events-index.sql
+++ b/backend/migrations/20220316_174259_add-extra-events-index.sql
@@ -1,0 +1,1 @@
+create index concurrently if not exists idx_events_for_dequeue2 on events (status, id) where status = 'scheduled'


### PR DESCRIPTION
This migration is already in production, but this adds it to the repo.

It will still be run when it goes to production, hence  `if not exists`. I've tested this locally on prodclone to ensure it's instant if the index already exists.

Adds an index which drops the DB CPU usage from 80% to 20%, see https://twitter.com/paulbiggar/status/1504182057928470529 for details.