### PR TITLE
Queueworker pass 11 - prevent stackoverflow

### DIFF
--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -794,6 +794,21 @@ module Dictionary =
     List.iter (fun (k, v) -> result[k] <- v) l
     result
 
+module ResizeArray =
+  type T<'v> = ResizeArray<'v>
+  let empty () = T()
+
+  let iter (f : 'v -> unit) (l : T<'v>) : unit =
+    FSharpx.Collections.ResizeArray.iter f l
+
+  let map (f : 'v -> 'v2) (l : T<'v>) : T<'v2> =
+    FSharpx.Collections.ResizeArray.map f l
+
+  let append (v : 'v) (list : T<'v>) : unit = list.Add(v)
+
+  let toList (l : T<'v>) : List<'v> = FSharpx.Collections.ResizeArray.toList l
+
+  let toSeq (l : T<'v>) : seq<'v> = FSharpx.Collections.ResizeArray.toSeq l
 
 
 // ----------------------

--- a/scripts/build/compile
+++ b/scripts/build/compile
@@ -234,6 +234,7 @@ def fsharp_backend_test():
 def fsharp_tool_restore():
   start = time.time()
   build = "./scripts/build/_dotnet-wrapper tool restore"
+
   return run_backend(start, build)
 
 
@@ -284,6 +285,7 @@ def fsharp_backend_quick_build():
     command = "build"
 
   build = f"./scripts/build/_dotnet-wrapper {command} \
+      /clp:ForceConsoleColor \
       --no-restore \
       --verbosity {verbosity} \
       --configuration {configuration}"
@@ -316,6 +318,7 @@ def fsharp_backend_full_build():
 
   # TODO publish trimmed https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#assembly-linking
   build = f"./scripts/build/_dotnet-wrapper {command} \
+      /clp:ForceConsoleColor \
       --verbosity {verbosity} \
       --configuration {configuration}"
 


### PR DESCRIPTION
When moving traces out of the main execution, I added them to a dictionary. However, it seems there is a very-bad performance impact from this: each item we add to a dictionary has a HashCode calculated, and hashcodes to Lists can be very slow.

This PR makes these more performant. We calculate our own hash for FunctionResults, so that we don't duplicate saving the data (still using Dictionarys). For FunctionArguments, don't use the arguments to hash a dictionary, instead just save the whole list (I'm not sure we saved anything by having a dictionary).