### PR TITLE
Clean up exception mess

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
@@ -170,8 +170,7 @@ let httpCall'
               req.Content.Headers.ContentType <-
                 Headers.MediaTypeHeaderValue.Parse(v)
             with
-            | :? System.FormatException ->
-              Exception.raiseDeveloper "Invalid content-type header" []
+            | :? System.FormatException -> Errors.throw "Invalid content-type header"
           else
             // Dark headers can only be added once, as they use a Dict. Remove them
             // so they don't get added twice (eg via Authorization headers above)
@@ -409,7 +408,7 @@ let encodeRequestBody (body : Dval option) (headers : HttpHeaders.T) : Content =
     | DObj _ when hasFormHeader headers ->
       match DvalReprExternal.toFormEncoding dv with
       | Ok content -> FormContent(content)
-      | Error msg -> Exception.raiseDeveloper msg
+      | Error msg -> Errors.throw msg
     | dv when hasTextHeader headers ->
       StringContent(DvalReprExternal.toEnduserReadableTextV0 dv)
     | _ -> // hasJsonHeader
@@ -432,11 +431,11 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query = DvalReprExternal.toQuery query |> Exception.unwrapResultDeveloper
+    let query = DvalReprExternal.toQuery query |> Errors.unwrapResult
 
     // Headers
     let encodedReqHeaders =
-      DvalReprExternal.toStringPairs reqHeaders |> Exception.unwrapResultDeveloper
+      DvalReprExternal.toStringPairs reqHeaders |> Errors.unwrapResult
     let contentType =
       HttpHeaders.get "content-type" encodedReqHeaders
       |> Option.defaultValue (guessContentType reqBody)

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyBaseHttpClient.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyBaseHttpClient.fs
@@ -278,8 +278,7 @@ let makeHttpCall
               req.Content.Headers.ContentType <-
                 Headers.MediaTypeHeaderValue.Parse(v)
             with
-            | :? System.FormatException ->
-              Exception.raiseDeveloper "Invalid content-type header" []
+            | :? System.FormatException -> Errors.throw "Invalid content-type header"
           else
             // Dark headers can only be added once, as they use a Dict. Remove them
             // so they don't get added twice (eg via Authorization headers above)
@@ -405,7 +404,7 @@ let encodeRequestBody
     | RT.DObj _ when ContentType.hasFormHeaderWithoutCharset headers ->
       match DvalReprExternal.toFormEncoding dv with
       | Ok content -> FormContent(content)
-      | Error msg -> Exception.raiseDeveloper msg
+      | Error msg -> Errors.throw msg
     | _ when ContentType.hasNoContentType headers ->
       FakeFormContentToMatchCurl(jsonFn dv)
     | _ -> StringContent(jsonFn dv)

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyBaseHttpClient.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyBaseHttpClient.fs
@@ -278,7 +278,8 @@ let makeHttpCall
               req.Content.Headers.ContentType <-
                 Headers.MediaTypeHeaderValue.Parse(v)
             with
-            | :? System.FormatException -> Errors.throw "Invalid content-type header"
+            | :? System.FormatException ->
+              Exception.raiseCode "Invalid content-type header"
           else
             // Dark headers can only be added once, as they use a Dict. Remove them
             // so they don't get added twice (eg via Authorization headers above)
@@ -404,7 +405,7 @@ let encodeRequestBody
     | RT.DObj _ when ContentType.hasFormHeaderWithoutCharset headers ->
       match DvalReprExternal.toFormEncoding dv with
       | Ok content -> FormContent(content)
-      | Error msg -> Errors.throw msg
+      | Error msg -> Exception.raiseCode msg
     | _ when ContentType.hasNoContentType headers ->
       FakeFormContentToMatchCurl(jsonFn dv)
     | _ -> StringContent(jsonFn dv)

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient0.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient0.fs
@@ -34,10 +34,9 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query = DvalRepr.toQuery query |> Exception.unwrapResultDeveloper
+    let query = DvalRepr.toQuery query |> Errors.unwrapResult
 
-    let encodedReqHeaders =
-      DvalRepr.toStringPairs reqHeaders |> Exception.unwrapResultDeveloper
+    let encodedReqHeaders = DvalRepr.toStringPairs reqHeaders |> Errors.unwrapResult
     let encodedReqBody = encodeRequestBody jsonFn encodedReqHeaders reqBody
 
     match! httpCall 0 false uri query verb encodedReqHeaders encodedReqBody with
@@ -92,13 +91,11 @@ let sendRequest
           // The OCaml version of this was Legacy.LibHttpClientv1, which called
           // Legacy.HttpClientv1.http_call, which threw exceptions for non-200 status
           // codes
-          return
-            Exception.raiseKnownIssue
-              $"Bad HTTP response ({response.code}) in call to {uri}"
-              []
+          return Errors.throw $"Bad HTTP response ({response.code}) in call to {uri}"
+
 
     // Raise to be caught in the right place
-    | Error err -> return Exception.raiseKnownIssue err.error []
+    | Error err -> return Errors.throw err.error
   }
 
 let call (method : HttpMethod) jsonFn : BuiltInFnSig =

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient0.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient0.fs
@@ -93,12 +93,12 @@ let sendRequest
           // Legacy.HttpClientv1.http_call, which threw exceptions for non-200 status
           // codes
           return
-            Exception.raiseLibrary
+            Exception.raiseKnownIssue
               $"Bad HTTP response ({response.code}) in call to {uri}"
               []
 
     // Raise to be caught in the right place
-    | Error err -> return Exception.raiseLibrary err.error []
+    | Error err -> return Exception.raiseKnownIssue err.error []
   }
 
 let call (method : HttpMethod) jsonFn : BuiltInFnSig =

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient0.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient0.fs
@@ -34,9 +34,10 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query = DvalRepr.toQuery query |> Errors.unwrapResult
+    let query = DvalRepr.toQuery query |> Exception.unwrapResultCode
 
-    let encodedReqHeaders = DvalRepr.toStringPairs reqHeaders |> Errors.unwrapResult
+    let encodedReqHeaders =
+      DvalRepr.toStringPairs reqHeaders |> Exception.unwrapResultCode
     let encodedReqBody = encodeRequestBody jsonFn encodedReqHeaders reqBody
 
     match! httpCall 0 false uri query verb encodedReqHeaders encodedReqBody with
@@ -91,11 +92,13 @@ let sendRequest
           // The OCaml version of this was Legacy.LibHttpClientv1, which called
           // Legacy.HttpClientv1.http_call, which threw exceptions for non-200 status
           // codes
-          return Errors.throw $"Bad HTTP response ({response.code}) in call to {uri}"
+          return
+            Exception.raiseCode
+              $"Bad HTTP response ({response.code}) in call to {uri}"
 
 
     // Raise to be caught in the right place
-    | Error err -> return Errors.throw err.error
+    | Error err -> return Exception.raiseCode err.error
   }
 
 let call (method : HttpMethod) jsonFn : BuiltInFnSig =

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient1.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient1.fs
@@ -32,10 +32,9 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query = DvalRepr.toQuery query |> Exception.unwrapResultDeveloper
+    let query = DvalRepr.toQuery query |> Errors.unwrapResult
 
-    let encodedReqHeaders =
-      DvalRepr.toStringPairs reqHeaders |> Exception.unwrapResultDeveloper
+    let encodedReqHeaders = DvalRepr.toStringPairs reqHeaders |> Errors.unwrapResult
     let encodedReqBody =
       encodeRequestBody
         DvalRepr.toPrettyMachineJsonStringV1

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient1.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient1.fs
@@ -32,9 +32,10 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query = DvalRepr.toQuery query |> Errors.unwrapResult
+    let query = DvalRepr.toQuery query |> Exception.unwrapResultCode
 
