### PR TITLE
Commentate+Tidy FuzzTests

### DIFF
--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -728,7 +728,6 @@ module String =
   let splitOnNewline (str : string) : List<string> =
     str.Split([| "\n"; "\r\n" |], System.StringSplitOptions.None) |> Array.toList
 
-
   let lengthInEgcs (s : string) : int =
     System.Globalization.StringInfo(s).LengthInTextElements
 
@@ -1246,6 +1245,7 @@ module Json =
       settings.Formatting <- Formatting.Indented
       JsonConvert.SerializeObject(data, settings)
 
+    /// Serialize to JSON
     let serialize (data : 'a) : string = JsonConvert.SerializeObject(data, _settings)
 
     /// Serialize WITHOUT redacting passwords. Only used for communicating to the

--- a/fsharp-backend/tests/FuzzTests/BytesToString.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/BytesToString.FuzzTests.fs
@@ -1,3 +1,5 @@
+/// Generators and FuzzTests ensuring `toString` yields
+/// consistent results for `byte`s across OCaml and F# backends
 module FuzzTests.BytesToString
 
 open System.Threading.Tasks
@@ -15,6 +17,8 @@ module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 type Generator =
   static member SafeString() : Arbitrary<string> = Arb.fromGen (Generators.string ())
 
+/// Checks that `toString` on a `byte[]` produces
+/// the same string for both OCaml and F# runtimes
 let toStringTest (bytes : byte []) : bool =
   let t =
     task {

--- a/fsharp-backend/tests/FuzzTests/DvalRepr.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/DvalRepr.FuzzTests.fs
@@ -16,7 +16,7 @@ module OCamlInterop = LibBackend.OCamlInterop
 module DvalReprExternal = LibExecution.DvalReprExternal
 module DvalReprInternal = LibExecution.DvalReprInternal
 
-/// Ensure text representation of DVals meant to be read by Dark users
+/// Ensure text representation of Dvals meant to be read by Dark users
 /// is produced consistently across OCaml and F# backends
 module DeveloperRepr =
   type Generator =

--- a/fsharp-backend/tests/FuzzTests/DvalRepr.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/DvalRepr.FuzzTests.fs
@@ -1,5 +1,5 @@
 /// Generators and FuzzTests to ensure consistent behaviour
-/// of Runtime DVals across OCaml and F# backends
+/// of Runtime Dvals across OCaml and F# backends
 module FuzzTests.DvalRepr
 
 open Expecto

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -6,14 +6,17 @@ open Prelude
 open Prelude.Tablecloth
 open Tablecloth
 
+/// Tests we know to have some issues to work out
+/// FSTODO resolve these
 let stillBuggy = testList "still buggy" [ OCamlInterop.tests; FQFnName.tests ]
 
+/// Tests we generally know to be consistent
 let knownGood =
   testList
     "known good"
     ([ OCamlInterop.Roundtrippable.tests
        OCamlInterop.Queryable.tests
-       DvalRepr.EndUserReadable.tests
+       DvalRepr.EnduserReadable.tests
        DvalRepr.Hashing.tests
        DvalRepr.DeveloperRepr.tests
        HttpClient.tests
@@ -23,7 +26,7 @@ let knownGood =
        Json.PrettyResponseJson.tests
        Passwords.tests
        BytesToString.tests
-       Date.tests
+       NodaTime.tests
        ExecutePureFunctions.tests ])
 
 let tests = testList "FuzzTests" [ knownGood; stillBuggy ]

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fsproj
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fsproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>6.0</LangVersion>
     <OtherFlags>--warnaserror</OtherFlags>
-    <!-- <PublishReadyToRun>true</PublishReadyToRun> -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>
     <SelfContained>true</SelfContained>
@@ -26,7 +25,7 @@
     <Compile Include="Json.FuzzTests.fs" />
     <Compile Include="Passwords.FuzzTests.fs" />
     <Compile Include="BytesToString.FuzzTests.fs" />
-    <Compile Include="Date.FuzzTests.fs" />
+    <Compile Include="NodaTime.FuzzTests.fs" />
     <Compile Include="ExecutePureFunctions.FuzzTests.fs" />
     <Compile Include="FuzzTests.fs" />
   </ItemGroup>

--- a/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
@@ -55,7 +55,7 @@ let dvalToQuery (l : List<string * RT.Dval>) : bool =
   DvalReprExternal.toQuery dv |> Result.unwrapUnsafe
   .=. (OCamlInterop.dvalToQuery dv).Result
 
-/// Checks that a DVal is consistently converted
+/// Checks that a Dval is consistently converted
 /// to a form-encoding-safe string across OCaml and F# backends
 let dvalToFormEncoding (l : List<string * RT.Dval>) : bool =
   let dv = RT.DObj(Map l)

--- a/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
@@ -48,7 +48,7 @@ let dvalToUrlStringExn (l : List<string * RT.Dval>) : bool =
 
   DvalReprExternal.toUrlString dv .=. (OCamlInterop.toUrlString dv).Result
 
-/// Checks that a DVal is consistently converted
+/// Checks that a Dval is consistently converted
 /// to a querystring-safe string across OCaml and F# backends
 let dvalToQuery (l : List<string * RT.Dval>) : bool =
   let dv = RT.DObj(Map l)

--- a/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
@@ -41,7 +41,7 @@ type QueryStringGenerator =
     |> Gen.map (String.concat "&")
     |> Arb.fromGen
 
-/// Checks that a DVal is consistently converted
+/// Checks that a Dval is consistently converted
 /// to a URL-safe string across OCaml and F# backends
 let dvalToUrlStringExn (l : List<string * RT.Dval>) : bool =
   let dv = RT.DObj(Map l)

--- a/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
@@ -1,3 +1,5 @@
+/// Generators and FuzzTests that ensure HttpClient functionality
+/// is consistent across OCaml and F# backends
 module FuzzTests.HttpClient
 
 open Expecto
@@ -7,6 +9,7 @@ open FsCheck
 open Prelude
 open Prelude.Tablecloth
 open Tablecloth
+
 open TestUtils.TestUtils
 open FuzzTests.Utils
 
@@ -14,8 +17,6 @@ module RT = LibExecution.RuntimeTypes
 module OCamlInterop = LibBackend.OCamlInterop
 module DvalReprExternal = LibExecution.DvalReprExternal
 module G = Generators
-
-let tpwg = testPropertyWithGenerator
 
 
 type Generator =
@@ -40,26 +41,32 @@ type QueryStringGenerator =
     |> Gen.map (String.concat "&")
     |> Arb.fromGen
 
-
+/// Checks that a DVal is consistently converted
+/// to a URL-safe string across OCaml and F# backends
 let dvalToUrlStringExn (l : List<string * RT.Dval>) : bool =
   let dv = RT.DObj(Map l)
 
   DvalReprExternal.toUrlString dv .=. (OCamlInterop.toUrlString dv).Result
 
+/// Checks that a DVal is consistently converted
+/// to a querystring-safe string across OCaml and F# backends
 let dvalToQuery (l : List<string * RT.Dval>) : bool =
   let dv = RT.DObj(Map l)
   DvalReprExternal.toQuery dv |> Result.unwrapUnsafe
   .=. (OCamlInterop.dvalToQuery dv).Result
 
+/// Checks that a DVal is consistently converted
+/// to a form-encoding-safe string across OCaml and F# backends
 let dvalToFormEncoding (l : List<string * RT.Dval>) : bool =
   let dv = RT.DObj(Map l)
   (DvalReprExternal.toFormEncoding dv |> Result.unwrapUnsafe)
   .=. (OCamlInterop.dvalToFormEncoding dv).Result
 
+/// Checks that provided query strings are parsed as URL route parameters
+/// consistently across OCaml and F# backends
 let queryStringToParams (s : string) : bool =
   DvalReprExternal.parseQueryString s
   .=. (OCamlInterop.queryStringToParams s).Result
-
 
 let queryToDval (q : List<string * List<string>>) : bool =
   DvalReprExternal.ofQuery q .=. (OCamlInterop.queryToDval q).Result
@@ -69,12 +76,15 @@ let queryToEncodedString (q : List<string * List<string>>) : bool =
   .=. (OCamlInterop.paramsToQueryString q).Result
 
 let tests =
-  let test name fn = tpwg typeof<Generator> name fn
+  let test name fn = testPropertyWithGenerator typeof<Generator> name fn
   testList
-    "FuzzHttpClient"
+    "HttpClient"
     [ test "dvalToUrlStringExn" dvalToUrlStringExn // FSTODO: unicode
       test "dvalToQuery" dvalToQuery
       test "dvalToFormEncoding" dvalToFormEncoding
-      tpwg typeof<QueryStringGenerator> "queryStringToParams" queryStringToParams // only &=& fails
+      testPropertyWithGenerator
+        typeof<QueryStringGenerator>
+        "queryStringToParams"
+        queryStringToParams // only &=& fails
       test "queryToDval" queryToDval
       test "queryToEncodedString" queryToEncodedString ]

--- a/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
@@ -1,3 +1,5 @@
+/// Generators and FuzzTests that ensure JSON serialization
+/// of Runtime Dvals functionality is consistent across OCaml and F# backends
 module FuzzTests.Json
 
 open System.Threading.Tasks
@@ -20,9 +22,9 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 module DvalReprInternal = LibExecution.DvalReprInternal
 module G = Generators
 
-let tpwg = testPropertyWithGenerator
-
-
+/// Generators and FuzzTests ensuring Runtime DVals are
+/// consistently pretty-printed for machines (code) across
+/// OCaml and F# backends.
 module PrettyMachineJson =
   type Generator =
     static member SafeString() : Arbitrary<string> = Arb.fromGen (G.string ())
@@ -34,6 +36,8 @@ module PrettyMachineJson =
         | RT.DFnVal _ -> false
         | _ -> true)
 
+  /// Ensures Runtime types are consistently serialized
+  /// to machine-friendly JSON across OCaml and F# backends
   let equalsOCaml (dv : RT.Dval) : bool =
     let actual =
       dv
@@ -51,8 +55,10 @@ module PrettyMachineJson =
   let tests =
     testList
       "prettyMachineJson"
-      [ tpwg typeof<Generator> "roundtripping prettyMachineJson" equalsOCaml ]
-
+      [ testPropertyWithGenerator
+          typeof<Generator>
+          "roundtripping prettyMachineJson"
+          equalsOCaml ]
 
 module PrettyResponseJson =
   type Generator =
@@ -91,8 +97,7 @@ module PrettyResponseJson =
   let tests =
     testList
       "prettyResponseJson"
-      [ tpwg typeof<Generator> "compare to ocaml" equalsOCaml ]
-
+      [ testPropertyWithGenerator typeof<Generator> "compare to ocaml" equalsOCaml ]
 
 module PrettyRequestJson =
   type Generator =
@@ -125,7 +130,7 @@ module PrettyRequestJson =
   let tests =
     testList
       "prettyRequestJson"
-      [ tpwg typeof<Generator> "compare to ocaml" equalsOCaml ]
+      [ testPropertyWithGenerator typeof<Generator> "compare to ocaml" equalsOCaml ]
 
 module LibJwtJson =
   type Generator =
@@ -148,55 +153,6 @@ module LibJwtJson =
     let expected = (OCamlInterop.toSafePrettyMachineYojsonV1 dv).Result
 
     actual .=. expected
-
-  let roundtripV1 (dv : RT.Dval) : bool =
-    let t =
-      task {
-        let! meta = initializeTestCanvas "jwt-roundtrip-v1"
-
-        let privateKey =
-          "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAvxW2wuTTK2d0ob5mu/ASJ9vYDc/SXy06QAIepF9x9eoVZZVZ\nd8ksxvk3JGp/L0+KHuVyXoZFRzE9rU4skIqLn9/0Ag9ua4ml/ft7COprfEYA7klN\nc+xp2lwnGsxL70KHyHvHo5tDK1OWT81ivOGWCV7+3DF2RvDV2okk3x1ZKyBy2Rw2\nuUjl0EzWLycYQjhRrby3gjVtUVanUgStsgTwMlHbmVv9QMY5UetA9o05uPaAXH4B\nCCw+SqhEEJqES4V+Y6WEfFWZTmvWv0GV+i/p4Ur22mtma+6ree45gsdnzlj1OASW\nDQx/7vj7Ickt+eTwrVqyRWb9iNZPXj3ZrkJ44wIDAQABAoIBAQC+0olj0a3MT5Fa\noNDpZ9JJubLmAB8e6wSbvUIqdiJRKUXa3y2sgNtVjLTzieKfNXhCaHIxUTdH5DWq\np0G7yo+qxbRghlaHz7tTitsQSUGzphjx3YQaewIujQ6EJXbDZZZBsNLqYHfQgbW+\n1eV/qGvzyckLzd1G9OUrSv/mS+GrPQ00kpIJIX+EInFOPQ04DheppGNdlxoAUwQQ\nXUUhE1LifY4DyyK71mNlUoYyCs+0ozLzbxQwr9n8PKnLKdukL6X0g3tlKEbqQWPv\nvz2J8QZeSyhnZM9AjtYdVqTO6qs4l9dyWjdpDRIV9WylasOsIbb8XP8bv2NpH2Ua\n6a54L/RJAoGBAPVWwU1jU6e86WrnocJf3miydkhF5VV1tporiuAi391N84zCG509\nrWZWa0xsD2tq2+yNDry1qdqMGmvBXKoTJAx3cjpvK/uK7Tkd+tnislDLw8Wq/fCz\nNBdSidGIuASXdh4Bo9OK8iYMBgfpUGXRKAs4rO45mwrS/+b0YYZSiX/1AoGBAMdj\namEa5SzXw7tSqtp4Vr4pp4H52YULKI84UKvEDQOROfazQrZMHxbtaSMXG69x7SBr\nr48MuRYWd8KZ3iUkYjQLhr4n4zw5DS4AVJqgrLootVWHgt6Ey29Xa1g+B4pZOre5\nPJcrxNsG0OjIAEUsTb+yeURSphVjYe+xlXlYD0Z3AoGACdxExKF7WUCEeSF6JN/J\nhpe1nU4B259xiVy6piuAp9pcMYoTpgw2jehnQ5kMPZr739QDhZ4fh4MeBLquyL8g\nMcgTNToGoIOC6UrFLECqPgkSgz1OG4B4VX+hvmQqUTTtMGOMfBIXjWPqUiMUciMn\n4tuSR7jU/GhilJu517Y1hIkCgYEAiZ5ypEdd+s+Jx1dNmbEJngM+HJYIrq1+9ytV\nctjEarvoGACugQiVRMvkj1W5xCSMGJ568+9CKJ6lVmnBTD2KkoWKIOGDE+QE1sVf\nn8Jatbq3PitkBpX9nAHok2Vs6u6feoOd8HFDVDGmK6Uvmo7zsuZKkP/CpmyMAla9\n5p0DHg0CgYEAg0Wwqo3sDFSyKii25/Sffjr6tf1ab+3gFMpahRslkUvyFE/ZweKb\nT/YWcgYPzBA6q8LBfGRdh80kveFKRluUERb0PuK+jiHXz42SJ4zEIaToWeK1TQ6I\nFW78LEsgtnna+JpWEr+ugcGN/FH8e9PLJDK7Z/HSLPtV8E6V/ls3VDM=\n-----END RSA PRIVATE KEY-----"
-        let publicKey =
-          "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvxW2wuTTK2d0ob5mu/AS\nJ9vYDc/SXy06QAIepF9x9eoVZZVZd8ksxvk3JGp/L0+KHuVyXoZFRzE9rU4skIqL\nn9/0Ag9ua4ml/ft7COprfEYA7klNc+xp2lwnGsxL70KHyHvHo5tDK1OWT81ivOGW\nCV7+3DF2RvDV2okk3x1ZKyBy2Rw2uUjl0EzWLycYQjhRrby3gjVtUVanUgStsgTw\nMlHbmVv9QMY5UetA9o05uPaAXH4BCCw+SqhEEJqES4V+Y6WEfFWZTmvWv0GV+i/p\n4Ur22mtma+6ree45gsdnzlj1OASWDQx/7vj7Ickt+eTwrVqyRWb9iNZPXj3ZrkJ4\n4wIDAQAB\n-----END PUBLIC KEY-----"
-
-        let callWithBoth code symtable =
-          task {
-            let ast = FSharpToExpr.parsePTExpr code
-            let! expected =
-              OCamlInterop.execute meta.owner meta.id ast symtable [] []
-
-            let! state = executionStateFor meta Map.empty Map.empty
-            let! actual =
-              LibExecution.Execution.executeExpr state symtable (PT2RT.Expr.toRT ast)
-            return (expected, actual)
-          }
-
-        // Encode it with v1 first
-        let code = "JWT.signAndEncode_v1_ster priv payload"
-        let symtable = Map [ "priv", RT.DStr privateKey; "payload", dv ]
-        let! (expectedEncoded, actual) = callWithBoth code symtable
-
-        Expect.equal (RT.Dval.isFake expectedEncoded) false "isn't an error"
-        Expect.equalDval actual expectedEncoded "signed string matches"
-
-        // check it can be read with v1 decode function
-        let code = "JWT.verifyAndExtract_v1_ster pub encoded"
-        let symtable = Map [ "pub", RT.DStr publicKey; "encoded", expectedEncoded ]
-        let! (expected, actual) = callWithBoth code symtable
-
-        Expect.equal (RT.Dval.isFake expected) false "isn't on the error rail"
-        Expect.equalDval actual expected "extracted matches ocaml"
-
-        return true
-      }
-    try
-      if containsPassword dv || containsFakeDval dv then true else t.Result
-    with
-    | :? System.AggregateException as e ->
-      print e.Message
-      print e.StackTrace
-      false
-
 
 
   let roundtripV0 (dv : RT.Dval) : bool =
@@ -254,9 +210,58 @@ module LibJwtJson =
       false
 
 
+  let roundtripV1 (dv : RT.Dval) : bool =
+    let t =
+      task {
+        let! meta = initializeTestCanvas "jwt-roundtrip-v1"
+
+        let privateKey =
+          "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAvxW2wuTTK2d0ob5mu/ASJ9vYDc/SXy06QAIepF9x9eoVZZVZ\nd8ksxvk3JGp/L0+KHuVyXoZFRzE9rU4skIqLn9/0Ag9ua4ml/ft7COprfEYA7klN\nc+xp2lwnGsxL70KHyHvHo5tDK1OWT81ivOGWCV7+3DF2RvDV2okk3x1ZKyBy2Rw2\nuUjl0EzWLycYQjhRrby3gjVtUVanUgStsgTwMlHbmVv9QMY5UetA9o05uPaAXH4B\nCCw+SqhEEJqES4V+Y6WEfFWZTmvWv0GV+i/p4Ur22mtma+6ree45gsdnzlj1OASW\nDQx/7vj7Ickt+eTwrVqyRWb9iNZPXj3ZrkJ44wIDAQABAoIBAQC+0olj0a3MT5Fa\noNDpZ9JJubLmAB8e6wSbvUIqdiJRKUXa3y2sgNtVjLTzieKfNXhCaHIxUTdH5DWq\np0G7yo+qxbRghlaHz7tTitsQSUGzphjx3YQaewIujQ6EJXbDZZZBsNLqYHfQgbW+\n1eV/qGvzyckLzd1G9OUrSv/mS+GrPQ00kpIJIX+EInFOPQ04DheppGNdlxoAUwQQ\nXUUhE1LifY4DyyK71mNlUoYyCs+0ozLzbxQwr9n8PKnLKdukL6X0g3tlKEbqQWPv\nvz2J8QZeSyhnZM9AjtYdVqTO6qs4l9dyWjdpDRIV9WylasOsIbb8XP8bv2NpH2Ua\n6a54L/RJAoGBAPVWwU1jU6e86WrnocJf3miydkhF5VV1tporiuAi391N84zCG509\nrWZWa0xsD2tq2+yNDry1qdqMGmvBXKoTJAx3cjpvK/uK7Tkd+tnislDLw8Wq/fCz\nNBdSidGIuASXdh4Bo9OK8iYMBgfpUGXRKAs4rO45mwrS/+b0YYZSiX/1AoGBAMdj\namEa5SzXw7tSqtp4Vr4pp4H52YULKI84UKvEDQOROfazQrZMHxbtaSMXG69x7SBr\nr48MuRYWd8KZ3iUkYjQLhr4n4zw5DS4AVJqgrLootVWHgt6Ey29Xa1g+B4pZOre5\nPJcrxNsG0OjIAEUsTb+yeURSphVjYe+xlXlYD0Z3AoGACdxExKF7WUCEeSF6JN/J\nhpe1nU4B259xiVy6piuAp9pcMYoTpgw2jehnQ5kMPZr739QDhZ4fh4MeBLquyL8g\nMcgTNToGoIOC6UrFLECqPgkSgz1OG4B4VX+hvmQqUTTtMGOMfBIXjWPqUiMUciMn\n4tuSR7jU/GhilJu517Y1hIkCgYEAiZ5ypEdd+s+Jx1dNmbEJngM+HJYIrq1+9ytV\nctjEarvoGACugQiVRMvkj1W5xCSMGJ568+9CKJ6lVmnBTD2KkoWKIOGDE+QE1sVf\nn8Jatbq3PitkBpX9nAHok2Vs6u6feoOd8HFDVDGmK6Uvmo7zsuZKkP/CpmyMAla9\n5p0DHg0CgYEAg0Wwqo3sDFSyKii25/Sffjr6tf1ab+3gFMpahRslkUvyFE/ZweKb\nT/YWcgYPzBA6q8LBfGRdh80kveFKRluUERb0PuK+jiHXz42SJ4zEIaToWeK1TQ6I\nFW78LEsgtnna+JpWEr+ugcGN/FH8e9PLJDK7Z/HSLPtV8E6V/ls3VDM=\n-----END RSA PRIVATE KEY-----"
+        let publicKey =
+          "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvxW2wuTTK2d0ob5mu/AS\nJ9vYDc/SXy06QAIepF9x9eoVZZVZd8ksxvk3JGp/L0+KHuVyXoZFRzE9rU4skIqL\nn9/0Ag9ua4ml/ft7COprfEYA7klNc+xp2lwnGsxL70KHyHvHo5tDK1OWT81ivOGW\nCV7+3DF2RvDV2okk3x1ZKyBy2Rw2uUjl0EzWLycYQjhRrby3gjVtUVanUgStsgTw\nMlHbmVv9QMY5UetA9o05uPaAXH4BCCw+SqhEEJqES4V+Y6WEfFWZTmvWv0GV+i/p\n4Ur22mtma+6ree45gsdnzlj1OASWDQx/7vj7Ickt+eTwrVqyRWb9iNZPXj3ZrkJ4\n4wIDAQAB\n-----END PUBLIC KEY-----"
+
+        let callWithBoth code symtable =
+          task {
+            let ast = FSharpToExpr.parsePTExpr code
+            let! expected =
+              OCamlInterop.execute meta.owner meta.id ast symtable [] []
+
+            let! state = executionStateFor meta Map.empty Map.empty
+            let! actual =
+              LibExecution.Execution.executeExpr state symtable (PT2RT.Expr.toRT ast)
+            return (expected, actual)
+          }
+
+        // Encode it with v1 first
+        let code = "JWT.signAndEncode_v1_ster priv payload"
+        let symtable = Map [ "priv", RT.DStr privateKey; "payload", dv ]
+        let! (expectedEncoded, actual) = callWithBoth code symtable
+
+        Expect.equal (RT.Dval.isFake expectedEncoded) false "isn't an error"
+        Expect.equalDval actual expectedEncoded "signed string matches"
+
+        // check it can be read with v1 decode function
+        let code = "JWT.verifyAndExtract_v1_ster pub encoded"
+        let symtable = Map [ "pub", RT.DStr publicKey; "encoded", expectedEncoded ]
+        let! (expected, actual) = callWithBoth code symtable
+
+        Expect.equal (RT.Dval.isFake expected) false "isn't on the error rail"
+        Expect.equalDval actual expected "extracted matches ocaml"
+
+        return true
+      }
+    try
+      if containsPassword dv || containsFakeDval dv then true else t.Result
+    with
+    | :? System.AggregateException as e ->
+      print e.Message
+      print e.StackTrace
+      false
+
+
   let tests =
     testList
       "jwtJson"
-      [ tpwg typeof<Generator> "roundtrip jwt v0" roundtripV0
-        tpwg typeof<Generator> "roundtrip jwt v1" roundtripV1
-        tpwg typeof<Generator> "comparing jwt json" equalsOCaml ]
+      [ testPropertyWithGenerator typeof<Generator> "comparing jwt json" equalsOCaml
+        testPropertyWithGenerator typeof<Generator> "roundtrip jwt v0" roundtripV0
+        testPropertyWithGenerator typeof<Generator> "roundtrip jwt v1" roundtripV1 ]

--- a/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
@@ -22,7 +22,7 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 module DvalReprInternal = LibExecution.DvalReprInternal
 module G = Generators
 
-/// Generators and FuzzTests ensuring Runtime DVals are
+/// Generators and FuzzTests ensuring Runtime Dvals are
 /// consistently pretty-printed for machines (code) across
 /// OCaml and F# backends.
 module PrettyMachineJson =

--- a/fsharp-backend/tests/FuzzTests/NodaTime.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/NodaTime.FuzzTests.fs
@@ -1,4 +1,5 @@
-module FuzzTests.Date
+/// FuzzTests around NodaTime dependency
+module FuzzTests.NodaTime
 
 open Expecto
 open FsCheck
@@ -7,6 +8,9 @@ open Prelude
 open TestUtils.TestUtils
 open FuzzTests.Utils
 
+/// Checks whether a `NodaTime.Instant` can be serialized
+/// and deserialized to/from an ISO String successfully,
+/// maintaining the same value
 let roundtrip (date : NodaTime.Instant) : bool =
   let date = date.truncate ()
   let roundTripped =
@@ -17,4 +21,5 @@ let roundtrip (date : NodaTime.Instant) : bool =
 
   roundTripped = date
 
-let tests = testList "date" [ testProperty "roundtrip" roundtrip ]
+let tests =
+  testList "NodaTime" [ testProperty "roundtrips to/from isoString" roundtrip ]

--- a/fsharp-backend/tests/FuzzTests/Passwords.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Passwords.FuzzTests.fs
@@ -1,3 +1,4 @@
+/// FuzzTests around Passwords
 module FuzzTests.Passwords
 
 open Expecto
@@ -19,12 +20,12 @@ module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
 module G = Generators
 
-let tpwg = testPropertyWithGenerator
-
 type Generator =
   static member SafeString() : Arbitrary<string> = Arb.fromGen (G.string ())
 
-let passwordChecks (rawPassword : string) : bool =
+/// We should be able to successfully 'check' a
+/// password against a hash of the same password
+let hashCheckRoundtrip (rawPassword : string) : bool =
   let t =
     task {
       let! meta = initializeTestCanvas "executePure"
@@ -41,4 +42,9 @@ let passwordChecks (rawPassword : string) : bool =
   t.Result
 
 let tests =
-  testList "password" [ tpwg typeof<Generator> "comparing passwords" passwordChecks ]
+  testList
+    "password"
+    [ testPropertyWithGenerator
+        typeof<Generator>
+        "hash/check roundtrip"
+        hashCheckRoundtrip ]

--- a/fsharp-backend/tests/FuzzTests/README.md
+++ b/fsharp-backend/tests/FuzzTests/README.md
@@ -19,7 +19,7 @@ run by developers.
 
 [Expecto](https://github.com/haf/expecto) is used to run tests.
 
-You can trigger test runs by running `./scripts/run-fsharp-tests` within the dev container
+You can trigger test runs by running `./scripts/run-fsharp-fuzzer` within the dev container
 
 (View the project's root README.md for details on how to run within the dev container.)
 

--- a/fsharp-backend/tests/FuzzTests/README.md
+++ b/fsharp-backend/tests/FuzzTests/README.md
@@ -1,4 +1,28 @@
-This aims to find test cases that violate certain properties that we expect.
+# FuzzTests
+
+This aims to find test cases that violate certain properties that we expect hold true.
 
 Desired properties include that OCaml Dark programs and functions work the
 same as F# ones, and things related to serialization and output.
+
+Some generators written here may be used in the adjacent `../Tests` project,
+for tackling specific corner cases.
+
+At time of writing, these tests are not run as part of CI, but are only manually
+run by developers.
+
+## Writing Tests
+
+[FsCheck](https://fscheck.github.io/FsCheck/) is used to generate test cases and encode properties that we expect to be true.
+
+## Running Tests
+
+[Expecto](https://github.com/haf/expecto) is used to run tests.
+
+You can trigger test runs by running `./scripts/run-fsharp-tests` within the dev container
+
+(View the project's root README.md for details on how to run within the dev container.)
+
+If you only want to run some of the tests,
+- include flag `--filter-test-case 'case-name'` to run specific tests that match the pattern
+- include flag `--filter-test-list 'list-name'` to run test lists that match the pattern

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -275,7 +275,7 @@ let allRoundtrips =
         "queryable interop v1"
         FuzzTests.OCamlInterop.Queryable.isInteroperableV1
         (dvs DvalReprInternal.isQueryableDval)
-      t "enduserReadable" FuzzTests.DvalRepr.EndUserReadable.equalsOCaml all
+      t "enduserReadable" FuzzTests.DvalRepr.EnduserReadable.equalsOCaml all
       t "developerRepr" FuzzTests.DvalRepr.DeveloperRepr.equalsOCaml all
       t "prettyMachineJson" FuzzTests.Json.PrettyMachineJson.equalsOCaml all ]
 


### PR DESCRIPTION
- [x] ~consider file naming pattern. X.FuzzTests.fs is pretty length.~ going to ignore this for now
- [x] ~mention properties, fuzzers, etc.~ nevermind, link to fscheck docs is fine
- [x] ~reread fscheck docs and reconsider if our usage of FsCheck is reasonable. It feels like we could have simpler tests if we 'inverted' the tests a bit, but hard to describe so far.~ can of worms for another day
- [x] ensure everything is well /// commentated (top of file, per test, etc.) (edit: I didn't do _everything_ but it's good enough for now)
- [x] improve readme text
- [x] include notes about dependencies in readme
- [x] tell how to run tests in readme. filters. link to docs
- [x] mention that other project(s) reference this one for some generators
- [x] mention that the fuzztests aren't run in CI
