### PR TITLE
Refactor LibJwt

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -329,13 +329,6 @@ module Serialization =
       let msg = if str = "" then "JSON string was empty" else e.Message
       Error msg
 
-module STJSerialization =
-  // TODO add property tests to check comparisons of these serializers
-  // TODO make these match the ones under Serialization
-  // TODO use these, make them the default one, and purge the old one
-  let serialize = Json.Vanilla.serialize
-  let deserialize = Json.Vanilla.deserialize
-
 // SERIALIZER_USAGE Custom LibJwt.SignAndEncode
 /// Forms signed JWT given payload, extra header, and key
 let signAndEncode (key : string) (extraHeaders : DvalMap) (payload : Dval) : string =

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -138,8 +138,6 @@ let private verifyAndExtractV1
 /// </summary>
 /// <remarks>
 /// CLEANUP: make new version with a roundtrippable non-Newtonsoft format
-/// SERIALIZER_DEF Newtonsoft/Custom LibJwt.serialize
-/// SERIALIZER_DEF Newtonsoft/Custom LibJwt.deserialize
 ///
 /// The LibJWT functions use signatures based off the exact string encoding of
 /// Dvals. This was defined in the original OCaml version. We need to keep this
@@ -276,16 +274,16 @@ module Serialization =
     | DErrorRail dv -> toString' v dv
     | DResult (Ok dv) -> toString' v dv
 
+  // SERIALIZER_DEF Custom LibJwt.serialize
   let serialize (j : Dval) : string =
     let v = Vector 10
-
     toString' v j
-
     v.ToArray() |> UTF8.ofBytesUnsafe
 
   open Newtonsoft.Json
   open Newtonsoft.Json.Linq
 
+  // SERIALIZER_DEF Newtonsoft/Custom LibJwt.deserialize
   /// Parses header or payload of a JWT, transforming results into a Dval
   let deserialize (str : string) : Result<Dval, string> =
     /// Parses header or payload of a JWT
@@ -321,18 +319,7 @@ module Serialization =
 
       // Json.NET does a bunch of magic based on the contents of various types.
       // For example, it has tokens for Dates, constructors, etc. We've
-      // disabled all those so we fail if we see them.
-      | JTokenType.None
-      | JTokenType.Undefined
-      | JTokenType.Constructor
-      | JTokenType.Property
-      | JTokenType.Guid
-      | JTokenType.Raw
-      | JTokenType.Bytes
-      | JTokenType.TimeSpan
-      | JTokenType.Uri
-      | JTokenType.Comment
-      | JTokenType.Date
+      // disabled all those so we fail if we see any other JTokenType.
       | _ -> Exception.raiseInternal "Invalid type in json" [ "json", string j ]
 
     try

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -201,7 +201,7 @@ module Serialization =
       appendString v s
       append v "\""
 
-    let handleAssoc l =
+    let handleObj l =
       append v "{"
 
       let f ((k, j) : string * Dval) =
@@ -263,10 +263,10 @@ module Serialization =
     | DBytes bytes -> bytes |> Base64.defaultEncodeToString |> handleString
 
     // objects
-    | DObj o -> o |> Map.toList |> List.map (fun (k, v) -> (k, v)) |> handleAssoc
-    | DError _ -> handleAssoc [ "Error", DNull ]
-    | DPassword _ -> handleAssoc [ "Error", DStr "Password is redacted" ]
-    | DResult (Error dv) -> handleAssoc [ ("Error", dv) ]
+    | DObj o -> o |> Map.toList |> List.map (fun (k, v) -> (k, v)) |> handleObj
+    | DError _ -> handleObj [ "Error", DNull ]
+    | DPassword _ -> handleObj [ "Error", DStr "Password is redacted" ]
+    | DResult (Error dv) -> handleObj [ ("Error", dv) ]
 
     // wrapper types
     | DHttpResponse (Response (_, _, hdv)) -> toString' v hdv

--- a/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -1,4 +1,31 @@
+/// <summary>
 /// StdLib functions to encode, verify, and extract details from JWTs
