### PR TITLE
Fix user cors settings

### DIFF
--- a/fsharp-backend/src/HttpMiddleware/MiddlewareV0.fs
+++ b/fsharp-backend/src/HttpMiddleware/MiddlewareV0.fs
@@ -72,7 +72,8 @@ let addCorsHeaders
   inferCorsOriginHeader corsSetting reqHeaders
   |> Option.map (fun origin ->
     { response with
-        headers = response.headers @ [ "Access-Control-Allow-Origin", origin ] })
+        // these are added in order, so make sure the user's setting wins
+        headers = [ "Access-Control-Allow-Origin", origin ] @ response.headers })
   |> Option.defaultValue response
 
 

--- a/fsharp-backend/tests/httptestfiles/cors-no-setting-user-setting-wins.test
+++ b/fsharp-backend/tests/httptestfiles/cors-no-setting-user-setting-wins.test
@@ -1,0 +1,25 @@
+[http-handler GET /hello/:name]
+Http.responseWithHeaders "" { ``Access-Control-Allow-Origin`` = "my-origin"} 200
+
+[request]
+GET /hello/alice-bob HTTP/1.1
+Host: HOST
+Origin: xxx
+Date: Sun, 08 Nov 2020 15:38:01 GMT
+Content-Length: 0
+
+
+
+[response]
+HTTP/1.1 200 OK
+Date: xxx, xx xxx xxxx xx:xx:xx xxx
+Access-Control-Allow-Origin: my-origin // FSHARPONLY
+access-control-allow-origin: my-origin // OCAMLONLY
+x-darklang-execution-id: 0123456789
+Content-Type: text/plain; charset=utf-8
+Server: nginx/1.16.1 // OCAMLONLY
+Server: darklang // FSHARPONLY
+Connection: keep-alive // OCAMLONLY
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload // FSHARPONLY
+Content-Length: 0
+

--- a/fsharp-backend/tests/httptestfiles/cors-one-header-user-setting-wins.test
+++ b/fsharp-backend/tests/httptestfiles/cors-one-header-user-setting-wins.test
@@ -1,0 +1,27 @@
+[http-handler GET /hello/:name]
+Http.responseWithHeaders "" { ``Access-Control-Allow-Origin`` = "my-origin"} 200
+
+[cors https://xxx:8000]
+
+[request]
+GET /hello/alice-bob HTTP/1.1
+Host: HOST
+Origin: xxx
+Date: Sun, 08 Nov 2020 15:38:01 GMT
+Content-Length: 0
+
+
+
+[response]
+HTTP/1.1 200 OK
+Date: xxx, xx xxx xxxx xx:xx:xx xxx
+Access-Control-Allow-Origin: my-origin // FSHARPONLY
+access-control-allow-origin: my-origin // OCAMLONLY
+x-darklang-execution-id: 0123456789
+Content-Type: text/plain; charset=utf-8
+Server: nginx/1.16.1 // OCAMLONLY
+Server: darklang // FSHARPONLY
+Connection: keep-alive // OCAMLONLY
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload // FSHARPONLY
+Content-Length: 0
+

--- a/fsharp-backend/tests/httptestfiles/cors-star-user-setting-wins.test
+++ b/fsharp-backend/tests/httptestfiles/cors-star-user-setting-wins.test
@@ -1,0 +1,27 @@
+[http-handler GET /hello/:name]
+Http.responseWithHeaders "" { ``Access-Control-Allow-Origin`` = "my-origin"} 200
+
+[cors *]
+
+[request]
+GET /hello/alice-bob HTTP/1.1
+Host: HOST
+Origin: xxx
+Date: Sun, 08 Nov 2020 15:38:01 GMT
+Content-Length: 0
+
+
+
+[response]
+HTTP/1.1 200 OK
+Date: xxx, xx xxx xxxx xx:xx:xx xxx
+Access-Control-Allow-Origin: my-origin // FSHARPONLY
+access-control-allow-origin: my-origin // OCAMLONLY
+x-darklang-execution-id: 0123456789
+Content-Type: text/plain; charset=utf-8
+Server: nginx/1.16.1 // OCAMLONLY
+Server: darklang // FSHARPONLY
+Connection: keep-alive // OCAMLONLY
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload // FSHARPONLY
+Content-Length: 0
+

--- a/services/honeycomb-agent/shipit.yaml
+++ b/services/honeycomb-agent/shipit.yaml
@@ -8,9 +8,9 @@ k8s:
   namespace: default
   manually-deployed:
     configs: []
-    configmaps:
-      honeycomb-agent:
-        text-file: config.yaml
+    configmaps: {}
+      # honeycomb-agent:
+      #   text-file: config.yaml
 
     custom-post-apply:
       - kubectl rollout restart ds/honeycomb-agent

--- a/services/honeycomb-agent/shipit.yaml
+++ b/services/honeycomb-agent/shipit.yaml
@@ -8,9 +8,9 @@ k8s:
   namespace: default
   manually-deployed:
     configs: []
-    configmaps: {}
-      # honeycomb-agent:
-      #   text-file: config.yaml
+    configmaps: { }
+    # honeycomb-agent:
+    #   text-file: config.yaml
 
     custom-post-apply:
       - kubectl rollout restart ds/honeycomb-agent


### PR DESCRIPTION
Got a bug report from @xtopherbrandt that CORS was not functioning right.

```
let headers = { Access-Control-Allow-Origin : "x" }
Http::responseWithHeaders {} headers 200
```

The middleware would overwrite the custom header.

Turns out we added headers in the wrong order. Tests included.