### PR TITLE
Fix: include packageFns in OCamlInterop executeExpr

### DIFF
--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -347,10 +347,11 @@ let executeExpr
   let args =
     symtable |> Map.toList |> List.map (fun (k, dv) -> (k, Convert.rt2ocamlDval dv))
 
-  let dbs, fns = [], []
+  let dbs, fns, packageFns = [], [], []
 
-  let str =
-    Json.OCamlCompatible.serialize ((ownerID, canvasID, program, args, dbs, fns))
+  let tuple = (ownerID, canvasID, program, args, dbs, fns, packageFns)
+
+  let str = Json.OCamlCompatible.serialize tuple
 
   task {
     try


### PR DESCRIPTION
Before merging #3643, I missed that the OCaml legacy backend is now expecting an extra (`packageFns`) item in the tuple that's sent over as part of expr evaluations.

`OCamlInterop.execute` had been adjusted (outside of that PR) for the change, but not `executeExpr`, which was used (only) by `executePureFunctions` fuzztests, causing those to fail without this change.