+/// </summary>
+/// <remarks>
+/// Here's how JWT with RS256, and this library, work:
+///
+///   Users provide a private key, some headers, and a payload.
+///
+///   We add fields "type" "JWT" and "alg" "RS256" to the header.
+///
+///   We create the body by base64-encoding the header and the payload,
+///   and joining them with a period:
+///
+///   body = (b64encode header) ^ "." ^ (b64encode payload)
+///
+///   We use the private key to sign the body:
+///
+///   signature = sign body
+///
+///   Then we join the body with the signature with a period.
+///
+///   token = body ^ "." ^ signature
+///
+///   We verify by splitting the parts, checking the signature against the body,
+///   and then de-base-64-ing the body and parsing the JSON.
+///
+///   https://jwt.io/ is helpful for validating this!
+/// </remarks>
 module BackendOnlyStdLib.LibJwt
 
 open System.Security.Cryptography
@@ -7,7 +34,6 @@ open LibExecution.RuntimeTypes
 open Prelude
 open LibExecution.VendoredTablecloth
 
-module DvalReprExternal = LibExecution.DvalReprExternal
 module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
@@ -18,218 +44,13 @@ let varA = TVariable "a"
 let varB = TVariable "b"
 let varErr = TVariable "err"
 
-// Here's how JWT with RS256, and this library, work:
-//
-//   Users provide a private key, some headers, and a payload.
-//
-//   We add fields "type" "JWT" and "alg" "RS256" to the header.
-//
-//   We create the body by base64-encoding the header and the payload,
-//   and joining them with a period:
-//
-//   body = (b64encode header) ^ "." ^ (b64encode payload)
-//
-//   We use the private key to sign the body:
-//
-//   signature = sign body
-//
-//   Then we join the body with the signature with a period.
-//
-//   token = body ^ "." ^ signature
-//
-//   We verify by splitting the parts, checking the signature against the body,
-//   and then de-base-64-ing the body and parsing the JSON.
-//
-//   https://jwt.io/ is helpful for validating this!
-
-module Legacy =
-  // The LibJWT functions use signitures based off the exact string encoding of
-  // Dvals. This was defined in the original OCaml version. We need to keep
-  // this exactly the same or the signatures won't match.
-
-  // The way the OCaml functions worked:
-  // - convert the payload to YoJson using to_pretty_machine_yojson_v1
-  // - foreach element of the header, convert to to YoJson using to_pretty_machine_yojson_v1
-  // - convert both the payload and header YoJsons to strings using YoJson.Safe.to_string, version 1.7.0
-
-  // This is the subset of Yojson.Safe that we used
-  type Yojson =
-    | Int of int64
-    | Float of float
-    | String of string
-    | Bool of bool
-    | List of List<Yojson>
-    | Assoc of List<string * Yojson>
-    | Null
-
-  // Direct clone of OCaml Dval.to_pretty_machine_yojson_v1
-  let rec toYojson (dval : Dval) : Yojson =
-    match dval with
-    | DInt i -> Int i
-    | DFloat f -> Float f
-    | DBool b -> Bool b
-    | DNull -> Null
-    | DStr s -> String s
-    | DList l -> List(List.map toYojson l)
-    | DObj o -> o |> Map.toList |> List.map (fun (k, v) -> (k, toYojson v)) |> Assoc
-    // See docs/dblock-serialization.ml
-    | DFnVal _ -> Null
-    | DIncomplete _ -> Null
-    | DChar c -> String c
-    | DError _ -> Assoc [ "Error", Null ]
-    | DHttpResponse (Redirect _) -> Null
-    | DHttpResponse (Response (_, _, hdv)) -> toYojson hdv
-    | DDB name -> String name
-    | DDate date -> String(DDateTime.toIsoString date)
-    | DPassword _ -> Assoc [ "Error", String "Password is redacted" ]
-    | DUuid uuid -> String(string uuid)
-    | DOption None -> Null
-    | DOption (Some dv) -> toYojson dv
-    | DErrorRail dv -> toYojson dv
-    | DResult (Ok dv) -> toYojson dv
-    | DResult (Error dv) -> Assoc [ ("Error", toYojson dv) ]
-    | DBytes bytes -> bytes |> Base64.defaultEncodeToString |> String
-
-  // We are adding bytes to match the old OCaml implementation. Don't use strings
-  // or characters as those are different sizes: OCaml strings were literally
-  // just byte arrays.
-  // A SCG.List is a growing vector (unlike an F# List, which is a linked
-  // list). This should have not-awful performance
-  type Vector = System.Collections.Generic.List<byte>
-
-  let append (v : Vector) (s : string) : unit =
-    let bytes = UTF8.toBytes s
-    v.Capacity <- v.Capacity + bytes.Length // avoid resizing multiple times
-    Array.iter (fun b -> v.Add b) bytes
-
-  let rec listToStringList (v : Vector) (l : List<'a>) (f : 'a -> unit) : unit =
-    match l with
-    | [] -> ()
-    | [ h ] -> f h
-    | h :: tail ->
-      f h
-      append v ","
-      listToStringList v tail f
-
-  and appendString (v : Vector) (s : string) : unit =
-    s
-    |> UTF8.toBytes
-    |> Array.iter (fun b ->
-      match b with
-      // " - quote
-      | 0x22uy -> append v "\\\""
-      // \ - backslash
-      | 0x5cuy -> append v "\\\\"
-      // \b - backspace
-      | 0x08uy -> append v "\\b"
-      // \f - form feed
-      | 0x0cuy -> append v "\\f"
-      // \n - new line
-      | 0x0auy -> append v "\\n"
-      // \r  - carriage return
-      | 0x0duy -> append v "\\r"
-      // \t - tab
-      | 0x09uy -> append v "\\t"
-      // write_control_char
-      | b when b >= 0uy && b <= 0x1fuy ->
-        append v "\\u"
-        append v (b.ToString("x4"))
-      | 0x7fuy -> append v "\\u007f"
-      | b -> v.Add b)
-
-  and toString' (v : Vector) (j : Yojson) : unit =
-    match j with
-    | Null -> append v "null"
-    | Bool true -> append v "true"
-    | Bool false -> append v "false"
-    | Int i -> append v (string i)
-    // write_float
-    | Float f when System.Double.IsNaN f -> append v "NaN"
-    | Float f when System.Double.IsPositiveInfinity f -> append v "Infinity"
-    | Float f when System.Double.IsNegativeInfinity f -> append v "-Infinity"
-    | Float f ->
-      let s =
-        // based  on yojson code
-        let s = sprintf "%.16g" f
-        if System.Double.Parse s = f then s else (sprintf "%.17g" f)
-
-      append v s
-      let mutable needsZero = true
-
-      String.toArray s
-      |> Array.iter (fun d ->
-        if d >= '0' && d <= '9' || d = '-' then () else needsZero <- false)
-
-      if needsZero then append v ".0"
-
-    // write_string
-    | String s ->
-      append v "\""
-      appendString v s
-      append v "\""
-    | List l ->
-      append v "["
-      listToStringList v l (toString' v)
-      append v "]"
-    | Assoc l ->
-      append v "{"
-
-      let f ((k, j) : string * Yojson) =
-        append v "\""
-        appendString v k
-        append v "\":"
-        toString' v j
-
-      listToStringList v l f
-
-      append v "}"
-
-  let toString (j : Yojson) : string =
-    let v = Vector 10
-    toString' v j
-    v.ToArray() |> UTF8.ofBytesUnsafe
-
-/// Forms signed JWT given payload, extra header, and key
-let signAndEncode (key : string) (extraHeaders : DvalMap) (payload : Dval) : string =
-  let header =
-    extraHeaders
-    |> Map.add "alg" (DStr "RS256")
-    |> Map.add "type" (DStr "JWT")
-    |> Map.mapWithIndex (fun k v -> Legacy.toYojson v)
-    |> Map.toList
-    |> Legacy.Assoc
-    |> Legacy.toString
-    |> UTF8.toBytes
-    |> Base64.urlEncodeToString
-
-  let payload =
-    payload
-    |> Legacy.toYojson
-    |> Legacy.toString
-    |> UTF8.toBytes
-    |> Base64.urlEncodeToString
-
-  let body = header + "." + payload
-
-  let signature =
-    let rsa = RSA.Create()
-    rsa.ImportFromPem(System.ReadOnlySpan(key.ToCharArray()))
-    let RSAFormatter = RSAPKCS1SignatureFormatter rsa
-    RSAFormatter.SetHashAlgorithm "SHA256"
-    let sha256 = SHA256.Create()
-
-    body
-    |> UTF8.toBytes
-    |> sha256.ComputeHash
-    |> RSAFormatter.CreateSignature
-    |> Base64.urlEncodeToString
-
-  body + "." + signature
-
 /// Verifies the signature of, and extracts data from, a JWT
 ///
 /// Deprecated in favor of equivalent v1 function
-let verifyAndExtractV0 (key : RSA) (token : string) : (string * string) option =
+let private verifyAndExtractV0
+  (key : RSA)
+  (token : string)
+  : (string * string) option =
   match Seq.toList (String.split "." token) with
   | [ header; payload; signature ] ->
     // do the minimum of parsing and decoding before verifying signature.
@@ -261,11 +82,11 @@ let verifyAndExtractV0 (key : RSA) (token : string) : (string * string) option =
         else
           None
     with
-    | e -> None
+    | _e -> None
   | _ -> None
 
 /// Verifies the signature of, and extracts data from, a JWT
-let verifyAndExtractV1
+let private verifyAndExtractV1
   (key : RSA)
   (token : string)
   : Result<string * string, string> =
@@ -309,68 +130,256 @@ let verifyAndExtractV1
     | e -> Error e.Message
   | _ -> Error "Invalid token format"
 
-// This is its own thing because it need to be exactly the same as it was, or we
-// won't be able to extract the old values, and that would be bad.
-// CLEANUP: make new version with a roundtrippable format
+/// <summary>
+/// Bespoke serialization to match OCaml backend's JWTs
+///
+/// This is a thing because it need to be exactly the same as it was, or we
+/// won't be able to extract the old values, and that would be bad.
+/// </summary>
+/// <remarks>
+/// CLEANUP: make new version with a roundtrippable non-Newtonsoft format
+/// SERIALIZER_DEF Newtonsoft/Custom LibJwt.serialize
+/// SERIALIZER_DEF Newtonsoft/Custom LibJwt.deserialize
+///
+/// The LibJWT functions use signatures based off the exact string encoding of
+/// Dvals. This was defined in the original OCaml version. We need to keep this
+/// exactly the same or the signatures won't match.
+//// </remarks>
+module Serialization =
+  // We are adding bytes to match the old OCaml implementation. Don't use strings
+  // or characters as those are different sizes: OCaml strings were literally
+  // just byte arrays.
+  // A SCG.List is a growing vector (unlike an F# List, which is a linked
+  // list). This should have not-awful performance
+  type private Vector = System.Collections.Generic.List<byte>
 
-open Newtonsoft.Json
-open Newtonsoft.Json.Linq
+  let private append (v : Vector) (s : string) : unit =
+    let bytes = UTF8.toBytes s
+    v.Capacity <- v.Capacity + bytes.Length // avoid resizing multiple times
+    Array.iter (fun b -> v.Add b) bytes
 
-/// Parses header or payload of a JWT
-let parseJson (s : string) : JToken =
-  let reader = new JsonTextReader(new System.IO.StringReader(s))
-  let jls = JsonLoadSettings()
-  jls.CommentHandling <- CommentHandling.Load // Load them so we can error later
-  jls.DuplicatePropertyNameHandling <- DuplicatePropertyNameHandling.Error
-  jls.CommentHandling <- CommentHandling.Ignore
+  let private appendString (v : Vector) (s : string) : unit =
+    s
+    |> UTF8.toBytes
+    |> Array.iter (fun b ->
+      match b with
+      // " - quote
+      | 0x22uy -> append v "\\\""
+      // \ - backslash
+      | 0x5cuy -> append v "\\\\"
+      // \b - backspace
+      | 0x08uy -> append v "\\b"
+      // \f - form feed
+      | 0x0cuy -> append v "\\f"
+      // \n - new line
+      | 0x0auy -> append v "\\n"
+      // \r  - carriage return
+      | 0x0duy -> append v "\\r"
+      // \t - tab
+      | 0x09uy -> append v "\\t"
+      // write_control_char
+      | b when b >= 0uy && b <= 0x1fuy ->
+        append v "\\u"
+        append v (b.ToString("x4"))
+      | 0x7fuy -> append v "\\u007f"
+      | b -> v.Add b)
 
-  reader.DateParseHandling <- DateParseHandling.None
-  JToken.ReadFrom(reader)
+  let rec private listToStringList
+    (v : Vector)
+    (l : List<'a>)
+    (f : 'a -> unit)
+    : unit =
+    match l with
+    | [] -> ()
+    | [ h ] -> f h
+    | h :: tail ->
+      f h
+      append v ","
+      listToStringList v tail f
 
-/// Parses header or payload of a JWT, transforming results into a Dval
-let ofJson (str : string) : Result<Dval, string> =
-  // We cannot change this to use System.Text.Json because STJ does not
-  // allow "raw infinity"
-  let rec convert (j : JToken) =
-    match j.Type with
-    | JTokenType.Integer -> DInt(j.Value<int64>())
-    | JTokenType.Float -> DFloat(j.Value<float>())
-    | JTokenType.Boolean -> DBool(j.Value<bool>())
-    | JTokenType.Null -> DNull
-    | JTokenType.String -> DStr(j.Value<string>())
-    | JTokenType.Array ->
-      j.Values<JToken>() |> Seq.toList |> List.map convert |> Dval.list
-    | JTokenType.Object ->
-      j.Values()
-      |> seq
-      |> Seq.toList
-      |> List.map (fun (jp : JProperty) -> (jp.Name, jp.Value))
-      |> List.fold Map.empty (fun m (k, v) -> Map.add k (convert v) m)
-      |> DObj
+  let rec private toString' (v : Vector) (dval : Dval) : unit =
+    let handleString s =
+      append v "\""
+      appendString v s
+      append v "\""
 
-    // Json.NET does a bunch of magic based on the contents of various types.
-    // For example, it has tokens for Dates, constructors, etc. We've tried to
-    // disable all those so we fail if we see them. However, we might need to
-    // just convert some of these into strings.
-    | JTokenType.None
-    | JTokenType.Undefined
-    | JTokenType.Constructor
-    | JTokenType.Property
-    | JTokenType.Guid
-    | JTokenType.Raw
-    | JTokenType.Bytes
-    | JTokenType.TimeSpan
-    | JTokenType.Uri
-    | JTokenType.Comment
-    | JTokenType.Date
-    | _ -> Exception.raiseInternal "Invalid type in json" [ "json", string j ]
+    let handleAssoc l =
+      append v "{"
 
-  try
-    str |> parseJson |> convert |> Ok
-  with
-  | :? JsonReaderException as e ->
-    let msg = if str = "" then "JSON string was empty" else e.Message
-    Error msg
+      let f ((k, j) : string * Dval) =
+        append v "\""
+        appendString v k
+        append v "\":"
+        toString' v j
+
+      listToStringList v l f
+
+      append v "}"
+
+    match dval with
+    // null
+    | DNull
+    | DOption None
+    | DFnVal _ // See docs/dblock-serialization.md
+    | DHttpResponse (Redirect _)
+    | DIncomplete _ -> append v "null"
+
+    // ints
+    | DInt i -> append v (string i)
+
+    // floats
+    | DFloat f when System.Double.IsNaN f -> append v "NaN"
+    | DFloat f when System.Double.IsPositiveInfinity f -> append v "Infinity"
+    | DFloat f when System.Double.IsNegativeInfinity f -> append v "-Infinity"
+    | DFloat f ->
+      let s =
+        // based  on yojson code
+        let s = sprintf "%.16g" f
+        if System.Double.Parse s = f then s else (sprintf "%.17g" f)
+
+      append v s
+      let mutable needsZero = true
+
+      String.toArray s
+      |> Array.iter (fun d ->
+        if d >= '0' && d <= '9' || d = '-' then () else needsZero <- false)
+
+      if needsZero then append v ".0"
+
+    // bools
+    | DBool true -> append v "true"
+    | DBool false -> append v "false"
+
+    // lists
+    | DList l ->
+      append v "["
+      listToStringList v l (toString' v)
+      append v "]"
+
+    // strings
+    | DStr s -> handleString s
+    | DChar c -> handleString c
+    | DDB name -> handleString name
+    | DUuid uuid -> string uuid |> handleString
+    | DDate date -> DDateTime.toIsoString date |> handleString
+    | DBytes bytes -> bytes |> Base64.defaultEncodeToString |> handleString
+
+    // objects
+    | DObj o -> o |> Map.toList |> List.map (fun (k, v) -> (k, v)) |> handleAssoc
+    | DError _ -> handleAssoc [ "Error", DNull ]
+    | DPassword _ -> handleAssoc [ "Error", DStr "Password is redacted" ]
+    | DResult (Error dv) -> handleAssoc [ ("Error", dv) ]
+
+    // wrapper types
+    | DHttpResponse (Response (_, _, hdv)) -> toString' v hdv
+    | DOption (Some dv) -> toString' v dv
+    | DErrorRail dv -> toString' v dv
+    | DResult (Ok dv) -> toString' v dv
+
+  let serialize (j : Dval) : string =
+    let v = Vector 10
+
+    toString' v j
+
+    v.ToArray() |> UTF8.ofBytesUnsafe
+
+  open Newtonsoft.Json
+  open Newtonsoft.Json.Linq
+
+  /// Parses header or payload of a JWT, transforming results into a Dval
+  let deserialize (str : string) : Result<Dval, string> =
+    /// Parses header or payload of a JWT
+    let parseJson (s : string) : JToken =
+      let reader = new JsonTextReader(new System.IO.StringReader(s))
+      let jls = JsonLoadSettings()
+      jls.CommentHandling <- CommentHandling.Load // Load them so we can error later
+      jls.DuplicatePropertyNameHandling <- DuplicatePropertyNameHandling.Error
+      jls.CommentHandling <- CommentHandling.Ignore
+
+      reader.DateParseHandling <- DateParseHandling.None
+      JToken.ReadFrom(reader)
+
+    // We cannot change this to use System.Text.Json because STJ does not
+    // allow "raw infinity"
+    // Q: why can't we use JsonNumberHandling.AllowNamedFloatingPointLiterals?
+    let rec convert (j : JToken) =
+      match j.Type with
+      | JTokenType.Integer -> DInt(j.Value<int64>())
+      | JTokenType.Float -> DFloat(j.Value<float>())
+      | JTokenType.Boolean -> DBool(j.Value<bool>())
+      | JTokenType.Null -> DNull
+      | JTokenType.String -> DStr(j.Value<string>())
+      | JTokenType.Array ->
+        j.Values<JToken>() |> Seq.toList |> List.map convert |> Dval.list
+      | JTokenType.Object ->
+        j.Values()
+        |> seq
+        |> Seq.toList
+        |> List.map (fun (jp : JProperty) -> (jp.Name, jp.Value))
+        |> List.fold Map.empty (fun m (k, v) -> Map.add k (convert v) m)
+        |> DObj
+
+      // Json.NET does a bunch of magic based on the contents of various types.
+      // For example, it has tokens for Dates, constructors, etc. We've
+      // disabled all those so we fail if we see them.
+      | JTokenType.None
+      | JTokenType.Undefined
+      | JTokenType.Constructor
+      | JTokenType.Property
+      | JTokenType.Guid
+      | JTokenType.Raw
+      | JTokenType.Bytes
+      | JTokenType.TimeSpan
+      | JTokenType.Uri
+      | JTokenType.Comment
+      | JTokenType.Date
+      | _ -> Exception.raiseInternal "Invalid type in json" [ "json", string j ]
+
+    try
+      str |> parseJson |> convert |> Ok
+    with
+    | :? JsonReaderException as e ->
+      let msg = if str = "" then "JSON string was empty" else e.Message
+      Error msg
+
+module STJSerialization =
+  // TODO add property tests to check comparisons of these serializers
+  // TODO make these match the ones under Serialization
+  // TODO use these, make them the default one, and purge the old one
+  let serialize = Json.Vanilla.serialize
+  let deserialize = Json.Vanilla.deserialize
+
+// SERIALIZER_USAGE Custom LibJwt.SignAndEncode
+/// Forms signed JWT given payload, extra header, and key
+let signAndEncode (key : string) (extraHeaders : DvalMap) (payload : Dval) : string =
+  let headerPartNew =
+    extraHeaders
+    |> Map.add "alg" (DStr "RS256")
+    |> Map.add "type" (DStr "JWT")
+    |> DObj
+    |> Serialization.serialize
+    |> UTF8.toBytes
+    |> Base64.urlEncodeToString
+
+  let payloadPart =
+    payload |> Serialization.serialize |> UTF8.toBytes |> Base64.urlEncodeToString
+
+  let body = headerPartNew + "." + payloadPart
+
+  let signaturePart =
+    let rsa = RSA.Create()
+    rsa.ImportFromPem(System.ReadOnlySpan(key.ToCharArray()))
+    let RSAFormatter = RSAPKCS1SignatureFormatter rsa
+    RSAFormatter.SetHashAlgorithm "SHA256"
+    let sha256 = SHA256.Create()
+
+    body
+    |> UTF8.toBytes
+    |> sha256.ComputeHash
+    |> RSAFormatter.CreateSignature
+    |> Base64.urlEncodeToString
+
+  body + "." + signaturePart
 
 let fns : List<BuiltInFn> =
   [ { name = fn "JWT" "signAndEncode" 0
@@ -458,11 +467,12 @@ let fns : List<BuiltInFn> =
             | _ ->
               Exception.raiseCode
                 "No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file."
+
           match result with
           | Some (headers, payload) ->
             let unwrap = Exception.unwrapResultCode
-            [ ("header", ofJson headers |> unwrap)
-              ("payload", ofJson payload |> unwrap) ]
+            [ ("header", Serialization.deserialize headers |> unwrap)
+              ("payload", Serialization.deserialize payload |> unwrap) ]
             |> Map.ofList
             |> DObj
             |> Some
@@ -489,11 +499,12 @@ let fns : List<BuiltInFn> =
               verifyAndExtractV1 rsa token
             with
             | _ -> Error "Invalid public key"
+
           match result with
           | Ok (headers, payload) ->
             let unwrap = Exception.unwrapResultCode
-            [ ("header", ofJson headers |> unwrap)
-              ("payload", ofJson payload |> unwrap) ]
+            [ ("header", Serialization.deserialize headers |> unwrap)
+              ("payload", Serialization.deserialize payload |> unwrap) ]
             |> Map.ofList
             |> DObj
             |> Ok


### PR DESCRIPTION
I found LibJwt to be pretty confusing, while researching the serializers that we use.

This:
- consolidates the existing serialization
- adds needed commentary
- removes Yojson intermediate serialization type
- removes needless circular fn definitions
- adds SERIALIZER_DEF and SERIALIZER_USAGE comments
- places verifyAndExtract functions to above Serialization module, to indicate there's no serialization occuring there

---

I'm researching our serializers and their usages. I got pretty confused by this module's code, so spent some time to better understand it and consolidate the bits we'd like to get away from.

Now that the serialization is consolidated to just 2 `serialize` and `deserialize` fns, I think it'd be pretty reasonable to write a property-based test to ensure a new set of these functions exactly matches the current set. Maybe I'm under-afraid about being _exactly_ the same?