### PR TITLE
Rename function params of StdLib fns (f -> fn)

### DIFF
--- a/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
@@ -224,10 +224,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "foreach" 0
       parameters =
         [ Param.make "dict" (TDict varA) ""
-          Param.makeWithArgs "f" (TFn([ varA ], varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TDict varB
       description =
-        "Returns a new dictionary that contains the same keys as the original `dict` with values that have been transformed by `f`, which operates on each value."
+        "Returns a new dictionary that contains the same keys as the original `dict` with values that have been transformed by `fn`, which operates on each value."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -249,10 +249,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "map" 0
       parameters =
         [ Param.make "dict" (TDict varA) ""
-          Param.makeWithArgs "f" (TFn([ TStr; varA ], varB)) "" [ "key"; "value" ] ]
+          Param.makeWithArgs "fn" (TFn([ TStr; varA ], varB)) "" [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Returns a new dictionary that contains the same keys as the original `dict` with values that have been transformed by `f`, which operates on each key-value pair.
+        "Returns a new dictionary that contains the same keys as the original `dict` with values that have been transformed by `fn`, which operates on each key-value pair.
           Consider `Dict::filterMap` if you also want to drop some of the entries."
       fn =
         (function
@@ -283,10 +283,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "filter" 0
       parameters =
         [ Param.make "dict" (TDict varA) ""
-          Param.makeWithArgs "f" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
+          Param.makeWithArgs "fn" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
       returnType = TDict varA
       description =
-        "Calls `f` on every entry in `dict`, returning a dictionary of only those entries for which `f key value` returns `true`.
+        "Calls `fn` on every entry in `dict`, returning a dictionary of only those entries for which `fn key value` returns `true`.
               Consider `Dict::filterMap` if you also want to transform the entries."
       fn =
         (function
@@ -311,7 +311,7 @@ let fns : List<BuiltInFn> =
                   incomplete.Value <- true
                   return false
                 | v ->
-                  return Exception.raiseCode (Errors.expectedLambdaType "f" TBool v)
+                  return Exception.raiseCode (Errors.expectedLambdaType "fn" TBool v)
               }
 
             if incomplete.Value then
@@ -329,10 +329,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "filter" 1
       parameters =
         [ Param.make "dict" (TDict varA) ""
-          Param.makeWithArgs "f" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
+          Param.makeWithArgs "fn" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Evaluates `f key value` on every entry in `dict`. Returns a new dictionary that contains only the entries of `dict` for which `f` returned `true`."
+        "Evaluates `fn key value` on every entry in `dict`. Returns a new dictionary that contains only the entries of `dict` for which `fn` returned `true`."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -362,7 +362,9 @@ let fns : List<BuiltInFn> =
                   | (DError _ as e) -> return Error e
                   | other ->
                     return
-                      Exception.raiseCode (Errors.expectedLambdaType "f" TBool other)
+                      Exception.raiseCode (
+                        Errors.expectedLambdaType "fn" TBool other
+                      )
                 }
 
             let! filtered_result =
@@ -382,15 +384,15 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "dict" (TDict varA) ""
           Param.makeWithArgs
-            "f"
+            "fn"
             (TFn([ TStr; varA ], TOption varB))
             ""
             [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Calls `f` on every entry in `dict`, returning a new dictionary that drops some entries (filter) and transforms others (map).
-          If `f key value` returns `Nothing`, does not add `key` or `value` to the new dictionary, dropping the entry.
-          If `f key value` returns `Just newValue`, adds the entry `key`: `newValue` to the new dictionary.
+        "Calls `fn` on every entry in `dict`, returning a new dictionary that drops some entries (filter) and transforms others (map).
+          If `fn key value` returns `Nothing`, does not add `key` or `value` to the new dictionary, dropping the entry.
+          If `fn key value` returns `Just newValue`, adds the entry `key`: `newValue` to the new dictionary.
           This function combines `Dict::filter` and `Dict::map`."
       fn =
         (function
@@ -422,7 +424,7 @@ let fns : List<BuiltInFn> =
                     return None
                   | v ->
                     Exception.raiseCode (
-                      Errors.expectedLambdaType "f" (TOption varB) v
+                      Errors.expectedLambdaType "fn" (TOption varB) v
                     )
 
                     return None

--- a/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
@@ -21,14 +21,14 @@ let varA = TVariable "a"
 let varB = TVariable "b"
 let varC = TVariable "c"
 let optionA = Param.make "option" (TOption varA) ""
-let fnAToB = Param.makeWithArgs "f" (TFn([ varA ], varB)) "" [ "val" ]
+let fnAToB = Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ]
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Option" "map" 0
       parameters = [ optionA; fnAToB ]
       returnType = TOption varB
       description =
-        "If `option` is `Just value`, returns `Just (f value)` (the lambda `f` is applied to `value` and the result is wrapped in `Just`).
+        "If `option` is `Just value`, returns `Just (fn value)` (the lambda `fn` is applied to `value` and the result is wrapped in `Just`).
         If `result` is `Nothing`, returns `Nothing`."
       fn =
         (function
@@ -75,10 +75,10 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "option1" (TOption varA) ""
           Param.make "option2" (TOption varB) ""
-          Param.makeWithArgs "f" (TFn([ varA; varB ], varC)) "" [ "v1"; "v2" ] ]
+          Param.makeWithArgs "fn" (TFn([ varA; varB ], varC)) "" [ "v1"; "v2" ] ]
       returnType = TOption varC
       description =
-        "If both arguments are {{Just}} (<param option1> is {{Just <var v1>}} and <param option2> is {{Just <var v2>}}), then return {{Just (f <var v1> <var v2>)}} -- The lambda <param f> should have two parameters, representing <var v1> and <var v2>. But if either <param option1> or <param option2> are {{Nothing}}, returns {{Nothing}} without applying <param f>."
+        "If both arguments are {{Just}} (<param option1> is {{Just <var v1>}} and <param option2> is {{Just <var v2>}}), then return {{Just (fn <var v1> <var v2>)}} -- The lambda <param fn> should have two parameters, representing <var v1> and <var v2>. But if either <param option1> or <param option2> are {{Nothing}}, returns {{Nothing}} without applying <param fn>."
       fn =
         (function
         | state, [ DOption o1; DOption o2; DFnVal b ] ->
@@ -101,10 +101,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Option" "andThen" 0
       parameters =
         [ optionA
-          Param.makeWithArgs "f" (TFn([ TOption varA ], TOption varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ TOption varA ], TOption varB)) "" [ "val" ] ]
       returnType = TOption varB
       description =
-        "If <param option> is {{Just <var input>}}, returns {{f <var input>}}. Where the lambda <param f> is applied to <var input> and must return {{Just <var output>}} or {{Nothing}}. Otherwise if <param option> is {{Nothing}}, returns {{Nothing}}."
+        "If <param option> is {{Just <var input>}}, returns {{fn <var input>}}. Where the lambda <param fn> is applied to <var input> and must return {{Just <var output>}} or {{Nothing}}. Otherwise if <param option> is {{Nothing}}, returns {{Nothing}}."
       fn =
         (function
         | state, [ DOption o; DFnVal b ] ->
@@ -119,7 +119,7 @@ let fns : List<BuiltInFn> =
               | other ->
                 return
                   Exception.raiseCode (
-                    Errors.expectedLambdaType "f" (TOption varB) other
+                    Errors.expectedLambdaType "fn" (TOption varB) other
                   )
             | None -> return DOption None
           }

--- a/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
@@ -27,10 +27,10 @@ let fns : List<BuiltInFn> =
   [ { name = fn "Result" "map" 0
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
-          Param.makeWithArgs "f" (TFn([ varOk ], varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = TResult(varB, varErr)
       description =
-        "If `result` is `Ok value`, returns `Ok (f value)` (the lambda `f` is applied to `value` and the result is wrapped in `Ok`). If `result` is `Error msg`, returns `result` unchanged."
+        "If `result` is `Ok value`, returns `Ok (fn value)` (the lambda `fn` is applied to `value` and the result is wrapped in `Ok`). If `result` is `Error msg`, returns `result` unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal b ] ->
@@ -52,10 +52,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "map" 1
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
-          Param.makeWithArgs "f" (TFn([ varOk ], varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = TResult(varB, varErr)
       description =
-        "If <param result> is {{Ok <var value>}}, returns {{Ok (f <var value>)}}. The lambda <param f> is applied to <var value> and the result is wrapped in {{Ok}}. If <param result> is {{Error <var msg>}}, returns <param result> unchanged."
+        "If <param result> is {{Ok <var value>}}, returns {{Ok (fn <var value>)}}. The lambda <param fn> is applied to <var value> and the result is wrapped in {{Ok}}. If <param result> is {{Error <var msg>}}, returns <param result> unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal d ] ->
@@ -77,10 +77,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "mapError" 0
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
-          Param.makeWithArgs "f" (TFn([ varOk ], varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varB, varErr))
       description =
-        "If `result` is `Error msg`, returns `Error (f msg)` (the lambda `f` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok value`, returns `result` unchanged."
+        "If `result` is `Error msg`, returns `Error (f msg)` (the lambda `fn` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok value`, returns `result` unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal b ] ->
@@ -102,10 +102,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "mapError" 1
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
-          Param.makeWithArgs "f" (TFn([ varOk ], varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varB, varErr))
       description =
-        "If <param result> is {{Error <var msg>}}, returns {{Error (f <var msg>)}}. The lambda <var f> is applied to <var msg> and the result is wrapped in {{Error}}. If <param result> is {{Ok <var value>}}, returns <param result> unchanged."
+        "If <param result> is {{Error <var msg>}}, returns {{Error (fn <var msg>)}}. The lambda <var fn> is applied to <var msg> and the result is wrapped in {{Error}}. If <param result> is {{Ok <var value>}}, returns <param result> unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal b ] ->
@@ -215,10 +215,10 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "result1" (TResult(varA, varErr)) ""
           Param.make "result2" (TResult(varB, varErr)) ""
-          Param.makeWithArgs "f" (TFn([ varA; varB ], varC)) "" [ "v1"; "v2" ] ]
+          Param.makeWithArgs "fn" (TFn([ varA; varB ], varC)) "" [ "v1"; "v2" ] ]
       returnType = (TResult(varC, varErr))
       description =
-        "If both <param result1> is {{Ok <var v1>}} and <param result2> is {{Ok <var v2>}}, returns {{Ok (f <var v1> <var v2>)}} -- the lambda <var f> is applied to <var v1> and <var v2>, and the result is wrapped in {{Ok}}. Otherwise, returns the first of <param result1> and <param result2> that is an error."
+        "If both <param result1> is {{Ok <var v1>}} and <param result2> is {{Ok <var v2>}}, returns {{Ok (fn <var v1> <var v2>)}} -- the lambda <var fn> is applied to <var v1> and <var v2>, and the result is wrapped in {{Ok}}. Otherwise, returns the first of <param result1> and <param result2> that is an error."
       fn =
         (function
         | state, [ DResult r1; DResult r2; DFnVal b ] ->
@@ -241,10 +241,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "andThen" 0
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
-          Param.makeWithArgs "f" (TFn([ varOk ], varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varB, varErr))
       description =
-        "If `result` is `Ok value`, returns `f value` (the lambda `f` is applied to `value` and must return `Error msg` or `Ok newValue`). If `result` is `Error msg`, returns `result` unchanged."
+        "If `result` is `Ok value`, returns `fn value` (the lambda `fn` is applied to `value` and must return `Error msg` or `Ok newValue`). If `result` is `Error msg`, returns `result` unchanged."
       fn =
         (function
         | state, [ DResult o; DFnVal b ] ->
@@ -259,7 +259,7 @@ let fns : List<BuiltInFn> =
               | other ->
                 return
                   Exception.raiseCode (
-                    Errors.expectedLambdaType "f" (TResult(varOk, varErr)) other
+                    Errors.expectedLambdaType "fn" (TResult(varOk, varErr)) other
                   )
             | Error msg -> return DResult(Error msg)
           }
@@ -272,10 +272,10 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "andThen" 1
       parameters =
         [ Param.make "result" (TResult(varOk, varErr)) ""
-          Param.makeWithArgs "f" (TFn([ varOk ], varB)) "" [ "val" ] ]
+          Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varOk, varErr))
       description =
-        "If <param result> is {{Ok <var value>}}, returns {{f <var value>}}. The lambda <param f> is applied to <var value> and must return {{Error <var msg>}} or {{Ok <var newValue>}}. If <param result> is {{Error <var msg>}}, returns <param result> unchanged."
+        "If <param result> is {{Ok <var value>}}, returns {{fn <var value>}}. The lambda <param fn> is applied to <var value> and must return {{Error <var msg>}} or {{Ok <var newValue>}}. If <param result> is {{Error <var msg>}}, returns <param result> unchanged."
       fn =
         (function
         | state, [ DResult o; DFnVal b ] ->
@@ -291,7 +291,7 @@ let fns : List<BuiltInFn> =
               | other ->
                 return
                   Exception.raiseCode (
-                    Errors.expectedLambdaType "f" (TResult(varOk, varErr)) other
+                    Errors.expectedLambdaType "fn" (TResult(varOk, varErr)) other
                   )
             | Error msg -> return DResult(Error msg)
           }

--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -42,7 +42,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "s" TStr "string to iterate over"
           Param.makeWithArgs
-            "f"
+            "fn"
             (TFn([ TChar ], TChar))
             "function used to convert one character to another"
             [ "char" ] ]
@@ -61,7 +61,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "foreach" 1
       parameters =
         [ Param.make "s" TStr ""
-          Param.makeWithArgs "f" (TFn([ TChar ], TChar)) "" [ "character" ] ]
+          Param.makeWithArgs "fn" (TFn([ TChar ], TChar)) "" [ "character" ] ]
       returnType = TStr
       description =
         "Iterate over each Character (EGC, not byte) in the string, performing the operation in the block on each one."
@@ -90,7 +90,7 @@ let fns : List<BuiltInFn> =
                      (function
                      | DChar c -> c
                      | dv ->
-                       Exception.raiseCode (Errors.expectedLambdaType "f" TChar dv))
+                       Exception.raiseCode (Errors.expectedLambdaType "fn" TChar dv))
                      dvals
 
                  let str = String.concat "" chars

--- a/fsharp-backend/tests/testfiles/dict.tests
+++ b/fsharp-backend/tests/testfiles/dict.tests
@@ -3,20 +3,20 @@ Dict.empty_v0 = {}
 Dict.filterMap_v0 {} (fun (key, value) -> 0) = {}
 Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then Nothing else (Just (key ++ value))) = { c = "cz"; a = "ax"}
 Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then blank else (Just (key ++ value))) = blank
-Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then false else (Just (key ++ value))) = Test.typeError_v0 "Expected `f` to return a Option, but it returned `false`"
+Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then false else (Just (key ++ value))) = Test.typeError_v0 "Expected `fn` to return a Option, but it returned `false`"
 Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> k == "key1") = { key1 = "val1"}
 Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> k == blank) = blank
 Dict.filter_v1 { key1 = 1; key2 = 3 }  (fun (k, v) -> v < 2) = { key1 = 1 }
 Dict.filter_v1 { key1 = 1; key2 = blank; key3 = 3 }  (fun (k, v) -> v > 0) = { key3 = 3; key1 = 1}
 Dict.filter_v1 {} (fun (k, v) -> 0) = {}
