### PR TITLE
No longer read cors from the DB

### DIFF
--- a/fsharp-backend/src/BwdServer/Server.fs
+++ b/fsharp-backend/src/BwdServer/Server.fs
@@ -268,17 +268,15 @@ exception NotFoundException of msg : string with
 
 // CLEANUP we'd like to get rid of corsSetting and move it out of the DB and
 // entirely into code in some middleware
-let canvasMetadataFromHost
-  (host : string)
-  : Task<Option<Canvas.Meta * Option<Canvas.CorsSetting>>> =
+let canvasMetadataFromHost (host : string) : Task<Option<Canvas.Meta>> =
   task {
     match Routing.canvasSourceFromHost host with
     | Routing.Bwd canvasName ->
       match CanvasName.create canvasName with
-      | Ok canvasName -> return! Canvas.getMetaAndCors canvasName
+      | Ok canvasName -> return! Canvas.getMeta canvasName
       | Error _ -> return None
     | Routing.CustomDomain customDomain ->
-      return! Canvas.getMetaAndCorsForCustomDomain customDomain
+      return! Canvas.getMetaForCustomDomain customDomain
   }
 
 /// ---------------
@@ -287,13 +285,14 @@ let canvasMetadataFromHost
 let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
   task {
     let host = Exception.catch (fun () -> ctx.Request.Host.Host)
-    let! canvasMetadata =
+    let! canvasMeta =
       match host with
       | None -> Task.FromResult None
       | Some host -> canvasMetadataFromHost host
 
-    match canvasMetadata with
-    | Some (meta, corsSetting) ->
+    match canvasMeta with
+    | Some meta ->
+
       ctx.Items[ "canvasName" ] <- meta.name // store for exception tracking
       ctx.Items[ "canvasOwnerID" ] <- meta.owner // store for exception tracking
 
@@ -353,7 +352,7 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
 
           // Execute - note that these are outside the handler
           let result = Resp.toHttpResponse result
-          let result = Cors.addCorsHeaders reqHeaders corsSetting result
+          let result = Cors.addCorsHeaders reqHeaders meta.name result
 
           do! writeResponseToContext ctx result
 
@@ -371,7 +370,7 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
 
       | [] when ctx.Request.Method = "OPTIONS" ->
         let reqHeaders = getHeaders ctx
-        match Cors.optionsResponse reqHeaders corsSetting with
+        match Cors.optionsResponse reqHeaders meta.name with
         | Some response -> do! writeResponseToContext ctx response
         | None -> ()
         return ctx

--- a/fsharp-backend/src/ExecHost/ExecHost.fs
+++ b/fsharp-backend/src/ExecHost/ExecHost.fs
@@ -118,7 +118,7 @@ let usesDB (options : Options) =
 let convertToRT (canvasName : string) : Task<unit> =
   task {
     let canvasName = CanvasName.createExn canvasName
-    let! canvasInfo = LibBackend.Canvas.getMeta canvasName
+    let! canvasInfo = LibBackend.Canvas.getMetaExn canvasName
     let! canvas = LibBackend.Canvas.loadAll canvasInfo
     let _program = LibBackend.Canvas.toProgram canvas
     let _handlers =

--- a/fsharp-backend/src/HttpMiddleware/CorsV0.fs
+++ b/fsharp-backend/src/HttpMiddleware/CorsV0.fs
@@ -14,13 +14,56 @@ module Resp = ResponseV0
 // TODO: Remove access to LibBackend from here
 module Canvas = LibBackend.Canvas
 
+
+type CorsSetting =
+  | AllOrigins
+  | Origins of List<string>
+
+module Test =
+  let mutable corsSettings : Dictionary.T<string, CorsSetting> = null
+
+  let initialize () : unit = corsSettings <- Dictionary.empty ()
+
+  let addAllOrigins (canvasName : CanvasName.T) : unit =
+    Dictionary.add (string canvasName) AllOrigins corsSettings
+
+  let addOrigins (canvasName : CanvasName.T) (origins : List<string>) : unit =
+    Dictionary.add (string canvasName) (Origins origins) corsSettings
+
+/// We used to have a feature where we'd set the cors setting on the canvas. It's
+/// much better to do this in middleware. These canvases are the remaining user
+/// canvases while we had a setting. We can remove all this once this is gone.
+let corsSettingForCanvas (canvasName : CanvasName.T) : Option<CorsSetting> =
+  match string canvasName with
+  | "ops-presence" ->
+    Some(Origins [ "localhost"; "darklang.localhost"; "https://darklang.com" ])
+  | "ops-adduser" -> Some(Origins [ "https://darklang.com" ])
+  | "listo" ->
+    Some(
+      Origins(
+        [ "http://localhost:8000"
+          "https://usealtitude.com"
+          "https://app.usealtitude.com"
+          "http://localhost:3000"
+          "https://elegant-galileo.netlify.com" ]
+      )
+    )
+  | canvasName ->
+    // There's actually a lot of tests for this. I don't want to slow things down by
+    // adding every test canvas here, so instead there's a nullable dictionary.
+    if isNull Test.corsSettings then
+      None
+    else
+      Dictionary.get canvasName Test.corsSettings
+
 // ---------------
 // CORS
 // ---------------
 let inferCorsOriginHeader
-  (corsSetting : Option<Canvas.CorsSetting>)
+  (canvasName : CanvasName.T)
   (headers : HttpHeaders.T)
   : string option =
+  let corsSetting = corsSettingForCanvas canvasName
   let originHeader = HttpHeaders.get "Origin" headers
 
   let defaultOrigins =
@@ -39,13 +82,13 @@ let inferCorsOriginHeader
     // This is helpful as a debugging aid since users will always see
     // Access-Control-Allow-Origin: * in their browsers, even if the
     // request has no Origin.
-    | _, Some Canvas.AllOrigins -> Some "*"
+    | _, Some AllOrigins -> Some "*"
 
     // if there's no supplied origin, don't set the header at all.
     | None, _ -> None
 
     // Return the origin if and only if it's in the setting
-    | Some origin, Some (Canvas.Origins origins) when List.contains origin origins ->
+    | Some origin, Some (Origins origins) when List.contains origin origins ->
       Some origin
 
     // Otherwise: there was a supplied origin and it's not in the setting.
@@ -56,10 +99,10 @@ let inferCorsOriginHeader
 
 let addCorsHeaders
   (reqHeaders : HttpHeaders.T)
-  (corsSetting : Option<Canvas.CorsSetting>)
+  (canvasName : CanvasName.T)
   (response : Resp.HttpResponse)
   : Resp.HttpResponse =
-  inferCorsOriginHeader corsSetting reqHeaders
+  inferCorsOriginHeader canvasName reqHeaders
   |> Option.map (fun origin ->
     { response with
         // these are added in order, so make sure the user's setting wins
@@ -69,7 +112,7 @@ let addCorsHeaders
 
 let optionsResponse
   (reqHeaders : HttpHeaders.T)
-  (corsSetting : Option<Canvas.CorsSetting>)
+  (canvasName : CanvasName.T)
   : Option<Resp.HttpResponse> =
   // When javascript in a browser tries to make an unusual cross-origin
   // request (for example, a POST with a weird content-type or something with
@@ -90,7 +133,7 @@ let optionsResponse
   let acReqHeaders = HttpHeaders.get "access-control-request-headers" reqHeaders
   let allowHeaders = Option.defaultValue "*" acReqHeaders
 
-  (inferCorsOriginHeader corsSetting reqHeaders)
+  (inferCorsOriginHeader canvasName reqHeaders)
   |> Option.map (fun origin ->
     { statusCode = 200
       body = [||]

--- a/fsharp-backend/src/LibBackend/CanvasClone.fs
+++ b/fsharp-backend/src/LibBackend/CanvasClone.fs
@@ -116,7 +116,7 @@ let cloneCanvas
   // an acceptable risk - users would have to get their welcome to dark email,
   // reset their password, and log in, before we finish running cloneCanvas.
   task {
-    let! fromMeta = Canvas.getMeta fromCanvasName
+    let! fromMeta = Canvas.getMetaExn fromCanvasName
     let! fromTLIDs = Serialize.fetchAllLiveTLIDs fromMeta.id
     // CLEANUP this could be substantially simplified once we know that oplist_cache is
     // non-null.

--- a/fsharp-backend/tests/DataTests/DataTests.fs
+++ b/fsharp-backend/tests/DataTests/DataTests.fs
@@ -176,11 +176,11 @@ let forEachCanvasWithClient
 let loadAllUserData (concurrency : int) (failOnError : bool) =
   forEachCanvas concurrency failOnError (fun canvasName ->
     task {
-      let! meta = Canvas.getMeta canvasName
+      let! meta = Canvas.getMetaExn canvasName
       let! c = Canvas.loadAllDBs meta
       let dbs =
         c.dbs |> Map.values |> List.map (fun db -> db.name, PT2RT.DB.toRT db) |> Map
-      let! state = TestUtils.TestUtils.executionStateFor meta dbs Map.empty
+      let! state = executionStateFor meta dbs Map.empty
       let! (result : List<unit>) =
         dbs
         |> Map.values
@@ -318,7 +318,7 @@ let main args =
 
   let fn (canvasName : CanvasName.T) : Task<unit> =
     task {
-      let! meta = Canvas.getMeta canvasName
+      let! meta = Canvas.getMetaExn canvasName
       let! tlids = Serialize.fetchAllTLIDs meta.id
 
       do! checkCached meta tlids

--- a/fsharp-backend/tests/Tests/ApiServer.Tests.fs
+++ b/fsharp-backend/tests/Tests/ApiServer.Tests.fs
@@ -408,7 +408,7 @@ let testGetTraceData (client : C) (canvasName : CanvasName.T) : Task<unit> =
 
 let testDBStats (client : C) (canvasName : CanvasName.T) : Task<unit> =
   task {
-    let! canvas = Canvas.getMeta canvasName
+    let! canvas = Canvas.getMetaExn canvasName
 
     let! canvasWithJustDBs = Canvas.loadAllDBs canvas
     let parameters =
@@ -486,7 +486,7 @@ let testTriggerHandler (client : C) (canvasName : CanvasName.T) =
 
 let testWorkerStats (client : C) (canvasName : CanvasName.T) : Task<unit> =
   task {
-    let! canvas = Canvas.getMeta canvasName
+    let! canvas = Canvas.getMetaExn canvasName
     let! canvasWithJustWorkers = Canvas.loadAllWorkers canvas
 
     do!

--- a/fsharp-backend/tests/Tests/Canvas.Tests.fs
+++ b/fsharp-backend/tests/Tests/Canvas.Tests.fs
@@ -477,7 +477,7 @@ let testCanvasClone =
 
     do! CanvasClone.cloneCanvas sourceCanvasName targetCanvasName false
     // Do this after to test the clone has created the canvas
-    let! targetMeta = Canvas.getMeta targetCanvasName
+    let! targetMeta = Canvas.getMetaExn targetCanvasName
 
     let! (sourceCanvas : Canvas.T) = Canvas.loadAll sourceMeta
     let! (targetCanvas : Canvas.T) = Canvas.loadAll targetMeta

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -54,10 +54,6 @@ DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentaluserna
 DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'name with space', can only contain lowercase roman letters and digits, or '_'" // FSHARPONLY
 
 [tests.canvases]
-DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "Unknown Err: \"No owner found for host not-a-canvas\"" // OCAMLONLY
-DarkInternal.getCORSSetting_v0 "not-a-canvas" = Test.typeError_v0 "Unknown error" // FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1
-DarkInternal.getCORSSetting_v0 "test-cors1" = Nothing
-
 DarkInternal.canvasIdOfCanvasName_v0 "not-a-canvas" = Nothing
 
 [test.checkPermission with none]
@@ -100,23 +96,3 @@ DarkInternal.canvasIdOfCanvasName_v0 "not-a-canvas" = Nothing
 [test.canvasId length]
 (let _ = DarkInternal.clearStaticAssets "test-canvas-id-of-canvas-name"  // get the canvas created
  DarkInternal.canvasIdOfCanvasName_v0 "test-canvas-id-of-canvas-name") |> Option.map_v1 (fun x -> String.length_v1 x) = Just 36
-
-[test.roundtrip cors just empty]
-(let _ = DarkInternal.setCORSSetting_v0 "test-cors2" (Just []) in
- DarkInternal.getCORSSetting_v0 "test-cors2") = Just []
-
-[test.roundtrip cors just list]
-(let _ = DarkInternal.setCORSSetting_v0 "test-cors3" (Just ["localhost:8000"]) in
- DarkInternal.getCORSSetting_v0 "test-cors3") = Just ["localhost:8000"]
-
-[test.roundtrip cors just number]
-(let _ = DarkInternal.setCORSSetting_v0 "test-cors4" (Just 5) in
- DarkInternal.getCORSSetting_v0 "test-cors4") = Nothing
-
-[test.roundtrip cors just number list]
-(let _ = DarkInternal.setCORSSetting_v0 "test-cors5" (Just [5]) in
- DarkInternal.getCORSSetting_v0 "test-cors5") = Nothing
-
-[test.roundtrip cors just star]
-(let _ = DarkInternal.setCORSSetting_v0 "test-cors6" (Just "*") in
- DarkInternal.getCORSSetting_v0 "test-cors6") = Just "*"


### PR DESCRIPTION
This stops us from fetching cors setting from the DB. Instead, we have a table in the code with the only cors settings that remain, and the DB column is no longer used and can be deleted.

The goal here is to simplify the loading code for BwdServer (from a readability perspective).

This feature is not documented anywhere, and only 3 users continue to use it (two of them being us).