### PR TITLE
Fix 500 due to bad StdLib function names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,10 @@ fsharp-backend/.paket/load/
 
 # Templates for these are in services/*/*.template.yaml
 services/apiserver-deployment/apiserver-deployment.yaml
+services/apiserver-deployment-darklang/apiserver-deployment.yaml
 services/bwd-deployment/bwd-deployment.yaml
 services/bwdserver-deployment/bwdserver-deployment.yaml
+services/bwdserver-deployment-darklang/bwdserver-deployment.yaml
 services/cron-deployment/cron-deployment.yaml
 services/cronchecker-deployment/cronchecker-deployment.yaml
 services/editor-deployment/editor-deployment.yaml

--- a/fsharp-backend/src/ApiServer/Functions.fs
+++ b/fsharp-backend/src/ApiServer/Functions.fs
@@ -79,7 +79,7 @@ let convertFn (fn : RT.BuiltInFn) : FunctionMetadata =
     description = fn.description
     return_type = typToApiString fn.returnType
     preview_safety = if fn.previewable = RT.Pure then Safe else Unsafe
-    infix = LibExecutionStdLib.StdLib.isInfixName fn.name
+    infix = LibExecutionStdLib.StdLib.isInfixName fn.name.module_ fn.name.function_
     deprecated = fn.deprecated <> RT.NotDeprecated
     is_supported_in_query = fn.sqlSpec.isQueryable () }
 

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -185,10 +185,12 @@ let main (args : string []) : int =
   with
   | e ->
     // Don't reraise or report as ExecHost is only run interactively
-    print e.Message
-    print (e |> Exception.toMetadata |> string)
-    print e.StackTrace
-    if e.InnerException <> null then
-      print e.InnerException.Message
-      print e.InnerException.StackTrace
+    let rec printException (e : exn) : unit =
+      print e.Message
+      printMetadata (Exception.toMetadata e)
+      print e.StackTrace
+      let inner = e.InnerException
+      if inner <> null then printException inner
+    printException e
+
     1

