### PR TITLE
Use new custom domains ingress

### DIFF
--- a/docs/production/custom-domains.md
+++ b/docs/production/custom-domains.md
@@ -27,13 +27,13 @@
 
 Deleting custom domains is inherently lossy cause k8s sucks.
 
-Domains are stored in three places: in our custom_domains table in the main DB,
-and also in the `darkcustomdomain-l4-ingress` in `.spec.tls[]` and also in
-`.spec.rules[]`. The latter is to enable SSL, the former is to connect the
-request to the appropriate canvas.
+Domains are stored in three places: in our custom_domains table in the main DB, and
+also in the `darklang/darkcustomdomain-tls-ingress` in `.spec.tls[]` and also in
+`.spec.rules[]`. The latter is to enable SSL, the former is to connect the request to
+the appropriate canvas.
 
 Removing from the DB is straightforward with SQL. Removing from
-`darkcustomdomain-l4-ingress` is not. They are lists, and there is no safe way
+`darkcustomdomain-tls-ingress` is not. They are lists, and there is no safe way
 to remove a single entry from a list in k8s (it does not have a "remove the
 array element with this value" command).
 
@@ -56,11 +56,10 @@ instructions](https://cert-manager.io/docs/installation/kubernetes/), see
 "installing with regular manifests" since we don't use Helm. The [cert-manager
 Concepts doc](https://cert-manager.io/docs/concepts/) may also be useful.
 
-tl;dr: adding a tls host to the `darkcustomdomain-l4-ingress` resource causes
+tl;dr: adding a tls host to the `darkcustomdomain-tls-ingress` resource causes
 Cert Manager to request a cert from Let's Encrypt and launch a pod to respond to
 [Let's Encrypt/ACME's HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/).
 
 If you're interested in `darkcustomdomain-ingress.yaml`,
-`nginx-ingress-controller.yaml`, or `darkcustomdomain-ip-svc.yaml`, those are
-derived from the [kubernetes/ingress-nginx static-ip
-example](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/static-ip).
+`darkcustomdomain-nginx-ingress-controller.yaml`, or `darkcustomdomain-service.yaml`,
+those are derived from the [kubernetes/ingress-nginx static-ip example](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/static-ip).

--- a/scripts/custom-domains/_add-to-cert-manager
+++ b/scripts/custom-domains/_add-to-cert-manager
@@ -72,7 +72,7 @@ PATCH
 # control ("delete the nth entry in the spec.tls array" risks race conditions).
 #
 # So we may as well do it the easy way:
-# kubectl get ingress darkcustomdomain-l4-ingress -o yaml > tmp.yaml
+# kubectl get ingress -n darklang darkcustomdomain-tls-ingress -o yaml > tmp.yaml
 # Edit tmp.yaml to remove the duplicate objects from both spec.rules and
 # spec.tls
 # kubectl diff -f tmp.yaml # check that the diff is what you expect
@@ -81,11 +81,11 @@ PATCH
 # Note: if changes have been made between `kubectl get` and `kubectl apply`, you
 # WILL LOSE THOSE CHANGES. So exercise caution. `kubectl diff` helps reduce the
 # window of exposure but does not eliminate it.
-if ( kubectl get ingress darkcustomdomain-l4-ingress -o json | jq ".spec.tls[] | select(.hosts[0] == \"${DOMAIN}\")" | grep . ); then
+if ( kubectl get ingress -n darklang darkcustomdomain-tls-ingress -o json | jq ".spec.tls[] | select(.hosts[0] == \"${DOMAIN}\")" | grep . ); then
     echo "Can't continue - you already have a TLS cert for this domain."
     exit 1
 fi
 
-kubectl patch ingress darkcustomdomain-l4-ingress --type=json -p "${PATCH}"
+kubectl patch ingress -n darklang darkcustomdomain-tls-ingress --type=json -p "${PATCH}"
 
 echo "Done adding cert. (Run ./scripts/custom-domains/_check-cert-added to check on it)"

--- a/scripts/custom-domains/_check-cert-added
+++ b/scripts/custom-domains/_check-cert-added
@@ -41,5 +41,5 @@ else
     echo "Cert is still not ready. You should check the events at"
     echo "kubectl describe certificate ${DOMAIN}-tls"
     echo "or possibly on the ingress"
-    echo "kubectl describe ingress darkcustomdomain-l4-ingress"
+    echo "kubectl describe ingress -n darklang darkcustomdomain-tls-ingress"
 fi

--- a/scripts/custom-domains/add
+++ b/scripts/custom-domains/add
@@ -15,7 +15,7 @@ in place, and extract the desired canvas name from it.
 
 Once that's done, we:
 - add a record to the db that webserver.ml will use to route domain->canvas
-- add annotations (rules.hosts[] and tls[]) to the darkcustomdomain-l4-ingress,
+- add annotations (rules.hosts[] and tls[]) to the darkcustomdomain-tls-ingress,
   that cert-manager notices and sets up a cert for (talks to Let's Encrypt and
 stores the provisioned cert in a k8s secret)
 

--- a/scripts/custom-domains/check-consistency
+++ b/scripts/custom-domains/check-consistency
@@ -11,8 +11,8 @@ anything has gone wrong.
 
 The three places are:
 - the custom_domains table in the DB
-- the .spec.tls array in darkcustomdomain-l4-ingress
-- the .spec.rules in darkcustomdomain-l4-ingress
+- the .spec.tls array in darklang/darkcustomdomain-tls-ingress
+- the .spec.rules in darklang/darkcustomdomain-tls-ingress
 
 For more docs, see docs/custom-domains.md
 EOF
@@ -32,7 +32,7 @@ echo "\\copy (${select_query}) TO ${tmpfile}" \
     | ./scripts/production/gcp-psql
 DBHOSTS=$(sort ${tmpfile})
 
-CERTMANAGER_JSON=$(kubectl get ingress darkcustomdomain-l4-ingress -o json)
+CERTMANAGER_JSON=$(kubectl get -n darklang ingress darkcustomdomain-tls-ingress -o json)
 TLSES=$(printf "%s" "${CERTMANAGER_JSON}" \
   | jq -r '.spec.tls | map ( .hosts[0] ) | sort | .[] ' \
   | grep -v ops-placeholder.darkcustomdomain.com \

--- a/scripts/custom-domains/delete-from-cert-manager
+++ b/scripts/custom-domains/delete-from-cert-manager
@@ -29,9 +29,9 @@ fi
 
 DOMAIN=$1
 
-BACKUPFILE="darkcustomdomain-l4-ingress.backup.$(date -u +"%FT%H%MZ").json"
-kubectl get ingress darkcustomdomain-l4-ingress -o json | jq . > "${BACKUPFILE}"
-echo -e "Saving backup of darkcustomdomain-l4-ingress to ${BACKUPFILE}. If " \
+BACKUPFILE="darkcustomdomain-tls-ingress.backup.$(date -u +"%FT%H%MZ").json"
+kubectl get -n darklang ingress darkcustomdomain-tls-ingress -o json | jq . > "${BACKUPFILE}"
+echo -e "Saving backup of darkcustomdomain-tls-ingress to ${BACKUPFILE}. If " \
          "something goes wrong, you can roll it back with: \n" \
          "  kubectl apply -f ${BACKUPFILE}"
 

--- a/services/bwdserver-deployment-darklang/bwdserver-deployment.template.yaml
+++ b/services/bwdserver-deployment-darklang/bwdserver-deployment.template.yaml
@@ -8,7 +8,7 @@ metadata:
 
 spec:
   revisionHistoryLimit: 10
-  replicas: 1 # FSTODO
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/custom-domains-darklang/cert-manager-clusterrolebinding.yaml
+++ b/services/custom-domains-darklang/cert-manager-clusterrolebinding.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: ServiceAccount
     name: cert-manager
     namespace: darklang
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: default

--- a/services/custom-domains-darklang/cert-manager-issuer.yaml
+++ b/services/custom-domains-darklang/cert-manager-issuer.yaml
@@ -22,4 +22,4 @@ spec:
     solvers:
       - http01:
           ingress:
-            name: darkcustomdomain-l4-ingress
+            name: darkcustomdomain-tls-ingress

--- a/services/custom-domains/nginx-ingress-controller.yaml
+++ b/services/custom-domains/nginx-ingress-controller.yaml
@@ -72,6 +72,7 @@ spec:
           args:
             - /nginx-ingress-controller
             - --publish-service=default/nginx-ingress-lb
+            - --watch-namespace=default
 ---
 kind: ClusterRoleBinding
 # kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1

--- a/services/custom-domains/nginx-ingress-controller.yaml
+++ b/services/custom-domains/nginx-ingress-controller.yaml
@@ -74,20 +74,6 @@ spec:
             - --publish-service=default/nginx-ingress-lb
             - --watch-namespace=default
 ---
-kind: ClusterRoleBinding
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cert-manager
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: cert-manager
-    namespace: default
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Change the cert-manager scripts to use the new ingress.

Make sure the old deployment doesn't use the new deployment's ingress.

Increase the number of bwdservers in the darklang deployment.