### PR TITLE
Queueworker pass 7

### DIFF
--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -218,7 +218,6 @@ let main _ =
     let packages = LibBackend.PackageManager.allFunctions().Result
     run packages
     // CLEANUP I suspect this isn't called
-    (LibBackend.Init.shutdown name).Result
     LibService.Init.shutdown name
     0
   with

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -520,7 +520,6 @@ let main _ =
     (LibRealExecution.Init.init name).Result
     run ()
     // CLEANUP I suspect this isn't called
-    (LibBackend.Init.shutdown name).Result
     LibService.Init.shutdown name
     0
   with

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -50,7 +50,6 @@ let main _ : int =
       (run ()).Result
     else
       Telemetry.addEvent "Pointing at prodclone; will not trigger crons" []
-    (LibBackend.Init.shutdown name).Result
     LibService.Init.shutdown name
     0
   with

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -202,7 +202,6 @@ let main (args : string []) : int =
       (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
     let executionID = Telemetry.executionID ()
     let result = (run executionID options).Result
-    (LibBackend.Init.shutdown name).Result
     LibService.Init.shutdown name
     result
   with
@@ -215,6 +214,5 @@ let main (args : string []) : int =
       let inner = e.InnerException
       if inner <> null then printException inner
     printException e
-    (LibBackend.Init.shutdown name).Result
     LibService.Init.shutdown name
     1

--- a/fsharp-backend/src/LibBackend/EventQueueV2.fs
+++ b/fsharp-backend/src/LibBackend/EventQueueV2.fs
@@ -444,12 +444,3 @@ let unpauseWorker (canvasID : CanvasID) (handlerName : string) : Task<unit> =
     do! SchedulingRules.removeSchedulingRule "pause" canvasID handlerName
     return! requeueSavedEvents canvasID handlerName
   }
-
-
-let shutdown () =
-  task {
-    // https://cloud.google.com/dotnet/docs/reference/help/cleanup#grpc-based-apis-and-channels
-    do! PublisherServiceApiClient.ShutdownDefaultChannelsAsync()
-    do! SubscriberServiceApiClient.ShutdownDefaultChannelsAsync()
-    return ()
-  }

--- a/fsharp-backend/src/LibBackend/Init.fs
+++ b/fsharp-backend/src/LibBackend/Init.fs
@@ -87,11 +87,3 @@ let init (shouldWaitForDB : WaitForDB) (serviceName : string) : Task<unit> =
 
     print $" Inited LibBackend in {serviceName}"
   }
-
-/// Called when shutting down, probably. Used to explicitly flush any buffered
-/// connections.
-let shutdown (serviceName : string) : Task<unit> =
-  task {
-    print $"Shutting down LibBackend in {serviceName}"
-    do! EventQueueV2.shutdown ()
-  }

--- a/fsharp-backend/src/LibBackend/Pusher.fs
+++ b/fsharp-backend/src/LibBackend/Pusher.fs
@@ -10,17 +10,14 @@ open Tablecloth
 module AT = LibExecution.AnalysisTypes
 module FireAndForget = LibService.FireAndForget
 
-// PusherClient has own internal serializer which matches this interface.
-type Serializer() =
-  interface PusherServer.ISerializeObjectsToJson with
-    member this.Serialize(x : obj) : string = Json.OCamlCompatible.serialize x
-
 
 let pusherClient : Lazy<PusherServer.Pusher> =
   lazy
     (let options = PusherServer.PusherOptions()
      options.Cluster <- Config.pusherCluster
-     options.set_JsonSerializer (Serializer())
+     options.Encrypted <- true
+     // Use the raw serializer and expect everywhere to serialize appropriately
+     options.set_JsonSerializer (PusherServer.RawBodySerializer())
 
      PusherServer.Pusher(
        Config.pusherID,
@@ -40,7 +37,7 @@ let push
   (executionID : ExecutionID)
   (canvasID : CanvasID)
   (eventName : string)
-  (payload : 'x)
+  (payload : string) // The raw string is sent, it's the job of the caller to have it as appropriate json
   : unit =
   FireAndForget.fireAndForgetTask executionID $"pusher: {eventName}" (fun () ->
     task {
@@ -64,7 +61,7 @@ let pushNewTraceID
   (traceID : AT.TraceID)
   (tlids : tlid list)
   : unit =
-  push executionID canvasID "new_trace" (traceID, tlids)
+  push executionID canvasID "new_trace" (Json.Vanilla.serialize (traceID, tlids))
 
 
 let pushNew404
@@ -72,7 +69,7 @@ let pushNew404
   (canvasID : CanvasID)
   (f404 : TraceInputs.F404)
   =
-  push executionID canvasID "new_404" f404
+  push executionID canvasID "new_404" (Json.Vanilla.serialize f404)
 
 
 let pushNewStaticDeploy
@@ -80,7 +77,7 @@ let pushNewStaticDeploy
   (canvasID : CanvasID)
   (asset : StaticAssets.StaticDeploy)
   =
-  push executionID canvasID "new_static_deploy" asset
+  push executionID canvasID "new_static_deploy" (Json.Vanilla.serialize asset)
 
 
 // For exposure as a DarkInternal function
@@ -89,14 +86,14 @@ let pushAddOpEvent
   (canvasID : CanvasID)
   (event : Op.AddOpEvent)
   =
-  push executionID canvasID "add_op" event
+  push executionID canvasID "add_op" (Json.OCamlCompatible.serialize event)
 
 let pushWorkerStates
   (executionID : ExecutionID)
   (canvasID : CanvasID)
   (ws : QueueSchedulingRules.WorkerStates.T)
   : unit =
-  push executionID canvasID "worker_state" ws
+  push executionID canvasID "worker_state" (Json.Vanilla.serialize ws)
 
 type JsConfig = { enabled : bool; key : string; cluster : string }
 

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -319,7 +319,6 @@ let main _ : int =
       Telemetry.createRoot "Pointing at prodclone; will not dequeue"
       |> ignore<Telemetry.Span.T>
 
-    (LibBackend.Init.shutdown name).Result
     LibService.Init.shutdown name
     0
 


### PR DESCRIPTION
Small fix to how we use pusher.

The issue here is that `DarkInternal::pushStrollerEvent_v1` was having its body double encoded.  We encoded it once in LibDarkInternal, and then via an implicit encoding when the payload was added.

The fix is to do no encoding by default, and require the caller to do the encoding. This seems to work out.