### PR TITLE
Correct arg. order of Expect.equal in HSTS test

### DIFF
--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -691,8 +691,8 @@ let testHsts (client : C) (canvasName : CanvasName.T) =
           None)
 
     Expect.equal
-      [ "max-age=31536000; includeSubDomains; preload" ]
       hstsHeader
+      [ "max-age=31536000; includeSubDomains; preload" ]
       "Strict-Transport-Security header either missing or incorrect"
 
   task {


### PR DESCRIPTION
Inspired by being confused by this error report: https://github.com/darklang/dark/issues/3745, as the expectation/actual are reversed.