--- a/fsharp-backend/src/HttpMiddleware/ResponseV0.fs
+++ b/fsharp-backend/src/HttpMiddleware/ResponseV0.fs
@@ -9,6 +9,7 @@ type HttpResponse = { statusCode : int; body : byte array; headers : HttpHeaders
 module ContentType = HeadersV0.ContentType
 module MediaType = HeadersV0.MediaType
 module DvalReprExternal = LibExecution.DvalReprExternal
+module Telemetry = LibService.Telemetry
 
 
 let inferContentTypeHeader (dv : RT.Dval) : ContentType.T =
@@ -20,19 +21,50 @@ let inferContentTypeHeader (dv : RT.Dval) : ContentType.T =
 
 let toHttpResponse (result : RT.Dval) : HttpResponse =
   match result with
+  // ----------
+  // errors
+  // ----------
   | RT.DErrorRail (RT.DOption None)
   | RT.DErrorRail (RT.DResult (Error _)) ->
     // CLEANUP: result should become a 500 error
+    Telemetry.addTags [ "response-type", "Common ErrorRail response"
+                        "result", result ]
     { statusCode = 404
       headers = [ "Server", "darklang"; ContentType.textHeader ]
       body = UTF8.toBytes "Not found" }
+
   | RT.DErrorRail _ ->
+    Telemetry.addTags [ "response-type", "Unexpected ErrorRail response"
+                        "result", result ]
     { statusCode = 500
       headers = [ "Server", "darklang"; ContentType.textHeader ]
       body = UTF8.toBytes "Invalid conversion from errorrail" }
+
+  | RT.DIncomplete _ ->
+    Telemetry.addTags [ "response-type", "dincomplete"; "result", result ]
+    let message =
+      "Application error: the executed code was not complete. This error can be resolved by the application author by completing the incomplete code."
+    { statusCode = 500
+      headers = [ ContentType.textHeader ]
+      body = UTF8.toBytes message }
+
+  | RT.DError _ ->
+    Telemetry.addTags [ "response-type", "derror"; "result", result ]
+    let message =
+      "Application error: the executed program was invalid. This problem can be resolved by the application's author by resolving the invalid code (often a type error)."
+    { statusCode = 500
+      headers = [ ContentType.textHeader ]
+      body = UTF8.toBytes message }
+
+  // ----------
+  // expected user responses
+  // ----------
   | RT.DHttpResponse (RT.Redirect str) ->
+    Telemetry.addTags [ "response-type", "httpResponse redirect" ]
     { statusCode = int 302; headers = [ "Location", str ]; body = [||] }
+
   | RT.DHttpResponse (RT.Response (code, headers, body)) ->
+    Telemetry.addTags [ "response-type", "httpResponse response" ]
     let contentType = HeadersV0.getContentType headers
     // Potential extra header
     let inferredContentTypeHeader =
@@ -62,19 +94,9 @@ let toHttpResponse (result : RT.Dval) : HttpResponse =
     { statusCode = int code
       headers = headers @ inferredContentTypeHeader
       body = body }
-  | RT.DIncomplete _ ->
-    let message =
-      "Application error: the executed code was not complete. This error can be resolved by the application author by completing the incomplete code."
-    { statusCode = 500
-      headers = [ ContentType.textHeader ]
-      body = UTF8.toBytes message }
-  | RT.DError _ ->
-    let message =
-      "Application error: the executed program was invalid. This problem can be resolved by the application's author by resolving the invalid code (often a type error)."
-    { statusCode = 500
-      headers = [ ContentType.textHeader ]
-      body = UTF8.toBytes message }
+
   | dv ->
+    Telemetry.addTags [ "response-type", "user value" ]
     // for demonstrations sake, let's return 200 Okay when
     // no HTTP response object is returned
     { statusCode = 200

--- a/fsharp-backend/src/LibBackend/Canvas.fs
+++ b/fsharp-backend/src/LibBackend/Canvas.fs
@@ -360,6 +360,7 @@ let loadFrom
   : Task<T> =
   task {
     try
+      Telemetry.addTags [ "tlids", tlids; "loadAmount", loadAmount ]
       // CLEANUP: rename "rendered" and "cached" to be consistent
 
       // load

--- a/fsharp-backend/src/LibBinarySerialization/LibBinarySerialization.fsproj
+++ b/fsharp-backend/src/LibBinarySerialization/LibBinarySerialization.fsproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <ProjectReference Include="../Prelude/Prelude.fsproj" />
     <ProjectReference Include="../LibExecution/LibExecution.fsproj" />
+    <!-- CLEANUP LibExecutionStdLib is only included as a hack, should be removed when OCaml is gone -->
+    <ProjectReference Include="../LibExecutionStdLib/LibExecutionStdLib.fsproj" />
     <ProjectReference Include="../LibService/LibService.fsproj" />
   </ItemGroup>
   <ItemGroup>

--- a/fsharp-backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/fsharp-backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -67,8 +67,12 @@ module Expr =
     | PT.EFnCall (id, name, args, ster) ->
       ST.EFnCall(id, FQFnName.toST name, List.map toST args, SendToRail.toST ster)
     | PT.EBinOp (id, name, arg1, arg2, ster) ->
-      assertFn "is a binop" Set.contains name PTParser.FQFnName.infixFunctions
-      let name = ST.FQFnName.Stdlib { module_ = ""; function_ = name; version = 0 }
+      let module_ = Option.unwrap "" name.module_
+      let isInfix = LibExecutionStdLib.StdLib.isInfixName
+      assertFn2 "is a binop" isInfix module_ name.function_
+      let name =
+        ST.FQFnName.Stdlib
+          { module_ = module_; function_ = name.function_; version = 0 }
       ST.EBinOp(id, name, toST arg1, toST arg2, SendToRail.toST ster)
     | PT.ELambda (id, vars, body) -> ST.ELambda(id, vars, toST body)
     | PT.ELet (id, lhs, rhs, body) -> ST.ELet(id, lhs, toST rhs, toST body)

--- a/fsharp-backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/fsharp-backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -7,6 +7,7 @@ open Tablecloth
 // Used for conversion functions
 module ST = SerializedTypes
 module PT = LibExecution.ProgramTypes
+module PTParser = LibExecution.ProgramTypesParser
 
 module FQFnName =
   module PackageFnName =
@@ -66,7 +67,9 @@ module Expr =
     | PT.EFnCall (id, name, args, ster) ->
       ST.EFnCall(id, FQFnName.toST name, List.map toST args, SendToRail.toST ster)
     | PT.EBinOp (id, name, arg1, arg2, ster) ->
-      ST.EBinOp(id, FQFnName.toST name, toST arg1, toST arg2, SendToRail.toST ster)
+      assertFn "is a binop" Set.contains name PTParser.FQFnName.infixFunctions
+      let name = ST.FQFnName.Stdlib { module_ = ""; function_ = name; version = 0 }
+      ST.EBinOp(id, name, toST arg1, toST arg2, SendToRail.toST ster)
     | PT.ELambda (id, vars, body) -> ST.ELambda(id, vars, toST body)
     | PT.ELet (id, lhs, rhs, body) -> ST.ELet(id, lhs, toST rhs, toST body)
     | PT.EIf (id, cond, thenExpr, elseExpr) ->

--- a/fsharp-backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
+++ b/fsharp-backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
@@ -7,6 +7,7 @@ open Tablecloth
 // Used for conversion functions
 module ST = SerializedTypes
 module PT = LibExecution.ProgramTypes
+module PTParser = LibExecution.ProgramTypesParser
 
 module FQFnName =
   module PackageFnName =
@@ -24,6 +25,18 @@ module FQFnName =
   let toPT (fqfn : ST.FQFnName.T) : PT.FQFnName.T =
     match fqfn with
     | ST.FQFnName.User u -> PT.FQFnName.User u
+    // CLEANUP We accidentally parsed user functions with versions (that is, named
+    // like "myFunction_v2") into StdLib functions. Those names are saved in the
+    // serialized opcodes in the DB, and need to be migrated. However, we can
+    // identify them and convert them back to UserFunctions here
+    | ST.FQFnName.Stdlib fn when
+      fn.module_ = ""
+      && not (Set.contains fn.function_ PTParser.FQFnName.oneWordFunctions)
+      && not (Set.contains fn.function_ PTParser.FQFnName.infixFunctions)
+      ->
+      // It must have had a "_v0" or similar to get here, so always print the
+      // version, even if it's 0
+      PT.FQFnName.User($"{fn.function_}_v{fn.version}")
     | ST.FQFnName.Stdlib fn -> PT.FQFnName.Stdlib(StdlibFnName.toPT fn)
     | ST.FQFnName.Package p -> PT.FQFnName.Package(PackageFnName.toPT p)
 

--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -370,7 +370,10 @@ module Convert =
         ocamlSter2PT ster
       )
     | ORT.EBinOp (id, name, arg1, arg2, ster) ->
-      PT.EBinOp(id, PTParser.FQFnName.parse name, r arg1, r arg2, ocamlSter2PT ster)
+      assert_
+        "is a valid infix function"
+        (Set.contains name ProgramTypesParser.FQFnName.infixFunctions)
+      PT.EBinOp(id, name, r arg1, r arg2, ocamlSter2PT ster)
     | ORT.ELambda (id, vars, body) -> PT.ELambda(id, vars, r body)
     | ORT.ELet (id, lhs, rhs, body) -> PT.ELet(id, lhs, r rhs, r body)
     | ORT.EIf (id, cond, thenExpr, elseExpr) ->
@@ -689,16 +692,7 @@ module Convert =
 
       ORT.EFnCall(id, name, List.map r args, pt2ocamlSter ster)
     | PT.EBinOp (id, name, arg1, arg2, ster) ->
-      ORT.EBinOp(
-        id,
-        name
-        |> PT2RT.FQFnName.toRT
-        |> RT.FQFnName.toString
-        |> String.replace "_v0" "",
-        r arg1,
-        r arg2,
-        pt2ocamlSter ster
-      )
+      ORT.EBinOp(id, name, r arg1, r arg2, pt2ocamlSter ster)
     | PT.ELambda (id, vars, body) -> ORT.ELambda(id, vars, r body)
     | PT.ELet (id, lhs, rhs, body) -> ORT.ELet(id, lhs, r rhs, r body)
     | PT.EIf (id, cond, thenExpr, elseExpr) ->

--- a/fsharp-backend/src/LibExecution/ProgramTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypes.fs
@@ -14,6 +14,9 @@ module FQFnName =
   /// Standard Library Function Name
   type StdlibFnName = { module_ : string; function_ : string; version : int }
 
+  /// Standard Library Infix Function Name
+  type InfixStdlibFnName = string
+
   /// A UserFunction is a function written by a Developer in their canvas
   type UserFnName = string
 
@@ -25,6 +28,7 @@ module FQFnName =
       function_ : string
       version : int }
 
+  // We don't include InfixStdlibFnName here as that is used directly by EBinOp
   type T =
     | User of UserFnName
     | Stdlib of StdlibFnName
@@ -64,7 +68,7 @@ type Expr =
   | EBlank of id
   | ELet of id * string * Expr * Expr
   | EIf of id * Expr * Expr * Expr
-  | EBinOp of id * FQFnName.T * Expr * Expr * SendToRail
+  | EBinOp of id * FQFnName.InfixStdlibFnName * Expr * Expr * SendToRail
   | ELambda of id * List<id * string> * Expr
   | EFieldAccess of id * Expr * string
   | EVariable of id * string

--- a/fsharp-backend/src/LibExecution/ProgramTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypes.fs
@@ -15,7 +15,9 @@ module FQFnName =
   type StdlibFnName = { module_ : string; function_ : string; version : int }
 
   /// Standard Library Infix Function Name
-  type InfixStdlibFnName = string
+  // CLEANUP The module is only there for a few functions in the Date module, such as
+  // Date::<. Making these infix wasn't a great idea, and we should remove them.
+  type InfixStdlibFnName = { module_ : Option<string>; function_ : string }
 
   /// A UserFunction is a function written by a Developer in their canvas
   type UserFnName = string

--- a/fsharp-backend/src/LibExecution/ProgramTypesParser.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesParser.fs
@@ -38,6 +38,23 @@ module FQFnName =
           "emit_v0"
           "emit_v1" ]
 
