### PR TITLE
Change pipe definition to remove impossible states

### DIFF
--- a/client/src/app/IntegrationTest.res
+++ b/client/src/app/IntegrationTest.res
@@ -81,7 +81,7 @@ let field_access_closes = (m: model): testResult =>
 
 let field_access_pipes = (m: model): testResult =>
   switch onlyExpr(m) {
-  | Some(EPipe(_, list{EFieldAccess(_, EVariable(_, "request"), "body"), EBlank(_)})) => pass
+  | Some(EPipe(_, EFieldAccess(_, EVariable(_, "request"), "body"), EBlank(_), list{})) => pass
   | expr => fail(~f=showOption(show_fluidExpr), expr)
   }
 

--- a/client/src/core/Encoders.res
+++ b/client/src/core/Encoders.res
@@ -539,7 +539,7 @@ and fluidExpr = (expr: FluidExpression.t): Js.Json.t => {
   | EBinOp(id', name, left, right, r) =>
     ev("EBinOp", list{id(id'), string(name), fe(left), fe(right), sendToRail(r)})
   | ELambda(id', vars, body) => ev("ELambda", list{id(id'), list(pair(id, string), vars), fe(body)})
-  | EPipe(id', exprs) => ev("EPipe", list{id(id'), list(fe, exprs)})
+  | EPipe(id', e1, e2, rest) => ev("EPipe", list{id(id'), list(fe, list{e1, e2, ...rest})})
   | EFieldAccess(id', obj, field) => ev("EFieldAccess", list{id(id'), fe(obj), string(field)})
   | EString(id', v) => ev("EString", list{id(id'), string(v)})
   | EInteger(id', v) => ev("EInteger", list{id(id'), string(Int64.to_string(v))})

--- a/client/src/core/ProgramTypes.res
+++ b/client/src/core/ProgramTypes.res
@@ -95,7 +95,7 @@ module Expr = {
     | ELeftPartial(id, string, t)
     | EList(id, list<t>)
     | ERecord(id, list<(string, t)>)
-    | EPipe(id, list<t>) // CLEANUP: should be EPipe(id, t, t, list<t>)
+    | EPipe(id, t, t, list<t>)
     | EConstructor(id, string, list<t>)
     | EMatch(id, t, list<(Pattern.t, t)>)
     | EPipeTarget(id)

--- a/client/src/fluid/FluidPrinter.res
+++ b/client/src/fluid/FluidPrinter.res
@@ -106,8 +106,7 @@ let rec eToTestcase = (e: E.t): string => {
       listed(List.map(pairs, ~f=((k, v)) => "(" ++ (quoted(k) ++ (", " ++ (r(v) ++ ")"))))),
     })
   | EList(_, exprs) => spaced(list{"list", listed(List.map(~f=r, exprs))})
-  | EPipe(_, list{a, ...rest}) => spaced(list{"pipe", r(a), listed(List.map(~f=r, rest))})
-  | EPipe(_, list{}) => "INVALID PIPE - NO ELEMENTS"
+  | EPipe(_, e1, e2, rest) => spaced(list{"pipe", r(e1), r(e2), listed(List.map(~f=r, rest))})
   | EConstructor(_, name, exprs) =>
     spaced(list{"constructor", quoted(name), listed(List.map(exprs, ~f=r))})
   | EIf(_, cond, thenExpr, elseExpr) => spaced(list{"if'", r(cond), r(thenExpr), r(elseExpr)})

--- a/client/src/fluid/FluidShortcuts.res
+++ b/client/src/fluid/FluidShortcuts.res
@@ -67,10 +67,7 @@ let lambda = (~id=gid(), varNames: list<string>, body: t): t => ELambda(
   body,
 )
 
-let pipe = (~id=gid(), first: t, second: t, rest: list<t>): t => EPipe(
-  id,
-  list{first, second, ...rest},
-)
+let pipe = (~id=gid(), first: t, second: t, rest: list<t>): t => EPipe(id, first, second, rest)
 
 let constructor = (~id=gid(), name: string, args: list<t>): t => EConstructor(id, name, args)
 

