### PR TITLE
Use rules to point everything to the F# backend

### DIFF
--- a/services/editor-deployment/darklang-ingress.yaml
+++ b/services/editor-deployment/darklang-ingress.yaml
@@ -19,6 +19,19 @@ spec:
     # see what works.
     - http:
         paths:
+          # Due to an unknown issue with the load balancer, we cannot change the
+          # defaultBackend without causing the service to go down. So instead we'll
+          # just make a rule that sends everything to the F# backend.  I'm leaving
+          # everything else alone on purpose.
+          # CLEANUP Later, I'll just add a new load balancer and change the DNS over.
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: apiserver-service
+                port:
+                  number: 80
+
           # Testing so that any user can use these
           - path: /a-testing-fsharp/*
             pathType: ImplementationSpecific


### PR DESCRIPTION
Since we can't switch the defaultBackend over to use ApiServer everywhere, let's try something else. The built-in rules clearly work, so let's use them instead.

We can later create a whole new load-balancer to avoid the switchover.