### PR TITLE
Add tools to use new binary serialization for packages

### DIFF
--- a/backend/migrations/20220319_140703_add-package-binary-column.sql
+++ b/backend/migrations/20220319_140703_add-package-binary-column.sql
@@ -1,0 +1,2 @@
+-- These is for the the F# serialization, that will live alongside the old body for now.
+ALTER TABLE packages_v0 ADD COLUMN IF NOT EXISTS body2 BYTEA

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -75,6 +75,7 @@ let help () : unit =
     "  ExecHost migrations run"
     "  ExecHost trigger-rollbar"
     "  ExecHost trigger-pageable-rollbar"
+    "  ExecHost convert-packages"
     "  ExecHost help" ]
   |> List.join "\n"
   |> print
@@ -109,6 +110,10 @@ let run (executionID : ExecutionID) (args : string []) : Task<int> =
       return 0
 
     | [| "trigger-paging-rollbar" |] -> return triggerPagingRollbar ()
+
+    | [| "convert-packages" |] ->
+      do! LibBackend.PackageManager.convertPackagesToFSharpBinary ()
+      return 0
 
     | [| "help" |] ->
       help ()

--- a/fsharp-backend/src/LibBackend/BinarySerialization.fs
+++ b/fsharp-backend/src/LibBackend/BinarySerialization.fs
@@ -47,6 +47,14 @@ let wrapSerializationException (tlid : tlid) (f : unit -> 'a) : 'a =
     Exception.callExceptionCallback e
     raise (InternalException("error deserializing toplevel", [ "tlid", tlid ], e))
 
+let serializeExpr (tlid : tlid) (e : PT.Expr) : byte [] =
+  wrapSerializationException tlid (fun () ->
+    MessagePack.MessagePackSerializer.Serialize(e, optionsWithoutZip))
+
+let deserializeExpr (tlid : tlid) (data : byte []) : PT.Expr =
+  wrapSerializationException tlid (fun () ->
+    MessagePack.MessagePackSerializer.Deserialize(data, optionsWithoutZip))
+
 let serializeToplevel (tl : PT.Toplevel.T) : byte [] =
   wrapSerializationException (PT.Toplevel.toTLID tl) (fun () ->
     MessagePack.MessagePackSerializer.Serialize(tl, optionsWithoutZip))


### PR DESCRIPTION
Same as #3607, but just the first few commits. The goal is to get the migration safely merged (it has already been applied), and to ensure that things still works (low risk, just being careful).