--- a/client/test/FluidFuzzer.res
+++ b/client/test/FluidFuzzer.res
@@ -235,7 +235,7 @@ let unwrap = (id: id, ast: E.t): E.t => {
     | EList(_, exprs) => childOr(exprs)
     | EMatch(_, mexpr, pairs) => childOr(list{mexpr, ...List.map(~f=Tuple2.second, pairs)})
     | ERecord(_, fields) => childOr(List.map(~f=Tuple2.second, fields))
-    | EPipe(_, exprs) => childOr(exprs)
+    | EPipe(_, e1, e2, rest) => childOr(list{e1, e2, ...rest})
     | EConstructor(_, _, exprs) => childOr(exprs)
     | EPartial(_, _, oldExpr) => childOr(list{oldExpr})
     | ERightPartial(_, _, oldExpr) => childOr(list{oldExpr})
@@ -350,8 +350,8 @@ let remove = (id: id, ast: E.t): E.t => {
             Some(name, expr)
           }
         , fields))
-    | EPipe(id, exprs) =>
-      switch removeFromList(exprs) {
+    | EPipe(id, e1, e2, rest) =>
+      switch removeFromList(list{e1, e2, ...rest}) {
       | list{EBlank(_), EBinOp(id, op, EPipeTarget(ptid), rexpr, ster)}
       | list{EBinOp(id, op, EPipeTarget(ptid), rexpr, ster), EBlank(_)} =>
         EBinOp(id, op, EBlank(ptid), rexpr, ster)
@@ -360,7 +360,7 @@ let remove = (id: id, ast: E.t): E.t => {
         EFnCall(id, name, list{EBlank(ptid), ...tail}, ster)
       | list{justOne} => justOne
       | list{} => EBlank(id)
-      | newExprs => EPipe(id, newExprs)
+      | list{e1, e2, ...rest} => EPipe(id, e1, e2, rest)
       }
     | EConstructor(id, name, exprs) => EConstructor(id, name, removeFromList(exprs))
     | expr => expr

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -607,7 +607,7 @@ let defaultTestFunctions = {
     fnName: op,
     fnParameters: list{fnParam("a", tipe, false), fnParam("b", tipe, false)},
     fnReturnTipe: rtTipe,
-    fnDescription: "Some infix function",
+    fnDescription: "Some binop",
     fnPreviewSafety: Safe,
     fnDeprecated: false,
     fnInfix: true,

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -3455,7 +3455,7 @@ let run = () => {
       "___\n|>~10\n",
     )
     t(
-      "adding infix functions adds the right number of blanks",
+      "adding binops adds the right number of blanks",
       emptyPipe,
       ~pos=6,
       inputs(list{InsertText("+"), keypress(K.Enter)}),

--- a/client/test/TestRefactor.res
+++ b/client/test/TestRefactor.res
@@ -164,10 +164,9 @@ let run = () => {
         switch FluidAST.toExpr(h.ast) {
         | EPipe(
             _,
-            list{
-              EList(_, list{}),
-              EFnCall(_, "List::getAt_v2", list{EPipeTarget(_), EInteger(_, 5L)}, NoRail),
-            },
+            EList(_, list{}),
+            EFnCall(_, "List::getAt_v2", list{EPipeTarget(_), EInteger(_, 5L)}, NoRail),
+            list{},
           ) => true
         | _ => false
         }
@@ -407,7 +406,7 @@ let run = () => {
   })
   describe("reorderFnCallArgs", () => {
     let matchExpr = (a, e) =>
-      expect(e) |> withEquality(FluidExpression.testEqualIgnoringIds) |> toEqual(a)
+      expect(e |> FluidPrinter.eToTestString) |> toEqual(a |> FluidPrinter.eToTestString)
 
     test("simple example", () =>
       fn("myFn", list{int(1), int(2), int(3)})


### PR DESCRIPTION
This changes the pipe definition to match the definition on the backend. There were quite a few test errors - fortunately this code is super well tested so I have high but not perfect confidence.

That said, nothing massively bad can break here.