### PR TITLE
Handle partials in pipes

### DIFF
--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -314,8 +314,8 @@ let runDarkHandler
       // and leave it to middleware to say what it wants to do with that
       let searchMethod = if method = "HEAD" then "GET" else method
 
-      /// Canvas to process request against,
-      /// with enough loaded to handle this request
+      // Canvas to process request against, with enough loaded to handle this
+      // request
       let! canvas = Canvas.loadHttpHandlers meta requestPath searchMethod
 
       let url : string = ctx.Request.GetEncodedUrl() |> canonicalizeURL (isHttps ctx)

--- a/fsharp-backend/src/LibBackend/SqlCompiler.fs
+++ b/fsharp-backend/src/LibBackend/SqlCompiler.fs
@@ -416,9 +416,6 @@ let partiallyEvaluate
             | EConstructor (id, name, exprs) ->
               let! exprs = Ply.List.mapSequentially r exprs
               return EConstructor(id, name, exprs)
-            | EPartial (id, oldExpr) ->
-              let! oldExpr = r oldExpr
-              return EPartial(id, oldExpr)
             | EFeatureFlag (id, cond, casea, caseb) ->
               let! cond = r cond
               let! casea = r casea

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -52,7 +52,6 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
   uply {
     match e with
     | EBlank id -> return (incomplete id)
-    | EPartial (_, expr) -> return! eval state st expr
     | ELet (_id, lhs, rhs, body) ->
       let! rhs = eval state st rhs
 

--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -745,7 +745,6 @@ module Convert =
     | RT.ELet (id, lhs, rhs, body) -> ORT.ELet(id, lhs, r rhs, r body)
     | RT.EIf (id, cond, thenExpr, elseExpr) ->
       ORT.EIf(id, r cond, r thenExpr, r elseExpr)
-    | RT.EPartial (id, oldExpr) -> ORT.EPartial(id, "partial", r oldExpr)
     | RT.EList (id, exprs) -> ORT.EList(id, List.map r exprs)
     | RT.ERecord (id, pairs) -> ORT.ERecord(id, List.map (Tuple2.mapSecond r) pairs)
     | RT.EConstructor (id, name, exprs) ->

--- a/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -116,7 +116,7 @@ module Expr =
               )
             // If there's a hole, run the computation right through it as if it wasn't there
             | PT.EBlank _ -> prev
-            // Partials break
+            // We can ignore partials as we just want whatever is inside them
             | PT.EPartial (_, _, oldExpr) -> convert oldExpr
             // Here, the expression evaluates to an FnValue. This is for eg variables containing values
             | other ->

--- a/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -128,7 +128,8 @@ module Expr =
         toRT mexpr,
         List.map (Tuple2.mapFirst Pattern.toRT << Tuple2.mapSecond toRT) pairs
       )
-    | PT.EPipeTarget id -> Exception.raiseInternal "No EPipeTargets should remain" []
+    | PT.EPipeTarget id ->
+      Exception.raiseInternal "No EPipeTargets should remain" [ "id", id ]
     | PT.EFeatureFlag (id, name, cond, caseA, caseB) ->
       RT.EFeatureFlag(id, toRT cond, toRT caseA, toRT caseB)
 

--- a/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -78,9 +78,9 @@ module Expr =
     | PT.ELet (id, lhs, rhs, body) -> RT.ELet(id, lhs, toRT rhs, toRT body)
     | PT.EIf (id, cond, thenExpr, elseExpr) ->
       RT.EIf(id, toRT cond, toRT thenExpr, toRT elseExpr)
-    | PT.EPartial (id, _, oldExpr)
-    | PT.ERightPartial (id, _, oldExpr)
-    | PT.ELeftPartial (id, _, oldExpr) -> RT.EPartial(id, toRT oldExpr)
+    | PT.EPartial (_, _, oldExpr)
+    | PT.ERightPartial (_, _, oldExpr)
+    | PT.ELeftPartial (_, _, oldExpr) -> toRT oldExpr
     | PT.EList (id, exprs) -> RT.EList(id, List.map toRT exprs)
     | PT.ERecord (id, pairs) ->
       RT.ERecord(id, List.map (Tuple2.mapSecond toRT) pairs)

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -168,8 +168,6 @@ type Expr =
   /// This is a function call, the first expression is the value of the function.
   | EApply of id * Expr * List<Expr> * IsInPipe * SendToRail
 
