### PR TITLE
More httpclient info

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/HttpClient.fs
@@ -301,15 +301,9 @@ let httpCall'
       return Error { url = url; code = 0; error = "Invalid URI" }
     | :? IOException as e -> return Error { url = url; code = 0; error = e.Message }
     | :? HttpRequestException as e ->
-      Telemetry.addTags [ "error", true; "error_msg", e.Message ]
       let code = if e.StatusCode.HasValue then int e.StatusCode.Value else 0
-      let message =
-        if isNull e.InnerException then
-          e.Message
-        else
-          Telemetry.addTag "inner_exception_error_msg" e.InnerException.Message
-          $"{e.Message} {e.InnerException.Message}"
-
+      let message = e |> Exception.getMessages |> String.concat " "
+      Telemetry.addTags [ "error", true; "error_msg", e.Message; "code", code ]
       return Error { url = url; code = code; error = message }
   }
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LegacyBaseHttpClient.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LegacyBaseHttpClient.fs
@@ -422,14 +422,9 @@ let makeHttpCall
       return
         Error { url = url; code = 0; error = prependInternalErrorMessage e.Message }
     | :? HttpRequestException as e ->
-      Telemetry.addTags [ "error", true; "error_msg", e.Message ]
       let code = if e.StatusCode.HasValue then int e.StatusCode.Value else 0
-      let message =
-        if isNull e.InnerException then
-          e.Message
-        else
-          Telemetry.addTag "inner_exception_error_msg" e.InnerException.Message
-          $"{e.Message} {e.InnerException.Message}"
+      let message = e |> Exception.getMessages |> String.concat " "
+      Telemetry.addTags [ "error", true; "error_msg", e.Message; "code", code ]
       return
         Error { url = url; code = code; error = prependInternalErrorMessage message }
   }

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -93,7 +93,10 @@ module Exception =
   /// Returns a list of exceptions of this exception, and all nested inner
   /// exceptions.
   let rec getMessages (e : exn) : List<string> =
-    if isNull e.InnerException then [] else e.Message :: getMessages e
+    if isNull e.InnerException then
+      [ e.Message ]
+    else
+      e.Message :: getMessages e.InnerException
 
   let rec toMetadata (e : exn) : Metadata =
     let innerMetadata =

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -89,6 +89,12 @@ type PageableException(message : string, metadata : Metadata, inner : exn) =
 let mutable exceptionCallback = (fun (e : exn) -> ())
 
 module Exception =
+
+  /// Returns a list of exceptions of this exception, and all nested inner
+  /// exceptions.
+  let rec getMessages (e : exn) : List<string> =
+    if isNull e.InnerException then [] else e.Message :: getMessages e
+
   let rec toMetadata (e : exn) : Metadata =
     let innerMetadata =
       if not (isNull e.InnerException) then toMetadata e.InnerException else []

--- a/fsharp-backend/src/QueueWorker/QueueWorker.fs
+++ b/fsharp-backend/src/QueueWorker/QueueWorker.fs
@@ -51,7 +51,12 @@ let processNotification
                         "event.pubsub.ack_id", notification.pubSubAckID
                         "event.pubsub.message_id", notification.pubSubMessageID ]
     let resultType (dv : RT.Dval) : string =
-      dv |> RT.Dval.toType |> DvalReprExternal.typeToDeveloperReprV0
+      match dv with
+      | RT.DOption None -> "Option(None)"
+      | RT.DOption (Some _) -> "Option(Some)"
+      | RT.DResult (Error _) -> "Result(Error)"
+      | RT.DResult (Ok _) -> "Result(Ok)"
+      | _ -> dv |> RT.Dval.toType |> DvalReprExternal.typeToDeveloperReprV0
 
     // Function used to quit this event
     let stop


### PR DESCRIPTION
This adds a little more info to see if things are working (or why they aren't).

In http requests, get more errors if they exist, and see if we can get enough info from this to know why a http request has failed.

In the queues, we now see `Option(None)` or `Option(Some)` (and similar for results) instead of `Option`. We have that info in OCaml, so it makes for a better comparison.
