### PR TITLE
Show an error instead of failing

### DIFF
--- a/fsharp-backend/src/HttpMiddleware/RequestV0.fs
+++ b/fsharp-backend/src/HttpMiddleware/RequestV0.fs
@@ -138,13 +138,18 @@ let fromRequest
       parseFormBody headers body
     with
     | _ -> if allowUnparseable then RT.DNull else reraise ()
+  let fullBody =
+    try
+      UTF8.ofBytesUnsafe body |> RT.DStr
+    with
+    | _ -> RT.DError(RT.SourceNone, "Invalid UTF8 input")
   let parts =
     [ "body", parseBody
       "jsonBody", jsonBody
       "formBody", formBody
       "queryParams", parseQueryString query
       "headers", parseHeaders headers
-      "fullBody", RT.DStr(UTF8.ofBytesUnsafe body)
+      "fullBody", fullBody
       "cookies", cookies headers
       "url", url headers uri ]
   RT.Dval.obj parts


### PR DESCRIPTION
I thought about a couple of different approaches here:

- continue to fail if allowUnparseable is false

I didn't like this because I think the allowUnparseable thing sucks

- try parsing using replacements (`Prelude.UTF8.ofBytesWithReplacement`)

This wasn't a terrible idea, but I worry that users will see this and wonder what's going on

- add a DError

The nice thing about a DError is that we have a clear error, with a clear message, and it propagates.