### PR TITLE
Fix oplists in the DB

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APIOps.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIOps.fs
@@ -21,6 +21,78 @@ module ORT = LibExecution.OCamlTypes.RuntimeT
 module AT = LibExecution.AnalysisTypes
 module Convert = LibExecution.OCamlTypes.Convert
 
+open Npgsql.FSharp
+open Npgsql
+open LibBackend.Db
+
+let loadTLDetails
+  (canvasID : CanvasID)
+  : Task<List<tlid * array<byte> * Option<array<byte>> * Option<array<byte>> * Option<array<byte>>>> =
+  let query =
+    "SELECT tlid, data, rendered_oplist_cache, oplist, oplist_cache FROM toplevel_oplists
+        WHERE canvas_id = @canvasID
+          AND (oplist is null OR oplist_cache is null)
+          AND deleted IS NOT NULL"
+  Sql.query query
+  |> Sql.parameters [ "canvasID", Sql.uuid canvasID ]
+  |> Sql.executeAsync (fun read ->
+    (read.tlid "tlid",
+     read.bytea "data",
+     read.byteaOrNone "rendered_oplist_cache",
+     read.byteaOrNone "oplist",
+     read.byteaOrNone "oplist_cache"))
+
+/// Fill in the oplist and oplist_cache fields in the toplevel_oplists table in the DB
+let clean (ctx : HttpContext) : Task<unit> =
+  // CLEANUP remove this once it's been run on all canvases
+  task {
+    use t = startTimer "read-api" ctx
+    let meta = loadCanvasInfo ctx
+    let! details = loadTLDetails meta.id
+    do!
+      details
+      |> Task.iterWithConcurrency
+        20
+        (fun (tlid, ocOplist, ocCache, fsOplist, fsCache) ->
+          task {
+            // if the oplist is missing, read it from ocaml, and save it
+            let! oplist =
+              match fsOplist with
+              | None ->
+                task {
+                  let! oplist = LibBackend.OCamlInterop.oplistOfBinary ocOplist
+                  do! Serialize.saveOplistToFSharpCache meta.id tlid ocOplist oplist
+                  return oplist
+                }
+              | Some bytes ->
+                Task.FromResult(
+                  LibBinarySerialization.BinarySerialization.deserializeOplist
+                    tlid
+                    bytes
+                )
+
+            // if the cached toplevel is missing (but ocaml has it), read the
+            // ocaml one, and save it
+            match ocCache, fsCache with
+            | Some ocamlBytes, None ->
+              // OCaml interop doesn't have a converter for toplevels, so just
+              // recreating using the oplists we have already.
+              let c = LibBackend.Canvas.fromOplist meta [] oplist
+              match LibBackend.Canvas.getToplevel tlid c with
+              | Some (_, tl) ->
+                do! Serialize.saveToplevelToFSharpCache meta.id ocamlBytes tl
+              | None ->
+                // The sample-gettingstarted canvas has some toplevels that were
+                // deleted. As part of the canvas_clone process, those toplevels were
+                // trimmed to their latest op. But since the toplevel was deleted,
+                // the latest op was just a DeletedTL or similar. That means that we
+                // don't actually have enough ops to make a cached toplevel. The
+                // obvious solution is to delete these, probably manually.
+                ()
+            | _ -> ()
+          })
+  }
+
 
 // Toplevel deletion:
 // * The server announces that a toplevel is deleted by it appearing in

--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -95,6 +95,7 @@ let addRoutes
   addRoute "GET" "/a/{canvasName}/trigger-exception" std R exceptionFn
 
   api "add_op" RW AddOps.addOp
+  api "clean_ops" RW AddOps.clean
   api "all_traces" R Traces.AllTraces.fetchAll
   api "delete_404" RW F404s.Delete.delete
   apiOption "delete-toplevel-forever" RW Toplevels.Delete.delete

--- a/fsharp-backend/src/LibBackend/CanvasClone.fs
+++ b/fsharp-backend/src/LibBackend/CanvasClone.fs
@@ -116,6 +116,8 @@ let cloneCanvas
   task {
     let! fromMeta = Canvas.getMeta fromCanvasName
     let! fromTLIDs = Serialize.fetchAllLiveTLIDs fromMeta.id
+    // CLEANUP this could be substantially simplified once we know that oplist_cache is
+    // non-null.
     let! fromOps =
       Serialize.loadOplists Serialize.LiveToplevels fromMeta.id fromTLIDs
     let! fromCanvas = Canvas.loadAll fromMeta

--- a/fsharp-backend/src/LibBinarySerialization/BinarySerialization.fs
+++ b/fsharp-backend/src/LibBinarySerialization/BinarySerialization.fs
@@ -64,7 +64,7 @@ let serializeToplevel (tl : PT.Toplevel.T) : byte [] =
 let deserializeToplevel (tlid : tlid) (data : byte []) : PT.Toplevel.T =
   wrapSerializationException tlid (fun () ->
     MessagePack.MessagePackSerializer.Deserialize(data, optionsWithoutZip)
-    |> ST2PT.Toplevel.toST)
+    |> ST2PT.Toplevel.toPT)
 
 
 let serializeOplist (tlid : tlid) (oplist : PT.Oplist) : byte [] =

--- a/fsharp-backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
+++ b/fsharp-backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
@@ -249,7 +249,7 @@ module UserFunction =
       body = Expr.toPT f.body }
 
 module Toplevel =
-  let toST (tl : ST.Toplevel.T) : PT.Toplevel.T =
+  let toPT (tl : ST.Toplevel.T) : PT.Toplevel.T =
     match tl with
     | ST.Toplevel.TLHandler h -> PT.Toplevel.TLHandler(Handler.toPT h)
     | ST.Toplevel.TLDB db -> PT.Toplevel.TLDB(DB.toPT db)


### PR DESCRIPTION
I was investigating the DB, and discovered that contrary to my expectations, very many rows in toplevel_oplist did not have the columns for the F# serialization of oplist or toplevel (these are called oplist and oplist_cache).

This investigation is in https://github.com/darklang/dark/issues/3727. I went through all the canvases and found reasons why various groups of canvases didn't have these, and it seems that overall, if the canvas is deleted or live, it should have an F# version of the oplist and the oplist_cache.

```
          ol           |           opcache           | deleted |         meta          | count
-----------------------+-----------------------------+---------+-----------------------+-------
 error: oplist missing | error: missing oplist cache | f       | error: missing meta   |     2
 error: oplist missing | error: missing oplist cache | t       | meta null as expected |    30
 error: oplist missing | error: missing oplist cache | f       | meta ok               |   624
 error: oplist missing | oplist cache ok             | f       | error: meta blank     |     1
 error: oplist missing | oplist cache ok             | f       | error: missing meta   |  3144
 error: oplist missing | oplist cache ok             | f       | meta ok               | 83850
 oplist ok             | error: missing oplist cache | t       | meta null as expected | 24326
 oplist ok             | oplist cache ok             | f       | error: missing meta   |    45
 oplist ok             | oplist cache ok             | t       | meta null as expected |   260
 oplist ok             | oplist cache ok             |         | meta null as expected | 37681
 oplist ok             | oplist cache ok             | f       | meta ok               |   715
```

Process:
- [ ] merge this
- [ ] get the list of canvases with null oplists or oplist_cache
  - `\copy (select distinct c.name from toplevel_oplists t, canvases c where oplist is null OR oplist_cache is null and c.id = t.canvas_id) to oplistless.csv csv`
- [ ] call the clean_ops api call on all the canvases
  - from the browser, copy the network request for `unlocked_dbs`, and change it to call the `clean_ops` api instead. 

