### PR TITLE
Make Wasm/EvalWorker.OnMessage synchronous with .Result

### DIFF
--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -334,7 +334,7 @@ type EvalWorker =
         with
         | e -> reportAndRollUpExceptionIntoError "Error running analysis" e
 
-    // Serialize the result, and post it to the JS world (BlazorWorker)
+    // Serialize the result
     let serialized =
       try
         Json.Vanilla.serialize result


### PR DESCRIPTION
Locally, this makes it so I can't reproduce [these](https://github.com/darklang/dark/issues/4099) nasty things.

Maybe we can escape Blazor hell? :)