### PR TITLE
Reference window.Dark.analysis over window.Dark.fsharpAnalysis

### DIFF
--- a/integration-tests/utils.ts
+++ b/integration-tests/utils.ts
@@ -200,7 +200,7 @@ export async function awaitAnalysis(page: Page, lastTimestamp: number) {
 }
 
 export async function awaitAnalysisLoaded(page: Page) {
-  await page.waitForFunction(() => window.Dark.fsharpAnalysis.initialized);
+  await page.waitForFunction(() => window.Dark.analysis.initialized);
 }
 
 //********************************


### PR DESCRIPTION
`fsharpAnalysis` is no longer a thing, per #4157 