### PR TITLE
Handle sql errors better

### DIFF
--- a/fsharp-backend/src/LibBackend/SqlCompiler.fs
+++ b/fsharp-backend/src/LibBackend/SqlCompiler.fs
@@ -246,16 +246,17 @@ let rec lambdaToSql
     let name = randomString 10
     $"(@{name})", [ name, Sql.string v ]
   | EFieldAccess (_, EVariable (_, v), fieldname) when v = paramName ->
-    let typ =
+    let dbFieldType =
       match Map.get fieldname dbFields with
       | Some v -> v
       | None -> error2 "The datastore does not have a field named" fieldname
 
-    if expectedType <> TNull (* Fields are allowed be null *) then
-      typecheck fieldname typ expectedType
+    if expectedType <> TNull // Fields are allowed to be null
+    then
+      typecheck fieldname dbFieldType expectedType
 
     let fieldname = escapeFieldname fieldname
-    let typename = typeToSqlType typ
+    let typename = typeToSqlType dbFieldType
 
     (match expectedType with
      | TDate ->

--- a/fsharp-backend/src/LibBackend/SqlCompiler.fs
+++ b/fsharp-backend/src/LibBackend/SqlCompiler.fs
@@ -21,7 +21,7 @@ module Errors = LibExecution.Errors
 
 // CLEANUP mention Slack explicitly. Maybe even try to get a clickable URL into this.
 let errorTemplate =
-  "You're using our new experimental Datastore query compiler. It compiles your lambdas into optimized (and partially indexed) Datastore queries, which should be reasonably faster.\n\nUnfortunately, we hit a snag while compiling your lambda. We only support a subset of Dark's functionality, but will be expanding it in the future.\n\nSome Dark code is not supported in DB::query lambdas for now, and some of it won't be supported because it's an odd thing to do in a datastore query. If you think your operation should be supported, let us know in #general.\n\nError: "
+  "You're using our new experimental Datastore query compiler. It compiles your lambdas into optimized (and partially indexed) Datastore queries, which should be reasonably faster.\n\nUnfortunately, we hit a snag while compiling your lambda. We only support a subset of Dark's functionality, but will be expanding it in the future.\n\nSome Dark code is not supported in DB::query lambdas for now, and some of it won't be supported because it's an odd thing to do in a datastore query. If you think your operation should be supported, let us know in #general.\n\n  Error: "
 
 let error (str : string) : 'a = Exception.raiseCode (errorTemplate + str)
 

--- a/fsharp-backend/tests/testfiles/db.tests
+++ b/fsharp-backend/tests/testfiles/db.tests
@@ -554,6 +554,7 @@ friendsError (fun p -> "; select * from users;" = p.name ) = []
 friendsError (fun p -> p.height == "string") =
   Test.sqlError "A type error occurred at run-time"
 
+// CLEANUP we should catch this. See note about SqlBinOp in SqlCompiler.fs
 [test.db invalid type comparison FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1] with DB Person
 friendsError (fun p -> p.height == "string") =
   Test.sqlError "An error occurred while querying the Datastore"

--- a/fsharp-backend/tests/testfiles/db.tests
+++ b/fsharp-backend/tests/testfiles/db.tests
@@ -478,6 +478,10 @@ DB.update_v0 "a" X = Test.typeError_v0 "DB::update_v0 was removed from Dark"
 [fn.rossDOB x:any]
 (Date.parse_v1_ster  "1967-05-12T00:00:00Z")
 
+[fn.friendsError lambda:any]
+(let _ = prepFriends null in
+ DB.query_v4 Person lambda)
+
 [fn.friends lambda:any]
 (let _ = prepFriends null in
  ((DB.query_v4 Person lambda)
@@ -531,16 +535,20 @@ DB.update_v0 "a" X = Test.typeError_v0 "DB::update_v0 was removed from Dark"
 (friends (fun p -> let obj = { field1 = { field2 = 42 } } in p.height > obj.field1.field2 )) =
   [" Chandler "; "Rachel"; "Ross" ]
 
-[test.db lambda doesnt return a bool] with DB Person
-(friends (fun p -> "x")) =
-  Test.typeError_v0 "Fn called with an error as an argument"
+[test.db lambda doesnt return a bool OCAMLONLY] with DB Person
+(friendsError (fun p -> "x")) =
+  Test.sqlError "Incorrect type in `\"x\"`, expected Bool but got a Str in \"x\""
+
+[test.db lambda doesnt return a bool FSHARPONLY] with DB Person
+(friendsError (fun p -> "x")) =
+  Test.sqlError "Incorrect type in string \"x\", expected Bool, but got a Str"
 
 [test.db bad variable name] with DB Person
-(friends (fun p -> let x = 32 in true && p.height > y)) =
-  Test.typeError_v0 "Fn called with an error as an argument"
+(friendsError (fun p -> let x = 32 in true && p.height > y)) =
+  Test.sqlError "This variable is not defined: y"
 
 [test.db sql injection] with DB Person
-(friends (fun p -> "; select * from users;" = p.name )) = []
+(friendsError (fun p -> "; select * from users;" = p.name )) = []
 
 // ------------
 // Test compiled functions

--- a/fsharp-backend/tests/testfiles/db.tests
+++ b/fsharp-backend/tests/testfiles/db.tests
@@ -532,23 +532,23 @@ DB.update_v0 "a" X = Test.typeError_v0 "DB::update_v0 was removed from Dark"
   [" Chandler "; "Rachel"; "Ross" ]
 
 [test.db nested fieldaccess] with DB Person
-(friends (fun p -> let obj = { field1 = { field2 = 42 } } in p.height > obj.field1.field2 )) =
+friends (fun p -> let obj = { field1 = { field2 = 42 } } in p.height > obj.field1.field2 ) =
   [" Chandler "; "Rachel"; "Ross" ]
 
 [test.db lambda doesnt return a bool OCAMLONLY] with DB Person
-(friendsError (fun p -> "x")) =
+friendsError (fun p -> "x") =
   Test.sqlError "Incorrect type in `\"x\"`, expected Bool but got a Str in \"x\""
 
 [test.db lambda doesnt return a bool FSHARPONLY] with DB Person
-(friendsError (fun p -> "x")) =
+friendsError (fun p -> "x") =
   Test.sqlError "Incorrect type in string \"x\", expected Bool, but got a Str"
 
 [test.db bad variable name] with DB Person
-(friendsError (fun p -> let x = 32 in true && p.height > y)) =
+friendsError (fun p -> let x = 32 in true && p.height > y) =
   Test.sqlError "This variable is not defined: y"
 
 [test.db sql injection] with DB Person
-(friendsError (fun p -> "; select * from users;" = p.name )) = []
+friendsError (fun p -> "; select * from users;" = p.name ) = []
 
 // ------------
 // Test compiled functions

--- a/fsharp-backend/tests/testfiles/db.tests
+++ b/fsharp-backend/tests/testfiles/db.tests
@@ -550,6 +550,24 @@ friendsError (fun p -> let x = 32 in true && p.height > y) =
 [test.db sql injection] with DB Person
 friendsError (fun p -> "; select * from users;" = p.name ) = []
 
+[test.db invalid type comparison OCAMLONLY] with DB Person
+friendsError (fun p -> p.height == "string") =
+  Test.sqlError "A type error occurred at run-time"
+
+[test.db invalid type comparison FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1] with DB Person
+friendsError (fun p -> p.height == "string") =
+  Test.sqlError "An error occurred while querying the Datastore"
+
+// This test checks do we look up dates correctly when the function type is not a date
+[test.db invalid date comparison OCAMLONLY] with DB Person
+friendsError (fun p -> p.dob != Date.now_v0) =
+  Test.sqlError "A type error occurred at run-time"
+
+// This test checks do we look up dates correctly when the function type is not a date
+[test.db invalid date comparison FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1] with DB Person
+friendsError (fun p -> p.dob != Date.now_v0) =
+  Test.sqlError "An error occurred while querying the Datastore"
+
 // ------------
 // Test compiled functions
 // ------------


### PR DESCRIPTION
Partial fix for https://github.com/darklang/dark/issues/3699

There's an exception in rollbar that comes from the following code:

```
DB::query TableWithIntField \p -> p.intField = "string"
```

This is because for the `=` function we check the two arguments separately to see if they are the `TAny` type, which they are. In fact, we should check that both arguments are the **same** type.

However, this was also a bug in the old version, so I'm not fixing that. Instead, I'm fixing two related problems:
- we didn't catch the error in tests
- we raised an internal exception instead of showing a semi-nice error to users

This catches the exception and tidies up how we do tests a little in db.tests to be able to see the error.

We don't need to do the rest of #3699 for the migration to be complete (in fact, it's bad to do so, as the two versions will have slightly different behaviour).

While I was here, I also marked a few QueryFunctions that were not previous marked.