-    let encodedReqHeaders = DvalRepr.toStringPairs reqHeaders |> Errors.unwrapResult
+    let encodedReqHeaders =
+      DvalRepr.toStringPairs reqHeaders |> Exception.unwrapResultCode
     let encodedReqBody =
       encodeRequestBody
         DvalRepr.toPrettyMachineJsonStringV1

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient2.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient2.fs
@@ -39,10 +39,9 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query = DvalRepr.toQuery query |> Exception.unwrapResultDeveloper
+    let query = DvalRepr.toQuery query |> Errors.unwrapResult
 
-    let encodedReqHeaders =
-      DvalRepr.toStringPairs reqHeaders |> Exception.unwrapResultDeveloper
+    let encodedReqHeaders = DvalRepr.toStringPairs reqHeaders |> Errors.unwrapResult
     let encodedReqBody =
       encodeRequestBody
         DvalRepr.toPrettyMachineJsonStringV1

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient2.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyHttpClient2.fs
@@ -39,9 +39,10 @@ let sendRequest
   (reqHeaders : Dval)
   : Ply<Dval> =
   uply {
-    let query = DvalRepr.toQuery query |> Errors.unwrapResult
+    let query = DvalRepr.toQuery query |> Exception.unwrapResultCode
 
-    let encodedReqHeaders = DvalRepr.toStringPairs reqHeaders |> Errors.unwrapResult
+    let encodedReqHeaders =
+      DvalRepr.toStringPairs reqHeaders |> Exception.unwrapResultCode
     let encodedReqBody =
       encodeRequestBody
         DvalRepr.toPrettyMachineJsonStringV1

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -569,12 +569,10 @@ that's already taken, returns an error."
                 | Some Canvas.AllOrigins -> "*" |> DStr |> Some |> DOption
                 | Some (Canvas.Origins os) ->
                   os |> List.map DStr |> DList |> Some |> DOption
-              try
-                let! c = Canvas.getMeta (CanvasName.create host)
-                let! cors = Canvas.fetchCORSSetting c.id
-                return corsSettingToDval cors
-              with
-              | e -> return DError(SourceNone, Exception.toDeveloperMessage e)
+
+              let! c = Canvas.getMeta (CanvasName.create host)
+              let! cors = Canvas.fetchCORSSetting c.id
+              return corsSettingToDval cors
             }
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -606,7 +604,7 @@ that's already taken, returns an error."
                     os
                     |> List.map (function
                       | DStr v -> v
-                      | _ -> Exception.raiseGrandUser "Invalid origin string")
+                      | _ -> Errors.throw "Invalid origin string")
                     |> Canvas.Origins
                     |> Some
                     |> Ok

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -604,7 +604,7 @@ that's already taken, returns an error."
                     os
                     |> List.map (function
                       | DStr v -> v
-                      | _ -> Errors.throw "Invalid origin string")
+                      | _ -> Exception.raiseCode "Invalid origin string")
                     |> Canvas.Origins
                     |> Some
                     |> Ok

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient0.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient0.fs
@@ -57,10 +57,10 @@ module PrettyRequestJson =
       | DOption (Some dv) -> "Just " + to_repr_ indent dv
       | DErrorRail dv -> "ErrorRail: " + to_repr_ indent dv
       | DResult _ ->
-        Exception.raiseDeveloper
+        LibExecution.Errors.throw
           "Unknown Err: (Failure \"printing an unprintable value:<result>\")"
       | DBytes _ ->
-        Exception.raiseDeveloper
+        LibExecution.Errors.throw
           "Unknown Err: (Failure \"printing an unprintable value:<bytes>\")"
     to_repr_ 0 dv
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient0.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClient0.fs
@@ -57,10 +57,10 @@ module PrettyRequestJson =
       | DOption (Some dv) -> "Just " + to_repr_ indent dv
       | DErrorRail dv -> "ErrorRail: " + to_repr_ indent dv
       | DResult _ ->
-        LibExecution.Errors.throw
+        Exception.raiseCode
           "Unknown Err: (Failure \"printing an unprintable value:<result>\")"
       | DBytes _ ->
-        LibExecution.Errors.throw
+        Exception.raiseCode
           "Unknown Err: (Failure \"printing an unprintable value:<bytes>\")"
     to_repr_ 0 dv
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
@@ -19,7 +19,7 @@ let encodeBasicAuthBroken (u : string) (p : string) : string =
   let input : byte [] =
     if u.Contains("-") then
       // CLEANUP, this says colon but this is a hyphen
-      Errors.throw "Username cannot contain a colon"
+      Exception.raiseCode "Username cannot contain a colon"
     else
       ([ (System.Text.Encoding.UTF8.GetBytes u)
          [| byte ':' |]
@@ -33,7 +33,7 @@ let encodeBasicAuth (u : string) (p : string) : string =
   let input : byte [] =
     if u.Contains("-") then
       // CLEANUP, this says colon but this is a hyphen
-      Errors.throw "Username cannot contain a colon"
+      Exception.raiseCode "Username cannot contain a colon"
     else
       toBytes $"{u}:{p}"
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -463,7 +463,7 @@ let fns : List<BuiltInFn> =
                 "No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file."
           match result with
           | Some (headers, payload) ->
-            let unwrap = Exception.unwrapResultDeveloper
+            let unwrap = Errors.unwrapResult
             [ ("header", ofJson headers |> unwrap)
               ("payload", ofJson payload |> unwrap) ]
             |> Map.ofList
@@ -495,7 +495,7 @@ let fns : List<BuiltInFn> =
             | _ -> Error "Invalid public key"
           match result with
           | Ok (headers, payload) ->
-            let unwrap = Exception.unwrapResultDeveloper
+            let unwrap = Errors.unwrapResult
             [ ("header", ofJson headers |> unwrap)
               ("payload", ofJson payload |> unwrap) ]
             |> Map.ofList

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -459,11 +459,11 @@ let fns : List<BuiltInFn> =
               verifyAndExtractV0 rsa token
             with
             | _ ->
-              Errors.throw
+              Exception.raiseCode
                 "No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file."
           match result with
           | Some (headers, payload) ->
-            let unwrap = Errors.unwrapResult
+            let unwrap = Exception.unwrapResultCode
             [ ("header", ofJson headers |> unwrap)
               ("payload", ofJson payload |> unwrap) ]
             |> Map.ofList
@@ -495,7 +495,7 @@ let fns : List<BuiltInFn> =
             | _ -> Error "Invalid public key"
           match result with
           | Ok (headers, payload) ->
-            let unwrap = Errors.unwrapResult
+            let unwrap = Exception.unwrapResultCode
             [ ("header", ofJson headers |> unwrap)
               ("payload", ofJson payload |> unwrap) ]
             |> Map.ofList

--- a/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
@@ -47,11 +47,11 @@ let getV0 (url : string) : Task<byte []> =
       let code = int response.StatusCode
       let! body = response.Content.ReadAsByteArrayAsync()
       if code < 200 || code >= 300 then
-        return Errors.throw $"Bad HTTP response ({code}) in call to {url}"
+        return Exception.raiseCode $"Bad HTTP response ({code}) in call to {url}"
       else
         return body
     with
-    | e -> return Errors.throw $"Internal HTTP-stack exception: {e.Message}"
+    | e -> return Exception.raiseCode $"Internal HTTP-stack exception: {e.Message}"
   }
 
 /// Replaces legacy HttpClientv1. Returns bytes, headers, and status code, and throws
@@ -65,11 +65,11 @@ let getV1 (url : string) : Task<byte [] * List<string * string> * int> =
       let headers = response.Headers |> HttpHeaders.fromAspNetHeaders
       let! body = response.Content.ReadAsByteArrayAsync()
       if code < 200 || code >= 300 then
-        return Errors.throw $"Bad HTTP response ({code}) in call to {url}"
+        return Exception.raiseCode $"Bad HTTP response ({code}) in call to {url}"
       else
         return body, headers, code
     with
-    | e -> return Errors.throw $"Internal HTTP-stack exception: {e.Message}"
+    | e -> return Exception.raiseCode $"Internal HTTP-stack exception: {e.Message}"
   }
 
 /// Replaces legacy HttpClientv2. Returns bytes, headers, and status code, and throws
