### PR TITLE
Blazor analysis result serialization now results in Rollbars

### DIFF
--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -340,10 +340,8 @@ type EvalWorker =
         }
 
       let serialized =
-        let serialize = Json.Vanilla.serialize
-
         try
-          serialize result
+          Json.Vanilla.serialize result
         with
         | e ->
           let metadata = Exception.nestedMetadata e
@@ -352,7 +350,9 @@ type EvalWorker =
           System.Console.WriteLine(
             $"caught exception: \"{e.Message}\" \"{metadata}\""
           )
-          serialize (Error($"exception: {e.Message}, metadata: {metadata}"))
+          Json.Vanilla.serialize (
+            $"exception: {e.Message}, metadata: {metadata}"
+          )
 
       EvalWorker.postMessage serialized
     }

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -320,22 +320,39 @@ type EvalWorker =
           )
           Error($"exception: {e.Message}, metdata: {metadata}")
 
-      match args with
-      | Error e -> return Error e
-      | Ok args ->
+      let! result =
+        task {
+          match args with
+          | Error e -> return Error e
+          | Ok args ->
+            try
+              let! result = Eval.performAnalysis args
+              return Ok result
+            with
+            | e ->
+              let metadata = Exception.nestedMetadata e
+              System.Console.WriteLine("Error running analysis in Blazor")
+              System.Console.WriteLine($"called with message: {message}")
+              System.Console.WriteLine(
+                $"caught exception: \"{e.Message}\" \"{metadata}\""
+              )
+              return Error($"exception: {e.Message}, metadata: {metadata}")
+        }
+
+      let serialized =
+        let serialize = Json.Vanilla.serialize
+
         try
-          let! result = Eval.performAnalysis args
-          return Ok result
+          serialize result
         with
         | e ->
           let metadata = Exception.nestedMetadata e
-          System.Console.WriteLine("Error running analysis in Blazor")
+          System.Console.WriteLine("Error serializing results of Blazor analysis")
           System.Console.WriteLine($"called with message: {message}")
           System.Console.WriteLine(
             $"caught exception: \"{e.Message}\" \"{metadata}\""
           )
-          return Error($"exception: {e.Message}, metadata: {metadata}")
+          serialize (Error($"exception: {e.Message}, metadata: {metadata}"))
+
+      EvalWorker.postMessage serialized
     }
-    |> Task.map Json.Vanilla.serialize
-    |> Task.map EvalWorker.postMessage
-    |> ignore<Task<unit>>


### PR DESCRIPTION
Prior to this, serialization failures led to an infinite loading spinner in the client.