### PR TITLE
When deploying, don't try to upload .br files

### DIFF
--- a/scripts/build/_generate-etags
+++ b/scripts/build/_generate-etags
@@ -6,7 +6,7 @@ set -euo pipefail
 # static/etags.json
 
 body=$(
-  find backend/static -type f -and -not  -name "*.gz" -printf "%p\n" \
+  find backend/static -type f -and -not  -name "*.gz" -and -not  -name "*.br" -printf "%p\n" \
   | xargs sha256sum \
   | sed 's!\([a-z0-9]\+\)  backend/static/\(.*\)!, "\2": "\1"!g')
 

--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -84,7 +84,7 @@ function skipFile {
   fi
 }
 
-files=$(find backend/static -type f -and -not -name "*.gz")
+files=$(find backend/static -type f -and -not -name "*.gz" -and -not -name "*.br")
 
 echo "Checking mime types"
 for file in $files; do


### PR DESCRIPTION
Relates to #3811 and #3872.

It seems that the CI step of uploading static assets is failing on .br files. This should fix that.