@@ -84,7 +84,7 @@ let getV2 (url : string) : Task<byte [] * List<string * string> * int> =
       let! body = response.Content.ReadAsByteArrayAsync()
       return body, headers, code
     with
-    | e -> return Errors.throw $"Internal HTTP-stack exception: {e.Message}"
+    | e -> return Exception.raiseCode $"Internal HTTP-stack exception: {e.Message}"
 
   }
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
@@ -47,18 +47,11 @@ let getV0 (url : string) : Task<byte []> =
       let code = int response.StatusCode
       let! body = response.Content.ReadAsByteArrayAsync()
       if code < 200 || code >= 300 then
-        return
-          Exception.raiseKnownIssue
-            $"Bad HTTP response ({code}) in call to {url}"
-            [ "url", url; "code", code; "body", UTF8.ofBytesWithReplacement body ]
+        return Errors.throw $"Bad HTTP response ({code}) in call to {url}"
       else
         return body
     with
-    | e ->
-      return
-        Exception.raiseKnownIssue
-          $"Internal HTTP-stack exception: {e.Message}"
-          [ "url", url ]
+    | e -> return Errors.throw $"Internal HTTP-stack exception: {e.Message}"
   }
 
 /// Replaces legacy HttpClientv1. Returns bytes, headers, and status code, and throws
@@ -72,18 +65,11 @@ let getV1 (url : string) : Task<byte [] * List<string * string> * int> =
       let headers = response.Headers |> HttpHeaders.fromAspNetHeaders
       let! body = response.Content.ReadAsByteArrayAsync()
       if code < 200 || code >= 300 then
-        return
-          Exception.raiseKnownIssue
-            $"Bad HTTP response ({code}) in call to {url}"
-            [ "url", url; "code", code; "body", UTF8.ofBytesWithReplacement body ]
+        return Errors.throw $"Bad HTTP response ({code}) in call to {url}"
       else
         return body, headers, code
     with
-    | e ->
-      return
-        Exception.raiseKnownIssue
-          $"Internal HTTP-stack exception: {e.Message}"
-          [ "url", url ]
+    | e -> return Errors.throw $"Internal HTTP-stack exception: {e.Message}"
   }
 
 /// Replaces legacy HttpClientv2. Returns bytes, headers, and status code, and throws
@@ -98,11 +84,8 @@ let getV2 (url : string) : Task<byte [] * List<string * string> * int> =
       let! body = response.Content.ReadAsByteArrayAsync()
       return body, headers, code
     with
-    | e ->
-      return
-        Exception.raiseKnownIssue
-          $"Internal HTTP-stack exception: {e.Message}"
-          [ "url", url ]
+    | e -> return Errors.throw $"Internal HTTP-stack exception: {e.Message}"
+
   }
 
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
@@ -48,7 +48,7 @@ let getV0 (url : string) : Task<byte []> =
       let! body = response.Content.ReadAsByteArrayAsync()
       if code < 200 || code >= 300 then
         return
-          Exception.raiseLibrary
+          Exception.raiseKnownIssue
             $"Bad HTTP response ({code}) in call to {url}"
             [ "url", url; "code", code; "body", UTF8.ofBytesWithReplacement body ]
       else
@@ -56,7 +56,7 @@ let getV0 (url : string) : Task<byte []> =
     with
     | e ->
       return
-        Exception.raiseLibrary
+        Exception.raiseKnownIssue
           $"Internal HTTP-stack exception: {e.Message}"
           [ "url", url ]
   }
@@ -73,7 +73,7 @@ let getV1 (url : string) : Task<byte [] * List<string * string> * int> =
       let! body = response.Content.ReadAsByteArrayAsync()
       if code < 200 || code >= 300 then
         return
-          Exception.raiseLibrary
+          Exception.raiseKnownIssue
             $"Bad HTTP response ({code}) in call to {url}"
             [ "url", url; "code", code; "body", UTF8.ofBytesWithReplacement body ]
       else
@@ -81,7 +81,7 @@ let getV1 (url : string) : Task<byte [] * List<string * string> * int> =
     with
     | e ->
       return
-        Exception.raiseLibrary
+        Exception.raiseKnownIssue
           $"Internal HTTP-stack exception: {e.Message}"
           [ "url", url ]
   }
@@ -100,7 +100,7 @@ let getV2 (url : string) : Task<byte [] * List<string * string> * int> =
     with
     | e ->
       return
-        Exception.raiseLibrary
+        Exception.raiseKnownIssue
           $"Internal HTTP-stack exception: {e.Message}"
           [ "url", url ]
   }

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -182,7 +182,7 @@ let userIDForUserName (username : UserName.T) : Task<UserID> =
   |> Sql.executeRowOptionAsync (fun read -> read.uuid "id")
   |> Task.map (function
     | Some v -> v
-    | None -> Exception.raiseDeveloper "User not found")
+    | None -> Exception.raiseGrandUser "User not found")
 
 let usernameForUserID (userID : UserID) : Task<Option<UserName.T>> =
   Sql.query

--- a/fsharp-backend/src/LibBackend/SqlCompiler.fs
+++ b/fsharp-backend/src/LibBackend/SqlCompiler.fs
@@ -19,8 +19,10 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 module RuntimeTypesAst = LibExecution.RuntimeTypesAst
 module Errors = LibExecution.Errors
 
-let error (str : string) : 'a =
-  raise (Errors.StdlibException(Errors.DBQueryException str))
+let errorTemplate =
+  "You're using our new experimental Datastore query compiler. It compiles your lambdas into optimized (and partially indexed) Datastore queries, which should be reasonably faster.\n\nUnfortunately, we hit a snag while compiling your lambda. We only support a subset of Dark's functionality, but will be expanding it in the future.\n\nSome Dark code is not supported in DB::query lambdas for now, and some of it won't be supported because it's an odd thing to do in a datastore query. If you think your operation should be supported, let us know in #general.\n\nError: "
+
+let error (str : string) : 'a = Exception.raiseCode (errorTemplate + str)
 
 let error2 (msg : string) (str : string) : 'a = error $"{msg}: {str}"
 

--- a/fsharp-backend/src/LibBackend/SqlCompiler.fs
+++ b/fsharp-backend/src/LibBackend/SqlCompiler.fs
@@ -19,7 +19,8 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 module RuntimeTypesAst = LibExecution.RuntimeTypesAst
 module Errors = LibExecution.Errors
 
-let error (str : string) : 'a = raise (Errors.DBQueryException str)
+let error (str : string) : 'a =
+  raise (Errors.StdlibException(Errors.DBQueryException str))
 
 let error2 (msg : string) (str : string) : 'a = error $"{msg}: {str}"
 
