### PR TITLE
Load testing

### DIFF
--- a/containers/base-fsharp-nginx.conf
+++ b/containers/base-fsharp-nginx.conf
@@ -1,0 +1,36 @@
+# This is the base nginx.conf from nginx:1.16.1, _minus_ keepalive_timeout so
+# we can set that in "our" nginx.conf.  Got by running
+# `docker run -t nginx:1.16.1 cat /etc/nginx/nginx.conf`
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #gzip  on;
+
+    # Include relative to prefix path, which is /etc/nginx in prod but configured at
+    # the command line in dev to support running multiple different nginx servers
+    include conf.d/*.conf;
+}
+

--- a/containers/base-fsharp-nginx.conf
+++ b/containers/base-fsharp-nginx.conf
@@ -9,7 +9,10 @@ pid        /tmp/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    # CHANGED FOR DARK
+    # We use very beefy servers so they can handle a lot more traffic than the
+    # default of 1024.
+    worker_connections  20480;
 }
 
 

--- a/containers/base-fsharp-nginx.conf
+++ b/containers/base-fsharp-nginx.conf
@@ -1,12 +1,11 @@
-# This is the base nginx.conf from nginx:1.16.1, _minus_ keepalive_timeout so
-# we can set that in "our" nginx.conf.  Got by running
-# `docker run -t nginx:1.16.1 cat /etc/nginx/nginx.conf`
+# This is the base nginx.conf from nginx with settings removed so that we can set
+# them we can set that in "our" nginx.conf.
+# Got by running `docker run -t nginxinc/nginx-unprivileged@sha256:dc6c6c3052ec07e73ad87d8bcb30f23a9f95f6af3a50925eae334097450ec358 cat /etc/nginx/nginx.conf`
 
-user  nginx;
-worker_processes  1;
+worker_processes  auto;
 
-error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
+error_log  /var/log/nginx/error.log notice;
+pid        /tmp/nginx.pid;
 
 
 events {
@@ -15,6 +14,12 @@ events {
 
 
 http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
@@ -27,10 +32,13 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
+    # CHANGED FOR DARK - removed so that we can set it ourselves
+    # keepalive_timeout  65;
+
     #gzip  on;
 
+    # CHANGED FOR DARK
     # Include relative to prefix path, which is /etc/nginx in prod but configured at
     # the command line in dev to support running multiple different nginx servers
     include conf.d/*.conf;
 }
-

--- a/scripts/run-nginx-server
+++ b/scripts/run-nginx-server
@@ -52,7 +52,7 @@ setup() {
 setup_test() {
   name=$1
   source=$2
-  config_file=$2
+  config_file=$3
   listen_port=$4
   new_listen_port=$5
   upstream_port=$6

--- a/scripts/run-nginx-server
+++ b/scripts/run-nginx-server
@@ -30,10 +30,11 @@ done
 setup() {
   name=$1
   source=$2
+  config_file=$3
 
   sudo rm -Rf /etc/nginx-$name/
   sudo mkdir -p /etc/nginx-$name/conf.d
-  sudo cp /home/dark/app/containers/ocaml-nginx/base-nginx.conf /etc/nginx-$name/nginx.conf
+  sudo cp /home/dark/app/$config_file /etc/nginx-$name/nginx.conf
   sudo cp /home/dark/app/$source/nginx.conf /etc/nginx-$name/conf.d/$name-nginx.conf
 
   # Two log per server, in rundir
@@ -51,14 +52,15 @@ setup() {
 setup_test() {
   name=$1
   source=$2
-  listen_port=$3
-  new_listen_port=$4
-  upstream_port=$5
-  new_upstream_port=$6
+  config_file=$2
+  listen_port=$4
+  new_listen_port=$5
+  upstream_port=$6
+  new_upstream_port=$7
 
   sudo rm -Rf /etc/nginx-test-$name/
   sudo mkdir -p /etc/nginx-test-$name/conf.d
-  sudo cp /home/dark/app/containers/ocaml-nginx/base-nginx.conf /etc/nginx-test-$name/nginx.conf
+  sudo cp /home/dark/app/$config_file /etc/nginx-test-$name/nginx.conf
   sudo cp /home/dark/app/$source/nginx.conf /etc/nginx-test-$name/conf.d/test-$name-nginx.conf
 
   # Two log per server, in rundir
@@ -81,10 +83,10 @@ setup_test() {
 }
 
 sudo rm -f /etc/nginx/nginx.conf
-setup ocaml containers/ocaml-nginx/
-setup apiserver services/apiserver-deployment/
-setup bwdserver services/bwdserver-deployment/
-setup_test ocaml containers/ocaml-nginx/ 8000 10000 80 10001
-setup_test apiserver services/apiserver-deployment/ 9000 10020 9001 10021
-setup_test bwdserver services/bwdserver-deployment/ 11000 10010 11001 10011
+setup ocaml containers/ocaml-nginx/ containers/ocaml-nginx/base-nginx.conf
+setup apiserver services/apiserver-deployment/ containers/base-fsharp-nginx.conf
+setup bwdserver services/bwdserver-deployment/ containers/base-fsharp-nginx.conf
+setup_test ocaml containers/ocaml-nginx/ containers/ocaml-nginx/base-nginx.conf 8000 10000 80 10001
+setup_test apiserver services/apiserver-deployment/ containers/base-fsharp-nginx.conf 9000 10020 9001 10021
+setup_test bwdserver services/bwdserver-deployment/ containers/base-fsharp-nginx.conf 11000 10010 11001 10011
 

--- a/services/apiserver-deployment/apiserver-deployment.template.yaml
+++ b/services/apiserver-deployment/apiserver-deployment.template.yaml
@@ -350,8 +350,8 @@ spec:
         # Nginx inbound-proxy container
         #########################
         - name: http-proxy
-          # latest as of Jan 25, 2022. Probably 1.20
-          image: "nginxinc/nginx-unprivileged@sha256:dc6c6c3052ec07e73ad87d8bcb30f23a9f95f6af3a50925eae334097450ec358"
+          # 1.21.6
+          image: "nginxinc/nginx-unprivileged@sha256:a095510287e1f1f08ff3d9cda2b10457f48ca6d0454f5346d289a50773abb8de"
           ports:
             - name: http-proxy-port
               containerPort: 9000

--- a/services/apiserver-deployment/shipit.yaml
+++ b/services/apiserver-deployment/shipit.yaml
@@ -19,7 +19,7 @@ k8s:
     config-template: apiserver-deployment.template.yaml
     versioned-configmaps:
       apiserver-nginx-base-conf:
-        text-file: ../../containers/ocaml-nginx/base-nginx.conf
+        text-file: ../../containers/base-fsharp-nginx.conf
         namespace: default
       apiserver-nginx-conf:
         text-file: nginx.conf

--- a/services/bwdserver-deployment/bwdserver-deployment.template.yaml
+++ b/services/bwdserver-deployment/bwdserver-deployment.template.yaml
@@ -350,8 +350,8 @@ spec:
         # Nginx inbound-proxy container
         #########################
         - name: http-proxy
-          # latest as of Jan 25, 2022. Probably 1.20
-          image: "nginxinc/nginx-unprivileged@sha256:dc6c6c3052ec07e73ad87d8bcb30f23a9f95f6af3a50925eae334097450ec358"
+          # 1.21.6
+          image: "nginxinc/nginx-unprivileged@sha256:a095510287e1f1f08ff3d9cda2b10457f48ca6d0454f5346d289a50773abb8de"
           ports:
             - name: http-proxy-port
               containerPort: 11000

--- a/services/bwdserver-deployment/shipit.yaml
+++ b/services/bwdserver-deployment/shipit.yaml
@@ -19,7 +19,7 @@ k8s:
     config-template: bwdserver-deployment.template.yaml
     versioned-configmaps:
       bwdserver-nginx-base-conf:
-        text-file: ../../containers/ocaml-nginx/base-nginx.conf
+        text-file: ../../containers/base-fsharp-nginx.conf
         namespace: default
       bwdserver-nginx-conf:
         text-file: nginx.conf


### PR DESCRIPTION
I've started load testing the new F# implementation, using for now:

`./wrk -t 8 -c 5000 -d 5s https://trydarkfsharp.builtwithdark.com/fizzbuzz --timeout 4s`

I'm seeing a lot of 500 and 502 errors, along with an alert in the nginx logs that the container doesn't have enough workers. Hopefully this should fix this and we'll see where we are then.

Also, it seems that after switching to an unprivileged version of nginx, we didn't use the default config from that container. So this switches to that, and then makes the appropriate changes.