### PR TITLE
Queueworker, 5th pass

### DIFF
--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -10,11 +10,11 @@ open Tablecloth
 module Telemetry = LibService.Telemetry
 module Rollbar = LibService.Rollbar
 
-let shouldShutdown = ref false
+let mutable shouldShutdown = false
 
 let run () : Task<unit> =
   task {
-    while not shouldShutdown.Value do
+    while not shouldShutdown do
       try
         use (span : Telemetry.Span.T) = Telemetry.createRoot "CronChecker.run"
         do! LibBackend.Cron.checkAndScheduleWorkForAllCrons ()
@@ -39,7 +39,7 @@ let main _ : int =
     // This fn is called if k8s tells us to stop
     let shutdownCallback () =
       Telemetry.addEvent "Shutting down" []
-      shouldShutdown.Value <- true
+      shouldShutdown <- true
 
     // Set up healthchecks and shutdown with k8s
     let port = LibService.Config.croncheckerKubernetesPort

--- a/fsharp-backend/src/LibBackend/EventQueueV2.fs
+++ b/fsharp-backend/src/LibBackend/EventQueueV2.fs
@@ -263,47 +263,50 @@ let subscriber : Lazy<Task<SubscriberServiceApiClient>> =
       return client
     })
 
-/// Returns the next available notification in the queue, and will pause until it has
-/// done so
-let dequeue () : Task<Notification> =
+/// Returns the next available notification in the queue, or None if it doesn't find
+/// one within a timeout
+let dequeue () : Task<Option<Notification>> =
   task {
     let! subscriber = subscriber.Force()
-    let mutable notification : Option<Notification> = None
-    while notification = None do
-      let! response = subscriber.PullAsync(subscriptionName, maxMessages = 1)
-      let messages = response.ReceivedMessages
-      // PubSub might return 0 Messages. In that case, pause and loop again
-      if messages.Count > 0 then
-        let envelope = messages[0]
-        let message = envelope.Message
-        let data =
-          message.Data.ToByteArray()
-          |> UTF8.ofBytesUnsafe
-          |> Json.Vanilla.deserialize<NotificationData>
-        let deliveryAttempt =
-          let da = message.GetDeliveryAttempt()
-          if da.HasValue then Some da.Value else None
-        notification <-
-          Some
-            { data = data
-              deliveryAttempt = Option.defaultValue 1 deliveryAttempt
-              pubSubMessageID = message.MessageId
-              pubSubAckID = envelope.AckId }
-        Telemetry.addTags [ "canvas_id", data.canvasID
-                            "queue.event.content_length", message.Data.Length
-                            "queue.event.id", data.id
-                            "queue.event.pubsub_id", message.MessageId
-                            "queue.event.ack_id", envelope.AckId
-                            "queue.event.delivery_attempt", deliveryAttempt
-                            "queue.event.publish_time",
-                            message.PublishTime.ToDateTime()
-                            "queue.event.time_in_queue",
-                            (System.DateTime.Now - message.PublishTime.ToDateTime())
-                              .TotalMilliseconds ]
-      else
-        do! Task.Delay(LD.queueDelayBetweenPullsInMillis ())
-
-    return notification |> Exception.unwrapOptionInternal "expect a notification" []
+    let expiration =
+      Google.Api.Gax.Expiration.FromTimeout(System.TimeSpan.FromSeconds 5)
+    let callSettings = Google.Api.Gax.Grpc.CallSettings.FromExpiration expiration
+    let! response =
+      subscriber.PullAsync(
+        subscriptionName,
+        callSettings = callSettings,
+        maxMessages = 1
+      )
+    let messages = response.ReceivedMessages
+    if messages.Count > 0 then
+      let envelope = messages[0]
+      let message = envelope.Message
+      let data =
+        message.Data.ToByteArray()
+        |> UTF8.ofBytesUnsafe
+        |> Json.Vanilla.deserialize<NotificationData>
+      let deliveryAttempt =
+        let da = message.GetDeliveryAttempt()
+        if da.HasValue then Some da.Value else None
+      Telemetry.addTags [ "canvas_id", data.canvasID
+                          "queue.event.content_length", message.Data.Length
+                          "queue.event.id", data.id
+                          "queue.event.pubsub_id", message.MessageId
+                          "queue.event.ack_id", envelope.AckId
+                          "queue.event.delivery_attempt", deliveryAttempt
+                          "queue.event.publish_time",
+                          message.PublishTime.ToDateTime()
+                          "queue.event.time_in_queue",
+                          (System.DateTime.Now - message.PublishTime.ToDateTime())
+                            .TotalMilliseconds ]
+      return
+        Some
+          { data = data
+            deliveryAttempt = Option.defaultValue 1 deliveryAttempt
+            pubSubMessageID = message.MessageId
+            pubSubAckID = envelope.AckId }
+    else
+      return None
   }
 
 let createNotifications (canvasID : CanvasID) (ids : List<EventID>) : Task<unit> =

--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -92,6 +92,6 @@ let init (shouldWaitForDB : WaitForDB) (serviceName : string) : Task<unit> =
 /// connections.
 let shutdown (serviceName : string) : Task<unit> =
   task {
-    print $"Shutting down LibService in {serviceName}"
+    print $"Shutting down LibBackend in {serviceName}"
     do! EventQueueV2.shutdown ()
   }

