### PR TITLE
Fuzztests: fixes and reorg

### DIFF
--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -795,7 +795,7 @@ module Convert =
 
       let pipeTarget = ORT.EPipeTarget(gid ())
       let fnCall = ORT.EFnCall(id, name, pipeTarget :: actualArgs, rt2ocamlSter rail)
-      ORT.EPipe(pipeID, pipeStart @ [ fnCall ]) |> debug "converted to pipe"
+      ORT.EPipe(pipeID, pipeStart @ [ fnCall ])
     | RT.EFQFnValue _
     | RT.EApply (_, _, _, _, _) ->
       // these shouldn't happen in practice at the moment

--- a/fsharp-backend/tests/FuzzTests/BytesToString.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/BytesToString.FuzzTests.fs
@@ -15,32 +15,28 @@ module OCamlInterop = LibBackend.OCamlInterop
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 
 type Generator =
-  static member SafeString() : Arbitrary<string> = Arb.fromGen (Generators.string ())
+  static member SafeString() : Arbitrary<string> =
+    Generators.ocamlSafeString |> Arb.fromGen
 
 /// Checks that `toString` on a `byte[]` produces
 /// the same string for both OCaml and F# runtimes
 let toStringTest (bytes : byte []) : bool =
-  let t =
-    task {
-      let! meta = initializeTestCanvas "bytes-to-string"
+  task {
+    let! meta = initializeTestCanvas "bytes-to-string"
 
-      let ast = $"toString_v0 myValue" |> FSharpToExpr.parsePTExpr
-      let symtable = Map [ "myvalue", RT.DBytes bytes ]
+    let ast = $"toString_v0 myValue" |> FSharpToExpr.parsePTExpr
+    let symtable = Map [ "myvalue", RT.DBytes bytes ]
 
-      let! expected = OCamlInterop.execute meta.owner meta.id ast symtable [] []
+    let! expected = OCamlInterop.execute meta.owner meta.id ast symtable [] []
 
-      let! state = executionStateFor meta Map.empty Map.empty
-      let! actual =
-        LibExecution.Execution.executeExpr state symtable (PT2RT.Expr.toRT ast)
+    let! state = executionStateFor meta Map.empty Map.empty
+    let! actual =
+      LibExecution.Execution.executeExpr state symtable (PT2RT.Expr.toRT ast)
 
-      if Expect.dvalEquality actual expected then return true else return false
-    }
-  t.Result
+    if Expect.dvalEquality actual expected then return true else return false
+  } |> result
 
 let tests =
   testList
     "bytesToString"
-    [ testPropertyWithGenerator
-        typeof<Generator>
-        "comparing bytesToString"
-        toStringTest ]
+    [ testProperty typeof<Generator> "comparing bytesToString" toStringTest ]

--- a/fsharp-backend/tests/FuzzTests/DvalRepr.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/DvalRepr.FuzzTests.fs
@@ -20,8 +20,10 @@ module DvalReprInternal = LibExecution.DvalReprInternal
 /// is produced consistently across OCaml and F# backends
 module DeveloperRepr =
   type Generator =
+    inherit Generators.NodaTime.All
+    
     static member SafeString() : Arbitrary<string> =
-      Arb.fromGen (Generators.string ())
+      Arb.fromGen (Generators.ocamlSafeString)
 
     // The format here is only used for errors so it doesn't matter all that
     // much. These are places where we've manually checked the differing
@@ -42,14 +44,16 @@ module DeveloperRepr =
   let tests =
     testList
       "toDeveloperRepr"
-      [ testPropertyWithGenerator typeof<Generator> "roundtripping" equalsOCaml ]
+      [ testProperty typeof<Generator> "roundtripping" equalsOCaml ]
 
 /// Ensure text representation of DVals meant to be read by "end users"
 /// is produced consistently across OCaml and F# backends
 module EnduserReadable =
   type Generator =
+    inherit Generators.NodaTime.All
+
     static member SafeString() : Arbitrary<string> =
-      Arb.fromGen (Generators.string ())
+      Arb.fromGen (Generators.ocamlSafeString)
 
     static member Dval() : Arbitrary<RT.Dval> =
       Arb.Default.Derive()
@@ -65,13 +69,15 @@ module EnduserReadable =
   let tests =
     testList
       "toEnduserReadable"
-      [ testPropertyWithGenerator typeof<Generator> "roundtripping" equalsOCaml ]
+      [ testProperty typeof<Generator> "roundtripping" equalsOCaml ]
 
 /// Ensure hashing of RT DVals is consistent across OCaml and F# backends
 module Hashing =
   type Generator =
