### PR TITLE
Resolve FQFnName roundtrip test

### DIFF
--- a/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
@@ -44,7 +44,8 @@ let parseTests =
           ("", PT.FQFnName.Stdlib { module_ = ""; function_ = "++"; version = 0 })
           ("", PT.FQFnName.Stdlib { module_ = ""; function_ = "+"; version = 0 })
           ("", p "-")
-          ("", p "^") ]
+          ("", p "^")
+          ("", PT.FQFnName.User "gm32_v6") ]
       testMany
         "FQFnName parse tests"
         (fun name ->


### PR DESCRIPTION
This was discovered by fuzztesting, reported as a failure against [this test](https://github.com/darklang/dark/blob/4237ff6b227abe87c2580d0072377630633d368c/fsharp-backend/tests/FuzzTests/FQFnName.FuzzTests.fs#L83).

In practice, I haven't noticed that this causes any issue - user functions that I define in this form seem to work totally fine in the editor, against both OCaml and F# servers. What should be done here?

Maybe (unlikely?) the property itself is flawed.