### PR TITLE
Rewrite _push-assets-to-cdn in Python

### DIFF
--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -12,114 +12,114 @@ ROOT_OF_FILES="backend/static/"
 BUCKET="gs://darklang-static-assets"
 
 # Gather list of files in known dir
-allStaticFiles = [f for f in glob.glob(ROOT_OF_FILES + '**', recursive=True) if os.path.isfile(f)]
+all_static_files = [f for f in glob.glob(f"{ROOT_OF_FILES}**", recursive=True) if os.path.isfile(f)]
 
 
 # Filter out files we don't care about
-def shouldCopyFile(filename):
-  filesToSkip = [ROOT_OF_FILES + ".gitkeep", ROOT_OF_FILES + "etags.json"]
-  if filename in filesToSkip:
+def should_copy_file(file_name):
+  files_to_skip = [f"{ROOT_OF_FILES}.gitkeep", f"{ROOT_OF_FILES}etags.json"]
+  if file_name in files_to_skip:
     return False
 
-  if filename.endswith(".gz") or filename.endswith(".br"):
+  if file_name.endswith(".gz") or file_name.endswith(".br"):
     return False
 
   return True
-staticFilesToCopy = [f for f in allStaticFiles if shouldCopyFile(f)]
+static_files_to_copy = [f for f in all_static_files if should_copy_file(f)]
 
 
 # We want to call `gsutil cp` in bulk by Content-Type shortly, but it doesn't
 # support a way to copy multiple files in one call while also renaming them.
 # So, we copy files to a new temp dir, adjusting file names to have hashes
 # injected where relevant.
-tempDir = tempfile.gettempdir() + "/static-assets/"
-shutil.rmtree(tempDir, ignore_errors=True)
+temp_dir = tempfile.gettempdir() + "/static-assets/"
+shutil.rmtree(temp_dir, ignore_errors=True)
 
-with open(ROOT_OF_FILES + '/etags.json', 'r') as f:
+with open(f"{ROOT_OF_FILES}/etags.json", 'r') as f:
   etags = json.load(f)
 
-def shouldHash(filename):
+def should_hash(filename):
   return not filename.startswith("vendor/")
 
-def getRemoteFileName(filePath):
-  filePath = filePath.replace(ROOT_OF_FILES, '')
+def get_remote_file_name(file_path):
+  file_path = file_path.replace(ROOT_OF_FILES, '')
 
-  if shouldHash(filePath):
-    fileHash = etags[filePath]
-    (base, _dot, extension) = filePath.rpartition('.')
-    return f'{base}-{fileHash}.{extension}'
+  if should_hash(file_path):
+    file_hash = etags[file_path]
+    (base, _dot, extension) = file_path.rpartition('.')
+    return f'{base}-{file_hash}.{extension}'
   else:
-    return filePath
+    return file_path
 
-def getRemoteFilePath(filename):
-  return tempDir + getRemoteFileName(filename)
+def get_remote_file_path(filename):
+  return temp_dir + get_remote_file_name(filename)
 
-for f in staticFilesToCopy:
-  target = getRemoteFilePath(f)
-  os.makedirs( os.path.dirname(target), exist_ok=True)
+for f in static_files_to_copy:
+  target = get_remote_file_path(f)
+  os.makedirs(os.path.dirname(target), exist_ok=True)
   shutil.copy(f, target)
 
 # from now on, we don't care about the original paths
-staticFilesToCopy = [getRemoteFilePath(f) for f in staticFilesToCopy]
-ROOT_OF_FILES = tempDir
+static_files_to_copy = [get_remote_file_path(f) for f in static_files_to_copy]
+ROOT_OF_FILES = temp_dir
 
 
 # Determine content-type / mimetype
 # See also ApiServer.configureStaticContent
-def mimeTypeFor(filename):
+def mime_type_for(file_name):
   # Common web stuff
