### PR TITLE
Support reading more events from the queue

### DIFF
--- a/fsharp-backend/tests/Tests/EventQueueV2.Tests.fs
+++ b/fsharp-backend/tests/Tests/EventQueueV2.Tests.fs
@@ -103,11 +103,14 @@ let checkSavedEvents (canvasID : CanvasID) (count : int) =
 
 let rec dequeueAndProcess () : Task<Result<_, _>> =
   task {
-    match! EQ.dequeue () with
-    | Some notification -> return! QueueWorker.processNotification notification
-    | None ->
+    match! EQ.dequeue 1 with
+    | [ notification ] -> return! QueueWorker.processNotification notification
+    | [] ->
       do! Task.Delay 1000
       return! dequeueAndProcess ()
+    | results ->
+      return!
+        Exception.raiseInternal "got more than 1" [ "count", List.length results ]
   }
 
 let testSuccess =


### PR DESCRIPTION
Also improve comments a lot

The reason for this is that pulling events from the queue is quite slow right now - we do a full loop iteration for each event.

For context, here are events all queued at roughly the same time via cron:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/181762/168907754-cbad24fb-e7f3-4771-80c5-04a19f0f6d64.png">

Even though we have the 2 workers set to take 8 events each, it takes over two seconds to get all 27 values out of the queue (most complete in about 250ms). Really we have the capacity to start them all at once, so let's not be coy about this.