### PR TITLE
Add F# code coverage analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -357,6 +357,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
 
 RUN sudo dotnet workload install wasm-tools
 RUN dotnet tool install -g dotnet-sos
+
 # TODO: is this the right directory?
 RUN echo "plugin load /home/dark/.dotnet/tools/.store/dotnet-sos/5.0.160202/dotnet-sos/5.0.160202/tools/netcoreapp2.1/any/linux-x64/libsosplugin.so" > ~/.lldbinit
 
@@ -364,6 +365,10 @@ RUN echo "plugin load /home/dark/.dotnet/tools/.store/dotnet-sos/5.0.160202/dotn
 RUN dotnet tool install fantomas-tool --version 4.6.3 -g
 RUN curl https://raw.githubusercontent.com/darklang/build-files/main/ocamlformat --output ~/bin/ocamlformat && chmod +x ~/bin/ocamlformat
 ENV PATH "$PATH:/home/dark/bin:/home/dark/.dotnet/tools"
+
+# code coverage
+RUN dotnet tool install -g altcover.global
+RUN dotnet tool install -g dotnet-reportgenerator-globaltool
 
 #############
 # tunnel user

--- a/fsharp-backend/paket.dependencies
+++ b/fsharp-backend/paket.dependencies
@@ -28,6 +28,11 @@ nuget FSharp.Compiler.Service = 41.0.3
 nuget NReco.Logging.File = 1.1.3
 nuget SimpleBase = 3.1.0
 
+// Code Coverage
+nuget YoloDev.Expecto.TestSdk 0.12.12
+nuget Microsoft.NET.Test.Sdk 17.1.0-preview-20211109-03
+nuget altcover ~> 8.2.825
+
 // Services
 nuget Lib.AspNetCore.ServerTiming = 4.3.0
 nuget PusherServer = 4.6.1

--- a/fsharp-backend/paket.lock
+++ b/fsharp-backend/paket.lock
@@ -2,6 +2,7 @@ STORAGE: NONE
 RESTRICTION: == net6.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
+    altcover (8.2.837)
     Argu (6.1.1)
       FSharp.Core (>= 4.3.2)
       System.Configuration.ConfigurationManager (>= 4.4)
@@ -122,6 +123,7 @@ NUGET
       System.Configuration.ConfigurationManager (>= 4.7)
       System.Security.Permissions (>= 4.7)
       System.Text.Encoding.CodePages (>= 4.0.1)
+    Microsoft.CodeCoverage (17.1)
     Microsoft.Extensions.Configuration (6.0)
       Microsoft.Extensions.Configuration.Abstractions (>= 6.0)
       Microsoft.Extensions.Primitives (>= 6.0)
@@ -193,8 +195,17 @@ NUGET
     Microsoft.NET.StringTools (1.0)
       System.Memory (>= 4.5.4)
       System.Runtime.CompilerServices.Unsafe (>= 5.0)
+    Microsoft.NET.Test.Sdk (17.1.0-preview-20211109-03)
+      Microsoft.CodeCoverage (>= 17.1.0-preview-20211109-03)
+      Microsoft.TestPlatform.TestHost (>= 17.1.0-preview-20211109-03)
     Microsoft.NETCore.Platforms (5.0.4)
     Microsoft.NETCore.Targets (5.0)
+    Microsoft.TestPlatform.ObjectModel (17.1)
+      NuGet.Frameworks (>= 5.11)
+      System.Reflection.Metadata (>= 1.6)
+    Microsoft.TestPlatform.TestHost (17.1)
+      Microsoft.TestPlatform.ObjectModel (>= 17.1)
+      Newtonsoft.Json (>= 9.0.1)
     Microsoft.Win32.Primitives (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
@@ -225,6 +236,7 @@ NUGET
       Microsoft.Extensions.Logging (>= 2.0)
       Microsoft.Extensions.Logging.Configuration (>= 2.0)
       Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.0)
+    NuGet.Frameworks (6.1)
     OpenTelemetry (1.2.0-rc2)
       Microsoft.Extensions.Logging (>= 2.1)
       Microsoft.Extensions.Logging.Configuration (>= 2.1)
@@ -759,6 +771,10 @@ NUGET
     System.ValueTuple (4.5)
     System.Windows.Extensions (5.0)
       System.Drawing.Common (>= 5.0)
+    YoloDev.Expecto.TestSdk (0.12.12)
+      Expecto (>= 9.0 < 10.0)
+      FSharp.Core (>= 4.6)
+      System.Collections.Immutable (>= 1.5)
 
 GROUP Wasm
 NUGET

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -9,40 +9,112 @@ open Prelude
 
 module Telemetry = LibService.Telemetry
 
