### PR TITLE
Store traces in the background

### DIFF
--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -331,24 +331,16 @@ let runDarkHandler
           let program = Canvas.toProgram canvas
           let expr = PT2RT.Expr.toRT expr
 
-          // Store trace - Do not resolve task, send this into the ether
-          let traceHook (request : RT.Dval) : unit =
-            FireAndForget.fireAndForgetTask executionID "store-event" (fun () ->
-              TI.storeEvent meta.id traceID ("HTTP", requestPath, method) request)
-
-          // Send to Pusher - Do not resolve task, send this into the ether
-          let notifyHook (touchedTLIDs : List<tlid>) : unit =
-            Pusher.pushNewTraceID executionID meta.id traceID touchedTLIDs
-
           // Do request
           let! result =
             Middleware.executeHandler
+              meta.id
               tlid
               executionID
               traceID
-              traceHook
-              notifyHook
               url
+              requestPath
+              method
               routeVars
               reqHeaders
               reqQuery

--- a/fsharp-backend/src/HttpMiddleware/RequestV0.fs
+++ b/fsharp-backend/src/HttpMiddleware/RequestV0.fs
@@ -111,7 +111,7 @@ let url (headers : List<string * string>) (uri : string) =
 
 
 // -------------------------
-// Exported *)
+// Exported
 // -------------------------
 
 // If allow_unparsed is true, we fall back to DNull; this allows us to create a

--- a/fsharp-backend/src/LibBackend/Db.fs
+++ b/fsharp-backend/src/LibBackend/Db.fs
@@ -127,6 +127,9 @@ module Sql =
   let instantWithoutTimeZone (i : NodaTime.Instant) : SqlValue =
     Sql.timestamp (i.toUtcLocalTimeZone().ToDateTimeUnspecified())
 
+  let instantWithTimeZone (i : NodaTime.Instant) : SqlValue =
+    Sql.timestamptz (i.ToDateTimeUtc())
+
 
 
 // Extension methods

--- a/fsharp-backend/src/LibBackend/TraceFunctionArguments.fs
+++ b/fsharp-backend/src/LibBackend/TraceFunctionArguments.fs
@@ -19,6 +19,10 @@ module DvalReprInternal = LibExecution.DvalReprInternal
 // External
 // -------------------------
 
+// FSTODO: use a transaction
+// FSTODO: pull out the timestamp
+type FunctionArgumentStore = tlid * RT.DvalMap
+
 let store
   (canvasID : CanvasID)
   (traceID : AT.TraceID)
@@ -40,6 +44,18 @@ let store
                            DvalReprInternal.toInternalRoundtrippableV0 (RT.DObj args)
                          )) ]
     |> Sql.executeStatementAsync
+
+let storeMany
+  (canvasID : CanvasID)
+  (traceID : AT.TraceID)
+  (functionResults : List<tlid * RT.DvalMap>)
+  : Task<unit> =
+  task {
+    do!
+      functionResults
+      |> Task.iterWithConcurrency 3 (fun (tlid, args) ->
+        store canvasID traceID tlid args)
+  }
 
 
 let loadForAnalysis

--- a/fsharp-backend/src/LibBackend/TraceFunctionResults.fs
+++ b/fsharp-backend/src/LibBackend/TraceFunctionResults.fs
@@ -53,6 +53,7 @@ let store
                          |> Sql.string) ]
     |> Sql.executeStatementAsync
 
+// CLEANUP store these in Cloud Storage instead of the DB
 let storeMany
   (canvasID : CanvasID)
   (traceID : AT.TraceID)

--- a/fsharp-backend/src/LibExecution/Execution.fs
+++ b/fsharp-backend/src/LibExecution/Execution.fs
@@ -12,9 +12,9 @@ module AT = AnalysisTypes
 let traceNoDvals : RT.TraceDval = fun _ _ _ -> ()
 let traceNoTLIDs : RT.TraceTLID = fun _ -> ()
 let loadNoFnResults : RT.LoadFnResult = fun _ _ -> None
