### PR TITLE
Add a redirect for static assets API calls

### DIFF
--- a/scripts/devcontainer/_setup-hosts
+++ b/scripts/devcontainer/_setup-hosts
@@ -8,3 +8,8 @@ echo 127.0.0.1 static.darklang.localhost | sudo tee -a /etc/hosts
 echo 127.0.0.1 builtwithdark.localhost | sudo tee -a /etc/hosts
 echo 127.0.0.1 test.builtwithdark.localhost | sudo tee -a /etc/hosts
 echo 127.0.0.1 dark.builtwithdark.localhost | sudo tee -a /etc/hosts
+
+# CLEANUP This is used as part of the static_assets redirect to the editor service
+# from the APIserver.  It's needed here as nginx will complain if the DNS does not
+# resolve.
+echo 127.0.0.1 darklang-nodeport | sudo tee -a /etc/hosts

--- a/services/apiserver-deployment/nginx.conf
+++ b/services/apiserver-deployment/nginx.conf
@@ -83,6 +83,14 @@ server {
   # tell clients to stop going to http://darklang.com
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
+  # Static assets are handled by the old OCaml editor for now. We can't redirect from
+  # the ingress, so redirect from here instead.
+  location ~ /api/.*/static_assets {
+    proxy_pass         http://darklang-nodeport:80;
+    proxy_set_header   Host $host;
+    proxy_http_version 1.1;
+  }
+
   # These prefixes are handled by the backend.
   location ~ (/a/|/a-testing-fsharp/|/api/|/api-testing-fsharp/|/login|/logout|/check-apiserver) {
     # https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/linux-nginx?view=aspnetcore-6.0#configure-nginx


### PR DESCRIPTION
When API requests to /api/CANVASNAME/static_assets come in to the Apiserver, nginx will now proxy the request to the darklang-nodeport service (which is what the service which points to the editor-deployment is actually called).

This is so that we don't have to reimplement the static_assets API in F# and can do
it in Dark instead.

I would prefer to have done this in the load balancer, but the google load balancer does not allow wildcards of the form `/api/*/static_assets` while nginx does.