### PR TITLE
Attempt to fix exception in the CronChecker

### DIFF
--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -43,7 +43,7 @@ let waitForDB () : Task<unit> =
         success <- true
       with
       | _ -> do! Task.Delay 1000
-      return ()
+    return ()
   }
 
 


### PR DESCRIPTION
The Cronchecker is supposed to wait until the DB is ready to start up. The exceptions
in Rollbar indicate that it is trying to run the crons before the DB is actually
ready for it, implying it got past the WaitForDB call.

This could be because the `return` was in the wrong place, executing after the first
iteration of the loop, as opposed to after the loop is over.

Hard to tell if this fixes things without trying it.