### PR TITLE
Turn deployments down to zero for now

### DIFF
--- a/services/qw-deployment/qw-deployment.template.yaml
+++ b/services/qw-deployment/qw-deployment.template.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: qw-worker
-  replicas: 40
+  replicas: 0
   template:
     metadata:
       labels:

--- a/services/scheduler-deployment/scheduler-deployment.template.yaml
+++ b/services/scheduler-deployment/scheduler-deployment.template.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: scheduler-worker
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Turn down queueworkers to nothing.

Removing them is not hard but not completely trivial either, so let's just go down to zero for now.