-let storeNoFnResults : RT.StoreFnResult = fun _ _ _ -> task { return () }
+let storeNoFnResults : RT.StoreFnResult = fun _ _ _ -> ()
 let loadNoFnArguments : RT.LoadFnArguments = fun _ -> []
-let storeNoFnArguments : RT.StoreFnArguments = fun _ _ -> task { return () }
+let storeNoFnArguments : RT.StoreFnArguments = fun _ _ -> ()
 
 let noTracing (realOrPreview : RT.RealOrPreview) : RT.Tracing =
   { traceDval = traceNoDvals

--- a/fsharp-backend/src/LibExecution/Interpreter.fs
+++ b/fsharp-backend/src/LibExecution/Interpreter.fs
@@ -704,7 +704,7 @@ and execFn
               }
             // there's no point storing data we'll never ask for
             if fn.previewable <> Pure then
-              do! state.tracing.storeFnResult fnRecord arglist result
+              state.tracing.storeFnResult fnRecord arglist result
 
             return result
         | PackageFunction (_tlid, body) ->
@@ -733,13 +733,13 @@ and execFn
                   // handler/call site.
                   let! result = eval state argsWithGlobals body
 
-                  do! state.tracing.storeFnResult fnRecord arglist result
+                  state.tracing.storeFnResult fnRecord arglist result
 
                   return
                     result |> Dval.unwrapFromErrorRail |> typeErrorOrValue Map.empty
                 }
             // For now, always store these results
-            do! state.tracing.storeFnResult fnRecord arglist result
+            state.tracing.storeFnResult fnRecord arglist result
 
             return
               result
@@ -765,11 +765,11 @@ and execFn
             | _ ->
               // It's okay to execute user functions in both Preview and Real contexts,
               // But in Preview we might not have all the data we need
-              do! state.tracing.storeFnArguments tlid args
+              state.tracing.storeFnArguments tlid args
 
               let state = { state with tlid = tlid }
               let! result = eval state argsWithGlobals body
-              do! state.tracing.storeFnResult fnRecord arglist result
+              state.tracing.storeFnResult fnRecord arglist result
 
               return
                 result

--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -866,11 +866,11 @@ and TraceTLID = tlid -> unit
 
 and LoadFnResult = FunctionRecord -> List<Dval> -> Option<Dval * NodaTime.Instant>
 
-and StoreFnResult = FunctionRecord -> Dval list -> Dval -> Task<unit>
+and StoreFnResult = FunctionRecord -> Dval list -> Dval -> unit
 
 and LoadFnArguments = tlid -> List<DvalMap * NodaTime.Instant>
 
-and StoreFnArguments = tlid -> DvalMap -> Task<unit>
+and StoreFnArguments = tlid -> DvalMap -> unit
 
 /// Every part of a user's program
 and ProgramContext =

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -71,8 +71,6 @@ let createState
       Dictionary.empty ()
 
 
-    // CLEANUP: we should really just store these in memory and then upload the trace
-    // at the very end.
     let tracing =
       { Exe.noTracing RT.Real with
           storeFnResult =

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -152,13 +152,34 @@ let traceResultHook
             canvasID
             traceID
             (HashSet.toList traceResult.functionResults)
-        // Send to Pusher - Do not resolve task, send this into the ether
+        // Send to Pusher
         Pusher.pushNewTraceID
           executionID
           canvasID
           traceID
           (HashSet.toList traceResult.tlids)
       })
+
+module Test =
+  let saveTraceResult
+    (canvasID : CanvasID)
+    (traceID : AT.TraceID)
+    (traceResult : TraceResult)
+    : Task<unit> =
+    task {
+      do!
+        TraceFunctionArguments.storeMany
+          canvasID
+          traceID
+          (HashSet.toList traceResult.functionArguments)
+      do!
+        TraceFunctionResults.storeMany
+          canvasID
+          traceID
+          (HashSet.toList traceResult.functionResults)
+      return ()
+    }
+
 
 
 