@@ -44,7 +45,7 @@ let dvalToSql (dval : Dval) : SqlValue =
   match dval with
   | DError _
   | DIncomplete _
-  | DErrorRail _ -> raise (LibExecution.Errors.FakeValFoundInQuery dval)
+  | DErrorRail _ -> Errors.foundFakeDval dval
   | DObj _
   | DList _
   | DHttpResponse _
@@ -79,7 +80,7 @@ let typecheck (name : string) (actualType : DType) (expectedType : DType) : unit
 // TODO: support character. And maybe lists and bytes.
 // Probably something can be done with options and results.
 let typecheckDval (name : string) (dval : Dval) (expectedType : DType) : unit =
-  if Dval.isFake dval then raise (Errors.FakeValFoundInQuery dval)
+  if Dval.isFake dval then Errors.foundFakeDval dval
   typecheck name (Dval.toType dval) expectedType
 
 let escapeFieldname (str : string) : string =

--- a/fsharp-backend/src/LibBackend/SqlCompiler.fs
+++ b/fsharp-backend/src/LibBackend/SqlCompiler.fs
@@ -19,6 +19,7 @@ module DvalReprExternal = LibExecution.DvalReprExternal
 module RuntimeTypesAst = LibExecution.RuntimeTypesAst
 module Errors = LibExecution.Errors
 
+// CLEANUP mention Slack explicitly. Maybe even try to get a clickable URL into this.
 let errorTemplate =
   "You're using our new experimental Datastore query compiler. It compiles your lambdas into optimized (and partially indexed) Datastore queries, which should be reasonably faster.\n\nUnfortunately, we hit a snag while compiling your lambda. We only support a subset of Dark's functionality, but will be expanding it in the future.\n\nSome Dark code is not supported in DB::query lambdas for now, and some of it won't be supported because it's an odd thing to do in a datastore query. If you think your operation should be supported, let us know in #general.\n\nError: "
 

--- a/fsharp-backend/src/LibBackend/UserDB.fs
+++ b/fsharp-backend/src/LibBackend/UserDB.fs
@@ -117,7 +117,9 @@ and typeCheck (db : RT.DB.T) (obj : RT.DvalMap) : RT.DvalMap =
         | RT.TRecord _, RT.DObj _ -> value
         | _, RT.DNull -> value // allow nulls for now
         | expectedType, valueOfActualType ->
-          Errors.throw (Errors.typeErrorMsg key expectedType valueOfActualType))
+          Exception.raiseCode (
+            Errors.typeErrorMsg key expectedType valueOfActualType
+          ))
       obj
   else
     let missingKeys = Set.difference tipeKeys objKeys
@@ -135,11 +137,11 @@ and typeCheck (db : RT.DB.T) (obj : RT.DvalMap) : RT.DvalMap =
       + "]"
 
     match (Set.isEmpty missingKeys, Set.isEmpty extraKeys) with
-    | false, false -> Errors.throw $"{missingMsg} & {extraMsg}"
-    | false, true -> Errors.throw missingMsg
-    | true, false -> Errors.throw extraMsg
+    | false, false -> Exception.raiseCode $"{missingMsg} & {extraMsg}"
+    | false, true -> Exception.raiseCode missingMsg
+    | true, false -> Exception.raiseCode extraMsg
     | true, true ->
-      Errors.throw
+      Exception.raiseCode
         "Type checker error! Deduced expected and actual did not unify, but could not find any examples!"
 
 

--- a/fsharp-backend/src/LibExecution/DvalReprExternal.fs
+++ b/fsharp-backend/src/LibExecution/DvalReprExternal.fs
@@ -513,7 +513,7 @@ let unsafeOfUnknownJsonV0 str : Dval =
     use document = parseJson str
     convert document.RootElement
   with
-  | _ -> Exception.raiseCode "Invalid json"
+  | _ -> Exception.raiseGrandUser "Invalid json"
 
 
 // When receiving unknown json from the user, or via a HTTP API, attempt to

--- a/fsharp-backend/src/LibExecution/DvalReprExternal.fs
+++ b/fsharp-backend/src/LibExecution/DvalReprExternal.fs
@@ -450,10 +450,11 @@ let unsafeOfUnknownJsonV0 str : Dval =
         headers
         |> List.map (function
           | JList [ JString k; JString v ] -> (k, v)
-          | _ -> Exception.raiseCode "Invalid DHttpResponse headers")
+          | h ->
+            Exception.raiseInternal "Invalid DHttpResponse headers" [ "headers", h ])
 
       Response(code, headers, dv)
-    | _ -> Exception.raiseCode "Invalid response json"
+    | _ -> Exception.raiseInternal "Invalid response json" [ "json", j ]
 
 
   let rec convert json =
@@ -506,7 +507,7 @@ let unsafeOfUnknownJsonV0 str : Dval =
           ("values", JList [ dv ]) ] -> DResult(Error(convert dv))
       | _ -> fields |> List.map (fun (k, v) -> (k, convert v)) |> Map.ofList |> DObj
     | JUndefined
-    | _ -> Exception.raiseCode "Invalid type in json"
+    | _ -> Exception.raiseInternal "Invalid type in json" [ "json", json ]
 
   try
     use document = parseJson str

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -698,7 +698,7 @@ and execFn
                       // information, so best not to show it to the user. If we'd
                       // like to show it to the user, we should catch it and give
                       // them a known safe error.
-                      Dval.errSStr sourceID e.Message
+                      Dval.errSStr sourceID Exception.unknownErrorMessage
               }
             // there's no point storing data we'll never ask for
             if fn.previewable <> Pure then

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -770,15 +770,11 @@ and handleException
   let context : Metadata =
     [ "fn", fnDesc; "args", argList; "callerID", callerID; "isInPipe", isInPipe ]
   match e with
-  | Errors.StdlibException err ->
-    match err with
-    | Errors.DBQueryException msg ->
-      Dval.errStr (Errors.queryCompilerErrorTemplate + msg)
-    | Errors.StringError msg -> Dval.errSStr source msg
-    | Errors.IncorrectArgs -> Errors.incorrectArgsToDError source fn argList
-    | Errors.FakeDvalFound dv ->
-      state.notify state "fakedval found" (context @ [ "dval", dv ])
-      dv
+  | Errors.IncorrectArgs -> Errors.incorrectArgsToDError source fn argList
+  | Errors.FakeDvalFound dv ->
+    state.notify state "fakedval found" (context @ [ "dval", dv ])
+    dv
+  | :? CodeException as e -> Dval.errSStr source e.Message
   | e ->
     // CLEANUP could we show the user the execution id here?
     state.reportException state context e

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -188,7 +188,7 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
 
       let! conditionResult =
         // under no circumstances should this cause code to fail