+  let infixFunctions =
+    Set [ "+"
+          "-"
+          "*"
+          "/"
+          "++"
+          ">"
+          ">="
+          "<"
+          "<="
+          "%"
+          "^"
+          "=="
+          "!="
+          "&&"
+          "||" ]
+
   let namePat = @"^[a-z][a-z0-9_]*$"
   let modNamePat = @"^[A-Z][a-z0-9A-Z_]*$"
   let fnnamePat = @"^([a-z][a-z0-9A-Z_]*|[-+><&|!=^%/*]{1,2})$"
@@ -103,7 +120,6 @@ module FQFnName =
   let binopFqName (op : string) : PT.FQFnName.T = stdlibFqName "" op 0
 
   let parse (fnName : string) : PT.FQFnName.T =
-    // These should match up with the regexes in RuntimeTypes
     match fnName with
     | Regex "^([a-z][a-z0-9_]*)/([a-z][a-z0-9A-Z]*)/([A-Z][a-z0-9A-Z_]*)::([a-z][a-z0-9A-Z_]*)_v(\d+)$"
             [ owner; package; module_; name; version ] ->
@@ -117,8 +133,6 @@ module FQFnName =
             [ module_; name; version ] -> stdlibFqName module_ name (int version)
     | Regex "^([A-Z][a-z0-9A-Z_]*)::([a-z][a-z0-9A-Z_]*)$" [ module_; name ] ->
       stdlibFqName module_ name 0
-    | Regex "^([a-z][a-z0-9A-Z_]*)_v(\d+)$" [ name; version ] ->
-      stdlibFqName "" name (int version)
     | Regex "^Date::([-+><&|!=^%/*]{1,2})$" [ name ] -> stdlibFqName "Date" name 0
     | Regex "^([-+><&|!=^%/*]{1,2})$" [ name ] -> stdlibFqName "" name 0
     | Regex "^([-+><&|!=^%/*]{1,2})_v(\d+)$" [ name; version ] ->
@@ -136,7 +150,7 @@ module FQFnName =
     | Regex "^([a-z][a-z0-9A-Z_]*)$" [ name ] -> userFqName name
     // CLEANUP People have the most ridiculous names in userFunctions. One user had a
     // fully qualified url in there! Ridiculous. This needs a data cleanup before it
-    // can be removed.
+    // can be removed. Also some functions have "_v2" or similar in them.
     | Regex "^(.*)$" [ name ] -> userFqName name
     | _ -> Exception.raiseInternal "Bad format in function name" [ "fnName", fnName ]
 

--- a/fsharp-backend/src/LibExecution/ProgramTypesParser.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesParser.fs
@@ -38,23 +38,6 @@ module FQFnName =
           "emit_v0"
           "emit_v1" ]
 
-  let infixFunctions =
-    Set [ "+"
-          "-"
-          "*"
-          "/"
-          "++"
-          ">"
-          ">="
-          "<"
-          "<="
-          "%"
-          "^"
-          "=="
-          "!="
-          "&&"
-          "||" ]
-
   let namePat = @"^[a-z][a-z0-9_]*$"
   let modNamePat = @"^[A-Z][a-z0-9A-Z_]*$"
   let fnnamePat = @"^([a-z][a-z0-9A-Z_]*|[-+><&|!=^%/*]{1,2})$"
