### PR TITLE
Upgrade k8s/dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:48713d2
+      - image: darklang/dark-base:63e8ebf
   # Rust is so big we create a separate container for it and only use that
   # for rust builds
   in-rust-container:
@@ -26,7 +26,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-rust:48713d2
+      - image: darklang/dark-rust:63e8ebf
 
 commands:
   show-large-files-and-directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -366,7 +366,7 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
 RUN sudo dotnet workload install wasm-tools
 
 # formatting
-RUN dotnet tool install fantomas-tool --version 4.6.3 -g
+RUN dotnet tool install fantomas-tool --version 4.7.9 -g
 RUN curl https://raw.githubusercontent.com/darklang/build-files/main/ocamlformat --output ~/bin/ocamlformat && chmod +x ~/bin/ocamlformat
 ENV PATH "$PATH:/home/dark/bin:/home/dark/.dotnet/tools"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       nodejs \
       google-cloud-sdk \
       google-cloud-sdk-pubsub-emulator \
+      google-cloud-sdk-gke-gcloud-auth-plugin \
       jq \
       vim \
       unzip \
@@ -257,6 +258,9 @@ RUN sudo wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
 
 # PubSub
 ENV PUBSUB_EMULATOR_HOST=0.0.0.0:8085
+
+# GKE
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 # crcmod for gsutil; this gets us the compiled (faster), not pure Python
 # (slower) crcmod, as described in `gsutil help crcmod`

--- a/Dockerfile
+++ b/Dockerfile
@@ -311,7 +311,7 @@ RUN \
 # Kubeconform - for linting k8s files
 ############################
 RUN \
-  VERSION=v0.4.12 \
+  VERSION=v0.4.13 \
   && wget -P tmp_install_folder/ https://github.com/yannh/kubeconform/releases/download/$VERSION/kubeconform-linux-amd64.tar.gz \
   && tar xvf tmp_install_folder/kubeconform-linux-amd64.tar.gz -C  tmp_install_folder \
   && sudo cp tmp_install_folder/kubeconform /usr/bin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -364,9 +364,6 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
     && dotnet help
 
 RUN sudo dotnet workload install wasm-tools
-RUN dotnet tool install -g dotnet-sos
-# TODO: is this the right directory?
-RUN echo "plugin load /home/dark/.dotnet/tools/.store/dotnet-sos/5.0.160202/dotnet-sos/5.0.160202/tools/netcoreapp2.1/any/linux-x64/libsosplugin.so" > ~/.lldbinit
 
 # formatting
 RUN dotnet tool install fantomas-tool --version 4.6.3 -g

--- a/Dockerfile
+++ b/Dockerfile
@@ -340,7 +340,7 @@ RUN wget -q https://honeycomb.io/download/honeymarker/linux/honeymarker_1.9_amd6
 # (runtime-deps, runtime, and sdk), see
 # https://github.com/dotnet/dotnet-docker/blob/master/src
 
-ENV DOTNET_SDK_VERSION=6.0.201 \
+ENV DOTNET_SDK_VERSION=6.0.300 \
     # Skip extraction of XML docs - generally not useful within an
     # image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
@@ -354,7 +354,7 @@ ENV DOTNET_SDK_VERSION=6.0.201 \
     DOTNET_USE_POLLING_FILE_WATCHER=true
 
 RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='a4d96b6ca2abb7d71cc2c64282f9bd07cedc52c03d8d6668346ae0cd33a9a670d7185ab0037c8f0ecd6c212141038ed9ea9b19a188d1df2aae10b2683ce818ce' \
+    && dotnet_sha512='52d720e90cfb889a92d605d64e6d0e90b96209e1bd7eab00dab1d567017d7a5a4ff4adbc55aff4cffcea4b1bf92bb8d351859d00d8eb65059eec5e449886c938' \
     && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
     && sudo mkdir -p /usr/share/dotnet \
     && sudo tar -C /usr/share/dotnet -oxzf dotnet.tar.gz . \

--- a/fsharp-backend/global.json
+++ b/fsharp-backend/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.201",
+    "version": "6.0.300",
     "rollForward": "disable"
   }
 }

--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -435,7 +435,9 @@ let configureApp (healthCheckPort : int) (app : IApplicationBuilder) =
       try
         canvasName
         |> Option.map (fun canvasName ->
-          canvasName |> Account.ownerNameFromCanvasName |> fun on -> on.toUserName ())
+          canvasName
+          |> Account.ownerNameFromCanvasName
+          |> fun on -> on.toUserName ())
       with
       | _ -> None
 

