### PR TITLE
Include inner exception details in Blazor rollbars

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -137,9 +137,9 @@ function displayError(msg) {
 }
 
 window.onerror = function (msg, url, lineno, colno, error) {
+  console.error("Uncaught exception", msg, url, lineno, colno, error);
   window.Rollbar.error(msg, error);
   window.lastError = error;
-  console.error("Uncaught exception", msg, url, lineno, colno, error);
   displayError(msg);
 };
 


### PR DESCRIPTION
- remove some redundancy in Wasm.fs
- use Exception.getMessages to roll inner exception into returned error message for Blazor errors