### PR TITLE
Expose more internal staticassets fns for uploads

### DIFF
--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -791,34 +791,19 @@ human-readable data."
     { name = fn "DarkInternal" "finishStaticAssetDeploy" 0
       parameters =
         [ Param.make "canvasID" TUuid ""; Param.make "deployHash" TStr "" ]
-      returnType =
-        TResult(
-          TRecord [ "deployHash", TStr
-                    "url", TStr
-                    "status", TStr
-                    "lastUpdate", TDate ],
-          TStr
-        )
+      returnType = TResult(TNull, TStr)
       description = "Marks an in-progress static asset deployment as finished"
       fn =
         internalFn (function
           | _, [ DUuid canvasID; DStr deployHash ] ->
             uply {
               let! canvasMeta = Canvas.getMetaFromID canvasID
-              let! deploy =
+              let! _updatedAt =
                 StaticAssets.finishStaticAssetDeploy
                   canvasID
                   canvasMeta.name
                   deployHash
-              return
-                DObj(
-                  Map [ "deployHash", DStr deploy.deployHash
-                        "url", DStr deploy.url
-                        "status", DStr(string deploy.status)
-                        "lastUpdate", DDate(DDateTime.fromInstant deploy.lastUpdate) ]
-                )
-                |> Ok
-                |> DResult
+              return DResult(Ok DNull)
             }
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -804,6 +804,46 @@ human-readable data."
       previewable = Impure
       deprecated = NotDeprecated }
 
+
+    // TODO: re-evaluate access control of this fn. (might need some work)
+    // though likely such access control should be in the Dark code which uses this!
+    { name = fn "DarkInternal" "finishStaticAssetDeploy" 0
+      parameters =
+        [ Param.make "canvasID" TUuid ""; Param.make "deployHash" TStr "" ]
+      returnType =
+        TResult(
+          TRecord [ "deployHash", TStr
+                    "url", TStr
+                    "status", TStr
+                    "lastUpdate", TDate ],
+          TStr
+        )
+      description = "Marks an in-progress static asset deployment as finished"
+      fn =
+        internalFn (function
+          | _, [ DUuid canvasID; DStr deployHash ] ->
+            uply {
+              let! canvasMeta = Canvas.getMetaFromID canvasID
+              let! deploy =
+                StaticAssets.finishStaticAssetDeploy
+                  canvasID
+                  canvasMeta.name
+                  deployHash
+              return
+                DObj(
+                  Map [ "deployHash", DStr deploy.deployHash
+                        "url", DStr deploy.url
+                        "status", DStr(string deploy.status)
+                        "lastUpdate", DDate(DDateTime.fromInstant deploy.lastUpdate) ]
+                )
+                |> Ok
+                |> DResult
+            }
+          | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
     // ---------------------
     // Apis - 404s
     // ---------------------

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -776,13 +776,12 @@ human-readable data."
             uply {
               match! Account.getUser (UserName.create username) with
               | None ->
-                Exception.raiseInternal $"User not found" [ "username", username ]
                 return DResult(Error(DStr "User not found"))
               | Some user ->
                 let! canvasMeta = Canvas.getMetaFromID canvasID
                 let! deployHash =
                   StaticAssets.startStaticAssetDeploy user canvasID canvasMeta.name
-                return DStr deployHash |> Ok |> DResult
+                return DResult(Ok(DStr deployHash))
             }
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -767,15 +767,9 @@ human-readable data."
 
     { name = fn "DarkInternal" "startStaticAssetDeploy" 0
       parameters = [ Param.make "username" TStr ""; Param.make "canvasID" TUuid "" ]
-      returnType =
-        TResult(
-          TRecord [ "deployHash", TStr
-                    "url", TStr
-                    "status", TStr
-                    "lastUpdate", TDate ],
-          TStr
-        )
-      description = "Records an in-progress static asset deployment"
+      returnType = TResult(TStr, TStr)
+      description =
+        "Records an in-progress static asset deployment, returning the deployHash"
       fn =
         internalFn (function
           | _, [ DStr username; DUuid canvasID ] ->
@@ -786,18 +780,9 @@ human-readable data."
                 return DResult(Error(DStr "User not found"))
               | Some user ->
                 let! canvasMeta = Canvas.getMetaFromID canvasID
-                let! deploy =
+                let! deployHash =
                   StaticAssets.startStaticAssetDeploy user canvasID canvasMeta.name
-                return
-                  DObj(
-                    Map [ "deployHash", DStr deploy.deployHash
-                          "url", DStr deploy.url
-                          "status", DStr(string deploy.status)
-                          "lastUpdate",
-                          DDate(DDateTime.fromInstant deploy.lastUpdate) ]
-                  )
-                  |> Ok
-                  |> DResult
+                return DStr deployHash |> Ok |> DResult
             }
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -805,8 +805,6 @@ human-readable data."
       deprecated = NotDeprecated }
 
 
-    // TODO should this take username as a parameter?
-    // should user B be able to finish user A's upload?
     { name = fn "DarkInternal" "finishStaticAssetDeploy" 0
       parameters =
         [ Param.make "canvasID" TUuid ""; Param.make "deployHash" TStr "" ]
@@ -851,7 +849,7 @@ human-readable data."
           Param.make "canvasID" TUuid ""
           Param.make "deployHash" TStr "" ]
       returnType =
-        // TODO what should the return type be here? I basically want an empty result.
+        // CLEANUP reconsider this return type (get away from `null`).
         TResult(TNull, TStr)
       description = "Deletes a static asset deployment"
       fn =

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -845,29 +845,21 @@ human-readable data."
 
     { name = fn "DarkInternal" "deleteStaticAssetDeploy" 0
       parameters =
-        [ Param.make "username" TStr ""
-          Param.make "canvasID" TUuid ""
-          Param.make "deployHash" TStr "" ]
-      returnType =
-        // CLEANUP reconsider this return type (get away from `null`).
-        TResult(TNull, TStr)
+        [ Param.make "canvasID" TUuid ""; Param.make "deployHash" TStr "" ]
+      returnType = TNull
       description = "Deletes a static asset deployment"
       fn =
         internalFn (function
-          | _, [ DStr username; DUuid canvasID; DStr deployHash ] ->
+          | _, [ DUuid canvasID; DStr deployHash ] ->
             uply {
-              match! Account.getUser (UserName.create username) with
-              | None ->
-                Exception.raiseInternal $"User not found" [ "username", username ]
-                return DResult(Error(DStr "User not found"))
-              | Some user ->
-                do! StaticAssets.deleteStaticAssetDeploy user canvasID deployHash
-                return DResult(Ok DNull)
+              do! StaticAssets.deleteStaticAssetDeploy canvasID deployHash
+              return DNull
             }
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
+
 
     // ---------------------
     // Apis - 404s

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -775,8 +775,7 @@ human-readable data."
           | _, [ DStr username; DUuid canvasID ] ->
             uply {
               match! Account.getUser (UserName.create username) with
-              | None ->
-                return DResult(Error(DStr "User not found"))
+              | None -> return DResult(Error(DStr "User not found"))
               | Some user ->
                 let! canvasMeta = Canvas.getMetaFromID canvasID
                 let! deployHash =
@@ -831,7 +830,7 @@ human-readable data."
       parameters =
         [ Param.make "canvasID" TUuid ""; Param.make "deployHash" TStr "" ]
       returnType = TNull
-      description = "Deletes a static asset deployment"
+      description = "Deletes references to a now-deleted static asset deploy"
       fn =
         internalFn (function
           | _, [ DUuid canvasID; DStr deployHash ] ->

--- a/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -777,9 +777,7 @@ human-readable data."
               match! Account.getUser (UserName.create username) with
               | None -> return DResult(Error(DStr "User not found"))
               | Some user ->
-                let! canvasMeta = Canvas.getMetaFromID canvasID
-                let! deployHash =
-                  StaticAssets.startStaticAssetDeploy user canvasID canvasMeta.name
+                let! deployHash = StaticAssets.startStaticAssetDeploy user canvasID
                 return DResult(Ok(DStr deployHash))
             }
           | _ -> incorrectArgs ())

--- a/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
@@ -152,7 +152,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.url state.program.canvasName deployHash SA.Short
@@ -173,7 +173,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return DOption None
             | Some deployHash ->
               let url = SA.url state.program.canvasName deployHash SA.Short
@@ -207,7 +207,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some hash ->
               let url = SA.urlFor state.program.canvasName hash SA.Short file
@@ -289,7 +289,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -313,7 +313,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -336,7 +336,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -424,7 +424,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -458,7 +458,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.getLatestDeployHash state.program.canvasID with
+            match! SA.latestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file

--- a/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
+++ b/fsharp-backend/src/BackendOnlyStdLib/LibStaticAssets.fs
@@ -152,7 +152,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.url state.program.canvasName deployHash SA.Short
@@ -173,7 +173,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return DOption None
             | Some deployHash ->
               let url = SA.url state.program.canvasName deployHash SA.Short
@@ -207,7 +207,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some hash ->
               let url = SA.urlFor state.program.canvasName hash SA.Short file
@@ -289,7 +289,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -313,7 +313,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -336,7 +336,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -424,7 +424,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file
@@ -458,7 +458,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr file ] ->
           uply {
-            match! SA.latestDeployHash state.program.canvasID with
+            match! SA.getLatestDeployHash state.program.canvasID with
             | None -> return Dval.errStr "No deploy hash found"
             | Some deployHash ->
               let url = SA.urlFor state.program.canvasName deployHash SA.Short file

--- a/fsharp-backend/src/LibBackend/StaticAssets.fs
+++ b/fsharp-backend/src/LibBackend/StaticAssets.fs
@@ -38,6 +38,9 @@ type StaticDeploy =
     lastUpdate : NodaTime.Instant
     status : DeployStatus }
 
+// The `static_asset_deploys` table has a `branch` column, but it's currently
+// always set to `"main"`. There were plans to use this, but they haven't been
+// followed through yet.
 let branch = "main"
 
 // let static_deploy_to_yojson (sd : static_deploy) : Yojson.Safe.t =
@@ -51,7 +54,6 @@ let branch = "main"
 //              sd.last_update
 //              ~zone:Core.Time.Zone.utc) )
 //     ; ("status", deploy_status_to_yojson sd.status) ]
-
 
 let appHash (canvasName : CanvasName.T) : string =
   // enough of a hash to make this not easily discoverable
@@ -148,7 +150,6 @@ let startStaticAssetDeploy
       url = url canvasName deployHash Short
       lastUpdate = lastUpdate
       status = Deploying })
-
 
 // TODO: what should happen if the deploy hash doesn't exist?
 // TODO: what if the deploy is already finished?

--- a/fsharp-backend/src/LibBackend/StaticAssets.fs
+++ b/fsharp-backend/src/LibBackend/StaticAssets.fs
@@ -186,27 +186,18 @@ let finishStaticAssetDeploy
 /// files/dirs not known to the DB and delete them. TODO.
 /// </remarks>
 let deleteStaticAssetDeploy
-  (user : Account.UserInfo)
   (canvasID : CanvasID)
   (deployHash : string)
   : Task<unit> =
 
-  // CLEANUP the query here only allows someone to delete a deploy if they're
-  // the one who uploaded it (via `AND uploaded_by_account_id=@userId`). If
-  // more than one user are working within a canvas, shouldn't we allow anyone
-  // involved to delete the deploy? I believe so.
-  // If/when we adjust for such, ensure canvas access of relevant user in
-  // StdLib fn.
   Sql.query
     "DELETE FROM static_asset_deploys
     WHERE canvas_id=@canvasID
       AND branch=@branch
-      AND deploy_hash=@deployHash
-      AND uploaded_by_account_id=@uploadedBy"
+      AND deploy_hash=@deployHash"
   |> Sql.parameters [ "canvasID", Sql.uuid canvasID
                       "branch", Sql.string branch
-                      "deployHash", Sql.string deployHash
-                      "uploadedBy", Sql.uuid user.id ]
+                      "deployHash", Sql.string deployHash ]
   |> Sql.executeStatementAsync
 
 

--- a/fsharp-backend/src/LibBackend/StaticAssets.fs
+++ b/fsharp-backend/src/LibBackend/StaticAssets.fs
@@ -88,7 +88,7 @@ let urlFor
   : string =
   url canvasName deployHash variant + "/" + file
 
-let getLatestDeployHash (canvasID : CanvasID) : Task<Option<string>> =
+let latestDeployHash (canvasID : CanvasID) : Task<Option<string>> =
   Sql.query
     "SELECT deploy_hash FROM static_asset_deploys
        WHERE canvas_id=@canvasID AND branch=@branch AND live_at IS NOT NULL

--- a/fsharp-backend/src/LibBackend/StaticAssets.fs
+++ b/fsharp-backend/src/LibBackend/StaticAssets.fs
@@ -126,7 +126,6 @@ let allDeploysInCanvas
 let startStaticAssetDeploy
   (user : Account.UserInfo)
   (canvasID : CanvasID)
-  (canvasName : CanvasName.T)
   : Task<string> =
 
   // we include .fff (milliseconds) to ensure we don't encoutner conflicts,

--- a/fsharp-backend/src/LibBackend/StaticAssets.fs
+++ b/fsharp-backend/src/LibBackend/StaticAssets.fs
@@ -121,6 +121,8 @@ let allDeploysInCanvas
       status = status
       lastUpdate = lastUpdate })
 
