### PR TITLE
Fix cronchecker initialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,6 +439,8 @@ jobs:
           command: |
             # Run the server first to set up the DB correctly for the prep script
             scripts/run-fsharp-server --published
+            # Wait for users to be added so prep.sh works
+            ./scripts/devcontainer/_wait-until-apiserver-ready
             integration-tests/run.sh --concurrency=3 --retry --pattern="`cat test-pattern`" --published
             rm test-pattern
 

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -35,7 +35,6 @@ let main _ : int =
     LibService.Init.init name
     Telemetry.Console.loadTelemetry name Telemetry.DontTraceDBQueries
     (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
-    (LibRealExecution.Init.init name).Result
 
     // This fn is called if k8s tells us to stop
     let shutdownCallback () =

--- a/fsharp-backend/src/LibRealExecution/Init.fs
+++ b/fsharp-backend/src/LibRealExecution/Init.fs
@@ -11,4 +11,5 @@ let init (serviceName : string) : Task<unit> =
     print $"Initing LibRealExecution in {serviceName}"
     do! RealExecution.init ()
     print $" Inited LibRealExecution in {serviceName}"
+    return ()
   }


### PR DESCRIPTION
The Cronchecker container wouldn't initialize because we were trying to call legacy-ctr, which it doesn't have.