### PR TITLE
Potentially prevent DB errors when cronchecker is shutting down

### DIFF
--- a/services/cronchecker-deployment/cronchecker-deployment.template.yaml
+++ b/services/cronchecker-deployment/cronchecker-deployment.template.yaml
@@ -120,7 +120,14 @@ spec:
             limits:
               memory: "50Mi"
               cpu: "500m"
-          command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-instances={BUILTIN:CLOUDSQL_INSTANCE_NAME}=tcp:5432", "-credential_file=/secrets/cloudsql/credentials.json"]
+
+          command: ["/cloud_sql_proxy",
+                    "-dir=/cloudsql",
+                    "-instances={BUILTIN:CLOUDSQL_INSTANCE_NAME}=tcp:5432",
+                    "-credential_file=/secrets/cloudsql/credentials.json",
+                    "-structured_logs",
+                    "-term_timeout=30s"]
+
           volumeMounts:
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql


### PR DESCRIPTION
We see several errors in Rollbar that happen on every deploy. The errors are about the connection to the DB being missing. While I initially thought this happened on startup, my current guess is that it happens on shutdown.

This configures the cloud_sql_proxy to wait until connections have closed before shutting down. It seems a pretty reasonable guess as to the cause of the exceptions.