### PR TITLE
Avoid risk of bad packages at startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,12 @@ jobs:
             PATTERN=${PATTERN%?}
 
             echo $PATTERN > test-pattern
+      # We need to run DB migrations for the prep.sh script to work
+      - run:
+          name: DB migrations
+          command: |
+            cd fsharp-backend
+            ./Build/out/ExecHost/Release/net6.0/linux-x64/publish/ExecHost migrations run
       - run:
           name: Run integration tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,15 +434,11 @@ jobs:
             PATTERN=${PATTERN%?}
 
             echo $PATTERN > test-pattern
-      # We need to run DB migrations for the prep.sh script to work
-      - run:
-          name: DB migrations
-          command: |
-            cd fsharp-backend
-            ./Build/out/ExecHost/Release/net6.0/linux-x64/publish/ExecHost migrations run
       - run:
           name: Run integration tests
           command: |
+            # Run the server first to set up the DB correctly for the prep script
+            scripts/run-fsharp-server --published
             integration-tests/run.sh --concurrency=3 --retry --pattern="`cat test-pattern`" --published
             rm test-pattern
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,16 +435,9 @@ jobs:
 
             echo $PATTERN > test-pattern
       - run:
-          name: DB migrations
-          command: |
-            cd fsharp-backend
-            ./Build/out/ExecHost/Release/net6.0/linux-x64/publish/ExecHost migrations run
-      - run:
           name: Run integration tests
           command: |
-            scripts/run-fsharp-server --published
-            scripts/devcontainer/_wait-until-apiserver-ready
-            integration-tests/run.sh --concurrency=3 --retry --pattern="`cat test-pattern`"
+            integration-tests/run.sh --concurrency=3 --retry --pattern="`cat test-pattern`" --published
             rm test-pattern
 
       - run: integration-tests/_integration-test-results-to-honeycomb.sh

--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -46,10 +46,23 @@
 - For file header comments, use `///` and add them to the first line of the file
   before the module declaration
 
-## SQL
+## SQL migrations
 
 - add `set statement_timeout = '1s'` or `set lock_timeout = '1s'` to the first line
   of your script, so that it fails instead of taking the service down.
+
+## Initialization
+
+- initialization code should be in a function called `init` in a file called `Init.fs`
+
+- Library initialization code can rely on the DB but the services (eg ApiServer) must
+  ensure to call them in the right order to ensure the DB is available and in the right
+  shape (as migrations will not necessarily have run in tests at that point).
+
+- Do not block in library initialization code, instead return `Lazy` or `Task`, and
+  let the service resolve it.
+
+- remove unused `Init.fs` files - they create cognitive load
 
 ### Creating types
 

--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -2,8 +2,7 @@
 
 ## File layout
 
-- Every file should start with a comment describing it (this is currently not done
-  very much at all).
+- Every file should start with a comment describing it.
 
 - all files have a formatter, which should be setup automatically in VSCode. Use
   `scripts/format format` to format otherwise. Unformatted files fail in CI.
@@ -34,10 +33,10 @@
 
 - use `print` instead of `Console.WriteLine` or similar, the latter deadlocks
 
-- ensure that `try` do not have a `uply` in the body unless you know what you are
-  doing and provide a comment. Typically, the `uply` should be on the outside, which
-  causes the compiler to compile the `try` into a version which supports Tasks.
-  Otherwise, it won't catch an exception thrown within the `uply`.
+- ensure that `try` do not have a `uply`/`task` in the body unless you know what you
+  are doing and provide a comment. Typically, the `uply`/`task` should be on the
+  outside, which causes the compiler to compile the `try` into a version which supports
+  Tasks. Otherwise, it won't catch an exception thrown within the `uply`/`task`.
 
 - you can only use Tasks (aka `Ply`) once. Using it a second time is undefined.
 
@@ -46,12 +45,14 @@
 - For file header comments, use `///` and add them to the first line of the file
   before the module declaration
 
-## SQL migrations
+### SQL migrations
 
 - add `set statement_timeout = '1s'` or `set lock_timeout = '1s'` to the first line
   of your script, so that it fails instead of taking the service down.
 
-## Initialization
+- migrations are run manually before deployment (using `ExecHost migrations run`)
+
+### Initialization
 
 - initialization code should be in a function called `init` in a file called `Init.fs`
 
@@ -64,7 +65,16 @@
 
 - remove unused `Init.fs` files - they create cognitive load
 
-### Creating types
+### Types
+
+- Avoid using bools for function parameters to configure. Instead use a type with two
+  cases. Do match on the type to ensure
+
+- Unless impossible or impractical to do so, avoid using wildcards in pattern
+  matches. When changing a type we would like the compiler to tell us everywhere that
+  has to be changed.
+
+#### Creating types
 
 When creating a type:
 

--- a/fsharp-backend/src/ApiServer/Api/APIPackages.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIPackages.fs
@@ -18,15 +18,12 @@ module List =
   type T = List<OT.PackageManager.fn>
 
   /// API endpoint to fetch a list of available Packages
