### PR TITLE
More CI speedups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,6 @@ commands:
       # let's delete those first.
       - run: rm -Rf /home/dark/app/*
       - checkout
-      # Set the timestamp to the commit time. This allows timestamp-based build tools
-      # like .NET to use their incremental build feature. Without this, the checkout
-      # time is always newer than the cached object file, and files are always
-      # rebuilt.
-      # https://stackoverflow.com/a/22638823/104021
-      - run: git log --pretty=%at --name-status --reverse | perl -ane '($x,$f)=@F;next if !$x;$t=$x,next if !defined($f)||$s{$f};$s{$f}=utime($t,$t,$f),next if $x=~/[AM]/;'
-
 
 
   ##########################
@@ -301,6 +294,12 @@ jobs:
     resource_class: xlarge
     steps:
       - darkcheckout
+      # Set the timestamp to the commit time. This allows timestamp-based build tools
+      # like .NET to use their incremental build feature. Without this, the checkout
+      # time is always newer than the cached object file, and files are always
+      # rebuilt.
+      - run: sudo apt update && sudo apt install git-restore-mtime
+      - run: git restore-mtime
       - setup-app
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:
@@ -348,6 +347,12 @@ jobs:
     resource_class: xlarge
     steps:
       - darkcheckout
+      # Set the timestamp to the commit time. This allows timestamp-based build tools
+      # like .NET to use their incremental build feature. Without this, the checkout
+      # time is always newer than the cached object file, and files are always
+      # rebuilt.
+      - run: sudo apt update && sudo apt install git-restore-mtime
+      - run: git restore-mtime
       - setup-app
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:
           keys:
-            - v10-fsharp-backend-{{ checksum "../checksum" }}
+            - v11-fsharp-backend-{{ checksum "../checksum" }}
             # Fails often enough that it's better not to have a fallback
       - show-large-files-and-directories
       # For tests
@@ -318,7 +318,7 @@ jobs:
       - run: ./scripts/build/_dotnet-wrapper tool restore
       - run: ./scripts/build/_dotnet-wrapper paket restore
       # DebugType=None and DebugSymbol=false tells dotnet not to copy .pdb files to publish/
-      - run: ./scripts/build/_dotnet-wrapper publish -c Release fsbinaries.sln --no-restore /p:DebugType=None /p:DebugSymbols=false
+      - run: ./scripts/build/_dotnet-wrapper publish -c Release fsbinaries.sln /p:DebugType=None /p:DebugSymbols=false
       - run: scripts/run-fsharp-tests --published
       - assert-clean-worktree
       - persist_to_workspace:
@@ -333,7 +333,9 @@ jobs:
             - fsharp-backend/Build/out/ExecHost/Release/net6.0/linux-x64/publish/
       - show-large-files-and-directories
       - save_cache:
-          paths: [fsharp-backend/Build/obj]
+          paths:
+            - fsharp-backend/Build/obj
+            - /home/dark/.nuget
           key: v10-fsharp-backend-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
@@ -350,12 +352,12 @@ jobs:
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:
           keys:
-            - v1-fsharp-blazor-{{ checksum "../checksum" }}
+            - v2-fsharp-blazor-{{ checksum "../checksum" }}
             # Fails often enough that it's better not to have a fallback
       - show-large-files-and-directories
       - run: ./scripts/build/_dotnet-wrapper tool restore
       - run: ./scripts/build/_dotnet-wrapper paket restore
-      - run: ./scripts/build/_dotnet-wrapper publish -c Release --no-restore src/Wasm/Wasm.fsproj
+      - run: ./scripts/build/_dotnet-wrapper publish -c Release src/Wasm/Wasm.fsproj
       - run: cp -f fsharp-backend/src/Wasm/static/BlazorWorker.js backend/static/
       - run: rsync -a fsharp-backend/Build/out/Wasm/Release/net6.0/publish/wwwroot/_framework/ backend/static/blazor/
       - assert-clean-worktree
@@ -366,8 +368,10 @@ jobs:
             - backend/static/blazor
       - show-large-files-and-directories
       - save_cache:
-          paths: [fsharp-backend/Build/obj]
-          key: v1-fsharp-blazor-{{ checksum "../checksum" }}
+          paths:
+            - fsharp-backend/Build/obj
+            - /home/dark/.nuget
+          key: v2-fsharp-blazor-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - slack-notify-job-failure
       - deploy-lock-remove-on-fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ jobs:
       - run: ./scripts/build/_dotnet-wrapper tool restore
       - run: ./scripts/build/_dotnet-wrapper paket restore
       # DebugType=None and DebugSymbol=false tells dotnet not to copy .pdb files to publish/
-      - run: ./scripts/build/_dotnet-wrapper publish -c Release fsbinaries.sln /p:DebugType=None /p:DebugSymbols=false
+      - run: ./scripts/build/_dotnet-wrapper publish -c Release fsbinaries.sln --no-restore /p:DebugType=None /p:DebugSymbols=false
       - run: scripts/run-fsharp-tests --published
       - assert-clean-worktree
       - persist_to_workspace:
@@ -355,7 +355,7 @@ jobs:
       - show-large-files-and-directories
       - run: ./scripts/build/_dotnet-wrapper tool restore
       - run: ./scripts/build/_dotnet-wrapper paket restore
-      - run: ./scripts/build/_dotnet-wrapper publish -c Release src/Wasm/Wasm.fsproj
+      - run: ./scripts/build/_dotnet-wrapper publish -c Release --no-restore src/Wasm/Wasm.fsproj
       - run: cp -f fsharp-backend/src/Wasm/static/BlazorWorker.js backend/static/
       - run: rsync -a fsharp-backend/Build/out/Wasm/Release/net6.0/publish/wwwroot/_framework/ backend/static/blazor/
       - assert-clean-worktree

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,14 @@ commands:
       # let's delete those first.
       - run: rm -Rf /home/dark/app/*
       - checkout
+      # Set the timestamp to the commit time. This allows timestamp-based build tools
+      # like .NET to use their incremental build feature. Without this, the checkout
+      # time is always newer than the cached object file, and files are always
+      # rebuilt.
+      # https://stackoverflow.com/a/22638823/104021
+      - run: git log --pretty=%at --name-status --reverse | perl -ane '($x,$f)=@F;next if !$x;$t=$x,next if !defined($f)||$s{$f};$s{$f}=utime($t,$t,$f),next if $x=~/[AM]/;'
+
+
 
   ##########################
   # Setup app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,16 +222,16 @@ jobs:
       - setup-app
       - restore_cache:
           keys:
-            - v3-client-{{ checksum "package-lock.json" }}-{{ .Branch }}
-            - v3-client-{{ checksum "package-lock.json" }}
-            - v3-client
+            - v4-client-{{ checksum "package-lock.json" }}-{{ .Branch }}
+            - v4-client-{{ checksum "package-lock.json" }}
+            - v4-client
       - run: scripts/build/compile-project client --test
       - assert-clean-worktree
       - show-large-files-and-directories
       - save_cache:
           name: "Save packagejson-specific cache"
           paths: ["node_modules"]
-          key: v3-client-{{ checksum "package-lock.json" }}-{{ .Branch }}
+          key: v4-client-{{ checksum "package-lock.json" }}-{{ .Branch }}
       - persist_to_workspace:
           root: "."
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:59432bc
+      - image: darklang/dark-base:dcf86ff
 
 commands:
   show-large-files-and-directories:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:63e8ebf
+      - image: darklang/dark-base:59432bc
 
 commands:
   show-large-files-and-directories:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,6 @@ jobs:
       # like .NET to use their incremental build feature. Without this, the checkout
       # time is always newer than the cached object file, and files are always
       # rebuilt.
-      - run: sudo apt update && sudo apt install git-restore-mtime
       - run: git restore-mtime
       - setup-app
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
@@ -351,7 +350,6 @@ jobs:
       # like .NET to use their incremental build feature. Without this, the checkout
       # time is always newer than the cached object file, and files are always
       # rebuilt.
-      - run: sudo apt update && sudo apt install git-restore-mtime
       - run: git restore-mtime
       - setup-app
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           paths:
             - fsharp-backend/Build/obj
             - /home/dark/.nuget
-          key: v10-fsharp-backend-{{ checksum "../checksum" }}
+          key: v11-fsharp-backend-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
       - slack-notify-job-failure

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,6 @@ RUN curl -sSL https://baltocdn.com/helm/signing.asc | apt-key add -
 # We want postgres 9.6, but it is not in ubuntu 20.04
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 
-RUN echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-
 RUN echo "deb https://nginx.org/packages/ubuntu/ bionic nginx" > /etc/apt/sources.list.d/nginx.list
 
 RUN echo "deb https://deb.nodesource.com/node_14.x focal main" > /etc/apt/sources.list.d/nodesource.list
@@ -88,7 +86,6 @@ RUN echo "deb https://baltocdn.com/helm/stable/debian/ all main" > /etc/apt/sour
 
 # Deps:
 # - apt-transport-https for npm
-# - expect for unbuffer
 # - most libs re for ocaml
 # - net-tools for netstat
 # - esy packages need texinfo
@@ -105,8 +102,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
       wget \
       sudo \
       locales \
-      expect \
-      tcl8.6 \
       libev-dev \
       libgmp-dev \
       pkg-config \
@@ -115,7 +110,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
       postgresql-9.6 \
       postgresql-client-9.6 \
       postgresql-contrib-9.6 \
-      google-chrome-stable \
       nodejs \
       google-cloud-sdk \
       google-cloud-sdk-pubsub-emulator \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ RUN echo "deb https://baltocdn.com/helm/stable/debian/ all main" > /etc/apt/sour
 # - most libs re for ocaml
 # - net-tools for netstat
 # - esy packages need texinfo
+# - libgbm1 for playwright/chrome
 RUN DEBIAN_FRONTEND=noninteractive \
     apt update --allow-releaseinfo-change && \
     DEBIAN_FRONTEND=noninteractive \
@@ -111,6 +112,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       postgresql-client-9.6 \
       postgresql-contrib-9.6 \
       nodejs \
+      libgbm1 \
       google-cloud-sdk \
       google-cloud-sdk-pubsub-emulator \
       google-cloud-sdk-gke-gcloud-auth-plugin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       postgresql-9.6 \
       postgresql-client-9.6 \
       postgresql-contrib-9.6 \
+      git-restore-mtime \
       nodejs \
       libgbm1 \
       google-cloud-sdk \

--- a/scripts/build/_dune-wrapper.sh
+++ b/scripts/build/_dune-wrapper.sh
@@ -12,7 +12,7 @@ errorline=
 # the exit code of dune.
 shopt -s lastpipe
 
-unbuffer esy build dune "$@" 2>&1 | while read -r line; do
+esy build dune "$@" 2>&1 | while read -r line; do
   # this error consistently breaks our compile, esp on CI
   if [[ "$line" == *"make inconsistent assumptions over "* ]]; then
     error=1;
@@ -28,7 +28,7 @@ if [[ "$error" == 1 ]]; then
   echo "Cleaning"
   rm -Rf _build/*
   echo "Running again"
-  unbuffer esy build dune "$@"
+  esy build dune "$@"
 else
   exit $result
 fi

--- a/scripts/build/_npm-run-build-with-retry
+++ b/scripts/build/_npm-run-build-with-retry
@@ -12,7 +12,7 @@ errorline=
 # the exit code of dune.
 shopt -s lastpipe
 
-unbuffer npm run build --silent 2>&1 | while read -r line; do
+FORCE_COLOR=true npm run build --silent 2>&1 | while read -r line; do
   # sometimes this happens for unclear reasons
   if [[ "$line" == *"npm-run-all: not found"* ]]; then
     error=1;
@@ -27,7 +27,7 @@ if [[ "$error" == 1 ]]; then
   echo "Ran into an error running npm build: $errorline"
   echo "Running again"
   ./scripts/build/_npm-install-with-retry
-  unbuffer npm run build --silent
+  FORCE_COLOR=true npm run build --silent
 else
   exit $result
 fi

--- a/scripts/build/_rescript-wrapper.sh
+++ b/scripts/build/_rescript-wrapper.sh
@@ -12,7 +12,7 @@ errorline=
 # the exit code of dune.
 shopt -s lastpipe
 
-unbuffer bsb "$@" 2>&1 | while read -r line; do
+NINJA_ANSI_FORCED=1 bsb "$@" 2>&1 | while read -r line; do
   # this error consistently breaks our compile, esp on CI
   if [[ "$line" == *"Fatal error: exception Unix.Unix_error(Unix.ENOENT, \"execv\", \"/home/dark/app/node_modules/bs-platform/lib/ninja.exe\")"* ]]; then
     error=1;
@@ -33,7 +33,7 @@ if [[ "$error" == 1 ]]; then
   ./scripts/build/clear-node-modules
   echo "Running again"
   ./scripts/npm-install-with-retry
-  unbuffer bsb "$@"
+  NINJA_ANSI_FORCED=1 bsb "$@"
 else
   exit $result
 fi

--- a/scripts/build/compile
+++ b/scripts/build/compile
@@ -106,20 +106,20 @@ def copy_fsharp_static():
 
 def client_build():
   start = time.time()
-  build = "unbuffer ./scripts/build/_npm-run-build-with-retry"
+  build = "./scripts/build/_npm-run-build-with-retry"
   result = run_frontend(start, build)
   return result
 
 
 def npm_install():
   start = time.time()
-  build = "unbuffer ./scripts/build/_npm-install-with-retry"
+  build = "./scripts/build/_npm-install-with-retry"
   return run_frontend(start, build)
 
 
 def esy_install():
   start = time.time()
-  build = "unbuffer esy install && esy build --release"
+  build = "esy install && esy build --release"
   return run_backend(start, build)
 
 
@@ -193,8 +193,7 @@ def backend_build():
   else:
     compilation_profile = "dev"
 
-  build = "unbuffer" \
-        + " scripts/build/_dune-wrapper.sh build" \
+  build = "scripts/build/_dune-wrapper.sh build" \
         + f" --profile {compilation_profile}" \
         + " --display short" \
         + " -j 8 " \
@@ -206,8 +205,8 @@ def backend_test():
   start = time.time()
   ci = "--verbose" if in_ci else "--quick"
   return run_test(start,
-          f"unbuffer scripts/build/_dune-wrapper.sh build backend/test/test.exe" \
-          f" && unbuffer scripts/run-backend-tests --show-errors {ci}" \
+          f"scripts/build/_dune-wrapper.sh build backend/test/test.exe" \
+          f" && scripts/run-backend-tests --show-errors {ci}" \
           f" 2>&1")
 
 


### PR DESCRIPTION
A few more fixes to make CI faster.

Before: 9m22sm

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/181762/172028228-04dda2c6-920e-4752-b572-b144f3038834.png">

After: 8m7s

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/181762/172028265-60004b9b-d408-49cb-b29c-38b354489d6b.png">

There's two changes:
- use a 5% smaller docker container (not a great win)
- figure out (and fix) why dotnet was rebuilding so much (which is that the git checkout mtime was recent, while the CircleCI cached build objects' mtime was not recent).
