### PR TITLE
Get correct junit.xml in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,9 +324,7 @@ jobs:
       # For tests
       - run: cp client/static/favicon-32x32.png backend/static/
       - run: scripts/build/_generate-etags
-      - run: scripts/build/compile-project fsharp-backend
-      # Expecto needs `--colours 0` or the xml will be invalid - https://github.com/haf/expecto/issues/434
-      - run: scripts/run-fsharp-tests --debug --colours 0 --published
+      - run: scripts/build/compile-project fsharp-backend --test
       - assert-clean-worktree
       - persist_to_workspace:
           # Do this before reducing size of cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ jobs:
       - run: scripts/build/_generate-etags
       - run: scripts/build/compile-project fsharp-backend
       # Expecto needs `--colours 0` or the xml will be invalid - https://github.com/haf/expecto/issues/434
-      - run: scripts/run-fsharp-tests --debug --colours 0
+      - run: scripts/run-fsharp-tests --debug --colours 0 --published
       - assert-clean-worktree
       - persist_to_workspace:
           # Do this before reducing size of cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,9 @@ jobs:
       # For tests
       - run: cp client/static/favicon-32x32.png backend/static/
       - run: scripts/build/_generate-etags
-      - run: scripts/build/compile-project fsharp-backend --test
+      - run: scripts/build/compile-project fsharp-backend
+      # Expecto needs `--colours 0` or the xml will be invalid - https://github.com/haf/expecto/issues/434
+      - run: scripts/run-fsharp-tests --debug --colours 0
       - assert-clean-worktree
       - persist_to_workspace:
           # Do this before reducing size of cache

--- a/scripts/run-fsharp-tests
+++ b/scripts/run-fsharp-tests
@@ -84,6 +84,13 @@ JUNIT_FILE="${DARK_CONFIG_RUNDIR}/test_results/fsharp-backend.xml"
 # $RANDOM as RANDOM is only 5 digits
 RANDOM_VALUE=$(cat /proc/sys/kernel/random/uuid)
 
+COLOURS="256"
+if [[ -v CI ]]; then
+  # Expecto needs `--colours 0` or the xml will be invalid
+  # https://github.com/haf/expecto/issues/434
+  COLOURS="0"
+fi
+
 cd fsharp-backend
 if [[ "$LLDB" == "true" ]]; then
   DARK_CONFIG_TELEMETRY_EXPORTER=none \
@@ -94,7 +101,7 @@ if [[ "$LLDB" == "true" ]]; then
   DARK_CONFIG_DB_PASSWORD=darklang \
   DARK_CONFIG_LAUNCHDARKLY_SDK_API_KEY=none \
   DARK_CONFIG_QUEUE_PUBSUB_PROJECT_ID=pubsub-test-${RANDOM_VALUE} \
-  lldb -- "${EXE}" --no-spinner --junit-summary "${JUNIT_FILE}" "${EXPECTO_ARGS[@]}"
+  lldb -- "${EXE}" --no-spinner --colours 0 --junit-summary "${JUNIT_FILE}" "${EXPECTO_ARGS[@]}"
 else
   DARK_CONFIG_TELEMETRY_EXPORTER=none \
   DARK_CONFIG_ROLLBAR_ENABLED=n \
@@ -104,5 +111,5 @@ else
   DARK_CONFIG_DB_PASSWORD=darklang \
   DARK_CONFIG_LAUNCHDARKLY_SDK_API_KEY=none \
   DARK_CONFIG_QUEUE_PUBSUB_PROJECT_ID=pubsub-test-${RANDOM_VALUE} \
-  "${EXE}" --no-spinner --junit-summary "${JUNIT_FILE}" "${EXPECTO_ARGS[@]}"
+  "${EXE}" --no-spinner --colours "${COLOURS}" --junit-summary "${JUNIT_FILE}" "${EXPECTO_ARGS[@]}"
 fi

--- a/scripts/run-fsharp-tests
+++ b/scripts/run-fsharp-tests
@@ -13,17 +13,14 @@ function ctrl_c() {
 LLDB=false
 PUBLISHED=false
 
+EXPECTO_ARGS=()
+
 for i in "$@"
 do
   case "${i}" in
-    --lldb)
-    LLDB=true
-    shift
-    ;;
-    --published)
-    PUBLISHED=true
-    shift
-    ;;
+    --lldb) LLDB=true ;;
+    --published) PUBLISHED=true ;;
+    *) EXPECTO_ARGS+=("${i}");;
   esac
 done
 
@@ -97,7 +94,7 @@ if [[ "$LLDB" == "true" ]]; then
   DARK_CONFIG_DB_PASSWORD=darklang \
   DARK_CONFIG_LAUNCHDARKLY_SDK_API_KEY=none \
   DARK_CONFIG_QUEUE_PUBSUB_PROJECT_ID=pubsub-test-${RANDOM_VALUE} \
-  lldb -- "${EXE}" --no-spinner --junit-summary "${JUNIT_FILE}" "${@}"
+  lldb -- "${EXE}" --no-spinner --junit-summary "${JUNIT_FILE}" "${EXPECTO_ARGS[@]}"
 else
   DARK_CONFIG_TELEMETRY_EXPORTER=none \
   DARK_CONFIG_ROLLBAR_ENABLED=n \
@@ -107,6 +104,5 @@ else
   DARK_CONFIG_DB_PASSWORD=darklang \
   DARK_CONFIG_LAUNCHDARKLY_SDK_API_KEY=none \
   DARK_CONFIG_QUEUE_PUBSUB_PROJECT_ID=pubsub-test-${RANDOM_VALUE} \
-  "${EXE}" --no-spinner --junit-summary "${JUNIT_FILE}" "${@}"
+  "${EXE}" --no-spinner --junit-summary "${JUNIT_FILE}" "${EXPECTO_ARGS[@]}"
 fi
-

--- a/scripts/run-fsharp-tests
+++ b/scripts/run-fsharp-tests
@@ -10,14 +10,14 @@ function ctrl_c() {
   exit 1
 }
 
-DEBUG=false
+LLDB=false
 PUBLISHED=false
 
 for i in "$@"
 do
   case "${i}" in
-    --debug)
-    DEBUG=true
+    --lldb)
+    LLDB=true
     shift
     ;;
     --published)
@@ -88,7 +88,7 @@ JUNIT_FILE="${DARK_CONFIG_RUNDIR}/test_results/fsharp-backend.xml"
 RANDOM_VALUE=$(cat /proc/sys/kernel/random/uuid)
 
 cd fsharp-backend
-if [[ "$DEBUG" == "true" ]]; then
+if [[ "$LLDB" == "true" ]]; then
   DARK_CONFIG_TELEMETRY_EXPORTER=none \
   DARK_CONFIG_ROLLBAR_ENABLED=n \
   DARK_CONFIG_DB_HOST=localhost \


### PR DESCRIPTION
Forgot to merge this it seems

This fixes the junit output on fsharp tests in CI. This would have been useful for diagnosing the flaky tests.