-  if filename.endswith(".css"): return "text/css"
-  elif filename.endswith(".js"): return "application/javascript"
-  elif filename.endswith(".json"): return "application/json"
-  elif filename.endswith(".txt"): return "text/plain"
-  elif filename.endswith(".png"): return "image/png"
-  elif filename.endswith(".svg"): return "image/svg+xml"
-  elif filename.endswith(".html"): return "text/html"
+  if file_name.endswith(".css"): return "text/css"
+  elif file_name.endswith(".js"): return "application/javascript"
+  elif file_name.endswith(".json"): return "application/json"
+  elif file_name.endswith(".txt"): return "text/plain"
+  elif file_name.endswith(".png"): return "image/png"
+  elif file_name.endswith(".svg"): return "image/svg+xml"
+  elif file_name.endswith(".html"): return "text/html"
   # Fonts
-  elif filename.endswith(".ttf"): return "font/ttf"
-  elif filename.endswith(".woff"): return "font/woff"
-  elif filename.endswith(".woff2"): return "font/woff2"
-  elif filename.endswith(".eot"): return "application/vnd.ms-fontobject"
+  elif file_name.endswith(".ttf"): return "font/ttf"
+  elif file_name.endswith(".woff"): return "font/woff"
+  elif file_name.endswith(".woff2"): return "font/woff2"
+  elif file_name.endswith(".eot"): return "application/vnd.ms-fontobject"
   # Blazor
-  elif filename.endswith(".wasm"): return "application/wasm"
-  elif filename.endswith(".pdb"): return "text/plain"
-  elif filename.endswith(".dll"): return "application/octet-stream"
-  elif filename.endswith(".dat"): return "application/octet-stream"
-  elif filename.endswith(".blat"): return "application/octet-stream"
+  elif file_name.endswith(".wasm"): return "application/wasm"
+  elif file_name.endswith(".pdb"): return "text/plain"
+  elif file_name.endswith(".dll"): return "application/octet-stream"
+  elif file_name.endswith(".dat"): return "application/octet-stream"
+  elif file_name.endswith(".blat"): return "application/octet-stream"
   else:
     # Don't allow anything else
-    print(f'Unknown extension for {filename}')
+    print(f'Unknown extension for {file_name}')
     sys.exit(-1)
 
 
 # Group the files to copy by the Content-Type we want to send it as
 # key = mimetype, value = list of static file (by local name)
-filesGroupedByMimetype = {}
-for f in staticFilesToCopy:
-  mimetype = mimeTypeFor(f)
+files_grouped_by_mimetype = {}
+for f in static_files_to_copy:
+  mimetype = mime_type_for(f)
 
-  if mimetype in filesGroupedByMimetype:
-    filesGroupedByMimetype[mimetype].append(f)
+  if mimetype in files_grouped_by_mimetype:
+    files_grouped_by_mimetype[mimetype].append(f)
   else:
-    filesGroupedByMimetype[mimetype] = [f]
+    files_grouped_by_mimetype[mimetype] = [f]
 
 # Copy the files to CDN - one `gsutil cp` call per Content-Type
-for mimetype in filesGroupedByMimetype:
-  filesToCopy = " ".join(filesGroupedByMimetype[mimetype])
-
+for mimetype in files_grouped_by_mimetype:
+  files_to_copy = " ".join(files_grouped_by_mimetype[mimetype])
   # Prepare a `gsutil cp` call
   # -h: set header
   # -Z: Uploaded file is served as zipped. Also adds 'no-transform' to Cache-Control header
   # -n: Don't overwrite
   # -m: Upload assets in parallel, within call
-  gsutilCommand = ''' gsutil \
+
+  gsutil_command = f'''gsutil \
     -h "Content-Type:{mimetype}" \
     -h "Cache-Control:public" \
-    cp -Z -n {files} "{remoteDir}"
-    '''.format(mimetype=mimetype, files=filesToCopy, remoteDir=BUCKET)
+    cp -Z -n {files_to_copy} "{BUCKET}"
+    '''
 
-  subprocess.run(gsutilCommand, shell=True)
+  subprocess.run(gsutil_command, shell=True)
 
 # Wrap up
-shutil.rmtree(tempDir, ignore_errors=True)
+shutil.rmtree(temp_dir, ignore_errors=True)
 print("Done!")

--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -1,115 +1,109 @@
-#! /usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python3.8
+
+import glob
+import os
+import sys
+import json
+import subprocess
 
 PREFIX_TO_REMOVE="backend/static/"
 BUCKET="gs://darklang-static-assets"
 