--- a/fsharp-backend/src/LibService/FireAndForget.fs
+++ b/fsharp-backend/src/LibService/FireAndForget.fs
@@ -14,8 +14,11 @@ let fireAndForgetTask
   (name : string)
   (f : unit -> Task<'b>)
   : unit =
+  // CLEANUP: this should be a backgroundTask, but that doesn't work due to
+  // https://github.com/dotnet/fsharp/issues/12761
   task {
     try
+      // Resolve to make sure we catch the exception
       let! (_ : 'b) = f ()
       return ()
     with

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -221,10 +221,7 @@ let createCustom
   // CLEANUP rollbar has a built-in way to do this called "Service links"
   custom["message.honeycomb"] <- honeycombLinkOfExecutionID executionID
   custom["execution_id"] <- string executionID
-  List.iter
-    (fun (k, v) ->
-      Dictionary.add k (v :> obj) custom |> ignore<Dictionary.T<string, obj>>)
-    metadata
+  List.iter (fun (k, v) -> Dictionary.add k (v :> obj) custom) metadata
   custom
 
 // -------------------------------

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -771,9 +771,9 @@ module Dictionary =
   let get (k : 'k) (t : T<'k, 'v>) : Option<'v> =
     FSharpPlus.Dictionary.tryGetValue k t
 
-  let add (k : 'k) (v : 'v) (d : T<'k, 'v>) : T<'k, 'v> =
+  let add (k : 'k) (v : 'v) (d : T<'k, 'v>) : unit =
     d[k] <- v
-    d
+    ()
 
   let empty () : T<'k, 'v> = System.Collections.Generic.Dictionary<'k, 'v>()
 

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -109,7 +109,7 @@ let dequeueAndProcess () : Task<Result<Option<RT.Dval>, exn>> =
                   do! EQ.putBack event EQ.Missing
                   return Ok None
                 | Some h ->
-                  let! (state, touchedTLIDs) =
+                  let! (state, traceResult) =
                     RealExecution.createState
                       executionID
                       traceID
@@ -124,11 +124,13 @@ let dequeueAndProcess () : Task<Result<Option<RT.Dval>, exn>> =
                     |> PT2RT.Expr.toRT
                     |> Execution.executeHandler state symtable
 
-                  Pusher.pushNewTraceID
-                    executionID
+                  HashSet.add h.tlid traceResult.tlids
+
+                  RealExecution.traceResultHook
                     canvasID
                     traceID
-                    (h.tlid :: HashSet.toList touchedTLIDs)
+                    executionID
+                    traceResult
 
                   let resultType =
                     match result with

--- a/fsharp-backend/tests/Tests/EventQueue.Tests.fs
+++ b/fsharp-backend/tests/Tests/EventQueue.Tests.fs
@@ -58,7 +58,13 @@ let testEventQueueRoundtrip =
         |> Exception.unwrapOptionInternal "missing eventID" []
         |> Tuple2.first
 
-      let! functionResults = TFR.load meta.id traceID h.tlid
+      // Saving happens in the background so wait for it
+      let mutable functionResults = []
+      for i in 1..10 do
+        if functionResults = [] then
+          let! result = TFR.load meta.id traceID h.tlid
+          functionResults <- result
+          if functionResults = [] then do! Task.Delay 300
 
       Expect.equal (List.length functionResults) 1 "should have stored fn result"
       Expect.equal (RT.DInt 123L) resultDval "Round tripped value"


### PR DESCRIPTION
We were storing traces in the foreground, which in an async server slowed things down.

I was trying to switch a user over, and their handlers that used to run in 3-5 seconds now took 10 (which timed out some other stuff). It's not a particularly interesting function, it just calls a few user-defined functions on a reasonable chunk of data. The json generated is about 70k.

The problem here is that we are over-storing traces for functions. We store argument- and result-traces for every time a user-function is called (for stdlib functions, we only save results for impure one function calls). This PR actually doesn't do anything to address this problem, it just deals with the volume of calls created by this.

I tried a few different things like running the requests in the background as they occur. In the end, it made more sense to send them all at the end in one batch. This gets us halfway to moving the trace out of the DB and into S3 or some equivalent.

In my local tests, this speeds up a particularly big handler from 2s to 150ms, by moving saving traces to a background task.

There's not a lot interesting here. The most major change is that I calculate timestamps in the server now and send them to the DB.