-        task {
+        uply {
           try
             return! eval state st cond
           with
@@ -667,7 +667,7 @@ and execFn
             | None -> return DIncomplete sourceID
           else
             let! result =
-              task {
+              uply {
                 try
                   return! f (state, arglist)
                 with

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -798,12 +798,21 @@ and handleException
   | Errors.StdlibException (Errors.FakeDvalFound dv) ->
     state.notify state "fakedval found" [ "dval", dv ]
     dv
-  | :? DeveloperException as e ->
+  | :? KnownIssueException ->
     state.notify
       state
-      $"DevException against {fnDesc}"
-      [ "context", "An exception was caught in fncall"
-        "fn", fnDesc
+      $"KnownIssue triggered calling {FQFnName.toString fnDesc}"
+      [ "fn", fnDesc
+        "args", arglist
+        "callerID", id
+        "isInPipe", isInPipe
+        "error", e.Message ]
+    Dval.errSStr sourceID (Exception.toDeveloperMessage e)
+  | :? DeveloperException ->
+    state.notify
+      state
+      $"DeveloperException calling {FQFnName.toString fnDesc}"
+      [ "fn", fnDesc
         "args", arglist
         "callerID", id
         "isInPipe", isInPipe

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -687,7 +687,8 @@ and execFn
                         let context = (context @ [ "dval", dv ])
                         state.notify state "fakedval found" context
                       dv
-                    | :? CodeException as e ->
+                    | (:? CodeException
+                    | :? GrandUserException) as e ->
                       // There errors are created by us, within the libraries, so they are
                       // safe to show to users (but not grandusers)
                       Dval.errSStr sourceID e.Message

--- a/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
@@ -116,11 +116,11 @@ let fns : List<BuiltInFn> =
               Errors.throw (Errors.argumentWasnt "a string" "key" k)
             | (DIncomplete _
             | DErrorRail _
-            | DError _) as dv -> Errors.foundFakeDval (dv)
+            | DError _) as dv -> Errors.foundFakeDval dv
             | _ -> Errors.throw "All list items must be `[key, value]`"
 
           let result = List.fold Map.empty f l
-          Ply((DObj(result)))
+          Ply(DObj result)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
@@ -113,11 +113,11 @@ let fns : List<BuiltInFn> =
             match e with
             | DList [ DStr k; value ] -> Map.add k value acc
             | DList [ k; value ] ->
-              Errors.throw (Errors.argumentWasnt "a string" "key" k)
+              Exception.raiseCode (Errors.argumentWasnt "a string" "key" k)
             | (DIncomplete _
             | DErrorRail _
             | DError _) as dv -> Errors.foundFakeDval dv
-            | _ -> Errors.throw "All list items must be `[key, value]`"
+            | _ -> Exception.raiseCode "All list items must be `[key, value]`"
 
           let result = List.fold Map.empty f l
           Ply(DObj result)
@@ -147,8 +147,9 @@ let fns : List<BuiltInFn> =
               | DErrorRail _
               | DError _) as dv) -> Errors.foundFakeDval dv
             | Some _, DList [ k; _ ] ->
-              Errors.throw (Errors.argumentWasnt "a string" "key" k)
-            | Some _, _ -> Errors.throw "All list items must be `[key, value]`"
+              Exception.raiseCode (Errors.argumentWasnt "a string" "key" k)
+            | Some _, _ ->
+              Exception.raiseCode "All list items must be `[key, value]`"
             | None, _ -> None
 
           let result = List.fold (Some Map.empty) f l
@@ -309,7 +310,8 @@ let fns : List<BuiltInFn> =
                 | DIncomplete _ ->
                   incomplete.Value <- true
                   return false
-                | v -> return Errors.throw (Errors.expectedLambdaType "f" TBool v)
+                | v ->
+                  return Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
               }
 
             if incomplete.Value then
@@ -359,7 +361,8 @@ let fns : List<BuiltInFn> =
                   | (DIncomplete _ as e)
                   | (DError _ as e) -> return Error e
                   | other ->
-                    return Errors.throw (Errors.expectedLambdaType "f" TBool other)
+                    return
+                      Exception.raiseCode (Errors.expectedLambdaType "f" TBool other)
                 }
 
             let! filtered_result =
@@ -418,7 +421,9 @@ let fns : List<BuiltInFn> =
                     abortReason.Value <- Some dv
                     return None
                   | v ->
-                    Errors.throw (Errors.expectedLambdaType "f" (TOption varB) v)
+                    Exception.raiseCode (
+                      Errors.expectedLambdaType "f" (TOption varB) v
+                    )
 
                     return None
 

--- a/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
@@ -261,7 +261,10 @@ let fns : List<BuiltInFn> =
               (fun f ->
                 match f with
                 | DFloat ft -> ft
-                | t -> Errors.throw (Errors.argumentWasnt "a list of floats" "a" ldv))
+                | t ->
+                  Exception.raiseCode (
+                    Errors.argumentWasnt "a list of floats" "a" ldv
+                  ))
               l
 
           let sum = List.fold (fun acc elem -> acc + elem) 0.0 floats

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
@@ -49,7 +49,8 @@ let fns : List<BuiltInFn> =
             |> List.map (fun (k, v) ->
               match k, v with
               | k, DStr v -> k, v
-              | k, v -> Errors.throw (Errors.argumentWasnt "a string" "value" v))
+              | k, v ->
+                Exception.raiseCode (Errors.argumentWasnt "a string" "value" v))
 
           Ply(DHttpResponse(Response(code, pairs, dv)))
         | _ -> incorrectArgs ())
@@ -218,7 +219,7 @@ let fns : List<BuiltInFn> =
             | "expires", DInt i -> [ sprintf "%s=%s" x (string i) ]
             // Throw if there's not a good way to transform the k/v pair
             | _ ->
-              Errors.throw
+              Exception.raiseCode
                 $"Unknown set-cookie param: {x}: {DvalReprExternal.toDeveloperReprV0 y}")
           // Combine it into a set-cookie header
           |> List.concat
@@ -264,7 +265,7 @@ let fns : List<BuiltInFn> =
             | "expires", DInt i -> [ sprintf "%s=%s" x (string i) ]
             // Throw if there's not a good way to transform the k/v pair
             | _ ->
-              Errors.throw
+              Exception.raiseCode
                 $"Unknown set-cookie param: {x}: {DvalReprExternal.toDeveloperReprV0 y}")
           // Combine it into a set-cookie header
           |> List.concat
@@ -315,7 +316,7 @@ let fns : List<BuiltInFn> =
               (match v with
                | DBool b -> if b then (key :: acc) else acc
                | _ ->
-                 Errors.throw (
+                 Exception.raiseCode (
                    Errors.argumentWasnt "`true` or `false`" "Secure or HttpOnly" v
                  ))
             // key=data set-cookie params
@@ -324,7 +325,7 @@ let fns : List<BuiltInFn> =
               (match v with
                | DStr str -> (sprintf "%s=%s" key str :: acc)
                | _ ->
-                 Errors.throw (
+                 Exception.raiseCode (
                    Errors.argumentWasnt "a string" "`Path` or `Domain`" v
                  ))
             | "samesite", v ->
@@ -334,14 +335,14 @@ let fns : List<BuiltInFn> =
                  ->
                  (sprintf "%s=%s" key str :: acc)
                | _ ->
-                 Errors.throw (
+                 Exception.raiseCode (
                    Errors.argumentWasnt "`Strict`, `Lax`, or `None`" "SameSite" v
                  ))
             | "max-age", v ->
               (match v with
                | DInt i -> (sprintf "%s=%s" key (string i) :: acc)
                | _ ->
-                 Errors.throw (
+                 Exception.raiseCode (
                    Errors.argumentWasnt "a `Int` representing seconds" "Max-Age" v
                  ))
             | "expires", v ->
@@ -353,10 +354,10 @@ let fns : List<BuiltInFn> =
                    key
                    (dt.ToString("ddd, dd MMM yyyy HH':'mm':'ss 'GMT'"))
                   :: acc)
-               | _ -> Errors.throw (Errors.argumentWasnt "a date" "Expires" v))
+               | _ -> Exception.raiseCode (Errors.argumentWasnt "a date" "Expires" v))
             // Error if the set-cookie parameter is invalid
             | _ ->
