### PR TITLE
Prevent failures of large analysis requests to Blazor

### DIFF
--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -354,6 +354,7 @@ type EvalWorker =
       EvalWorker.postMessage serialized)
 
     // Magic.
-    // Without this, AOT builds somehow reach beyond their memory limits
+    // Without this, a "memory access out of bounds" error is somehow raised,
+    // only for AOT builds
     // See https://github.com/darklang/dark/issues/4059
     |> Task.map (fun _ -> ())

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -223,7 +223,6 @@ module Eval =
       let ast = expr |> OT.Convert.ocamlExpr2PT |> PT2RT.Expr.toRT
       let inputVars = Map traceData.input
       let! (_result : RT.Dval) = Exe.executeExpr state inputVars ast
-
       let ocamlResults =
         dvalResults
         |> Dictionary.toList
@@ -306,39 +305,39 @@ type EvalWorker =
   ///
   /// Once evaluated, an async call to `self.postMessage` will be made
   static member OnMessage(message : string) =
+    // parse an analysis request, in JSON, from the JS world (BlazorWorker)
+    let args : Result<ClientInterop.performAnalysisParams, string> =
+      try
+        Ok(Json.Vanilla.deserialize<ClientInterop.performAnalysisParams> message)
+      with
+      | e ->
+        let metadata = Exception.nestedMetadata e
+        System.Console.WriteLine("Error parsing analysis request in Blazor")
+        System.Console.WriteLine($"called with message: {message}")
+        System.Console.WriteLine($"caught exception: \"{e.Message}\" \"{metadata}\"")
+        Error($"exception: {e.Message}, metdata: {metadata}")
+
+    // run the actual analysis (eval. the fn/handler)
     task {
-      let args =
+      match args with
+      | Error e -> return Error e
+      | Ok args ->
         try
-          Ok(Json.Vanilla.deserialize<ClientInterop.performAnalysisParams> message)
+          let! result = Eval.performAnalysis args
+          return Ok result
         with
         | e ->
           let metadata = Exception.nestedMetadata e
-          System.Console.WriteLine("Error parsing analysis in Blazor")
+          System.Console.WriteLine("Error running analysis in Blazor")
           System.Console.WriteLine($"called with message: {message}")
           System.Console.WriteLine(
             $"caught exception: \"{e.Message}\" \"{metadata}\""
           )
-          Error($"exception: {e.Message}, metdata: {metadata}")
+          return Error($"exception: {e.Message}, metadata: {metadata}")
+    }
 
-      let! result =
-        task {
-          match args with
-          | Error e -> return Error e
-          | Ok args ->
-            try
-              let! result = Eval.performAnalysis args
-              return Ok result
-            with
-            | e ->
-              let metadata = Exception.nestedMetadata e
-              System.Console.WriteLine("Error running analysis in Blazor")
-              System.Console.WriteLine($"called with message: {message}")
-              System.Console.WriteLine(
-                $"caught exception: \"{e.Message}\" \"{metadata}\""
-              )
-              return Error($"exception: {e.Message}, metadata: {metadata}")
-        }
-
+    // Serialize the result, and post it to the JS world (BlazorWorker)
+    |> Task.map (fun (result : Result<ClientInterop.AnalysisEnvelope, string>) ->
       let serialized =
         try
           Json.Vanilla.serialize result
@@ -352,5 +351,9 @@ type EvalWorker =
           )
           Json.Vanilla.serialize ($"exception: {e.Message}, metadata: {metadata}")
 
-      EvalWorker.postMessage serialized
-    }
+      EvalWorker.postMessage serialized)
+
+    // Magic.
+    // Without this, AOT builds somehow reach beyond their memory limits
+    // See https://github.com/darklang/dark/issues/4059
+    |> Task.map (fun _ -> ())


### PR DESCRIPTION
As discovered/discussed in #4059, large requests to the Blazor-powered WASM analysis sometimes resulted in this nasty runtime error, _only_ when built in Release mode with AOT compilation flag on in `Wasm.fsproj`:
![image](https://user-images.githubusercontent.com/906686/171496787-ef5f25c7-ac1b-4f39-8b2a-a0dff4f18527.png)

(Note: #4059 includes a fair amount of discovery around this issue. If you're reading this in the future, start there)

This PR resolves that. 

It's unclear _exactly_ why this works, but two things have changed:
- the old code had a nested `task{}` and `let!` pair when computing the `result`, before serializing and posting back the result.
- we added a `|> Task.map (fun _ -> ())` at the end of the last `task{}`. Without this, we still get the error

The underlying problem seems to be related to some of { GC, binding scope, `tasks`, AOT/release builds }, but I'm not sure. Personally I'm satisfied with this for now, and separately creating a minimal repro to hand to .net team.