### PR TITLE
Another attempt at using System.Text.Json for the API

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APIDBs.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIDBs.fs
@@ -41,7 +41,7 @@ module Unlocked =
 module DBStats =
   type Params = { tlids : tlid list }
   type Stat = { count : int; example : Option<ORT.dval * string> }
-  type T = Map<tlid, Stat>
+  type T = Map<string, Stat>
 
   /// API endpoint to get statistical data regarding User DBs
   let getStats (ctx : HttpContext) : Task<T> =
@@ -60,12 +60,14 @@ module DBStats =
       t.next "write-api"
       // CLEANUP, this is shimming an RT.Dval into an ORT.dval. Nightmare.
       let (result : T) =
-        Map.map
-          (fun (s : Stats.DBStat) ->
-            { count = s.count
-              example =
-                Option.map (fun (dv, s) -> (Convert.rt2ocamlDval dv, s)) s.example })
-          result
+        result
+        |> Map.toList
+        |> List.map (fun (k, (s : Stats.DBStat)) ->
+          (string k),
+          { count = s.count
+            example =
+              Option.map (fun (dv, s) -> (Convert.rt2ocamlDval dv, s)) s.example })
+        |> Map
 
       return result
     }

--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -68,9 +68,9 @@ let addRoutes
   let std = standardMiddleware
   let html = htmlMiddleware
 
-  // CLEANUP: switch everything over to vanilla and get rid of ocamlCompatible
-  let vanillaApi name perm f =
-    let handler = vanillaJsonHandler f
+  // CLEANUP: switch everything over to clientJson and get rid of ocamlCompatible
+  let clientJsonApi name perm f =
+    let handler = clientJsonHandler f
     let route = $"/api/{{canvasName}}/{name}"
     addRoute "POST" route std perm handler
 
@@ -80,8 +80,8 @@ let addRoutes
     addRoute "POST" route std perm handler
 
 
-  let vanillaApiOption name perm f =
-    let handler = vanillaJsonOptionHandler f
+  let clientJsonApiOption name perm f =
+    let handler = clientJsonOptionHandler f
     let route = $"/api/{{canvasName}}/{name}"
     addRoute "POST" route std perm handler
 
@@ -115,7 +115,7 @@ let addRoutes
   ocamlCompatibleApi "execute_function" RW Execution.Function.execute
   ocamlCompatibleApi "get_404s" R F404s.List.get
   ocamlCompatibleApi "get_db_stats" R DBs.DBStats.getStats
-  ocamlCompatibleApiOption "get_trace_data" R Traces.TraceData.getTraceData
+  clientJsonApiOption "get_trace_data" R Traces.TraceData.getTraceData
   ocamlCompatibleApi "get_unlocked_dbs" R DBs.Unlocked.get
   ocamlCompatibleApi "get_worker_stats" R Workers.WorkerStats.getStats
   ocamlCompatibleApi "initial_load" R InitialLoad.initialLoad

--- a/fsharp-backend/src/ApiServer/ApiServer.fsproj
+++ b/fsharp-backend/src/ApiServer/ApiServer.fsproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />
+    <Compile Include="Json.fs" />
     <Compile Include="Http.fs" />
     <Compile Include="Middleware.fs" />
     <Compile Include="Login.fs" />

--- a/fsharp-backend/src/ApiServer/Json.fs
+++ b/fsharp-backend/src/ApiServer/Json.fs
@@ -54,11 +54,23 @@ type LocalDateTimeConverter() =
 
 
 let options =
-  let options = Prelude.Json.Vanilla.getOptions ()
-  options.Converters.Add(NodaConverters.InstantConverter)
-  options.Converters.Add(LocalDateTimeConverter())
+  let fsharpConverter =
+    JsonFSharpConverter(
+      unionEncoding =
+        (JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.UnwrapOption)
+    )
+  let options = JsonSerializerOptions()
+  options.MaxDepth <- System.Int32.MaxValue // infinite
   options.Converters.Add(FloatConverter())