-Dict.filter_v1 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `2`"
+Dict.filter_v1 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `2`"
 Dict.filter_v0 { key1 = 1; key2 = 3 }  (fun (k, v) -> v < 2) = { key1 = 1 }
 Dict.filter_v0 { a = 1; b = 9; c = -20 } (fun (k, v) -> v >= 1) = { b = 9; a = 1 }
 Dict.filter_v0 { a = 1; b = 2; c = 3 } (fun (k, v) -> match v with | 1 -> true | 2 -> false | 3 -> true) = { c = 3; a = 1 }
 Dict.filter_v0 { a = 1; b = -1; c = -2; d = -3; e = 2; f = 3 } (fun (k, v) -> (match v with | v -> if v > -2 then true else false)) = { f = 3; e = 2; b = -1; a = 1 }
 Dict.filter_v0 {} (fun (k, v) -> 0) = {}
-Dict.filter_v0 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `2`"
-Dict.filter_v0 { a = true; b = false; c = true } (fun (k, v) -> "a") = Test.typeError_v0 "Expected `f` to return a Bool, but it returned `\"a\"`"
+Dict.filter_v0 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `2`"
+Dict.filter_v0 { a = true; b = false; c = true } (fun (k, v) -> "a") = Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `\"a\"`"
 Dict.foreach_v0 { key1 = "val1"; key2 = "val2" } (fun x -> x ++ "_append") = { key2 = "val2_append"; key1 = "val1_append"}
 Dict.foreach_v0 { key1 = 1; key2 = 2 } (fun x -> x + 1) = { key2 = 3; key1 = 2 }
 Dict.foreach_v0 {} (fun (key, value) -> 0) = {}

