### PR TITLE
Increase timeout

### DIFF
--- a/fsharp-backend/src/LibBackend/OCamlInterop.fs
+++ b/fsharp-backend/src/LibBackend/OCamlInterop.fs
@@ -44,8 +44,9 @@ let client =
      let client = new System.Net.Http.HttpClient(handler, disposeHandler = false)
      // Since this is now only used for saving as part of AddOps, we have have a
      // longer window. People were running up against the 5 second limit, so make
-     // this 10s. But the real solution is to remove OCamlInterop.
-     client.Timeout <- System.TimeSpan.FromSeconds 10
+     // this 10s [edit: 10 was too short for big toplevels]. But the real solution is
+     // to remove OCamlInterop.
+     client.Timeout <- System.TimeSpan.FromSeconds 20
      client)
 
 /// Make a request to the legacy OCaml server


### PR DESCRIPTION
This should hopefully allow the final 3 toplevels to use F# as their primary store,
and also should allow more saves to go through (some are failing due to this timeout)

