### PR TITLE
Use proxy for libstaticassets

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
@@ -16,13 +16,14 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = Errors.incorrectArgs
 
-open System.IO
-open System.IO.Compression
 open System.Net.Http
 
 let httpClient =
   let socketHandler : HttpMessageHandler =
     let handler = new SocketsHttpHandler()
+
+    handler.UseProxy <- true
+    handler.Proxy <- System.Net.WebProxy(LibBackend.Config.httpclientProxyUrl, false)
 
     // Cookies shouldn't be necessary
     handler.UseCookies <- false


### PR DESCRIPTION
Use the tunnel2 proxy, same as LibHttpClient.

The proxy is firewalled so that it can't touch internal stuff. This makes sense for LibHttpClient as we don't want customers poking around. However, potentially people could try to access stuff via malformed StaticAssets URLs, so this provides some extra protection.