--- a/fsharp-backend/src/LibBackend/Tracing.fs
+++ b/fsharp-backend/src/LibBackend/Tracing.fs
@@ -172,8 +172,7 @@ let createNonTracer () : TraceResults.T * RT.Tracing =
 
 /// Collections of functions and values used during a single execution
 type T =
-  {
-    /// Store the tracing input, if enabled
+  { /// Store the tracing input, if enabled
     storeInput : HandlerDesc -> RT.Dval -> unit
 
     /// Store the trace results calculated over the execution, if enabled

--- a/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
@@ -73,7 +73,7 @@ let fns : List<BuiltInFn> =
       description = "Returns `dict`'s values in a list, in an arbitrary order."
       fn =
         (function
-        | _, [ DObj o ] -> o |> Map.values |> Seq.toList |> fun l -> DList l |> Ply
+        | _, [ DObj o ] -> o |> Map.values |> Seq.toList |> (fun l -> DList l |> Ply)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -971,14 +971,14 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList l; DFnVal b ] ->
           uply {
-            let abortReason = ref None
+            let mutable abortReason = None
 
-            let rec f : List<Dval> -> Ply<List<Dval>> =
-              function
-              | [] -> Ply []
-              | dv :: dvs ->
-                uply {
-                  let run = abortReason.Value = None
+            let rec f (list : List<Dval>) : Ply<List<Dval>> =
+              uply {
+                match list with
+                | [] -> return []
+                | dv :: dvs ->
+                  let run = abortReason = None
 
                   if run then
                     let! result =
@@ -990,18 +990,18 @@ let fns : List<BuiltInFn> =
                     | (DIncomplete _
                     | DErrorRail _
                     | DError _) as dv ->
-                      abortReason.Value <- Some dv
+                      abortReason <- Some dv
                       return []
                     | v ->
                       return
                         Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
                   else
                     return []
-                }
+              }
 
             let! result = f l
 
-            match abortReason.Value with
+            match abortReason with
             | None -> return DList result
             | Some v -> return v
           }
@@ -1038,14 +1038,14 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DList l; DFnVal b ] ->
           uply {
-            let abortReason = ref None
+            let mutable abortReason = None
 
-            let rec f : List<Dval> -> Ply<List<Dval>> =
-              function
-              | [] -> Ply []
-              | dv :: dvs ->
-                uply {
-                  let run = abortReason.Value = None
+            let rec f (list : List<Dval>) : Ply<List<Dval>> =
+              uply {
+                match list with
+                | [] -> return []
+                | dv :: dvs ->
+                  let run = abortReason = None
 
                   if run then
                     let! result =
@@ -1059,18 +1059,18 @@ let fns : List<BuiltInFn> =
                     | (DIncomplete _
                     | DErrorRail _
                     | DError _) as dv ->
-                      abortReason.Value <- Some dv
+                      abortReason <- Some dv
                       return []
                     | v ->
                       return
                         Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
                   else
                     return []
-                }
+              }
 
             let! result = f l
 
-            match abortReason.Value with
+            match abortReason with
             | None -> return DList result
             | Some v -> return v
           }

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -88,7 +88,7 @@ let fns : List<BuiltInFn> =
           let chars = String.toEgcSeq s
 
           if Seq.length chars = 1 then
-            chars |> Seq.toList |> fun l -> l[0] |> DChar |> Some |> DOption |> Ply
+            chars |> Seq.toList |> (fun l -> l[0] |> DChar |> Some |> DOption |> Ply)
           else
             Ply(DOption None)
         | _ -> incorrectArgs ())

--- a/scripts/linting/yamllinter
+++ b/scripts/linting/yamllinter
@@ -23,7 +23,7 @@ check_k8s_files() {
   xargs \
     kubeconform \
       -strict \
-      -kubernetes-version 1.20.15 \
+      -kubernetes-version 1.22.9 \
       -skip CustomResourceDefinition \
       -schema-location default \
       -schema-location 'scripts/linting/crd-schemas/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json'

--- a/services/custom-domains-darklang/cert-manager-clusterrolebinding.yaml
+++ b/services/custom-domains-darklang/cert-manager-clusterrolebinding.yaml
@@ -1,7 +1,6 @@
 # See docs/custom-domains.md for more detail.
 
 kind: ClusterRoleBinding
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cert-manager


### PR DESCRIPTION
Upgrades involving kubernetes and the dockerfile:

- use the new non-deprecated version of gke cloud plugin
- upgrade kubeconform
  - set version of kubeconform to match cluster
- upgrade to dotnet 6.0.5
  - fix code to not fail in 6.0.5
- remove unused sos plugin
- upgrade fantomas
  - reformat to match fantomas