-  let packages (ctx : HttpContext) : Task<T> =
+  let packages (packages : List<PT.Package.Fn>) (ctx : HttpContext) : Task<T> =
     task {
       use t = startTimer "read-api" ctx
 
-      t.next "load-functions"
-      let! fns = Lazy.force LibBackend.PackageManager.cachedForAPI
-
       t.next "convert"
-      return fns |> List.map Convert.pt2ocamlPackageManagerFn
+      return packages |> List.map Convert.pt2ocamlPackageManagerFn
     }
 
 

--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -211,13 +211,12 @@ let main _ =
     let name = "ApiServer"
     print "Starting ApiServer"
     LibService.Init.init name
-    (LibBackend.Init.init
-      LibBackend.Init.DontRunSideEffects
-      LibBackend.Init.WaitForDB
-      name)
-      .Result
+    (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
     (LibRealExecution.Init.init name).Result
-    let packages = (LibBackend.PackageManager.allFunctions ()).Result
+
+    if Config.createAccounts then LibBackend.Account.init(name).Result
+
+    let packages = LibBackend.PackageManager.allFunctions().Result
     run packages
     0
   with

--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -203,12 +203,15 @@ let run () : unit =
 [<EntryPoint>]
 let main _ =
   try
+    let name = "ApiServer"
     print "Starting ApiServer"
-    LibService.Init.init "ApiServer"
-    LibExecution.Init.init "ApiServer"
-    LibExecutionStdLib.Init.init "ApiServer"
-    (LibBackend.Init.init "ApiServer" true).Result
-    LibRealExecution.Init.init "ApiServer"
+    LibService.Init.init name
+    (LibBackend.Init.init
+      LibBackend.Init.DontRunSideEffects
+      LibBackend.Init.WaitForDB
+      name)
+      .Result
+    (LibRealExecution.Init.init name).Result
     run ()
     0
   with

--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -214,7 +214,8 @@ let main _ =
     (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
     (LibRealExecution.Init.init name).Result
 
-    if Config.createAccounts then LibBackend.Account.init(name).Result
+    if Config.createAccounts then
+      LibBackend.Account.initializeDevelopmentAccounts(name).Result
 
     let packages = LibBackend.PackageManager.allFunctions().Result
     run packages

--- a/fsharp-backend/src/ApiServer/Ui.fs
+++ b/fsharp-backend/src/ApiServer/Ui.fs
@@ -23,26 +23,25 @@ module Account = LibBackend.Account
 ///
 /// Handles the replacement of known used variables
 /// such as `{{ENVIRONMENT_NAME}}`
-let adminUiTemplate : Lazy<string> =
-  lazy
-    (let liveReloadStr =
-      "<script type=\"text/javascript\" src=\"//localhost:35729/livereload.js\"> </script>"
+let adminUiTemplate : string =
+  let liveReloadStr =
+    "<script type=\"text/javascript\" src=\"//localhost:35729/livereload.js\"> </script>"
 
-     let liveReloadJs = if Config.browserReloadEnabled then liveReloadStr else ""
-     let uiHtml = File.readfile Config.Templates "ui.html"
-     let appSupport = File.readfile Config.Webroot "appsupport.js"
+  let liveReloadJs = if Config.browserReloadEnabled then liveReloadStr else ""
+  let uiHtml = File.readfile Config.Templates "ui.html"
+  let appSupport = File.readfile Config.Webroot "appsupport.js"
 
-     // Load as much of this as we can in advance
-     // CLEANUP make APIs to load the dynamic data
-     uiHtml
-       .Replace("{{ENVIRONMENT_NAME}}", LibService.Config.envDisplayName)
-       .Replace("{{LIVERELOADJS}}", liveReloadJs)
-       .Replace("{{HEAPIO_ID}}", LibService.Config.heapioId)
-       .Replace("{{ROLLBARCONFIG}}", Config.rollbarJs)
-       .Replace("{{PUSHERCONFIG}}", LibBackend.Pusher.jsConfigString)
-       .Replace("{{USER_CONTENT_HOST}}", Config.bwdServerContentHost)
-       .Replace("{{APPSUPPORT}}", appSupport)
-       .Replace("{{BUILD_HASH}}", LibService.Config.buildHash))
+  // Load as much of this as we can in advance
+  // CLEANUP make APIs to load the dynamic data
+  uiHtml
+    .Replace("{{ENVIRONMENT_NAME}}", LibService.Config.envDisplayName)
+    .Replace("{{LIVERELOADJS}}", liveReloadJs)
+    .Replace("{{HEAPIO_ID}}", LibService.Config.heapioId)
+    .Replace("{{ROLLBARCONFIG}}", Config.rollbarJs)
+    .Replace("{{PUSHERCONFIG}}", LibBackend.Pusher.jsConfigString)
+    .Replace("{{USER_CONTENT_HOST}}", Config.bwdServerContentHost)
+    .Replace("{{APPSUPPORT}}", appSupport)
+    .Replace("{{BUILD_HASH}}", LibService.Config.buildHash)
 
 let hashedFilename (filename : string) (hash : string) : string =
   let parts = filename.Split '.'
@@ -55,22 +54,20 @@ let hashedFilename (filename : string) (hash : string) : string =
     $"/{name}-{hash}.{extension}"
 
 
-let prodHashReplacements : Lazy<Map<string, string>> =
-  lazy
-    ("etags.json"
-     |> File.readfile Config.Webroot
-     |> Json.Vanilla.deserialize<Map<string, string>>
-     |> Map.remove "__date"
-     |> Map.remove ".gitkeep"
-     // Only hash our assets, not vendored assets
-     |> Map.filterWithIndex (fun k _ -> not (String.includes "vendor/" k))
-     |> Map.toList
-     |> List.map (fun (filename, hash) ->
-       ($"/{filename}", hashedFilename filename hash))
-     |> Map.ofList)
+let prodHashReplacements : Map<string, string> =
+  "etags.json"
+  |> File.readfile Config.Webroot
+  |> Json.Vanilla.deserialize<Map<string, string>>
+  |> Map.remove "__date"
+  |> Map.remove ".gitkeep"
+  // Only hash our assets, not vendored assets
+  |> Map.filterWithIndex (fun k _ -> not (String.includes "vendor/" k))
+  |> Map.toList
+  |> List.map (fun (filename, hash) -> ($"/{filename}", hashedFilename filename hash))
+  |> Map.ofList
 
-let prodHashReplacementsString : Lazy<string> =
-  lazy (prodHashReplacements.Force() |> Json.Vanilla.serialize)
+let prodHashReplacementsString : string =
+  prodHashReplacements |> Json.Vanilla.serialize
 
 
 // TODO: clickjacking/ CSP/ frame-ancestors
@@ -86,8 +83,7 @@ let uiHtml
   let shouldHash =
     if localhostAssets = None then Config.hashStaticFilenames else false
 
-  let hashReplacements =
-    if shouldHash then prodHashReplacementsString.Force() else "{}"
+  let hashReplacements = if shouldHash then prodHashReplacementsString else "{}"
 
   let accountCreatedMsTs =
     accountCreated.ToUnixTimeMilliseconds()
@@ -102,19 +98,18 @@ let uiHtml
     | _ -> Config.apiServerStaticHost
 
 
-  let t = StringBuilder(adminUiTemplate.Force())
+  let t = StringBuilder(adminUiTemplate)
 
   // Replace any filenames in the response html with the hashed version
   if shouldHash then
     prodHashReplacements
-    |> Lazy.force
     |> Map.iter (fun filename hashed ->
       t.Replace(filename, hashed) |> ignore<StringBuilder>)
 
   // CLEANUP move functions into an API call, or even to the CDN
   // CLEANUP move the user info into an API call
   t
-    .Replace("{{ALLFUNCTIONS}}", (Functions.functions user.admin).Force())
+    .Replace("{{ALLFUNCTIONS}}", Functions.functions user.admin)
     .Replace("{{USER_CONTENT_HOST}}", Config.bwdServerContentHost)
     .Replace("{{USER_USERNAME}}", string user.username)
     .Replace("{{USER_EMAIL}}", user.email)

--- a/fsharp-backend/src/BackendOnlyStdLib/StdLib.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/StdLib.fs
@@ -19,24 +19,23 @@ let renames =
     fn "DB" "queryOneWithKey" 2, fn "DB" "queryOneWithExactFieldsWithKey" 0 ]
 
 
-let fns : Lazy<List<RT.BuiltInFn>> =
-  lazy
-    ([ LibDB.fns
-       LibCrypto.fns
-       LibDarkInternal.fns
-       LibEvent.fns
-       LibHttpClient0.fns
-       LibHttpClient1.fns
-       LibHttpClient2.fns
-       LibHttpClient3.fns
-       LibHttpClient4.fns
-       LibHttpClient5.fns
-       LibHttpClientAuth.fns
-       LibJwt.fns
-       LibPassword.fns
-       LibStaticAssets.fns
-       LibTwilio.fns
-       LibX509.fns
-       LibDB2.fns ]
-     |> List.concat
-     |> RT.renameFunctions renames)
+let fns : List<RT.BuiltInFn> =
+  [ LibDB.fns
+    LibCrypto.fns
+    LibDarkInternal.fns
+    LibEvent.fns
+    LibHttpClient0.fns
+    LibHttpClient1.fns
+    LibHttpClient2.fns
+    LibHttpClient3.fns
+    LibHttpClient4.fns
+    LibHttpClient5.fns
+    LibHttpClientAuth.fns
+    LibJwt.fns
+    LibPassword.fns
+    LibStaticAssets.fns
+    LibTwilio.fns
+    LibX509.fns
+    LibDB2.fns ]
+  |> List.concat
+  |> RT.renameFunctions renames

--- a/fsharp-backend/src/Benchmark/Benchmark.fs
+++ b/fsharp-backend/src/Benchmark/Benchmark.fs
@@ -161,8 +161,13 @@ let parser = ArgumentParser.Create<Arguments>(programName = "Benchmark")
 let main args : int =
   try
     let cliArgs = parser.ParseCommandLine args
+    let name = "Benchmark"
     print "Starting Benchmark"
-    (LibBackend.Init.init "Benchmark" false).Result
+    (LibBackend.Init.init
+      LibBackend.Init.DontRunSideEffects
+      LibBackend.Init.WaitForDB
+      name)
+      .Result
     let filename = cliArgs.GetResult Filename
     let warmUpCount = cliArgs.GetResult(Warmups, 3u)
     let iterations = cliArgs.GetResult(Iterations, 3u)

--- a/fsharp-backend/src/Benchmark/Benchmark.fs
+++ b/fsharp-backend/src/Benchmark/Benchmark.fs
@@ -163,11 +163,7 @@ let main args : int =
     let cliArgs = parser.ParseCommandLine args
     let name = "Benchmark"
     print "Starting Benchmark"
-    (LibBackend.Init.init
-      LibBackend.Init.DontRunSideEffects
-      LibBackend.Init.WaitForDB
-      name)
-      .Result
+    (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
     let filename = cliArgs.GetResult Filename
     let warmUpCount = cliArgs.GetResult(Warmups, 3u)
     let iterations = cliArgs.GetResult(Iterations, 3u)

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -522,11 +522,7 @@ let main _ =
     let name = "BwdServer"
     print "Starting BwdServer"
     LibService.Init.init name
-    (LibBackend.Init.init
-      LibBackend.Init.DontRunSideEffects
-      LibBackend.Init.WaitForDB
-      name)
-      .Result
+    (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
     (LibRealExecution.Init.init name).Result
     run ()
     0

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -519,13 +519,15 @@ let run () : unit =
 [<EntryPoint>]
 let main _ =
   try
+    let name = "BwdServer"
     print "Starting BwdServer"
-    LibService.Init.init "BwdServer"
-    LibExecution.Init.init "BwdServer"
-    LibExecutionStdLib.Init.init "BwdServer"
-    (LibBackend.Init.init "BwdServer" false).Result
-    LibRealExecution.Init.init "BwdServer"
-    HttpMiddleware.Init.init "BwdServer"
+    LibService.Init.init name
+    (LibBackend.Init.init
+      LibBackend.Init.DontRunSideEffects
+      LibBackend.Init.WaitForDB
+      name)
+      .Result
+    (LibRealExecution.Init.init name).Result
     run ()
     0
   with

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -34,19 +34,15 @@ let main _ : int =
     print "Starting CronChecker"
     LibService.Init.init name
     Telemetry.Console.loadTelemetry name Telemetry.DontTraceDBQueries
-    (LibBackend.Init.init
-      LibBackend.Init.DontRunSideEffects
-      LibBackend.Init.WaitForDB
-      name)
-      .Result
+    (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
     (LibRealExecution.Init.init name).Result
-
 
     // This fn is called if k8s tells us to stop
     let shutdownCallback () =
       Telemetry.addEvent "Shutting down" []
       shouldShutdown.Value <- true
 
+    // Set up healthchecks and shutdown with k8s
     let port = LibService.Config.croncheckerKubernetesPort
     LibService.Kubernetes.runKubernetesServer name [] port shutdownCallback
     |> ignore<Task>

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -30,31 +30,26 @@ let run () : Task<unit> =
 [<EntryPoint>]
 let main _ : int =
   try
+    let name = "CronChecker"
     print "Starting CronChecker"
-    LibService.Init.init "CronChecker"
-    LibExecution.Init.init "CronChecker"
-    LibExecutionStdLib.Init.init "CronChecker"
-    (LibBackend.Init.init "CronChecker" false).Result
-    LibRealExecution.Init.init "CronChecker"
+    LibService.Init.init name
+    Telemetry.Console.loadTelemetry name Telemetry.DontTraceDBQueries
+    (LibBackend.Init.init
+      LibBackend.Init.DontRunSideEffects
+      LibBackend.Init.WaitForDB
+      name)
+      .Result
+    (LibRealExecution.Init.init name).Result
 
-    Telemetry.Console.loadTelemetry "CronChecker" Telemetry.DontTraceDBQueries
 
     // This fn is called if k8s tells us to stop
     let shutdownCallback () =
       Telemetry.addEvent "Shutting down" []
       shouldShutdown.Value <- true
 
-    LibService.Kubernetes.runKubernetesServer
-      "CronChecker"
-      []
-      LibService.Config.croncheckerKubernetesPort
-      shutdownCallback
+    let port = LibService.Config.croncheckerKubernetesPort
+    LibService.Kubernetes.runKubernetesServer name [] port shutdownCallback
     |> ignore<Task>
-
-
-    // Don't start until the DB is available. Otherwise we'll just spin off
-    // exceptions in a loop.
-    LibBackend.Init.waitForDB().Result
 
     if LibBackend.Config.triggerCrons then
       (run ()).Result

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -162,16 +162,13 @@ let run (executionID : ExecutionID) (options : Options) : Task<int> =
 [<EntryPoint>]
 let main (args : string []) : int =
   try
-    LibService.Init.init "ExecHost"
-    Telemetry.Console.loadTelemetry "ExecHost" Telemetry.TraceDBQueries
-    let executionID = Telemetry.executionID ()
+    let name = "ExecHost"
+    LibService.Init.init name
+    Telemetry.Console.loadTelemetry name Telemetry.TraceDBQueries
     let options = parse args
     if usesDB options then
-      (LibBackend.Init.init
-        LibBackend.Init.DontRunSideEffects
-        LibBackend.Init.WaitForDB
-        "ExecHost")
-        .Result
+      (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
+    let executionID = Telemetry.executionID ()
     (run executionID options).Result
   with
   | e ->

--- a/fsharp-backend/src/HttpMiddleware/HttpMiddleware.fsproj
+++ b/fsharp-backend/src/HttpMiddleware/HttpMiddleware.fsproj
@@ -16,7 +16,6 @@
     <Compile Include="RequestV0.fs" />
     <Compile Include="ResponseV0.fs" />
     <Compile Include="MiddlewareV0.fs" />
-    <Compile Include="Init.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/fsharp-backend/src/HttpMiddleware/Init.fs
+++ b/fsharp-backend/src/HttpMiddleware/Init.fs
@@ -1,8 +1,0 @@
-/// Initialize HttpMiddleware
-module HttpMiddleware.Init
-
-open Prelude
-
-let init (serviceName : string) : unit =
-  print $"Initing HttpMiddleware in {serviceName}"
-  print $" Inited HttpMiddleware in {serviceName}"

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -413,7 +413,7 @@ let initAdmins () : Task<unit> =
   }
 
 /// Initialize accounts needed for development and testing
-let init (serviceName : string) : Task<unit> =
+let initializeDevelopmentAccounts (serviceName : string) : Task<unit> =
   task {
     print $"Initing LibBackend.Account in {serviceName}"
     do! initTestAccounts ()

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -412,13 +412,11 @@ let initAdmins () : Task<unit> =
     return ()
   }
 
+/// Initialize accounts needed for development and testing
 let init (serviceName : string) : Task<unit> =
   task {
     print $"Initing LibBackend.Account in {serviceName}"
-    if Config.createAccounts then
-      do! initTestAccounts ()
-      do! initAdmins ()
-      return ()
-    else
-      return ()
+    do! initTestAccounts ()
+    do! initAdmins ()
+    return ()
   }

--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -70,6 +70,8 @@ let init (serviceName : string) (runSideEffects : bool) : Task<unit> =
       EventQueue.WorkerStates.STJJsonConverter.WorkerStateConverter()
     )
 
+    do! PackageManager.init ()
+
     if runSideEffects then do! Account.init serviceName
 
     print $" Inited LibBackend in {serviceName}"

--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -59,7 +59,7 @@ type WaitForDB =
   | WaitForDB
   | DontWaitForDB
 
-/// Initialize LibBackend.
+/// <summary>Initialize LibBackend.</summary>
 ///
 /// <remarks> This function does not do any behaviour which accesses DB tables and
 /// data, as the DB might not be migrated to it's correct form at this point (eg in

--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -55,14 +55,9 @@ let _waitForDB () : Task<unit> =
     return ()
   }
 
-type RunSideEffects =
-  | RunSideEffects
-  | DontRunSideEffects
-
 type WaitForDB =
   | WaitForDB
   | DontWaitForDB
-
 
 /// Initialize LibBackend.
 ///
@@ -71,11 +66,7 @@ type WaitForDB =
 /// the test of dev environment). This is called by ExecHost, which does the
 /// migration. You cannot expect the DB to be ready when LibBackend is initialized -
 /// call `waitForDB` if you need that.</remarks>
-let init
-  (shouldRunSideEffects : RunSideEffects)
-  (shouldWaitForDB : WaitForDB)
-  (serviceName : string)
-  : Task<unit> =
+let init (shouldWaitForDB : WaitForDB) (serviceName : string) : Task<unit> =
   task {
     print $"Initing LibBackend in {serviceName}"
     Db.init ()
@@ -91,12 +82,6 @@ let init
     match shouldWaitForDB with
     | WaitForDB -> do! _waitForDB ()
     | DontWaitForDB -> ()
-
-    // CLEANUP move this elsewhere and keep LibBackend.Init more about initializing
-    // the library, not the app in the dev/prod environment
-    match shouldRunSideEffects with
-    | RunSideEffects -> do! Account.init serviceName
-    | DontRunSideEffects -> ()
 
     print $" Inited LibBackend in {serviceName}"
   }

--- a/fsharp-backend/src/LibBackend/PackageManager.fs
+++ b/fsharp-backend/src/LibBackend/PackageManager.fs
@@ -389,17 +389,3 @@ let allFunctions () : Task<List<PT.Package.Fn>> =
                deprecated = deprecated
                tlid = tlid } : PT.Package.Fn)
         }))