-              Errors.throw (
+              Exception.raiseCode (
                 $"Keys must be `Expires`, `Max-Age`, `Domain`, `Path`, `Secure`, `HttpOnly`, and/or `SameSite`, but one of the keys was {key}"
               )
 

--- a/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
@@ -326,7 +326,8 @@ let fns : List<BuiltInFn> =
               (fun i ->
                 match i with
                 | DInt it -> it
-                | t -> Errors.throw (Errors.argumentWasnt "a list of ints" "a" ldv))
+                | t ->
+                  Exception.raiseCode (Errors.argumentWasnt "a list of ints" "a" ldv))
               l
 
           let sum = List.fold (fun acc elem -> acc + elem) 0L ints

--- a/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
@@ -26,10 +26,12 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DStr json ] ->
-          (try
-            json |> DvalReprExternal.unsafeOfUnknownJsonV0 |> Ply
-           with
-           | _ -> Ply DNull)
+          uply {
+            try
+              return DvalReprExternal.unsafeOfUnknownJsonV0 json
+            with
+            | _ -> return DNull
+          }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -503,7 +503,7 @@ let fns : List<BuiltInFn> =
           let f acc i =
             match i with
             | DList l -> List.append acc l
-            | _ -> Errors.throw "Flattening non-lists"
+            | _ -> Exception.raiseCode "Flattening non-lists"
 
           List.fold f [] l |> DList |> Ply
         | _ -> incorrectArgs ())
@@ -671,7 +671,9 @@ let fns : List<BuiltInFn> =
               | DInt i when i = 1L || i = 0L || i = -1L -> return int i
               | _ ->
                 return
-                  Errors.throw (Errors.expectedLambdaValue "f" "-1, 0, 1" result)
+                  Exception.raiseCode (
+                    Errors.expectedLambdaValue "f" "-1, 0, 1" result
+                  )
             }
 
           uply {
@@ -681,8 +683,6 @@ let fns : List<BuiltInFn> =
               // CLEANUP: check fakevals
               return array |> Array.toList |> DList |> Ok |> DResult
             with
-            | Errors.StdlibException (Errors.StringError m) as e ->
-              return DResult(Error(DStr m))
             | e -> return DResult(Error(DStr e.Message))
           }
         | _ -> incorrectArgs ())
@@ -730,7 +730,8 @@ let fns : List<BuiltInFn> =
                 | DIncomplete _ ->
                   incomplete.Value <- true
                   return false
-                | v -> return Errors.throw (Errors.expectedLambdaType "f" TBool v)
+                | v ->
+                  return Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
               }
 
             if incomplete.Value then
@@ -776,7 +777,7 @@ let fns : List<BuiltInFn> =
     //                   incomplete := true
     //                   return false
     //               | v ->
-    //                   Errors.throw (Errors.expectedLambdaType TBool dv)
+    //                   Exception.raiseCode (Errors.expectedLambdaType TBool dv)
     //                   return false
     //             }
     //
@@ -821,7 +822,9 @@ let fns : List<BuiltInFn> =
                   | DErrorRail _) as dv ->
                     fakecf.Value <- Some dv
                     return false
-                  | v -> return Errors.throw (Errors.expectedLambdaType "f" TBool v)
+                  | v ->
+                    return
+                      Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
                 else
                   return false
               }
@@ -868,7 +871,9 @@ let fns : List<BuiltInFn> =
                   | DError _) as dv ->
                     abortReason.Value <- Some dv
                     return false
-                  | v -> return Errors.throw (Errors.expectedLambdaType "f" TBool v)
+                  | v ->
+                    return
+                      Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
                 else
                   return false
               }
@@ -920,7 +925,9 @@ let fns : List<BuiltInFn> =
                     return None
                   | v ->
                     return
-                      Errors.throw (Errors.expectedLambdaType "f" (TOption varB) v)
+                      Exception.raiseCode (
+                        Errors.expectedLambdaType "f" (TOption varB) v
+                      )
                 else
                   return None
               }
@@ -986,7 +993,8 @@ let fns : List<BuiltInFn> =
                       abortReason.Value <- Some dv
                       return []
                     | v ->
-                      return Errors.throw (Errors.expectedLambdaType "f" TBool v)
+                      return
+                        Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
                   else
                     return []
                 }
@@ -1054,7 +1062,8 @@ let fns : List<BuiltInFn> =
                       abortReason.Value <- Some dv
                       return []
                     | v ->
-                      return Errors.throw (Errors.expectedLambdaType "f" TBool v)
+                      return
+                        Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
                   else
                     return []
                 }
@@ -1313,7 +1322,7 @@ let fns : List<BuiltInFn> =
                 | nonList ->
                   $". It is of type {DvalReprExternal.prettyTypename v} instead of `List`"
 
-              Errors.throw (
+              Exception.raiseCode (
                 Errors.argumentWasnt "a list with exactly two values" "pairs" v
                 + errDetails
               )

--- a/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
@@ -118,7 +118,9 @@ let fns : List<BuiltInFn> =
               | DOption result -> return DOption result
               | other ->
                 return
-                  Errors.throw (Errors.expectedLambdaType "f" (TOption varB) other)
+                  Exception.raiseCode (
+                    Errors.expectedLambdaType "f" (TOption varB) other
+                  )
             | None -> return DOption None
           }
         | _ -> incorrectArgs ())

--- a/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
@@ -258,7 +258,7 @@ let fns : List<BuiltInFn> =
               | DResult result -> return (DResult result)
               | other ->
                 return
-                  Errors.throw (
+                  Exception.raiseCode (
                     Errors.expectedLambdaType "f" (TResult(varOk, varErr)) other
                   )
             | Error msg -> return DResult(Error msg)
@@ -290,7 +290,7 @@ let fns : List<BuiltInFn> =
               | DResult (Error result) -> return Dval.resultError result
               | other ->
                 return
-                  Errors.throw (
+                  Exception.raiseCode (
                     Errors.expectedLambdaType "f" (TResult(varOk, varErr)) other
                   )
             | Error msg -> return DResult(Error msg)

--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -87,7 +87,8 @@ let fns : List<BuiltInFn> =
                    List.map
                      (function
                      | DChar c -> c
-                     | dv -> Errors.throw (Errors.expectedLambdaType "f" TChar dv))
+                     | dv ->
+                       Exception.raiseCode (Errors.expectedLambdaType "f" TChar dv))
                      dvals
 
                  let str = String.concat "" chars
@@ -575,7 +576,7 @@ let fns : List<BuiltInFn> =
               (fun s ->
                 match s with
                 | DStr st -> st
-                | dv -> Errors.throw (Errors.argumentMemberWasnt TStr "l" dv))
+                | dv -> Exception.raiseCode (Errors.argumentMemberWasnt TStr "l" dv))
               l
 
           // CLEANUP: The OCaml doesn't normalize after concat, so we don't either
@@ -610,7 +611,7 @@ let fns : List<BuiltInFn> =
             l
             |> List.map (function
               | DChar c -> c
-              | dv -> Errors.throw (Errors.argumentMemberWasnt TChar "l" dv))
+              | dv -> Exception.raiseCode (Errors.argumentMemberWasnt TChar "l" dv))
             |> String.concat ""
           )
           |> Ply

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -56,6 +56,12 @@ type GrandUserException(message : string, inner : exn) =
   inherit System.Exception(message, inner)
   new(msg : string) = GrandUserException(msg, null)
 
