### PR TITLE
Queueworker pass 8

### DIFF
--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -150,7 +150,7 @@ let rollbarCtxToMetadata
     try
       loadUserInfo ctx |> LibBackend.Account.userInfoToPerson
     with
-    | _ -> LibService.Rollbar.emptyPerson
+    | _ -> None
   let canvas =
     try
       string (loadCanvasInfo ctx).name

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -42,10 +42,14 @@ let internalFn (f : BuiltInFnSig) : BuiltInFnSig =
         if canAccess then
           let fnName =
             state.executingFnName
-            |> Option.map string
+            |> Option.map FQFnName.toString
             |> Option.defaultValue "unknown"
           use _span =
-            Telemetry.child "internal_fn" [ "user", username; "fnName", fnName ]
+            Telemetry.child
+              "internal_fn"
+              [ "canvas", state.program.canvasName
+                "user", username
+                "fnName", fnName ]
           return! f (state, args)
         else
           return

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -459,7 +459,8 @@ let configureApp (healthCheckPort : int) (app : IApplicationBuilder) =
       |> Option.map (fun cn -> [ "canvas", string cn :> obj ])
       |> Option.defaultValue []
 
-    let person : Rollbar.Person = Some { id = id; username = username; email = None }
+    let person : Rollbar.Person =
+      id |> Option.map (fun id -> { id = id; username = username })
 
     (person, metadata)
 

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -459,7 +459,7 @@ let configureApp (healthCheckPort : int) (app : IApplicationBuilder) =
       |> Option.map (fun cn -> [ "canvas", string cn :> obj ])
       |> Option.defaultValue []
 
-    let person : Rollbar.Person = { id = id; username = username; email = None }
+    let person : Rollbar.Person = Some { id = id; username = username; email = None }
 
     (person, metadata)
 

--- a/fsharp-backend/src/CronChecker/CronChecker.fs
+++ b/fsharp-backend/src/CronChecker/CronChecker.fs
@@ -21,7 +21,7 @@ let run () : Task<unit> =
       with
       | e ->
         // If there's an exception, alert and continue
-        Rollbar.sendException (ExecutionID "cronchecker") Rollbar.emptyPerson [] e
+        Rollbar.sendException (ExecutionID "cronchecker") None [] e
       do! Task.Delay LibBackend.Config.pauseBetweenCronsInMs
     return ()
   }

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -57,7 +57,7 @@ let triggerRollbar (executionID : ExecutionID) : unit =
 
   // Send async exception
   let e = new System.Exception($"{prefix} sendException exception")
-  Rollbar.sendException executionID Rollbar.emptyPerson tags e
+  Rollbar.sendException executionID None tags e
 
 /// Send a message to Rollbar that should result in a Page (notification)
 /// going out

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -39,7 +39,7 @@ type UserInfoAndCreatedAt =
     createdAt : NodaTime.Instant }
 
 let userInfoToPerson (ui : UserInfo) : LibService.Rollbar.Person =
-  Some { id = Some ui.id; email = Some ui.email; username = Some ui.username }
+  Some { id = ui.id; username = Some ui.username }
 
 
 // **********************

--- a/fsharp-backend/src/LibBackend/Account.fs
+++ b/fsharp-backend/src/LibBackend/Account.fs
@@ -39,7 +39,7 @@ type UserInfoAndCreatedAt =
     createdAt : NodaTime.Instant }
 
 let userInfoToPerson (ui : UserInfo) : LibService.Rollbar.Person =
-  { id = Some ui.id; email = Some ui.email; username = Some ui.username }
+  Some { id = Some ui.id; email = Some ui.email; username = Some ui.username }
 
 
 // **********************

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -106,7 +106,7 @@ let createState
     let sendException (state : RT.ExecutionState) (metadata : Metadata) (exn : exn) =
       let metadata = extraMetadata state @ metadata
       let person : LibService.Rollbar.Person =
-        { id = Some state.program.accountID; username = None; email = None }
+        Some { id = Some program.accountID; username = None; email = None }
       LibService.Rollbar.sendException state.executionID person metadata exn
 
 

--- a/fsharp-backend/src/LibRealExecution/RealExecution.fs
+++ b/fsharp-backend/src/LibRealExecution/RealExecution.fs
@@ -89,15 +89,19 @@ let createState
 
     let! libraries = Lazy.force libraries
 
+    let username () =
+      (Account.ownerNameFromCanvasName program.canvasName).toUserName ()
+
     let extraMetadata (state : RT.ExecutionState) : Metadata =
       [ "tlid", tlid
-        "traceID", traceID
-        "touchedTLIDs", touchedTLIDs
-        "executingFnName", state.executingFnName
+        "trace_id", traceID
+        "touched_tlids", touchedTLIDs
+        "executing_fn_name", state.executingFnName
         "callstack", state.callstack
-        "canvas", state.program.canvasName
-        "canvasID", state.program.canvasID
-        "accountID", state.program.accountID ]
+        "canvas", program.canvasName
+        "username", username ()
+        "canvas_id", program.canvasID
+        "account_id", program.accountID ]
 
     let notify (state : RT.ExecutionState) (msg : string) (metadata : Metadata) =
       let metadata = extraMetadata state @ metadata
