### PR TITLE
Add new pusher credentials for a different pusher app

### DIFF
--- a/config/gke-builtwithdark
+++ b/config/gke-builtwithdark
@@ -108,6 +108,21 @@ DARK_CONFIG_HTTPCLIENT_TUNNEL_PROXY_URL=socks5://tunnel2-service.darklang:1080
 DARK_CONFIG_PUBLIC_DOMAIN=localhost
 
 # Pusher
+
+# CLEANUP
+#
+# There are two pusher production accounts/credentials. The old one is
+# "pusher-account-credentials". This is used by the old servers because I didn't want
+# to disturb them, so it will be left in until we remove the old servers or decide to
+# switch to new credentials. To support these old users, I have left the APP_ID and
+# CLUSTER at their old values, which they need.
+
+# The second is "credentials-pusher" (following the new format of putting
+# "credentials" first). This should be used by all new stuff. This is in a different
+# data center (cluster) and is a different app because each app is unique to a data
+# center. The deployments pull all 4 of these env vars from secrets (which override
+# the defaults listed here).
+
 DARK_CONFIG_PUSHER_APP_ID=710063
 #DARK_CONFIG_PUSHER_KEY=k8s
 #DARK_CONFIG_PUSHER_SECRET=k8s

--- a/services/apiserver-deployment-darklang/apiserver-deployment.template.yaml
+++ b/services/apiserver-deployment-darklang/apiserver-deployment.template.yaml
@@ -131,16 +131,26 @@ spec:
                   name: launchdarkly-account-credentials
                   key: key
             # pusher
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
             # database (sql server in the same pod)
             - name: DARK_CONFIG_DB_HOST
               value: 127.0.0.1
@@ -263,17 +273,26 @@ spec:
                   name: rollbar-account-credentials
                   key: post_token
             # pusher
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
-
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
         #########################
         # Cloudsql proxy container
         # To connect to postgres from kubernetes, we need to add a proxy. See

--- a/services/bwdserver-deployment-darklang/bwdserver-deployment.template.yaml
+++ b/services/bwdserver-deployment-darklang/bwdserver-deployment.template.yaml
@@ -131,16 +131,26 @@ spec:
                   name: launchdarkly-account-credentials
                   key: key
             # pusher
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
             # database (sql server in the same pod)
             - name: DARK_CONFIG_DB_HOST
               value: 127.0.0.1
@@ -263,17 +273,26 @@ spec:
                   name: rollbar-account-credentials
                   key: post_token
             # pusher
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
-
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
 
         #########################
         # Cloudsql proxy container

--- a/services/cronchecker-deployment/cronchecker-deployment.template.yaml
+++ b/services/cronchecker-deployment/cronchecker-deployment.template.yaml
@@ -83,16 +83,26 @@ spec:
                   name: launchdarkly-account-credentials
                   key: key
             # pusher
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
             # database (sql server in the same pod)
             - name: DARK_CONFIG_DB_HOST
               value: 127.0.0.1

--- a/services/exechost-deployment/exechost-deployment.template.yaml
+++ b/services/exechost-deployment/exechost-deployment.template.yaml
@@ -97,16 +97,26 @@ spec:
                   name: launchdarkly-account-credentials
                   key: key
             # pusher (not used here but needed for startup)
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
             # database (sql server in the same pod)
             - name: DARK_CONFIG_DB_HOST
               value: 127.0.0.1

--- a/services/queueworker-deployment/queueworker-deployment.template.yaml
+++ b/services/queueworker-deployment/queueworker-deployment.template.yaml
@@ -127,16 +127,26 @@ spec:
                   name: launchdarkly-account-credentials
                   key: key
             # pusher
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
             # database (sql server in the same pod)
             - name: DARK_CONFIG_DB_HOST
               value: 127.0.0.1
@@ -258,17 +268,26 @@ spec:
                   name: rollbar-account-credentials
                   key: post_token
             # pusher
+            - name: DARK_CONFIG_PUSHER_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: app_id
             - name: DARK_CONFIG_PUSHER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: key
             - name: DARK_CONFIG_PUSHER_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: pusher-account-credentials
+                  name: credentials-pusher
                   key: secret
-
+            - name: DARK_CONFIG_PUSHER_CLUSTER
+              valueFrom:
+                secretKeyRef:
+                  name: credentials-pusher
+                  key: cluster
 
         #########################
         # Cloudsql proxy container


### PR DESCRIPTION
This one is in Oregon. I'm hoping that it will prevent the timeouts we're seeing (our k8s cluster is in oregon).

I'm a little sketch on this change though - will the old stuff continue to work? Will the new stuff? I've added the credentials to k8s already.