### PR TITLE
Don't error when the push is too big

### DIFF
--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -26,6 +26,13 @@
   comment unless extremely obvious. If unsure, add a comment. The comment does not need
   to be long, describing the purpose of the thing is usually enough.
 
+## HTTP API
+
+- Use REST where possible, don't hang on ceremony if it doesn't fit nicely
+  - We haven't been good about doing REST, so migrate to it where possible
+- JSON objects should use camelCase
+  - in the past, they used snake_case, so we should switch
+
 ## F#
 
 - `ignore` should always use a type signature (this should be enforced by the

--- a/fsharp-backend/src/LibBackend/Pusher.fs
+++ b/fsharp-backend/src/LibBackend/Pusher.fs
@@ -80,8 +80,10 @@ let pushAddOpEvent (canvasID : CanvasID) (event : Op.AddOpEvent) =
   if String.length payload > 10240 then
     let tlids = List.map LibExecution.OCamlTypes.tlidOf event.``params``.ops
     let tooBigPayload = { tlids = tlids } |> Json.Vanilla.serialize
+    // CLEANUP: when changes are too big, notify the client to reload them. We'll
+    // have to add support to the client before enabling this. The client would
+    // reload after this.
     // push canvasID "addOpTooBig" tooBigPayload
-    // CLEANUP: when changes are too big, notify the client to reload them
     ()
   else
     push canvasID "add_op" payload

--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -290,6 +290,40 @@ type 'expr_type op =
   | DeleteType of tlid
   | DeleteTypeForever of tlid
 
+let tlidOf (op : op<'expr_type>) : tlid =
+  match op with
+  | DeleteColInDBMigration (tlid, _) -> tlid
+  | DeprecatedInitDbm (tlid, _, _, _, _) -> tlid
+  | SetHandler (tlid, _, _) -> tlid
+  | CreateDB (tlid, _, _) -> tlid
+  | AddDBCol (tlid, _, _) -> tlid
+  | SetDBColName (tlid, _, _) -> tlid
+  | ChangeDBColName (tlid, _, _) -> tlid
+  | SetDBColType (tlid, _, _) -> tlid
+  | ChangeDBColType (tlid, _, _) -> tlid
+  | SetExpr (tlid, _, _) -> tlid
+  | TLSavepoint tlid -> tlid
+  | UndoTL tlid -> tlid
+  | RedoTL tlid -> tlid
+  | DeleteTL tlid -> tlid
+  | MoveTL (tlid, _) -> tlid
+  | SetFunction f -> f.tlid
+  | DeleteFunction tlid -> tlid
+  | CreateDBMigration (tlid, _, _, _) -> tlid
+  | AddDBColToDBMigration (tlid, _, _) -> tlid
+  | AbandonDBMigration tlid -> tlid
+  | SetDBColNameInDBMigration (tlid, _, _) -> tlid
+  | SetDBColTypeInDBMigration (tlid, _, _) -> tlid
+  | DeleteDBCol (tlid, _) -> tlid
+  | RenameDBname (tlid, _) -> tlid
+  | CreateDBWithBlankOr (tlid, _, _, _) -> tlid
+  | SetType ut -> ut.tlid
+  | DeleteType tlid -> tlid
+  | DeleteFunctionForever tlid -> tlid
+  | DeleteTLForever tlid -> tlid
+  | DeleteTypeForever tlid -> tlid
+
+
 type 'expr_type oplist = 'expr_type op list
 type 'expr_type tlid_oplist = (tlid * 'expr_type oplist)
 


### PR DESCRIPTION
Large pushes are happening because the user is renaming something (probably a DB), that causes a ton of other TLs to be pushed.

For now, it's much much easier to drop these. I'd rather put the effort into making renames not change every toplevel, and this happens rarely and canvases are fairly rarely used by two people at once anyway.