+    inherit Generators.NodaTime.All
+
     static member SafeString() : Arbitrary<string> =
-      Arb.fromGen (Generators.string ())
+      Arb.fromGen (Generators.ocamlSafeString)
 
     static member Dval() : Arbitrary<RT.Dval> =
       Arb.Default.Derive()
@@ -98,9 +104,6 @@ module Hashing =
   let tests =
     testList
       "hash"
-      [ testPropertyWithGenerator
-          typeof<Generator>
-          "toHashableRepr"
-          equalsOCamlToHashable
-        testPropertyWithGenerator typeof<Generator> "hashv0" equalsOCamlV0
-        testPropertyWithGenerator typeof<Generator> "hashv1" equalsOCamlV1 ]
+      [ testProperty typeof<Generator> "toHashableRepr" equalsOCamlToHashable
+        testProperty typeof<Generator> "hashv0" equalsOCamlV0
+        testProperty typeof<Generator> "hashv1" equalsOCamlV1 ]

--- a/fsharp-backend/tests/FuzzTests/ExecutePureFunctions.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/ExecutePureFunctions.FuzzTests.fs
@@ -57,8 +57,11 @@ let allowedErrors = AllowedFuzzerErrors.readAllowedErrors ()
 
 
 type Generator =
-  static member SafeString() : Arbitrary<string> =
-    Arb.fromGenShrink (G.string (), Arb.shrink<string>)
+  inherit G.NodaTime.All
+  
+  // static member NodaTimeInstant() : Arbitrary<NodaTime.Instant> = G.NodaTime.instant |> Arb.fromGen
+  // static member NodaTimeLocalDateTime() : Arbitrary<NodaTime.LocalDateTime> = G.NodaTime.localDateTime |> Arb.fromGen
+  static member SafeString() : Arbitrary<string> = G.ocamlSafeString |> Arb.fromGen
 
   static member Float() : Arbitrary<float> =
     Arb.fromGenShrink (
@@ -163,7 +166,7 @@ type Generator =
             let! v = Arb.generate<int64>
             return RT.EInteger(gid (), v)
           | RT.TStr ->
-            let! v = Generators.string ()
+            let! v = Generators.ocamlSafeString
             return RT.EString(gid (), v)
           | RT.TChar ->
             // We don't have a construct for characters, so create code to generate the character
@@ -192,7 +195,7 @@ type Generator =
                 (fun l -> RT.ERecord(gid (), l))
                 (Gen.listOfLength
                   s
-                  (Gen.zip (Generators.string ()) (genExpr' typ (s / 2))))
+                  (Gen.zip (Generators.ocamlSafeString) (genExpr' typ (s / 2))))
           | RT.TUserType (_name, _version) ->
             let! typ = Arb.generate<RT.DType>
 
@@ -201,7 +204,7 @@ type Generator =
                 (fun l -> RT.ERecord(gid (), l))
                 (Gen.listOfLength
                   s
-                  (Gen.zip (Generators.string ()) (genExpr' typ (s / 2))))
+                  (Gen.zip (Generators.ocamlSafeString) (genExpr' typ (s / 2))))
 
           | RT.TRecord pairs ->
             let! entries =
@@ -246,7 +249,7 @@ type Generator =
             let v = RT.EString(gid (), Base64.defaultEncodeToString bytes)
             return call "String" "toBytes" 0 [ v ]
           | RT.TDB _ ->
-            let! name = Generators.string ()
+            let! name = Generators.ocamlSafeString
             let ti = System.Globalization.CultureInfo.InvariantCulture.TextInfo
             let name = ti.ToTitleCase name
             return RT.EVariable(gid (), name)
@@ -280,7 +283,7 @@ type Generator =
             let! v = Arb.generate<int64>
             return RT.DInt v
           | RT.TStr ->
-            let! v = Generators.string ()
+            let! v = Generators.ocamlSafeString
             return RT.DStr v
           | RT.TVariable _ ->
             let! newtyp = Arb.generate<RT.DType>
@@ -301,10 +304,10 @@ type Generator =
                 (fun l -> RT.DObj(Map.ofList l))
                 (Gen.listOfLength
                   s
-                  (Gen.zip (Generators.string ()) (genDval' typ (s / 2))))
+                  (Gen.zip (Generators.ocamlSafeString) (genDval' typ (s / 2))))
           // | RT.TIncomplete -> return! Gen.map RT.TIncomplete Arb.generate<incomplete>
           // | RT.TError -> return! Gen.map RT.TError Arb.generate<error>
-          | RT.TDB _ -> return! Gen.map RT.DDB (Generators.string ())
+          | RT.TDB _ -> return! Gen.map RT.DDB (Generators.ocamlSafeString)
           | RT.TDate ->
             return!
               Gen.map
@@ -350,7 +353,7 @@ type Generator =
             let! list =
               Gen.listOfLength
                 s
-                (Gen.zip (Generators.string ()) (genDval' typ (s / 2)))
+                (Gen.zip (Generators.ocamlSafeString) (genDval' typ (s / 2)))
 
             return RT.DObj(Map list)
           | RT.TRecord (pairs) ->
@@ -712,4 +715,4 @@ let equalsOCaml ((fn, args) : (PT.FQFnName.StdlibFnName * List<RT.Dval>)) : bool
 let tests =
   testList
     "executePureFunctions"
-    [ testPropertyWithGenerator typeof<Generator> "equalsOCaml" equalsOCaml ]
+    [ testProperty typeof<Generator> "equalsOCaml" equalsOCaml ]

--- a/fsharp-backend/tests/FuzzTests/FQFnName.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FQFnName.FuzzTests.fs
@@ -13,7 +13,7 @@ module PT = LibExecution.ProgramTypes
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module PTParser = LibExecution.ProgramTypesParser
 module RT = LibExecution.RuntimeTypes
-module G = FuzzTests.Utils.Generators
+module G = FuzzTests.Generators
 
 /// Helper function to generate allowed function name parts
 let nameGenerator (first : char list) (other : char list) : Gen<string> =
@@ -33,7 +33,7 @@ let fnName : Gen<string> = nameGenerator [ 'a' .. 'z' ] G.alphaNumericString
 
 type Generator =
   static member SafeString() : Arbitrary<string> =
-    Arb.fromGenShrink (G.string (), Arb.shrink<string>)
+    Arb.fromGenShrink (G.ocamlSafeString, Arb.shrink<string>)
 
   static member PTFQFnName() : Arbitrary<PT.FQFnName.T> =
     { new Arbitrary<PT.FQFnName.T>() with
@@ -42,7 +42,7 @@ type Generator =
             gen {
               let! module_ = modName
               let! function_ = fnName
-              let! version = G.nonNegativeInt ()
+              let! version = G.nonNegativeInt
               return PTParser.FQFnName.stdlibFqName module_ function_ version
             }
 
@@ -54,7 +54,7 @@ type Generator =
               let! package = packageName
               let! module_ = modName
               let! function_ = fnName
-              let! version = G.nonNegativeInt ()
+              let! version = G.nonNegativeInt
 
               return
                 PTParser.FQFnName.packageFqName
@@ -68,9 +68,7 @@ type Generator =
           Gen.oneof [ stdlib; user; package ] }
 
   static member RTFQFnName() : Arbitrary<RT.FQFnName.T> =
-    { new Arbitrary<RT.FQFnName.T>() with
-        member _.Generator =
-          Generator.PTFQFnName().Generator |> Gen.map PT2RT.FQFnName.toRT }
+    Generator.PTFQFnName().Generator |> Gen.map PT2RT.FQFnName.toRT |> Arb.fromGen
 
 /// ProgramType can roundtrip cleanly to/from RuntimeType
 let ptRoundtrip (a : PT.FQFnName.T) : bool =
@@ -80,4 +78,4 @@ let ptRoundtrip (a : PT.FQFnName.T) : bool =
 let tests =
   testList
     "PT.FQFnName"
-    [ testPropertyWithGenerator typeof<Generator> "roundtripping" ptRoundtrip ]
+    [ testProperty typeof<Generator> "roundtripping" ptRoundtrip ]

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -8,28 +8,41 @@ open Tablecloth
 
 /// Tests we know to have some issues to work out
 /// FSTODO resolve these
-let stillBuggy = testList "still buggy" [ OCamlInterop.tests; FQFnName.tests ]
+let stillBuggy =
+  [ //OCamlInterop.tests
+    //FQFnName.tests
+    //HttpClient.tests // failing eventually, on "&=&"
+    //DvalRepr.EnduserReadable.tests // fails eventually on DObj (map [("𥉉", DNull); ("", DNull)])
+    //DvalRepr.DeveloperRepr.tests // fails eventually on DObj (map [("𢡊", DNull); ("ﺢ", DNull)])
+    //DvalRepr.Hashing.tests // fails eventually, on [DObj (map [("𥉉", DNull); ("", DNull)])]
+    //Json.PrettyMachineJson.tests // fails eventually, on DObj (map [("𥳐", DNull); ("", DNull)])
+    //Json.LibJwtJson.tests// fails eventually, on DObj (map [("𣏕", DNull); ("", DNull)])
+    //Json.PrettyResponseJson.tests // fails eventually , on some odd characters I think
+    //ExecutePureFunctions.tests // fails eventually, on some odd characters I think (module and fn names are odd)
+  ]
 
 /// Tests we generally know to be consistent
 let knownGood =
-  testList
-    "known good"
-    ([ OCamlInterop.Roundtrippable.tests
-       OCamlInterop.Queryable.tests
-       DvalRepr.EnduserReadable.tests
-       DvalRepr.Hashing.tests
-       DvalRepr.DeveloperRepr.tests
-       HttpClient.tests
-       Json.PrettyMachineJson.tests
-       Json.LibJwtJson.tests
-       Json.PrettyRequestJson.tests
-       Json.PrettyResponseJson.tests
-       Passwords.tests
-       BytesToString.tests
-       NodaTime.tests
-       ExecutePureFunctions.tests ])
+  [ Passwords.tests // passes with 10,000; 8 tests/s
+    OCamlInterop.Queryable.tests // passes with 1,000,000; 25 tests/s
+    BytesToString.tests // passes with 10,000; 200 tests/s
+    OCamlInterop.Roundtrippable.tests // passes with 100,000; 520 tests/s
+    Json.PrettyRequestJson.tests // passes with 10,000; 800 tests/s
+    NodaTime.tests // passes with 1,000,000; 140k tests/s
+    ]
 
-let tests = testList "FuzzTests" [ knownGood; stillBuggy ]
+let tests =
+  knownGood
+  //knownGood @ stillBuggy
+  //Playground.tests
 
 [<EntryPoint>]
-let main args = runTestsWithCLIArgs [] args tests
+let main args =
+  LibService.Init.init "FuzzTests"
+
+  // this does async stuff within it, so do not run it from a task/async
+  // context or it may hang
+  let exitCode = runTestsWithCLIArgs [] args (testList "FuzzTests" tests)
+
+  Prelude.NonBlockingConsole.wait () // flush stdout
+  exitCode

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fsproj
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fsproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Utils.FuzzTests.fs" />
+    <Compile Include="Generators.fs" />
     <Compile Include="FQFnName.FuzzTests.fs" />
     <Compile Include="OCamlInterop.FuzzTests.fs" />
     <Compile Include="DvalRepr.FuzzTests.fs" />
@@ -27,6 +28,7 @@
     <Compile Include="BytesToString.FuzzTests.fs" />
     <Compile Include="NodaTime.FuzzTests.fs" />
     <Compile Include="ExecutePureFunctions.FuzzTests.fs" />
+    <Compile Include="Playground.FuzzTests.fs" />
     <Compile Include="FuzzTests.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/fsharp-backend/tests/FuzzTests/Generators.fs
+++ b/fsharp-backend/tests/FuzzTests/Generators.fs
@@ -1,0 +1,88 @@
+/// Generators
+module FuzzTests.Generators
+
+open Expecto
+open Expecto.ExpectoFsCheck
+open FsCheck
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+open System.Text.RegularExpressions
+
+open Prelude
+open Prelude.Tablecloth
+open Tablecloth
+open TestUtils.TestUtils
+open NodaTime
+
+module PT = LibExecution.ProgramTypes
+module RT = LibExecution.RuntimeTypes
+module OCamlInterop = LibBackend.OCamlInterop
+module DvalReprExternal = LibExecution.DvalReprExternal
+module DvalReprInternal = LibExecution.DvalReprInternal
+
+let isSafeOCamlString (s : string) : bool = s <> null && not (s.Contains('\u0000'))
+
+/// We disallow `\u0000` in OCaml because Postgres doesn't like it; see `of_utf8_encoded_string.ml`
+/// FSTODO: add in unicode
+let safeOCamlString = Arb.Default.String() |> Arb.filter isSafeOCamlString
+
+/// List of all a..z, A..Z, 0..9, and _ characters
+let alphaNumericString =
+  List.concat [ [ 'a' .. 'z' ]; [ '0' .. '9' ]; [ 'A' .. 'Z' ]; [ '_' ] ]
+
+/// Generates a string that 'normalizes' successfully,
+/// and is safe for use in OCaml
+let ocamlSafeString =
+  let isValid (s : string) : bool =
+    try
+      String.normalize s |> ignore<string>
+      true
+    with
+    | e ->
+      // debuG
+      //   "Failed to normalize :"
+      //   $"{e}\n '{s}': (len {s.Length}, {System.BitConverter.ToString(toBytes s)})"
+
+      false
+
+  Arb.generate<UnicodeString>
+  |> Gen.map (fun (UnicodeString s) -> s)
+  |> Gen.filter isValid
+  // Now that we know it can be normalized, actually normalize it
+  |> Gen.map String.normalize
+  |> Gen.filter isSafeOCamlString
+
+let char () : Gen<string> =
+  ocamlSafeString
+  |> Gen.map String.toEgcSeq
+  |> Gen.map Seq.toList
+  |> Gen.map List.head
+  |> Gen.filter Option.isSome
+  |> Gen.map (Option.defaultValue "")
+  |> Gen.filter ((<>) "")
+
+
+/// Generates an `int` >= 0
+let nonNegativeInt =
+  gen {
+    let! (NonNegativeInt i) = Arb.generate<NonNegativeInt>
+    return i
+  }
+
+module NodaTime =
+  let instant =
+    Arb.generate<System.DateTime>
+    |> Gen.map (fun dt -> dt.ToUniversalTime())
+    |> Gen.map (fun dt -> Instant.FromDateTimeUtc dt)
+
+  let localDateTime: Gen<NodaTime.LocalDateTime> =
+    Arb.generate<System.DateTime>
+    |> Gen.map NodaTime.LocalDateTime.FromDateTime
+
+  type All =
+    static member Instant() = instant |> Arb.fromGen
+    static member LocalDateTime() = localDateTime |> Arb.fromGen
+
+module Dval =
+  let dBool () = Arb.generate<bool> |> Gen.map RT.DBool

--- a/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/HttpClient.FuzzTests.fs
@@ -20,10 +20,10 @@ module G = Generators
 
 
 type Generator =
-  static member SafeString() : Arbitrary<string> =
-    // FSTODO: add in unicode
-    // G.string () |> Arb.fromGen
-    Arb.Default.String() |> Arb.filter G.safeOCamlString
+  inherit G.NodaTime.All
+  // can we instead make the SafeString usage explicit?
+  // as is, I think this will generate "full strings" as DChars, which isn't helpful
+  static member SafeString() : Arbitrary<string> = G.safeOCamlString
 
   static member Dval() : Arbitrary<RT.Dval> =
     Arb.Default.Derive()
@@ -32,11 +32,12 @@ type Generator =
       | _ -> true)
 
 type QueryStringGenerator =
+  // which of the below is winning?
   static member SafeString() : Arbitrary<string> =
-    Arb.Default.String() |> Arb.filter G.safeOCamlString
+    Arb.Default.String() |> Arb.filter G.isSafeOCamlString
 
   static member String() : Arbitrary<string> =
-    Gen.listOf (Gen.listOf (G.string ()))
+    Gen.listOf (Gen.listOf (G.ocamlSafeString))
     |> Gen.map (List.map (String.concat "="))
     |> Gen.map (String.concat "&")
     |> Arb.fromGen
@@ -76,13 +77,15 @@ let queryToEncodedString (q : List<string * List<string>>) : bool =
   .=. (OCamlInterop.paramsToQueryString q).Result
 
 let tests =
-  let test name fn = testPropertyWithGenerator typeof<Generator> name fn
+  // name, property, generator (option), config override (option)
+
+  let test name fn = testProperty typeof<Generator> name fn
   testList
     "HttpClient"
-    [ test "dvalToUrlStringExn" dvalToUrlStringExn // FSTODO: unicode
+    [ test "dvalToUrlStringExn" dvalToUrlStringExn
       test "dvalToQuery" dvalToQuery
       test "dvalToFormEncoding" dvalToFormEncoding
-      testPropertyWithGenerator
+      testProperty
         typeof<QueryStringGenerator>
         "queryStringToParams"
         queryStringToParams // only &=& fails

--- a/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
@@ -27,7 +27,9 @@ module G = Generators
 /// OCaml and F# backends.
 module PrettyMachineJson =
   type Generator =
-    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.string ())
+    inherit G.NodaTime.All
+
+    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.ocamlSafeString)
 
     // This should produce identical JSON to the OCaml function or customers will have an unexpected change
     static member Dval() : Arbitrary<RT.Dval> =
@@ -55,14 +57,12 @@ module PrettyMachineJson =
   let tests =
     testList
       "prettyMachineJson"
-      [ testPropertyWithGenerator
-          typeof<Generator>
-          "roundtripping prettyMachineJson"
-          equalsOCaml ]
+      [ testProperty typeof<Generator> "roundtripping prettyMachineJson" equalsOCaml ]
 
 module PrettyResponseJson =
   type Generator =
-    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.string ())
+    inherit G.NodaTime.All
+    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.ocamlSafeString)
 
     // This should produce identical JSON to the OCaml function or customers will have an unexpected change
     static member Dval() : Arbitrary<RT.Dval> =
@@ -97,11 +97,12 @@ module PrettyResponseJson =
   let tests =
     testList
       "prettyResponseJson"
-      [ testPropertyWithGenerator typeof<Generator> "compare to ocaml" equalsOCaml ]
+      [ testProperty typeof<Generator> "compare to ocaml" equalsOCaml ]
 
 module PrettyRequestJson =
   type Generator =
-    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.string ())
+    inherit G.NodaTime.All
+    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.ocamlSafeString)
 
     // This should produce identical JSON to the OCaml function or customers will have an unexpected change
     static member Dval() : Arbitrary<RT.Dval> =
@@ -130,11 +131,13 @@ module PrettyRequestJson =
   let tests =
     testList
       "prettyRequestJson"
-      [ testPropertyWithGenerator typeof<Generator> "compare to ocaml" equalsOCaml ]
+      [ testProperty typeof<Generator> "compare to ocaml" equalsOCaml ]
 
 module LibJwtJson =
   type Generator =
-    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.string ())
+    inherit G.NodaTime.All
+
+    static member SafeString() : Arbitrary<string> = Arb.fromGen (G.ocamlSafeString)
 
     static member Dval() : Arbitrary<RT.Dval> =
       Arb.Default.Derive()
@@ -262,6 +265,6 @@ module LibJwtJson =
   let tests =
     testList
       "jwtJson"
-      [ testPropertyWithGenerator typeof<Generator> "comparing jwt json" equalsOCaml
-        testPropertyWithGenerator typeof<Generator> "roundtrip jwt v0" roundtripV0
-        testPropertyWithGenerator typeof<Generator> "roundtrip jwt v1" roundtripV1 ]
+      [ testProperty typeof<Generator> "comparing jwt json" equalsOCaml
+        testProperty typeof<Generator> "roundtrip jwt v0" roundtripV0
+        testProperty typeof<Generator> "roundtrip jwt v1" roundtripV1 ]

--- a/fsharp-backend/tests/FuzzTests/NodaTime.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/NodaTime.FuzzTests.fs
@@ -8,18 +8,24 @@ open Prelude
 open TestUtils.TestUtils
 open FuzzTests.Utils
 
-/// Checks whether a `NodaTime.Instant` can be serialized
-/// and deserialized to/from an ISO String successfully,
-/// maintaining the same value
-let roundtrip (date : NodaTime.Instant) : bool =
-  let date = date.truncate ()
-  let roundTripped =
-    date.toIsoString ()
-    |> NodaTime.Instant.ofIsoString
-    |> fun d -> d.toIsoString ()
-    |> NodaTime.Instant.ofIsoString
+module Properties =
+  /// Checks whether a `NodaTime.Instant` can be serialized
+  /// and deserialized to/from an ISO String successfully,
+  /// maintaining the same value
+  let roundtrip (date : NodaTime.Instant) : bool =
+    let date = date.truncate ()
+    let roundTripped =
+      date.toIsoString ()
+      |> NodaTime.Instant.ofIsoString
+      |> fun d -> d.toIsoString ()
+      |> NodaTime.Instant.ofIsoString
 
-  roundTripped = date
+    roundTripped = date
 
 let tests =
-  testList "NodaTime" [ testProperty "roundtrips to/from isoString" roundtrip ]
+  testList
+    "NodaTime"
+    [ testProperty
+        typeof<Generators.NodaTime.All>
+        "roundtrips to/from isoString"
+        Properties.roundtrip ]

--- a/fsharp-backend/tests/FuzzTests/Passwords.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Passwords.FuzzTests.fs
@@ -21,7 +21,7 @@ module RT = LibExecution.RuntimeTypes
 module G = Generators
 
 type Generator =
-  static member SafeString() : Arbitrary<string> = Arb.fromGen (G.string ())
+  static member SafeString() : Arbitrary<string> = Arb.fromGen (G.ocamlSafeString)
 
 /// We should be able to successfully 'check' a
 /// password against a hash of the same password
@@ -44,7 +44,4 @@ let hashCheckRoundtrip (rawPassword : string) : bool =
 let tests =
   testList
     "password"
-    [ testPropertyWithGenerator
-        typeof<Generator>
-        "hash/check roundtrip"
-        hashCheckRoundtrip ]
+    [ testProperty typeof<Generator> "hash/check roundtrip" hashCheckRoundtrip ]

--- a/fsharp-backend/tests/FuzzTests/Playground.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Playground.FuzzTests.fs
@@ -1,0 +1,56 @@
+/// Playgrond environment for testing
+module FuzzTests.Playground
+
+open Expecto
+open Expecto.ExpectoFsCheck
+open FsCheck
+
+open Prelude
+open Prelude.Tablecloth
+open Tablecloth
+open TestUtils.TestUtils
+
+open FuzzTests.Utils
+
+module PT = LibExecution.ProgramTypes
+module RT = LibExecution.RuntimeTypes
+module G = Generators
+
+type Widget =
+  /// Counter - starts at 0, and clicks upward by one
+  | Counter of int
+
+  /// Very useful flag
+  | Flag of bool
+
+module Generators =
+  let widgetBad =
+    Gen.oneof [ Arb.generate<int> |> Gen.map Counter
+                Arb.generate<bool> |> Gen.map Flag ]
+
+  let widgetGood =
+    Gen.oneof [ G.nonNegativeInt |> Gen.map Counter
+                Arb.generate<bool> |> Gen.map Flag ]
+
+  type WidgetGood =
+    static member Arb() = Arb.fromGen widgetGood
+
+  type WidgetBad =
+    static member Arb() = Arb.fromGen widgetBad
+
+module Properties =
+  /// We should be able to successfully 'check' a
+  /// password against a hash of the same password
+  let doNotHaveNegativeInts (widget : Widget) : bool =
+    match widget with
+    | Counter i -> i >= 0
+    | Flag _ -> true
+
+
+let tests =
+  testList
+    "widgets"
+    [ testProperty
+        typeof<Generators.WidgetGood>
+        "don't have negative ints"
+        Properties.doNotHaveNegativeInts ]

--- a/fsharp-backend/tests/FuzzTests/Utils.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Utils.FuzzTests.fs
@@ -14,12 +14,6 @@ open Prelude.Tablecloth
 open Tablecloth
 open TestUtils.TestUtils
 
-module PT = LibExecution.ProgramTypes
-module RT = LibExecution.RuntimeTypes
-module OCamlInterop = LibBackend.OCamlInterop
-module DvalReprExternal = LibExecution.DvalReprExternal
-module DvalReprInternal = LibExecution.DvalReprInternal
-
 /// Extracts the result from a task
 let result (t : Task<'a>) : 'a = t.Result
 
@@ -33,61 +27,10 @@ let (.=.) actual expected : bool =
     Expect.equal (actual, o) (expected, e) ""
     false
 
-let baseConfig : FsCheckConfig =
-  { FsCheckConfig.defaultConfig with maxTest = 100000 }
+let private baseConfigWithGenerator (typ : System.Type) : FsCheckConfig =
+  { FsCheckConfig.defaultConfig
+    with maxTest = 100
+         arbitrary = [ typ ] }
 
-let baseConfigWithGenerator (typ : System.Type) : FsCheckConfig =
-  { baseConfig with arbitrary = [ typ ] }
-
-let testProperty (name : string) (x : 'a) : Test =
-  testPropertyWithConfig baseConfig name x
-
-let testPropertyWithGenerator (typ : System.Type) (name : string) (x : 'a) : Test =
-  testPropertyWithConfig (baseConfigWithGenerator typ) name x
-
-/// Lower-level generators
-module Generators =
-  /// We disallow `\u0000` in OCaml because Postgres doesn't like it; see `of_utf8_encoded_string.ml`
-  let safeOCamlString (s : string) : bool = s <> null && not (s.Contains('\u0000'))
-
-  /// List of all a..z, A..Z, 0..9, and _ characters
-  let alphaNumericString =
-    List.concat [ [ 'a' .. 'z' ]; [ '0' .. '9' ]; [ 'A' .. 'Z' ]; [ '_' ] ]
-
-  /// Generates a string that 'normalizes' successfully,
-  /// and is safe for use in OCaml
-  let string () =
-    let isValid (s : string) : bool =
-      try
-        String.normalize s |> ignore<string>
-        true
-      with
-      | e ->
-        // debuG
-        //   "Failed to normalize :"
-        //   $"{e}\n '{s}': (len {s.Length}, {System.BitConverter.ToString(toBytes s)})"
-
-        false
-
-    Arb.generate<UnicodeString>
-    |> Gen.map (fun (UnicodeString s) -> s)
-    |> Gen.filter isValid
-    // Now that we know it can be normalized, actually normalize it
-    |> Gen.map String.normalize
-    |> Gen.filter safeOCamlString
-
-  /// Generates an `int` >= 0
-  let nonNegativeInt () =
-    gen {
-      let! (NonNegativeInt i) = Arb.generate<NonNegativeInt>
-      return i
-    }
-
-  let char () : Gen<string> =
-    string ()
-    |> Gen.map String.toEgcSeq
-    |> Gen.map Seq.toList
-    |> Gen.map List.head
-    |> Gen.filter Option.isSome
-    |> Gen.map (Option.defaultValue "")
-    |> Gen.filter ((<>) "")
+let testProperty (typ : System.Type) (name : string) (propertyToTest : 'a) : Test =
+  propertyToTest |> testPropertyWithConfig (baseConfigWithGenerator typ) name

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -36,7 +36,7 @@ let testInternalRoundtrippableDoesntCareAboutOrder =
 let testDvalRoundtrippableRoundtrips =
   testMany
     "special roundtrippable dvals roundtrip"
-    FuzzTests.OCamlInterop.Roundtrippable.roundtrip
+    FuzzTests.OCamlInterop.Roundtrippable.canRoundtrip
     [ RT.DObj(
         Map.ofList [ ("", RT.DFloat 1.797693135e+308)
                      ("a", RT.DErrorRail(RT.DFloat nan)) ]
@@ -261,7 +261,7 @@ let allRoundtrips =
     "roundtrips"
     [ t
         "roundtrippable"
-        FuzzTests.OCamlInterop.Roundtrippable.roundtrip
+        FuzzTests.OCamlInterop.Roundtrippable.canRoundtrip
         (dvs (DvalReprInternal.isRoundtrippableDval false))
       t
         "roundtrippable interop"

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -11,11 +11,6 @@ module Telemetry = LibService.Telemetry
 
 [<EntryPoint>]
 let main (args : string array) : int =
-  let name = "Tests"
-  LibService.Init.init name
-  (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
-  (LibRealExecution.Init.init name).Result
-  (LibBackend.Account.initializeDevelopmentAccounts name).Result
 
   let tests =
     [ Tests.Account.tests
@@ -47,6 +42,11 @@ let main (args : string array) : int =
     print "Serialized to backend/serialization"
     0
   else
+    let name = "Tests"
+    LibService.Init.init name
+    (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
+    (LibRealExecution.Init.init name).Result
+    (LibBackend.Account.initializeDevelopmentAccounts name).Result
     let cancelationTokenSource = new System.Threading.CancellationTokenSource()
     let bwdServerTestsTask = Tests.BwdServer.init cancelationTokenSource.Token
     let httpClientTestsTask = Tests.HttpClient.init cancelationTokenSource.Token


### PR DESCRIPTION
WIP.

- errant `|> debug` was causing tests to fail
- `NodaTime` usage was causing tests to fail. Copying these to every generator got tiresome quickly, so started to create a reusable set of Generators
- it seems we need a `LibBackend.init` to run properly now
- opinion: it's always best to provide an explicit generator, even if it's the default one
- some tests still are eventually failing on odd characters; likely that `Generators.ocamlSafeString` needs adjustment
- idea: expose the ability to change `maxTests` via CLI so we don't have to recomplie every time you change it in the Utils file
- idea: run some of the tests in CI, likely with a lower maxTest #
- idea: benchmark both our generators and our property tests
- finding: password tests are _very_ slow. (8tests/second).
- finding: HttpClient.tests fail eventually, on "&=&". Check this out further.
- Others vary in duration. Once we have the above-mentioned benchmarks
- idea: consider the "complexity" of a ;type that we're testing against. Given the type's complexity, what's a "reasonable" number of tests to run?
- I will remove the "Playground.fs" file prior to merge

will resolve #3500 