--- a/fsharp-backend/tests/testfiles/result.tests
+++ b/fsharp-backend/tests/testfiles/result.tests
@@ -2,13 +2,13 @@ Result.andThen_v0 (Error "test") (fun x -> Error "test") = Error "test"
 Result.andThen_v0 (Error "test") (fun x -> Ok 5) = Error "test"
 Result.andThen_v0 (Ok 5) (fun x -> Error "test") = Error "test"
 Result.andThen_v0 (Ok 5) (fun x -> Ok (1 + x)) = Ok 6
-Result.andThen_v0 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expected `f` to return a Result, but it returned `4`"
+Result.andThen_v0 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expected `fn` to return a Result, but it returned `4`"
 Result.andThen_v1 (Error "test") (fun x -> Error "test") = Error "test"
 Result.andThen_v1 (Error "test") (fun x -> Ok 5) = Error "test"
 Result.andThen_v1 (Ok 5) (fun x -> Error "test") = Error "test"
 Result.andThen_v1 (Ok 5) (fun x -> Ok (1 + x)) = Ok 6
-Result.andThen_v1 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expected `f` to return a Result, but it returned `4`"
-Result.andThen_v1 (Ok 5) (fun x -> [blank]) = Test.typeError_v0 "Expected `f` to return a Result, but it returned `[]`"
+Result.andThen_v1 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expected `fn` to return a Result, but it returned `4`"
+Result.andThen_v1 (Ok 5) (fun x -> [blank]) = Test.typeError_v0 "Expected `fn` to return a Result, but it returned `[]`"
 Result.fromOption_v0 (Just 6) "test" = Ok 6
 Result.fromOption_v0 Nothing "test" = Error "test"
 


### PR DESCRIPTION
This excludes LibList fns, which have been separately updated in #4150. This will resolve #4153.

Personally I think this is in the right direction, per a single CLEANUP item in LibList.fs.