### PR TITLE
Remove unused functions

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -72,16 +72,7 @@ let modifySchedule (fn : CanvasID -> string -> Task<unit>) =
 
 
 let fns : List<BuiltInFn> =
-  [ { name = fn "DarkInternal" "checkAccess" 0
-      parameters = []
-      returnType = TNull
-      description = "TODO"
-      fn = internalFn (fun _ -> Ply DNull)
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-    { name = fn "DarkInternal" "endUsers" 0
+  [ { name = fn "DarkInternal" "endUsers" 0
       parameters = []
       returnType = TList varA
       description =
@@ -101,96 +92,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
-
-    { name = fn "DarkInternal" "checkAllCanvases" 0
-      parameters = []
-      returnType = TNull
-      description = "TODO"
-      fn = internalFn (fun _ -> Ply DNull)
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = DeprecatedBecause "oldinternal" }
-
-    { name = fn "DarkInternal" "migrateAllCanvases" 0
-      parameters = []
-      returnType = TNull
-      description = "REMOVED"
-      fn = internalFn (fun _ -> Ply DNull)
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = DeprecatedBecause "oldinternal" }
-
-    { name = fn "DarkInternal" "cleanupOldTraces" 0
-      parameters = []
-      returnType = TNull
-      description = "Deprecated, use v1"
-      fn = internalFn (fun _ -> Ply DNull)
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DarkInternal" "cleanupOldTraces" 0) }
-
-
-    { name = fn "DarkInternal" "cleanupOldTraces" 1
-      parameters = []
-      returnType = TFloat
-      description = "Cleanup the old traces from a canvas"
-      fn =
-        internalFn (function
-          | state, [] -> Ply(DFloat 0.0)
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DarkInternal" "cleanupOldTracesForCanvas" 1) }
-
-
-    { name = fn "DarkInternal" "cleanupOldTracesForCanvas" 1
-      parameters = [ Param.make "canvas_id" TUuid "" ]
-      returnType = TFloat
-      description =
-        "Cleanup the old traces for a specific canvas. Returns elapsed time in ms."
-      fn =
-        internalFn (function
-          | state, [ DUuid canvas_id ] -> Ply(DFloat 0.0)
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = DeprecatedBecause "old internal" }
-
-
-    { name = fn "DarkInternal" "checkCanvas" 0
-      parameters = [ Param.make "host" TStr "" ]
-      returnType = TBool
-      description = "Validate the canvas' opcodes"
-      fn =
-        internalFn (function
-          | state, [ DStr host ] -> Ply DNull
-          // CLEANUP
-          // (match Canvas.validate_host host with
-          //  | Ok _ -> Ply(DBool true)
-          //  | Error _ -> Ply(DBool false))
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      // CLEANUP should be marked deprecated
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "migrateCanvas" 0
-      parameters = [ Param.make "host" TStr "" ]
-      returnType = TResult(varA, TStr)
-      description = "Migrate a canvas' opcodes"
-      fn =
-        internalFn (function
-          | state, [ DStr host ] -> Ply DNull
-          // CLEANUP
-          // (match Canvas.migrate_host (Unicode_string.to_string host) with
-          //  | Ok () -> DResult(Ok DNull)
-          //  | Error msg -> DResult(Error(DStr msg)))
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-    // deprecated = DeprecatedBecause "old internal" } CLEANUP
 
 
     { name = fn "DarkInternal" "upsertUser" 0
@@ -472,92 +373,6 @@ that's already taken, returns an error."
       deprecated = NotDeprecated }
 
 
-    { name = fn "DarkInternal" "schema" 0
-      parameters = [ Param.make "host" TStr ""; Param.make "dbid" TStr "" ]
-      returnType = TDict TStr
-      // returnType = varA CLEANUP
-      description = "Return a schema for the db"
-      fn =
-        internalFn (function
-          | _, [ DStr canvas_name; DStr tlid ] -> Ply DNull
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "canvasAsText" 0
-      parameters = [ Param.make "host" TStr "" ]
-      returnType = TStr
-      description = "TODO"
-      fn =
-        internalFn (function
-          | _, [ DStr host ] ->
-            (* Removed, no longer useful now that you can copy from Fluid *)
-            Ply(DStr "")
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "handlers" 0
-      parameters = [ Param.make "host" TStr "" ]
-      returnType = TList varA
-      description = "Returns a list of toplevel ids of handlers in `host`"
-      fn =
-        internalFn (function
-          | _, [ DStr host ] -> Ply DNull
-          // let c =
-          //   Canvas.load_all (Unicode_string.to_string host) []
-          //   |> Result.map_error (String.concat ", ")
-          //   |> Prelude.Result.ok_or_internal_exception "Canvas load error"
-          // !c.handlers
-          // |> IDMap.data
-          // |> Ply.List.filterMapSequentially Libexecution.Toplevel.as_handler
-          // |> List.map (fun h -> DStr(Libexecution.Types.string_of_id h.tlid))
-          // |> fun l -> DList l
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "functions" 0
-      parameters = [ Param.make "host" TStr "" ]
-      returnType = TList varA
-      description = "Returns a list of toplevel ids of the functions in `host`"
-      fn =
-        internalFn (function
-          | _, [ DStr host ] -> Ply DNull
-          // let c =
-          //   Canvas.load_all (Unicode_string.to_string host) []
-          //   |> Result.map_error (String.concat ", ")
-          //   |> Prelude.Result.ok_or_internal_exception "Canvas load error"
-          // !c.user_functions
-          // |> IDMap.data
-          // |> List.map (fun fn -> DStr(Libexecution.Types.string_of_id fn.tlid))
-          // |> fun l -> DList l
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "canLoadTraces" 0
-      parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
-      returnType = TBool
-      description =
-        "Takes a <var host> and a <var tlid> and returns {{true}} iff we can load and parse traces for the handler identified by <var tlid>, and {{false}} otherwise."
-      fn =
-        internalFn (function
-          | _, [ DStr host; DStr tlid ] -> Ply DNull
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
     { name = fn "DarkInternal" "dbs" 0
       parameters = [ Param.make "host" TStr "" ]
       returnType = TList TStr
@@ -581,46 +396,6 @@ that's already taken, returns an error."
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "oplistInfo" 0
-      parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
-      returnType = TDict TStr
-      // returnType = varA // CLEANUP
-      description =
-        "Returns the information from the toplevel_oplists table for the (host, tlid)"
-      fn =
-        internalFn (function
-          | _, [ DStr host; DStr tlid_str ] -> Ply DNull
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "storedEvents" 0
-      parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
-      returnType = TOption varA
-      description =
-        "Returns {{Just <var events>}}, where <var events> is the most recent stored events for the <param tlid> if it is a handler or {{Nothing}} if it is not."
-      fn = internalFn (fun (_, _) -> Ply DNull)
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "pushStrollerEvent" 0
-      parameters =
-        [ Param.make "canvas_id" TStr ""
-          Param.make "event" TStr ""
-          Param.make "payload" (TDict TStr) "" ]
-      // Param.make "payload" varA "" ] // CLEANUP
-      returnType = TResult(varA, TStr)
-      description = "Pushes an event to Stroller"
-      fn = internalFn (fun _ -> Ply DNull)
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = ReplacedBy(fn "DarkInternal" "pushStrollerEvent" 1) }
 
 
     { name = fn "DarkInternal" "pushStrollerEvent" 1
@@ -709,9 +484,7 @@ that's already taken, returns an error."
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
-      deprecated = NotDeprecated
-
-    }
+      deprecated = NotDeprecated }
 
 
     { name = fn "DarkInternal" "grant" 0
@@ -855,48 +628,6 @@ that's already taken, returns an error."
       deprecated = NotDeprecated }
 
 
-    { name = fn "DarkInternal" "fnsUsed" 0
-      parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
-      returnType = TList varA
-      description =
-        "Iterates through all ops of the AST, returning for each op a list of the functions used in that op. The last value will be the functions currently used."
-      fn =
-        internalFn (function
-          | _, [ DStr host; DStr tlid ] -> Ply DNull
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "fieldNamesUsed" 0
-      parameters = [ Param.make "host" TStr ""; Param.make "tlid" TStr "" ]
-      returnType = TList varA
-      description =
-        "Iterates through all ops of the AST, returning for each op a list of the field names used in that op. The last value will be the fieldnames in the current code."
-      fn =
-        internalFn (function
-          | _, [ DStr host; DStr tlid ] -> Ply DNull
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "fnMetadata" 0
-      parameters = [ Param.make "name" TStr "" ]
-      returnType = TResult(varA, TStr)
-      description =
-        "Returns an object with the metadata of the built-in function name"
-      fn =
-        internalFn (function
-          | _, [ DStr fnname ] -> Ply DNull
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
     { name = fn "DarkInternal" "allFunctions" 0
       parameters = []
       returnType = TList varA
@@ -924,20 +655,6 @@ that's already taken, returns an error."
               Dval.obj alist)
             |> DList
             |> Ply
-          | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "clearStaticAssets" 0
-      parameters = [ Param.make "host" TStr "" ]
-      returnType = TNull
-      description =
-        "Deletes our record of static assets for a handler. Does not delete the data from the bucket. This is a hack for making Ellen's demo easier and should not be used for other uses in this form."
-      fn =
-        internalFn (function
-          | _, [ DStr host ] -> Ply DNull
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
@@ -1166,37 +883,6 @@ human-readable data."
               "DarkInternal::raiseInternalException"
               [ "arg", arg ]
           | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "getHandlerTraces" 0
-      parameters =
-        [ Param.make "canvas_id" TUuid ""
-          Param.make "tlid" TStr ""
-          Param.make "count" TInt "" ]
-      returnType = TList varA
-      description = "Get the most recent [count] traces for the handler"
-      fn =
-        internalFn (function
-          | _, _ -> Ply(DInt 0))
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DarkInternal" "copyToplevelTraces" 0
-      parameters =
-        [ Param.make "canvas_id" TUuid ""
-          Param.make "tlid" TStr ""
-          Param.make "traces" (TList varA) ""
-          Param.make "count" TInt "" ]
-      returnType = TInt
-      description = "Doesn't exist anymore"
-      fn =
-        internalFn (function
-          | _, _ -> Ply(DInt 0))
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated } ]

--- a/fsharp-backend/src/LibBackend/CanvasClone.fs
+++ b/fsharp-backend/src/LibBackend/CanvasClone.fs
@@ -116,7 +116,9 @@ let cloneCanvas
   // an acceptable risk - users would have to get their welcome to dark email,
   // reset their password, and log in, before we finish running cloneCanvas.
   task {
-    let! fromMeta = Canvas.getMetaExn fromCanvasName
+    // In production, this canvas will always already exist. We use the AndCreate
+    // version here to make tests not fail.
+    let! fromMeta = Canvas.getMetaAndCreate fromCanvasName
     let! fromTLIDs = Serialize.fetchAllLiveTLIDs fromMeta.id
     // CLEANUP this could be substantially simplified once we know that oplist_cache is
     // non-null.

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -201,7 +201,11 @@ module Exception =
     with
     | _ -> None
 
-
+  let catchError (f : unit -> 'r) : Result<'r, string> =
+    try
+      Ok(f ())
+    with
+    | e -> Error e.Message
 
 
 // ----------------------

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -3,16 +3,14 @@ Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 23
 
 [tests.grants]
 
-[test.empty grants]
-// CLEANUP remove upsertUser_v1
+[test.empty grants FSHARPONLY]
 (let _ = Test.deleteUser_v0 "empty_grants"
- let _ = DarkInternal.upsertUser_v1_ster "empty_grants" "a@eg.com" "test user"
+ let _ = DarkInternal.insertUser_v2_ster "empty_grants" "a@eg.com" "test user" {}
  DarkInternal.orgsFor "empty_grants") = {}
 
-[test.grants and orgs]
-// CLEANUP remove upsertUser_v1
-(let _ = DarkInternal.upsertUser_v1_ster "gao_org" "gao-test-org@darklang.com" "gao test org"
- let _ = DarkInternal.upsertUser_v1_ster "gao_user" "gao-test-user@darklang.com" "gao test user"
+[test.grants and orgs FSHARPONLY]
+(let _ = DarkInternal.insertUser_v2_ster "gao_org" "gao-test-org@darklang.com" "gao test org" {}
+ let _ = DarkInternal.insertUser_v2_ster "gao_user" "gao-test-user@darklang.com" "gao test user" {}
  let _ = DarkInternal.grant_v0_ster "gao_user" "gao_org" "rw" in
  DarkInternal.orgsFor "gao_user") = { ``gao_org`` = "rw" }
 
@@ -44,50 +42,44 @@ Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 23
 (let session1 = DarkInternal.newSessionForUsername_v1_ster "test" in
  DarkInternal.deleteSession_v0 session1.sessionKey) = 1
 
-[tests.users]
+[tests.users FSHARPONLY]
 DarkInternal.getUser_v1 "test" = Just { admin = false; email = "test@darklang.com"; name = "Dark Backend Tests"; username = "test"}
 DarkInternal.getUserByEmail_v0 "test@darklang.com" = Just { admin = false; email = "test@darklang.com"; name = "Dark Backend Tests"; username = "test"}
 DarkInternal.usernameToUserInfo_v0 "test" = Just { admin = false; email = "test@darklang.com"; name = "Dark Backend Tests"; username = "test"}
-DarkInternal.upsertUser_v0 "name with space" "valid@email.com" "accidentalusername" = Test.typeError_v0 "Invalid username 'name with space', must match /^[a-z][a-z0-9_]{2,20}$/" // OCAMLONLY
-DarkInternal.upsertUser_v0 "name with space" "valid@email.com" "accidentalusername" = Test.typeError_v0 "Invalid username 'name with space', can only contain lowercase roman letters and digits, or '_'" // FSHARPONLY
-DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'name with space', must match /^[a-z][a-z0-9_]{2,20}$/" // OCAMLONLY
-DarkInternal.upsertUser_v1 "name with space" "valid@email.com" "accidentalusername" = Error "Invalid username 'name with space', can only contain lowercase roman letters and digits, or '_'" // FSHARPONLY
+DarkInternal.insertUser_v2 "name with space" "valid@email.com" "accidentalusername" {} = Error "Invalid username 'name with space', can only contain lowercase roman letters and digits, or '_'" // FSHARPONLY
 
 [tests.canvases]
 DarkInternal.canvasIdOfCanvasName_v0 "not-a-canvas" = Nothing
 
-[test.checkPermission with none]
+[test.checkPermission with none FSHARPONLY]
 (let user1 = ("cpn_user1_" ++ (String.random 5)) |> String.toLowercase_v1
  let user2 = ("cpn_user2_" ++ (String.random 5)) |> String.toLowercase_v1
  let user1Email = user1 ++ "-test@darklang.com"
  let user2Email = user2 ++ "-test@darklang.com"
-// CLEANUP remove upsertUser_v1
- let _ = DarkInternal.upsertUser_v1_ster user1 user1Email "cpn test user1"
- let _ = DarkInternal.upsertUser_v1_ster user2 user2Email "cpn test user2"
+ let _ = DarkInternal.insertUser_v2_ster user1 user1Email "cpn test user1" {}
+ let _ = DarkInternal.insertUser_v2_ster user2 user2Email "cpn test user2" {}
  let startingPermission = DarkInternal.checkPermission_v0 user1 user2
  let _ = DarkInternal.grant_v0_ster user1 user2 "" in
  [DarkInternal.checkPermission_v0 user1 user2; startingPermission] ) = ["" ; ""]
 
-[test.checkPermission with r]
+[test.checkPermission with r FSHARPONLY]
 (let user1 = ("cpr_user1_" ++ (String.random 5)) |> String.toLowercase_v1
  let user2 = ("cpr_user2_" ++ (String.random 5)) |> String.toLowercase_v1
  let user1Email = user1 ++ "-test@darklang.com"
  let user2Email = user2 ++ "-test@darklang.com"
-// CLEANUP remove upsertUser_v1
- let _ = DarkInternal.upsertUser_v1_ster user1 user1Email "cpr test user1"
- let _ = DarkInternal.upsertUser_v1_ster user2 user2Email "cpr test user2"
+ let _ = DarkInternal.insertUser_v2_ster user1 user1Email "cpr test user1" {}
+ let _ = DarkInternal.insertUser_v2_ster user2 user2Email "cpr test user2" {}
  let startingPermission = DarkInternal.checkPermission_v0 user1 user2
  let _ = DarkInternal.grant_v0_ster user1 user2 "r" in
  [DarkInternal.checkPermission_v0 user1 user2; startingPermission] ) = ["r" ; ""]
 
-[test.checkPermission with r]
+[test.checkPermission with r FSHARPONLY]
 (let user1 = ("cprw_user1_" ++ (String.random 5)) |> String.toLowercase_v1
  let user2 = ("cprw_user2_" ++ (String.random 5)) |> String.toLowercase_v1
  let user1Email = user1 ++ "-test@darklang.com"
  let user2Email = user2 ++ "-test@darklang.com"
-// CLEANUP remove upsertUser_v1
- let _ = DarkInternal.upsertUser_v1_ster user1 user1Email "cprw test user1"
- let _ = DarkInternal.upsertUser_v1_ster user2 user2Email "cprw test user2"
+ let _ = DarkInternal.insertUser_v2_ster user1 user1Email "cprw test user1" {}
+ let _ = DarkInternal.insertUser_v2_ster user2 user2Email "cprw test user2" {}
  let startingPermission = DarkInternal.checkPermission_v0 user1 user2
  let _ = DarkInternal.grant_v0_ster user1 user2 "rw" in
  [DarkInternal.checkPermission_v0 user1 user2; startingPermission] ) = ["rw" ; ""]

--- a/fsharp-backend/tests/testfiles/language.tests
+++ b/fsharp-backend/tests/testfiles/language.tests
@@ -393,8 +393,8 @@ Error (Test.errorRailValue_v0 Nothing) = Test.errorRailValue_v0 Nothing
 // DarkInternal tests are internal
 // ---------------------------
 [tests.darkinternal]
-DarkInternal.checkAccess_v0 = Test.typeError_v0 "User executed an internal function but isn't an admin: test" // OCAMLONLY
-DarkInternal.checkAccess_v0 = Test.typeError_v0 "Unknown error" // FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1
+DarkInternal.setAdmin "test" true = Test.typeError_v0 "User executed an internal function but isn't an admin: test" // OCAMLONLY
+DarkInternal.setAdmin "test" true = Test.typeError_v0 "Unknown error" // FSHARPONLY EXPECTED_EXCEPTION_COUNT: 1
 
 // ---------------------------
 // Equality


### PR DESCRIPTION
Removes LibDarkInternal functions that do nothing, and that have been replaced. I checked in honeycomb to see what the usage was for the last month and removed any that were not used which had a successor. I left in some that seemed like they would be useful going forward.