### PR TITLE
Re-include metadata in F# Wasm exceptions

### DIFF
--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -62,7 +62,9 @@ let inline isNull (x : ^T when ^T : not struct) = obj.ReferenceEquals(x, null)
 
 type Metadata = List<string * obj>
 
-// Do not show to anyone, we need to rollbar this and address it
+/// An error within Dark itself - we need to rollbar this and address it.
+///
+/// Do not show to anyone, unless within a WASM request.
 type InternalException(message : string, metadata : Metadata, inner : exn) =
   inherit System.Exception(message, inner)
   member _.metadata = metadata
@@ -70,14 +72,14 @@ type InternalException(message : string, metadata : Metadata, inner : exn) =
   new(msg : string, metadata : Metadata) = InternalException(msg, metadata, null)
   new(msg : string, inner : exn) = InternalException(msg, [], inner)
 
-// An error caused by the grand user making the request, show the error to the
-// requester no matter who they are
+/// An error caused by the grand user making the request, show the error to the
+/// requester no matter who they are
 type GrandUserException(message : string, inner : exn) =
   inherit System.Exception(message, inner)
   new(msg : string) = GrandUserException(msg, null)
 
-// An error caused by how the developer wrote the code, such as calling a function
-// with the wrong type
+/// An error caused by how the developer wrote the code, such as calling a function
+/// with the wrong type
 type DeveloperException(message : string, inner : exn) =
   inherit System.Exception(message, inner)
   new(msg : string) = DeveloperException(msg, null)

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -312,10 +312,13 @@ type EvalWorker =
           )
         with
         | e ->
+          let metadata = Exception.toMetadata e
           System.Console.WriteLine("Error parsing analysis in Blazor")
           System.Console.WriteLine($"called with message: {message}")
-          System.Console.WriteLine($"caught exception: \"{e.Message}\"")
-          Error(e.Message)
+          System.Console.WriteLine(
+            $"caught exception: \"{e.Message}\" \"{metadata}\""
+          )
+          Error($"exception: {e.Message}, metdata: {metadata}")
 
       match args with
       | Error e -> return Error e
@@ -325,10 +328,13 @@ type EvalWorker =
           return Ok result
         with
         | e ->
+          let metadata = Exception.toMetadata e
           System.Console.WriteLine("Error running analysis in Blazor")
           System.Console.WriteLine($"called with message: {message}")
-          System.Console.WriteLine($"caught exception: \"{e.Message}\"")
-          return Error(e.Message)
+          System.Console.WriteLine(
+            $"caught exception: \"{e.Message}\" \"{metadata}\""
+          )
+          return Error($"exception: {e.Message}, metadata: {metadata}")
     }
     |> Task.map Json.OCamlCompatible.serialize
     |> Task.map EvalWorker.postMessage


### PR DESCRIPTION
Reverts darklang/dark#3581

I believe we reverted this change because we thought it caused an issue. It turns out that the actual issue was irrelevant, to do with hashing, and has since been resolved.