@@ -72,7 +55,7 @@ module FQFnName =
     assertRe "package must match" namePat package
     if module_ <> "" then assertRe "modName name must match" modNamePat module_
     assertRe "package function name must match" fnnamePat function_
-    assert_ "version can't be negative" (version >= 0)
+    assert_ "version can't be negative" [ "version", version ] (version >= 0)
 
     { owner = owner
       package = package
@@ -105,7 +88,7 @@ module FQFnName =
     : PT.FQFnName.StdlibFnName =
     if module_ <> "" then assertRe "modName name must match" modNamePat module_
     assertRe "stdlib function name must match" fnnamePat function_
-    assert_ "version can't be negative" (version >= 0)
+    assert_ "version can't be negative" [ "version", version ] (version >= 0)
     { module_ = module_; function_ = function_; version = version }
 
   let stdlibFqName

--- a/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -74,7 +74,11 @@ module Expr =
       )
     | PT.EBinOp (id, fnName, arg1, arg2, ster) ->
       let name =
-        PT.FQFnName.Stdlib({ module_ = ""; function_ = fnName; version = 0 })
+        PT.FQFnName.Stdlib(
+          { module_ = Option.unwrap "" fnName.module_
+            function_ = fnName.function_
+            version = 0 }
+        )
       toRT (PT.EFnCall(id, name, [ arg1; arg2 ], ster))
     | PT.ELambda (id, vars, body) -> RT.ELambda(id, vars, toRT body)
     | PT.ELet (id, lhs, rhs, body) -> RT.ELet(id, lhs, toRT rhs, toRT body)
@@ -110,7 +114,11 @@ module Expr =
             // TODO: support currying
             | PT.EBinOp (id, fnName, PT.EPipeTarget ptID, expr2, rail) ->
               let name =
-                PT.FQFnName.Stdlib({ module_ = ""; function_ = fnName; version = 0 })
+                PT.FQFnName.Stdlib(
+                  { module_ = Option.unwrap "" fnName.module_
+                    function_ = fnName.function_
+                    version = 0 }
+                )
               RT.EApply(
                 id,
                 RT.EFQFnValue(ptID, FQFnName.toRT name),

--- a/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -72,7 +72,9 @@ module Expr =
         RT.NotInPipe,
         SendToRail.toRT ster
       )
-    | PT.EBinOp (id, name, arg1, arg2, ster) ->
+    | PT.EBinOp (id, fnName, arg1, arg2, ster) ->
+      let name =
+        PT.FQFnName.Stdlib({ module_ = ""; function_ = fnName; version = 0 })
       toRT (PT.EFnCall(id, name, [ arg1; arg2 ], ster))
     | PT.ELambda (id, vars, body) -> RT.ELambda(id, vars, toRT body)
     | PT.ELet (id, lhs, rhs, body) -> RT.ELet(id, lhs, toRT rhs, toRT body)
@@ -106,7 +108,9 @@ module Expr =
                 SendToRail.toRT rail
               )
             // TODO: support currying