@@ -106,7 +110,7 @@ let createState
     let sendException (state : RT.ExecutionState) (metadata : Metadata) (exn : exn) =
       let metadata = extraMetadata state @ metadata
       let person : LibService.Rollbar.Person =
-        Some { id = Some program.accountID; username = None; email = None }
+        Some { id = program.accountID; username = Some(username ()) }
       LibService.Rollbar.sendException state.executionID person metadata exn
 
 

--- a/fsharp-backend/src/LibService/FireAndForget.fs
+++ b/fsharp-backend/src/LibService/FireAndForget.fs
@@ -30,11 +30,7 @@ let fireAndForgetTask
     with
     | e ->
       Telemetry.addTag "success" false
-      Rollbar.sendException
-        executionID
-        Rollbar.emptyPerson
-        [ "fire-and-forget", name ]
-        e
+      Rollbar.sendException executionID None [ "fire-and-forget", name ] e
       return ()
   }
   |> ignore<Task<unit>>

--- a/fsharp-backend/src/LibService/Kubernetes.fs
+++ b/fsharp-backend/src/LibService/Kubernetes.fs
@@ -153,11 +153,7 @@ let runKubernetesServer
   registerShutdownCallback shutdownCallback
 
   let app = builder.Build()
-  Rollbar.AspNet.addRollbarToApp
-    app
-    (fun _ -> Rollbar.emptyPerson, [])
-    (Some startupPath)
-
+  Rollbar.AspNet.addRollbarToApp app (fun _ -> None, []) (Some startupPath)
   |> fun app -> app.UseRouting()
   |> configureApp port
   |> ignore<IApplicationBuilder>

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -189,13 +189,9 @@ let honeycombLinkOfExecutionID (executionID : ExecutionID) : string =
 // Include person data
 // -------------------------------
 
-type PersonData =
-  { id : Option<UserID>
-    email : Option<string>
-    username : Option<UserName.T> }
+type PersonData = { id : UserID; username : Option<UserName.T> }
 
-/// Optional person data. This is a better interface than expecting a person, as you
-/// can't put in a fake person
+/// Optional person data
 type Person = Option<PersonData>
 
 /// Take a Person and an Exception and create a RollbarPackage that can be reported
@@ -206,9 +202,8 @@ let createPackage (exn : exn) (person : Person) : Rollbar.IRollbarPackage =
   | Some person ->
     Rollbar.PersonPackageDecorator(
       package,
-      person.id |> Option.map string |> Option.defaultValue null,
-      person.username |> Option.map string |> Option.defaultValue null,
-      person.email |> Option.defaultValue null
+      person.id |> string,
+      person.username |> string
     )
   | None -> package
 

--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -128,8 +128,8 @@ let init (serviceName : string) : unit =
 
   // Debug Rollbar internals - when a Rollbar log is made, we lose sight of it.
   // Enabling this callback lets us see what actually happens when it's processed
-  // Rollbar.RollbarInfrastructure.Instance.QueueController.InternalEvent.AddHandler
-  //   (fun this e -> print $"rollbar internal error: {e.TraceAsString()}")
+  Rollbar.RollbarInfrastructure.Instance.QueueController.InternalEvent.AddHandler
+    (fun this e -> print $"rollbar internal error: {e.TraceAsString()}")
 
   // Disable the ConnectivityMonitor: https://github.com/rollbar/Rollbar.NET/issues/615
   // We actually want to call

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -91,7 +91,7 @@ let mutable exceptionCallback = (fun (e : exn) -> ())
 module Exception =
   let rec toMetadata (e : exn) : Metadata =
     let innerMetadata =
-      if e.InnerException <> null then toMetadata e.InnerException else []
+      if not (isNull e.InnerException) then toMetadata e.InnerException else []
     let thisMetadata =
       match e with
       | :? PageableException as e -> [ "is_pageable", true :> obj ] @ e.metadata

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -286,7 +286,7 @@ let run () : Task<unit> =
         // continue
         Rollbar.sendException
           (Telemetry.executionID ())
-          Rollbar.emptyPerson
+          None
           []
           (PageableException("Unhandled exception bubbled to run", [], e))
   }


### PR DESCRIPTION
It turns out there's a bunch of exceptions we're not seeing - any thing that doesn't have an id (much more common for queues and cronworkers than anything else, though probably it was hiding any PageableExceptions).

This includes code to debug the issue, which I might leave on and see how it goes. It prints to stdout, which we don't much use otherwise.

I removed the email from the Person type and made it an option.

Also adds more info to exceptions.
