### PR TITLE
Queueworker pass 6

### DIFF
--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -93,10 +93,9 @@ let processNotification
   (notification : EQ.Notification)
   : Task<Result<EQ.T * EQ.Notification, string * EQ.Notification>> =
   task {
-    use _span =
-      Telemetry.child
-        "process"
-        [ "process.cpu", cpuUsage; "process.memory", memoryUsage ]
+    use _span = Telemetry.createRoot "process"
+    Telemetry.addTags [ "process.cpu.percentage", cpuUsage
+                        "process.memory.private_bytes", memoryUsage ]
     let resultType (dv : RT.Dval) : string =
       dv |> RT.Dval.toType |> DvalReprExternal.typeToDeveloperReprV0
 

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -53,37 +53,6 @@ type ShouldRetry =
   | Retry of NodaTime.Duration
   | NoRetry
 
-let mutable cpuUsage : float = 0.0
-let mutable memoryUsage : int64 = 0L
-
-/// Background thread tracking current CPU and memory usage. We intend to use this to
-/// decide whether to schedule more workers, but for now let's just track what the
-/// numbers say
-let cpuThread : unit =
-  let proc = System.Diagnostics.Process.GetCurrentProcess()
-  let threadFunc () =
-    while not shouldShutdown do
-      // Measure CPU usage over a time period
-      // From https://medium.com/@jackwild/getting-cpu-usage-in-net-core-7ef825831b8b
-      let startTime = System.DateTime.UtcNow
-      let startCpuUsage = proc.TotalProcessorTime
-
-      System.Threading.Thread.Sleep 1000
-
-      let endTime = System.DateTime.UtcNow
-      let endCpuUsage = proc.TotalProcessorTime
-      let cpuUsedMs = (endCpuUsage - startCpuUsage).TotalMilliseconds
-      let totalMsPassed = (endTime - startTime).TotalMilliseconds
-      let cpuUsageTotal =
-        cpuUsedMs / (float System.Environment.ProcessorCount * totalMsPassed)
-      cpuUsage <- cpuUsageTotal * 100.0
-      memoryUsage <- proc.PrivateMemorySize64
-  let thread = System.Threading.Thread(System.Threading.ThreadStart(threadFunc))
-  thread.IsBackground <- true
-  thread.Start()
-
-
-
 /// The algorithm here is described in the chart in docs/eventsV2.md. The algorithm
 /// below is annotated with names from chart. `dequeueAndProcess` will block until it
 /// receives a notification. Returns a Result containing the notification and the
@@ -94,8 +63,6 @@ let processNotification
   : Task<Result<EQ.T * EQ.Notification, string * EQ.Notification>> =
   task {
     use _span = Telemetry.createRoot "process"
-    Telemetry.addTags [ "process.cpu.percentage", cpuUsage
-                        "process.memory.private_bytes", memoryUsage ]
     let resultType (dv : RT.Dval) : string =
       dv |> RT.Dval.toType |> DvalReprExternal.typeToDeveloperReprV0
 

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -63,6 +63,13 @@ let processNotification
   : Task<Result<EQ.T * EQ.Notification, string * EQ.Notification>> =
   task {
     use _span = Telemetry.createRoot "process"
+    Telemetry.addTags [ "event.time_in_queue_ms",
+                        notification.timeInQueue.TotalMilliseconds
+                        "event.id", notification.data.id
+                        "event.canvas_id", notification.data.canvasID
+                        "event.delivery_attempt", notification.deliveryAttempt
+                        "event.pubsub.ack_id", notification.pubSubAckID
+                        "event.pubsub.message_id", notification.pubSubMessageID ]
     let resultType (dv : RT.Dval) : string =
       dv |> RT.Dval.toType |> DvalReprExternal.typeToDeveloperReprV0
 


### PR DESCRIPTION
Remove the CPU usage stuff - it was the wrong way to approach it.

Have a fresh Telemetry parent for each event, and ensure it has the right data