-
-// TODO: this keeps a cached version so we're not loading them all the time.
-// Of course, this won't be up to date if we add more functions. Given that all
-// functions need to be loaded for the API, when this becomes a problem we want
-// to look at breaking it up into different packages
-let cachedForAPI : Lazy<Task<List<PT.Package.Fn>>> = lazy (allFunctions ())
-
-/// Initialize packages. Call this after the DB connection is initialized.
-let init () : Task<unit> =
-  // Make sure functions are present during startup
-  task {
-    let! (_ : List<PT.Package.Fn>) = cachedForAPI |> Lazy.force
-    return ()
-  }

--- a/fsharp-backend/src/LibBackend/PackageManager.fs
+++ b/fsharp-backend/src/LibBackend/PackageManager.fs
@@ -395,3 +395,11 @@ let allFunctions () : Task<List<PT.Package.Fn>> =
 // functions need to be loaded for the API, when this becomes a problem we want
 // to look at breaking it up into different packages
 let cachedForAPI : Lazy<Task<List<PT.Package.Fn>>> = lazy (allFunctions ())
+
+/// Initialize packages. Call this after the DB connection is initialized.
+let init () : Task<unit> =
+  // Make sure functions are present during startup
+  task {
+    let! (_ : List<PT.Package.Fn>) = cachedForAPI |> Lazy.force
+    return ()
+  }

