### PR TITLE
Save F# binary serialization whenever reading from OCaml legacy server

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APIOps.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIOps.fs
@@ -72,7 +72,8 @@ let addOp (ctx : HttpContext) : Task<T> =
 
     let allTLIDs = (List.map Op.tlidOf newOps) @ dbTLIDs
     // We're going to save this, so we need all the ops
-    let! oldOps = C.loadOplists C.IncludeDeletedToplevels canvasInfo.id allTLIDs
+    let! oldOps =
+      Serialize.loadOplists Serialize.IncludeDeletedToplevels canvasInfo.id allTLIDs
     let oldOps = oldOps |> List.map Tuple2.second |> List.concat
 
     let c = C.fromOplist canvasInfo oldOps newOps

--- a/fsharp-backend/src/LibBackend/Canvas.fs
+++ b/fsharp-backend/src/LibBackend/Canvas.fs
@@ -494,13 +494,13 @@ let getToplevel (tlid : tlid) (c : T) : Option<Deleted * PT.Toplevel.T> =
 let saveTLIDs
   (meta : Meta)
   (oplists : List<tlid * PT.Oplist * PT.Toplevel.T * Deleted>)
-  : Task =
+  : Task<unit> =
   try
     // Use ops rather than just set of toplevels, because toplevels may
     // have been deleted or undone, and therefore not appear, but it's
     // important to record them.
     oplists
-    |> List.map (fun (tlid, oplist, tl, deleted) ->
+    |> Task.iterInParallel (fun (tlid, oplist, tl, deleted) ->
       task {
         let string2option (s : string) : Option<string> =
           if s = "" then None else Some s
@@ -590,8 +590,6 @@ let saveTLIDs
                               "oplistCache", Sql.bytea fsharpOplistCache ]
           |> Sql.executeStatementAsync
       })
-    |> List.map (fun t -> t : Task)
-    |> Task.WhenAll
   with
   | e -> Exception.reraiseAsPageable "canvas save failed" e
 

--- a/fsharp-backend/src/LibBackend/CanvasClone.fs
+++ b/fsharp-backend/src/LibBackend/CanvasClone.fs
@@ -119,7 +119,8 @@ let cloneCanvas
   task {
     let! fromMeta = Canvas.getMeta fromCanvasName
     let! fromTLIDs = Serialize.fetchAllLiveTLIDs fromMeta.id
-    let! fromOps = Canvas.loadOplists Canvas.LiveToplevels fromMeta.id fromTLIDs
+    let! fromOps =
+      Serialize.loadOplists Serialize.LiveToplevels fromMeta.id fromTLIDs
     let! fromCanvas = Canvas.loadAll fromMeta
 
     let! toMeta = Canvas.getMeta toCanvasName

--- a/fsharp-backend/src/LibBackend/PackageManager.fs
+++ b/fsharp-backend/src/LibBackend/PackageManager.fs
@@ -312,7 +312,7 @@ let allFunctions () : Task<List<PT.Package.Fn>> =
      read.int64 "tlid"))
   |> Task.bind (fun fns ->
     fns
-    |> List.map
+    |> Task.mapInParallel
       (fun (username,
             package,
             module_,
@@ -358,8 +358,7 @@ let allFunctions () : Task<List<PT.Package.Fn>> =
                author = author
                deprecated = deprecated
                tlid = tlid |> uint64 } : PT.Package.Fn)
-        })
-    |> Task.flatten)
+        }))
 
 // TODO: this keeps a cached version so we're not loading them all the time.
 // Of course, this won't be up to date if we add more functions. Given that all

--- a/fsharp-backend/src/LibBackend/Serialize.fs
+++ b/fsharp-backend/src/LibBackend/Serialize.fs
@@ -131,17 +131,16 @@ let cacheOplist
       Sql.query
         "UPDATE toplevel_oplists
          SET oplist = @oplist
-         WHERE
-          canvas_id = @canvasID,
-          tlid = @tlid,
-          data = @ocamlOplist"
-      |> Sql.parameters [ "canvasID", Sql.uuid canvasID
+         WHERE canvas_id = @canvasID
+           AND tlid = @tlid
+           AND data = @ocamlOplist"
+      |> Sql.parameters [ "oplist", Sql.bytea serialized
+                          "canvasID", Sql.uuid canvasID
                           "tlid", Sql.id tlid
                           // There might have been writes since then, so don't update
                           // unless it exactly matches what we expect it to have,
                           // otherwise we might overwrite other writes.
-                          "ocamlOplist", Sql.bytea ocamlSerializedBytes
-                          "oplist", Sql.bytea serialized ]
+                          "ocamlOplist", Sql.bytea ocamlSerializedBytes ]
       |> Sql.executeNonQueryAsync
     match rowUpdateCount with
     | 1 -> ()