+/// An error during code execution, which is the responsibility of the
+/// User/Developer. The message can be shown to the developer.
+type CodeException(message : string, inner : exn) =
+  inherit System.Exception(message, inner)
+  new(msg : string) = CodeException(msg, null)
+
 /// An editor exception is one which is caused by an invalid action on the part of
 /// the Dark editor, such as an Redo or rename that isn't allowed.  We are
 /// interested in these, as the editor should have caught this on the client and not
@@ -117,6 +123,20 @@ module Exception =
     callExceptionCallback e
     raise e
 
+  let raiseCode (msg : string) =
+    let e = CodeException(msg)
+    callExceptionCallback e
+    raise e
+
+  let unwrapOptionCode (msg : string) (o : Option<'a>) : 'a =
+    match o with
+    | Some v -> v
+    | None -> raiseCode msg
+
+  let unwrapResultCode (r : Result<'a, string>) : 'a =
+    match r with
+    | Ok v -> v
+    | Error msg -> raiseCode msg
 
   let raiseEditor (msg : string) =
     let e = EditorException(msg)

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -50,7 +50,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DStr errorString ] ->
-          let msg = LibExecution.Errors.queryCompilerErrorTemplate + errorString
+          let msg = LibBackend.SqlCompiler.errorTemplate + errorString
           Ply(DError(SourceNone, msg))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -115,7 +115,6 @@ let testToPrettyRequestJson =
       try
         BackendOnlyStdLib.LibHttpClient0.PrettyRequestJson.toPrettyRequestJson v
       with
-      | Errors.StdlibException (Errors.StringError msg) -> msg
       | e -> e.Message)
     [ RT.DErrorRail(RT.DResult(Ok RT.DNull)),
       "Unknown Err: (Failure \"printing an unprintable value:<result>\")"

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -14,6 +14,7 @@ module RT = LibExecution.RuntimeTypes
 
 module DvalReprExternal = LibExecution.DvalReprExternal
 module DvalReprInternal = LibExecution.DvalReprInternal
+module Errors = LibExecution.Errors
 
 
 let testInternalRoundtrippableDoesntCareAboutOrder =
@@ -114,6 +115,7 @@ let testToPrettyRequestJson =
       try
         BackendOnlyStdLib.LibHttpClient0.PrettyRequestJson.toPrettyRequestJson v
       with
+      | Errors.StdlibException (Errors.StringError msg) -> msg
       | e -> e.Message)
     [ RT.DErrorRail(RT.DResult(Ok RT.DNull)),
       "Unknown Err: (Failure \"printing an unprintable value:<result>\")"

--- a/fsharp-backend/tests/Tests/EventQueue.Tests.fs
+++ b/fsharp-backend/tests/Tests/EventQueue.Tests.fs
@@ -55,7 +55,7 @@ let testEventQueueRoundtrip =
       let traceID =
         eventIDs
         |> List.head
-        |> Exception.unwrapOptionInternal "ADDMESSAGE" []
+        |> Exception.unwrapOptionInternal "missing eventID" []
         |> Tuple2.first
 
       let! functionResults = TFR.load meta.id traceID h.tlid
@@ -132,7 +132,7 @@ let testGetWorkerSchedulesForCanvas =
     let check (name : string) (value : EQ.WorkerStates.State) =
       let actual =
         Map.get name result
-        |> Exception.unwrapOptionInternal "ADDMESSAGE" []
+        |> Exception.unwrapOptionInternal "missing workerstate" [ "name", name ]
         |> string
       let expected = string value
       Expect.equal actual expected ($"{name} is {expected}")

--- a/fsharp-backend/tests/Tests/Execution.Tests.fs
+++ b/fsharp-backend/tests/Tests/Execution.Tests.fs
@@ -279,11 +279,11 @@ let testFeatureFlagPreview : Test =
 
       return
         (Dictionary.get ffID results
-         |> Exception.unwrapOptionInternal "ADDMESSAGE" [],
+         |> Exception.unwrapOptionInternal "missing ffID" [ "ffid", ffID ],
          Dictionary.get oldID results
-         |> Exception.unwrapOptionInternal "ADDMESSAGE" [],
+         |> Exception.unwrapOptionInternal "missing oldID" [ "oldID", oldID ],
          Dictionary.get newID results
-         |> Exception.unwrapOptionInternal "ADDMESSAGE" [])
+         |> Exception.unwrapOptionInternal "missing newID" [ "newID", newID ])
     }
 
   // see notes in above `testIfPreview` regarding how these tests work

--- a/fsharp-backend/tests/Tests/HttpClient.Tests.fs
+++ b/fsharp-backend/tests/Tests/HttpClient.Tests.fs
@@ -281,7 +281,9 @@ let runTestHandler (ctx : HttpContext) : Task<HttpContext> =
         testCase.result.status
         |> String.split " "
         |> List.getAt 1
-        |> Exception.unwrapOptionInternal "ADDMESSAGE" []
+        |> Exception.unwrapOptionInternal
+             "invalid status code"
+             [ "status", testCase.result.status ]
         |> int
       List.iter
         (fun (k, v) ->

--- a/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
@@ -12,6 +12,7 @@ open LibExecution.RuntimeTypes
 
 module C = LibBackend.SqlCompiler
 module S = TestUtils.RTShortcuts
+module Errors = LibExecution.Errors
 
 let compile
   (symtable : DvalMap)
@@ -30,9 +31,8 @@ let compile
       let args = Map.ofList args
       return sql, args
     with
-    | LibExecution.Errors.DBQueryException msg as e ->
-      Exception.raiseInternal msg [ "paramName", paramName; "expr", expr ]
-      return ("", Map.empty)
+    | Errors.StdlibException (Errors.DBQueryException msg) as e ->
+      return Exception.raiseInternal msg [ "paramName", paramName; "expr", expr ]
   }
 
 let matchSql

--- a/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/fsharp-backend/tests/Tests/SqlCompiler.Tests.fs
@@ -31,8 +31,9 @@ let compile
       let args = Map.ofList args
       return sql, args
     with
-    | Errors.StdlibException (Errors.DBQueryException msg) as e ->
-      return Exception.raiseInternal msg [ "paramName", paramName; "expr", expr ]
+    | e ->
+      return
+        Exception.raiseInternal e.Message [ "paramName", paramName; "expr", expr ]
   }
 
 let matchSql

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -58,7 +58,7 @@ let main (args : string array) : int =
       // context or it may hang
       let exitCode = runTestsWithCLIArgs [] args (testList "tests" tests)
 
-      Prelude.NonBlockingConsole.wait () // flush stdout
+      NonBlockingConsole.wait () // flush stdout
       cancelationTokenSource.Cancel()
       bwdServerTestsTask.Wait()
       httpClientTestsTask.Wait()
@@ -69,4 +69,5 @@ let main (args : string array) : int =
     let metadata = Exception.toMetadata e
     LibService.Rollbar.printMetadata metadata
     print e.StackTrace
+    NonBlockingConsole.wait () // flush stdout
     1

--- a/fsharp-backend/tests/Tests/TypeChecker.Tests.fs
+++ b/fsharp-backend/tests/Tests/TypeChecker.Tests.fs
@@ -30,11 +30,12 @@ let testBasicTypecheckWorks : Test =
     let args = Map.ofList args
 
     let fn =
+      let fn = fn |> PTParser.FQFnName.parse |> PT2RT.FQFnName.toRT
       libraries
       |> Lazy.force
       |> fun l -> l.stdlib
-      |> Map.get (PTParser.FQFnName.parse fn |> PT2RT.FQFnName.toRT)
-      |> Exception.unwrapOptionInternal "ADDMESSAGE" []
+      |> Map.get fn
+      |> Exception.unwrapOptionInternal "missing library function" [ "fn", fn ]
       |> RT.builtInFnToFn
 
     TypeChecker.checkFunctionCall Map.empty fn args