-            | PT.EBinOp (id, name, PT.EPipeTarget ptID, expr2, rail) ->
+            | PT.EBinOp (id, fnName, PT.EPipeTarget ptID, expr2, rail) ->
+              let name =
+                PT.FQFnName.Stdlib({ module_ = ""; function_ = fnName; version = 0 })
               RT.EApply(
                 id,
                 RT.EFQFnValue(ptID, FQFnName.toRT name),

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -70,7 +70,7 @@ module FQFnName =
     : StdlibFnName =
     if module_ <> "" then assertRe "modName name must match" modNamePat module_
     assertRe "stdlib function name must match" fnnamePat function_
-    assert_ "version can't be negative" (version >= 0)
+    assert_ "version can't be negative" [ "version", version ] (version >= 0)
     { module_ = module_; function_ = function_; version = version }
 
   module StdlibFnName =

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -78,7 +78,8 @@ let infixFnNames =
   infixFnMapping |> Map.toSeq |> Seq.map FSharpPlus.Operators.item2 |> Set
 
 // Is this the name of an infix function?
-let isInfixName (name : FQFnName.StdlibFnName) = infixFnNames.Contains name
+let isInfixName (module_ : string) (fnName : string) =
+  infixFnNames.Contains { module_ = module_; function_ = fnName; version = 0 }
 
 let infixFns : List<BuiltInFn> =
   let fns =

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -267,12 +267,6 @@ let sendError
   Rollbar.RollbarLocator.RollbarInstance.Error(message, custom)
   |> ignore<Rollbar.ILogger>
 
-let printMetadata (metadata : Metadata) =
-  try
-    List.iter (fun (k, v) -> print $"  {k}: {v}") metadata
-  with
-  | _ -> ()
-
 // If there is an exception while processing the exception
 let exceptionWhileProcessingException
   (original : exn)

--- a/fsharp-backend/src/LibService/Telemetry.fs
+++ b/fsharp-backend/src/LibService/Telemetry.fs
@@ -55,6 +55,7 @@ module Span =
   let root (name : string) : T =
     assert_
       "Telemetry must be initialized before creating root"
+      []
       (Internal._source <> null)
     // Deliberately created with no parent to make this a root
     // From https://github.com/open-telemetry/opentelemetry-dotnet/issues/984
@@ -80,6 +81,7 @@ module Span =
   let child (name : string) (parent : T) (tags : Metadata) : T =
     assert_
       "Telemetry must be initialized before creating root"
+      []
       (Internal._source <> null)
     let tags = tags |> List.map Tuple2.toKeyValuePair
     let parentId = if parent = null then null else parent.Id

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -330,6 +330,19 @@ let assertEq (msg : string) (expected : 'a) (actual : 'a) : unit =
       $"Assertion equality failure: {msg}"
       [ "expected", expected :> obj; "actual", actual :> obj ]
 
+let assertFn
+  (msg : string)
+  (fn : 'a -> 'b -> bool)
+  (expected : 'a)
+  (actual : 'b)
+  : unit =
+  if not (fn expected actual) then
+    Exception.raiseInternal
+      $"Function failure: {msg}"
+      [ "expected", expected :> obj; "actual", actual :> obj ]
+
+
+
 let assertRe (msg : string) (pattern : string) (input : string) : unit =
   let m = Regex.Match(input, pattern)
 

--- a/fsharp-backend/tests/DataTests/DataTests.fs
+++ b/fsharp-backend/tests/DataTests/DataTests.fs
@@ -54,7 +54,7 @@ module CD =
     | e ->
       print $"No test file found or test file error: {filename}"
       print e.Message
-      print (Exception.toMetadata e |> string)
+      printMetadata (Exception.toMetadata e)
       print e.StackTrace
       System.Environment.Exit(-1)
 
@@ -109,7 +109,7 @@ let catchException (failOnError : bool) (e : exn) =
   try
     if failOnError then print "exiting" else print "error found"
     print e.Message
-    print (Exception.toMetadata e |> string)
+    printMetadata (Exception.toMetadata e)
     if failOnError then
       CD.saveCheckpointData ()
       e.StackTrace

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -144,7 +144,8 @@ let rec convertToExpr' (ast : SynExpr) : PT.Expr =
       |> Exception.unwrapOptionInternal
            "can't find operation"
            [ "name", ident.idText ]
-    PT.EBinOp(id, op, placeholder, placeholder, PT.NoRail)
+    let fn : PT.FQFnName.InfixStdlibFnName = { module_ = None; function_ = op }
+    PT.EBinOp(id, fn, placeholder, placeholder, PT.NoRail)
   | SynExpr.Ident ident when ident.idText = "op_UnaryNegation" ->
     let name = PTParser.FQFnName.stdlibFqName "Int" "negate" 0
     PT.EFnCall(id, name, [], PT.NoRail)

--- a/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
+++ b/fsharp-backend/tests/TestUtils/FSharpToExpr.fs
@@ -144,8 +144,7 @@ let rec convertToExpr' (ast : SynExpr) : PT.Expr =
       |> Exception.unwrapOptionInternal
            "can't find operation"
            [ "name", ident.idText ]
-    let name = PTParser.FQFnName.stdlibFqName "" op 0
-    PT.EBinOp(id, name, placeholder, placeholder, PT.NoRail)
+    PT.EBinOp(id, op, placeholder, placeholder, PT.NoRail)
   | SynExpr.Ident ident when ident.idText = "op_UnaryNegation" ->
     let name = PTParser.FQFnName.stdlibFqName "Int" "negate" 0
     PT.EFnCall(id, name, [], PT.NoRail)

--- a/fsharp-backend/tests/Tests/BinarySerialization.Tests.fs
+++ b/fsharp-backend/tests/Tests/BinarySerialization.Tests.fs
@@ -68,14 +68,14 @@ let testExpr =
                           729246077UL,
                           PT.EBinOp(
                             94793109UL,
-                            "!=",
+                            { module_ = None; function_ = "!=" },
                             PT.EInteger(264400705UL, 5L),
                             PT.EInteger(335743639UL, 6L),
                             PT.NoRail
                           ),
                           PT.EBinOp(
                             775118986UL,
-                            "+",
+                            { module_ = None; function_ = "+" },
                             PT.EInteger(803876589UL, 5L),
                             PT.EInteger(219131014UL, 2L),
                             PT.NoRail
@@ -85,7 +85,7 @@ let testExpr =
                             [ (180359194UL, "y") ],
                             PT.EBinOp(
                               140609068UL,
-                              "+",
+                              { module_ = None; function_ = "+" },
                               PT.EInteger(450951790UL, 2L),
                               PT.EVariable(402203255UL, "y"),
                               PT.NoRail
@@ -94,10 +94,10 @@ let testExpr =
                         ),
                         PT.EBinOp(
                           265463935UL,
-                          "+",
+                          { module_ = None; function_ = "+" },
                           PT.EBinOp(
                             312092282UL,
-                            "+",
+                            { module_ = None; function_ = "+" },
                             PT.EFieldAccess(
                               974664608UL,
                               PT.EVariable(1002893266UL, "x"),
@@ -133,7 +133,7 @@ let testExpr =
                                PT.EInteger(555880460UL, 5L),
                                PT.EBinOp(
                                  1021880969UL,
-                                 "+",
+                                 { module_ = None; function_ = "+" },
                                  PT.EPipeTarget 936577032UL,
                                  PT.EInteger(962393769UL, 2L),
                                  PT.NoRail
@@ -187,7 +187,7 @@ let testExpr =
                               (PT.PVariable(722099983UL, "var"),
                                PT.EBinOp(
                                  275666765UL,
-                                 "+",
+                                 { module_ = None; function_ = "+" },
                                  PT.EInteger(739193732UL, 6L),
                                  PT.EVariable(880556562UL, "var"),
                                  PT.NoRail

--- a/fsharp-backend/tests/Tests/BinarySerialization.Tests.fs
+++ b/fsharp-backend/tests/Tests/BinarySerialization.Tests.fs
@@ -68,16 +68,14 @@ let testExpr =
                           729246077UL,
                           PT.EBinOp(
                             94793109UL,
-                            PT.FQFnName.Stdlib
-                              { module_ = ""; function_ = "!="; version = 0 },
+                            "!=",
                             PT.EInteger(264400705UL, 5L),
                             PT.EInteger(335743639UL, 6L),
                             PT.NoRail
                           ),
                           PT.EBinOp(
                             775118986UL,
-                            PT.FQFnName.Stdlib
-                              { module_ = ""; function_ = "+"; version = 0 },
+                            "+",
                             PT.EInteger(803876589UL, 5L),
                             PT.EInteger(219131014UL, 2L),
                             PT.NoRail
@@ -87,8 +85,7 @@ let testExpr =
                             [ (180359194UL, "y") ],
                             PT.EBinOp(
                               140609068UL,
-                              PT.FQFnName.Stdlib
-                                { module_ = ""; function_ = "+"; version = 0 },
+                              "+",
                               PT.EInteger(450951790UL, 2L),
                               PT.EVariable(402203255UL, "y"),
                               PT.NoRail
@@ -97,12 +94,10 @@ let testExpr =
                         ),
                         PT.EBinOp(
                           265463935UL,
-                          PT.FQFnName.Stdlib
-                            { module_ = ""; function_ = "+"; version = 0 },
+                          "+",
                           PT.EBinOp(
                             312092282UL,
-                            PT.FQFnName.Stdlib
-                              { module_ = ""; function_ = "+"; version = 0 },
+                            "+",
                             PT.EFieldAccess(
                               974664608UL,
                               PT.EVariable(1002893266UL, "x"),
@@ -138,8 +133,7 @@ let testExpr =
                                PT.EInteger(555880460UL, 5L),
                                PT.EBinOp(
                                  1021880969UL,
-                                 PT.FQFnName.Stdlib
-                                   { module_ = ""; function_ = "+"; version = 0 },
+                                 "+",
                                  PT.EPipeTarget 936577032UL,
                                  PT.EInteger(962393769UL, 2L),
                                  PT.NoRail
@@ -193,8 +187,7 @@ let testExpr =
                               (PT.PVariable(722099983UL, "var"),
                                PT.EBinOp(
                                  275666765UL,
-                                 PT.FQFnName.Stdlib
-                                   { module_ = ""; function_ = "+"; version = 0 },
+                                 "+",
                                  PT.EInteger(739193732UL, 6L),
                                  PT.EVariable(880556562UL, "var"),
                                  PT.NoRail

--- a/fsharp-backend/tests/Tests/FSharpToExpr.Tests.fs
+++ b/fsharp-backend/tests/Tests/FSharpToExpr.Tests.fs
@@ -43,8 +43,14 @@ let parserTests =
         "(5 + 3) == 8"
         (PT.EBinOp(
           id,
-          "==",
-          PT.EBinOp(id, "+", PT.EInteger(id, 5), PT.EInteger(id, 3), PT.NoRail),
+          { module_ = None; function_ = "==" },
+          PT.EBinOp(
+            id,
+            { module_ = None; function_ = "+" },
+            PT.EInteger(id, 5),
+            PT.EInteger(id, 3),
+            PT.NoRail
+          ),
           PT.EInteger(id, 8),
           PT.NoRail
         ))

--- a/fsharp-backend/tests/Tests/FSharpToExpr.Tests.fs
+++ b/fsharp-backend/tests/Tests/FSharpToExpr.Tests.fs
@@ -43,14 +43,8 @@ let parserTests =
         "(5 + 3) == 8"
         (PT.EBinOp(
           id,
-          PTParser.FQFnName.stdlibFqName "" "==" 0,
-          PT.EBinOp(
-            id,
-            PTParser.FQFnName.stdlibFqName "" "+" 0,
-            PT.EInteger(id, 5),
-            PT.EInteger(id, 3),
-            PT.NoRail
-          ),
+          "==",
+          PT.EBinOp(id, "+", PT.EInteger(id, 5), PT.EInteger(id, 3), PT.NoRail),
           PT.EInteger(id, 8),
           PT.NoRail
         ))

--- a/fsharp-backend/tests/Tests/LibExecution.Tests.fs
+++ b/fsharp-backend/tests/Tests/LibExecution.Tests.fs
@@ -207,6 +207,7 @@ let t
       with
       | e ->
         let metadata = Exception.toMetadata e
+        printMetadata metadata
         return
           Expect.equal
             (e.Message, metadata, e.StackTrace)

--- a/fsharp-backend/tests/Tests/OCamlInterop.Tests.fs
+++ b/fsharp-backend/tests/Tests/OCamlInterop.Tests.fs
@@ -21,14 +21,6 @@ let fuzzedTests =
       FuzzTests.OCamlInterop.yojsonExprRoundtrip
       [ ("norail was copied wrong",
          PT.EFnCall(0UL, PTParser.FQFnName.parse "b/k/C::r_v1", [], PT.NoRail))
-        ("",
-         PT.EBinOp(
-           0UL,
-           PTParser.FQFnName.parse "b/k/C::r_v1",
-           PT.ERecord(0UL, []),
-           PT.EVariable(0UL, ""),
-           PT.NoRail
-         ))
         ("constructors were compared wrong",
          PT.EMatch(
            0UL,

--- a/fsharp-backend/tests/Tests/Prelude.Tests.fs
+++ b/fsharp-backend/tests/Tests/Prelude.Tests.fs
@@ -156,8 +156,22 @@ let dateTests =
         [ "2000-10-01T16:01:01Z",
           NodaTime.Instant.ofUtcInstant (2000, 10, 1, 16, 1, 1) ] ]
 
+let assertions =
+  testList
+    "Assertions"
+    [ test "assertFn" { assertFn "msg" Tablecloth.String.includes "x" "xxx" }
+      test "assertEq" { assertEq "msg" "x" "x" }
+      test "assert_" { assert_ "_" true } ]
+
 
 let tests =
   testList
     "prelude"
-    [ canvasName; userName; asyncTests; mapTests; listTests; floatTests; dateTests ]
+    [ canvasName
+      userName
+      asyncTests
+      mapTests
+      listTests
+      floatTests
+      dateTests
+      assertions ]

--- a/fsharp-backend/tests/Tests/Prelude.Tests.fs
+++ b/fsharp-backend/tests/Tests/Prelude.Tests.fs
@@ -159,9 +159,11 @@ let dateTests =
 let assertions =
   testList
     "Assertions"
-    [ test "assertFn" { assertFn "msg" Tablecloth.String.includes "x" "xxx" }
+    [ test "assertFn" { assertFn "msg" System.Double.IsFinite 6.0 }
+      test "assertFn2" { assertFn2 "msg" Tablecloth.String.includes "x" "xxx" }
       test "assertEq" { assertEq "msg" "x" "x" }
-      test "assert_" { assert_ "_" true } ]
+      test "assertIn" { assertIn "msg" [ "x" ] "x" }
+      test "assert_" { assert_ "_" [] true } ]
 
 
 let tests =

--- a/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
@@ -8,6 +8,7 @@ module ST = LibBinarySerialization.SerializedTypes
 module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
 module ST2PT = LibBinarySerialization.SerializedTypesToProgramTypes
+module PT2ST = LibBinarySerialization.ProgramTypesToSerializedTypes
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module PTParser = LibExecution.ProgramTypesParser
 module S = TestUtils.RTShortcuts
@@ -159,16 +160,67 @@ let testInfixSerializedTypesToProgramTypes =
   testMany
     "serialized infix types to program types"
     ST2PT.Expr.toPT
-    [ ST.EBinOp(
+    [ (ST.EBinOp(
         8UL,
         ST.FQFnName.Stdlib { module_ = ""; function_ = "+"; version = 0 },
         ST.EInteger(9UL, 6),
         ST.EInteger(10UL, 6),
         ST.NoRail
-      ),
-      PT.EBinOp(8UL, "+", PT.EInteger(9UL, 6), PT.EInteger(10UL, 6), PT.NoRail) ]
+       ),
+       PT.EBinOp(
+         8UL,
+         { module_ = None; function_ = "+" },
+         PT.EInteger(9UL, 6),
+         PT.EInteger(10UL, 6),
+         PT.NoRail
+       ))
+      (ST.EBinOp(
+        8UL,
+        ST.FQFnName.Stdlib { module_ = "Date"; function_ = "<"; version = 0 },
+        ST.EInteger(9UL, 6),
+        ST.EInteger(10UL, 6),
+        ST.NoRail
+       ),
+       PT.EBinOp(
+         8UL,
+         { module_ = Some "Date"; function_ = "<" },
+         PT.EInteger(9UL, 6),
+         PT.EInteger(10UL, 6),
+         PT.NoRail
+       )) ]
 
-
+let testInfixProgramTypesToSerializedTypes =
+  testMany
+    "infix program types to serialized types"
+    PT2ST.Expr.toST
+    [ (PT.EBinOp(
+        8UL,
+        { module_ = None; function_ = "+" },
+        PT.EInteger(9UL, 6),
+        PT.EInteger(10UL, 6),
+        PT.NoRail
+       ),
+       ST.EBinOp(
+         8UL,
+         ST.FQFnName.Stdlib { module_ = ""; function_ = "+"; version = 0 },
+         ST.EInteger(9UL, 6),
+         ST.EInteger(10UL, 6),
+         ST.NoRail
+       ))
+      (PT.EBinOp(
+        8UL,
+        { module_ = Some "Date"; function_ = "<" },
+        PT.EInteger(9UL, 6),
+        PT.EInteger(10UL, 6),
+        PT.NoRail
+       ),
+       ST.EBinOp(
+         8UL,
+         ST.FQFnName.Stdlib { module_ = "Date"; function_ = "<"; version = 0 },
+         ST.EInteger(9UL, 6),
+         ST.EInteger(10UL, 6),
+         ST.NoRail
+       )) ]
 
 /// We have functions that were written as user functions, but accidentally
 /// converted to StdLibFns before being saved to the DB

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -64,8 +64,7 @@ let main (args : string array) : int =
   with
   | e ->
     print e.Message
-    let metadata = Exception.toMetadata e
-    LibService.Rollbar.printMetadata metadata
+    printMetadata (Exception.toMetadata e)
     print e.StackTrace
     NonBlockingConsole.wait () // flush stdout
     1

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -45,7 +45,8 @@ myvar = Test.typeError_v0 "There is no variable named: myvar"
 
 
 [tests.fncall]
-(5 + 3) = 8
+5 + 3 = 8
+"xx" ++ "yy" = "xxyy"
 (5 + (partial "three" 3)) = 8
 Int.add_v0 5 3 = 8
 
@@ -479,6 +480,13 @@ stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to s
 stringFn "str1" "str2" = Test.typeError "stringFn has 1 parameters, but here was called with 2 arguments."
 throwsException 6 = Test.typeError "Unknown Err: (Failure \"throwsException message\")" // OCAMLONLY
 throwsException 6 = Test.typeError "Unknown error" // FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1
+
+
+[fn.myUserFunction_v2 str:str]
+6
+
+[test.user function with _v2 in it]
+(myUserFunction_v2 "x") = 6
 
 // ---------------------------
 // Package manager function calls

--- a/scripts/production/_gcp-proxy-db
+++ b/scripts/production/_gcp-proxy-db
@@ -6,36 +6,19 @@ set -euo pipefail
 
 # 1) `cloud_sql_proxy` is a google thing
 # (https://cloud.google.com/sql/docs/postgres/sql-proxy) that takes your gcloud
-# creds and uses them to open a proxy to the specified db and exposes it using
-# either a tcp port or a unix socket. (We're using the latter, it's not exposed
-# to the docker host so no need to use a port.)
+# creds and uses them to open a proxy to the specified db.
 #
-# 2) In theory we could block until this connects and then continue - perhaps
-# using `expect` - but in practice, the proxy is quick enough to launch that
-# this doesn't seem necessary
-#
-# 3) This does leave around a cloud_sql_proxy process per invoke of this script.
-# If that ends up being a problem, we could try reaping them periodically, or
-# perhaps if `ps | grep cloud_sql_proxy | wc -l` is greater than some threshold.
-#
-# 4) -verbose=false because we don't need to know about non-error'ing client
+# 2) -verbose=false because we don't need to know about non-error'ing client
 # connection open/close events
 
 PROJECT=balmy-ground-195100
 REGION=us-west1
-PROD_DB=dark-west
-
-echo "Connecting to production (port 2346)"
-DB="${PROD_DB}"
+DB=dark-west
 PORT=2346
-
-
 INSTANCE="${PROJECT}:${REGION}:${DB}"
 
-echo "Setting up proxy to ${INSTANCE}"
+echo "Setting up proxy to production: ${INSTANCE} (port ${PORT})"
 
 cloud_sql_proxy \
     -verbose=false \
     -instances "${INSTANCE}=tcp:${PORT}"
-
-

--- a/scripts/production/gcp-psql
+++ b/scripts/production/gcp-psql
@@ -3,13 +3,13 @@
 
 set -euo pipefail
 
+# Set up connection
 ./scripts/production/gcp-authorize-kubectl
-./scripts/production/_gcp-proxy-db &
-# Make sure it has time to come up before we try to connect to it
-sleep 1s
+./scripts/production/_gcp-proxy-db & # Start early
 
 PORT=2346
 
+# Get credentials from production
 SECRET=$(kubectl get secrets cloudsql-db-credentials -o json)
 
 PGUSERNAME=$(echo "${SECRET}" |  jq -r '.data.username' | base64 -d)
@@ -17,7 +17,17 @@ PGPASSWORD=$(echo "${SECRET}" |  jq -r '.data.password' | base64 -d)
 export PGUSERNAME
 export PGPASSWORD
 
-# If we're in a terminal (not a pipe), use pgcli, which has nice interactive features like autocomplete of columns.
-# If we're in a pipe, then use psql (pgcli doesn't let you pipe in a query, psql does)
-echo "Connecting to port $PORT"
+echo "Waiting for connection on port ${PORT}"
+until pg_isready -h localhost -p "${PORT}" --user=${PGUSERNAME}
+do
+  sleep 0.3;
+done
+
+# Ensure we always have statement timeout set. This can be checked with `show
+# statement_timeout;` and set to another value with something like `set
+# statement_timeout=2s;`
+PGOPTIONS="--statement-timeout=1s --lock-timeout=1s "
+export PGOPTIONS
+
+echo "Connecting to port ${PORT}"
 psql -h localhost -p "${PORT}" --user=${PGUSERNAME} postgres "$@"

--- a/scripts/run-exec-host
+++ b/scripts/run-exec-host
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+. ./scripts/devcontainer/_assert-in-container "$0" "$@"
+
+set -euo pipefail
+
+PUBLISHED=false
+
+for i in "$@"
+do
+  case "${i}" in
+    --published)
+    PUBLISHED=true
+    shift
+    ;;
+  esac
+done
+
+if [[ "$PUBLISHED" == "true" ]]; then
+  EXE="fsharp-backend/Build/out/ExecHost/Release/net6.0/linux-x64/publish/ExecHost"
+else
+  EXE="fsharp-backend/Build/out/ExecHost/Debug/net6.0/linux-x64/ExecHost"
+fi
+
+"${EXE}" "$@"

--- a/scripts/run-prodclone-exec-host
+++ b/scripts/run-prodclone-exec-host
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+. ./scripts/devcontainer/_assert-in-container "$0" "$@"
+
+set -euo pipefail
+
+PUBLISHED=false
+
+for i in "$@"
+do
+  case "${i}" in
+    --published)
+    PUBLISHED=true
+    shift
+    ;;
+  esac
+done
+
+if [[ "$PUBLISHED" == "true" ]]; then
+
+  EXE="fsharp-backend/Build/out/ExecHost/Release/net6.0/linux-x64/publish/ExecHost"
+else
+  EXE="fsharp-backend/Build/out/ExecHost/Debug/net6.0/linux-x64/ExecHost"
+fi
+
+DARK_CONFIG_TELEMETRY_EXPORTER=none \
+DARK_CONFIG_ROLLBAR_ENABLED=n \
+DARK_CONFIG_DB_HOST=localhost \
+DARK_CONFIG_DB_DBNAME=prodclone \
+DARK_CONFIG_DB_USER=dark \
+DARK_CONFIG_DB_PASSWORD=darklang \
+"${EXE}" "$@"


### PR DESCRIPTION
This solves #3641 and the second part of #3710.

This root cause of the issue is that we incorrectly parsed user functions ending in `_v6` (or any version number) as a StdLib function. Then we tried to call the StdLib function and couldn't find it.

So functions like `myFunction_v2` would return `<Incomplete>`.

However, the problem is a bit deeper because we have serialized these in the F# SerializedTypes that are stored in the DB.

This works around the issue for now. I still need to think about how to migrate the data.

The workaround is that if there is a Stdlib function found with no module, which is not a built-in infix function (eg `+`), and is not one of the built-in one word functions (eg `emit_v0`), then it must be one of these functions that is incorrectly parsed. As such, it should be converted to a `User` function instead.

To help ensure the bug is gone, I also changes the ProgramTypes format of function names used in EBinOps, adding checks and assertions during the translation process. Unfortunately, I had to step it back a little bit upon realizing that `Date::>` is an infix function, which we should remove as that was a bad choice we made once upon a time.

There's a checklist below which I intend to do before merging.

Also does:
- tidies up gcp-proxy-db script
- significant imporvements to gcp-psql script
- add some instrumentation
- add scripts to run exec-host locally (with the option to use prodclone)
- adds a selection of new assertion functions
- catch errors better in exechost


Options for migrating the data:
- read it again from ocaml (where it is OK as it uses string names).Advantages are that this is clean. It can't be out of sync as this is still what nearly all users are using. But the parsing code has changed so this might trigger more bugs.
- read and then write the serialized types. This should go through the conversion that cleans things up. This might trigger bugs in the change code.

TODO:
- [x] read known-failing canvas and see if this fixes it
- [x] read all toplevel_oplists from the DB and confirm we can process them
- [x] make a plan for how to migrate the data
- [x] add bug to remove Date infix functions and change the ProgramTypes representation