@@ -170,18 +169,17 @@ let cacheToplevel
     let! rowUpdateCount =
       Sql.query
         "UPDATE toplevel_oplists
-         SET oplist_cache = @oplist_cache
-         WHERE
-          canvas_id = @canvasID,
-          tlid = @tlid,
-          rendered_oplist_cache = @renderedOplistCache"
-      |> Sql.parameters [ "canvasID", Sql.uuid canvasID
+         SET oplist_cache = @oplistCache
+         WHERE canvas_id = @canvasID
+           AND tlid = @tlid
+           AND rendered_oplist_cache = @renderedOplistCache"
+      |> Sql.parameters [ "oplistCache", Sql.bytea serialized
+                          "canvasID", Sql.uuid canvasID
                           "tlid", Sql.id tlid
                           // There might have been writes since then, so don't update
                           // unless it exactly matches what we expect it to have,
                           // otherwise we might overwrite other writes.
-                          "renderedOplistCache", Sql.bytea ocamlSerializedBytes
-                          "oplistCache", Sql.bytea serialized ]
+                          "renderedOplistCache", Sql.bytea ocamlSerializedBytes ]
       |> Sql.executeNonQueryAsync
     match rowUpdateCount with
     | 1 -> ()

--- a/fsharp-backend/tests/DataTests/DataTests.fs
+++ b/fsharp-backend/tests/DataTests/DataTests.fs
@@ -311,7 +311,8 @@ let checkOplists (meta : Canvas.Meta) (tlids : List<tlid>) =
   task {
     let loadWatch = System.Diagnostics.Stopwatch()
     loadWatch.Start()
-    let! expected = Canvas.loadOplists Canvas.IncludeDeletedToplevels meta.id tlids
+    let! expected =
+      Serialize.loadOplists Serialize.IncludeDeletedToplevels meta.id tlids
     loadWatch.Stop()
     // debuG "load time" loadWatch.ElapsedMilliseconds
     // debuG "oplist load items" (List.length expected)

--- a/fsharp-backend/tests/Tests/Canvas.Tests.fs
+++ b/fsharp-backend/tests/Tests/Canvas.Tests.fs
@@ -32,7 +32,7 @@ let testDBOplistRoundtrip : Test =
       Canvas.saveTLIDs
         meta
         [ (db.tlid, oplist, PT.Toplevel.TLDB db, Canvas.NotDeleted) ]
-    let! ops = Canvas.loadOplists Canvas.LiveToplevels meta.id [ db.tlid ]
+    let! ops = Serialize.loadOplists Serialize.LiveToplevels meta.id [ db.tlid ]
     Expect.equal ops [ (db.tlid, oplist) ] "db oplist roundtrip"
   }
 
@@ -386,9 +386,9 @@ let testCanvasClone =
 
     let! tlids = Serialize.fetchAllTLIDs sourceMeta.id
     let! sourceOplists =
-      Canvas.loadOplists Canvas.IncludeDeletedToplevels sourceMeta.id tlids
+      Serialize.loadOplists Serialize.IncludeDeletedToplevels sourceMeta.id tlids
     let! targetOplists =
-      Canvas.loadOplists Canvas.IncludeDeletedToplevels targetMeta.id tlids
+      Serialize.loadOplists Serialize.IncludeDeletedToplevels targetMeta.id tlids
 
     let hasCreationOps oplists =
       oplists


### PR DESCRIPTION
Currently, when you edit code in the F# ApiServer, we save it in a binary format for both the OCaml and F# servers.

This PR also saves it in that format when you read code from F# servers (not just when you write it).

I tested this by loading some canvases and looking at what happened via honeycomb. I could see for example that in the ops-adduser trace (which has hundreds of toplevels), it made requests for all toplevels via the legacy server, then saved them with these new functions. Then future loads were practically instant (which is much faster than they are on ocaml servers).

ops-adduser went from 200s to load, to 600ms.

Once this is in production, any user who opens their canvas using the F# apiserver or bwdserver or queueworker will have their canvas auto-upgraded to the new serialization, while maintaining backwards compatibility with the OCaml server.