-# for debugging in CI
-# find backend/static
+# Fetch all files
+allStaticFiles = [f for f in glob.glob('backend/static/**', recursive=True) if os.path.isfile(f)]
 
-function mimeTypeFor {
-  # See also ApiServer.configureStaticContent
-  case "$1" in
-    # Common web stuff
-    *.css) echo "text/css" ;;
-    *.js) echo "application/javascript" ;;
-    *.json) echo "application/json" ;;
-    *.txt) echo "text/plain" ;;
-    *.png) echo "image/png" ;;
-    *.svg) echo "image/svg+xml" ;;
-    *.html) echo "text/html" ;;
-    # Fonts
-    *.ttf) echo "font/ttf" ;;
-    *.woff) echo "font/woff" ;;
-    *.woff2) echo "font/woff2" ;;
-    *.eot) echo "application/vnd.ms-fontobject" ;;
-    # Blazor
-    *.wasm) echo "application/wasm" ;;
-    *.pdb) echo "text/plain" ;;
-    *.dll) echo "application/octet-stream" ;;
-    *.dat) echo "application/octet-stream" ;;
-    *.blat) echo "application/octet-stream" ;;
+
+# Filter out files we don't care about
+def shouldCopyFile(filename):
+  filesToSkip = ["backend/static/.gitkeep", "backend/static/etags.json"]
+  if filename in filesToSkip:
+    return False
+
+  if filename.endswith(".gz") or filename.endswith(".br"):
+    return False
+
+  return True
+
+staticFilesToCopy = [f for f in allStaticFiles if shouldCopyFile(f)]
+
+
+# Determine content-type / mimetype
+# See also ApiServer.configureStaticContent
+def mimeTypeFor(filename):
+  # Common web stuff
+  if filename.endswith(".css"): return "text/css"
+  elif filename.endswith(".js"): return "application/javascript"
+  elif filename.endswith(".json"): return "application/json"
+  elif filename.endswith(".txt"): return "text/plain"
+  elif filename.endswith(".png"): return "image/png"
+  elif filename.endswith(".svg"): return "image/svg+xml"
+  elif filename.endswith(".html"): return "text/html"
+  # Fonts
+  elif filename.endswith(".ttf"): return "font/ttf"
+  elif filename.endswith(".woff"): return "font/woff"
+  elif filename.endswith(".woff2"): return "font/woff2"
+  elif filename.endswith(".eot"): return "application/vnd.ms-fontobject"
+  # Blazor
+  elif filename.endswith(".wasm"): return "application/wasm"
+  elif filename.endswith(".pdb"): return "text/plain"
+  elif filename.endswith(".dll"): return "application/octet-stream"
+  elif filename.endswith(".dat"): return "application/octet-stream"
+  elif filename.endswith(".blat"): return "application/octet-stream"
+  else:
     # Don't allow anything else
-    *) echo "Unknown extension for ${file}"; exit 1 ;;
-  esac
-}
+    print(f'Unknown extension for {filename}')
+    sys.exit(-1)
 
-function upload {
-  local localpath="$1"
-  local remotepath="$2"
-  local mimetype;
-  mimetype="$(mimeTypeFor ${localpath})"
-  echo -e "copy\n  ${localpath}\nto\n  ${remotepath}\nmime\n  ${mimetype}\n\n"
 
-  # We do separate uploads for each file to get the mimetype right
-  # -h: set header
-  # -Z: Uploaded file is served as zipped. Also adds 'no-transform' to Cache-Control header
-  # -n: Don't overwrite
-  gsutil \
-    -h "Content-Type:${mimetype}" \
-    -h "Cache-Control:public" \
-    cp \
-      -Z \
-      -n \
-      "${localpath}" \
-      "${BUCKET}/${remotepath}" \
-      &
-}
+# key = mimetype, value = list of static file (by local name))
+filesGroupedByMimetype = {}
+for f in staticFilesToCopy:
+  mimetype = mimeTypeFor(f)
 
