### PR TITLE
Increase the timeout

### DIFF
--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -42,8 +42,10 @@ let client =
      // In .NET 6, this is fine without having to do anything about socket exhaustion or
      // DNS.
      let client = new System.Net.Http.HttpClient(handler, disposeHandler = false)
-     // We prefer that this raise than hang
-     client.Timeout <- System.TimeSpan.FromSeconds 5
+     // Since this is now only used for saving as part of AddOps, we have have a
+     // longer window. People were running up against the 5 second limit, so make
+     // this 10s. But the real solution is to remove OCamlInterop.
+     client.Timeout <- System.TimeSpan.FromSeconds 10
      client)
 
 /// Make a request to the legacy OCaml server


### PR DESCRIPTION
We're seeing some timeouts here. We really can't help it if these take a long time, so let's just extend the timeout and hope that we can ride it out until we remove OCamlInterop.