### PR TITLE
Make build work on m1/m2 macs

### DIFF
--- a/scripts/builder
+++ b/scripts/builder
@@ -36,7 +36,8 @@ gid=$((gid > 1000 ? gid : 1000))
 # --------------
 if [[ ! -v NEVER_REBUILD_DOCKER ]]; then
   echo "Building docker image"
-  docker build -t dark --build-arg uid="$(id -u)" --build-arg gid="$gid" .
+  # Always build for linux/amd64 (new OSX arm machines have emulation)
+  docker buildx build --platform linux/amd64 -t dark --build-arg uid="$(id -u)" --build-arg gid="$gid" .
 
   echo "Removing running containers"
   c=$(docker ps --filter "name=dark-builder" -q)
@@ -129,6 +130,7 @@ docker run \
   --init \
   --rm \
   -i \
+  --platform linux/amd64 \
   --dns 8.8.8.8 \
   --dns 8.8.4.4 \
   --name dark-builder \


### PR DESCRIPTION
This makes the build work on macs with new(ish) arm chips. They still build in x86-64, which is what we want because that's the platform we deploy on.