+  options.Converters.Add(LocalDateTimeConverter())
+  options.Converters.Add(NodaConverters.InstantConverter)
+  options.Converters.Add(Prelude.Json.Vanilla.TLIDConverter())
+  options.Converters.Add(Prelude.Json.Vanilla.PasswordConverter())
+  options.Converters.Add(Prelude.Json.Vanilla.RawBytesConverter())
+  options.Converters.Add(fsharpConverter)
   options
+
+
 
 let serialize (data : 'a) : string = JsonSerializer.Serialize(data, options)
 

--- a/fsharp-backend/src/ApiServer/Json.fs
+++ b/fsharp-backend/src/ApiServer/Json.fs
@@ -1,0 +1,66 @@
+/// Json compatibility with the client, used by the middleware
+module ApiServer.Json
+
+// This provides a JSON encoding that exactly matches the encoding used in the
+// client, but uses System.Text.Json. The intent is to be significantly faster than
+// old ocamlCompatible one. It doesn't differ from Prelude.Json.Vanilla very much,
+// and I suspect it could be
+
+open Prelude
+
+open System.Text.Json
+open System.Text.Json.Serialization
+open NodaTime.Serialization.SystemTextJson
+
+
+type FloatConverter() =
+  // CLEANUP: check if we need the float converter
+  inherit JsonConverter<float>()
+
+  override _.Read(reader : byref<Utf8JsonReader>, _type, _options) =
+    reader.GetDouble()
+
+  override _.Write(writer : Utf8JsonWriter, value : float, _) =
+    let maxPreciselyRepresentedIntValue : float = float (1L <<< 49)
+    if System.Math.Abs(value % 1.0) < System.Double.Epsilon
+       && value < maxPreciselyRepresentedIntValue
+       && value > (-maxPreciselyRepresentedIntValue) then
+      let asString = string value
+      writer.WriteRawValue $"{value}.0"
+    else
+      writer.WriteRawValue(string value)
+
+type LocalDateTimeConverter() =
+  // CLEANUP: check if the default format is actually OK
+  // To match the client we use the format: 1906-11-23T23:01:23Z
+  // The default format is 1906-11-23T23:01:23.428
+  inherit JsonConverter<NodaTime.LocalDateTime>()
+
+  override _.Read(reader : byref<Utf8JsonReader>, _type, _options) =
+    NodaConverters.LocalDateTimeConverter.Read(&reader, _type, _options)
+
+  override _.Write
+    (
+      writer : Utf8JsonWriter,
+      value : NodaTime.LocalDateTime,
+      _
+    ) : unit =
+    let value =
+      NodaTime
+        .ZonedDateTime(value, NodaTime.DateTimeZone.Utc, NodaTime.Offset.Zero)
+        .ToInstant()
+        .toIsoString ()
+    writer.WriteStringValue value
+
+
+let options =
+  let options = Prelude.Json.Vanilla.getOptions ()
+  options.Converters.Add(NodaConverters.InstantConverter)
+  options.Converters.Add(LocalDateTimeConverter())
+  options.Converters.Add(FloatConverter())
+  options
+
+let serialize (data : 'a) : string = JsonSerializer.Serialize(data, options)
+
+let deserialize<'a> (json : string) : 'a =
+  JsonSerializer.Deserialize<'a>(json, options)

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -934,9 +934,8 @@ module Json =
 
   module OCamlCompatible =
     // CLEANUP: get rid of OCamlCompatible serializers, replacing it with Vanilla.
-    // AFAIK, the only places we really have to use it are:
-    // - ocamlinterop (needed to parse funky floats like infinity)
-    // - JSON api (we can change the client after the migration is done)
+    // AFAIK, the only places we have to use it is for actual ocamlinterop, and all
+    // other uses have been removed
     open Newtonsoft.Json
     open Microsoft.FSharp.Reflection
 

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -901,6 +901,7 @@ module Json =
       options.MaxDepth <- System.Int32.MaxValue // infinite
       // CLEANUP we can put these converters on the type or property if appropriate.
       options.Converters.Add(NodaConverters.InstantConverter)
+      options.Converters.Add(NodaConverters.LocalDateTimeConverter)
       options.Converters.Add(TLIDConverter())
       options.Converters.Add(PasswordConverter())
       options.Converters.Add(RawBytesConverter())

--- a/fsharp-backend/tests/FuzzTests/FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/FuzzTests.fs
@@ -35,6 +35,7 @@ let knownGood (config : FuzzTestConfig) =
     HttpClient.Tests.knownGood // passes with 1,000,000; 350 test/s
     OCamlInterop.Roundtrippable.tests // passes with 100,000; 520 tests/s
     Json.PrettyRequestJson.tests // passes with 10,000; 800 tests/s
+    Json.OCamlCompatibleVsApiServer.tests
     NodaTime.tests ] // passes with 1,000,000; 140k tests/s
   |> List.map (fun fn -> fn config)
 

--- a/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
+++ b/fsharp-backend/tests/FuzzTests/Json.FuzzTests.fs
@@ -301,14 +301,32 @@ module OCamlCompatibleVsApiServer =
 
 
 
-  let equalsOCaml (dv : LibExecution.OCamlTypes.RuntimeT.dval) : bool =
+  let isEqual<'a> (v : 'a) : bool =
     let toComparable str = str |> Newtonsoft.Json.Linq.JToken.Parse |> string
