### PR TITLE
Improve build speed

### DIFF
--- a/scripts/build/_dotnet-wrapper
+++ b/scripts/build/_dotnet-wrapper
@@ -9,7 +9,7 @@ set +e
 # the exit code.
 shopt -s lastpipe
 
-cd fsharp-backend && unbuffer dotnet "$@" 2>&1 | while read -r line; do
+cd fsharp-backend && dotnet "$@" 2>&1 | while read -r line; do
   # this error consistently breaks our compile in the build script
   if [[ "$line" == *"warning MSB3026: Could not copy "* ]]; then
     echo "Saw a failed copy, killing servers"

--- a/scripts/build/compile
+++ b/scripts/build/compile
@@ -284,7 +284,6 @@ def fsharp_backend_quick_build():
     command = "build"
 
   build = f"./scripts/build/_dotnet-wrapper {command} \
-      -graphBuild:true \
       --no-restore \
       --verbosity {verbosity} \
       --configuration {configuration}"
@@ -316,7 +315,7 @@ def fsharp_backend_full_build():
     command = "build"
 
   # TODO publish trimmed https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#assembly-linking
-  build = f"unbuffer ./scripts/build/_dotnet-wrapper {command} \
+  build = f"./scripts/build/_dotnet-wrapper {command} \
       --verbosity {verbosity} \
       --configuration {configuration}"
 
@@ -325,7 +324,7 @@ def fsharp_backend_full_build():
   start = time.time()
   # Publishing the Wasm leads to an assertion failure while initializing .net via BlazorWorker
   if result and optimize:
-    build = f"unbuffer ./scripts/build/_dotnet-wrapper build \
+    build = f"./scripts/build/_dotnet-wrapper build \
         --verbosity {verbosity} \
         --configuration {configuration} \
         src/Wasm/Wasm.fsproj"


### PR DESCRIPTION
I played around with build speed a little bit, culminating in removing `unbuffer` and
`-graphBuild:true`. Unbuffer was just used to get commands to display like they do in
a terminal (there's other ways to do it, but I'll just remove this for now)

```
unbuffer | graphBuild | no touch | change test file | change Prelude.fs
y        | y          | 4.7s     | 12.7s            | not tested
y        | n          | 5.3s     | 13.6s            | not tested
n        | y          | 3.0s     | 11.3s            | 47.9s
n        | n          | 1.8s     | 9.98s            | 46.92
```

