### PR TITLE
Small improvements to the error messages and signatures

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -228,8 +228,7 @@ that's already taken, returns an error."
     { name = fn "DarkInternal" "getAllCanvases" 0
       parameters = []
       returnType = TList TStr
-      description = "TODO"
-      // CLEANUP description = "Get a list of all canvas names"
+      description = "Get a list of all canvas names"
       fn =
         internalFn (fun _ ->
           uply {
@@ -467,8 +466,7 @@ that's already taken, returns an error."
 
     { name = fn "DarkInternal" "checkPermission" 0
       parameters = [ Param.make "username" TStr ""; Param.make "canvas" TStr "" ]
-      // CLEANUP: should be TStr
-      returnType = TBool
+      returnType = TStr
       description = "Check a user's permissions for a particular canvas."
       fn =
         internalFn (function

--- a/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibEvent.fs
@@ -18,10 +18,9 @@ let varA = TVariable "a"
 let fns : List<BuiltInFn> =
   [ { name = fn "" "emit" 0
       parameters =
-        // CLEANUP lowercase names
-        [ Param.make "Data" varA ""
-          Param.make "Space" TStr ""
-          Param.make "Name" TStr "" ]
+        [ Param.make "data" varA ""
+          Param.make "space" TStr ""
+          Param.make "name" TStr "" ]
       returnType = varA
       description =
         "Emit event `name` in `space`, passing along `data` as a parameter"
@@ -42,7 +41,7 @@ let fns : List<BuiltInFn> =
       deprecated = ReplacedBy(fn "" "emit" 1) }
 
     { name = fn "" "emit" 1
-      parameters = [ Param.make "event" varA ""; Param.make "Name" TStr "" ]
+      parameters = [ Param.make "event" varA ""; Param.make "name" TStr "" ]
       returnType = varA
       description = "Emit a `event` to the `name` worker"
       fn =

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
@@ -31,8 +31,7 @@ let encodeBasicAuthBroken (u : string) (p : string) : string =
 let encodeBasicAuth (u : string) (p : string) : string =
   let input : byte [] =
     if u.Contains("-") then
-      // CLEANUP, this says colon but this is a hyphen
-      Exception.raiseCode "Username cannot contain a colon"
+      Exception.raiseCode "Username cannot contain a hyphen"
     else
       toBytes $"{u}:{p}"
 

--- a/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibHttpClientAuth.fs
@@ -18,8 +18,7 @@ let incorrectArgs = LibExecution.Errors.incorrectArgs
 let encodeBasicAuthBroken (u : string) (p : string) : string =
   let input : byte [] =
     if u.Contains("-") then
-      // CLEANUP, this says colon but this is a hyphen
-      Exception.raiseCode "Username cannot contain a colon"
+      Exception.raiseCode "Username cannot contain a hyphen"
     else
       ([ (System.Text.Encoding.UTF8.GetBytes u)
          [| byte ':' |]

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -18,8 +18,6 @@ let varA = TVariable "a"
 let varB = TVariable "b"
 let varErr = TVariable "err"
 
-// CLEANUP: fix the typos in "unecnrypted"
-
 // Here's how JWT with RS256, and this library, work:
 //
 //   Users provide a private key, some headers, and a payload.
@@ -379,7 +377,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "pemPrivKey" TStr ""; Param.make "payload" varA "" ]
       returnType = TStr
       description =
-        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm. Takes an unecnrypted RSA private key in PEM format."
+        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm. Takes an unencrypted RSA private key in PEM format."
       fn =
         (function
         | _, [ DStr key; payload ] ->
@@ -396,7 +394,7 @@ let fns : List<BuiltInFn> =
           Param.make "payload" varA "" ]
       returnType = TStr
       description =
-        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm, with an extra header map. Takes an unecnrypted RSA private key in PEM format."
+        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm, with an extra header map. Takes an unencrypted RSA private key in PEM format."
       fn =
         (function
         | _, [ DStr key; DObj headers; payload ] ->
@@ -410,7 +408,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "pemPrivKey" TStr ""; Param.make "payload" varA "" ]
       returnType = TResult(varB, varErr)
       description =
-        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm. Takes an unecnrypted RSA private key in PEM format."
+        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm. Takes an unencrypted RSA private key in PEM format."
       fn =
         (function
         | _, [ DStr key; payload ] ->
@@ -430,7 +428,7 @@ let fns : List<BuiltInFn> =
           Param.make "payload" varA "" ]
       returnType = TResult(varB, varErr)
       description =
-        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm, with an extra header map. Takes an unecnrypted RSA private key in PEM format."
+        "Sign and encode an rfc751J9 JSON Web Token, using the RS256 algorithm, with an extra header map. Takes an unencrypted RSA private key in PEM format."
       fn =
         (function
         | _, [ DStr key; DObj headers; payload ] ->
@@ -447,8 +445,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "pemPubKey" TStr ""; Param.make "token" TStr "" ]
       returnType = TOption varA
       description =
-        // CLEANUP: the docstring should say "extract"
-        "Verify and extra the payload and headers from an rfc751J9 JSON Web Token that uses the RS256 algorithm. Takes an unencrypted RSA public key in PEM format."
+        "Verify and extract the payload and headers from an rfc751J9 JSON Web Token that uses the RS256 algorithm. Takes an unencrypted RSA public key in PEM format."
       fn =
         (function
         | _, [ DStr key; DStr token ] ->
@@ -481,8 +478,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "pemPubKey" TStr ""; Param.make "token" TStr "" ]
       returnType = TResult(varA, varErr)
       description =
-        // CLEANUP: the docstring should say "extract"
-        "Verify and extra the payload and headers from an rfc751J9 JSON Web Token that uses the RS256 algorithm. Takes an unencrypted RSA public key in PEM format."
+        "Verify and extract the payload and headers from an rfc751J9 JSON Web Token that uses the RS256 algorithm. Takes an unencrypted RSA public key in PEM format."
       fn =
         (function
         | _, [ DStr key; DStr token ] ->

--- a/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
@@ -274,8 +274,7 @@ let fns : List<BuiltInFn> =
               let! response = getV0 url
               match UTF8.ofBytesOpt response with
               | Some str -> return Dval.resultOk (DStr str)
-              // CLEANUP remove \n from error message
-              | None -> return Dval.resultError (DStr "Response was not\nUTF-8 safe")
+              | None -> return Dval.resultError (DStr "Response was not UTF-8 safe")
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
@@ -26,7 +26,6 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] ->
           Ply(
-            // CLEANUP why no charset?
             DObj(
               Map.ofList [ "Content-Type", DStr "application/x-www-form-urlencoded" ]
             )

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -457,11 +457,13 @@ let fns : List<BuiltInFn> =
 
     { name = fn "List" "fold" 0
       parameters =
-        [ Param.make "list" (TList varA) "" // CLEANUP add description "The list of items to process one at a time"
-          Param.make "init" varB "" // CLEANUP add description "The initial starting value"
-          Param.makeWithArgs "f" (TFn([ varB; varA ], varB)) "" [ "accum"; "curr" ] ]
-      // CLEANUP add description
-      //"the function taking the accumulated value and the next list item, returning the next accumulated item."
+        [ Param.make "list" (TList varA) "The list of items to process one at a time"
+          Param.make "init" varB "The initial starting value"
+          Param.makeWithArgs
+            "f"
+            (TFn([ varB; varA ], varB))
+            "the function taking the accumulated value and the next list item, returning the next accumulated item."
+            [ "accum"; "curr" ] ]
       returnType = varB
       description =
         "Folds `list` into a single value, by repeatedly applying `f` to any two pairs."
@@ -1109,7 +1111,7 @@ let fns : List<BuiltInFn> =
 
     { name = fn "List" "map" 0
       parameters =
-        [ Param.make "list" (TList varA) "" // CLEANUP "The list to be operated on"
+        [ Param.make "list" (TList varA) "The list to be operated on"
           Param.makeWithArgs "f" (TFn([ varA ], varB)) "" [ "val" ] ]
       description =
         "Calls `f` on every `val` in `list`, returning a list of the results of those calls.

--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -40,10 +40,12 @@ let fns : List<BuiltInFn> =
 
     { name = fn "String" "foreach" 0
       parameters =
-        [ Param.make "s" TStr "" // CLEANUP "string to iterate over"
-          Param.makeWithArgs "f" (TFn([ TChar ], TChar)) "" [ "char" ]
-          // CLEANUP "function used to convert one character to another"
-          ]
+        [ Param.make "s" TStr "string to iterate over"
+          Param.makeWithArgs
+            "f"
+            (TFn([ TChar ], TChar))
+            "function used to convert one character to another"
+            [ "char" ] ]
       returnType = TStr
       description =
         "Iterate over each character (byte, not EGC) in the string, performing the operation in the block on each one"
@@ -148,8 +150,8 @@ let fns : List<BuiltInFn> =
 
     { name = fn "String" "replaceAll" 0
       parameters =
-        [ Param.make "s" TStr "" // CLEANUP "The string to operate on"
-          Param.make "searchFor" TStr "" // CLEANUP "The string to search for within <param s>"
+        [ Param.make "s" TStr "The string to operate on"
+          Param.make "searchFor" TStr "The string to search for within <param s>"
           Param.make "replaceWith" TStr "" ]
       returnType = TStr
       description = "Replace all instances on `searchFor` in `s` with `replaceWith`"
@@ -1337,8 +1339,7 @@ let fns : List<BuiltInFn> =
 
     { name = fn "String" "endsWith" 0
       parameters =
-        [ Param.make "subject" TStr "" // CLEANUP "String to test"
-          Param.make "suffix" TStr "" ]
+        [ Param.make "subject" TStr "String to test"; Param.make "suffix" TStr "" ]
       returnType = TBool
       description = "Checks if `subject` ends with `suffix`"
       fn =

--- a/fsharp-backend/tests/testfiles/httpclient.tests
+++ b/fsharp-backend/tests/testfiles/httpclient.tests
@@ -18,14 +18,14 @@ HttpClient.bearerToken_v1 "YWxhZGRpbjpvcGVuc2VzYW1l" = { Authorization = "Bearer
 
 HttpClient.basicAuth_v0 "username" "password" = { Authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" }
 HttpClient.basicAuth_v0 "" "" = { Authorization = "Basic Og==" }
-HttpClient.basicAuth_v0 "-" "" = Test.typeError_v0 "Username cannot contain a colon"
+HttpClient.basicAuth_v0 "-" "" = Test.typeError_v0 "Username cannot contain a hyphen"
 HttpClient.basicAuth_v0 "" "-" = { Authorization = "Basic Oi0=" }
 HttpClient.basicAuth_v0 ":" "" = { Authorization = "Basic Ojo=" }
 HttpClient.basicAuth_v0 "" ":" = { Authorization = "Basic Ojo=" }
 
 HttpClient.basicAuth_v1 "username" "password" = { Authorization = "Basic dXNlcm5hbWU6cGFzc3dvcmQ=" }
 HttpClient.basicAuth_v1 "" "" = { Authorization = "Basic Og==" }
-HttpClient.basicAuth_v1 "-" "" = Test.typeError_v0 "Username cannot contain a colon"
+HttpClient.basicAuth_v1 "-" "" = Test.typeError_v0 "Username cannot contain a hyphen"
 HttpClient.basicAuth_v1 "" "-" = { Authorization = "Basic Oi0=" }
 HttpClient.basicAuth_v1 ":" "" = { Authorization = "Basic Ojo=" }
 HttpClient.basicAuth_v1 "" ":" = { Authorization = "Basic Ojo=" }


### PR DESCRIPTION
These were like this in OCaml so we kept them the same to match during the migration.