--- a/fsharp-backend/src/LibExecution/Init.fs
+++ b/fsharp-backend/src/LibExecution/Init.fs
@@ -1,9 +1,0 @@
-module LibExecution.Init
-
-// Initialize LibExecution
-
-open Prelude
-
-let init (serviceName : string) : unit =
-  print $"Initing LibExecution in {serviceName}"
-  print $" Inited LibExecution in {serviceName}"

--- a/fsharp-backend/src/LibExecution/LibExecution.fsproj
+++ b/fsharp-backend/src/LibExecution/LibExecution.fsproj
@@ -30,7 +30,6 @@
     <Compile Include="ProgramTypesToRuntimeTypes.fs" />
     <Compile Include="OCamlTypes.fs" />
     <Compile Include="OCamlTypesAst.fs" />
-    <Compile Include="Init.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Prelude/Prelude.fsproj" />

--- a/fsharp-backend/src/LibExecutionStdLib/Init.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/Init.fs
@@ -1,9 +1,0 @@
-module LibExecutionStdLib.Init
-
-// Initialize LibExecutionStdLib
-
-open Prelude
-
-let init (serviceName : string) : unit =
-  print $"Initing LibExecutionStdLib in {serviceName}"
-  print $" Inited LibExecutionStdLib in {serviceName}"

