### PR TITLE
Fix missing trace results of execute function

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APIExecution.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIExecution.fs
@@ -53,12 +53,21 @@ module Function =
 
       t.next "load-canvas"
       let! c = Canvas.loadTLIDsWithContext canvasInfo [ p.tlid ]
+      let program = Canvas.toProgram c
 
       t.next "execute-function"
       let fnname = p.fnname |> PTParser.FQFnName.parse |> PT2RT.FQFnName.toRT
 
+
       let! (result, traceResults) =
-        RealExe.reexecuteFunction c p.tlid p.caller_id p.trace_id fnname args
+        RealExe.reexecuteFunction
+          c.meta
+          program
+          p.tlid
+          p.caller_id
+          p.trace_id
+          fnname
+          args
 
       t.next "get-unlocked"
       let! unlocked = LibBackend.UserDB.unlocked canvasInfo.owner canvasInfo.id
@@ -103,11 +112,18 @@ module Handler =
 
       t.next "load-canvas"
       let! c = Canvas.loadTLIDsWithContext canvasInfo [ p.tlid ]
+      let program = Canvas.toProgram c
       let handler = c.handlers[p.tlid] |> PT2RT.Handler.toRT
 
       t.next "execute-handler"
       let! (_, traceResults) =
-        RealExe.executeHandler c handler p.trace_id inputVars RealExe.ReExecution
+        RealExe.executeHandler
+          c.meta
+          handler
+          program
+          p.trace_id
+          inputVars
+          RealExe.ReExecution
 
       t.next "write-api"
       return { touched_tlids = traceResults.tlids |> HashSet.toList }

--- a/fsharp-backend/src/ApiServer/Api/APIExecution.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIExecution.fs
@@ -58,7 +58,7 @@ module Function =
       let fnname = p.fnname |> PTParser.FQFnName.parse |> PT2RT.FQFnName.toRT
 
       let! (result, traceResults) =
-        RealExe.reexecuteFunction c p.tlid p.trace_id fnname args
+        RealExe.reexecuteFunction c p.tlid p.caller_id p.trace_id fnname args
 
       t.next "get-unlocked"
       let! unlocked = LibBackend.UserDB.unlocked canvasInfo.owner canvasInfo.id

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -336,8 +336,9 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
           let inputVars = routeVars |> Map |> Map.add "request" request
           let! (result, _) =
             RealExe.executeHandler
-              canvas
+              canvas.meta
               (PT2RT.Handler.toRT handler)
+              (Canvas.toProgram canvas)
               traceID
               inputVars
               (RealExe.InitialExecution(desc, request))

--- a/fsharp-backend/src/LibBackend/TraceFunctionResults.fs
+++ b/fsharp-backend/src/LibBackend/TraceFunctionResults.fs
@@ -110,10 +110,10 @@ let load
      ORDER BY fnname, id, hash, hash_version, timestamp DESC"
   |> Sql.parameters [ "canvasID", Sql.uuid canvasID
                       "traceID", Sql.uuid traceID
-                      "tlid", Sql.id tlid ]
+                      "tlid", Sql.tlid tlid ]
   |> Sql.executeAsync (fun read ->
     (read.string "fnname",
-     read.tlid "id",
+     read.id "id",
      read.string "hash",
      read.intOrNone "hash_version" |> Option.unwrap 0,
      read.string "value" |> DvalReprInternalDeprecated.ofInternalRoundtrippableV0))

--- a/fsharp-backend/src/LibBackend/Tracing.fs
+++ b/fsharp-backend/src/LibBackend/Tracing.fs
@@ -142,7 +142,7 @@ let createTelemetryTracer () : TraceResults.T * RT.Tracing =
               args
               |> DvalReprInternalDeprecated.hash
                    DvalReprInternalDeprecated.currentHashVersion
-            LibService.Telemetry.addEvent
+            Telemetry.addEvent
               $"function result for {name}"
               [ "fnName", stringifiedName
                 "tlid", tlid
@@ -157,13 +157,13 @@ let createTelemetryTracer () : TraceResults.T * RT.Tracing =
             standardTracing.storeFnResult (tlid, name, id) args result)
         storeFnArguments =
           (fun tlid args ->
-            LibService.Telemetry.addEvent
+            Telemetry.addEvent
               $"function arguments for {tlid}"
               [ "tlid", tlid; "id", id; "argCount", Map.count args ]
             standardTracing.storeFnArguments tlid args)
         traceTLID =
           fun tlid ->
-            LibService.Telemetry.addEvent $"called {tlid}" [ "tlid", tlid ]
+            Telemetry.addEvent $"called {tlid}" [ "tlid", tlid ]
             standardTracing.traceTLID tlid }
   (results, tracing)
 
@@ -213,7 +213,6 @@ let storeTraceResults
     })
 
 let create (c : Canvas.Meta) (tlid : tlid) (traceID : AT.TraceID) : T =
-  let canvasID = c.id
   let config = TracingConfig.forHandler c.name tlid traceID
   let traceResults, executionTracing =
     match config with

--- a/fsharp-backend/src/LibBackend/Tracing.fs
+++ b/fsharp-backend/src/LibBackend/Tracing.fs
@@ -53,7 +53,7 @@ module TraceSamplingRule =
     match parseRule ruleString with
     | Error msg ->
       Rollbar.sendError
-        "Invalid traceSamplingRule: {msg}"
+        $"Invalid traceSamplingRule: {msg}"
         [ "ruleString", ruleString; "canvasName", canvasName; "tlid", tlid ]
       SampleNone
     | Ok rule -> rule

--- a/fsharp-backend/src/LibExecution/Execution.fs
+++ b/fsharp-backend/src/LibExecution/Execution.fs
@@ -66,7 +66,7 @@ let executeExpr
 
 let executeFunction
   (state : RT.ExecutionState)
-  (callerID : tlid)
+  (callerID : id)
   (name : RT.FQFnName.T)
   (args : List<RT.Dval>)
   : Task<RT.Dval> =

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -190,10 +190,12 @@ let processNotification
 
                   // CLEANUP Set a time limit of 3m
                   try
+                    let program = Canvas.toProgram c
                     let! (result, traceResults) =
                       RealExecution.executeHandler
-                        c
+                        c.meta
                         (PT2RT.Handler.toRT h)
+                        program
                         traceID
                         (Map [ "event", event.value ])
                         (RealExecution.InitialExecution(


### PR DESCRIPTION
When executing functions, their traces were not showing on refresh.

This was due to a bug in the refactoring in #3867, where we [stopped using the `caller_id`](https://github.com/darklang/dark/pull/3867/files#diff-36cabfc96e28c87b2a5e82195618503964ce5ad8d5b811b869e3e285faa7c015R60)

Also some tiny code fixes, no changes.