### PR TITLE
Tidy test utility around expected exception count checking

### DIFF
--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -294,14 +294,7 @@ let executionStateFor
             // possibly too many to annotate, so we assume that errors are intended
             // to be reported anytime the result is a DError.
             let exceptionCountMatches =
-              if RT.Dval.isDError result then
-                // This should be greater than zero, but there's confusion between
-                // different kinds of exceptions. Once we untangle handleException
-                // this can be re-enabled.
-                // FSTODO tc.exceptionReports.Length > 0
-                true
-              else
-                tc.exceptionReports.Length = tc.expectedExceptionCount
+              tc.exceptionReports.Length = tc.expectedExceptionCount
 
             if not exceptionCountMatches then
               List.iter

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -343,7 +343,7 @@ Error (Test.errorRailValue_v0 Nothing) = Test.errorRailValue_v0 Nothing
 // ---------------------------
 [tests.darkinternal]
 DarkInternal.checkAccess_v0 = Test.typeError_v0 "User executed an internal function but isn't an admin: test" // OCAMLONLY
-DarkInternal.checkAccess_v0 = Test.typeError_v0 "Unknown error" // FSHARPONLY
+DarkInternal.checkAccess_v0 = Test.typeError_v0 "Unknown error" // FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1
 
 // ---------------------------
 // Equality
@@ -458,7 +458,7 @@ functionWhichDoesntExist 6 = blank
 stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
 stringFn "str1" "str2" = Test.typeError "stringFn has 1 parameters, but here was called with 2 arguments."
 throwsException 6 = Test.typeError "Unknown Err: (Failure \"throwsException message\")" // OCAMLONLY
-throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY
+throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1
 
 // ---------------------------
 // Package manager function calls
@@ -520,4 +520,4 @@ Test.Test.Test.returnsOptionNothingOnErrorRail 6 = Nothing
 Test.Test.Test.stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
 Test.Test.Test.stringFn "str1" "str2" = Test.typeError "test/test/Test::stringFn_v0 has 1 parameters, but here was called with 2 arguments."
 Test.Test.Test.throwsException 6 = Test.typeError "Unknown Err: (Failure \"package throwsException message\")" // OCAMLONLY
-Test.Test.Test.throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY
+Test.Test.Test.throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1


### PR DESCRIPTION
Following the advice provided [here](https://github.com/darklang/dark/pull/3654/files#r844069178), three tests failed locally as a result.

I've added `EXPECTED_EXCEPTION_COUNT: 1` to those tests, and they're now passing. Is that the expected change?