--- a/fsharp-backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
+++ b/fsharp-backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
@@ -32,7 +32,6 @@
     <Compile Include="LibString.fs" />
     <Compile Include="LibUuid.fs" />
     <Compile Include="StdLib.fs" />
-    <Compile Include="Init.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Prelude/Prelude.fsproj" />

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -21,29 +21,28 @@ let renames =
     fn "Object" "toJSON" 1, fn "Dict" "toJSON" 0 ]
 
 
-let prefixFns : Lazy<List<BuiltInFn>> =
-  lazy
-    ([ LibBool.fns
-       LibBytes.fns
-       LibChar.fns
-       LibDate.fns
-       LibDict.fns
-       LibFloat.fns
-       LibHttp.fns
-       LibHttpClient.fns
-       LibJson.fns
-       LibMath.fns
-       LibObject.fns
-       LibUuid.fns
-       LibInt.fns
-       LibList.fns
-       // LibMiddleware.fns
-       LibNoModule.fns
-       LibOption.fns
-       LibResult.fns
-       LibString.fns ]
-     |> List.concat
-     |> renameFunctions renames)
+let prefixFns : List<BuiltInFn> =
+  [ LibBool.fns
+    LibBytes.fns
+    LibChar.fns
+    LibDate.fns
+    LibDict.fns
+    LibFloat.fns
+    LibHttp.fns
+    LibHttpClient.fns
+    LibJson.fns
+    LibMath.fns
+    LibObject.fns
+    LibUuid.fns
+    LibInt.fns
+    LibList.fns
+    // LibMiddleware.fns
+    LibNoModule.fns
+    LibOption.fns
+    LibResult.fns
+    LibString.fns ]
+  |> List.concat
+  |> renameFunctions renames
 
 // -------------------------
 // Infix fns
