### PR TITLE
Fix another exception from bad urls, this one exception handling

### DIFF
--- a/fsharp-backend/src/LibService/Rollbar.fs
+++ b/fsharp-backend/src/LibService/Rollbar.fs
@@ -414,10 +414,10 @@ module AspNet =
             ()
           else
             try
-              printException
-                "rollbar in http middleware"
-                [ "url", (ctx.Request.GetEncodedUrl()) ]
-                e
+              let url =
+                Exception.catch ctx.Request.GetEncodedUrl
+                |> Option.defaultValue "invalid url"
+              printException "rollbar in http middleware" [ "url", url ] e
 
               let person, metadata =
                 try


### PR DESCRIPTION
This exception was fixed before in a different place, now it's cropping up in exception handling.

Fixes https://rollbar.com/darkops/darklang/items/3312/.