### PR TITLE
Adjust Interpreter.fs to handle DevExceptions

### DIFF
--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -776,11 +776,9 @@ and execFn
           state.notify state "fakedval found" [ "dval", dv ]
           return dv
         | :? DeveloperException as e ->
-          printfn "DevExn"
-          state.notify state "fakedval found" [ "dval", DStr "test" ]
+          state.notify state "Developer error found" [ "error", e.Message ]
           return Dval.errSStr sourceID e.Message
         | e ->
-          printfn "Unhandled thing %A" e
           // CLEANUP could we show the user the execution id here?
           state.reportException
             state

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -7,6 +7,7 @@ open FSharp.Control.Tasks.Affine.Unsafe
 
 open Prelude
 open RuntimeTypes
+open Prelude
 
 let globalsFor (state : ExecutionState) : Symtable =
   let secrets =
@@ -605,7 +606,7 @@ and execFn
        && not state.onExecutionPath
        && Set.contains fnDesc state.callstack then
       // Don't recurse (including transitively!) when previewing unexecuted paths
-      // in the editor. If we do, we'll recurse forever and blow the stack. *)
+      // in the editor. If we do, we'll recurse forever and blow the stack.
       return DIncomplete(SourceID(state.tlid, id))
     else
       // CLEANUP: optimization opp
@@ -638,10 +639,10 @@ and execFn
           arglist
 
       match badArg, isInPipe with
-      | Some (DIncomplete src), InPipe _ ->
+      | Some (DIncomplete _src), InPipe _ ->
         // That is, unless it's an incomplete in a pipe. In a pipe, we treat
         // the entire expression as a blank, and skip it, returning the input
-        // (first) value to be piped into the next statement instead. *)
+        // (first) value to be piped into the next statement instead.
         return List.head arglist
       | Some (DIncomplete src), _ -> return DIncomplete src
       | Some (DError (src, _) as err), _ ->
@@ -664,7 +665,7 @@ and execFn
                 do! state.tracing.storeFnResult fnRecord arglist result
 
               return result
-          | PackageFunction (tlid, body) ->
+          | PackageFunction (_tlid, body) ->
             // This is similar to InProcess but also has elements of UserCreated.
             match TypeChecker.checkFunctionCall Map.empty fn args with
             | Ok () ->
@@ -697,7 +698,7 @@ and execFn
                       |> Dval.unwrapFromErrorRail
                       |> typeErrorOrValue Map.empty
                   }
-              // there's no point storing data we'll never ask for *)
+              // there's no point storing data we'll never ask for
               if fn.previewable <> Pure then
                 do! state.tracing.storeFnResult fnRecord arglist result
 
@@ -774,7 +775,12 @@ and execFn
         | Errors.StdlibException (Errors.FakeDvalFound dv) ->
           state.notify state "fakedval found" [ "dval", dv ]
           return dv
+        | :? DeveloperException as e ->
+          printfn "DevExn"
+          state.notify state "fakedval found" [ "dval", DStr "test" ]
+          return Dval.errSStr sourceID e.Message
         | e ->
+          printfn "Unhandled thing %A" e
           // CLEANUP could we show the user the execution id here?
           state.reportException
             state

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -778,7 +778,7 @@ and execFn
         | :? DeveloperException as e ->
           state.notify
             state
-            $"Developer error found against {fnDesc}"
+            $"DevException against {fnDesc}"
             [ "context", "An exception was caught in fncall"
               "fn", fnDesc
               "args", args

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -776,7 +776,15 @@ and execFn
           state.notify state "fakedval found" [ "dval", dv ]
           return dv
         | :? DeveloperException as e ->
-          state.notify state "Developer error found" [ "error", e.Message ]
+          state.notify
+            state
+            $"Developer error found against {fnDesc}"
+            [ "context", "An exception was caught in fncall"
+              "fn", fnDesc
+              "args", args
+              "callerID", id
+              "isInPipe", isInPipe
+              "error", e.Message ]
           return Dval.errSStr sourceID e.Message
         | e ->
           // CLEANUP could we show the user the execution id here?

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -785,7 +785,7 @@ and execFn
               "callerID", id
               "isInPipe", isInPipe
               "error", e.Message ]
-          return Dval.errSStr sourceID e.Message
+          return Dval.errSStr sourceID (Exception.toDeveloperMessage e)
         | e ->
           // CLEANUP could we show the user the execution id here?
           state.reportException

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -60,6 +60,7 @@ let createState
 
     // Any real execution needs to track the touched TLIDs in order to send traces to pusher
     let touchedTLIDs, traceTLIDFn = Exe.traceTLIDs ()
+    HashSet.add tlid touchedTLIDs
 
     let tracing =
       { Exe.noTracing RT.Real with

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -60,7 +60,6 @@ let createState
 
     // Any real execution needs to track the touched TLIDs in order to send traces to pusher
     let touchedTLIDs, traceTLIDFn = Exe.traceTLIDs ()
-    HashSet.add tlid touchedTLIDs
 
     let tracing =
       { Exe.noTracing RT.Real with


### PR DESCRIPTION
Within the `HttpClient` stdlib fns, passing in a `string` where a `DObj<string>` is expected for `headers` results in a DeveloperException, both in OCaml and F# backends. Issue #3524.

## Context

This error comes from [Dval.to_string_pairs_exn request_headers](https://github.com/darklang/dark/blob/4de2da65b007579ec0e36ff27539007620101120/backend/libbackend/libhttpclient.ml#L104) and [DvalReprExternal.toStringPairs reqHeaders](https://github.com/darklang/dark/blob/4de2da65b007579ec0e36ff27539007620101120/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs#L439), respectively.

In the OCaml backend, these sort of expected runtime exceptions seem to be handled by the `InProcess` wrappers that surround many functions.
For example, `HttpClient::get_v5` is wrapped by `InProcess` [here](https://github.com/darklang/dark/blob/4de2da65b007579ec0e36ff27539007620101120/backend/libbackend/libhttpclient.ml#L223).
The actual `InProcess` impl. is [here](https://github.com/darklang/dark/blob/4de2da65b007579ec0e36ff27539007620101120/backend/libexecution/ast.ml#L802-L833), and the `try`/`catch` within works well to handle this.

In the F# backend, `Interpreter.fs`.`execFn` is the closeset equivalent to `InProcess` that I've found. This has a `try`/`catch`, but the `catch` doesn't handle DeveloperExceptions, so the [final wildcard branch](https://github.com/darklang/dark/blob/4de2da65b007579ec0e36ff27539007620101120/fsharp-backend/src/LibExecution/Interpreter.fs#L777) ends up getting triggered. This branch yields a rollbar and no useful UI that tells the developer what to do.

--- 

## WIP

Here I've attempted to resolve the issue by adding a `| :? DeveloperException` branch, which does get used, but it seems the error message still isn't visible in the UI. I suspect I need to change the `state.notify` usage.