@@ -81,21 +80,19 @@ let infixFnNames =
 // Is this the name of an infix function?
 let isInfixName (name : FQFnName.StdlibFnName) = infixFnNames.Contains name
 
-let infixFns : Lazy<List<BuiltInFn>> =
-  lazy
-    (let fns =
-      prefixFns
-      |> Lazy.force
-      |> List.choose (fun (builtin : BuiltInFn) ->
-        let opName = infixFnMapping.TryFind builtin.name
-        Option.map (fun newName -> { builtin with name = newName }) opName)
+let infixFns : List<BuiltInFn> =
+  let fns =
+    prefixFns
+    |> List.choose (fun (builtin : BuiltInFn) ->
+      let opName = infixFnMapping.TryFind builtin.name
+      Option.map (fun newName -> { builtin with name = newName }) opName)
 
-     assertEq "All infixes are parsed" fns.Length infixFnMapping.Count // make sure we got them all
-     fns)
+  assertEq "All infixes are parsed" fns.Length infixFnMapping.Count // make sure we got them all
+  fns
 
 
 
 // -------------------------
 // All fns
 // -------------------------
-let fns = lazy (Lazy.force infixFns @ Lazy.force prefixFns)
+let fns = infixFns @ prefixFns

--- a/fsharp-backend/src/LibRealExecution/Init.fs
+++ b/fsharp-backend/src/LibRealExecution/Init.fs
@@ -1,9 +1,14 @@
+/// Initialize LibRealExecution
 module LibRealExecution.Init
 