-    let vanilla = ApiServer.Json.serialize dv |> toComparable
-    let ocaml = Json.OCamlCompatible.serialize dv |> toComparable
+    let ocamlCompatible = Json.OCamlCompatible.serialize v |> toComparable
+    let clientJson = ApiServer.Json.serialize v |> toComparable
+    clientJson .=. ocamlCompatible
 
-    ocaml .=. vanilla
+  let testForType<'a> config =
+    testProperty config typeof<Generator> $"ocamlCompatible-{typeof<'a>}" isEqual<'a>
 
   let tests config =
     testList
       "ocamlCompatibleVsApiServerJson"
-      [ testProperty config typeof<Generator> "ocamlCompatible" equalsOCaml ]
+      [ testForType<LibExecution.OCamlTypes.RuntimeT.dval> config
+        testForType<ApiServer.F404s.List.T> config
+        testForType<ApiServer.F404s.Delete.T> config
+        testForType<ApiServer.DBs.Unlocked.T> config
+        testForType<ApiServer.DBs.DBStats.T> config
+        testForType<ApiServer.Execution.Handler.T> config
+        testForType<ApiServer.Execution.Function.T> config
+        testForType<ApiServer.InitialLoad.T> config
+        testForType<ApiServer.AddOps.T> config
+        testForType<ApiServer.Packages.List.T> config
+        testForType<ApiServer.Secrets.Insert.T> config
+        testForType<ApiServer.Secrets.Delete.T> config
+        testForType<ApiServer.Toplevels.Delete.T> config
+        testForType<ApiServer.Traces.AllTraces.T> config
+        testForType<ApiServer.Traces.TraceData.T> config
+        testForType<ApiServer.Workers.WorkerStats.T> config
+        testForType<ApiServer.Workers.Scheduler.T> config ]


### PR DESCRIPTION
We're seeing extremely slow loading of traces some traces (typically 50MB in size or so). Looking at Honeycomb, it was taking over 3 minutes to serialize the json. When I switched it to System.Text.Json, that turned into 3 seconds or so.

However, that broke. I though Prelude.Vanilla.Json would be close enough, but I don't think it was. So this adds a new format which is based on Prelude.Json.Vanilla, but matches the client exactly. It could probably be replaced by Json.Vanilla, but for now let's just keep it going as it is.

Added fuzzing to ensure it really does behave the same in all cases.