-  | EPartial of id * Expr
-
   /// Reference a fully-qualified function name
   /// Since functions aren't real values in the symbol table, we look them up directly
   | EFQFnValue of id * FQFnName.T
@@ -406,7 +404,6 @@ module Expr =
     | EBlank id
     | ELet (id, _, _, _)
     | EIf (id, _, _, _)
-    | EPartial (id, _)
     | EApply (id, _, _, _, _)
     | EList (id, _)
     | ERecord (id, _)

--- a/fsharp-backend/src/LibExecution/RuntimeTypesAst.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypesAst.fs
@@ -34,7 +34,6 @@ let rec preTraversal (f : Expr -> Expr) (expr : Expr) : Expr =
   | ERecord (id, fields) ->
     ERecord(id, List.map (fun (name, expr) -> (name, r expr)) fields)
   | EConstructor (id, name, exprs) -> EConstructor(id, name, List.map r exprs)
-  | EPartial (id, oldExpr) -> EPartial(id, r oldExpr)
   | EFeatureFlag (id, cond, casea, caseb) ->
     EFeatureFlag(id, r cond, r casea, r caseb)
 
@@ -64,7 +63,6 @@ let rec postTraversal (f : Expr -> Expr) (expr : Expr) : Expr =
     | ERecord (id, fields) ->
       ERecord(id, List.map (fun (name, expr) -> (name, r expr)) fields)
     | EConstructor (id, name, exprs) -> EConstructor(id, name, List.map r exprs)
-    | EPartial (id, oldExpr) -> EPartial(id, r oldExpr)
     | EFeatureFlag (id, cond, casea, caseb) ->
       EFeatureFlag(id, r cond, r casea, r caseb)
 

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -59,8 +59,8 @@ let (|Placeholder|_|) (input : PT.Expr) =
 
 let nameOrBlank (v : string) : string = if v = "___" then "" else v
 
-let rec convertToExpr (ast : SynExpr) : PT.Expr =
-  let c = convertToExpr
+let rec convertToExpr' (ast : SynExpr) : PT.Expr =
+  let c = convertToExpr'
 
   let rec convertPattern (pat : SynPat) : PT.Pattern =
     let id = gid ()
@@ -374,6 +374,19 @@ let rec convertToExpr (ast : SynExpr) : PT.Expr =
   | SynExpr.FromParseError _ as expr ->
     Exception.raiseInternal "There was a parser error parsing" [ "expr", expr ]
   | expr -> Exception.raiseInternal "Unsupported expression" [ "ast", ast ]
+
+let convertToExpr e =
+  e
+  |> convertToExpr'
+  |> LibExecution.ProgramTypesAst.postTraversal (fun e ->
+    match e with
+    | PT.EFnCall (id, PT.FQFnName.User "partial", [ PT.EString (_, msg); arg ], _) ->
+      PT.EPartial(gid (), msg, arg)
+    | PT.EFnCall (id,
+                  PT.FQFnName.User "partial",
+                  [ PT.EPipeTarget _; PT.EString (_, msg); arg ],
+                  _) -> PT.EPartial(gid (), msg, arg)
+    | e -> e)
 
 let convertToTest (ast : SynExpr) : bool * PT.Expr * PT.Expr =
   // Split equality into actual vs expected in tests.

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -632,7 +632,6 @@ module Expect =
     | EConstructor (_, s, ts), EConstructor (_, s', ts') ->
       check path s s'
       eqList (s :: path) ts ts'
-    | EPartial (_, e), EPartial (_, e') -> eq ("partial" :: path) e e'
     | ELambda (_, vars, e), ELambda (_, vars', e') ->
       let path = ("lambda" :: path)
       eq path e e'
@@ -664,7 +663,6 @@ module Expect =
     | EFieldAccess _, _
     | EFeatureFlag _, _
     | EConstructor _, _
-    | EPartial _, _
     | ELambda _, _
     | EMatch _, _ -> check path actual expected
 

--- a/fsharp-backend/tests/testfiles/README.md
+++ b/fsharp-backend/tests/testfiles/README.md
@@ -27,6 +27,14 @@ The code is written using F#, which is very similar to Dark. It is parsed by the
   editor). You can send them to the errorRail by calling the function with the suffix
   `_ster`.
 