+/// Creates a record of a new static asset deploy, returning a deployHash to be
+/// used by the actual upload process.
 let startStaticAssetDeploy
   (user : Account.UserInfo)
   (canvasID : CanvasID)
@@ -172,14 +174,9 @@ let finishStaticAssetDeploy
       status = Deployed })
 
 
-/// <summary>Removes references to a canvas' static asset deploy</summary>
-/// <remarks>
-/// Since postgres doesn't have named transactions, we just delete the db
-/// record in question. For now, we're leaving files where they are; the right
-/// thing to do here would be to shell out to `gsutil -m rm -r` - leaving  this
-/// for a later round of 'garbage collection' work, in which we can query for
-/// files/dirs not known to the DB and delete them. TODO.
-/// </remarks>
+/// Deletes references to a canvas' static asset deploy from the database.
+///
+/// The deletion of actual assets should be handled prior to calling this.
 let deleteStaticAssetDeploy
   (canvasID : CanvasID)
   (deployHash : string)

--- a/fsharp-backend/src/LibBackend/StaticAssets.fs
+++ b/fsharp-backend/src/LibBackend/StaticAssets.fs
@@ -158,7 +158,7 @@ let finishStaticAssetDeploy
   (canvasID : CanvasID)
   (canvasName : CanvasName.T)
   (deployHash : string)
