### PR TITLE
Pass secrets through in F# analysis

### DIFF
--- a/fsharp-backend/src/LibExecution/OCamlTypes.fs
+++ b/fsharp-backend/src/LibExecution/OCamlTypes.fs
@@ -673,7 +673,8 @@ module Convert =
     | BSTypes.UserType ut -> PT.Toplevel.TLType(ocamlUserType2PT ut)
     | BSTypes.UserFn uf -> PT.Toplevel.TLFunction(ocamlUserFunction2PT uf)
 
-
+  let ocamlSecret2RT (secret : secret) : RT.Secret.T =
+    { name = secret.secret_name; value = secret.secret_value }
 
   // ----------------
 // ProgramTypes to OCaml

--- a/fsharp-backend/src/Wasm/Wasm.fs
+++ b/fsharp-backend/src/Wasm/Wasm.fs
@@ -170,6 +170,7 @@ module Eval =
     (userTypes : List<ORT.user_tipe>)
     (dbs : List<ORT.fluidExpr ORT.DbT.db>)
     (expr : ORT.fluidExpr)
+    (secrets : List<OT.secret>)
     : Task<ClientInterop.AnalysisEnvelope> =
     task {
       let program : RT.ProgramContext =
@@ -194,7 +195,7 @@ module Eval =
             |> List.map PT2RT.DB.toRT
             |> List.map (fun t -> t.name, t)
             |> Map
-          secrets = [] }
+          secrets = secrets |> List.map (OT.Convert.ocamlSecret2RT) }
 
       let stdlib =
         LibExecutionStdLib.StdLib.fns
@@ -250,6 +251,7 @@ module Eval =
         ah.user_tipes
         (List.map ClientInterop.convert_db ah.dbs)
         ah.handler.ast
+        ah.secrets
     | ClientInterop.AnalyzeFunction af ->
       runAnalysis
         af.func.tlid
@@ -259,6 +261,7 @@ module Eval =
         af.user_tipes
         (List.map ClientInterop.convert_db af.dbs)
         af.func.ast
+        af.secrets
 
 open System
 open System.Reflection


### PR DESCRIPTION
An empty list `[]` of Secrets is currently being passed through for F# analysis. This fixes that.