+- to get a blank, use the word `blank`
+
+- to get a partial, use `partial "message" innerExpr`
+
+- to produce results that are hard to otherwise create, you can add functions to
+  LibTest.fs. For example, `Test.nan_v0` produces a NaN float, and `Test.typeError`
+  produces a built-in error.
+
 # Test file format
 
 Test file format is as follows:
@@ -76,9 +84,3 @@ indicator)
 `[packagefn.name arg1:int arg2:str]` creates a function which is available to all
 subsequent tests. The following lines are part of the function body (until we hit
 another test indicator). Package functions call be called as `Test.Test.Test.myFn`
-
-# Test functions
-
-To produce results that are hard to otherwise create, you can add functions to
-LibTest.fs. For example, `Test.nan_v0` produces a NaN float, and `Test.typeError`
-produces a built-in error.

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -46,6 +46,7 @@ myvar = Test.typeError_v0 "There is no variable named: myvar"
 
 [tests.fncall]
 (5 + 3) = 8
+(5 + (partial "three" 3)) = 8
 Int.add_v0 5 3 = 8
 
 [tests.fqfnname]
@@ -54,7 +55,9 @@ toString 5 = "5"
 
 [tests.if]
 (if true then "correct" else 0) = "correct")
+(if true then partial "" "correct" else 0) = "correct")
 (if false then "" else "correct") = "correct")
+(if false then "" else partial "" "correct") = "correct")
 (if null then "" else "correct") = "correct")
 (if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "Expected boolean, got error")
 (if List.head_v1_ster [] then "" else "") = Test.errorRailValue_v0 Nothing)
@@ -64,6 +67,7 @@ toString 5 = "5"
 
 [tests.featureflag]
 flag "test" true "old" "new" = "new"
+flag "test" true "old" (partial "outer" "new") = "new"
 // everything else is old
 flag "test" false "old" "new" = "old"
 flag "" [true] "old" "new" = "old"
@@ -72,6 +76,7 @@ flag "test" 5 "old" "new" = "old"
 flag "test" blank "old" "new" = "old"
 flag "test" (Test.typeError_v0 "test") "old" "new" = "old"
 flag "test" (List.head_v1_ster []) "old" "new" = "old"
+flag "test" {x = true} "old" "new" = "old"
 flag "test" {x = true} "old" "new" = "old"
 flag "test" [true] "old" "new" = "old"
 flag "test" (Test.errorRailValue "error") "old" "new" = "old"
@@ -124,6 +129,14 @@ List.push_v0 [] (fun x -> -4.611686018e+18) = [(fun x -> -4.611686018e+18)]
  |> x
  |> (+) 3
  |> blank)) = 10