-// Initialize LibRealExecution
+open FSharp.Control.Tasks
+open System.Threading.Tasks
 
 open Prelude
 
-let init (serviceName : string) : unit =
-  print $"Initing LibRealExecution in {serviceName}"
-  print $" Inited LibRealExecution in {serviceName}"
+let init (serviceName : string) : Task<unit> =
+  task {
+    print $"Initing LibRealExecution in {serviceName}"
+    do! RealExecution.init ()
+    print $" Inited LibRealExecution in {serviceName}"
+  }

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -25,7 +25,7 @@ let stdlibFns : Map<RT.FQFnName.T, RT.BuiltInFn> =
 let packageFns : Lazy<Task<Map<RT.FQFnName.T, RT.Package.Fn>>> =
   lazy
     (task {
-      let! packages = Lazy.force PackageManager.cachedForAPI
+      let! packages = PackageManager.allFunctions ()
 
       return
         packages
@@ -98,4 +98,11 @@ let createState
         tlid
         program,
        touchedTLIDs)
+  }
+
+/// Ensure library is ready to be called. Throws if it cannot initialize.
+let init () : Task<unit> =
+  task {
+    let! (_ : RT.Libraries) = Lazy.force libraries
+    return ()
   }

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -18,11 +18,9 @@ module Interpreter = LibExecution.Interpreter
 
 open LibBackend
 
-let stdlibFns : Lazy<Map<RT.FQFnName.T, RT.BuiltInFn>> =
-  lazy
-    (Lazy.force LibExecutionStdLib.StdLib.fns
-     @ Lazy.force BackendOnlyStdLib.StdLib.fns
-     |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name))
+let stdlibFns : Map<RT.FQFnName.T, RT.BuiltInFn> =
+  LibExecutionStdLib.StdLib.fns @ BackendOnlyStdLib.StdLib.fns
+  |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
 
 let packageFns : Lazy<Task<Map<RT.FQFnName.T, RT.Package.Fn>>> =
   lazy