--- a/fsharp-backend/src/LibService/LaunchDarkly.fs
+++ b/fsharp-backend/src/LibService/LaunchDarkly.fs
@@ -93,5 +93,11 @@ let useEventsV2 = Internal.canvasBool "use-events-v2" false false
 let queueAllowedExecutionTimeInSeconds =
   Internal.intConfig "queue-allowed-execution-time-in-seconds" 300 300
 
+/// Limit to the number of events each QueueWorker will run concurrently
+let queueMaxConcurrentEventsPerWorker =
+  // 4 is conservating, we probably set this much higher
+  Internal.intConfig "queue-max-concurrent-events-per-worker" 4 4
+
+/// Delay between fetches from the queue when something goes wrong
 let queueDelayBetweenPullsInMillis =
   Internal.intConfig "queue-delay-between-pubsub-pulls-in-millis" 1000 1000

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -61,14 +61,14 @@ let mutable memoryUsage : int64 = 0L
 /// numbers say
 let cpuThread =
   let proc = System.Diagnostics.Process.GetCurrentProcess()
-  backgroundTask {
+  let threadFunc () =
     while true do
       // Measure CPU usage over a time period
       // From https://medium.com/@jackwild/getting-cpu-usage-in-net-core-7ef825831b8b
       let startTime = System.DateTime.UtcNow
       let startCpuUsage = proc.TotalProcessorTime
 
-      do! Task.Delay 1000
+      System.Threading.Thread.Sleep 1000
 
       let endTime = System.DateTime.UtcNow
       let endCpuUsage = proc.TotalProcessorTime
@@ -78,8 +78,9 @@ let cpuThread =
         cpuUsedMs / (float System.Environment.ProcessorCount * totalMsPassed)
       cpuUsage <- cpuUsageTotal * 100.0
       memoryUsage <- proc.PrivateMemorySize64
-  }
-  |> ignore<Task<unit>>
+  let thread = System.Threading.Thread(System.Threading.ThreadStart(threadFunc))
+  thread.Start()
+
 
 
 /// The algorithm here is described in the chart in docs/eventsV2.md. The algorithm

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -59,10 +59,10 @@ let mutable memoryUsage : int64 = 0L
 /// Background thread tracking current CPU and memory usage. We intend to use this to
 /// decide whether to schedule more workers, but for now let's just track what the
 /// numbers say
-let cpuThread =
+let cpuThread : unit =
   let proc = System.Diagnostics.Process.GetCurrentProcess()
   let threadFunc () =
-    while true do
+    while not shouldShutdown do
       // Measure CPU usage over a time period
       // From https://medium.com/@jackwild/getting-cpu-usage-in-net-core-7ef825831b8b
       let startTime = System.DateTime.UtcNow
@@ -79,6 +79,7 @@ let cpuThread =
       cpuUsage <- cpuUsageTotal * 100.0
       memoryUsage <- proc.PrivateMemorySize64
   let thread = System.Threading.Thread(System.Threading.ThreadStart(threadFunc))
+  thread.IsBackground <- true
   thread.Start()
 
 

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -27,7 +27,7 @@ module LD = LibService.LaunchDarkly
 module Telemetry = LibService.Telemetry
 module Rollbar = LibService.Rollbar
 
-let shouldShutdown = ref false
+let mutable shouldShutdown = false
 
 let executeEvent
   (c : Canvas.T)
@@ -292,7 +292,7 @@ let run () : Task<unit> =
 
     // Only use the semaphore to count the threads that are done
     let maxEventsFn = LD.queueMaxConcurrentEventsPerWorker
-    while not shouldShutdown.Value do
+    while not shouldShutdown do
       try
         if initialCount - semaphore.CurrentCount >= maxEventsFn () then
           do! Task.Delay(LD.queueDelayBetweenPullsInMillis ())
@@ -331,7 +331,7 @@ let main _ : int =
     // Called if k8s tells us to stop
     let shutdownCallback () =
       Telemetry.addEvent "shutting down" []
-      shouldShutdown.Value <- true
+      shouldShutdown <- true
 
     // Set up healthchecks and shutdown with k8s
     let port = LibService.Config.queueWorkerKubernetesPort

--- a/fsharp-backend/tests/Tests/Tests.fs
+++ b/fsharp-backend/tests/Tests/Tests.fs
@@ -61,6 +61,7 @@ let main (args : string array) : int =
     cancelationTokenSource.Cancel()
     bwdServerTestsTask.Wait()
     httpClientTestsTask.Wait()
+    QueueWorker.shouldShutdown <- true
     exitCode
   with
   | e ->


### PR DESCRIPTION
Handles a couple of issues seen running in production.

The queueworker was de facto single threaded, but we have capacity to run probably hundreds of simultaneous events at a time. Now we run more than one, up to a number dictated by a feature flag.

Add something to calculate CPU and memory usage in the background. We're not ready to use these to factor into the decision making process, but let's collect the number for now and see what we get.

Add a fix for a production exception: when someone unpauses the queue but there's no jobs in it.