### PR TITLE
Add new Date fns with correct handling of pre-1970 dates

### DIFF
--- a/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
@@ -482,9 +482,22 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DDate d ] ->
-          // CLEANUP - this was made bug-for-bug compatible
+          // this was made bug-for-bug compatible with old OCaml backend
           let s = if d.Year < 1970 then d.Hour - 23 else d.Hour
           Ply(Dval.int s)
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'hour'" ])
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Date" "hour" 2
+      parameters = [ Param.make "date" TDate "" ]
+      returnType = TInt
+      description = "Returns the hour portion of the Date as an int"
+      fn =
+        (function
+        | _, [ DDate d ] -> Ply(Dval.int d.Hour)
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'hour'" ])
       previewable = Pure
@@ -498,7 +511,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DDate d ] ->
-          // CLEANUP - this was made bug-for-bug compatible
+          // this was made bug-for-bug compatible with the old OCaml backend
           let s =
             if d.Year < 1970 then
               if d.Second = 0 then (d.Minute - 60) % 60 else d.Minute - 59
@@ -512,6 +525,19 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "Date" "minute" 1
+      parameters = [ Param.make "date" TDate "" ]
+      returnType = TInt
+      description = "Returns the minute portion of the Date as an int"
+      fn =
+        (function
+        | _, [ DDate d ] -> Ply(Dval.int d.Minute)
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'minute'" ])
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
     { name = fn "Date" "second" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
@@ -519,9 +545,22 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ DDate d ] ->
-          // CLEANUP - this was made bug-for-bug compatible
+          // this was made bug-for-bug compatible with the old OCaml backend
           let s = if d.Year < 1970 then (d.Second - 60) % 60 else d.Second
           Ply(Dval.int s)
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'second'" ])
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Date" "second" 1
+      parameters = [ Param.make "date" TDate "" ]
+      returnType = TInt
+      description = "Returns the second portion of the Date as an int"
+      fn =
+        (function
+        | _, [ DDate d ] -> Ply(Dval.int d.Second)
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'second'" ])
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
@@ -488,7 +488,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'hour'" ])
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = ReplacedBy(fn "Date" "hour" 2) }
 
 
     { name = fn "Date" "hour" 2
@@ -522,7 +522,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'minute'" ])
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = ReplacedBy(fn "Date" "minute" 1) }
 
 
     { name = fn "Date" "minute" 1
@@ -551,7 +551,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'second'" ])
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = ReplacedBy(fn "Date" "second" 1) }
 
 
     { name = fn "Date" "second" 1

--- a/fsharp-backend/tests/testfiles/date.tests
+++ b/fsharp-backend/tests/testfiles/date.tests
@@ -181,7 +181,6 @@ Date.weekday_v0 (d "2019-07-27T22:42:36Z") = 6
 Date.weekday_v0 (d "2019-07-28T22:42:36Z") = 7
 
 
-// CLEANUP: a bug in our implementation causes dates before 1970 to be wrong
 [tests.date before the epoch is negative - 1919]
 Date.year_v0 (d "1919-07-28T22:42:36Z") = 1919
 Date.month_v0 (d "1919-07-28T22:42:36Z") = 7
@@ -189,10 +188,12 @@ Date.day_v0 (d "1919-07-28T22:42:36Z") = 28
 Date.weekday_v0 (d "1919-07-28T22:42:36Z") = 1
 Date.hour_v0 (d "1919-07-28T22:42:36Z") = -37
 Date.hour_v1 (d "1919-12-27T03:27:36Z")  = -20
+Date.hour_v2 (d "1919-12-27T03:27:36Z")  = 3
 Date.minute_v0 (d "1919-07-28T22:42:36Z") = -17
+Date.minute_v1 (d "1919-07-28T22:42:36Z") = 42
 Date.second_v0 (d "1919-07-28T22:42:36Z") = -24
+Date.second_v1 (d "1919-07-28T22:42:36Z") = 36
 
-// CLEANUP: a bug in our implementation causes dates before 1970 to be wrong
 [tests.date before the epoch is negative: 1969]
 Date.year_v0 (d "1969-07-28T22:42:36Z") = 1969
 Date.month_v0 (d "1969-07-28T22:42:36Z") = 7
@@ -200,10 +201,12 @@ Date.day_v0 (d "1969-07-28T22:42:36Z") = 28
 Date.weekday_v0 (d "1969-07-28T22:42:36Z") = 1
 Date.hour_v0 (d "1969-07-28T22:42:36Z") = -25
 Date.hour_v1 (d "1969-12-27T03:27:36Z")  = -20
+Date.hour_v2 (d "1969-12-27T03:27:36Z")  = 3
 Date.minute_v0 (d "1969-07-28T22:42:36Z") = -17
+Date.minute_v1 (d "1969-07-28T22:42:36Z") = 42
 Date.second_v0 (d "1969-07-28T22:42:36Z") = -24
+Date.second_v1 (d "1969-07-28T22:42:36Z") = 36
 
-// CLEANUP: a bug in our implementation causes dates before 1970 to be wrong
 [tests.date before the epoch is negative: 1970]
 Date.year_v0    (d "1970-07-28T22:42:36Z") = 1970
 Date.month_v0   (d "1970-07-28T22:42:36Z") = 7
@@ -211,7 +214,10 @@ Date.day_v0     (d "1970-07-28T22:42:36Z") = 28
 Date.weekday_v0 (d "1970-07-28T22:42:36Z") = 2
 Date.hour_v0    (d "1970-07-28T22:42:36Z") = 34
 Date.hour_v1    (d "1970-12-27T03:27:36Z")  = 3
+Date.hour_v2    (d "1970-12-27T03:27:36Z")  = 3
 Date.minute_v0  (d "1970-07-28T22:42:36Z") = 42
+Date.minute_v0  (d "1970-07-28T22:42:36Z") = 42
+Date.second_v0  (d "1970-07-28T22:42:36Z") = 36
 Date.second_v0  (d "1970-07-28T22:42:36Z") = 36
 
 [tests.date conversion]


### PR DESCRIPTION
Keep existing fns as-is (while removing CLEANUP annotations) and create new versions of `Date::` `hour`, `minute`, and `second`