@@ -41,7 +39,6 @@ let libraries : Lazy<Task<RT.Libraries>> =
   lazy
     (task {
       let! packageFns = Lazy.force packageFns
-      let stdlibFns = Lazy.force stdlibFns
       // TODO: this keeps a cached version so we're not loading them all the time.
       // Of course, this won't be up to date if we add more functions. This should be
       // some sort of LRU cache.

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -191,7 +191,6 @@ module Eval =
 
       let stdlib =
         LibExecutionStdLib.StdLib.fns
-        |> Lazy.force
         |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
 
       // TODO: get packages from caller

--- a/fsharp-backend/tests/DataTests/DataTests.fs
+++ b/fsharp-backend/tests/DataTests/DataTests.fs
@@ -331,8 +331,7 @@ let main args =
   LibService.Telemetry.Console.loadTelemetry
     "DataTests"
     LibService.Telemetry.DontTraceDBQueries
-  (LibBackend.Init.init LibBackend.Init.RunSideEffects LibBackend.Init.WaitForDB name)
-    .Result
+  (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
   (LibRealExecution.Init.init name).Result
 
   let fn (canvasName : CanvasName.T) : Task<unit> =

--- a/fsharp-backend/tests/DataTests/DataTests.fs
+++ b/fsharp-backend/tests/DataTests/DataTests.fs
@@ -326,17 +326,14 @@ let checkOplists (meta : Canvas.Meta) (tlids : List<tlid>) =
 
 [<EntryPoint>]
 let main args =
-  LibService.Init.init "Tests"
-  LibExecution.Init.init "Tests"
-  LibExecutionStdLib.Init.init "Tests"
-  (LibBackend.Init.init "Tests" true).Result
-  LibRealExecution.Init.init "Tests"
-  HttpMiddleware.Init.init "Tests"
-  TestUtils.Init.init "Tests"
-
+  let name = "DataTests"
+  LibService.Init.init name
   LibService.Telemetry.Console.loadTelemetry
     "DataTests"
     LibService.Telemetry.DontTraceDBQueries
+  (LibBackend.Init.init LibBackend.Init.RunSideEffects LibBackend.Init.WaitForDB name)
+    .Result
+  (LibRealExecution.Init.init name).Result
 
   let fn (canvasName : CanvasName.T) : Task<unit> =
     task {

--- a/fsharp-backend/tests/FuzzTests/ExecutePureFunctions.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/ExecutePureFunctions.FuzzTests.fs
@@ -389,15 +389,13 @@ type Generator =
           gen {
             let fns =
               LibRealExecution.RealExecution.stdlibFns
-              |> Lazy.force
               |> Map.values
               |> List.filter (fun fn ->
                 let name = RT.FQFnName.StdlibFnName.toString fn.name
                 let has set = Set.contains name set
                 let different = has allowedErrors.knownDifferingFunctions
-                let fsOnly = has (ApiServer.Functions.fsharpOnlyFns.Force())
 
-                if different || fsOnly then
+                if different then
                   false
                 elif allowedErrors.functionToTest = None then
                   // FSTODO: Add JWT and X509 functions here

--- a/fsharp-backend/tests/TestUtils/Init.fs
+++ b/fsharp-backend/tests/TestUtils/Init.fs
@@ -1,9 +1,0 @@
-module TestUtils.Init
-
-// Initialize TestUtils
-
-open Prelude
-
-let init (serviceName : string) : unit =
-  print $"Initing TestUtils in {serviceName}"
-  print $" Inited TestUtils in {serviceName}"

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -259,7 +259,7 @@ let libraries : Lazy<RT.Libraries> =
     (let testFns =
       LibTest.fns
       |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
-      |> Map.mergeFavoringLeft (Lazy.force LibRealExecution.RealExecution.stdlibFns)
+      |> Map.mergeFavoringLeft LibRealExecution.RealExecution.stdlibFns
      { stdlib = testFns; packageFns = Map.empty })
 
 let executionStateFor

--- a/fsharp-backend/tests/TestUtils/TestUtils.fsproj
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fsproj
@@ -24,7 +24,6 @@
     <Compile Include="FSharpToExpr.fs" />
     <Compile Include="TestUtils.fs" />
     <Compile Include="FSI.fs" />
-    <Compile Include="Init.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -285,16 +285,6 @@ let testUiReturnsTheSame (client : C) (canvas : CanvasName.T) : Task<unit> =
 
     Expect.equal fc oc ""
 
-    let fns = LibRealExecution.RealExecution.stdlibFns |> Lazy.force
-
-    let builtins =
-      fns
-      |> Map.values
-      |> List.filter (fun fn ->
-        Functions.fsharpOnlyFns |> Lazy.force |> Set.contains (string fn.name) |> not)
-      |> List.map (fun fn -> RT.FQFnName.Stdlib fn.name)
-      |> Set
-
     List.iter2
       (fun (ffn : Functions.FunctionMetadata) ofn -> Expect.equal ffn ofn ffn.name)
       fcfns

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -11,13 +11,11 @@ module Telemetry = LibService.Telemetry
 
 [<EntryPoint>]
 let main (args : string array) : int =
-  LibService.Init.init "Tests"
-  LibExecution.Init.init "Tests"
-  LibExecutionStdLib.Init.init "Tests"
-  (LibBackend.Init.init "Tests" true).Result
-  LibRealExecution.Init.init "Tests"
-  HttpMiddleware.Init.init "Tests"
-  TestUtils.Init.init "Tests"
+  let name = "Tests"
+  LibService.Init.init name
+  (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
+  (LibRealExecution.Init.init name).Result
+  (LibBackend.Account.init name).Result
 
   let tests =
     [ Tests.Account.tests

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -15,7 +15,7 @@ let main (args : string array) : int =
   LibService.Init.init name
   (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
   (LibRealExecution.Init.init name).Result
-  (LibBackend.Account.init name).Result
+  (LibBackend.Account.initializeDevelopmentAccounts name).Result
 
   let tests =
     [ Tests.Account.tests

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -18,6 +18,7 @@ REPEAT=1 # repeat allows us to repeat individual tests many times to check for e
 BASE_URL="http://darklang.localhost:9000"
 BWD_BASE_URL=".builtwithdark.localhost:11000"
 BROWSER="chromium"
+PUBLISHED=""
 
 for i in "$@"
 do
@@ -36,6 +37,10 @@ do
     ;;
     --repeat=*)
     REPEAT=${1/--repeat=/''}
+    shift
+    ;;
+    --published)
+    PUBLISHED="--published"
     shift
     ;;
     --debug)
@@ -82,7 +87,8 @@ fi
 
 # We need to restart the server after adding new packages. Integration tests test
 # against the dev environment, not the test one.
-./scripts/run-fsharp-server
+./scripts/run-fsharp-server "${PUBLISHED}"
+./scripts/devcontainer/_wait-until-apiserver-ready
 
 ######################
 # Run playwright

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -80,6 +80,10 @@ fi
 ######################
 ./integration-tests/prep.sh
 
+# We need to restart the server after adding new packages. Integration tests test
+# against the dev environment, not the test one.
+./scripts/run-fsharp-server
+
 ######################
 # Run playwright
 ######################

--- a/scripts/run-fsharp-tests
+++ b/scripts/run-fsharp-tests
@@ -58,7 +58,8 @@ cd fsharp-backend && \
   DARK_CONFIG_DB_USER=dark \
   DARK_CONFIG_DB_PASSWORD=darklang \
   DARK_CONFIG_ROLLBAR_ENABLED=n \
-  "${EXECHOST}" migrations run > "$LOGS/test-fsharp-migrations.log" && cd ..
+  "${EXECHOST}" migrations run > "$LOGS/test-fsharp-migrations.log"
+cd ..
 
 # These scripts run in the docker container. When this script is run from in the
 # container, these scripts and the spawned processes stay running. this is helpful if


### PR DESCRIPTION
This adds a path to use a binary serialization for packages. This makes it faster to load the first request on a server, but also makes it less error prone - we won't end up with a lazy exception.

The plan from here is:
- [x] run the migration
- [x] merge #3608
- [x] manually test to make ensure this still works
- [x] figure out why ExecHost isn't working in production
- [ ] merge this PR
- [ ] manually test to make ensure everything still works
- [ ] Run `ExecHost convert-packages` from production
- [ ] manually test to make sure this works
