### PR TITLE
Better descriptions

### DIFF
--- a/client/src/util/PrettyDocs.res
+++ b/client/src/util/PrettyDocs.res
@@ -1,7 +1,7 @@
 open Prelude
 module Regex = Util.Regex
 
-let tagEx = "^(.*)\\<(\\w+)\\s(.+)\\>(.*)$"
+let tagEx = "^(.*)\\<(\\w+)\\s(.+?)\\>(.*)$"
 
 let codeEx = "^(.*)\\{\\{(.+)\\}\\}(.*)$"
 

--- a/client/test/TestPrettyDocs.res
+++ b/client/test/TestPrettyDocs.res
@@ -37,6 +37,12 @@ let run = () => {
         ParseFail(list{("<type <var bad bunny>>", "contains nested tags")}),
       )
     )
+    test("convert_ parses nested tags correctly", () =>
+      expect(convert("{{<param d1> > <param d2>}}")) |> toEqual(list{
+        tag("code", list{tag("param", list{txt("d1")}), txt(" > "), tag("param", list{txt("d2")})}),
+      })
+    )
+
     test("convert_ catches nested code blocks", () =>
       expect(convert_("{{Just {{ok}} }}")) |> toEqual(
         ParseFail(list{("{{Just {{ok}} }}", "contains nested code blocks")}),

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDB2.fs
@@ -496,7 +496,7 @@ let fns : List<BuiltInFn> =
     { name = fn "DB" "getAll" 2
       parameters = [ tableParam ]
       returnType = TList varA
-      description = "Fetch all the values in `table`."
+      description = "Fetch all the values in <param table>"
       fn =
         (function
         | state, [ DDB dbname ] ->
@@ -514,7 +514,7 @@ let fns : List<BuiltInFn> =
     { name = fn "DB" "getAll" 3
       parameters = [ tableParam ]
       returnType = TList varA
-      description = "Fetch all the values in `table`."
+      description = "Fetch all the values in <param table>"
       fn =
         (function
         | state, [ DDB dbname ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibBool.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibBool.fs
@@ -16,7 +16,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "b" TBool "" ]
       returnType = TBool
       description =
-        "Returns the inverse of `b`: true if `b` is false and false if `b` is true"
+        "Returns the inverse of <param b>: {{true}} if <param b> is {{false}} and {{false}} if <param b> is {{true}}"
       fn =
         (function
         | _, [ DBool b ] -> Ply(DBool(not b))
@@ -29,7 +29,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Bool" "and" 0
       parameters = [ Param.make "a" TBool ""; Param.make "b" TBool "" ]
       returnType = TBool
-      description = "Returns true if both a and b are true"
+      description = "Returns {{true}} if both <param a> and <param b> are {{true}}"
       fn =
         (function
         | _, [ DBool a; DBool b ] -> Ply(DBool(a && b))
@@ -42,7 +42,8 @@ let fns : List<BuiltInFn> =
     { name = fn "Bool" "or" 0
       parameters = [ Param.make "a" TBool ""; Param.make "b" TBool "" ]
       returnType = TBool
-      description = "Returns true if either a is true or b is true"
+      description =
+        "Returns {{true}} if either <param a> is true or <param b> is {{true}}"
       fn =
         (function
         | _, [ DBool a; DBool b ] -> Ply(DBool(a || b))
@@ -56,7 +57,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "a" TBool ""; Param.make "b" TBool "" ]
       returnType = TBool
       description =
-        "Returns `true` if exactly one of `a` and `b` is `true`. Returns `false` if both are `true` or neither is `true`."
+        "Returns {{true}} if exactly one of <param a> and <param b> is {{true}}. Returns {{false}} if both are {{true}} or neither is {{true}}."
       fn =
         (function
         | _, [ DBool a; DBool b ] -> Ply(DBool(a <> b))
@@ -69,7 +70,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Bool" "isNull" 0
       parameters = [ Param.make "check" varA "" ]
       returnType = TBool
-      description = "Returns true if the `check` parameter is null"
+      description = "Returns {{true}} if the <param check> parameter is {{null}}"
       fn =
         (function
         | _, [ value ] ->
@@ -87,7 +88,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Bool" "isError" 0
       parameters = [ Param.make "check" varA "" ]
       returnType = TBool
-      description = "Returns `true` if the `check` parameter is an error"
+      description = "Returns {{true}} if the <param check> parameter is an error"
       fn =
         (function
         | _, [ value ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
@@ -16,7 +16,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TBytes, TStr)
       description =
-        "Base64 decodes a string. Works with both the URL-safe and standard Base64 alphabets defined in RFC 4648 sections 4 and 5."
+        "Base64 decodes a string. Works with both the URL-safe and standard Base64 alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html) sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
         (function
         | _, [ DStr s ] ->
@@ -52,7 +52,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TStr
       description =
-        "Base64URL encodes `bytes` with `=` padding. Uses URL-safe encoding with `-` and `_` instead of `+` and `/`, as defined in RFC 4648 section 5."
+        "Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648 section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
         (function
         | _, [ DBytes bytes ] ->
@@ -70,7 +70,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TStr
       description =
-        "Hex (Base16) encodes `bytes` using an uppercase alphabet. Complies with RFC 4648 section 8."
+        "Hex (Base16) encodes <param bytes> using an uppercase alphabet. Complies with [RFC 4648 section 8](https://www.rfc-editor.org/rfc/rfc4648.html#section-8)."
       fn =
         (function
         | _, [ DBytes bytes ] ->
@@ -96,7 +96,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Bytes" "length" 0
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TInt
-      description = "Length of encoded byte string"
+      description = "Returns the number of bytes in <param bytes>"
       fn =
         (function
         | _, [ DBytes bytes ] -> bytes |> Array.length |> Dval.int |> Ply

--- a/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibBytes.fs
@@ -16,7 +16,10 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TBytes, TStr)
       description =
-        "Base64 decodes a string. Works with both the URL-safe and standard Base64 alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html) sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
+        "Base64 decodes a string. Works with both the URL-safe and standard Base64
+         alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html)
+         sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
+         [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
         (function
         | _, [ DStr s ] ->
@@ -52,7 +55,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TStr
       description =
-        "Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648 section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
+        "Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding
+         with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648
+         section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
         (function
         | _, [ DBytes bytes ] ->
@@ -70,7 +75,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TStr
       description =
-        "Hex (Base16) encodes <param bytes> using an uppercase alphabet. Complies with [RFC 4648 section 8](https://www.rfc-editor.org/rfc/rfc4648.html#section-8)."
+        "Hex (Base16) encodes <param bytes> using an uppercase alphabet. Complies
+         with [RFC 4648 section 8](https://www.rfc-editor.org/rfc/rfc4648.html#section-8)."
       fn =
         (function
         | _, [ DBytes bytes ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
@@ -11,14 +11,14 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let incorrectArgs = LibExecution.Errors.incorrectArgs
+let incorrectArgs = Errors.incorrectArgs
 
 
 let fns : List<BuiltInFn> =
   [ { name = fn "Char" "toASCIICode" 0
       parameters = [ Param.make "c" TChar "" ]
       returnType = TInt
-      description = "Return `c`'s ASCII code"
+      description = "Return <param c>'s ASCII code"
       fn =
         function
         | state, [ c ] -> Errors.removedFunction state "Char::toASCIICode"
@@ -32,7 +32,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Char" "toASCIIChar" 0
       parameters = [ Param.make "i" TInt "" ]
       returnType = TChar
-      description = "convert an int to an ASCII character"
+      description = "Convert <param i> to an ASCII character"
       fn =
         function
         | state, [ i ] -> Errors.removedFunction state "Char::toASCIIChar"
@@ -46,7 +46,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Char" "toLowercase" 0
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar
-      description = "Return the lowercase value of `c`"
+      description = "Return the lowercase value of <param c>"
       fn =
         function
         | state, [ c ] -> Errors.removedFunction state "Char::toLowercase"
@@ -60,7 +60,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Char" "toUppercase" 0
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar
-      description = "Return the uppercase value of `c`"
+      description = "Return the uppercase value of <param c>"
       fn =
         function
         | state, [ c ] -> Errors.removedFunction state "Char::toUppercase"

--- a/fsharp-backend/src/LibExecutionStdLib/LibCrypto.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibCrypto.fs
@@ -29,7 +29,7 @@ let fns : List<BuiltInFn> =
   [ { name = fn "Crypto" "sha256" 0
       parameters = [ Param.make "data" TBytes "" ]
       returnType = TBytes
-      description = "Computes the SHA-256 digest of the given `data`."
+      description = "Computes the SHA-256 digest of the given <param data>."
       fn =
         (function
         | _, [ DBytes data ] -> SHA256.HashData(ReadOnlySpan data) |> DBytes |> Ply
@@ -42,7 +42,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Crypto" "sha384" 0
       parameters = [ Param.make "data" TBytes "" ]
       returnType = TBytes
-      description = "Computes the SHA-384 digest of the given `data`."
+      description = "Computes the SHA-384 digest of the given <param data>."
       fn =
         (function
         | _, [ DBytes data ] -> SHA384.HashData(ReadOnlySpan data) |> DBytes |> Ply

--- a/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDate.fs
@@ -2,6 +2,7 @@ module LibExecutionStdLib.LibDate
 
 open System.Threading.Tasks
 open FSharp.Control.Tasks
+
 open LibExecution.RuntimeTypes
 open Prelude
 
@@ -118,7 +119,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TDate, TStr)
       description =
-        "Parses a string representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns the Date wrapped in a Result."
+        "Parses a <type string> representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns the <type Date> wrapped in a <type Result>."
       fn =
         (function
         | _, [ DStr s ] ->
@@ -137,7 +138,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TDate, TStr)
       description =
-        "Parses a string representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns the Date wrapped in a Result."
+        "Parses a string representing a date and time in the ISO 8601 format (for example: 2019-09-07T22:44:25Z) and returns the {{Date}} wrapped in a {{Result}}."
       fn =
         (function
         | _, [ DStr s ] ->
@@ -156,7 +157,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
       description =
-        "Stringify `date` to the ISO 8601 format YYYY-MM-DD'T'hh:mm:ss'Z'"
+        "Stringify <param date> to the ISO 8601 format {{YYYY-MM-DD'T'hh:mm:ss'Z'}}"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -174,7 +175,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
       description =
-        "Stringify `date` to the ISO 8601 basic format YYYYMMDD'T'hhmmss'Z'"
+        "Stringify <param date> to the ISO 8601 basic format {{YYYYMMDD'T'hhmmss'Z'}}"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -188,7 +189,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "toStringISO8601BasicDate" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
-      description = "Stringify `date` to the ISO 8601 basic format YYYYMMDD"
+      description = "Stringify <param date> to the ISO 8601 basic format YYYYMMDD"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -202,7 +203,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "now" 0
       parameters = []
       returnType = TDate
-      description = "Returns the current time."
+      description = "Returns the current time"
       fn =
         (function
         | _, [] -> Instant.now () |> DDateTime.fromInstant |> DDate |> Ply
@@ -215,7 +216,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "today" 0
       parameters = []
       returnType = TDate
-      description = "Returns the Date with the time set to midnight"
+      description = "Returns the <type Date> with the time set to midnight"
       fn =
         (function
         | _, [] ->
@@ -230,7 +231,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "add" 0
       parameters = [ Param.make "d" TDate ""; Param.make "seconds" TInt "" ]
       returnType = TDate
-      description = "Returns a new Date `seconds` seconds after `d`"
+      description = "Returns a <type Date> <param seconds> seconds after <param d>"
       fn =
         (function
         | _, [ DDate d; DInt s ] ->
@@ -244,7 +245,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "sub" 0
       parameters = [ Param.make "d" TDate ""; Param.make "seconds" TInt "" ]
       returnType = TDate
-      description = "Returns a new Date `seconds` seconds before `d`"
+      description = "Returns a <type Date> <param seconds> seconds before <param d>"
       fn =
         (function
         | _, [ DDate d; DInt s ] ->
@@ -255,7 +256,7 @@ let fns : List<BuiltInFn> =
       deprecated = ReplacedBy(fn "Date" "subtract" 0) }
 
 
-    // Note: this was was previously named`Date::subtract_v0`.
+    // Note: this was was previously named `Date::subtract_v0`.
     // A new Date::subtract_v1 was created to replace this, and subtract_v0 got
     // replaced with this ::subtractSeconds_v0. "Date::subtract" implies that
     // you are subtracting one date from another, so subtracting anything else
@@ -263,7 +264,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "subtractSeconds" 0
       parameters = [ Param.make "d" TDate ""; Param.make "seconds" TInt "" ]
       returnType = TDate
-      description = "Returns a new Date `seconds` seconds before `d`"
+      description = "Returns a <type Date> <param seconds> seconds before <param d>"
       fn =
         (function
         | _, [ DDate d; DInt s ] ->
@@ -277,7 +278,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "greaterThan" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
-      description = "Returns whether `d1` > ` d2`"
+      description = "Returns whether {{<param d1> > <param d2>}}"
       fn =
         (function
         | _, [ DDate d1; DDate d2 ] -> Ply(DBool(d1 > d2))
@@ -290,7 +291,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "lessThan" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
-      description = "Returns whether `d1` < ` d2`"
+      description = "Returns whether {{<param d1> < <param d2>}}"
       fn =
         (function
         | _, [ DDate d1; DDate d2 ] -> Ply(DBool(d1 < d2))
@@ -303,7 +304,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "greaterThanOrEqualTo" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
-      description = "Returns whether `d1` >= ` d2`"
+      description = "Returns whether {{<param d1> >= <param d2>}}"
       fn =
         (function
         | _, [ DDate d1; DDate d2 ] -> Ply(DBool(d1 >= d2))
@@ -316,7 +317,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "lessThanOrEqualTo" 0
       parameters = [ Param.make "d1" TDate ""; Param.make "d2" TDate "" ]
       returnType = TBool
-      description = "Returns whether `d1` <= ` d2`"
+      description = "Returns whether {{<param d1> <= <param d2>}}"
       fn =
         (function
         | _, [ DDate d1; DDate d2 ] -> Ply(DBool(d1 <= d2))
@@ -330,7 +331,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
       description =
-        "Converts a Date `date` to an integer representing seconds since the Unix epoch"
+        "Converts <param date> to an <type integer> representing seconds since the Unix epoch"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -345,7 +346,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "seconds" TInt "" ]
       returnType = TDate
       description =
-        "Converts an integer representing seconds since the Unix epoch into a Date"
+        "Converts an <type integer> representing seconds since the Unix epoch into a <type Date>"
       fn =
         (function
         | _, [ DInt s ] ->
@@ -359,7 +360,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "toHumanReadable" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TStr
-      description = "Turn a Date into a human readable format"
+      description = "Turn a <type Date> into a human readable format"
       fn =
         (function
         | _, [ DDate date ] ->
@@ -412,7 +413,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "year" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the year portion of the Date as an int"
+      description = "Returns the year portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] -> d.Year |> Dval.int |> Ply
@@ -426,7 +427,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
       description =
-        "Returns the month portion of the Date as an int between 1 and 12"
+        "Returns the month portion of <param date> as an <type int> between {{1}} and {{12}}"
       fn =
         (function
         | _, [ DDate d ] -> d.Month |> Dval.int |> Ply
@@ -439,7 +440,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "day" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the day portion of the Date as an int"
+      description = "Returns the day portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] -> d.Day |> Dval.int |> Ply
@@ -453,7 +454,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
       description =
-        "Returns the weekday of `date` as an int. Monday = 1, Tuesday = 2, ... Sunday = 7 (in accordance with ISO 8601)."
+        "Returns the weekday of <param date> as an <type int>. Monday = {{1}}, Tuesday = {{2}}, ... Sunday = {{7}} (in accordance with ISO 8601)."
       fn =
         (function
         | _, [ DDate d ] -> d.DayOfWeek |> int64 |> DInt |> Ply
@@ -466,7 +467,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "hour" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the hour portion of the Date as an int"
+      description = "Returns the hour portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -482,7 +483,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "hour" 1
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the hour portion of the Date as an int"
+      description = "Returns the hour portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -498,7 +499,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "hour" 2
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the hour portion of the Date as an int"
+      description = "Returns the hour portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] -> Ply(Dval.int d.Hour)
@@ -511,7 +512,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "minute" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the minute portion of the Date as an int"
+      description = "Returns the minute portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -532,7 +533,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "minute" 1
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the minute portion of the Date as an int"
+      description = "Returns the minute portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] -> Ply(Dval.int d.Minute)
@@ -545,7 +546,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "second" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the second portion of the Date as an int"
+      description = "Returns the second portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] ->
@@ -561,7 +562,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "second" 1
       parameters = [ Param.make "date" TDate "" ]
       returnType = TInt
-      description = "Returns the second portion of the Date as an int"
+      description = "Returns the second portion of <param date> as an <type int>"
       fn =
         (function
         | _, [ DDate d ] -> Ply(Dval.int d.Second)
@@ -574,7 +575,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Date" "atStartOfDay" 0
       parameters = [ Param.make "date" TDate "" ]
       returnType = TDate
-      description = "Returns the Date with the time set to midnight"
+      description = "Returns <type date> with the time set to midnight"
       fn =
         (function
         | _, [ DDate d ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
@@ -25,7 +25,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "key" TStr ""; Param.make "value" varA "" ]
       returnType = TDict varA
       description =
-        "Returns a dictionary with a single entry <param key>: <param value>"
+        "Returns a dictionary with a single entry {{<param key>: <param value>}}"
       fn =
         (function
         | _, [ DStr k; v ] -> Ply(DObj(Map.ofList [ (k, v) ]))
@@ -104,9 +104,14 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "entries" (TList varA) "" ]
       returnType = TDict varA
       description =
-        "Returns a <type dict> with <param entries>. Each value in <param entries> must be a {{[key, value]}} list, where <var key> is a <type String>.
-        If <param entries> contains duplicate <var key>s, the last entry with that key will be used in the resulting dictionary (use <fn Dict::fromList> if you want to enforce unique keys).
-        This function is the opposite of <fn Dict::toList>."
+        "Returns a <type dict> with <param entries>. Each value in <param entries>
+         must be a {{[key, value]}} list, where <var key> is a <type String>.
+
+         If <param entries> contains duplicate <var key>s, the last entry with that
+         key will be used in the resulting dictionary (use <fn Dict::fromList> if you
+         want to enforce unique keys).
+
+         This function is the opposite of <fn Dict::toList>."
       fn =
         (function
         | state, [ DList l ] ->
@@ -119,7 +124,7 @@ let fns : List<BuiltInFn> =
             | (DIncomplete _
             | DErrorRail _
             | DError _) as dv -> Errors.foundFakeDval dv
-            | _ -> Exception.raiseCode "All list items must be {{[key, value]}}"
+            | _ -> Exception.raiseCode "All list items must be `[key, value]`"
 
           let result = List.fold Map.empty f l
           Ply(DObj result)
@@ -133,9 +138,14 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "entries" (TList varA) "" ]
       returnType = TOption(TDict varA)
       description =
-        "Each value in <param entries> must be a {{[key, value]}} list, where <var key> is a <type String>.
-         If <param entries> contains no duplicate keys, returns {{Just <var dict>}} where <var dict> has <param entries>.
-         Otherwise, returns {{Nothing}} (use <fn Dict::fromListOverwritingDuplicates> if you want to overwrite duplicate keys)."
+        "Each value in <param entries> must be a {{[key, value]}} list, where <var
+         key> is a <type String>.
+
+         If <param entries> contains no duplicate keys, returns {{Just <var dict>}}
+         where <var dict> has <param entries>.
+
+         Otherwise, returns {{Nothing}} (use <fn Dict::fromListOverwritingDuplicates>
+         if you want to overwrite duplicate keys)."
       fn =
         (function
         | _, [ DList l ] ->
@@ -199,7 +209,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TOption varA
       description =
-        "If the <param dict> contains <param key>, returns the corresponding value, wrapped in an <type option>: {{Just value}}. Otherwise, returns {{Nothing}}."
+        "If the <param dict> contains <param key>, returns the corresponding value,
+         wrapped in an <type option>: {{Just value}}. Otherwise, returns {{Nothing}}."
       fn =
         (function
         | _, [ DObj o; DStr s ] -> Map.tryFind s o |> Dval.option |> Ply
@@ -213,7 +224,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TBool
       description =
-        "Returns {{true}} if the <param dict> contains an entry with <param key>, and {{false}} otherwise"
+        "Returns {{true}} if the <param dict> contains an entry with <param key>, and
+         {{false}} otherwise"
       fn =
         (function
         | _, [ DObj o; DStr s ] -> Ply(DBool(Map.containsKey s o))
@@ -229,7 +241,9 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TDict varB
       description =
-        "Returns a <type Dict> that contains the same keys as the original <param dict> with values that have been transformed by {{fn}}, which operates on each value."
+        "Returns a <type Dict> that contains the same keys as the original <param
+         dict> with values that have been transformed by {{fn}}, which operates on
+         each value."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -254,8 +268,11 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TStr; varA ], varB)) "" [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Returns a new dictionary that contains the same keys as the original <param dict> with values that have been transformed by {{fn}}, which operates on each key-value pair.
-          Consider <fn Dict::filterMap> if you also want to drop some of the entries."
+        "Returns a new dictionary that contains the same keys as the original <param
+         dict> with values that have been transformed by {{fn}}, which operates on
+         each key-value pair.
+
+         Consider <fn Dict::filterMap> if you also want to drop some of the entries."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -288,8 +305,10 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
       returnType = TDict varA
       description =
-        "Calls <param fn> on every entry in <param dict>, returning a <type dict> of only those entries for which {{fn key value}} returns {{true}}.
-              Consider <fn Dict::filterMap> if you also want to transform the entries."
+        "Calls <param fn> on every entry in <param dict>, returning a <type dict> of
+         only those entries for which {{fn key value}} returns {{true}}.
+
+         Consider <fn Dict::filterMap> if you also want to transform the entries."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -334,7 +353,9 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Evaluates {{fn key value}} on every entry in <param dict>. Returns a <type dict> that contains only the entries of <param dict> for which <param fn> returned {{true}}."
+        "Evaluates {{fn key value}} on every entry in <param dict>. Returns a <type
+         dict> that contains only the entries of <param dict> for which <param fn>
+         returned {{true}}."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -450,7 +471,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "empty" 0
       parameters = []
       returnType = TDict varA
-      description = "Returns an empty dictionary."
+      description = "Returns an empty dictionary"
       fn =
         (function
         | _, [] -> Ply(DObj Map.empty)
@@ -463,7 +484,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "isEmpty" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TBool
-      description = "Returns {{true}} if the <param dict> contains no entries."
+      description = "Returns {{true}} if the <param dict> contains no entries"
       fn =
         (function
         | _, [ DObj dict ] -> Ply(DBool(Map.isEmpty dict))
@@ -492,7 +513,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "toJSON" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TStr
-      description = "Returns <param dict> as a JSON string."
+      description = "Returns <param dict> as a JSON string"
       fn =
         (function
         | _, [ DObj o ] ->
@@ -510,7 +531,7 @@ let fns : List<BuiltInFn> =
           Param.make "val" varA "" ]
       returnType = (TDict(TVariable "a"))
       description =
-        "Returns a copy of <param dict> with the <param key> set to <param val>."
+        "Returns a copy of <param dict> with the <param key> set to <param val>"
       fn =
         (function
         | _, [ DObj o; DStr k; v ] -> Ply(DObj(Map.add k v o))

--- a/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibDict.fs
@@ -24,7 +24,8 @@ let fns : List<BuiltInFn> =
   [ { name = fn "Dict" "singleton" 0
       parameters = [ Param.make "key" TStr ""; Param.make "value" varA "" ]
       returnType = TDict varA
-      description = "Returns a new dictionary with a single entry `key`: `value`."
+      description =
+        "Returns a dictionary with a single entry <param key>: <param value>"
       fn =
         (function
         | _, [ DStr k; v ] -> Ply(DObj(Map.ofList [ (k, v) ]))
@@ -37,8 +38,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "size" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TInt
-      description =
-        "Returns the number of entries in `dict` (the number of key-value pairs)."
+      description = "Returns the number of entries in <param dict>"
       fn =
         (function
         | _, [ DObj o ] -> Ply(DInt(int64 (Map.count o)))
@@ -51,7 +51,8 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "keys" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = (TList TStr)
-      description = "Returns `dict`'s keys in a list, in an arbitrary order."
+      description =
+        "Returns <param dict>'s keys in a <type List>, in an arbitrary order"
       fn =
         (function
         | _, [ DObj o ] ->
@@ -70,7 +71,8 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "values" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = (TList varA)
-      description = "Returns `dict`'s values in a list, in an arbitrary order."
+      description =
+        "Returns <param dict>'s values in a <type List>, in an arbitrary order"
       fn =
         (function
         | _, [ DObj o ] -> o |> Map.values |> Seq.toList |> (fun l -> DList l |> Ply)
@@ -84,7 +86,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = (TList varA)
       description =
-        "Returns `dict`'s entries as a list of `[key, value]` lists, in an arbitrary order. This function is the opposite of `Dict::fromList`."
+        "Returns <param dict>'s entries as a list of {{[key, value]}} lists, in an arbitrary order. This function is the opposite of <fn Dict::fromList>"
       fn =
         (function
         | _, [ DObj o ] ->
@@ -102,9 +104,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "entries" (TList varA) "" ]
       returnType = TDict varA
       description =
-        "Returns a new dict with `entries`. Each value in `entries` must be a `[key, value]` list, where `key` is a `String`.
-        If `entries` contains duplicate `key`s, the last entry with that key will be used in the resulting dictionary (use `Dict::fromList` if you want to enforce unique keys).
-        This function is the opposite of `Dict::toList`."
+        "Returns a <type dict> with <param entries>. Each value in <param entries> must be a {{[key, value]}} list, where <var key> is a <type String>.
+        If <param entries> contains duplicate <var key>s, the last entry with that key will be used in the resulting dictionary (use <fn Dict::fromList> if you want to enforce unique keys).
+        This function is the opposite of <fn Dict::toList>."
       fn =
         (function
         | state, [ DList l ] ->
@@ -117,7 +119,7 @@ let fns : List<BuiltInFn> =
             | (DIncomplete _
             | DErrorRail _
             | DError _) as dv -> Errors.foundFakeDval dv
-            | _ -> Exception.raiseCode "All list items must be `[key, value]`"
+            | _ -> Exception.raiseCode "All list items must be {{[key, value]}}"
 
           let result = List.fold Map.empty f l
           Ply(DObj result)
@@ -131,13 +133,12 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "entries" (TList varA) "" ]
       returnType = TOption(TDict varA)
       description =
-        "Each value in `entries` must be a `[key, value]` list, where `key` is a `String`.
-         If `entries` contains no duplicate keys, returns `Just dict` where `dict` has `entries`.
-         Otherwise, returns `Nothing` (use `Dict::fromListOverwritingDuplicates` if you want to overwrite duplicate keys)."
+        "Each value in <param entries> must be a {{[key, value]}} list, where <var key> is a <type String>.
+         If <param entries> contains no duplicate keys, returns {{Just <var dict>}} where <var dict> has <param entries>.
+         Otherwise, returns {{Nothing}} (use <fn Dict::fromListOverwritingDuplicates> if you want to overwrite duplicate keys)."
       fn =
         (function
         | _, [ DList l ] ->
-
           let f acc e =
             match acc, e with
             | Some acc, DList [ DStr k; value ] when Map.containsKey k acc -> None
@@ -167,7 +168,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = varA
       description =
-        "Looks up `key` in object `dict` and returns the value if found, and Error otherwise"
+        "Looks up <param key> in <param dict> and returns the value if found, and an error otherwise"
       fn =
         (function
         | _, [ DObj o; DStr s ] ->
@@ -183,7 +184,8 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "get" 1
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TOption varA
-      description = "Looks up `key` in object `dict` and returns an option"
+      description =
+        "Looks up <param key> in <param dict> and returns an <type Option>"
       fn =
         (function
         | _, [ DObj o; DStr s ] -> Ply(DOption(Map.tryFind s o))
@@ -197,7 +199,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TOption varA
       description =
-        "If the `dict` contains `key`, returns the corresponding value, wrapped in an option: `Just value`. Otherwise, returns `Nothing`."
+        "If the <param dict> contains <param key>, returns the corresponding value, wrapped in an <type option>: {{Just value}}. Otherwise, returns {{Nothing}}."
       fn =
         (function
         | _, [ DObj o; DStr s ] -> Map.tryFind s o |> Dval.option |> Ply
@@ -211,7 +213,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TBool
       description =
-        "Returns `true` if the `dict` contains an entry with `key`, and `false` otherwise."
+        "Returns {{true}} if the <param dict> contains an entry with <param key>, and {{false}} otherwise"
       fn =
         (function
         | _, [ DObj o; DStr s ] -> Ply(DBool(Map.containsKey s o))
@@ -227,7 +229,7 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TDict varB
       description =
-        "Returns a new dictionary that contains the same keys as the original `dict` with values that have been transformed by `fn`, which operates on each value."
+        "Returns a <type Dict> that contains the same keys as the original <param dict> with values that have been transformed by {{fn}}, which operates on each value."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -252,8 +254,8 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TStr; varA ], varB)) "" [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Returns a new dictionary that contains the same keys as the original `dict` with values that have been transformed by `fn`, which operates on each key-value pair.
-          Consider `Dict::filterMap` if you also want to drop some of the entries."
+        "Returns a new dictionary that contains the same keys as the original <param dict> with values that have been transformed by {{fn}}, which operates on each key-value pair.
+          Consider <fn Dict::filterMap> if you also want to drop some of the entries."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -286,8 +288,8 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
       returnType = TDict varA
       description =
-        "Calls `fn` on every entry in `dict`, returning a dictionary of only those entries for which `fn key value` returns `true`.
-              Consider `Dict::filterMap` if you also want to transform the entries."
+        "Calls <param fn> on every entry in <param dict>, returning a <type dict> of only those entries for which {{fn key value}} returns {{true}}.
+              Consider <fn Dict::filterMap> if you also want to transform the entries."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -332,7 +334,7 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TStr; varA ], TBool)) "" [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Evaluates `fn key value` on every entry in `dict`. Returns a new dictionary that contains only the entries of `dict` for which `fn` returned `true`."
+        "Evaluates {{fn key value}} on every entry in <param dict>. Returns a <type dict> that contains only the entries of <param dict> for which <param fn> returned {{true}}."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -390,10 +392,10 @@ let fns : List<BuiltInFn> =
             [ "key"; "value" ] ]
       returnType = TDict varB
       description =
-        "Calls `fn` on every entry in `dict`, returning a new dictionary that drops some entries (filter) and transforms others (map).
-          If `fn key value` returns `Nothing`, does not add `key` or `value` to the new dictionary, dropping the entry.
-          If `fn key value` returns `Just newValue`, adds the entry `key`: `newValue` to the new dictionary.
-          This function combines `Dict::filter` and `Dict::map`."
+        "Calls <param fn> on every entry in <param dict>, returning a <type dict> that drops some entries (filter) and transforms others (map).
+          If {{fn key value}} returns {{Nothing}}, does not add <var key> or <var value> to the new dictionary, dropping the entry.
+          If {{fn key value}} returns {{Just newValue}}, adds the entry <var key>: <var newValue> to the new dictionary.
+          This function combines <fn Dict::filter> and <fn Dict::map>."
       fn =
         (function
         | state, [ DObj o; DFnVal b ] ->
@@ -461,7 +463,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "isEmpty" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TBool
-      description = "Returns `true` if the `dict` contains no entries."
+      description = "Returns {{true}} if the <param dict> contains no entries."
       fn =
         (function
         | _, [ DObj dict ] -> Ply(DBool(Map.isEmpty dict))
@@ -476,7 +478,7 @@ let fns : List<BuiltInFn> =
         [ Param.make "left" (TDict varA) ""; Param.make "right" (TDict varA) "" ]
       returnType = TDict varA
       description =
-        "Returns a combined dictionary with both dictionaries' entries. If the same key exists in both `left` and `right`, it will have the value from `right`."
+        "Returns a combined dictionary with both dictionaries' entries. If the same key exists in both <param left> and <param right>, it will have the value from <param right>."
       fn =
         (function
         | _, [ DObj l; DObj r ] -> Ply(DObj(Map.mergeFavoringRight l r))
@@ -490,7 +492,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Dict" "toJSON" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TStr
-      description = "Returns `dict` as a JSON string."
+      description = "Returns <param dict> as a JSON string."
       fn =
         (function
         | _, [ DObj o ] ->
@@ -507,7 +509,8 @@ let fns : List<BuiltInFn> =
           Param.make "key" TStr ""
           Param.make "val" varA "" ]
       returnType = (TDict(TVariable "a"))
-      description = "Returns a copy of `dict` with the `key` set to `val`."
+      description =
+        "Returns a copy of <param dict> with the <param key> set to <param val>."
       fn =
         (function
         | _, [ DObj o; DStr k; v ] -> Ply(DObj(Map.add k v o))
@@ -521,7 +524,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TStr "" ]
       returnType = TDict varA
       description =
-        "If the `dict` contains `key`, returns a copy of `dict` with `key` and its associated value removed. Otherwise, returns `dict` unchanged."
+        "If the <param dict> contains <param key>, returns a copy of <param dict> with <param key> and its associated value removed. Otherwise, returns <param dict> unchanged."
       fn =
         (function
         | _, [ DObj o; DStr k ] -> Ply(DObj(Map.remove k o))

--- a/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
@@ -41,7 +41,11 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
       description =
-        "Round down to an integer value. Consider Float::truncate if your goal is to discard the fractional part of a number: `Float::floor -1.9 == -2.0` but `Float::truncate -1.9 == -1.0`."
+        "Round down to an integer value.
+
+        Consider <fn Float::truncate> if your goal
+        is to discard the fractional part of a number: {{Float::floor -1.9 == -2.0}}
+        but {{Float::truncate -1.9 == -1.0}}"
       fn =
         (function
         | _, [ DFloat a ] -> a |> Math.Floor |> int64 |> DInt |> Ply
@@ -55,7 +59,12 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
       description =
-        "Round down to an integer value. Consider Float::truncate if your goal is to discard the fractional part of a number: `Float::floor -1.9 == -2.0` but `Float::truncate -1.9 == -1.0`."
+        "Round down to an integer value.
+
+         Consider <fn Float::truncate> if your goal is to discard the fractional part
+         of a number: {{Float::floor -1.9 == -2.0}} but {{Float::truncate -1.9 ==
+         -1.0}}"
+
       fn =
         (function
         | _, [ DFloat a ] -> a |> Math.Floor |> int64 |> DInt |> Ply
@@ -82,7 +91,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
       description =
-        "Discard the fractional portion of the float, rounding towards zero."
+        "Discard the fractional portion of the float, rounding towards zero"
       fn =
         (function
         | _, [ DFloat a ] -> a |> Math.Truncate |> int64 |> DInt |> Ply
@@ -96,7 +105,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the absolute value of `a` (turning negative inputs into positive outputs)."
+        "Returns the absolute value of <param a> (turning negative inputs into positive outputs)"
       fn =
         (function
         | _, [ DFloat a ] -> DFloat(Math.Abs a) |> Ply
@@ -109,7 +118,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "negate" 0
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TFloat
-      description = "Returns the negation of `a`, `-a`."
+      description = "Returns the negation of <param a>, {{-a}}"
       fn =
         (function
         | _, [ DFloat a ] -> DFloat(a * -1.0) |> Ply
@@ -135,7 +144,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "power" 0
       parameters = [ Param.make "base" TFloat ""; Param.make "exponent" TFloat "" ]
       returnType = TFloat
-      description = "Returns `base` raised to the power of `exponent`"
+      description = "Returns <param base> raised to the power of <param exponent>"
       fn =
         (function
         | _, [ DFloat base_; DFloat exp ] -> Ply(DFloat(base_ ** exp))
@@ -148,7 +157,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "divide" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
-      description = "Divide float `a` by float `b`"
+      description = "Divide <type float> <param a> by <type float> <param b>"
       fn =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(a / b))
@@ -161,7 +170,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "add" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
-      description = "Add float `a` to float `b`"
+      description = "Add <type float> <param a> to <type float> <param b>"
       fn =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(a + b))
@@ -174,7 +183,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "multiply" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
-      description = "Multiply float `a` by float `b`"
+      description = "Multiply <type float> <param a> by <type float> <param b>"
       fn =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(a * b))
@@ -187,7 +196,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "subtract" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
-      description = "Subtract float `b` from float `a`"
+      description = "Subtract `float` `b` from `float` `a`"
       fn =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(a - b))
@@ -278,7 +287,8 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "min" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
-      description = "Returns the lesser of float `a` and float `b`"
+      description =
+        "Returns the lesser of <type float> <param a> and <type float> <param b>"
       fn =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(Math.Min(a, b)))
@@ -291,7 +301,8 @@ let fns : List<BuiltInFn> =
     { name = fn "Float" "max" 0
       parameters = [ Param.make "a" TFloat ""; Param.make "b" TFloat "" ]
       returnType = TFloat
-      description = "Returns the greater of float `a` and float `b`"
+      description =
+        "Returns the greater of <type float> <param a> and <type float> <param b>"
       fn =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(Math.Max(a, b)))
@@ -308,9 +319,13 @@ let fns : List<BuiltInFn> =
           Param.make "limitB" TFloat "" ]
       returnType = TFloat
       description =
-        "If `value` is within the range given by `limitA` and `limitB`, returns `value`.
-         If `value` is outside the range, returns `limitA` or `limitB`, whichever is closer to `value`.
-         `limitA` and `limitB` can be provided in any order."
+        "If <param value> is within the range given by <param limitA> and <param
+         limitB>, returns <param value>.
+
+         If <param value> is outside the range, returns <param limitA> or <param
+         limitB>, whichever is closer to <param value>.
+
+         <param limitA> and <param limitB> can be provided in any order."
       fn =
         (function
         | _, [ DFloat v; DFloat a; DFloat b ] ->
@@ -329,7 +344,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
       description =
-        "Discard the fractional portion of the float, rounding towards zero."
+        "Discard the fractional portion of <type float> <param a>, rounding towards zero."
       fn =
         (function
         | _, [ DFloat a ] -> a |> Math.Truncate |> int64 |> DInt |> Ply

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttp.fs
@@ -24,7 +24,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with HTTP status <param code> and <param response> body."
       fn =
         (function
         | _, [ dv; DInt code ] -> Ply(DHttpResponse(Response(code, [], dv)))
@@ -37,11 +38,13 @@ let fns : List<BuiltInFn> =
     { name = fn "Http" "responseWithHeaders" 0
       parameters =
         [ Param.make "response" varA ""
-          Param.make "headers" (TDict varA) ""
+          Param.make "headers" (TDict TStr) ""
           Param.make "code" TInt "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code`, `response` body, and `headers`."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with HTTP status <param code>, <param response> body, and <param
+         headers>."
       fn =
         (function
         | _, [ dv; DObj o; DInt code ] ->
@@ -64,7 +67,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "response" varA "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status 200 and `response` body."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with HTTP status 200 and <param response> body."
       fn =
         (function
         | _, [ dv ] -> Ply(DHttpResponse(Response(200L, [], dv)))
@@ -78,7 +82,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"text/html\"."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with HTTP status <param code> and <param response> body, with
+         {{content-type}} set to {{\"text/html\"}}"
       fn =
         (function
         | _, [ dv; DInt code ] ->
@@ -93,7 +99,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"text/plain\"."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with HTTP status <param code> and <param response> body, with
+         {{content-type}} set to {{\"text/plain\"}}"
       fn =
         (function
         | _, [ dv; DInt code ] ->
@@ -108,7 +116,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "response" varA ""; Param.make "code" TInt "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with HTTP status `code` and `response` body, with `content-type` set to \"application/json\""
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with HTTP status <param code> and <param response> body, with
+         {{content-type}} set to {{\"application/json\"}}"
       fn =
         (function
         | _, [ dv; DInt code ] ->
@@ -127,7 +137,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "url" TStr "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with a 302 redirect to `url`."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with a {{302}} redirect to <param url>"
       fn =
         (function
         | _, [ DStr url ] -> Ply(DHttpResponse(Redirect url))
@@ -141,7 +152,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "error" TStr "" ]
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with a 400 status and string `error` message."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with a {{400}} status and string <param error> message"
       fn =
         (function
         | _, [ DStr _ as msg ] -> Ply(DHttpResponse(Response(400L, [], msg)))
@@ -155,7 +167,8 @@ let fns : List<BuiltInFn> =
       parameters = []
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with 404 Not Found."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with {{404}} status code (not found)"
       fn =
         (function
         | _, [] -> Ply(DHttpResponse(Response(404L, [], DNull)))
@@ -169,7 +182,8 @@ let fns : List<BuiltInFn> =
       parameters = []
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with 401 Unauthorized."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with {{401}} status code (unauthorized)"
       fn =
         (function
         | _, [] -> Ply(DHttpResponse(Response(401L, [], DNull)))
@@ -183,7 +197,8 @@ let fns : List<BuiltInFn> =
       parameters = []
       returnType = THttpResponse varA
       description =
-        "Returns a Response that can be returned from an HTTP handler to respond with 403 Forbidden."
+        "Returns a <type Response> that can be returned from an HTTP handler to
+         respond with {{403}} status code (forbidden)"
       fn =
         (function
         | _, [] -> Ply(DHttpResponse(Response(403L, [], DNull)))
@@ -200,7 +215,9 @@ let fns : List<BuiltInFn> =
           Param.make "params" (TDict varA) "" ]
       returnType = TDict varA
       description =
-        "Generate an HTTP Set-Cookie header Object suitable for Http::responseWithHeaders given a cookie name, a string value for it, and an Object of Set-Cookie parameters."
+        "Generate an HTTP Set-Cookie header value suitable for <fn
+         Http::responseWithHeaders> given a cookie name, a string value for it, and a
+         <type dict> of Set-Cookie parameters."
       fn =
         (function
         | _, [ DStr name; DStr value; DObj o ] ->
@@ -246,7 +263,9 @@ let fns : List<BuiltInFn> =
           Param.make "params" (TDict varA) "" ]
       returnType = TDict varA
       description =
-        "Generate an HTTP Set-Cookie header Object suitable for Http::responseWithHeaders given a cookie name, a string value for it, and an Object of Set-Cookie parameters."
+        "Generate an HTTP Set-Cookie header value suitable for <fn
+         Http::responseWithHeaders> given a cookie name, a string value for it, and an
+         <type dict> of Set-Cookie parameters."
       fn =
         (function
         | _, [ DStr name; DStr value; DObj o ] ->
@@ -299,7 +318,11 @@ let fns : List<BuiltInFn> =
           Param.make "params" (TDict varA) "" ]
       returnType = TDict varA
       description =
-        "Returns an HTTP Set-Cookie header <type Dict> suitable for use with <fn Http::responseWithHeaders>, given a cookie <param name>, a <type String> <param value> for it, and a <type Dict> of Set-Cookie <param params> ({{Expires}}, {{Max-Age}}, {{Domain}}, {{Path}}, {{Secure}}, {{HttpOnly}}, and/or {{SameSite}})."
+        "Returns an HTTP Set-Cookie header <type Dict> suitable for use with <fn
+         Http::responseWithHeaders>, given a cookie <param name>, a <type String>
+         <param value> for it, and a <type Dict> of Set-Cookie <param params>
+         ({{Expires}}, {{Max-Age}}, {{Domain}}, {{Path}}, {{Secure}}, {{HttpOnly}},
+         and/or {{SameSite}})."
       fn =
         (function
         | state, [ DStr name; DStr value; DObj o ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttpClient.fs
@@ -21,7 +21,8 @@ let fns : List<BuiltInFn> =
       parameters = []
       returnType = TDict TStr
       description =
-        "Returns an object with 'Content-Type' for url-encoded HTML forms"
+        "Returns a header <type Dict> with {{Content-Type}} set for HTML form
+         requests or responses"
       fn =
         (function
         | _, [] ->
@@ -39,7 +40,9 @@ let fns : List<BuiltInFn> =
     { name = fn "HttpClient" "jsonContentType" 0
       parameters = []
       returnType = TDict TStr
-      description = "Returns an object with 'Content-Type' for JSON"
+      description =
+        "Returns a header <type dict> with {{Content-Type}} set for JSON requests or
+         responses"
       fn =
         (function
         | _, [] ->
@@ -57,7 +60,9 @@ let fns : List<BuiltInFn> =
     { name = fn "HttpClient" "plainTextContentType" 0
       parameters = []
       returnType = TDict TStr
-      description = "Returns an object with 'Content-Type' for plain text"
+      description =
+        "Returns a header <type Dict> with {{'Content-Type'}} set for plain text
+         requests or responses"
       fn =
         (function
         | _, [] ->
@@ -71,7 +76,9 @@ let fns : List<BuiltInFn> =
     { name = fn "HttpClient" "htmlContentType" 0
       parameters = []
       returnType = TDict TStr
-      description = "Returns an object with 'Content-Type' for html"
+      description =
+        "Returns a header <type Dict> with {{'Content-Type'}} set for html requests
+         or responses"
       fn =
         (function
         | _, [] ->
@@ -85,7 +92,8 @@ let fns : List<BuiltInFn> =
     { name = fn "HttpClient" "bearerToken" 0
       parameters = [ Param.make "token" TStr "" ]
       returnType = TDict TStr
-      description = "Returns an object with 'Authorization' set to the passed token"
+      description =
+        "Returns a header <type Dict> with {{'Authorization'}} set to <param token>"
       fn =
         (function
         | _, [ DStr token ] ->
@@ -100,7 +108,8 @@ let fns : List<BuiltInFn> =
     { name = fn "HttpClient" "bearerToken" 1
       parameters = [ Param.make "token" TStr "" ]
       returnType = TDict TStr
-      description = "Returns an object with 'Authorization' set to the passed token"
+      description =
+        "Returns a header <type Dict> with {{'Authorization'}} set to <param token>"
       fn =
         (function
         | _, [ DStr token ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibHttpClientAuth.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibHttpClientAuth.fs
@@ -10,7 +10,7 @@ module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
 
-let incorrectArgs = LibExecution.Errors.incorrectArgs
+let incorrectArgs = Errors.incorrectArgs
 
 /// Base64-encodes username/password combination for basic authentication
 ///
@@ -42,7 +42,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "username" TStr ""; Param.make "password" TStr "" ]
       returnType = TDict TStr
       description =
-        "Returns an object with 'Authorization' created using HTTP basic auth"
+        "Returns a header <type Dict> with {{'Authorization'}} created using HTTP basic auth"
       fn =
         (function
         | _, [ DStr u; DStr p ] ->
@@ -57,7 +57,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "username" TStr ""; Param.make "password" TStr "" ]
       returnType = TDict TStr
       description =
-        "Returns an object with 'Authorization' created using HTTP basic auth"
+        "Returns a header <type Dict> with {{'Authorization'}} created using HTTP basic auth"
       fn =
         (function
         | _, [ DStr u; DStr p ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibInt.fs
@@ -213,7 +213,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Int" "negate" 0
       parameters = [ Param.make "a" TInt "" ]
       returnType = TInt
-      description = "Returns the negation of <param a>, {{-a}}."
+      description = "Returns the negation of <param a>, {{-a}}"
       fn =
         (function
         | _, [ DInt a ] -> Ply(DInt(-a))

--- a/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibJson.fs
@@ -12,7 +12,7 @@ module DvalReprLegacyExternal = LibExecution.DvalReprLegacyExternal
 
 let fn = FQFnName.stdlibFnName
 
-let incorrectArgs = LibExecution.Errors.incorrectArgs
+let incorrectArgs = Errors.incorrectArgs
 
 
 let varErr = TVariable "err"
@@ -23,7 +23,12 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "json" TStr "" ]
       returnType = varA
       description =
-        "Parses a json string and returns its value. HTTPClient functions, and our request handler, automatically parse JSON into the `body` and `jsonbody` fields, so you probably won't need this. However, if you need to consume bad JSON, you can use string functions to fix the JSON and then use this function to parse it."
+        "Parses a json string and returns its value.
+
+         HTTPClient functions, and our request handler, automatically parse JSON into
+         the {{body}} and {{jsonBody}} fields, so you probably won't need this.
+         However, if you need to consume bad JSON, you can use string functions to
+         fix the JSON and then use this function to parse it."
       fn =
         (function
         | _, [ DStr json ] ->
@@ -36,7 +41,6 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      // a.k.a. Json::parse_v0
       deprecated = ReplacedBy(fn "JSON" "read" 1) }
 
 
@@ -44,7 +48,12 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "json" TStr "" ]
       returnType = varA
       description =
-        "Parses a json string and returns its value. HTTPClient functions, and our request handler, automatically parse JSON into the `body` and `jsonbody` fields, so you probably won't need this. However, if you need to consume bad JSON, you can use string functions to fix the JSON and then use this function to parse it."
+        "Parses a json string and returns its value.
+
+         HTTPClient functions, and our request handler, automatically parse JSON into
+         the {{body}} and {{jsonBody}} fields, so you probably won't need this.
+         However, if you need to consume bad JSON, you can use string functions to
+         fix the JSON and then use this function to parse it."
       fn =
         (function
         | _, [ DStr json ] ->
@@ -61,7 +70,12 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "json" TStr "" ]
       returnType = TResult(varA, varErr)
       description =
-        "Parses a json string and returns its value. HTTPClient functions, and our request handler, automatically parse JSON into the `body` and `jsonbody` fields, so you probably won't need this. However, if you need to consume bad JSON, you can use string functions to fix the JSON and then use this function to parse it."
+        "Parses a json string and returns its value.
+
+         HTTPClient functions, and our request handler, automatically parse JSON into
+         the {{body}} and {{jsonBody}} fields, so you probably won't need this.
+         However, if you need to consume bad JSON, you can use string functions to
+         fix the JSON and then use this function to parse it."
       fn =
         (function
         | _, [ DStr json ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -131,7 +131,7 @@ let fns : List<BuiltInFn> =
   [ { name = fn "List" "singleton" 0
       parameters = [ Param.make "val" (TVariable "a") "" ]
       returnType = TList(TVariable "a")
-      description = "Returns a one-element list containing the given <param val>."
+      description = "Returns a one-element list containing the given <param val>"
       fn =
         (function
         | _, [ v ] -> Ply(DList [ v ])

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -131,7 +131,7 @@ let fns : List<BuiltInFn> =
   [ { name = fn "List" "singleton" 0
       parameters = [ Param.make "val" (TVariable "a") "" ]
       returnType = TList(TVariable "a")
-      description = "Returns a one-element list containing the given `val`."
+      description = "Returns a one-element list containing the given <param val>."
       fn =
         (function
         | _, [ v ] -> Ply(DList [ v ])
@@ -145,7 +145,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = varA
       description =
-        "Returns the head of a list. Returns null if the empty list is passed."
+        "Returns the head of a list. Returns {{null}} if the empty list is passed."
       fn =
         (function
         | _, [ DList l ] -> List.tryHead l |> Option.defaultValue DNull |> Ply
@@ -158,7 +158,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "head" 1
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
-      description = "Fetches the head of the list and returns an option"
+      description = "Fetches the head of the list and returns an <type Option>"
       fn =
         (function
         | _, [ DList l ] -> Ply(DOption(List.tryHead l))
@@ -172,7 +172,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
       description =
-        "Returns `Just` the head (first value) of a list. Returns `Nothing` if the list is empty."
+        "Returns {{Just}} the head (first value) of a list. Returns {{Nothing}} if
+         the list is empty."
       fn =
         (function
         | _, [ DList l ] -> l |> List.tryHead |> Dval.option |> Ply
@@ -186,7 +187,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption(TList varA)
       description =
-        "If the list contains at least one value, returns `Just` a list of every value other than the first. Otherwise, returns `Nothing`."
+        "If <param list> contains at least one value, returns {{Just}} with a list of
+         every value other than the first. Otherwise, returns {{Nothing}}."
       fn =
         // This matches Elm's implementation, with the added benefit that the error rail
         // means you don't need to handle unwrapping the option
@@ -203,7 +205,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "empty" 0
       parameters = []
       returnType = TList varA
-      description = "Returns an empty list."
+      description = "Returns an empty list"
       fn =
         (function
         | _, [] -> Ply(DList [])
@@ -216,7 +218,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "push" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
       returnType = TList varA
-      description = "Add element `val` to front of list `list`"
+      description = "Add element <param val> to front of <type list> <param list>"
       fn =
         // fakeval handled by call
         (function
@@ -230,7 +232,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "pushBack" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
       returnType = TList varA
-      description = "Add element `val` to back of list `list`"
+      description = "Add element <param val> to back of <type list> <param list>"
       fn =
         (function
         | _, [ DList l; i ] -> Ply(DList(l @ [ i ]))
@@ -244,7 +246,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = varA
       description =
-        "Returns the last value in `list`. Returns null if the list is empty."
+        "Returns the last value in <param list>. Returns {{null}} if the list is empty"
       fn =
         (function
         | _, [ DList l ] -> (if List.isEmpty l then DNull else List.last l) |> Ply
@@ -258,7 +260,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
       description =
-        "Returns the last value in `list`, wrapped in an option (`Nothing` if the list is empty)."
+        "Returns the last value in <param list>, wrapped in an option ({{Nothing}} if
+         the list is empty)"
       fn =
         (function
         | _, [ DList l ] -> Ply(DOption(List.tryLast l))
@@ -272,7 +275,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
       description =
-        "Returns the last value in `list`, wrapped in an option (`Nothing` if the list is empty)."
+        "Returns the last value in <param list>, wrapped in an option (<param
+         Nothing> if the list is empty)"
       fn =
         (function
         | _, [ DList l ] -> l |> List.tryLast |> Dval.option |> Ply
@@ -285,7 +289,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "reverse" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TList varA
-      description = "Returns a reversed copy of `list`."
+      description = "Returns a reversed copy of <param list>"
       fn =
         (function
         | _, [ DList l ] -> Ply(DList(List.rev l))
@@ -301,7 +305,8 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], TBool)) "" [ "val" ] ]
       returnType = varA
       description =
-        "Returns the first value of `list` for which `fn val` returns `true`. Returns null if no such value exists."
+        "Returns the first value of <param list> for which {{fn val}} returns
+         {{true}}. Returns {{null}} if no such value exists."
       fn =
         (function
         | state, [ DList l; DFnVal fn ] ->
@@ -329,7 +334,8 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], TBool)) "" [ "val" ] ]
       returnType = TOption varA
       description =
-        "Returns the first value of `list` for which `fn val` returns `true`. Returns `Nothing` if no such value exists."
+        "Returns {{Just}} the first value of <param list> for which {{fn val}}
+         returns {{true}}. Returns {{Nothing}} if no such value exists"
       fn =
         (function
         | state, [ DList l; DFnVal fn ] ->
@@ -357,7 +363,9 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], TBool)) "" [ "val" ] ]
       returnType = TOption varA
       description =
-        "Returns `Just firstMatch` where `firstMatch` is the first value of the list for which `fn` returns `true`. Returns `Nothing` if no such value exists."
+        "Returns {{Just firstMatch}} where <var firstMatch> is the first value of the
+         list for which <param fn> returns {{true}}. Returns {{Nothing}} if no such
+         value exists"
       fn =
         (function
         | state, [ DList l; DFnVal fn ] ->
@@ -379,24 +387,10 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "List" "contains" 0
-      parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
-      returnType = TBool
-      description = "Returns `true` if `val` is in the list."
-      fn =
-        (function
-        | _, [ DList l; i ] -> Ply(DBool(List.contains i l))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      // Deprecated in favor of List::member for consistency with Elm's naming
-      deprecated = ReplacedBy(fn "List" "member" 0) }
-
-
     { name = fn "List" "member" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "val" varA "" ]
       returnType = TBool
-      description = "Returns `true` if `val` is in the list."
+      description = "Returns {{true}} if <param val> is in the list"
       fn =
         (function
         | _, [ DList l; i ] -> Ply(DBool(List.contains i l))
@@ -409,7 +403,8 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "repeat" 0
       parameters = [ Param.make "times" TInt ""; Param.make "val" varA "" ]
       returnType = TList varA
-      description = "Returns a new list containing `val` repeated `times` times."
+      description =
+        "Returns a list containing <param val> repeated <param times> times"
       fn =
         (function
         | _, [ DInt times; v ] ->
@@ -428,7 +423,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "length" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TInt
-      description = "Returns the number of values in `list`."
+      description = "Returns the number of values in <param list>"
       fn =
         (function
         | _, [ DList l ] -> Ply(Dval.int (l.Length))
@@ -444,7 +439,9 @@ let fns : List<BuiltInFn> =
           Param.make "highest" TInt "Last, largest number in the list" ]
       returnType = TList TInt
       description =
-        "Returns a list of numbers where each element is 1 larger than the previous. You provide the `lowest` and `highest` numbers in the list. If `lowest` is greater than `highest`, returns the empty list."
+        "Returns a list of numbers where each element is {{1}} larger than the
+         previous. You provide the <param lowest> and <param highest> numbers in the
+         list."
       fn =
         (function
         | _, [ DInt start; DInt stop ] ->
@@ -466,11 +463,12 @@ let fns : List<BuiltInFn> =
             [ "accum"; "curr" ] ]
       returnType = varB
       description =
-        "Folds `list` into a single value, by repeatedly applying `fn` to any two pairs."
+        "Folds <param list> into a single value, by repeatedly applying <param fn> to
+         any two pairs."
       fn =
         (function
         | state, [ DList l; init; DFnVal b ] ->
-          (* Fake cf should be propagated by the blocks so we dont need to check *)
+          // Fake cf should be propagated by the blocks so we dont need to check
           uply {
             let f (accum : DvalTask) (item : Dval) : DvalTask =
               uply {
@@ -498,7 +496,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList(TList varA)) "" ]
       returnType = TList varA
       description =
-        "Returns a single list containing the values of every list directly in `list` (does not recursively flatten nested lists)."
+        "Returns a single list containing the values of every list directly in <param
+         list> (does not recursively flatten nested lists)"
       fn =
         (function
         | _, [ DList l ] ->
@@ -518,7 +517,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) ""; Param.make "sep" varA "" ]
       returnType = TList varA
       description =
-        "Returns a single list containing the values of `list` separated by `sep`."
+        "Returns a single list containing the values of <param list> separated by <param sep>"
       fn =
         (function
         | _, [ DList l; i ] ->
@@ -542,7 +541,9 @@ let fns : List<BuiltInFn> =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varB) "" ]
       returnType = TList varA
       description =
-        "Returns a new list with the first value from <param as> then the first value from <param bs>, then the second value from <param as> then the second value from <param bs>, etc, until one list ends, then the remaining items from the other list."
+        "Returns a list with the first value from <param as> then the first value
+         from <param bs>, then the second value from <param as> then the second value
+         other list."
       fn =
         (function
         | _, [ DList l1; DList l2 ] ->
@@ -567,7 +568,9 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TList varA
       description =
-        "Returns the passed list, with only unique values, where uniqueness is based on the result of `fn`. Only one of each value will be returned, but the order will not be maintained."
+        "Returns the passed list, with only unique values, where uniqueness is based
+         on the result of <param fn>. Only one of each value will be returned, but the
+         order will not be maintained."
       fn =
         (function
         | state, [ DList l; DFnVal b ] ->
@@ -596,7 +599,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "isEmpty" 0
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TBool
-      description = "Returns true if `list` has no values."
+      description = "Returns true if <param list> has no values"
       fn =
         (function
         | _, [ DList l ] -> Ply(DBool(List.isEmpty l))
@@ -610,8 +613,12 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TList varA
       description =
-        "Returns a copy of `list` with every value sorted in ascending order. Use this if the values have types Dark knows how to sort.
-         Consider `List::sortBy` or `List::sortByComparator` if you need more control over the sorting process."
+        "Returns a copy of <param list> with every value sorted in ascending order.
+
+         Use this if the values have types Dark knows how to sort.
+
+         Consider <fn List::sortBy> or <fn List::sortByComparator> if you need more
+         control over the sorting process."
       fn =
         (function
         | _, [ DList list ] -> list |> List.sort |> DList |> Ply
@@ -627,15 +634,21 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TList varA
       description =
-        "Returns a copy of `list`, sorted in ascending order, as if each value evaluated to `fn val`.
-           For example, `List::sortBy [\"x\",\"jkl\",\"ab\"] \\val -> String::length val` returns `[ \"x\", \"ab\", \"jkl\" ]`.
-           Consider `List::sort` if the list values can be directly compared, or `List::sortByComparator` if you want more control over the sorting process."
+        "Returns a copy of <param list>, sorted in ascending order, as if each value
+         evaluated to {{fn val}}.
+
+         For example, {{List::sortBy [\"x\",\"jkl\",\"ab\"] \\val -> String::length
+         val}} returns {{[ \"x\", \"ab\", \"jkl\" ]}}.
+
+         Consider <fn List::sort> if the list values can be directly compared, or <fn
+         List::sortByComparator> if you want more control over the sorting process."
       fn =
         (function
         | state, [ DList list; DFnVal b ] ->
           uply {
             let fn dv = Interpreter.applyFnVal state 0UL b [ dv ] NotInPipe NoRail
-            // FSNOTE: This isn't exactly the same as the ocaml one. We get all the keys in one pass.
+            // NOTE: This isn't exactly the same as the ocaml one. We get all the
+            // keys in one pass.
             let! withKeys =
               list
               |> Ply.List.mapSequentially (fun v ->
@@ -658,9 +671,15 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA; varA ], TInt)) "" [ "a"; "b" ] ]
       returnType = TResult(varA, TStr)
       description =
-        "Returns a copy of `list`, sorted using `fn a b` to compare values `a` and `b`.
-        `f` must return `-1` if `a` should appear before `b`, `1` if `a` should appear after `b`, and `0` if the order of `a` and `b` doesn't matter.
-        Consider `List::sort` or `List::sortBy` if you don't need this level of control."
+        "Returns a copy of <param list>, sorted using {{fn a b}} to compare values
+         <var a> and <var b>.
+
+         <param f> must return {{-1}} if <var a> should appear before <var b>, {{1}}
+         if <var a> should appear after <var b>, and {{0}} if the order of <var a>
+         and <var b> doesn't matter.
+
+         Consider <fn List::sort> or <fn List::sortBy> if you don't need this level
+         of control."
       fn =
         (function
         | state, [ DList list; DFnVal f ] ->
@@ -698,7 +717,8 @@ let fns : List<BuiltInFn> =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varA) "" ]
       returnType = TList varA
       description =
-        "Returns a new list with all values in `as` followed by all values in `bs`, preserving the order."
+        "Returns a new list with all values in <param as> followed by all values in <param bs>,
+         preserving the order."
       fn =
         (function
         | _, [ DList l1; DList l2 ] ->
@@ -715,7 +735,8 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], TBool)) "" [ "val" ] ]
       returnType = TList varA
       description =
-        "Return only values in `list` which meet the function's criteria. The function should return true to keep the entry or false to remove it."
+        "Return only values in <param list> which meet the function's criteria. The
+         function should return true to keep the entry or false to remove it."
       fn =
         (function
         | state, [ DList l; DFnVal fn ] ->
@@ -757,7 +778,7 @@ let fns : List<BuiltInFn> =
             "Function to be applied on all list elements;" ]
       returnType = TBool
       description =
-        "Return true if all elements in the list meet the function's criteria, else false."
+        "Return {{true}} if all elements in the list meet the function's criteria, else {{false}}"
       fn =
         (function
         | state, [ DList l; DFnVal b ] ->
@@ -803,9 +824,12 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], TBool)) "" [ "val" ] ]
       returnType = TList varA
       description =
-        "Calls `f` on every `val` in `list`, returning a list of only those values for which `fn val` returns `true`.
-        Preserves the order of values that were not dropped.
-        Consider `List::filterMap` if you also want to transform the values."
+        "Calls <param f> on every <var val> in <param list>, returning a list of only
+         those values for which {{fn val}} returns {{true}}.
+
+         Preserves the order of values that were not dropped.
+
+         Consider <fn List::filterMap> if you also want to transform the values."
       fn =
         (function
         | state, [ DList l; DFnVal fn ] ->
@@ -851,9 +875,11 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], TBool)) "" [ "val" ] ]
       returnType = TList varA
       description =
-        "Calls `f` on every `val` in `list`, returning a list of only those values for which `fn val` returns `true`.
-        Preserves the order of values that were not dropped.
-        Consider `List::filterMap` if you also want to transform the values."
+        "Calls <param f> on every <var val> in <param list>, returning a list of only
+         those values for which {{fn val}} returns {{true}}.
+
+         Preserves the order of values that were not dropped. Consider <fn
+         List::filterMap> if you also want to transform the values."
       fn =
         (function
         | state, [ DList l; DFnVal fn ] ->
@@ -900,11 +926,16 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], TOption varB)) "" [ "val" ] ]
       returnType = TList varB
       description =
-        "Calls `fn` on every `val` in `list`, returning a new list that drops some values (filter) and transforms others (map).
-        If `fn val` returns `Nothing`, drops `val` from the list.
-        If `fn val` returns `Just newValue`, replaces `val` with `newValue`.
-        Preserves the order of values that were not dropped.
-        This function combines `List::filter` and `List::map`."
+        "Calls <param fn> on every <var val> in <param list>, returning a list that
+         drops some values (filter) and transforms others (map).
+
+         If {{fn val}} returns {{Nothing}}, drops <var val> from the list.
+
+         If {{fn val}} returns {{Just newValue}}, replaces <var val> with <var newValue>.
+
+         Preserves the order of values that were not dropped.
+
+         This function combines <fn List::filter> and <fn List::map>."
       fn =
         (function
         | state, [ DList l; DFnVal b ] ->
@@ -951,7 +982,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "drop" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "count" TInt "" ]
       returnType = TList varA
-      description = "Drops the first `count` values from `list`."
+      description = "Drops the first <param count> values from <param list>"
       fn =
         (function
         | _, [ DList l; DInt c ] ->
@@ -970,7 +1001,7 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TList varB
       description =
-        "Drops the longest prefix of `list` which satisfies the predicate `val`"
+        "Drops the longest prefix of <param list> which satisfies the predicate <param val>"
       fn =
         (function
         | state, [ DList l; DFnVal b ] ->
@@ -1018,7 +1049,7 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "take" 0
       parameters = [ Param.make "list" (TList varA) ""; Param.make "count" TInt "" ]
       returnType = TList varA
-      description = "Drops all but the first `count` values from `list`."
+      description = "Drops all but the first <param count> values from <param list>"
       fn =
         (function
         | _, [ DList l; DInt c ] ->
@@ -1037,7 +1068,7 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TList varA
       description =
-        "Return the longest prefix of `list` which satisfies the predicate `val`"
+        "Return the longest prefix of <param list> which satisfies the predicate <param fn>"
       fn =
         (function
         | state, [ DList l; DFnVal b ] ->
@@ -1090,7 +1121,7 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       returnType = TList varB
       description =
-        "Call `fn` on every `val` in the list, returning a list of the results of
+        "Call <param fn> on every <param val> in the list, returning a list of the results of
          those calls"
       fn =
         (function
@@ -1115,8 +1146,10 @@ let fns : List<BuiltInFn> =
         [ Param.make "list" (TList varA) "The list to be operated on"
           Param.makeWithArgs "fn" (TFn([ varA ], varB)) "" [ "val" ] ]
       description =
-        "Calls `fn` on every `val` in `list`, returning a list of the results of those calls.
-        Consider `List::filterMap` if you also want to drop some of the values."
+        "Calls <param fn> on every <var val> in <param list>, returning a list of the
+         results of those calls.
+
+         Consider <fn List::filterMap> if you also want to drop some of the values."
       returnType = TList varB
       fn =
         (function
@@ -1142,8 +1175,10 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TInt; varA ], varB)) "" [ "index"; "val" ] ]
       returnType = TList varB
       description =
-        "Calls `fn` on every `val` and its `index` in `list`, returning a list of the results of those calls.
-        Consider `List::map` if you don't need the index."
+        "Calls <fn fn> on every <var val> and its <var index> in <param list>,
+         returning a list of the results of those calls.
+
+         Consider <fn List::map> if you don't need the index."
       fn =
         (function
         | state, [ DList l; DFnVal b ] ->
@@ -1177,10 +1212,16 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA; varB ], varC)) "" [ "a"; "b" ] ]
       returnType = TList varC
       description =
-        "Maps `fn` over `as` and `bs` in parallel, calling `fn a b` on every pair of values from `as` and `bs`.
-        If the lists differ in length, values from the longer list are dropped.
-        For example, if `as` is `[1,2]` and `bs` is `[\"x\",\"y\",\"z\"]`, returns `[(f 1 \"x\"), (f 2 \"y\")]`.
-        Use `List::map2` if you want to enforce equivalent lengths for `as` and `bs`."
+        "Maps <param fn> over <param as> and <param bs> in parallel, calling {{fn a
+         b}} on every pair of values from <param as> and <param bs>.
+
+         If the lists differ in length, values from the longer list are dropped.
+
+         For example, if <param as> is {{[1,2]}} and <param bs> is
+         {{[\"x\",\"y\",\"z\"]}}, returns {{[(f 1 \"x\"), (f 2 \"y\")]}}
+
+         Use <fn List::map2> if you want to enforce equivalent lengths for <param as>
+         and <param bs>."
       fn =
         (function
         | state, [ DList l1; DList l2; DFnVal b ] ->
@@ -1212,10 +1253,17 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA; varB ], varC)) "" [ "a"; "b" ] ]
       returnType = TOption varC
       description =
-        "If the lists are the same length, returns `Just list` formed by mapping `fn` over `as` and `bs` in parallel,
-         calling `fn a b` on every pair of values from `as` and `bs`.
-         For example, if `as` is `[1,2,3]` and `bs` is `[\"x\",\"y\",\"z\"]`, returns `[(fn 1 \"x\"), (f 2 \"y\"), (f 3 \"z\")]`.
-         If the lists differ in length, returns `Nothing` (consider `List::map2shortest` if you want to drop values from the longer list instead)."
+        "If the lists are the same length, returns {{Just list}} formed by mapping
+         <param fn> over <param as> and <param bs> in parallel, calling {{fn a b}} on
+         every pair of values from <param as> and <param bs>.
+
+         For example, if <param as> is {{[1,2,3]}} and <param bs> is
+         {{[\"x\",\"y\",\"z\"]}}, returns {{[(fn 1 \"x\"), (f 2 \"y\"), (f 3
+         \"z\")]}}.
+
+         If the lists differ in length, returns {{Nothing}} (consider <fn
+         List::map2shortest> if you want to drop values from the longer list
+         instead)."
       fn =
         (function
         | state, [ DList l1; DList l2; DFnVal b ] ->
@@ -1250,11 +1298,18 @@ let fns : List<BuiltInFn> =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varB) "" ]
       returnType = TList varA
       description =
-        "Returns a list of parallel pairs from `as` and `bs`.
+        "Returns a list of parallel pairs from <param as> and <param bs>.
+
         If the lists differ in length, values from the longer list are dropped.
-        For example, if `as` is `[1,2]` and `bs` is `[\"x\",\"y\",\"z\"]`, returns `[[1,\"x\"], [2,\"y\"]]`.
-        Use `List::zip` if you want to enforce equivalent lengths for `as` and `bs`.
-        See `List::unzip` if you want to deconstruct the result into `as` and `bs` again."
+
+        For example, if <param as> is {{[1,2]}} and <param bs> is
+        {{[\"x\",\"y\",\"z\"]}}, returns {{[[1,\"x\"], [2,\"y\"]]}}.
+
+        Use <fn List::zip> if you want to enforce equivalent lengths for <param as>
+        and <param bs>.
+
+        See <fn List::unzip> if you want to deconstruct the result into <param as>
+        and <param bs> again."
       fn =
         (function
         | state, [ DList l1; DList l2 ] ->
@@ -1279,10 +1334,18 @@ let fns : List<BuiltInFn> =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varB) "" ]
       returnType = TOption(TList(TList varA))
       description =
-        "If the lists have the same length, returns `Just list` formed from parallel pairs in `as` and `bs`.
-        For example, if `as` is `[1,2,3]` and `bs` is `[\"x\",\"y\",\"z\"]`, returns `[[1,\"x\"], [2,\"y\"], [3,\"z\"]]`.
-        See `List::unzip` if you want to deconstruct `list` into `as` and `bs` again.
-        If the lists differ in length, returns `Nothing` (consider `List::zipShortest` if you want to drop values from the longer list instead)."
+        "If the lists have the same length, returns {{Just list}} formed from
+        parallel pairs in <param as> and <param bs>.
+
+        For example, if <param as> is {{[1,2,3]}} and <param bs> is
+        {{[\"x\",\"y\",\"z\"]}}, returns {{[[1,\"x\"], [2,\"y\"], [3,\"z\"]]}}.
+
+        See <fn List::unzip> if you want to deconstruct <var list> into <param as>
+        and <param bs> again.
+
+        If the lists differ in length, returns {{Nothing}} (consider
+        <fn List::zipShortest> if you want to drop values from the longer list
+        instead)."
       fn =
         (function
         | state, [ DList l1; DList l2 ] ->
@@ -1305,8 +1368,13 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "pairs" (TList(TList varA)) "" ]
       returnType = TList(TList varA)
       description =
-        "Given a `pairs` list where each value is a list of two values (such lists are constructed by `List::zip` and `List::zipShortest`), returns a list of two lists,
-        one with every first value, and one with every second value. For example, if `pairs` is `[[1,\"x\"], [2,\"y\"], [3,\"z\"]]`, returns `[[1,2,3], [\"x\",\"y\",\"z\"]]`."
+        "Given a <param pairs> list where each value is a list of two values (such
+         lists are constructed by <fn List::zip> and <fn List::zipShortest>), returns
+         a list of two lists, one with every first value, and one with every second
+         value.
+
+         For example, if <fn pairs> is {{[[1,\"x\"], [2,\"y\"], [3,\"z\"]]}}, returns
+         {{[[1,2,3], [\"x\",\"y\",\"z\"]]}}."
       fn =
         (function
         | state, [ DList l ] ->
@@ -1345,7 +1413,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) ""; Param.make "index" TInt "" ]
       returnType = TOption varA
       description =
-        "Returns `Just value` at `index` in `list` if `index` is less than the length of the list. Otherwise returns `Nothing`."
+        "Returns {{Just value}} at <param index> in <param list> if <param index> is
+         less than the length of the list. Otherwise returns {{Nothing}}."
       fn =
         (function
         | _, [ DList l; DInt index ] ->
@@ -1363,7 +1432,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) ""; Param.make "index" TInt "" ]
       returnType = TOption varA
       description =
-        "Returns `Just value` at `index` in `list` if `index` is less than the length of the list otherwise returns `Nothing`."
+        "Returns {{Just value}} at <param index> in <param list> if <param index> is
+         less than the length of the list otherwise returns {{Nothing}}."
       fn =
         (function
         | _, [ DList l; DInt index ] ->
@@ -1378,7 +1448,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TOption varA
       description =
-        "Returns {{Just <var randomValue>}}, where <var randomValue> is a randomly selected value in <param list>. Returns {{Nothing}} if <param list> is empty."
+        "Returns {{Just <var randomValue>}}, where <var randomValue> is a randomly
+         selected value in <param list>. Returns {{Nothing}} if <param list> is
+         empty."
       fn =
         (function
         | _, [ DList [] ] -> Ply(DOption None)

--- a/fsharp-backend/src/LibExecutionStdLib/LibMath.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibMath.fs
@@ -20,7 +20,8 @@ let fns : List<BuiltInFn> =
       parameters = []
       returnType = TFloat
       description =
-        "Returns an approximation for the mathematical constant π, the ratio of a circle's circumference to its diameter."
+        "Returns an approximation for the mathematical constant {{π}}, the ratio of a
+         circle's circumference to its diameter."
       fn =
         (function
         | _, [] -> Ply(DFloat System.Math.PI)
@@ -34,7 +35,8 @@ let fns : List<BuiltInFn> =
       parameters = []
       returnType = TFloat
       description =
-        "Returns an approximation for the mathematical constant τ, the number of radians in one turn. Equivalent to `Float::multiply Math::pi 2`."
+        "Returns an approximation for the mathematical constant {{τ}}, the number of
+         radians in one turn. Equivalent to {{Float::multiply Math::pi 2}}."
       fn =
         (function
         | _, [] -> Ply(DFloat System.Math.Tau)
@@ -48,7 +50,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "angleInDegrees" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the equivalent of `angleInDegrees` in radians, the unit used by all of Dark's trigonometry functions.
+        "Returns the equivalent of <param angleInDegrees> in radians, the unit used
+         by all of Dark's trigonometry functions.
+
          There are 360 degrees in a circle."
       fn =
         (function
@@ -63,7 +67,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "angleInTurns" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the equivalent of `angleInTurns` in radians, the unit used by all of Dark's trigonometry functions.
+        "Returns the equivalent of <param angleInTurns> in radians, the unit used by all of
+         Dark's trigonometry functions.
+
          There is 1 turn in a circle."
       fn =
         (function
@@ -78,8 +84,11 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns `angleInRadians` in radians, the unit used by all of Dark's trigonometry functions.
-        There are `Float::multiply 2 Math::pi` radians in a circle."
+        "Returns <param angleInRadians> in radians, the unit used by all of Dark's
+         trigonometry functions.
+
+         There are {{Float::multiply 2 Math::pi}} radians in a
+         circle."
       fn =
         (function
         | _, [ DFloat rads ] -> Ply(DFloat rads)
@@ -93,8 +102,11 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the cosine of the given `angleInRadians`.
-         One interpretation of the result relates to a right triangle: the cosine is the ratio of the lengths of the side adjacent to the angle and the hypotenuse."
+        "Returns the cosine of the given <param angleInRadians>.
+
+         One interpretation of the result relates to a right triangle: the cosine is
+         the ratio of the lengths of the side adjacent to the angle and the
+         hypotenuse."
       fn =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Cos a))
@@ -108,8 +120,10 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the sine of the given `angleInRadians`.
-         One interpretation of the result relates to a right triangle: the sine is the ratio of the lengths of the side opposite the angle and the hypotenuse."
+        "Returns the sine of the given <param angleInRadians>.
+
+         One interpretation of the result relates to a right triangle: the sine is
+         the ratio of the lengths of the side opposite the angle and the hypotenuse"
       fn =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Sin a))
@@ -123,8 +137,11 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the tangent of the given `angleInRadians`.
-         One interpretation of the result relates to a right triangle: the tangent is the ratio of the lengths of the side opposite the angle and the side adjacent to the angle."
+        "Returns the tangent of the given <param angleInRadians>.
+
+         One interpretation of the result relates to a right triangle: the tangent is
+         the ratio of the lengths of the side opposite the angle and the side
+         adjacent to the angle."
       fn =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Tan a))
@@ -138,10 +155,13 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TOption varA
       description =
-        "Returns the arc cosine of `ratio`, as an Option.
-         If `ratio` is in the inclusive range `[-1.0, 1.0]`, returns
-         `Just result` where `result` is in radians and is between `0.0` and `Math::pi`. Otherwise, returns `Nothing`.
-         This function is the inverse of `Math::cos`."
+        "Returns the arc cosine of <param ratio>, as an <type Option>.
+
+         If <param ratio> is in the inclusive range {{[-1.0, 1.0]}}, returns {{Just
+         result}} where <var result> is in radians and is between {{0.0}} and <fn
+         Math::pi>. Otherwise, returns {{Nothing}}.
+
+         This function is the inverse of <fn Math::cos>."
       fn =
         (function
         | _, [ DFloat r ] ->
@@ -161,10 +181,13 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TOption varA
       description =
-        "Returns the arc sine of `ratio`, as an Option.
-         If `ratio` is in the inclusive range `[-1.0, 1.0]`, returns
-         `Just result` where `result` is in radians and is between `-Math::pi/2` and `Math::pi/2`. Otherwise, returns `Nothing`.
-         This function is the inverse of `Math::sin`."
+        "Returns the arc sine of <param ratio>, as an <type Option>.
+
+         If <param ratio> is in the inclusive range {{[-1.0, 1.0]}}, returns {{Just
+         result}} where <var result> is in radians and is between {{-Math::pi/2}} and
+         {{Math::pi/2}}. Otherwise, returns {{Nothing}}.
+
+         This function is the inverse of <fn Math::sin>."
       fn =
         (function
         | _, [ DFloat r ] ->
@@ -184,8 +207,11 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the arc tangent of `ratio`. The result is in radians and is between `-Math::pi/2` and `Math::pi/2`.
-         This function is the inverse of `Math::tan`. Use `Math::atan2` to expand the output range, if you know the numerator and denominator of `ratio`."
+        "Returns the arc tangent of <param ratio>. The result is in radians and is between
+         {{-Math::pi/2}} and {{Math::pi/2}}.
+
+         This function is the inverse of <fn Math::tan>. Use <fn Math::atan2> to expand the
+         output range, if you know the numerator and denominator of <param ratio>."
       fn =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Atan a))
@@ -199,8 +225,13 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "y" TFloat ""; Param.make "x" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the arc tangent of `y / x`, using the signs of `y` and `x` to determine the quadrant of the result.
-         The result is in radians and is between `-Math::pi` and `Math::pi`. Consider `Math::atan` if you know the value of `y / x` but not the individual values `x` and `y`."
+        "Returns the arc tangent of {{y / x}}, using the signs of <param y> and
+         <param x> to determine the quadrant of the result.
+
+         The result is in radians and is between {{-Math::pi}} and {{Math::pi}}.
+
+         Consider <fn Math::atan> if you know the value of {{y / x}} but not the
+         individual values <param x> and <param y>."
       fn =
         (function
         | _, [ DFloat y; DFloat x ] -> Ply(DFloat(System.Math.Atan2(y, x)))
@@ -213,7 +244,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Math" "cosh" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
-      description = "Returns the hyperbolic cosine of `angleInRadians`."
+      description = "Returns the hyperbolic cosine of <param angleInRadians>"
       fn =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Cosh a))
@@ -226,7 +257,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Math" "sinh" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
-      description = "Returns the hyperbolic sine of `angleInRadians`."
+      description = "Returns the hyperbolic sine of <param angleInRadians>"
       fn =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Sinh a))
@@ -239,7 +270,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Math" "tanh" 0
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
-      description = "Returns the hyperbolic tangent of `angleInRadians`."
+      description = "Returns the hyperbolic tangent of <param angleInRadians>"
       fn =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Sinh a))

--- a/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -19,7 +19,8 @@ let varB = TVariable "b"
 let fns : List<BuiltInFn> =
   [ { name = fn "" "toString" 0
       description =
-        "Returns a string representation of `v`, suitable for displaying to a user. Redacts passwords."
+        "Returns a string representation of <param v>, suitable for displaying to a
+         user. Redacts passwords."
       parameters = [ Param.make "v" (TVariable "a") "" ]
       returnType = TStr
       fn =
@@ -36,7 +37,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "v" varA "" ]
       returnType = TStr
       description =
-        "Returns an adorned string representation of `v`, suitable for internal developer usage. Not designed for sending to end-users, use toString instead. Redacts passwords."
+        "Returns an adorned string representation of <param v>, suitable for internal
+         developer usage. Not designed for sending to end-users, use <fn toString>
+         instead.  Redacts passwords."
       fn =
         (function
         | _, [ a ] -> Ply(DStr(DvalReprDeveloper.toRepr a))
@@ -78,7 +81,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "obj" (TDict varA) ""; Param.make "submit" TStr "" ]
       returnType = TStr
       description =
-        "For demonstration only. Returns a HTML form with the labels and types described in `obj`. `submit` is the form's action."
+        "For demonstration only. Returns a HTML form with the labels and types
+         described in <param obj>. <param submit> is the form's action."
       fn =
         (function
         | _, [ DObj o; DStr uri ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibObject.fs
@@ -23,7 +23,8 @@ let varA = TVariable "a"
 // Note: this is used outside of this fn!
 module PrettyResponseJsonV0 =
 
-  // At time of writing, this is the same as Dval.unsafe_dval_to_yojson. It's being copied to be certain this format doesn't change.
+  // At time of writing, this is the same as Dval.unsafe_dval_to_yojson. It's being
+  // copied to be certain this format doesn't change.
   let writePrettyJson (f : JsonWriter -> unit) : string =
     let stream = new System.IO.StringWriter()
     let w = new JsonTextWriter(stream)
@@ -157,7 +158,7 @@ let fns : List<BuiltInFn> =
   [ { name = fn "Object" "toJSON" 0
       parameters = [ Param.make "obj" (TDict varA) "" ]
       returnType = TStr
-      description = "Dumps `obj` to a JSON string"
+      description = "Dumps <param obj> to a JSON string"
       fn =
         (function
         | _, [ DObj o ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibOption.fs
@@ -15,7 +15,7 @@ let fn = FQFnName.stdlibFnName
 
 let err (str : string) = Ply(Dval.errStr str)
 
-let incorrectArgs = LibExecution.Errors.incorrectArgs
+let incorrectArgs = Errors.incorrectArgs
 
 let varA = TVariable "a"
 let varB = TVariable "b"
@@ -28,8 +28,10 @@ let fns : List<BuiltInFn> =
       parameters = [ optionA; fnAToB ]
       returnType = TOption varB
       description =
-        "If `option` is `Just value`, returns `Just (fn value)` (the lambda `fn` is applied to `value` and the result is wrapped in `Just`).
-        If `result` is `Nothing`, returns `Nothing`."
+        "If <param option> is {{Just value}}, returns {{Just (fn value)}} (the lambda <param fn> is
+         applied to <var val> and the result is wrapped in {{Just}}).
+
+         If <param option> is {{Nothing}}, returns {{Nothing}}."
       fn =
         (function
         | state, [ DOption o; DFnVal b ] ->
@@ -52,7 +54,10 @@ let fns : List<BuiltInFn> =
       parameters = [ optionA; fnAToB ]
       returnType = TOption varB
       description =
-        "If <var option> is {{Just <var value>}}, then return {{Just (f <var value>)}}. The lambda <var f> applied to <var value> and the result is wrapped in {{Just}}. Otherwise if the result is {{Nothing}}, then return {{Nothing}}."
+        "If <param option> is {{Just <var val>}}, then return {{Just (f <var
+         val>)}}. The lambda <fn fn> applied to <var val> and the result is
+         wrapped in {{Just}}. Otherwise if the result is {{Nothing}}, then return
+         {{Nothing}}."
       fn =
         (function
         | state, [ DOption o; DFnVal b ] ->
@@ -78,7 +83,11 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA; varB ], varC)) "" [ "v1"; "v2" ] ]
       returnType = TOption varC
       description =
-        "If both arguments are {{Just}} (<param option1> is {{Just <var v1>}} and <param option2> is {{Just <var v2>}}), then return {{Just (fn <var v1> <var v2>)}} -- The lambda <param fn> should have two parameters, representing <var v1> and <var v2>. But if either <param option1> or <param option2> are {{Nothing}}, returns {{Nothing}} without applying <param fn>."
+        "If both arguments are {{Just}} (<param option1> is {{Just <var v1>}} and
+         <param option2> is {{Just <var v2>}}), then return {{Just (fn <var v1> <var
+         v2>)}}. The lambda <param fn> should have two parameters, representing <var
+         v1> and <var v2>. But if either <param option1> or <param option2> are
+         {{Nothing}}, returns {{Nothing}} without applying <param fn>."
       fn =
         (function
         | state, [ DOption o1; DOption o2; DFnVal b ] ->
@@ -104,7 +113,10 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TOption varA ], TOption varB)) "" [ "val" ] ]
       returnType = TOption varB
       description =
-        "If <param option> is {{Just <var input>}}, returns {{fn <var input>}}. Where the lambda <param fn> is applied to <var input> and must return {{Just <var output>}} or {{Nothing}}. Otherwise if <param option> is {{Nothing}}, returns {{Nothing}}."
+        "If <param option> is {{Just <var input>}}, returns {{fn <var input>}}. Where
+         the lambda <param fn> is applied to <var input> and must return {{Just <var
+         output>}} or {{Nothing}}. Otherwise if <param option> is {{Nothing}}, returns
+         {{Nothing}}."
       fn =
         (function
         | state, [ DOption o; DFnVal b ] ->
@@ -133,7 +145,8 @@ let fns : List<BuiltInFn> =
       parameters = [ optionA; Param.make "default" varA "" ]
       returnType = varA
       description =
-        "If <param option> is {{Just <var value>}}, returns <var value>. Returns <param default> otherwise."
+        "If <param option> is {{Just <var value>}}, returns <var value>. Returns
+         <param default> otherwise."
       fn =
         (function
         | _, [ DOption o; default' ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
@@ -182,7 +182,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "toOption" 0
       parameters = [ Param.make "result" (TResult(varOk, varErr)) "" ]
       returnType = TOption varB
-      description = "Turn a result into an option."
+      description = "Turn a result into an option"
       fn =
         (function
         | _, [ DResult o ] ->
@@ -198,7 +198,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "toOption" 1
       parameters = [ Param.make "result" (TResult(varOk, varErr)) "" ]
       returnType = TOption varB
-      description = "Turn a result into an option."
+      description = "Turn a result into an option"
       fn =
         (function
         | _, [ DResult o ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibResult.fs
@@ -30,7 +30,9 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = TResult(varB, varErr)
       description =
-        "If `result` is `Ok value`, returns `Ok (fn value)` (the lambda `fn` is applied to `value` and the result is wrapped in `Ok`). If `result` is `Error msg`, returns `result` unchanged."
+        "If <param result> is {{Ok value}}, returns {{Ok (fn value)}} (the lambda
+         <param fn> is applied to <param value> and the result is wrapped in {{Ok}}).
+         If <var result> is {{Error msg}}, returns {{result}} unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal b ] ->
@@ -55,7 +57,10 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = TResult(varB, varErr)
       description =
-        "If <param result> is {{Ok <var value>}}, returns {{Ok (fn <var value>)}}. The lambda <param fn> is applied to <var value> and the result is wrapped in {{Ok}}. If <param result> is {{Error <var msg>}}, returns <param result> unchanged."
+        "If <param result> is {{Ok <var value>}}, returns {{Ok (fn <var value>)}}.
+         The lambda <param fn> is applied to <var value> and the result is wrapped in
+         {{Ok}}. If <param result> is {{Error <var msg>}}, returns <param result>
+         unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal d ] ->
@@ -80,7 +85,9 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varB, varErr))
       description =
-        "If `result` is `Error msg`, returns `Error (f msg)` (the lambda `fn` is applied to `msg` and the result is wrapped in `Error`). If `result` is `Ok value`, returns `result` unchanged."
+        "If <param result> is <var Error msg>, returns {{Error (fn msg)}} (the lambda
+         <param fn> is applied to <var msg> and the result is wrapped in {{Error}}).
+         If <param result> is {{Ok value}}, returns <param result> unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal b ] ->
@@ -105,7 +112,10 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varB, varErr))
       description =
-        "If <param result> is {{Error <var msg>}}, returns {{Error (fn <var msg>)}}. The lambda <var fn> is applied to <var msg> and the result is wrapped in {{Error}}. If <param result> is {{Ok <var value>}}, returns <param result> unchanged."
+        "If <param result> is {{Error <var msg>}}, returns {{Error (fn <var msg>)}}.
+         The lambda <var fn> is applied to <var msg> and the result is wrapped in
+         {{Error}}. If <param result> is {{Ok <var value>}}, returns <param result>
+         unchanged."
       fn =
         (function
         | state, [ DResult r; DFnVal b ] ->
@@ -130,7 +140,8 @@ let fns : List<BuiltInFn> =
           Param.make "default" varB "" ]
       returnType = varB
       description =
-        "If <param result> is {{Ok <var value>}}, returns <var value>. Returns <param default> otherwise."
+        "If <param result> is {{Ok <var value>}}, returns <var value>. Returns <param
+         default> otherwise."
       fn =
         (function
         | _, [ DResult o; default' ] ->
@@ -148,7 +159,9 @@ let fns : List<BuiltInFn> =
         [ Param.make "option" (TOption(varOk)) ""; Param.make "error" TStr "" ]
       returnType = (TResult(varB, TStr))
       description =
-        "Turn an option into a result, using `error` as the error message for Error. Specifically, if `option` is `Just value`, returns `Ok value`. Returns `Error error` otherwise."
+        "Turn an <type option> into a <type result>, using <param error> as the error
+         message for {{Error}}.  Specifically, if <param option> is {{Just value}},
+         returns {{Ok value}}. Returns {{Error error}} otherwise."
       fn =
         (function
         | _, [ DOption o; DStr error ] ->
@@ -166,7 +179,10 @@ let fns : List<BuiltInFn> =
         [ Param.make "option" (TOption(varOk)) ""; Param.make "error" TStr "" ]
       returnType = (TResult(varB, TStr))
       description =
-        "Turn an option into a result, using <param error> as the error message for Error. Specifically, if <param option> is {{Just <var value>}}, returns {{Ok <var value>}}. Returns {{Error <var error>}} otherwise."
+        "Turn an <type option> into a <type result>, using <param error> as the error
+         message for {{Error}}. Specifically, if <param option> is {{Just <var
+         value>}}, returns {{Ok <var value>}}. Returns {{Error <var error>}}
+         otherwise."
       fn =
         (function
         | _, [ DOption o; DStr error ] ->
@@ -198,7 +214,7 @@ let fns : List<BuiltInFn> =
     { name = fn "Result" "toOption" 1
       parameters = [ Param.make "result" (TResult(varOk, varErr)) "" ]
       returnType = TOption varB
-      description = "Turn a result into an option"
+      description = "Turn a <type result> into an <type option>"
       fn =
         (function
         | _, [ DResult o ] ->
@@ -218,7 +234,11 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varA; varB ], varC)) "" [ "v1"; "v2" ] ]
       returnType = (TResult(varC, varErr))
       description =
-        "If both <param result1> is {{Ok <var v1>}} and <param result2> is {{Ok <var v2>}}, returns {{Ok (fn <var v1> <var v2>)}} -- the lambda <var fn> is applied to <var v1> and <var v2>, and the result is wrapped in {{Ok}}. Otherwise, returns the first of <param result1> and <param result2> that is an error."
+        "If both <param result1> is {{Ok <var v1>}} and <param result2> is {{Ok <var
+         v2>}}, returns {{Ok (fn <var v1> <var v2>)}} -- the lambda <param fn> is
+         applied to <var v1> and <var v2>, and the result is wrapped in {{Ok}}.
+         Otherwise, returns the first of <param result1> and <param result2> that is
+         an error."
       fn =
         (function
         | state, [ DResult r1; DResult r2; DFnVal b ] ->
@@ -244,7 +264,10 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varB, varErr))
       description =
-        "If `result` is `Ok value`, returns `fn value` (the lambda `fn` is applied to `value` and must return `Error msg` or `Ok newValue`). If `result` is `Error msg`, returns `result` unchanged."
+        "If <param result> is {{Ok value}}, returns {{fn value}} (the lambda <param
+         fn> is applied to <var value> and must return {{Error msg}} or {{Ok
+         newValue}}). If <param result> is {{Error msg}}, returns <param result>
+         unchanged."
       fn =
         (function
         | state, [ DResult o; DFnVal b ] ->
@@ -275,7 +298,10 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ varOk ], varB)) "" [ "val" ] ]
       returnType = (TResult(varOk, varErr))
       description =
-        "If <param result> is {{Ok <var value>}}, returns {{fn <var value>}}. The lambda <param fn> is applied to <var value> and must return {{Error <var msg>}} or {{Ok <var newValue>}}. If <param result> is {{Error <var msg>}}, returns <param result> unchanged."
+        "If <param result> is {{Ok <var value>}}, returns {{fn <var value>}}. The
+         lambda <param fn> is applied to <var value> and must return {{Error <var
+         msg>}} or {{Ok <var newValue>}}. If <param result> is {{Error <var msg>}},
+         returns <param result> unchanged."
       fn =
         (function
         | state, [ DResult o; DFnVal b ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -21,14 +21,14 @@ let fn = FQFnName.stdlibFnName
 
 let err (str : string) = Ply(Dval.errStr str)
 
-let incorrectArgs = LibExecution.Errors.incorrectArgs
+let incorrectArgs = Errors.incorrectArgs
 
 
 let fns : List<BuiltInFn> =
   [ { name = fn "String" "isEmpty" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TBool
-      description = "Returns `true` if `s` is the empty string \"\"."
+      description = "Returns {{true}} if <param s> is the empty string {{\"\"}}"
       fn =
         (function
         | _, [ DStr s ] -> Ply(DBool(s = ""))
@@ -48,7 +48,8 @@ let fns : List<BuiltInFn> =
             [ "char" ] ]
       returnType = TStr
       description =
-        "Iterate over each character (byte, not EGC) in the string, performing the operation in the block on each one"
+        "Iterate over each character (byte, not EGC) in the string, performing the
+         operation in the block on each one"
       fn =
         function
         | state, [ s; f ] -> Errors.removedFunction state "String::foreach"
@@ -64,7 +65,8 @@ let fns : List<BuiltInFn> =
           Param.makeWithArgs "fn" (TFn([ TChar ], TChar)) "" [ "character" ] ]
       returnType = TStr
       description =
-        "Iterate over each Character (EGC, not byte) in the string, performing the operation in the block on each one."
+        "Iterate over each Character (EGC, not byte) in the string, performing the
+         operation in <param fn> on each one."
       fn =
         (function
         | state, [ DStr s; DFnVal b ] ->
@@ -154,7 +156,9 @@ let fns : List<BuiltInFn> =
           Param.make "searchFor" TStr "The string to search for within <param s>"
           Param.make "replaceWith" TStr "" ]
       returnType = TStr
-      description = "Replace all instances on `searchFor` in `s` with `replaceWith`"
+      description =
+        "Replace all instances on <param searchFor> in <param s> with <param
+         replaceWith>"
       fn =
         (function
         | _, [ DStr s; DStr search; DStr replace ] ->
@@ -181,7 +185,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "toInt" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TInt
-      description = "Returns the int value of the string"
+      description = "Returns the <type int> value of the <type string>"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -207,7 +211,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TInt, TStr)
       description =
-        "Returns the int value of the string, wrapped in a `Ok`, or `Error <msg>` if the string contains characters other than numeric digits"
+        "Returns the <type int> value of the string, wrapped in a {{Ok}}, or {{Error
+         <msg>}} if the string contains characters other than numeric digits"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -257,7 +262,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "toFloat" 1
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TFloat, TStr)
-      description = "Returns the float value of the string"
+      description = "Returns the <type float> value of the <type string>"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -280,8 +285,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
       description =
-        // CLEANUP "Returns the string, uppercased (only ASCII characters are uppercased)"
-        "Returns the string, uppercased"
+        "Returns the string, uppercased (only ASCII characters are uppercased)"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -314,8 +318,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
       description =
-        // CLEANUP "Returns the string, lowercased (only ASCII characters are lowercased)"
-        "Returns the string, lowercased"
+        "Returns the string, lowercased (only ASCII characters are lowercased)"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -347,7 +350,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "length" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TInt
-      description = "Returns the length of the string"
+      description = "Returns the number of bytes in the string"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -372,11 +375,10 @@ let fns : List<BuiltInFn> =
 
 
     { name = fn "String" "append" 0
-      (* This used to provide "++" as an infix op.
-       * It was moved to [String::append_v1] instead,
-       * because we do not yet support versioning infix operators.
-       * We decided this was safe under the assumption that no one should be
-       * (and very likely no one is) relying on broken normalization. *)
+      // This used to provide "++" as an infix op. It was moved to
+      // [String::append_v1] instead, because we do not yet support versioning infix
+      // operators.  We decided this was safe under the assumption that no one should
+      // be (and very likely no one is) relying on broken normalization.
       parameters = [ Param.make "s1" TStr ""; Param.make "s2" TStr "" ]
       returnType = TStr
       description = "Concatenates the two strings and returns the joined string"
@@ -406,7 +408,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s1" TStr ""; Param.make "s2" TStr "" ]
       returnType = TStr
       description =
-        "Concatenates the two strings by appending `s2` to `s1` and returns the joined string."
+        "Concatenates the two strings by appending <param s2> to <param s1> and
+         returns the joined string."
       fn =
         (function
         // TODO add fuzzer to ensure all strings are normalized no matter what we do to them.
@@ -421,7 +424,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s1" TStr ""; Param.make "s2" TStr "" ]
       returnType = TStr
       description =
-        "Concatenates the two strings by prepending `s2` to `s1` and returns the joined string."
+        "Concatenates the two strings by prepending <param s2> to <param s1> and
+         returns the joined string."
       fn =
         (function
         | _, [ DStr s1; DStr s2 ] -> Ply(DStr(s2 + s1))
@@ -490,7 +494,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "string" TStr "" ]
       returnType = TStr
       description =
-        "Turns a string into a prettified slug, including only lowercased alphanumeric characters, joined by hyphens"
+        "Turns a string into a prettified slug, including only lowercased
+         alphanumeric characters, joined by hyphens"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -518,7 +523,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "reverse" 0
       parameters = [ Param.make "string" TStr "" ]
       returnType = TStr
-      description = "Reverses `string`"
+      description = "Reverses <param string>"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -668,7 +673,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "fromChar" 0
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar
-      description = "Converts a char to a string"
+      description = "Converts a <type char> to a <type string>"
       fn =
         function
         | state, [ c ] -> Errors.removedFunction state "String::fromChar"
@@ -681,7 +686,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "fromChar" 1
       parameters = [ Param.make "c" TChar "" ]
       returnType = TStr
-      description = "Converts a char to a string"
+      description = "Converts a <type char> to a <type string>"
       fn =
         (function
         | _, [ DChar c ] -> Ply(DStr(c))
@@ -695,7 +700,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
       description =
-        "URLBase64 encodes a string without padding. Uses URL-safe encoding with `-` and `_` instead of `+` and `/`, as defined in RFC 4648 section 5."
+        "URLBase64 encodes a string without padding. Uses URL-safe encoding with
+        {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in
+        [RFC 4648 section 5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -714,7 +721,11 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
       description =
-        "Base64 decodes a string. Works with both the URL-safe and standard Base64 alphabets defined in RFC 4648 sections 4 and 5."
+        "Base64 decodes a string. Works with both the URL-safe and standard Base64
+         alphabets defined in [RFC 4648
+         sections](https://www.rfc-editor.org/rfc/rfc4648.html)
+         [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
+         [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
         (function
         | _, [ DStr s ] ->
@@ -779,7 +790,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
       description =
-        "Take a string and hash it using SHA384. Please use Crypto::sha384 instead."
+        "Take a string and hash it using SHA384. Please use <fn Crypto::sha384>
+         instead."
       fn =
         (function
         | _, [ DStr s ] ->
@@ -802,7 +814,8 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr
       description =
-        "Take a string and hash it using SHA256. Please use Crypto::sha256 instead."
+        "Take a string and hash it using SHA256. Please use <fn Crypto::sha256>
+         instead."
       fn =
         (function
         | _, [ DStr s ] ->
@@ -824,7 +837,8 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "random" 0
       parameters = [ Param.make "length" TInt "" ]
       returnType = TStr
-      description = "Generate a string of length `length` from random characters."
+      description =
+        "Generate a <type string> of length <param length> from random characters."
       fn =
         (function
         | _, [ DInt l as dv ] ->
@@ -854,7 +868,8 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "random" 1
       parameters = [ Param.make "length" TInt "" ]
       returnType = TResult(TStr, TStr)
-      description = "Generate a string of length `length` from random characters."
+      description =
+        "Generate a <type string> of length <param length> from random characters"
       fn =
         (function
         | _, [ DInt l ] ->
@@ -884,7 +899,8 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "random" 2
       parameters = [ Param.make "length" TInt "" ]
       returnType = TResult(TStr, TStr)
-      description = "Generate a string of length `length` from random characters."
+      description =
+        "Generate a <type string> of length <param length> from random characters"
       fn =
         (function
         | _, [ DInt l as dv ] ->
@@ -920,7 +936,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "html" TStr "" ]
       returnType = TStr
       description =
-        "Escape an untrusted string in order to include it safely in HTML output."
+        "Escape an untrusted string in order to include it safely in HTML output"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -953,7 +969,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "uuid" TStr "" ]
       returnType = TUuid
       description =
-        "Parse a UUID of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX from the input `uuid` string"
+        "Parse a <type UUID> of form {{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}}"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -974,7 +990,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "uuid" TStr "" ]
       returnType = TResult(TUuid, TStr)
       description =
-        "Parse a UUID of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX from the input `uuid` string"
+        "Parse a <type UUID> of form {{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}}"
       fn =
         (function
         | _, [ DStr s ] ->
@@ -996,7 +1012,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "searchingFor" TStr ""; Param.make "lookingIn" TStr "" ]
       returnType = TBool
-      description = "Checks if `lookingIn` contains `searchingFor`"
+      description = "Checks if <param lookingIn> contains <param searchingFor>"
       fn =
         (function
         | _, [ DStr needle; DStr haystack ] -> DBool(haystack.Contains needle) |> Ply
@@ -1010,7 +1026,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "lookingIn" TStr ""; Param.make "searchingFor" TStr "" ]
       returnType = TBool
-      description = "Checks if `lookingIn` contains `searchingFor`"
+      description = "Checks if <param lookingIn> contains <param searchingFor>"
       fn =
         (function
         | _, [ DStr haystack; DStr needle ] -> DBool(haystack.Contains needle) |> Ply
@@ -1027,7 +1043,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "lookingIn" TStr ""; Param.make "searchingFor" TStr "" ]
       returnType = TBool
-      description = "Checks if `lookingIn` contains `searchingFor`"
+      description = "Checks if <param lookingIn> contains <param searchingFor>"
       fn =
         (function
         | _, [ DStr haystack; DStr needle ] -> Ply(DBool(haystack.Contains needle))
@@ -1047,9 +1063,10 @@ let fns : List<BuiltInFn> =
           Param.make "to" TInt "" ]
       returnType = TStr
       description =
-        "Returns the substring of `string` between the `from` and `to` indices.
-       Negative indices start counting from the end of `string`.
-       Indices represent characters."
+        "Returns the substring of <param string> between the <param from> and <param
+         to> indices.
+
+         Negative indices start counting from the end of <param string>."
       fn =
         (function
         | _, [ DStr s; DInt first; DInt last ] ->
@@ -1086,9 +1103,13 @@ let fns : List<BuiltInFn> =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
       returnType = TStr
       description =
-        "Returns the first `characterCount` characters of `string`, as a String.
-      If `characterCount` is longer than `string`, returns `string`.
-      If `characterCount` is negative, returns the empty string."
+        "Returns the first <param characterCount> characters of <param string>, as a
+         String.
+
+         If <param characterCount> is longer than <param string>, returns <param
+         string>.
+
+         If <param characterCount> is negative, returns the empty string."
       fn =
         (function
         | _, [ DStr s; DInt n ] ->
@@ -1112,9 +1133,13 @@ let fns : List<BuiltInFn> =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
       returnType = TStr
       description =
-        "Returns the last `characterCount` characters of `string`, as a String.
-      If `characterCount` is longer than `string`, returns `string`.
-      If `characterCount` is negative, returns the empty string."
+        "Returns the last <param characterCount> characters of <param string>, as a
+         String.
+
+         If <param characterCount> is longer than <param string>, returns <param
+         string>.
+
+         If <param characterCount> is negative, returns the empty string."
       fn =
         (function
         | _, [ DStr s; DInt n ] ->
@@ -1160,9 +1185,12 @@ let fns : List<BuiltInFn> =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
       returnType = TStr
       description =
-        "Returns all but the last `characterCount` characters of `string`, as a String.
-      If `characterCount` is longer than `string`, returns the empty string.
-      If `characterCount` is negative, returns `string`."
+        "Returns all but the last <param characterCount> characters of <param
+         string>, as a String.
+
+         If <param characterCount> is longer than <param string>, returns the empty string.
+
+         If <param characterCount> is negative, returns <param string>."
       fn =
         (function
         | _, [ DStr s; DInt n ] ->
@@ -1206,9 +1234,13 @@ let fns : List<BuiltInFn> =
         [ Param.make "string" TStr ""; Param.make "characterCount" TInt "" ]
       returnType = TStr
       description =
-        "Returns all but the first `characterCount` characters of `string`, as a String.
-        If `characterCount` is longer than `string`, returns the empty string.
-        If `characterCount` is negative, returns `string`."
+        "Returns all but the first <param characterCount> characters of <param
+         string>, as a <type String>.
+
+         If <param characterCount> is longer than <param string>, returns the empty
+         string.
+
+         If <param characterCount> is negative, returns <param string>."
       fn =
         (function
         | _, [ DStr s; DInt n ] ->
@@ -1247,8 +1279,11 @@ let fns : List<BuiltInFn> =
           Param.make "goalLength" TInt "" ]
       returnType = TStr
       description =
-        "If `string` is shorter than `goalLength` characters, returns a copy of `string` starting with enough copies of `padWith` for the result have `goalLength`.
-      If the `string` is longer than `goalLength`, returns an unchanged copy of `string`."
+        "If <param string> is shorter than <param goalLength> characters, returns a
+         copy of <param string> starting with enough copies of <param padWith> for the
+         result have <param goalLength>.
+
+         If the <param string> is longer than <param goalLength>, returns an unchanged copy of <param string>"
       fn =
         (function
         | _, [ DStr s; DStr padWith as dv; DInt l ] ->
@@ -1280,8 +1315,12 @@ let fns : List<BuiltInFn> =
           Param.make "goalLength" TInt "" ]
       returnType = TStr
       description =
-        "If `string` is shorter than `goalLength` characters, returns a copy of `string` ending with enough copies of `padWith` for the result have `goalLength`.
-      If the `string` is longer than `goalLength`, returns an unchanged copy of `string`."
+        "If <param string> is shorter than <param goalLength> characters, returns a
+         copy of <param string> ending with enough copies of <param padWith> for the
+         result have <param goalLength>.
+
+         If the <param string> is longer than <param goalLength>, returns an unchanged copy of
+         <param string>."
       fn =
         (function
         | _, [ DStr s; DStr padWith as dv; DInt l ] ->
@@ -1310,7 +1349,10 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "str" TStr "" ]
       returnType = TStr
       description =
-        "Returns a copy of `str` with all leading and trailing whitespace removed. 'whitespace' here means all Unicode characters with the `White_Space` property, which includes \" \", \"\\t\" and \"\\n\"."
+        "Returns a copy of <param str> with all leading and trailing whitespace
+         removed. 'whitespace' here means all Unicode characters with the
+         {{White_Space}} property, which includes {{\" \"}}, {{\"\\t\"}} and
+         {{\"\\n\"}}"
       fn =
         (function
         | _, [ DStr toTrim ] -> toTrim |> String.trim |> DStr |> Ply
@@ -1324,7 +1366,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "str" TStr "" ]
       returnType = TStr
       description =
-        "Returns a copy of `str` with all leading whitespace removed. 'whitespace' here means all Unicode characters with the `White_Space` property, which includes \" \", \"\\t\" and \"\\n\"."
+        "Returns a copy of <param str> with all leading whitespace removed. 'whitespace'
+         here means all Unicode characters with the {{White_Space}} property, which
+         includes {{\" \"}}, {{\"\\t\"}} and {{\"\\n\"}}"
       fn =
         (function
         | _, [ DStr toTrim ] -> Ply(DStr(toTrim.TrimStart()))
@@ -1338,7 +1382,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "str" TStr "" ]
       returnType = TStr
       description =
-        "Returns a copy of `str` with all trailing whitespace removed. 'whitespace' here means all Unicode characters with the `White_Space` property, which includes \" \", \"\\t\" and \"\\n\"."
+        "Returns a copy of <param str> with all trailing whitespace removed.
+         'whitespace' here means all Unicode characters with the {{White_Space}}
+         property, which includes {{\" \"}}, {{\"\\t\"}} and {{\"\\n\"}}."
       fn =
         (function
         | _, [ DStr toTrim ] -> Ply(DStr(toTrim.TrimEnd()))
@@ -1352,7 +1398,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "str" TStr "" ]
       returnType = TBytes
       description =
-        "Converts the given unicode string to a utf8-encoded byte sequence."
+        "Converts the given unicode string to a UTF8-encoded byte sequence."
       fn =
         (function
         | _, [ DStr str ] ->
@@ -1367,7 +1413,7 @@ let fns : List<BuiltInFn> =
     { name = fn "String" "startsWith" 0
       parameters = [ Param.make "subject" TStr ""; Param.make "prefix" TStr "" ]
       returnType = TBool
-      description = "Checks if `subject` starts with `prefix`"
+      description = "Checks if <param subject> starts with <param prefix>"
       fn =
         (function
         | _, [ DStr subject; DStr prefix ] ->
@@ -1382,7 +1428,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "subject" TStr "String to test"; Param.make "suffix" TStr "" ]
       returnType = TBool
-      description = "Checks if `subject` ends with `suffix`"
+      description = "Checks if <param subject> ends with <param suffix>"
       fn =
         (function
         | _, [ DStr subject; DStr suffix ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -8,6 +8,7 @@ module DvalReprLegacyExternal = LibExecution.DvalReprLegacyExternal
 let fn = FQFnName.stdlibFnName
 
 let renames =
+  // old names, new names
   [ fn "Http" "respond" 0, fn "Http" "response" 0
     fn "Http" "respondWithHtml" 0, fn "Http" "responseWithHtml" 0
     fn "Http" "respondWithText" 0, fn "Http" "responseWithText" 0
@@ -19,7 +20,8 @@ let renames =
     fn "Object" "empty" 0, fn "Dict" "empty" 0
     fn "Object" "merge" 0, fn "Dict" "merge" 0
     fn "Object" "toJSON" 1, fn "Dict" "toJSON" 0
-    fn "Date" "subtract" 0, fn "Date" "subtractSeconds" 0 ]
+    fn "Date" "subtract" 0, fn "Date" "subtractSeconds" 0
+    fn "List" "contains" 0, fn "List" "member" 0 ]
 
 
 let prefixFns : List<BuiltInFn> =

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -24,7 +24,7 @@ let fns : List<BuiltInFn> =
   [ { name = fn "Test" "errorRailValue" 0
       parameters = [ Param.make "value" varA "" ]
       returnType = varA
-      description = "Return an errorRail wrapping a value."
+      description = "Return an <type ErrorRail> wrapping <param value>"
       fn =
         (function
         | state, [ value ] -> Ply(DErrorRail(value))


### PR DESCRIPTION
We have the ability to have pretty docstrings, but we didn't use the formatting for most functions. This adds them for probably about 40-50% of functions, which now look like this:

<img width="475" alt="image" src="https://user-images.githubusercontent.com/181762/178851204-c8a1db17-a1ec-4a21-b02a-84cb365c2801.png">


Also:
- fixes a bug in the format parsing
- reformats untidy and too-long strings in the F# source
- rewrote some comments that were unclear