--- a/fsharp-backend/tests/Tests/Undo.Tests.fs
+++ b/fsharp-backend/tests/Tests/Undo.Tests.fs
@@ -53,7 +53,8 @@ let testUndo : Test =
         let c = Canvas.fromOplist meta [] ops
         let! state = executionStateFor meta Map.empty Map.empty
         let h =
-          Map.get tlid c.handlers |> Exception.unwrapOptionInternal "ADDMESSAGE" []
+          Map.get tlid c.handlers
+          |> Exception.unwrapOptionInternal "missing handler" [ "tlid", tlid ]
         return! Exe.executeExpr state Map.empty (PT2RT.Expr.toRT h.ast)
       }
 

--- a/fsharp-backend/tests/httpclienttestfiles/v0/response-json-invalid-fsharp.test
+++ b/fsharp-backend/tests/httpclienttestfiles/v0/response-json-invalid-fsharp.test
@@ -19,4 +19,4 @@ Content-Length: LENGTH
 
 [test]
 // FSHARPONLY
-HttpClient.get_v0 "http://URL" "" {} {} = Test.typeError "Unknown error"
+HttpClient.get_v0 "http://URL" "" {} {} = Test.typeError "Invalid json"

--- a/fsharp-backend/tests/httpclienttestfiles/v1/response-json-invalid-fsharp.test
+++ b/fsharp-backend/tests/httpclienttestfiles/v1/response-json-invalid-fsharp.test
@@ -19,4 +19,4 @@ Content-Length: LENGTH
 
 [test]
 // FSHARPONLY
-HttpClient.get_v1 "http://URL" {} {} = Test.typeError "Unknown error"
+HttpClient.get_v1 "http://URL" {} {} = Test.typeError "Invalid json"

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -343,7 +343,7 @@ Error (Test.errorRailValue_v0 Nothing) = Test.errorRailValue_v0 Nothing
 // ---------------------------
 [tests.darkinternal]
 DarkInternal.checkAccess_v0 = Test.typeError_v0 "User executed an internal function but isn't an admin: test" // OCAMLONLY
-DarkInternal.checkAccess_v0 = Test.typeError_v0 "User executed an internal function but isn't an admin" // FSHARPONLY
+DarkInternal.checkAccess_v0 = Test.typeError_v0 "Unknown error" // FSHARPONLY
 
 // ---------------------------
 // Equality
@@ -458,7 +458,7 @@ functionWhichDoesntExist 6 = blank
 stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
 stringFn "str1" "str2" = Test.typeError "stringFn has 1 parameters, but here was called with 2 arguments."
 throwsException 6 = Test.typeError "Unknown Err: (Failure \"throwsException message\")" // OCAMLONLY
-throwsException 6 = Test.typeError "throwsException message" // FSHARPONLY
+throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY
 
 // ---------------------------
 // Package manager function calls
@@ -520,4 +520,4 @@ Test.Test.Test.returnsOptionNothingOnErrorRail 6 = Nothing
 Test.Test.Test.stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
 Test.Test.Test.stringFn "str1" "str2" = Test.typeError "test/test/Test::stringFn_v0 has 1 parameters, but here was called with 2 arguments."
 Test.Test.Test.throwsException 6 = Test.typeError "Unknown Err: (Failure \"package throwsException message\")" // OCAMLONLY
-Test.Test.Test.throwsException 6 = Test.typeError "package throwsException message" // FSHARPONLY
+Test.Test.Test.throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -343,7 +343,7 @@ Error (Test.errorRailValue_v0 Nothing) = Test.errorRailValue_v0 Nothing
 // ---------------------------
 [tests.darkinternal]
 DarkInternal.checkAccess_v0 = Test.typeError_v0 "User executed an internal function but isn't an admin: test" // OCAMLONLY
-DarkInternal.checkAccess_v0 = Test.typeError_v0 "Unknown error" // FSHARPONLY
+DarkInternal.checkAccess_v0 = Test.typeError_v0 "User executed an internal function but isn't an admin" // FSHARPONLY
 
 // ---------------------------
 // Equality
@@ -432,7 +432,7 @@ Test.errorRailValue_v0 Nothing
 List.head_v1_ster [5]
 
 [fn.throwsException v:any]
-Test.raiseException "message"
+Test.raiseException "throwsException message"
 
 [tests.valid function calls]
 stringFn "string" = "string appended string"
@@ -457,8 +457,8 @@ returnsOptionNothingOnErrorRail 6 = Nothing
 functionWhichDoesntExist 6 = blank
 stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
 stringFn "str1" "str2" = Test.typeError "stringFn has 1 parameters, but here was called with 2 arguments."
-throwsException 6 = Test.typeError "Unknown Err: (Failure message)" // OCAMLONLY
-throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY
+throwsException 6 = Test.typeError "Unknown Err: (Failure \"throwsException message\")" // OCAMLONLY
+throwsException 6 = Test.typeError "throwsException message" // FSHARPONLY
 
 // ---------------------------
 // Package manager function calls
@@ -495,7 +495,7 @@ Test.errorRailValue_v0 Nothing
 List.head_v1_ster [5]
 
 [packagefn.throwsException v:any]
-Test.raiseException "message"
+Test.raiseException "package throwsException message"
 
 [tests.valid package function calls]
 Test.Test.Test.stringFn "string" = "string appended string"
@@ -519,5 +519,5 @@ Test.Test.Test.returnsOptionNothingOnErrorRail 6 = Nothing
 [tests.invalid function calls]
 Test.Test.Test.stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
 Test.Test.Test.stringFn "str1" "str2" = Test.typeError "test/test/Test::stringFn_v0 has 1 parameters, but here was called with 2 arguments."
-Test.Test.Test.throwsException 6 = Test.typeError "Unknown Err: (Failure message)" // OCAMLONLY
-Test.Test.Test.throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY
+Test.Test.Test.throwsException 6 = Test.typeError "Unknown Err: (Failure \"package throwsException message\")" // OCAMLONLY
+Test.Test.Test.throwsException 6 = Test.typeError "package throwsException message" // FSHARPONLY


### PR DESCRIPTION
## What is the problem/goal being addressed?

We have a lot of exceptions that all attempted to do some portion of the job of exceptions in stdlib:
1. DeveloperException
2. LibraryException
3. Errors.StdlibException.IncorrectArgs
4. Errors.StdlibException.StringError
5. Errors.StdlibException.FakeDvalFound
6. Errors.DBQueryException
7. Errors.FakeValFoundInQuery

Ostensibly they all had a different reason for existing, but the reasons were confused and didn't hold a lot of weight. For example, LibraryExceptions were for "known exceptions", but any exception we throw ourselves is by definition known, so how does this differ from the other exceptions we created for the purpose.

## What is the solution to this problem?

I tried combining them into a single exception, but there are actually 2 different use cases:
- raising a string exception (1,2,4,6)
- exiting from the current function execution. This has the subcategories of
  - return to the callsite to create a good error message (3)
  - we have found a fakeDval and wish to return it instead of continuing (5,7)

For the second use case, it was impossible to craft a good `.Message`. This broke a lot of tests in ways that were very difficult to fix, which was what indicated that these did in fact need to be separate. 

I added `CodeException`, and put all string exceptions into it.

I broke out `FakeDvalFoundException` (combining it with `FakeValFoundInQuery`)

I also broke out IncorrectArgs into its own exception


