### PR TITLE
Adjust query param parsing so empty vals result in DStrs

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/HttpQueryEncoding.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/HttpQueryEncoding.fs
@@ -6,7 +6,7 @@ module BackendOnlyStdLib.HttpQueryEncoding
 /// prefer not to share code like this as we may need to mutate one and don't want to
 /// change how other parts of the framework and standard library work. If we do
 /// further work on any of this, we may want to split functionality out in some way,
-/// including dupliucating code.
+/// including duplicating code.
 ///
 /// CLEANUP: this isn't a great place for this file, at time of writing we don't have
 /// a better idea.
@@ -95,7 +95,6 @@ let ofQuery (query : List<string * List<string>>) : RT.Dval =
   |> List.map (fun (k, v) ->
     match v with
     | [] -> k, RT.DNull
-    | [ "" ] -> k, RT.DNull // CLEANUP this should be a string
     | [ v ] -> k, RT.DStr v
     | list -> k, RT.DList(List.map RT.DStr list))
   |> Map

--- a/fsharp-backend/tests/httptestfiles/request-form-empty-param-equals.test
+++ b/fsharp-backend/tests/httptestfiles/request-form-empty-param-equals.test
@@ -22,10 +22,10 @@ Content-Length: LENGTH
 
 {
   "b": {
-    "param": null
+    "param": ""
   },
   "f": {
-    "param": null
+    "param": ""
   },
   "fb": "param=",
   "j": null

--- a/fsharp-backend/tests/httptestfiles/request-queryparams-empty-param-equals.test
+++ b/fsharp-backend/tests/httptestfiles/request-queryparams-empty-param-equals.test
@@ -20,5 +20,5 @@ Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
 Content-Length: LENGTH
 
 {
-  "param": null
+  "param": ""
 }


### PR DESCRIPTION
per a CLEANUP item.

They were previously parsed as DNulls to match the old OCaml backend.