### PR TITLE
Revert "Use vanilla json version instead for loading traces"

### DIFF
--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -115,7 +115,7 @@ let addRoutes
   ocamlCompatibleApi "execute_function" RW Execution.Function.execute
   ocamlCompatibleApi "get_404s" R F404s.List.get
   ocamlCompatibleApi "get_db_stats" R DBs.DBStats.getStats
-  vanillaApiOption "get_trace_data" R Traces.TraceData.getTraceData
+  ocamlCompatibleApiOption "get_trace_data" R Traces.TraceData.getTraceData
   ocamlCompatibleApi "get_unlocked_dbs" R DBs.Unlocked.get
   ocamlCompatibleApi "get_worker_stats" R Workers.WorkerStats.getStats
   ocamlCompatibleApi "initial_load" R InitialLoad.initialLoad


### PR DESCRIPTION
This reverts commit 9c35b9d757d70b893f07261b6709574ba827ebe6.

When users try to load a trace, it responds just fine, but then it calls the API again, hundreds of times a minute. Reverting until we figure this out and have a test on it.