+
+[test.pipe through partial]
+// partials need to be removed when converting to RT, and we had issues with pipes
+(5
+|> (+) 1
+|> partial "outer" (fun x -> partial "inner" (if (x + 4) > 1 then x else (1 + x)))
+) = 6
+
 
 [tests.match]
 (match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"

--- a/scripts/production/gcp-psql
+++ b/scripts/production/gcp-psql
@@ -3,12 +3,7 @@
 
 set -euo pipefail
 
-# Despite the name, this launches either pgcli (interactive mode) or psql (allowing piped input) - see comment at the bottom
-
-# Don't call this for the user - if their kubectl context is set to another
-# cluster, this will break that.
-# ./scripts/production/gcp-authorize-kubectl
-
+./scripts/production/gcp-authorize-kubectl
 ./scripts/production/_gcp-proxy-db &
 # Make sure it has time to come up before we try to connect to it
 sleep 1s

--- a/scripts/production/gcp-psql
+++ b/scripts/production/gcp-psql
@@ -20,4 +20,4 @@ export PGPASSWORD
 # If we're in a terminal (not a pipe), use pgcli, which has nice interactive features like autocomplete of columns.
 # If we're in a pipe, then use psql (pgcli doesn't let you pipe in a query, psql does)
 echo "Connecting to port $PORT"
-psql -h localhost -p "${PORT}" --user=${PGUSERNAME} postgres $@
+psql -h localhost -p "${PORT}" --user=${PGUSERNAME} postgres "$@"

--- a/scripts/production/gcp-psql
+++ b/scripts/production/gcp-psql
@@ -20,4 +20,4 @@ export PGPASSWORD
 # If we're in a terminal (not a pipe), use pgcli, which has nice interactive features like autocomplete of columns.
 # If we're in a pipe, then use psql (pgcli doesn't let you pipe in a query, psql does)
 echo "Connecting to port $PORT"
-psql -h localhost -p "${PORT}" --user=${PGUSERNAME} postgres
+psql -h localhost -p "${PORT}" --user=${PGUSERNAME} postgres $@

--- a/scripts/production/get-production-handler
+++ b/scripts/production/get-production-handler
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Script to do fetch data from production postgres
+
+import psycopg2
+import subprocess
+import json
+import base64
+import sys
+
+# Get the username and password
+command = ["kubectl", "get", "secrets", "cloudsql-db-credentials", "-o", "json"]
+creds = subprocess.check_output(command)
+creds = json.loads(creds)["data"]
+username = base64.b64decode(creds["username"]).decode("utf-8")
+password = base64.b64decode(creds["password"]).decode("utf-8")
+
+canvas_name = sys.argv[1]
+tlid = sys.argv[2]
+local_canvas_name = sys.argv[3]
+
+print(
+    f"Fetching from {canvas_name}, tlid {tlid}, and slotting it into {local_canvas_name}"
+)
+
+# Connect to production DB
+prod = psycopg2.connect(dbname="postgres",
+                        port=2346,
+                        host="localhost",
+                        user=username,
+                        password=password,
+                        options='-c statement_timeout=2000')
+
+# Connect to local DB
+local = psycopg2.connect(dbname="devdb", port=5432, user="dark", password="dark")
+
+# Fetch the canvas ID
+pcur = prod.cursor()
+pcur.execute("SELECT id FROM canvases WHERE name=%s", (canvas_name, ))
+(prod_canvas_id) = pcur.fetchone()
+print("Got production id", prod_canvas_id)
+
+# Fetch the data from prod
+pcur = prod.cursor()
+pcur.execute(
+    "SELECT\
+      digest, tipe, name, module, modifier, data, rendered_oplist_cache,\
+      deleted, pos, oplist, oplist_cache\
+     FROM toplevel_oplists\
+     WHERE canvas_id=%s\
+       AND tlid=%s\
+     LIMIT 1", (prod_canvas_id, tlid))
+(digest, tipe, name, module, modifier, data, rendered_oplist_cache, deleted, pos,
+ oplist, oplist_cache) = pcur.fetchone()
+print("row", name, module, modifier, name, tipe, digest, len(data), pos, deleted)
+prod = None  # Kill it so we can't do anything by accident
+
+# Fetch the local ID
+lcur = local.cursor()
+lcur.execute("SELECT id, account_id FROM canvases WHERE name=%s",
+             (local_canvas_name, ))
+(local_canvas_id, local_account_id) = lcur.fetchone()
+print("Got local ids", local_canvas_id, local_account_id)
+
+lcur = local.cursor()
+lcur.execute("""
+  INSERT INTO toplevel_oplists
+    (canvas_id, account_id, tlid, digest, tipe, name, module, modifier, data,
+     rendered_oplist_cache, deleted, pos, oplist, oplist_cache)
+  VALUES
+    (%s, %s, %s, %s, %s, %s, %s, %s,%s, %s,%s, %s, %s, %s)
+  """,\
+  (local_canvas_id, local_account_id, tlid, digest, tipe, name, module, modifier, data,\
+    rendered_oplist_cache, deleted, json.dumps(pos), oplist, oplist_cache))
+local.commit()
+print("Done")


### PR DESCRIPTION
When switching new users over to the BwdServer today, we ran into some [exceptions](https://rollbar.com/darkops/darklang/items/3094/) which caused the handlers to break. The exceptions were 
"No EPipeTargets should remain".

The problem was on code such as:

```
something
|> partial "my" (myFn 5)
```

which is to say, piping into a partial.

When being converted to RuntimeTypes, the partial got in the way of the pattern matches when deconstructing the pipe.

My first attempts to solve this was to remove EPartial from RuntimeTypes. That was a good move imo, even though it didn't solve the problem.

It didn't solve the problem because the pattern matching was at the ProgramType level, so it didn't make a difference whether there was an RT.EPartial.

So to solve it we needed to unwrap the contents from the partial during the execution.

I added a number of features that helped me test this
- You can now write `partial "msg" expr` to get a partial, and I added a few tests for them.
- Also added a script to download toplevels from the production DB and insert them into the local DB.
- added a function to ExecHost that lets us test the conversion from PT to RT.