+// [<EntryPoint>]
+// let main (args : string array) : int =
+//   try
+//     let name = "Tests"
+//     LibService.Init.init name
+//     (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
+//     (LibRealExecution.Init.init name).Result
+//     (LibBackend.Account.initializeDevelopmentAccounts name).Result
+
+//     let tests =
+//       [ Tests.Account.tests
+//         Tests.ApiServer.tests
+//         Tests.Authorization.tests
+//         Tests.BinarySerialization.tests
+//         Tests.BwdServer.tests
+//         Tests.Canvas.tests
+//         Tests.Cron.tests
+//         Tests.DvalReprExternal.tests
+//         Tests.EventQueue.tests
+//         Tests.Execution.tests
+//         Tests.FSharpToExpr.tests
+//         Tests.HttpClient.tests
+//         Tests.LibExecution.tests.Force()
+//         Tests.OCamlInterop.tests
+//         Tests.Prelude.tests
+//         Tests.ProgramTypes.tests
+//         Tests.Routing.tests
+//         Tests.SqlCompiler.tests
+//         Tests.StdLib.tests
+//         Tests.Traces.tests
+//         Tests.TypeChecker.tests
+//         Tests.Undo.tests
+//         Tests.UserDB.tests ]
+
+//     let cancelationTokenSource = new System.Threading.CancellationTokenSource()
+//     let bwdServerTestsTask = Tests.BwdServer.init cancelationTokenSource.Token
+//     let httpClientTestsTask = Tests.HttpClient.init cancelationTokenSource.Token
+//     Telemetry.Console.loadTelemetry "tests" Telemetry.TraceDBQueries
+//     (LibBackend.Account.initTestAccounts ()).Wait()
+
+//     // Generate this so that we can see if the format has changed in a git diff
+//     BinarySerialization.generateBinarySerializationTestFiles ()
+
+//     // this does async stuff within it, so do not run it from a task/async
+//     // context or it may hang
+//     let exitCode = runTestsWithCLIArgs [] args (testList "tests" tests)
+
+//     NonBlockingConsole.wait () // flush stdout
+//     cancelationTokenSource.Cancel()
+//     bwdServerTestsTask.Wait()
+//     httpClientTestsTask.Wait()
+//     exitCode
+//   with
+//   | e ->
+//     print e.Message
+//     printMetadata (Exception.toMetadata e)
+//     print e.StackTrace
+//     NonBlockingConsole.wait () // flush stdout
+//     1
+
+let name = "Tests"
+LibService.Init.init name
+(LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
+(LibRealExecution.Init.init name).Result
+(LibBackend.Account.initializeDevelopmentAccounts name).Result
+
+
+[<Tests>]
+let tests =
+  [ // passes consistently with `dotnet test`
+    Tests.Account.tests // <-
+    Tests.Authorization.tests
+    Tests.BinarySerialization.tests
+    Tests.Cron.tests
+    Tests.Execution.tests
+    Tests.FSharpToExpr.tests
+    Tests.OCamlInterop.tests
+    Tests.Prelude.tests
+    Tests.ProgramTypes.tests
+    Tests.Routing.tests
+    Tests.SqlCompiler.tests
+    Tests.StdLib.tests
+    Tests.Traces.tests
+    Tests.TypeChecker.tests
+    Tests.Undo.tests
+    Tests.UserDB.tests
+
+    // breaks when loading (before runtime)
+    //Tests.BwdServer.tests
+    //Tests.DvalReprExternal.tests
+    //Tests.HttpClient.tests
+
+    // loads OK, but breaks during runtime
+    //Tests.ApiServer.tests
+    //Tests.Canvas.tests // _one_ test breaks during runtime
+    //Tests.EventQueue.tests // 2 tests fail, likely due to sequenced aspect not being respected
+
+    // untested
+    //Tests.LibExecution.tests.Force()
+  ]
+  |> testList "tests"
+
+
 [<EntryPoint>]
 let main (args : string array) : int =
   try
-    let name = "Tests"
-    LibService.Init.init name
-    (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
-    (LibRealExecution.Init.init name).Result
-    (LibBackend.Account.initializeDevelopmentAccounts name).Result
-
-    let tests =
-      [ Tests.Account.tests
-        Tests.ApiServer.tests
-        Tests.Authorization.tests
-        Tests.BinarySerialization.tests
-        Tests.BwdServer.tests
-        Tests.Canvas.tests
-        Tests.Cron.tests
-        Tests.DvalReprExternal.tests
-        Tests.EventQueue.tests
-        Tests.Execution.tests
-        Tests.FSharpToExpr.tests
-        Tests.HttpClient.tests
-        Tests.LibExecution.tests.Force()
-        Tests.OCamlInterop.tests
-        Tests.Prelude.tests
-        Tests.ProgramTypes.tests
-        Tests.Routing.tests
-        Tests.SqlCompiler.tests
-        Tests.StdLib.tests
-        Tests.Traces.tests
-        Tests.TypeChecker.tests
-        Tests.Undo.tests
-        Tests.UserDB.tests ]
-
     let cancelationTokenSource = new System.Threading.CancellationTokenSource()
     let bwdServerTestsTask = Tests.BwdServer.init cancelationTokenSource.Token
     let httpClientTestsTask = Tests.HttpClient.init cancelationTokenSource.Token
@@ -54,7 +126,7 @@ let main (args : string array) : int =
 
     // this does async stuff within it, so do not run it from a task/async
     // context or it may hang
-    let exitCode = runTestsWithCLIArgs [] args (testList "tests" tests)
+    let exitCode = runTestsWithCLIArgs [] args tests
 
     NonBlockingConsole.wait () // flush stdout
     cancelationTokenSource.Cancel()

--- a/fsharp-backend/tests/Tests/Tests.fsproj
+++ b/fsharp-backend/tests/Tests/Tests.fsproj
@@ -11,6 +11,7 @@
     <!-- <PublishSingleFile>true</PublishSingleFile> -->
     <PublishTrimmed>false</PublishTrimmed>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Prelude/Prelude.fsproj" />

--- a/fsharp-backend/tests/Tests/paket.references
+++ b/fsharp-backend/tests/Tests/paket.references
@@ -4,3 +4,6 @@ Expecto
 FsCheck
 Expecto.FsCheck
 SimpleBase
+Microsoft.NET.Test.Sdk
+YoloDev.Expecto.TestSdk
+altcover


### PR DESCRIPTION
This is a work in progress aimed to add code coverage to the F# backend. It will resolve #3688.

[AltCover](https://github.com/SteveGilham/altcover) was chosen as the coverage tool.

Seemingly, all .NET code coverage tools assume that `dotnet test` will run your tests.
Expecto is not build to expose tests to `dotnet test`, either plainly or via `[<Tests>]` attributes common in .NET, so we needed to tackle this first. The NuGet packages `YoloDev.Expecto.TestSdk` and `Microsoft.NET.Test.Sdk` were added for this effect. After adding those, we also needed 1+ `[<Tests>]` attributes for the test-runner to discover - I opted to add this to the root `Tests` module containing all tests, rather than drop the attribute in many files. `[<Tests>]` seems to only be respected when attributing a `Test` binding, so `Tests.fs` had to adjust a bit, in order to expose such in a new `tests` binding.

With these changes, we can now `dotnet test` within the `fsharp-backend` directory, and it runs many of the tests well.

With `dotnet test` now discovering and running those tests successfully, the next step was to involve a code coverage tool - AltCover. Altcover is installed as a global tool via the `dotnet tool` CLI, installed in the dockerfile.

With altcover installed, we can run `dotnet test /p:AltCover=true`.
It seems to work at least at a basic level - here are some results:
```
A total of 773,417,102 visits recorded
Coverage statistics flushing took 6.862 seconds
Visited Classes 1807 of 15372 (11.76)
Visited Methods 3221 of 38990 (8.26)
Visited Points 10094 of 157756 (6.4)
Visited Branches 4714 of 134704 (3.5)
Maximum CRAP score 1176140

==== Alternative Results (includes all methods including those without corresponding source) ====
Alternative Visited Classes 3528 of 22131 (15.94)
Alternative Visited Methods 5981 of 59821 (10)
Alternative maximum CRAP score 1176140
```

Some outstanding tasks:
- [ ] Adjust altcover settings to only cover our source code.
  Currently, altcover is likely ensuring that we're testing things like TestUtils, and potentially some external dependencies
- [ ] Ensure _all_ of our tests in `Tests` are included in the new `tests` binding
  Several test modules are commented out - some of them fail during `dotnet test` _discovery_, and others fail during `dotnet test` _execution_. The ones that fail due in discovery, I forget the details of now; will have to follow up. The ones that fail during execution are likely failing due to the _sequenced_ aspects of those tests not being respected, though there may be additional reasons.
- [ ] Determine where we want to store the coverage analysis and reporting (in the directory), and set up to do such
  currently, the coverage ends up at `fsharp-backend/tests/Tests/coverage`. I imagine we'd want to create a _top-level_ `coverage` folder, with a sub-folder for pretty .html output
- [ ] Review the actual report! Tidy things until it looks reasonable (testing the right things, with the right results)
- [ ] Determine if we need the `altcover` NuGet package in addition to the global tool (i.e. can we remove it?)
  I added this when borrowing code from [MiniScaffold](https://github.com/TheAngryByrd/MiniScaffold/), and need to follow up
- [ ] Generate a nice (.html?) report from the coverage analysis
  I took an initial attempt with [ReportGenerator](https://github.com/danielpalme/ReportGenerator), but sticking with AltCover's [Visualizer](https://github.com/SteveGilham/altcover/wiki/The-Visualizer) may be our best move here. I haven't yet spent much time here. It may make sense to actually install the visualizer tool on the dev's host machine (outside of container) and then inspect the resultant analysis file, and use the traditional ReportGenerator for CI or other uses.
- [ ] Determine if/how we want to hook coverage analysis into CI
- [ ] Consider including tests from other test projects (fuzz? integration?)