-function uploadHashed {
-  local file="$1"
-  local basefile="${file//$PREFIX_TO_REMOVE}"
-  local filehash
-  echo -e "hashing ${basefile}"
-  filehash="$(jq -r --arg FILE "${basefile}" '.[$FILE]' backend/static/etags.json)"
-  echo -e "hash for ${basefile}: ${filehash}"
-  local hashed_file="${basefile%.*}-${filehash}.${basefile##*.}"
+  if mimetype in filesGroupedByMimetype:
+    filesGroupedByMimetype[mimetype].append(f)
+  else:
+    filesGroupedByMimetype[mimetype] = [f]
 
-  upload "${file}" "${hashed_file}"
-}
 
-function uploadUnhashed {
-  local file=$1
-  local basefile="${file//$PREFIX_TO_REMOVE}"
+# Copy the files to CDN - some of the files are hashed
+def shouldHash(filename):
+  return not filename.startswith("backend/static/vendor/")
 
-  upload "${file}" "${basefile}"
-}
+with open('backend/static/etags.json', 'r') as f:
+  etags = json.load(f)
 
-function skipFile {
-  local file=$1
-  if [[ "${file}" == "backend/static/.gitkeep" ]]; then
-    return 0
-  elif [[ "${file}" == "backend/static/etags.json" ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
+def remoteFileName(filename):
+  filename = filename.replace(PREFIX_TO_REMOVE, '')
 
-files=$(find backend/static -type f -and -not -name "*.gz" -and -not -name "*.br")
+  if shouldHash(filename):
+    filehash = etags[filename]
+    (base, _dot, extension) = filename.rpartition('.')
+    hashedFile = f'{base}-{filehash}.{extension}'
+    return hashedFile
+  else:
+    return filename
 
-echo "Checking mime types"
-for file in $files; do
-  if skipFile "$file"; then
-    : # do nothing
-  else
-    mimeTypeFor "$file"
-  fi
-done
+def remoteFilePath(fileName):
+  return f'{BUCKET}/{remoteFileName(fileName)}'
 
-echo "Uploading"
 
-# Upload in parallel
-for file in $files ; do
-  if skipFile "$file"; then
-    echo "skipping $file"
-  elif [[ "${file}" == "backend/static/vendor/"* ]]; then
-    uploadUnhashed "${file}"
-  else
-    uploadHashed "${file}"
-  fi
-done
+for mimetype in filesGroupedByMimetype:
+  localFilesForMimeType = filesGroupedByMimetype[mimetype]
+  for file in localFilesForMimeType:
+    remotePath = remoteFileName(file)
 
-# Wait for uploads to be done
-wait
-echo "Done!"
+    gsutilCommand = '''gsutil \
+      -h "Content-Type:{mimetype}" \
+      -h "Cache-Control:public" \
+      cp \
+        -Z \
+        -n \
+        "{localpath}" \
+        "{remotepath}" &
+      '''.format(mimetype=mimetype, localpath=file, remotepath=remoteFilePath(file))
+
+    subprocess.run(gsutilCommand, shell=True)
+
+# Wrap up
+print("Done!")

--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -5,17 +5,19 @@ import os
 import sys
 import json
 import subprocess
+import tempfile
+import shutil
 
-PREFIX_TO_REMOVE="backend/static/"
+ROOT_OF_FILES="backend/static/"
 BUCKET="gs://darklang-static-assets"
 
-# Fetch all files
-allStaticFiles = [f for f in glob.glob('backend/static/**', recursive=True) if os.path.isfile(f)]
+# Gather list of files in known dir
+allStaticFiles = [f for f in glob.glob(ROOT_OF_FILES + '**', recursive=True) if os.path.isfile(f)]
 
 
 # Filter out files we don't care about
 def shouldCopyFile(filename):
-  filesToSkip = ["backend/static/.gitkeep", "backend/static/etags.json"]
+  filesToSkip = [ROOT_OF_FILES + ".gitkeep", ROOT_OF_FILES + "etags.json"]
   if filename in filesToSkip:
     return False
 
@@ -23,8 +25,43 @@ def shouldCopyFile(filename):
     return False
 
   return True
-
 staticFilesToCopy = [f for f in allStaticFiles if shouldCopyFile(f)]
+
+
+# We want to call `gsutil cp` in bulk by Content-Type shortly, but it doesn't
+# support a way to copy multiple files in one call while also renaming them.
+# So, we copy files to a new temp dir, adjusting file names to have hashes
+# injected where relevant.
+tempDir = tempfile.gettempdir() + "/static-assets/"
+shutil.rmtree(tempDir, ignore_errors=True)
+
+with open(ROOT_OF_FILES + '/etags.json', 'r') as f:
+  etags = json.load(f)
+
+def shouldHash(filename):
+  return not filename.startswith("vendor/")
+
+def getRemoteFileName(filePath):
+  filePath = filePath.replace(ROOT_OF_FILES, '')
+
+  if shouldHash(filePath):
+    fileHash = etags[filePath]
+    (base, _dot, extension) = filePath.rpartition('.')
+    return f'{base}-{fileHash}.{extension}'
+  else:
+    return filePath
+
+def getRemoteFilePath(filename):
+  return tempDir + getRemoteFileName(filename)
+
+for f in staticFilesToCopy:
+  target = getRemoteFilePath(f)
+  os.makedirs( os.path.dirname(target), exist_ok=True)
+  shutil.copy(f, target)
+
+# from now on, we don't care about the original paths
+staticFilesToCopy = [getRemoteFilePath(f) for f in staticFilesToCopy]
+ROOT_OF_FILES = tempDir
 
 
 # Determine content-type / mimetype
@@ -55,7 +92,8 @@ def mimeTypeFor(filename):
     sys.exit(-1)
 
 
-# key = mimetype, value = list of static file (by local name))
+# Group the files to copy by the Content-Type we want to send it as
+# key = mimetype, value = list of static file (by local name)
 filesGroupedByMimetype = {}
 for f in staticFilesToCopy:
   mimetype = mimeTypeFor(f)
@@ -65,45 +103,23 @@ for f in staticFilesToCopy:
   else:
     filesGroupedByMimetype[mimetype] = [f]
 
-
-# Copy the files to CDN - some of the files are hashed
-def shouldHash(filename):
-  return not filename.startswith("backend/static/vendor/")
-
-with open('backend/static/etags.json', 'r') as f:
-  etags = json.load(f)
-
-def remoteFileName(filename):
-  filename = filename.replace(PREFIX_TO_REMOVE, '')
-
-  if shouldHash(filename):
-    filehash = etags[filename]
-    (base, _dot, extension) = filename.rpartition('.')
-    hashedFile = f'{base}-{filehash}.{extension}'
-    return hashedFile
-  else:
-    return filename
-
-def remoteFilePath(fileName):
-  return f'{BUCKET}/{remoteFileName(fileName)}'
-
-
+# Copy the files to CDN - one `gsutil cp` call per Content-Type
 for mimetype in filesGroupedByMimetype:
-  localFilesForMimeType = filesGroupedByMimetype[mimetype]
-  for file in localFilesForMimeType:
-    remotePath = remoteFileName(file)
+  filesToCopy = " ".join(filesGroupedByMimetype[mimetype])
 
-    gsutilCommand = '''gsutil \
-      -h "Content-Type:{mimetype}" \
-      -h "Cache-Control:public" \
-      cp \
-        -Z \
-        -n \
-        "{localpath}" \
-        "{remotepath}" &
-      '''.format(mimetype=mimetype, localpath=file, remotepath=remoteFilePath(file))
+  # Prepare a `gsutil cp` call
+  # -h: set header
+  # -Z: Uploaded file is served as zipped. Also adds 'no-transform' to Cache-Control header
+  # -n: Don't overwrite
+  # -m: Upload assets in parallel, within call
+  gsutilCommand = ''' gsutil \
+    -h "Content-Type:{mimetype}" \
+    -h "Cache-Control:public" \
+    cp -Z -n {files} "{remoteDir}"
+    '''.format(mimetype=mimetype, files=filesToCopy, remoteDir=BUCKET)
 
-    subprocess.run(gsutilCommand, shell=True)
+  subprocess.run(gsutilCommand, shell=True)
 
 # Wrap up
+shutil.rmtree(tempDir, ignore_errors=True)
 print("Done!")


### PR DESCRIPTION
Currently, this script is failing, seemingly due to high memory usage. See commentary in #3872.

The intention here is to reduce the # of gsutil calls, uploading in batches per file extension or content-type.
The needs of the script got complex enough where it made sense to port to Python.

I'm at a point now where this is ported to match the original.

I'm not well-versed in Python or Bash, so I could be doing some plain dumb things here, stylistically.