-  : Task<StaticDeploy> =
+  : Task<NodaTime.Instant> =
   Sql.query
     "UPDATE static_asset_deploys
       SET live_at = NOW()
@@ -167,11 +167,6 @@ let finishStaticAssetDeploy
   |> Sql.parameters [ "canvasID", Sql.uuid canvasID
                       "deployHash", Sql.string deployHash ]
   |> Sql.executeRowAsync (fun reader -> reader.instant "live_at")
-  |> Task.map (fun lastUpdate ->
-    { deployHash = deployHash
-      url = url canvasName deployHash Short
-      lastUpdate = lastUpdate
-      status = Deployed })
 
 
 /// Deletes references to a canvas' static asset deploy from the database.

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -209,11 +209,14 @@ let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deploying"]
 
 [test.finishing a started static asset deploy changes the status]
-(let deployHash =
+(let deployHashMaybe =
   (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
-  |> Option.withDefault {}
+  |> Result.withDefault {}
   |> Dict.get_v2 "deployHash" in
-let hmm = DarkInternal.finishStaticAssetDeploy Test.getCanvasID deployHash in
-let _ = Test.inspect hmm "hmm" in
-let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
-deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deployed"]
+
+match deployHashMaybe with
+| None -> []
+| Just deployHash ->
+  let _ = DarkInternal.finishStaticAssetDeploy Test.getCanvasID deployHash in
+  let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
+  deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deployed"]

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -220,3 +220,37 @@ match deployHashMaybe with
   let _ = DarkInternal.finishStaticAssetDeploy Test.getCanvasID deployHash in
   let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
   deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deployed"]
+
+
+[test.static asset deploys can be deleted]
+(let deployHashMaybe =
+  (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
+  |> Result.withDefault {}
+  |> Dict.get_v2 "deployHash" in
+
+match deployHashMaybe with
+| None -> ["not empty"]
+| Just deployHash ->
+  let _ = DarkInternal.deleteStaticAssetDeploy "test" Test.getCanvasID deployHash in
+  DarkInternal.staticAssetsDeploys Test.getCanvasID) = []
+
+
+// TODO should this fail?
+[test.trying to delete a non-existant static asset deploy doesn't fail]
+(DarkInternal.deleteStaticAssetDeploy "test" Test.getCanvasID "fake-deployhash") = Ok null
+
+
+[test.trying to delete a static asset deploy as the non-uploader fails]
+(let deployHashMaybe =
+  (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
+  |> Result.withDefault {}
+  |> Dict.get_v2 "deployHash" in
+
+let countAfterDeploy = (DarkInternal.staticAssetsDeploys Test.getCanvasID) |> List.length_v0 in
+
+match deployHashMaybe with
+| None -> false
+| Just deployHash ->
+  let _ = DarkInternal.deleteStaticAssetDeploy "test_unhashed" Test.getCanvasID deployHash in
+  let countAfterDeleteAttempt = (DarkInternal.staticAssetsDeploys Test.getCanvasID) |> List.length_v0 in
+  countAfterDeploy = countAfterDeleteAttempt)

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -211,6 +211,16 @@ List.length_v0 deploys) = 2
 let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deploying"]
 
+[test.finishing an invalid static asset deploy fails EXPECTED_EXCEPTION_COUNT: 1]
+DarkInternal.finishStaticAssetDeploy Test.getCanvasID "fakeHash" = Test.typeError_v0 "Unknown error"
+
+[test.finishing a started static asset deploy is OK]
+(let deployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+match deployHashMaybe with
+| Error -> []
+| Ok deployHash ->
+  DarkInternal.finishStaticAssetDeploy Test.getCanvasID deployHash) = Ok null
+
 [test.finishing a started static asset deploy changes the status]
 (let deployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 match deployHashMaybe with

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -197,13 +197,23 @@ let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 List.length_v0 deploys) = 1
 
 // TODO this currently fails - somehow we have a deployHash conflict.
-[test.static assets contains as many elements as deploys]
-(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
-let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
-let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
-List.length_v0 deploys) = 2
+//[test.static assets contains as many elements as deploys]
+//(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+//let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+//let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
+//List.length_v0 deploys) = 2
 
 [test.static assets deploy is 'deploying' after just started]
 (let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deploying"]
+
+[test.finishing a started static asset deploy changes the status]
+(let deployHash =
+  (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
+  |> Option.withDefault {}
+  |> Dict.get_v2 "deployHash" in
+let hmm = DarkInternal.finishStaticAssetDeploy Test.getCanvasID deployHash in
+let _ = Test.inspect hmm "hmm" in
+let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
+deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deployed"]

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -185,6 +185,7 @@ DarkInternal.unlockedDBs Test.getCanvasID = [1]
 (let _ = DB.set_v1 { x = "str" } "test" X in
  DarkInternal.unlockedDBs Test.getCanvasID) = []
 
+
 // ---------------
 // static assets
 // ---------------
@@ -196,12 +197,11 @@ DarkInternal.staticAssetsDeploys Test.getCanvasID = []
 let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 List.length_v0 deploys) = 1
 
-// TODO this currently fails - somehow we have a deployHash conflict.
-//[test.static assets contains as many elements as deploys]
-//(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
-//let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
-//let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
-//List.length_v0 deploys) = 2
+[test.static assets contains as many elements as deploys]
+(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
+List.length_v0 deploys) = 2
 
 [test.static assets deploy is 'deploying' after just started]
 (let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
@@ -221,33 +221,27 @@ match deployHashMaybe with
   let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
   deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deployed"]
 
-
 [test.static asset deploys can be deleted]
 (let deployHashMaybe =
   (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
   |> Result.withDefault {}
   |> Dict.get_v2 "deployHash" in
-
 match deployHashMaybe with
 | None -> ["not empty"]
 | Just deployHash ->
   let _ = DarkInternal.deleteStaticAssetDeploy "test" Test.getCanvasID deployHash in
   DarkInternal.staticAssetsDeploys Test.getCanvasID) = []
 
-
-// TODO should this fail?
+// CLEANUP this should fail
 [test.trying to delete a non-existant static asset deploy doesn't fail]
 (DarkInternal.deleteStaticAssetDeploy "test" Test.getCanvasID "fake-deployhash") = Ok null
-
 
 [test.trying to delete a static asset deploy as the non-uploader fails]
 (let deployHashMaybe =
   (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
   |> Result.withDefault {}
   |> Dict.get_v2 "deployHash" in
-
 let countAfterDeploy = (DarkInternal.staticAssetsDeploys Test.getCanvasID) |> List.length_v0 in
-
 match deployHashMaybe with
 | None -> false
 | Just deployHash ->

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -197,6 +197,9 @@ DarkInternal.staticAssetsDeploys Test.getCanvasID = []
 let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 List.length_v0 deploys) = 1
 
+[test.starting a static asset deploy for a non-existant user fails]
+(DarkInternal.startStaticAssetDeploy "fake_username" Test.getCanvasID) = Error "User not found"
+
 [test.static assets contains as many elements as deploys]
 (let _firstDeployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 let _secondDeployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -184,3 +184,26 @@ DarkInternal.unlockedDBs Test.getCanvasID = [1]
 [test.unlocked, one but locked] with DB X
 (let _ = DB.set_v1 { x = "str" } "test" X in
  DarkInternal.unlockedDBs Test.getCanvasID) = []
+
+// ---------------
+// static assets
+// ---------------
+[test.no static assets without deploys]
+DarkInternal.staticAssetsDeploys Test.getCanvasID = []
+
+[test.static assets non-empty after starting a deploy]
+(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
+List.length_v0 deploys) = 1
+
+// TODO this currently fails - somehow we have a deployHash conflict.
+[test.static assets contains as many elements as deploys]
+(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
+List.length_v0 deploys) = 2
+
+[test.static assets deploy is 'deploying' after just started]
+(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
+deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deploying"]

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -229,22 +229,8 @@ match deployHashMaybe with
 match deployHashMaybe with
 | None -> ["not empty"]
 | Just deployHash ->
-  let _ = DarkInternal.deleteStaticAssetDeploy "test" Test.getCanvasID deployHash in
+  let _ = DarkInternal.deleteStaticAssetDeploy Test.getCanvasID deployHash in
   DarkInternal.staticAssetsDeploys Test.getCanvasID) = []
 
-// CLEANUP this should fail
 [test.trying to delete a non-existant static asset deploy doesn't fail]
-(DarkInternal.deleteStaticAssetDeploy "test" Test.getCanvasID "fake-deployhash") = Ok null
-
-[test.trying to delete a static asset deploy as the non-uploader fails]
-(let deployHashMaybe =
-  (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
-  |> Result.withDefault {}
-  |> Dict.get_v2 "deployHash" in
-let countAfterDeploy = (DarkInternal.staticAssetsDeploys Test.getCanvasID) |> List.length_v0 in
-match deployHashMaybe with
-| None -> false
-| Just deployHash ->
-  let _ = DarkInternal.deleteStaticAssetDeploy "test_unhashed" Test.getCanvasID deployHash in
-  let countAfterDeleteAttempt = (DarkInternal.staticAssetsDeploys Test.getCanvasID) |> List.length_v0 in
-  countAfterDeploy = countAfterDeleteAttempt)
+(DarkInternal.deleteStaticAssetDeploy Test.getCanvasID "fake-deployhash") = null

--- a/fsharp-backend/tests/testfiles/internal.tests
+++ b/fsharp-backend/tests/testfiles/internal.tests
@@ -193,42 +193,35 @@ DarkInternal.unlockedDBs Test.getCanvasID = [1]
 DarkInternal.staticAssetsDeploys Test.getCanvasID = []
 
 [test.static assets non-empty after starting a deploy]
-(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+(let _deployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 List.length_v0 deploys) = 1
 
 [test.static assets contains as many elements as deploys]
-(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
-let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+(let _firstDeployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+let _secondDeployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 List.length_v0 deploys) = 2
 
 [test.static assets deploy is 'deploying' after just started]
-(let _ = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
+(let _deployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
 deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deploying"]
 
 [test.finishing a started static asset deploy changes the status]
-(let deployHashMaybe =
-  (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
-  |> Result.withDefault {}
-  |> Dict.get_v2 "deployHash" in
-
+(let deployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 match deployHashMaybe with
-| None -> []
-| Just deployHash ->
+| Error -> []
+| Ok deployHash ->
   let _ = DarkInternal.finishStaticAssetDeploy Test.getCanvasID deployHash in
   let deploys = DarkInternal.staticAssetsDeploys Test.getCanvasID in
   deploys |> List.map_v0 (fun d -> Dict.get_v2 d "status")) = [Just "Deployed"]
 
 [test.static asset deploys can be deleted]
-(let deployHashMaybe =
-  (DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID)
-  |> Result.withDefault {}
-  |> Dict.get_v2 "deployHash" in
+(let deployHashMaybe = DarkInternal.startStaticAssetDeploy "test" Test.getCanvasID in
 match deployHashMaybe with
-| None -> ["not empty"]
-| Just deployHash ->
+| Error -> ["not deployed"]
+| Ok deployHash ->
   let _ = DarkInternal.deleteStaticAssetDeploy Test.getCanvasID deployHash in
   DarkInternal.staticAssetsDeploys Test.getCanvasID) = []
 


### PR DESCRIPTION
This PR will expose and test 3 new functions for use in `dark-editor`, to support an eventual replacement of the OCaml-supported static asset upload. It's a piece of #4259.
The three functions will support `start`ing, `finish`ing, and `delete`-ing a deploy.