### PR TITLE
Switch client-side types to match backend types, pt 2

### DIFF
--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -70,7 +70,7 @@ let apiCall = (
   Tea.Http.send(callback, request)
 }
 
-let opsParams = (ops: list<op>, opCtr: int, clientOpCtrId: string): addOpAPIParams => {
+let opsParams = (ops: list<PT.Op.t>, opCtr: int, clientOpCtrId: string): addOpAPIParams => {
   ops: ops,
   opCtr: opCtr,
   clientOpCtrId: clientOpCtrId,
@@ -282,7 +282,7 @@ let sendInvite = (m: model, invite: SettingsViewTypes.inviteFormMessage): Tea.Cm
  * */
 let filterOpsAndResult = (m: model, params: addOpAPIParams, result: option<addOpAPIResult>): (
   model,
-  list<op>,
+  list<PT.Op.t>,
   option<addOpAPIResult>,
 ) => {
   let newOpCtrs = /* if the opCtr in params is greater than the one in the map, we'll create
@@ -309,7 +309,7 @@ let filterOpsAndResult = (m: model, params: addOpAPIParams, result: option<addOp
     // NOTE: DO NOT UPDATE WITHOUT UPDATING THE SERVER-SIDE LIST
     let filter_ops_received_out_of_order = List.filter(~f=op =>
       switch op {
-      | SetHandler(_)
+      | PT.Op.SetHandler(_)
       | SetFunction(_)
       | SetType(_)
       | MoveTL(_)
@@ -333,7 +333,7 @@ let filterOpsAndResult = (m: model, params: addOpAPIParams, result: option<addOp
     )
 
     let ops = params.ops |> filter_ops_received_out_of_order
-    let opTlids = ops |> List.map(~f=op => Encoders.tlidOf(op))
+    let opTlids = ops |> List.map(~f=op => PT.Op.tlidOf(op))
     // We also want to ignore the result of ops we ignored
     let result = Option.map(result, ~f=(result: addOpAPIResult) => {
       ...result,

--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -337,7 +337,9 @@ let filterOpsAndResult = (m: model, params: addOpAPIParams, result: option<addOp
     // We also want to ignore the result of ops we ignored
     let result = Option.map(result, ~f=(result: addOpAPIResult) => {
       ...result,
-      handlers: result.handlers |> List.filter(~f=h => List.member(~value=h.hTLID, opTlids)),
+      handlers: result.handlers |> List.filter(~f=(h: PT.Handler.t) =>
+        List.member(~value=h.hTLID, opTlids)
+      ),
       userFunctions: result.userFunctions |> List.filter(~f=(uf: PT.UserFunction.t) =>
         List.member(~value=uf.tlid, opTlids)
       ),

--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -338,7 +338,7 @@ let filterOpsAndResult = (m: model, params: addOpAPIParams, result: option<addOp
     let result = Option.map(result, ~f=(result: addOpAPIResult) => {
       ...result,
       handlers: result.handlers |> List.filter(~f=(h: PT.Handler.t) =>
-        List.member(~value=h.hTLID, opTlids)
+        List.member(~value=h.tlid, opTlids)
       ),
       userFunctions: result.userFunctions |> List.filter(~f=(uf: PT.UserFunction.t) =>
         List.member(~value=uf.tlid, opTlids)

--- a/client/src/app/IntegrationTest.res
+++ b/client/src/app/IntegrationTest.res
@@ -48,7 +48,7 @@ let onlyTL = (m: model): option<toplevel> => {
   }
 }
 
-let onlyHandler = (m: model): option<handler> => m |> onlyTL |> Option.andThen(~f=TL.asHandler)
+let onlyHandler = (m: model): option<PT.Handler.t> => m |> onlyTL |> Option.andThen(~f=TL.asHandler)
 
 let onlyDB = (m: model): option<PT.DB.t> => m |> onlyTL |> Option.andThen(~f=TL.asDB)
 
@@ -103,7 +103,8 @@ let no_request_global_in_non_http_space = (m: model): testResult =>
   }
 
 let ellen_hello_world_demo = (m: model): testResult => {
-  let spec = onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=x => x.spec)
+  let spec =
+    onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=(h: PT.Handler.t) => h.spec)
 
   switch spec {
   | Some(spec) =>
@@ -116,7 +117,8 @@ let ellen_hello_world_demo = (m: model): testResult => {
 }
 
 let editing_headers = (m: model): testResult => {
-  let spec = onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=x => x.spec)
+  let spec =
+    onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=(h: PT.Handler.t) => h.spec)
 
   switch spec {
   | Some(s) =>
@@ -132,7 +134,8 @@ let editing_headers = (m: model): testResult => {
 type rec handler_triple = (blankOr<string>, blankOr<string>, blankOr<string>)
 
 let switching_from_http_space_removes_leading_slash = (m: model): testResult => {
-  let spec = onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=x => x.spec)
+  let spec =
+    onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=(h: PT.Handler.t) => h.spec)
 
   switch spec {
   | Some(s) =>
@@ -149,7 +152,8 @@ let switching_from_http_to_cron_space_removes_leading_slash = switching_from_htt
 let switching_from_http_to_repl_space_removes_leading_slash = switching_from_http_space_removes_leading_slash
 
 let switching_from_http_space_removes_variable_colons = (m: model): testResult => {
-  let spec = onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=x => x.spec)
+  let spec =
+    onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=(h: PT.Handler.t) => h.spec)
 
   switch spec {
   | Some(s) =>
@@ -162,7 +166,8 @@ let switching_from_http_space_removes_variable_colons = (m: model): testResult =
 }
 
 let switching_to_http_space_adds_slash = (m: model): testResult => {
-  let spec = onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=x => x.spec)
+  let spec =
+    onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=(h: PT.Handler.t) => h.spec)
 
   switch spec {
   | Some(s) =>
@@ -175,7 +180,8 @@ let switching_to_http_space_adds_slash = (m: model): testResult => {
 }
 
 let switching_from_default_repl_space_removes_name = (m: model): testResult => {
-  let spec = onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=x => x.spec)
+  let spec =
+    onlyTL(m) |> Option.andThen(~f=TL.asHandler) |> Option.map(~f=(h: PT.Handler.t) => h.spec)
 
   switch spec {
   | Some(s) =>
@@ -235,7 +241,7 @@ let rename_db_type = (m: model): testResult =>
 
 let feature_flag_works = (m: model): testResult => {
   let h = onlyHandler(m)
-  let ast = h |> Option.map(~f=h => h.ast |> FluidAST.toExpr)
+  let ast = h |> Option.map(~f=(h: PT.Handler.t) => h.ast |> FluidAST.toExpr)
   switch ast {
   | Some(ELet(
       _,
@@ -251,7 +257,7 @@ let feature_flag_works = (m: model): testResult => {
     )) =>
     let res =
       h
-      |> Option.map(~f=x => x.hTLID)
+      |> Option.map(~f=(h: PT.Handler.t) => h.hTLID)
       |> Option.andThen(~f=Analysis.getSelectedTraceID(m))
       |> Option.andThen(~f=Analysis.getLiveValue(m, id))
 
@@ -294,7 +300,10 @@ let feature_flag_in_function = (m: model): testResult => {
 }
 
 let rename_function = (m: model): testResult =>
-  switch m.handlers |> Map.values |> List.head |> Option.map(~f=h => h.ast |> FluidAST.toExpr) {
+  switch m.handlers
+  |> Map.values
+  |> List.head
+  |> Option.map(~f=(h: PT.Handler.t) => h.ast |> FluidAST.toExpr) {
   | Some(EFnCall(_, "hello", _, _)) => pass
   | Some(expr) => fail(show_fluidExpr(expr))
   | None => fail("no handlers")

--- a/client/src/app/IntegrationTest.res
+++ b/client/src/app/IntegrationTest.res
@@ -257,7 +257,7 @@ let feature_flag_works = (m: model): testResult => {
     )) =>
     let res =
       h
-      |> Option.map(~f=(h: PT.Handler.t) => h.hTLID)
+      |> Option.map(~f=(h: PT.Handler.t) => h.tlid)
       |> Option.andThen(~f=Analysis.getSelectedTraceID(m))
       |> Option.andThen(~f=Analysis.getLiveValue(m, id))
 

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -547,7 +547,7 @@ let rec updateMod = (mod_: modification, (m, cmd): (model, Cmd.t<msg>)): (model,
         bringBackCurrentTL(oldM, m)
       }
       let m = {
-        let hTLIDs = List.map(~f=h => h.hTLID, handlers)
+        let hTLIDs = List.map(~f=h => h.tlid, handlers)
         let dbTLIDs = List.map(~f=db => db.tlid, dbs)
         {
           ...m,
@@ -584,7 +584,7 @@ let rec updateMod = (mod_: modification, (m, cmd): (model, Cmd.t<msg>)): (model,
       let ddbs = Map.mergeRight(m.deletedDBs, DB.fromList(ddbs))
       updateMod(SetDeletedToplevels(Map.values(dhandlers), Map.values(ddbs)), (m, cmd))
     | SetDeletedToplevels(dhandlers, ddbs) =>
-      let hTLIDs = List.map(~f=h => h.hTLID, dhandlers)
+      let hTLIDs = List.map(~f=h => h.tlid, dhandlers)
       let dbTLIDs = List.map(~f=db => db.tlid, ddbs)
       let m = {
         ...m,
@@ -894,7 +894,7 @@ let rec updateMod = (mod_: modification, (m, cmd): (model, Cmd.t<msg>)): (model,
       let hcache = handlers |> List.fold(~initial=m.searchCache, ~f=(cache, h: PT.Handler.t) => {
         let value = FluidPrinter.eToHumanString(FluidAST.toExpr(h.ast))
 
-        cache |> Map.add(~key=h.hTLID, ~value)
+        cache |> Map.add(~key=h.tlid, ~value)
       })
 
       let searchCache = userFunctions |> List.fold(~initial=hcache, ~f=(
@@ -1779,7 +1779,7 @@ let update_ = (msg: msg, m: model): modification => {
         name: B.newF(path),
         modifier: B.newF(modifier),
       },
-      hTLID: tlid,
+      tlid: tlid,
       pos: pos,
     }
 

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -891,7 +891,7 @@ let rec updateMod = (mod_: modification, (m, cmd): (model, Cmd.t<msg>)): (model,
 
       ({...m, searchCache: searchCache}, Cmd.none)
     | InitASTCache(handlers, userFunctions) =>
-      let hcache = handlers |> List.fold(~initial=m.searchCache, ~f=(cache, h) => {
+      let hcache = handlers |> List.fold(~initial=m.searchCache, ~f=(cache, h: PT.Handler.t) => {
         let value = FluidPrinter.eToHumanString(FluidAST.toExpr(h.ast))
 
         cache |> Map.add(~key=h.hTLID, ~value)
@@ -1772,7 +1772,7 @@ let update_ = (msg: msg, m: model): modification => {
     let tlid = gtlid()
     let pos = center
     let ast = ProgramTypes.Expr.EBlank(gid())
-    let aHandler = {
+    let aHandler: PT.Handler.t = {
       ast: FluidAST.ofExpr(ast),
       spec: {
         space: B.newF(space),

--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -118,7 +118,7 @@ let handlerCategory = (
   action: omniAction,
   iconAction: option<msg>,
   tooltip: tooltipSource,
-  hs: list<handler>,
+  hs: list<PT.Handler.t>,
 ): category => {
   let handlers = hs |> List.filter(~f=h => filter(TLHandler(h)))
   {
@@ -148,7 +148,7 @@ let handlerCategory = (
   }
 }
 
-let httpCategory = (handlers: list<handler>): category =>
+let httpCategory = (handlers: list<PT.Handler.t>): category =>
   handlerCategory(
     TL.isHTTPHandler,
     "HTTP",
@@ -158,7 +158,7 @@ let httpCategory = (handlers: list<handler>): category =>
     handlers,
   )
 
-let cronCategory = (handlers: list<handler>): category =>
+let cronCategory = (handlers: list<PT.Handler.t>): category =>
   handlerCategory(
     TL.isCronHandler,
     "Cron",
@@ -168,10 +168,10 @@ let cronCategory = (handlers: list<handler>): category =>
     handlers,
   )
 
-let replCategory = (handlers: list<handler>): category =>
+let replCategory = (handlers: list<PT.Handler.t>): category =>
   handlerCategory(TL.isReplHandler, "REPL", NewReplHandler(None), None, Repl, handlers)
 
-let workerCategory = (handlers: list<handler>): category => handlerCategory(tl =>
+let workerCategory = (handlers: list<PT.Handler.t>): category => handlerCategory(tl =>
     TL.isWorkerHandler(tl) ||
     // Show the old workers here for now
     TL.isDeprecatedCustomHandler(tl)
@@ -214,7 +214,7 @@ let f404Category = (m: model): category => {
     let deletedHandlerSpecs =
       m.deletedHandlers
       |> Map.values
-      |> List.map(~f=h => {
+      |> List.map(~f=(h: PT.Handler.t) => {
         let space = B.valueWithDefault("", h.spec.space)
         let name = B.valueWithDefault("", h.spec.name)
         let modifier = B.valueWithDefault("", h.spec.modifier)
@@ -1176,13 +1176,13 @@ let viewSidebar_ = (m: model): Html.html<msg> => {
 
 let rtCacheKey = m =>
   (
-    m.handlers |> Map.mapValues(~f=(h: handler) => (h.pos, TL.sortkey(TLHandler(h)))),
+    m.handlers |> Map.mapValues(~f=(h: PT.Handler.t) => (h.pos, TL.sortkey(TLHandler(h)))),
     m.dbs |> Map.mapValues(~f=(db: PT.DB.t) => (db.pos, TL.sortkey(TLDB(db)))),
     m.userFunctions |> Map.mapValues(~f=(uf: PT.UserFunction.t) => uf.metadata.name),
     m.userTipes |> Map.mapValues(~f=(ut: PT.UserType.t) => ut.name),
     m.f404s,
     m.sidebarState,
-    m.deletedHandlers |> Map.mapValues(~f=(h: handler) => TL.sortkey(TLHandler(h))),
+    m.deletedHandlers |> Map.mapValues(~f=(h: PT.Handler.t) => TL.sortkey(TLHandler(h))),
     m.deletedDBs |> Map.mapValues(~f=(db: PT.DB.t) => (db.pos, TL.sortkey(TLDB(db)))),
     m.deletedUserFunctions |> Map.mapValues(~f=(uf: PT.UserFunction.t) => uf.metadata.name),
     m.deletedUserTipes |> Map.mapValues(~f=(ut: PT.UserType.t) => ut.name),

--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -129,7 +129,7 @@ let handlerCategory = (
     iconAction: iconAction,
     tooltip: setTooltips(tooltip, handlers),
     entries: List.map(handlers, ~f=h => {
-      let tlid = h.hTLID
+      let tlid = h.tlid
       Entry({
         name: h.spec.name |> B.toOption |> Option.unwrap(~default=missingEventRouteDesc),
         uses: None,

--- a/client/src/core/BaseTypes.res
+++ b/client/src/core/BaseTypes.res
@@ -7,6 +7,14 @@ type rec pos = {
   x: int,
   y: int,
 }
+let encodePos = (p: pos) => {
+  open Json_encode_extended
+  object_(list{("x", int(p.x)), ("y", int(p.y))})
+}
+let decodePos = (j): pos => {
+  open Json.Decode
+  {x: field("x", int, j), y: field("y", int, j)}
+}
 
 // CLEANUP: Move BlankOr to own module and file. Right now there's already a BlankOr
 // files with functions in it.
@@ -17,7 +25,6 @@ type rec blankOr<'a> =
 
 let encodeBlankOr = (encoder: 'a => Js.Json.t, v: blankOr<'a>) => {
   open Json_encode_extended
-
   switch v {
   | F(i, s) => variant("Filled", list{ID.encode(i), encoder(s)})
   | Blank(i) => variant("Blank", list{ID.encode(i)})

--- a/client/src/core/Decoders.res
+++ b/client/src/core/Decoders.res
@@ -448,25 +448,12 @@ let dvalDict = (j: Js.Json.t): dvalDict => strDict(ocamlDval, j)
 let analysisEnvelope = (j: Js.Json.t): (traceID, intermediateResultStore) =>
   tuple2(string, intermediateResultStore)(j)
 
-let handlerSpec = (j): handlerSpec => {
-  space: field("module", blankOr(string), j),
-  name: field("name", blankOr(string), j),
-  modifier: field("modifier", blankOr(string), j),
-}
-
-let handler = (pos, j): handler => {
-  ast: field("ast", PT.AST.decode, j),
-  spec: field("spec", handlerSpec, j),
-  hTLID: field("tlid", tlid, j),
-  pos: pos,
-}
-
 let tipeString = (j): string => map(RT.tipe2str, DType.decodeOld, j)
 
 let toplevel = (j): toplevel => {
   let pos = field("pos", pos, j)
   let variant = variants(list{
-    ("Handler", variant1(x => TLHandler(x), handler(pos))),
+    ("Handler", variant1(x => TLHandler(x), PT.Handler.decode(pos))),
     ("DB", variant1(x => TLDB(x), PT.DB.decode(pos))),
   })
 
@@ -584,7 +571,7 @@ let op = (j): op =>
           (t, p, h) => SetHandler(t, p, {...h, pos: p}),
           tlid,
           pos,
-          handler({x: -1286, y: -467}),
+          PT.Handler.decode({x: -1286, y: -467}),
         ),
       ),
       ("CreateDB", variant3((t, p, name) => CreateDB(t, p, name), tlid, pos, string)),

--- a/client/src/core/Decoders.res
+++ b/client/src/core/Decoders.res
@@ -134,7 +134,7 @@ let tlidOption = (j: Js.Json.t): option<TLID.t> => optional(tlid, j)
 let tlidDict = TLID.Dict.decode
 let idMap = ID.Map.decode
 
-let pos = (j): pos => {x: field("x", int, j), y: field("y", int, j)}
+let pos = BaseTypes.decodePos
 
 let vPos = (j): vPos => {vx: field("vx", int, j), vy: field("vy", int, j)}
 
@@ -562,44 +562,6 @@ let traces = (j): traces => j |> list(tuple2(TLID.decode, list(trace))) |> TLID.
 let permission = j =>
   variants(list{("Read", variant0(Read)), ("ReadWrite", variant0(ReadWrite))}, j)
 
-let op = (j): op =>
-  variants(
-    list{
-      (
-        "SetHandler",
-        variant3(
-          (t, p, h) => SetHandler(t, p, {...h, pos: p}),
-          tlid,
-          pos,
-          PT.Handler.decode({x: -1286, y: -467}),
-        ),
-      ),
-      ("CreateDB", variant3((t, p, name) => CreateDB(t, p, name), tlid, pos, string)),
-      ("AddDBCol", variant3((t, cn, ct) => AddDBCol(t, cn, ct), tlid, id, id)),
-      ("SetDBColName", variant3((t, i, name) => SetDBColName(t, i, name), tlid, id, string)),
-      ("ChangeDBColName", variant3((t, i, name) => ChangeDBColName(t, i, name), tlid, id, string)),
-      ("SetDBColType", variant3((t, i, tipe) => SetDBColType(t, i, tipe), tlid, id, string)),
-      ("ChangeDBColType", variant3((t, i, tipe) => ChangeDBColName(t, i, tipe), tlid, id, string)),
-      ("DeleteDBCol", variant2((t, i) => DeleteDBCol(t, i), tlid, id)),
-      ("TLSavepoint", variant1(t => TLSavepoint(t), tlid)),
-      ("UndoTL", variant1(t => UndoTL(t), tlid)),
-      ("RedoTL", variant1(t => RedoTL(t), tlid)),
-      ("DeleteTL", variant1(t => DeleteTL(t), tlid)),
-      ("MoveTL", variant2((t, p) => MoveTL(t, p), tlid, pos)),
-      ("SetFunction", variant1(uf => SetFunction(uf), PT.UserFunction.decode)),
-      ("DeleteFunction", variant1(t => DeleteFunction(t), tlid)),
-      ("SetExpr", variant3((t, i, e) => SetExpr(t, i, e), tlid, id, PT.Expr.decode)),
-      ("RenameDBname", variant2((t, name) => RenameDBname(t, name), tlid, string)),
-      (
-        "CreateDBWithBlankOr",
-        variant4((t, p, i, name) => CreateDBWithBlankOr(t, p, i, name), tlid, pos, id, string),
-      ),
-      ("SetType", variant1(t => SetType(t), PT.UserType.decode)),
-      ("DeleteType", variant1(t => DeleteType(t), tlid)),
-    },
-    j,
-  )
-
 let addOpAPIResult = (j): addOpAPIResult => {
   let tls = field("toplevels", list(toplevel), j)
   let dtls = field("deleted_toplevels", list(toplevel), j)
@@ -618,7 +580,7 @@ let addOpAPIResult = (j): addOpAPIResult => {
 let addOpAPI = (j: Js.Json.t): addOpAPIResponse => {result: field("result", addOpAPIResult, j)}
 
 let addOpAPIParams = (j): addOpAPIParams => {
-  ops: field("ops", list(op), j),
+  ops: field("ops", list(PT.Op.decode), j),
   opCtr: field("opCtr", int, j),
   clientOpCtrId: field("clientOpCtrId", string)(j),
 }

--- a/client/src/core/Encoders.res
+++ b/client/src/core/Encoders.res
@@ -194,27 +194,10 @@ and ops = (ops: list<Types.op>): Js.Json.t =>
     },
   )
 
-and spec = (spec: Types.handlerSpec): Js.Json.t =>
-  object_(list{
-    ("name", blankOr(string, spec.name)),
-    ("module", blankOr(string, spec.space)),
-    ("modifier", blankOr(string, spec.modifier)),
-    (
-      "types",
-      object_(list{
-        ("input", blankOr(int, BlankOr.new_())),
-        ("output", blankOr(int, BlankOr.new_())),
-      }),
-    ),
-  })
-
-and handler = (h: Types.handler): Js.Json.t =>
-  object_(list{("tlid", tlid(h.hTLID)), ("spec", spec(h.spec)), ("ast", PT.AST.encode(h.ast))})
-
 and op = (call: Types.op): Js.Json.t => {
   let ev = variant
   switch call {
-  | SetHandler(t, p, h) => ev("SetHandler", list{tlid(t), pos(p), handler(h)})
+  | SetHandler(t, p, h) => ev("SetHandler", list{tlid(t), pos(p), PT.Handler.encode(h)})
   | CreateDB(t, p, name) => ev("CreateDB", list{tlid(t), pos(p), string(name)})
   | AddDBCol(t, cn, ct) => ev("AddDBCol", list{tlid(t), id(cn), id(ct)})
   | SetDBColName(t, i, name) => ev("SetDBColName", list{tlid(t), id(i), string(name)})
@@ -322,7 +305,7 @@ and secret = (s: SecretTypes.t): Js.Json.t =>
 
 and performHandlerAnalysisParams = (params: Types.performHandlerAnalysisParams): Js.Json.t =>
   object_(list{
-    ("handler", handler(params.handler)),
+    ("handler", PT.Handler.encode(params.handler)),
     ("trace_id", traceID(params.traceID)),
     ("trace_data", traceData(params.traceData)),
     ("dbs", list(PT.DB.encode, params.dbs)),

--- a/client/src/core/ProgramTypes.res
+++ b/client/src/core/ProgramTypes.res
@@ -378,13 +378,13 @@ module Handler = {
   type rec t = {
     ast: AST.t,
     spec: Spec.t,
-    hTLID: TLID.t,
+    tlid: TLID.t,
     pos: pos,
   }
   let encode = (h: t): Js.Json.t => {
     open Json.Encode
     object_(list{
-      ("tlid", TLID.encode(h.hTLID)),
+      ("tlid", TLID.encode(h.tlid)),
       ("spec", Spec.encode(h.spec)),
       ("ast", AST.encode(h.ast)),
     })
@@ -395,7 +395,7 @@ module Handler = {
     {
       ast: field("ast", AST.decode, j),
       spec: field("spec", Spec.decode, j),
-      hTLID: field("tlid", TLID.decode, j),
+      tlid: field("tlid", TLID.decode, j),
       pos: pos,
     }
   }

--- a/client/src/core/ProgramTypes.res
+++ b/client/src/core/ProgramTypes.res
@@ -635,3 +635,131 @@ module UserType = {
     }
   }
 }
+
+module Op = {
+  @ppx.deriving(show({with_path: false}))
+  type rec t =
+    | SetHandler(TLID.t, pos, Handler.t)
+    | CreateDB(TLID.t, pos, string)
+    | AddDBCol(TLID.t, ID.t, ID.t)
+    | SetDBColName(TLID.t, ID.t, string)
+    | SetDBColType(TLID.t, ID.t, string)
+    | DeleteTL(TLID.t)
+    | MoveTL(TLID.t, pos)
+    | SetFunction(UserFunction.t)
+    | ChangeDBColName(TLID.t, ID.t, string)
+    | ChangeDBColType(TLID.t, ID.t, string)
+    | UndoTL(TLID.t)
+    | RedoTL(TLID.t)
+    | SetExpr(TLID.t, ID.t, Expr.t)
+    | TLSavepoint(TLID.t)
+    | DeleteFunction(TLID.t)
+    | DeleteDBCol(TLID.t, ID.t)
+    | RenameDBname(TLID.t, string)
+    | CreateDBWithBlankOr(TLID.t, pos, ID.t, string)
+    | SetType(UserType.t)
+    | DeleteType(TLID.t)
+
+  let tlidOf = (op: t): TLID.t =>
+    switch op {
+    | SetHandler(tlid, _, _) => tlid
+    | CreateDB(tlid, _, _) => tlid
+    | AddDBCol(tlid, _, _) => tlid
+    | SetDBColName(tlid, _, _) => tlid
+    | ChangeDBColName(tlid, _, _) => tlid
+    | SetDBColType(tlid, _, _) => tlid
+    | ChangeDBColType(tlid, _, _) => tlid
+    | TLSavepoint(tlid) => tlid
+    | UndoTL(tlid) => tlid
+    | RedoTL(tlid) => tlid
+    | DeleteTL(tlid) => tlid
+    | MoveTL(tlid, _) => tlid
+    | SetFunction(f) => f.tlid
+    | DeleteFunction(tlid) => tlid
+    | SetExpr(tlid, _, _) => tlid
+    | DeleteDBCol(tlid, _) => tlid
+    | RenameDBname(tlid, _) => tlid
+    | CreateDBWithBlankOr(tlid, _, _, _) => tlid
+    | SetType(ut) => ut.tlid
+    | DeleteType(tlid) => tlid
+    }
+
+  let encode = (op: t): Js.Json.t => {
+    open Json_encode_extended
+    let ev = variant
+    let tlid = TLID.encode
+    let id = ID.encode
+    let pos = BaseTypes.encodePos
+    switch op {
+    | SetHandler(t, p, h) => ev("SetHandler", list{tlid(t), pos(p), Handler.encode(h)})
+    | CreateDB(t, p, name) => ev("CreateDB", list{tlid(t), pos(p), string(name)})
+    | AddDBCol(t, cn, ct) => ev("AddDBCol", list{tlid(t), id(cn), id(ct)})
+    | SetDBColName(t, i, name) => ev("SetDBColName", list{tlid(t), id(i), string(name)})
+    | ChangeDBColName(t, i, name) => ev("ChangeDBColName", list{tlid(t), id(i), string(name)})
+    | SetDBColType(t, i, tipe) => ev("SetDBColType", list{tlid(t), id(i), string(tipe)})
+    | ChangeDBColType(t, i, name) => ev("ChangeDBColType", list{tlid(t), id(i), string(name)})
+    | DeleteDBCol(t, i) => ev("DeleteDBCol", list{tlid(t), id(i)})
+    | TLSavepoint(t) => ev("TLSavepoint", list{tlid(t)})
+    | UndoTL(t) => ev("UndoTL", list{tlid(t)})
+    | RedoTL(t) => ev("RedoTL", list{tlid(t)})
+    | DeleteTL(t) => ev("DeleteTL", list{tlid(t)})
+    | MoveTL(t, p) => ev("MoveTL", list{tlid(t), pos(p)})
+    | SetFunction(uf) => ev("SetFunction", list{UserFunction.encode(uf)})
+    | DeleteFunction(t) => ev("DeleteFunction", list{tlid(t)})
+    | SetExpr(t, i, e) => ev("SetExpr", list{tlid(t), id(i), Expr.encode(e)})
+    | RenameDBname(t, name) => ev("RenameDBname", list{tlid(t), string(name)})
+    | CreateDBWithBlankOr(t, p, i, name) =>
+      ev("CreateDBWithBlankOr", list{tlid(t), pos(p), id(i), string(name)})
+    | SetType(t) => ev("SetType", list{UserType.encode(t)})
+    | DeleteType(t) => ev("DeleteType", list{tlid(t)})
+    }
+  }
+  let decode = (j): t => {
+    open Json_decode_extended
+    let tlid = TLID.decode
+    let id = ID.decode
+    let pos = BaseTypes.decodePos
+    variants(
+      list{
+        (
+          "SetHandler",
+          variant3(
+            (t, p, h) => SetHandler(t, p, {...h, pos: p}),
+            tlid,
+            pos,
+            Handler.decode({x: -1286, y: -467}),
+          ),
+        ),
+        ("CreateDB", variant3((t, p, name) => CreateDB(t, p, name), tlid, pos, string)),
+        ("AddDBCol", variant3((t, cn, ct) => AddDBCol(t, cn, ct), tlid, id, id)),
+        ("SetDBColName", variant3((t, i, name) => SetDBColName(t, i, name), tlid, id, string)),
+        (
+          "ChangeDBColName",
+          variant3((t, i, name) => ChangeDBColName(t, i, name), tlid, id, string),
+        ),
+        ("SetDBColType", variant3((t, i, tipe) => SetDBColType(t, i, tipe), tlid, id, string)),
+        (
+          "ChangeDBColType",
+          variant3((t, i, tipe) => ChangeDBColName(t, i, tipe), tlid, id, string),
+        ),
+        ("DeleteDBCol", variant2((t, i) => DeleteDBCol(t, i), tlid, id)),
+        ("TLSavepoint", variant1(t => TLSavepoint(t), tlid)),
+        ("UndoTL", variant1(t => UndoTL(t), tlid)),
+        ("RedoTL", variant1(t => RedoTL(t), tlid)),
+        ("DeleteTL", variant1(t => DeleteTL(t), tlid)),
+        ("MoveTL", variant2((t, p) => MoveTL(t, p), tlid, pos)),
+        ("SetFunction", variant1(uf => SetFunction(uf), UserFunction.decode)),
+        ("DeleteFunction", variant1(t => DeleteFunction(t), tlid)),
+        ("SetExpr", variant3((t, i, e) => SetExpr(t, i, e), tlid, id, Expr.decode)),
+        ("RenameDBname", variant2((t, name) => RenameDBname(t, name), tlid, string)),
+        (
+          "CreateDBWithBlankOr",
+          variant4((t, p, i, name) => CreateDBWithBlankOr(t, p, i, name), tlid, pos, id, string),
+        ),
+        ("SetType", variant1(t => SetType(t), UserType.decode)),
+        ("DeleteType", variant1(t => DeleteType(t), tlid)),
+      },
+      j,
+    )
+  }
+}

--- a/client/src/core/Types.res
+++ b/client/src/core/Types.res
@@ -581,32 +581,6 @@ and workerStats = {
 }
 
 // -------------------
-// ops
-// -------------------
-
-and op =
-  | SetHandler(TLID.t, pos, PT.Handler.t)
-  | CreateDB(TLID.t, pos, string)
-  | AddDBCol(TLID.t, id, id)
-  | SetDBColName(TLID.t, id, string)
-  | SetDBColType(TLID.t, id, string)
-  | DeleteTL(TLID.t)
-  | MoveTL(TLID.t, pos)
-  | SetFunction(PT.UserFunction.t)
-  | ChangeDBColName(TLID.t, id, string)
-  | ChangeDBColType(TLID.t, id, string)
-  | UndoTL(TLID.t)
-  | RedoTL(TLID.t)
-  | SetExpr(TLID.t, id, fluidExpr)
-  | TLSavepoint(TLID.t)
-  | DeleteFunction(TLID.t)
-  | DeleteDBCol(TLID.t, id)
-  | RenameDBname(TLID.t, string)
-  | CreateDBWithBlankOr(TLID.t, pos, id, string)
-  | SetType(PT.UserType.t)
-  | DeleteType(TLID.t)
-
-// -------------------
 // APIs
 // -------------------
 // params
@@ -615,7 +589,7 @@ and sendPresenceParams = avatarModelMessage
 and sendInviteParams = SettingsViewTypes.inviteFormMessage
 
 and addOpAPIParams = {
-  ops: list<op>,
+  ops: list<PT.Op.t>,
   opCtr: int,
   clientOpCtrId: string,
 }
@@ -1053,7 +1027,7 @@ and modification =
   ReplaceAllModificationsWithThisOne(model => (model, Tea.Cmd.t<msg>))
 
   // API Calls
-  | AddOps((list<op>, focus))
+  | AddOps((list<PT.Op.t>, focus))
   | HandleAPIError(apiError)
   | GetUnlockedDBsAPICall
   | Get404sAPICall

--- a/client/src/core/Types.res
+++ b/client/src/core/Types.res
@@ -164,11 +164,6 @@ and blankOrType =
 // ----------------------
 // Toplevels
 // ----------------------
-type rec handlerSpaceName = string
-
-and handlerName = string
-
-and handlerModifer = string
 
 // usedIn is a TL that's refered to in the refersTo tl at id
 // refersTo is a TL that uses the usedIn tl at id
@@ -178,13 +173,6 @@ and usage = {
   id: id,
 }
 
-// handlers
-and handlerSpec = {
-  space: blankOr<handlerSpaceName>,
-  name: blankOr<handlerName>,
-  modifier: blankOr<handlerModifer>,
-}
-
 and handlerSpace =
   | HSHTTP
   | HSCron
@@ -192,14 +180,6 @@ and handlerSpace =
   | HSRepl
   | HSDeprecatedOther
 
-and handler = {
-  ast: fluidAST,
-  spec: handlerSpec,
-  hTLID: TLID.t,
-  pos: pos,
-}
-
-// dbs
 and functionTypes =
   | UserFunction(PT.UserFunction.t)
   | PackageFn(packageFn)
@@ -228,7 +208,7 @@ and packageFn = {
 
 // toplevels
 and toplevel =
-  | TLHandler(handler)
+  | TLHandler(PT.Handler.t)
   | TLDB(PT.DB.t)
   | TLPmFunc(packageFn)
   | TLFunc(PT.UserFunction.t)
@@ -605,7 +585,7 @@ and workerStats = {
 // -------------------
 
 and op =
-  | SetHandler(TLID.t, pos, handler)
+  | SetHandler(TLID.t, pos, PT.Handler.t)
   | CreateDB(TLID.t, pos, string)
   | AddDBCol(TLID.t, id, id)
   | SetDBColName(TLID.t, id, string)
@@ -673,7 +653,7 @@ and updateWorkerScheduleAPIParams = {
 }
 
 and performHandlerAnalysisParams = {
-  handler: handler,
+  handler: PT.Handler.t,
   traceID: traceID,
   traceData: traceData,
   dbs: list<PT.DB.t>,
@@ -714,8 +694,8 @@ and account = {
 
 // results
 and addOpAPIResult = {
-  handlers: list<handler>,
-  deletedHandlers: list<handler>,
+  handlers: list<PT.Handler.t>,
+  deletedHandlers: list<PT.Handler.t>,
   dbs: list<PT.DB.t>,
   deletedDBs: list<PT.DB.t>,
   userFunctions: list<PT.UserFunction.t>,
@@ -756,8 +736,8 @@ and workerStatsAPIResult = workerStats
 and allTracesAPIResult = {traces: list<(TLID.t, traceID)>}
 
 and initialLoadAPIResult = {
-  handlers: list<handler>,
-  deletedHandlers: list<handler>,
+  handlers: list<PT.Handler.t>,
+  deletedHandlers: list<PT.Handler.t>,
   dbs: list<PT.DB.t>,
   deletedDBs: list<PT.DB.t>,
   userFunctions: list<PT.UserFunction.t>,
@@ -1088,10 +1068,10 @@ and modification =
   | ClearHover(TLID.t, idOrTraceID)
   | Deselect
   | RemoveToplevel(toplevel)
-  | SetToplevels(list<handler>, list<PT.DB.t>, bool)
-  | UpdateToplevels(list<handler>, list<PT.DB.t>, bool)
-  | SetDeletedToplevels(list<handler>, list<PT.DB.t>)
-  | UpdateDeletedToplevels(list<handler>, list<PT.DB.t>)
+  | SetToplevels(list<PT.Handler.t>, list<PT.DB.t>, bool)
+  | UpdateToplevels(list<PT.Handler.t>, list<PT.DB.t>, bool)
+  | SetDeletedToplevels(list<PT.Handler.t>, list<PT.DB.t>)
+  | UpdateDeletedToplevels(list<PT.Handler.t>, list<PT.DB.t>)
   | UpdateAnalysis(analysisEnvelope)
   | SetUserFunctions(list<PT.UserFunction.t>, list<PT.UserFunction.t>, bool)
   | SetUnlockedDBs(unlockedDBs)
@@ -1144,7 +1124,7 @@ and modification =
   | ExpireAvatars
   | SetClipboardContents(clipboardContents, clipboardEvent)
   | UpdateASTCache(TLID.t, string)
-  | InitASTCache(list<handler>, list<PT.UserFunction.t>)
+  | InitASTCache(list<PT.Handler.t>, list<PT.UserFunction.t>)
   | FluidSetState(fluidState)
   | TLMenuUpdate(TLID.t, menuMsg)
   | SettingsViewUpdate(SettingsViewTypes.settingsMsg)
@@ -1647,8 +1627,8 @@ and model = {
   cursorState: cursorState,
   currentPage: page,
   hovering: list<(TLID.t, idOrTraceID)>,
-  handlers: TLID.Dict.t<handler>,
-  deletedHandlers: TLID.Dict.t<handler>,
+  handlers: TLID.Dict.t<PT.Handler.t>,
+  deletedHandlers: TLID.Dict.t<PT.Handler.t>,
   dbs: TLID.Dict.t<PT.DB.t>,
   deletedDBs: TLID.Dict.t<PT.DB.t>,
   userFunctions: TLID.Dict.t<PT.UserFunction.t>,

--- a/client/src/fluid/Refactor.res
+++ b/client/src/fluid/Refactor.res
@@ -37,7 +37,7 @@ let transformFnCalls = (
   let newHandlers = m.handlers |> Map.filterMapValues(~f=(h: PT.Handler.t) => {
     let newAst = h.ast |> transformCallsInAst
     if newAst != h.ast {
-      Some(SetHandler(h.hTLID, h.pos, {...h, ast: newAst}))
+      Some(SetHandler(h.tlid, h.pos, {...h, ast: newAst}))
     } else {
       None
     }
@@ -458,7 +458,7 @@ let renameDBReferences = (m: model, oldName: string, newName: string): list<op> 
       let newAST = h.ast |> FluidAST.map(~f=FluidExpression.renameVariableUses(~oldName, ~newName))
 
       if newAST != h.ast {
-        Some(SetHandler(h.hTLID, h.pos, {...h, ast: newAST}))
+        Some(SetHandler(h.tlid, h.pos, {...h, ast: newAST}))
       } else {
         None
       }

--- a/client/src/fluid/Refactor.res
+++ b/client/src/fluid/Refactor.res
@@ -23,7 +23,7 @@ let transformFnCalls = (
   m: model,
   uf: PT.UserFunction.t,
   f: FluidExpression.t => FluidExpression.t,
-): list<op> => {
+): list<PT.Op.t> => {
   let transformCallsInAst = (ast: FluidAST.t) => {
     let rec run = e =>
       switch e {
@@ -37,7 +37,7 @@ let transformFnCalls = (
   let newHandlers = m.handlers |> Map.filterMapValues(~f=(h: PT.Handler.t) => {
     let newAst = h.ast |> transformCallsInAst
     if newAst != h.ast {
-      Some(SetHandler(h.tlid, h.pos, {...h, ast: newAst}))
+      Some(PT.Op.SetHandler(h.tlid, h.pos, {...h, ast: newAst}))
     } else {
       None
     }
@@ -46,7 +46,7 @@ let transformFnCalls = (
   let newFunctions = m.userFunctions |> Map.filterMapValues(~f=(uf_: PT.UserFunction.t) => {
     let newAst = uf_.ast |> transformCallsInAst
     if newAst != uf_.ast {
-      Some(SetFunction({...uf_, ast: newAst}))
+      Some(PT.Op.SetFunction({...uf_, ast: newAst}))
     } else {
       None
     }
@@ -236,7 +236,7 @@ let extractFunction = (m: model, tl: toplevel, id: id): modification => {
   }
 }
 
-let renameFunction = (m: model, uf: PT.UserFunction.t, newName: string): list<op> => {
+let renameFunction = (m: model, uf: PT.UserFunction.t, newName: string): list<PT.Op.t> => {
   open ProgramTypes.Expr
   let fn = e =>
     switch e {
@@ -247,7 +247,7 @@ let renameFunction = (m: model, uf: PT.UserFunction.t, newName: string): list<op
   transformFnCalls(m, uf, fn)
 }
 
-let renameUserTipe = (m: model, old: PT.UserType.t, new_: PT.UserType.t): list<op> => {
+let renameUserTipe = (m: model, old: PT.UserType.t, new_: PT.UserType.t): list<PT.Op.t> => {
   let renameUserTipeInFnParameters = (fn, oldTipe: PT.UserType.t, newTipe: PT.UserType.t) => {
     let transformUse = (newName_, oldUse) =>
       switch oldUse {
@@ -279,7 +279,7 @@ let renameUserTipe = (m: model, old: PT.UserType.t, new_: PT.UserType.t): list<o
   let newFunctions = m.userFunctions |> Map.filterMapValues(~f=uf => {
     let newFn = renameUserTipeInFnParameters(uf, old, new_)
     if newFn != uf {
-      Some(SetFunction(newFn))
+      Some(PT.Op.SetFunction(newFn))
     } else {
       None
     }
@@ -358,7 +358,7 @@ let removeFunctionParameter = (
   m: model,
   uf: PT.UserFunction.t,
   ufp: PT.UserFunction.Parameter.t,
-): list<op> => {
+): list<PT.Op.t> => {
   open ProgramTypes.Expr
   let indexInList =
     List.findIndex(~f=(_, p) => p == ufp, uf.metadata.parameters)
@@ -449,7 +449,7 @@ let generateUserType = (dv: option<dval>): Result.t<PT.UserType.t, string> =>
   | None => Error("No live value.")
   }
 
-let renameDBReferences = (m: model, oldName: string, newName: string): list<op> =>
+let renameDBReferences = (m: model, oldName: string, newName: string): list<PT.Op.t> =>
   m
   |> TL.all
   |> Map.filterMapValues(~f=tl =>
@@ -458,7 +458,7 @@ let renameDBReferences = (m: model, oldName: string, newName: string): list<op> 
       let newAST = h.ast |> FluidAST.map(~f=FluidExpression.renameVariableUses(~oldName, ~newName))
 
       if newAST != h.ast {
-        Some(SetHandler(h.tlid, h.pos, {...h, ast: newAST}))
+        Some(PT.Op.SetHandler(h.tlid, h.pos, {...h, ast: newAST}))
       } else {
         None
       }
@@ -508,7 +508,7 @@ let createNewDB = (m: model, maybeName: option<string>, pos: pos): modification 
     let tlid = gtlid()
     let pageChanges = list{SetPage(FocusedDB(tlid, true))}
     let rpcCalls = list{
-      CreateDBWithBlankOr(tlid, pos, Prelude.gid(), name),
+      PT.Op.CreateDBWithBlankOr(tlid, pos, Prelude.gid(), name),
       AddDBCol(tlid, next, Prelude.gid()),
     }
 
@@ -559,7 +559,7 @@ let createAndInsertNewFunction = (
       metadata: {...fn.metadata, name: F(gid(), newFnName)},
     }
 
-    let op = SetFunction(newFn)
+    let op = PT.Op.SetFunction(newFn)
     // Update the old ast
     let replacement = E.EFnCall(partialID, newFnName, list{}, NoRail)
     let newAST = FluidAST.replace(partialID, ast, ~replacement)

--- a/client/src/fluid/Refactor.res
+++ b/client/src/fluid/Refactor.res
@@ -34,7 +34,7 @@ let transformFnCalls = (
     FluidAST.map(ast, ~f=run)
   }
 
-  let newHandlers = m.handlers |> Map.filterMapValues(~f=h => {
+  let newHandlers = m.handlers |> Map.filterMapValues(~f=(h: PT.Handler.t) => {
     let newAst = h.ast |> transformCallsInAst
     if newAst != h.ast {
       Some(SetHandler(h.hTLID, h.pos, {...h, ast: newAst}))

--- a/client/src/forms/Autocomplete.res
+++ b/client/src/forms/Autocomplete.res
@@ -373,7 +373,7 @@ let qHTTPHandler = (s: string): omniAction => {
   }
 }
 
-let handlerDisplayName = (h: handler): string => {
+let handlerDisplayName = (h: PT.Handler.t): string => {
   let space =
     h.spec.space |> B.toOption |> Option.map(~f=x => x ++ "::") |> Option.unwrap(~default="")
 
@@ -396,7 +396,7 @@ let handlerDisplayName = (h: handler): string => {
 let fnDisplayName = (f: PT.UserFunction.t): string =>
   f.metadata.name |> B.toOption |> Option.unwrap(~default="undefinedFunction")
 
-let foundHandlerOmniAction = (h: handler): omniAction => {
+let foundHandlerOmniAction = (h: PT.Handler.t): omniAction => {
   let name = "Found in " ++ handlerDisplayName(h)
   Goto(FocusedHandler(h.hTLID, None, true), h.hTLID, name, true)
 }

--- a/client/src/forms/Autocomplete.res
+++ b/client/src/forms/Autocomplete.res
@@ -398,7 +398,7 @@ let fnDisplayName = (f: PT.UserFunction.t): string =>
 
 let foundHandlerOmniAction = (h: PT.Handler.t): omniAction => {
   let name = "Found in " ++ handlerDisplayName(h)
-  Goto(FocusedHandler(h.hTLID, None, true), h.hTLID, name, true)
+  Goto(FocusedHandler(h.tlid, None, true), h.tlid, name, true)
 }
 
 let foundFnOmniAction = (f: PT.UserFunction.t): omniAction => {

--- a/client/src/forms/Entry.res
+++ b/client/src/forms/Entry.res
@@ -270,7 +270,7 @@ let newHandler = (m, space, name, modifier, pos) => {
       name: B.ofOption(name),
       modifier: B.ofOption(modifier),
     },
-    hTLID: tlid,
+    tlid: tlid,
     pos: pos,
   }
 

--- a/client/src/forms/Entry.res
+++ b/client/src/forms/Entry.res
@@ -263,7 +263,7 @@ let unsupportedBrowser = (): bool =>
 let newHandler = (m, space, name, modifier, pos) => {
   let tlid = gtlid()
   let spaceid = gid()
-  let handler = {
+  let handler: PT.Handler.t = {
     ast: FluidAST.ofExpr(EBlank(gid())),
     spec: {
       space: F(spaceid, space),
@@ -488,7 +488,7 @@ let submitACItem = (
             h.spec.modifier
           }
 
-          let specInfo: handlerSpec = {
+          let specInfo: PT.Handler.Spec.t = {
             space: h.spec.space,
             name: B.newF(f404.path),
             modifier: modifier,

--- a/client/src/toplevels/CurlCommand.res
+++ b/client/src/toplevels/CurlCommand.res
@@ -68,7 +68,7 @@ let objAsHeaderCurl = (dv: dval): option<string> =>
 let curlFromSpec = (m: model, tlid: TLID.t): option<string> =>
   TL.get(m, tlid)
   |> Option.andThen(~f=TL.asHandler)
-  |> Option.andThen(~f=h => {
+  |> Option.andThen(~f=(h: PT.Handler.t) => {
     let s = h.spec
     switch (s.space, s.name, s.modifier) {
     | (F(_, "HTTP"), F(_, path), F(_, meth)) =>
@@ -118,7 +118,7 @@ let curlFromCurrentTrace = (m: model, tlid: TLID.t): option<string> => {
         let meth =
           TL.get(m, tlid)
           |> Option.andThen(~f=TL.asHandler)
-          |> Option.andThen(~f=h => B.toOption(h.spec.modifier))
+          |> Option.andThen(~f=(h: PT.Handler.t) => B.toOption(h.spec.modifier))
           |> Option.andThen(~f=s => Some("-X " ++ s))
           |> wrapInList
 

--- a/client/src/toplevels/Handlers.res
+++ b/client/src/toplevels/Handlers.res
@@ -5,22 +5,25 @@ module B = BlankOr
 module P = Pointer
 module TD = TLID.Dict
 
-let fromList = (handlers: list<handler>): TLID.Dict.t<handler> =>
-  handlers |> List.map(~f=h => (h.hTLID, h)) |> TLID.Dict.fromList
+let fromList = (handlers: list<PT.Handler.t>): TLID.Dict.t<PT.Handler.t> =>
+  handlers |> List.map(~f=(h: PT.Handler.t) => (h.hTLID, h)) |> TLID.Dict.fromList
 
-let upsert = (m: model, h: handler): model => {
+let upsert = (m: model, h: PT.Handler.t): model => {
   ...m,
   handlers: Map.add(~key=h.hTLID, ~value=h, m.handlers),
 }
 
-let update = (m: model, ~tlid: TLID.t, ~f: handler => handler): model => {
+let update = (m: model, ~tlid: TLID.t, ~f: PT.Handler.t => PT.Handler.t): model => {
   ...m,
   handlers: Map.updateIfPresent(~key=tlid, ~f, m.handlers),
 }
 
-let remove = (m: model, h: handler): model => {...m, handlers: Map.remove(~key=h.hTLID, m.handlers)}
+let remove = (m: model, h: PT.Handler.t): model => {
+  ...m,
+  handlers: Map.remove(~key=h.hTLID, m.handlers),
+}
 
-let getWorkerSchedule = (m: model, h: handler): option<string> =>
+let getWorkerSchedule = (m: model, h: PT.Handler.t): option<string> =>
   switch h.spec.name {
   | F(_, name) => Map.get(~key=name, m.workerSchedules)
   | Blank(_) => None

--- a/client/src/toplevels/Handlers.res
+++ b/client/src/toplevels/Handlers.res
@@ -6,11 +6,11 @@ module P = Pointer
 module TD = TLID.Dict
 
 let fromList = (handlers: list<PT.Handler.t>): TLID.Dict.t<PT.Handler.t> =>
-  handlers |> List.map(~f=(h: PT.Handler.t) => (h.hTLID, h)) |> TLID.Dict.fromList
+  handlers |> List.map(~f=(h: PT.Handler.t) => (h.tlid, h)) |> TLID.Dict.fromList
 
 let upsert = (m: model, h: PT.Handler.t): model => {
   ...m,
-  handlers: Map.add(~key=h.hTLID, ~value=h, m.handlers),
+  handlers: Map.add(~key=h.tlid, ~value=h, m.handlers),
 }
 
 let update = (m: model, ~tlid: TLID.t, ~f: PT.Handler.t => PT.Handler.t): model => {
@@ -20,7 +20,7 @@ let update = (m: model, ~tlid: TLID.t, ~f: PT.Handler.t => PT.Handler.t): model 
 
 let remove = (m: model, h: PT.Handler.t): model => {
   ...m,
-  handlers: Map.remove(~key=h.hTLID, m.handlers),
+  handlers: Map.remove(~key=h.tlid, m.handlers),
 }
 
 let getWorkerSchedule = (m: model, h: PT.Handler.t): option<string> =>

--- a/client/src/toplevels/Introspect.res
+++ b/client/src/toplevels/Introspect.res
@@ -51,11 +51,11 @@ let tipesByName = (uts: TD.t<PT.UserType.t>): Map.String.t<TLID.t> =>
   })
   |> Map.String.fromList
 
-let tlidsToUpdateUsage = (ops: list<op>): list<TLID.t> =>
+let tlidsToUpdateUsage = (ops: list<PT.Op.t>): list<TLID.t> =>
   ops
   |> List.filterMap(~f=op =>
     switch op {
-    | SetHandler(tlid, _, _) | SetExpr(tlid, _, _) => Some(tlid)
+    | PT.Op.SetHandler(tlid, _, _) | SetExpr(tlid, _, _) => Some(tlid)
     | SetFunction(f) => Some(f.tlid)
     | CreateDB(_)
     | DeleteTL(_)

--- a/client/src/toplevels/Introspect.res
+++ b/client/src/toplevels/Introspect.res
@@ -14,9 +14,9 @@ let dbsByName = (dbs: TD.t<PT.DB.t>): Map.String.t<TLID.t> =>
   )
   |> Map.String.fromList
 
-let handlersByName = (hs: TD.t<handler>): Map.String.t<TLID.t> =>
+let handlersByName = (hs: TD.t<PT.Handler.t>): Map.String.t<TLID.t> =>
   hs
-  |> Map.mapValues(~f=h => {
+  |> Map.mapValues(~f=(h: PT.Handler.t) => {
     let space = h.spec.space |> B.toOption |> Option.unwrap(~default="_")
     let name = h.spec.name |> B.toOption |> Option.unwrap(~default="_")
     let key = keyForHandlerSpec(space, name)

--- a/client/src/toplevels/Introspect.res
+++ b/client/src/toplevels/Introspect.res
@@ -20,7 +20,7 @@ let handlersByName = (hs: TD.t<PT.Handler.t>): Map.String.t<TLID.t> =>
     let space = h.spec.space |> B.toOption |> Option.unwrap(~default="_")
     let name = h.spec.name |> B.toOption |> Option.unwrap(~default="_")
     let key = keyForHandlerSpec(space, name)
-    (key, h.hTLID)
+    (key, h.tlid)
   })
   |> Map.String.fromList
 

--- a/client/src/toplevels/SpecHeaders.res
+++ b/client/src/toplevels/SpecHeaders.res
@@ -4,7 +4,7 @@ open Prelude
 module B = BlankOr
 module P = Pointer
 
-let spaceOf = (hs: handlerSpec): handlerSpace => {
+let spaceOf = (hs: PT.Handler.Spec.t): handlerSpace => {
   let spaceOfStr = s => {
     let lwr = String.toUppercase(s)
     switch lwr {
@@ -25,10 +25,14 @@ let spaceOf = (hs: handlerSpec): handlerSpace => {
 let replaceEventModifier = (
   search: id,
   replacement: blankOr<string>,
-  hs: handlerSpec,
-): handlerSpec => {...hs, modifier: B.replace(search, replacement, hs.modifier)}
+  hs: PT.Handler.Spec.t,
+): PT.Handler.Spec.t => {...hs, modifier: B.replace(search, replacement, hs.modifier)}
 
-let replaceEventName = (search: id, replacement: blankOr<string>, hs: handlerSpec): handlerSpec => {
+let replaceEventName = (
+  search: id,
+  replacement: blankOr<string>,
+  hs: PT.Handler.Spec.t,
+): PT.Handler.Spec.t => {
   ...hs,
   name: B.replace(search, replacement, hs.name),
 }
@@ -36,25 +40,29 @@ let replaceEventName = (search: id, replacement: blankOr<string>, hs: handlerSpe
 let replaceEventSpace = (
   search: id,
   replacement: blankOr<string>,
-  hs: handlerSpec,
-): handlerSpec => {...hs, space: B.replace(search, replacement, hs.space)}
+  hs: PT.Handler.Spec.t,
+): PT.Handler.Spec.t => {...hs, space: B.replace(search, replacement, hs.space)}
 
-let replace = (search: id, replacement: blankOr<string>, hs: handlerSpec): handlerSpec =>
+let replace = (
+  search: id,
+  replacement: blankOr<string>,
+  hs: PT.Handler.Spec.t,
+): PT.Handler.Spec.t =>
   hs
   |> replaceEventModifier(search, replacement)
   |> replaceEventName(search, replacement)
   |> replaceEventSpace(search, replacement)
 
-let blankOrData = (spec: handlerSpec): list<blankOrData> => list{
+let blankOrData = (spec: PT.Handler.Spec.t): list<blankOrData> => list{
   PEventSpace(spec.space),
   PEventModifier(spec.modifier),
   PEventName(spec.name),
 }
 
-let firstBlank = (spec: handlerSpec): option<id> =>
+let firstBlank = (spec: PT.Handler.Spec.t): option<id> =>
   spec |> blankOrData |> List.filter(~f=Pointer.isBlank) |> List.head |> Option.map(~f=Pointer.toID)
 
-let lastBlank = (spec: handlerSpec): option<id> =>
+let lastBlank = (spec: PT.Handler.Spec.t): option<id> =>
   spec
   |> blankOrData
   |> List.filter(~f=Pointer.isBlank)

--- a/client/src/toplevels/Toplevel.res
+++ b/client/src/toplevels/Toplevel.res
@@ -66,7 +66,7 @@ let move = (tlid: TLID.t, xOffset: int, yOffset: int, m: model): model => {
   let newPos = p => {x: p.x + xOffset, y: p.y + yOffset}
   {
     ...m,
-    handlers: Map.updateIfPresent(m.handlers, ~key=tlid, ~f=(h: handler) => {
+    handlers: Map.updateIfPresent(m.handlers, ~key=tlid, ~f=(h: PT.Handler.t) => {
       ...h,
       pos: newPos(h.pos),
     }),
@@ -104,7 +104,7 @@ let isUserTipe = (tl: toplevel): bool =>
   | _ => false
   }
 
-let asHandler = (tl: toplevel): option<handler> =>
+let asHandler = (tl: toplevel): option<PT.Handler.t> =>
   switch tl {
   | TLHandler(h) => Some(h)
   | _ => None
@@ -128,11 +128,11 @@ let isHandler = (tl: toplevel): bool =>
   | _ => false
   }
 
-let handlers = (tls: list<toplevel>): list<handler> => List.filterMap(~f=asHandler, tls)
+let handlers = (tls: list<toplevel>): list<PT.Handler.t> => List.filterMap(~f=asHandler, tls)
 
 let dbs = (tls: TD.t<toplevel>): list<PT.DB.t> => tls |> Map.filterMapValues(~f=asDB)
 
-let spaceOfHandler = (h: handler): handlerSpace => SpecHeaders.spaceOf(h.spec)
+let spaceOfHandler = (h: PT.Handler.t): handlerSpace => SpecHeaders.spaceOf(h.spec)
 
 let spaceOf = (tl: toplevel): option<handlerSpace> =>
   tl |> asHandler |> Option.map(~f=spaceOfHandler)
@@ -193,7 +193,7 @@ let setAST = (tl: toplevel, newAST: FluidAST.t): toplevel =>
 
 let withAST = (m: model, tlid: TLID.t, ast: FluidAST.t): model => {
   ...m,
-  handlers: Map.updateIfPresent(m.handlers, ~key=tlid, ~f=h => {...h, ast: ast}),
+  handlers: Map.updateIfPresent(m.handlers, ~key=tlid, ~f=(h: PT.Handler.t) => {...h, ast: ast}),
   userFunctions: Map.updateIfPresent(m.userFunctions, ~key=tlid, ~f=(uf: PT.UserFunction.t) => {
     ...uf,
     ast: ast,
@@ -259,7 +259,7 @@ let replace = (p: blankOrData, replacement: blankOrData, tl: toplevel): toplevel
 }
 
 let combine = (
-  handlers: TD.t<handler>,
+  handlers: TD.t<PT.Handler.t>,
   dbs: TD.t<PT.DB.t>,
   userFunctions: TD.t<PT.UserFunction.t>,
   packageFn: TD.t<packageFn>,

--- a/client/src/toplevels/Toplevel.res
+++ b/client/src/toplevels/Toplevel.res
@@ -31,7 +31,7 @@ let sortkey = (tl: toplevel): string =>
 
 let id = tl =>
   switch tl {
-  | TLHandler(h) => h.hTLID
+  | TLHandler(h) => h.tlid
   | TLDB(db) => db.tlid
   | TLFunc(f) => f.tlid
   | TLPmFunc(f) => f.pfTLID
@@ -150,7 +150,7 @@ let isDeprecatedCustomHandler = (tl: toplevel): bool =>
 
 let toOp = (tl: toplevel): list<op> =>
   switch tl {
-  | TLHandler(h) => list{SetHandler(h.hTLID, h.pos, h)}
+  | TLHandler(h) => list{SetHandler(h.tlid, h.pos, h)}
   | TLFunc(fn) => list{SetFunction(fn)}
   | TLTipe(t) => list{SetType(t)}
   | TLPmFunc(_) => recover("Package Manager functions are not editable", ~debug=id(tl), list{})

--- a/client/src/toplevels/Toplevel.res
+++ b/client/src/toplevels/Toplevel.res
@@ -148,7 +148,7 @@ let isReplHandler = (tl: toplevel): bool => tl |> spaceOf |> \"="(Some(HSRepl))
 let isDeprecatedCustomHandler = (tl: toplevel): bool =>
   tl |> spaceOf |> \"="(Some(HSDeprecatedOther))
 
-let toOp = (tl: toplevel): list<op> =>
+let toOp = (tl: toplevel): list<PT.Op.t> =>
   switch tl {
   | TLHandler(h) => list{SetHandler(h.tlid, h.pos, h)}
   | TLFunc(fn) => list{SetFunction(fn)}
@@ -209,7 +209,7 @@ let setASTMod = (~ops=list{}, tl: toplevel, ast: FluidAST.t): modification =>
       NoChange
     } else {
       AddOps(
-        Belt.List.concat(ops, list{SetHandler(id(tl), h.pos, {...h, ast: ast})}),
+        Belt.List.concat(ops, list{PT.Op.SetHandler(id(tl), h.pos, {...h, ast: ast})}),
         FocusNoChange,
       )
     }

--- a/client/src/toplevels/ViewData.res
+++ b/client/src/toplevels/ViewData.res
@@ -193,7 +193,7 @@ let viewData = (vp: ViewUtils.viewProps): list<Html.html<msg>> => {
   let pauseBtn =
     vp.tl
     |> TL.asHandler
-    |> Option.andThen(~f=h =>
+    |> Option.andThen(~f=(h: PT.Handler.t) =>
       switch (h.spec.space, h.spec.name) {
       | (F(_, "WORKER"), F(_, name)) => Some(pauseWorkerButton(vp, name))
       | _ => None

--- a/client/src/toplevels/ViewHandler.res
+++ b/client/src/toplevels/ViewHandler.res
@@ -41,7 +41,7 @@ let handlerIsExeFail = (vp: viewProps): bool =>
     |> Option.unwrap(~default=false)
   }
 
-let triggerHandlerButton = (vp: viewProps, spec: handlerSpec): Html.html<msg> =>
+let triggerHandlerButton = (vp: viewProps, spec: PT.Handler.Spec.t): Html.html<msg> =>
   switch (spec.space, spec.name, spec.modifier) {
   /* Hide button if spec is not filled out because trace id
    is needed to recover handler traces on refresh. */
@@ -111,7 +111,7 @@ let externalLink = (vp: viewProps, name: string) => {
   "//" ++ (Tea.Http.encodeUri(vp.canvasName) ++ ("." ++ (vp.userContentHost ++ urlPath)))
 }
 
-let viewMenu = (vp: viewProps, spec: handlerSpec): Html.html<msg> => {
+let viewMenu = (vp: viewProps, spec: PT.Handler.Spec.t): Html.html<msg> => {
   let tlid = vp.tlid
   let actions = {
     let commonAction: TLMenu.menuItem = {
@@ -154,7 +154,7 @@ let viewMenu = (vp: viewProps, spec: handlerSpec): Html.html<msg> => {
   TLMenu.viewMenu(vp.menuState, tlid, actions)
 }
 
-let viewEventSpec = (vp: viewProps, spec: handlerSpec, dragEvents: domEventList): Html.html<
+let viewEventSpec = (vp: viewProps, spec: PT.Handler.Spec.t, dragEvents: domEventList): Html.html<
   msg,
 > => {
   let viewEventName = viewText(
@@ -216,7 +216,7 @@ let handlerAttrs: list<Vdom.property<msg>> = list{
   Vdom.noProp,
 }
 
-let view = (vp: viewProps, h: handler, dragEvents: domEventList): list<Html.html<msg>> => {
+let view = (vp: viewProps, h: PT.Handler.t, dragEvents: domEventList): list<Html.html<msg>> => {
   let attrs = handlerAttrs
   let ast = Html.div(attrs, FluidView.view(vp, dragEvents))
   let header = viewEventSpec(vp, h.spec, dragEvents)

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -242,8 +242,8 @@ let renderView = (originalTLID, direction, (tl, originalIDs)) =>
   switch tl {
   | TLDB({tlid, name: F(_, name), cols, _}) =>
     dbView(originalTLID, originalIDs, tlid, name, cols, direction)
-  | TLHandler({hTLID, spec: {space: F(_, space), name: F(_, name), modifier}, _}) =>
-    handlerView(originalTLID, originalIDs, hTLID, space, name, B.toOption(modifier), direction)
+  | TLHandler({tlid, spec: {space: F(_, space), name: F(_, name), modifier}, _}) =>
+    handlerView(originalTLID, originalIDs, tlid, space, name, B.toOption(modifier), direction)
   | TLFunc({tlid, metadata: {name: F(_, name), parameters, returnType, _}, ast: _}) =>
     fnView(originalTLID, originalIDs, tlid, name, parameters, returnType, direction)
   | TLPmFunc(pFn) =>

--- a/client/src/util/ViewUtils.res
+++ b/client/src/util/ViewUtils.res
@@ -280,8 +280,8 @@ let inCh = (w: int): string => w |> string_of_int |> (s => s ++ "ch")
 
 let widthInCh = (w: int): Vdom.property<msg> => w |> inCh |> Html.style("width")
 
-let createHandlerProp = (hs: list<handler>): TD.t<handlerProp> =>
-  hs |> List.map(~f=h => (h.hTLID, Defaults.defaultHandlerProp)) |> TD.fromList
+let createHandlerProp = (hs: list<PT.Handler.t>): TD.t<handlerProp> =>
+  hs |> List.map(~f=(h: PT.Handler.t) => (h.hTLID, Defaults.defaultHandlerProp)) |> TD.fromList
 
 let isHoverOverTL = (vp: viewProps): bool =>
   switch vp.hovering {

--- a/client/src/util/ViewUtils.res
+++ b/client/src/util/ViewUtils.res
@@ -281,7 +281,7 @@ let inCh = (w: int): string => w |> string_of_int |> (s => s ++ "ch")
 let widthInCh = (w: int): Vdom.property<msg> => w |> inCh |> Html.style("width")
 
 let createHandlerProp = (hs: list<PT.Handler.t>): TD.t<handlerProp> =>
-  hs |> List.map(~f=(h: PT.Handler.t) => (h.hTLID, Defaults.defaultHandlerProp)) |> TD.fromList
+  hs |> List.map(~f=(h: PT.Handler.t) => (h.tlid, Defaults.defaultHandlerProp)) |> TD.fromList
 
 let isHoverOverTL = (vp: viewProps): bool =>
   switch vp.hovering {

--- a/client/test/FluidUtils.res
+++ b/client/test/FluidUtils.res
@@ -14,7 +14,7 @@ let debugState = s =>
     },
   })
 
-let h = (expr: FluidExpression.t): handler => {
+let h = (expr: FluidExpression.t): PT.Handler.t => {
   ast: FluidAST.ofExpr(expr),
   hTLID: TLID.fromInt(7),
   pos: {x: 0, y: 0},

--- a/client/test/FluidUtils.res
+++ b/client/test/FluidUtils.res
@@ -16,7 +16,7 @@ let debugState = s =>
 
 let h = (expr: FluidExpression.t): PT.Handler.t => {
   ast: FluidAST.ofExpr(expr),
-  hTLID: TLID.fromInt(7),
+  tlid: TLID.fromInt(7),
   pos: {x: 0, y: 0},
   spec: {
     space: BlankOr.newF("HTTP"),

--- a/client/test/FuzzTests.res
+++ b/client/test/FuzzTests.res
@@ -65,7 +65,7 @@ let processMsg = (inputs: list<fluidInputEvent>, s: fluidState, ast: E.t): (E.t,
   let h = FluidUtils.h(ast)
   let m = {...defaultTestModel, handlers: Handlers.fromList(list{h})}
   List.fold(inputs, ~initial=(h.ast, s, list{}), ~f=((ast, s, _), input) =>
-    updateMsg(m, h.hTLID, ast, s, FluidInputEvent(input))
+    updateMsg(m, h.tlid, ast, s, FluidInputEvent(input))
   ) |> (((ast, s, _)) => (FluidAST.toExpr(ast), s))
 }
 

--- a/client/test/TestAutocomplete.res
+++ b/client/test/TestAutocomplete.res
@@ -52,7 +52,7 @@ let aHandler = (
     modifier: B.ofOption(modifier),
   }
 
-  {ast: FluidAST.ofExpr(expr), spec: spec, hTLID: tlid, pos: {x: 0, y: 0}}
+  {ast: FluidAST.ofExpr(expr), spec: spec, tlid: tlid, pos: {x: 0, y: 0}}
 }
 
 let aFunction = (
@@ -552,11 +552,11 @@ let run = () => {
       let searchCache =
         m.searchCache
         |> Map.add(
-          ~key=http.hTLID,
+          ~key=http.tlid,
           ~value=http.ast |> FluidAST.toExpr |> FluidPrinter.eToHumanString,
         )
         |> Map.add(
-          ~key=repl.hTLID,
+          ~key=repl.tlid,
           ~value=repl.ast |> FluidAST.toExpr |> FluidPrinter.eToHumanString,
         )
         |> Map.add(~key=fn.tlid, ~value=fn.ast |> FluidAST.toExpr |> FluidPrinter.eToHumanString)
@@ -581,7 +581,7 @@ let run = () => {
       test("find field access", () => {
         let foundActions = switch qSearch(m, "request.query") {
         | list{Goto(FocusedHandler(_), tlid, "Found in HTTP::/hello - GET", true)}
-          if tlid == http.hTLID => true
+          if tlid == http.tlid => true
         | _ => false
         }
 
@@ -590,7 +590,7 @@ let run = () => {
       test("find function call", () => {
         let foundActions = switch qSearch(m, "Int::add") {
         | list{Goto(FocusedHandler(_), tlid, "Found in REPL::findingDori", true)}
-          if tlid == repl.hTLID => true
+          if tlid == repl.tlid => true
         | _ => false
         }
 

--- a/client/test/TestAutocomplete.res
+++ b/client/test/TestAutocomplete.res
@@ -45,8 +45,8 @@ let aHandler = (
   ~name: option<string>=None,
   ~modifier: option<string>=None,
   (),
-): handler => {
-  let spec = {
+): PT.Handler.t => {
+  let spec: PT.Handler.Spec.t = {
     space: B.ofOption(space),
     name: B.ofOption(name),
     modifier: B.ofOption(modifier),

--- a/client/test/TestCurl.res
+++ b/client/test/TestCurl.res
@@ -7,7 +7,7 @@ let defaultTLID = TLID.fromInt(7)
 
 let http = (~path: string, ~meth="GET", ()): PT.Handler.t => {
   ast: FluidAST.ofExpr(EBlank(gid())),
-  hTLID: defaultTLID,
+  tlid: defaultTLID,
   pos: {x: 0, y: 0},
   spec: {space: B.newF("HTTP"), name: B.newF(path), modifier: B.newF(meth)},
 }
@@ -75,7 +75,7 @@ let run = () => {
       let cronTLID = gtlid()
       let cron: PT.Handler.t = {
         ast: FluidAST.ofExpr(EBlank(gid())),
-        hTLID: cronTLID,
+        tlid: cronTLID,
         pos: {x: 0, y: 0},
         spec: {
           space: B.newF("CRON"),

--- a/client/test/TestCurl.res
+++ b/client/test/TestCurl.res
@@ -5,7 +5,7 @@ module B = BlankOr
 
 let defaultTLID = TLID.fromInt(7)
 
-let http = (~path: string, ~meth="GET", ()): handler => {
+let http = (~path: string, ~meth="GET", ()): PT.Handler.t => {
   ast: FluidAST.ofExpr(EBlank(gid())),
   hTLID: defaultTLID,
   pos: {x: 0, y: 0},
@@ -73,7 +73,7 @@ let run = () => {
     )
     test("returns None for non-HTTP handlers", () => {
       let cronTLID = gtlid()
-      let cron = {
+      let cron: PT.Handler.t = {
         ast: FluidAST.ofExpr(EBlank(gid())),
         hTLID: cronTLID,
         pos: {x: 0, y: 0},

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -391,7 +391,7 @@ let processMsg = (inputs: list<fluidInputEvent>, astInfo: ASTInfo.t): ASTInfo.t 
   let m = {...defaultTestModel, handlers: Handlers.fromList(list{h})}
   let astInfo = Fluid.updateAutocomplete(m, TLID.fromInt(7), astInfo)
   List.fold(inputs, ~initial=astInfo, ~f=(astInfo: ASTInfo.t, input) =>
-    Fluid.updateMsg'(m, h.hTLID, astInfo, FluidInputEvent(input))
+    Fluid.updateMsg'(m, h.tlid, astInfo, FluidInputEvent(input))
   )
 }
 
@@ -3758,7 +3758,13 @@ let run = () => {
     t("insert space into multi list", multiList, ~pos=6, key(K.Space), "[56,78~]")
     t("insert space into single list", singleElementList, ~pos=3, key(K.Space), "[56~]")
     t("insert into existing list item", singleElementList, ~pos=1, ins("4"), "[4~56]")
-    t("insert separator before item creates blank", singleElementList, ~pos=1, ins(","), "[~___,56]")
+    t(
+      "insert separator before item creates blank",
+      singleElementList,
+      ~pos=1,
+      ins(","),
+      "[~___,56]",
+    )
     t("insert separator after item creates blank", singleElementList, ~pos=3, ins(","), "[56,~___]")
     t(
       "insert separator after separator creates blank",
@@ -3785,7 +3791,13 @@ let run = () => {
     // t "insert separator mid integer makes two items" single (ins ',' 2)
     // ("[5,6]", 3) ;
     // TODO: when on a separator in a nested list, pressing comma makes an entry outside the list.
-    t("insert separator mid string does nothing special ", listWithStr, ~pos=3, ins(","), "[\"a,~b\"]")
+    t(
+      "insert separator mid string does nothing special ",
+      listWithStr,
+      ~pos=3,
+      ins(","),
+      "[\"a,~b\"]",
+    )
     t("backspacing open bracket of empty list dels list", emptyList, ~pos=1, bs, "~___")
     t("backspacing close bracket of empty list moves inside list", emptyList, ~pos=2, bs, "[~]")
     t("deleting open bracket of empty list dels list", emptyList, ~pos=0, del, "~___")
@@ -3992,43 +4004,41 @@ let run = () => {
     )
     ()
   })
-  describe("Tuples",  () => {
+  describe("Tuples", () => {
     describe("render", () => {
-      t(
-        "blank tuple",
-        tuple2WithBothBlank,
-        render,
-        "~(___,___)"
-      )
-      t(
-        "simple tuple",
-        tuple2WithNoBlank,
-        render,
-        "~(56,78)"
-      )
+      t("blank tuple", tuple2WithBothBlank, render, "~(___,___)")
+      t("simple tuple", tuple2WithNoBlank, render, "~(56,78)")
       t(
         "a very long tuple wraps",
         tupleHuge,
         render,
-        "~(56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,\n 56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78)"
+        "~(56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,\n 56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78)",
       )
       t(
         "a tuple of long floats does not break upon wrap",
         tuple(
-          EFloat(gid (), Positive, "4611686018427387", "12345678901234567989048290381902830912830912830912830912309128901234567890123456789"),
-          EFloat(gid (), Positive, "4611686018427387", "1234567890183918309183091809183091283019832345678901234567890123456789"),
-          list{
-            EFloat(gid (), Positive, "4611686018427387", "123456")
-          }
+          EFloat(
+            gid(),
+            Positive,
+            "4611686018427387",
+            "12345678901234567989048290381902830912830912830912830912309128901234567890123456789",
+          ),
+          EFloat(
+            gid(),
+            Positive,
+            "4611686018427387",
+            "1234567890183918309183091809183091283019832345678901234567890123456789",
+          ),
+          list{EFloat(gid(), Positive, "4611686018427387", "123456")},
         ),
         render,
-        "~(4611686018427387.12345678901234567989048290381902830912830912830912830912309128901234567890123456789,\n 4611686018427387.1234567890183918309183091809183091283019832345678901234567890123456789,\n 4611686018427387.123456)"
+        "~(4611686018427387.12345678901234567989048290381902830912830912830912830912309128901234567890123456789,\n 4611686018427387.1234567890183918309183091809183091283019832345678901234567890123456789,\n 4611686018427387.123456)",
       )
       t(
         "a nested very tuple wraps with proper indents",
         let'("a", tupleHuge, b),
         render,
-        "~let a = (56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n         78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,\n         56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n         78,56,78,56,78,56,78,56,78,56,78)\n___"
+        "~let a = (56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n         78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,\n         56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n         78,56,78,56,78,56,78,56,78,56,78)\n___",
       )
       ()
     })
@@ -4038,18 +4048,17 @@ let run = () => {
         tuple(fiftySix, seventyEight, list{fiftySix, seventyEight, fiftySix, seventyEight}),
         ~pos=10, // after the third comma, before the 2nd 78
         ctrlLeft,
-        "(56,78,~56,78,56,78)"
+        "(56,78,~56,78,56,78)",
       )
       t(
         "ctrl+right at the end of tuple item moves to end of next tuple item",
         tuple6,
         ~pos=12,
         ctrlRight,
-        "(56,78,56,78,56~,78)"
+        "(56,78,56,78,56~,78)",
       )
       ()
     })
-
 
     if Fluid.allowUserToCreateTuple {
       describe("create", () => {
@@ -4066,70 +4075,70 @@ let run = () => {
         tuple2WithBothBlank,
         ~pos=0,
         list{InsertText("c")},
-        tuple2WithBothBlank
+        tuple2WithBothBlank,
       )
       t(
         "insert space into multi tuple does nothing",
         tuple2WithNoBlank,
         ~pos=6, // right before closing )
         key(K.Space),
-        "(56,78~)"
+        "(56,78~)",
       )
       t(
         "insert separator after opening parens creates blank",
         tuple(int(1), int(2), list{int(3)}),
         ~pos=1, // after the (
         ins(","),
-        "(~___,1,2,3)"
+        "(~___,1,2,3)",
       )
       t(
         "insert separator before closing parens creates blank",
         tuple(int(1), int(2), list{int(3)}), // (1,2,3)
         ~pos=6, // before the )
         ins(","),
-        "(1,2,3,~___)"
+        "(1,2,3,~___)",
       )
       t(
         "insert separator after separator creates blank",
         tuple(int(1), int(2), list{int(3)}),
         ~pos=5, // after the second comma
         ins(","),
-        "(1,2,~___,3)"
+        "(1,2,~___,3)",
       )
       t(
         "inserting space into simple tuple does nothing",
         tuple2WithNoBlank,
         ~pos=3,
         key(K.Space),
-        "(56~,78)"
+        "(56~,78)",
       )
       t(
         "insert separator before item creates blank",
         tuple2WithNoBlank,
         ~pos=1,
         ins(","),
-        "(~___,56,78)"
+        "(~___,56,78)",
       )
       t(
         "insert separator after item creates blank",
         tuple2WithNoBlank,
         ~pos=6, // after 78
         ins(","),
-        "(56,78,~___)"
+        "(56,78,~___)",
       )
       t(
         "insert , in string in tuple types ,",
         tuple(str("01234567890123456789012345678901234567890"), fiftySix, list{}),
         ~pos=44, // right before the last 0
         ins(","),
-        "(\"0123456789012345678901234567890123456789\n ,~0\",56)"
+        "(\"0123456789012345678901234567890123456789\n ,~0\",56)",
       )
       t(
         "insert separator after item creates blank when tuple is in match",
-        match'(tuple2WithNoBlank, list{(pBlank (), b)}),
+        match'(tuple2WithNoBlank, list{(pBlank(), b)}),
         ~pos=12, // before the closing )
         ins(","),
-        "match (56,78,~___)\n  *** -> ___\n"
+        "match (56,78,~___)\n  *** -> ___\n",
       )
 
       t(
@@ -4137,14 +4146,14 @@ let run = () => {
         tuple2WithNoBlank,
         ~pos=3, // before the first comma
         ins(","),
-        "(56,~78)"
+        "(56,~78)",
       )
       t(
         "insert separator just after another creates blank",
         tuple2WithNoBlank,
         ~pos=4, // just after the comma
         ins(","),
-        "(56,~___,78)"
+        "(56,~___,78)",
       )
 
       t(
@@ -4152,47 +4161,41 @@ let run = () => {
         tuple2WithNoBlank,
         ~pos=2, // halfway through `56`
         ins(","),
-        "(5~6,78)"
+        "(5~6,78)",
       )
       t(
         "insert separator mid string does nothing special ",
         tuple3WithStrs,
         ~pos=3, // in between the a and b of the first str
         ins(","),
-        "(\"a,~b\",\"cd\",\"ef\")"
+        "(\"a,~b\",\"cd\",\"ef\")",
       )
       t(
         "close bracket at end of tuple is swallowed",
         tuple2WithNoBlank,
         ~pos=6, // right before closing )
         ins(")"),
-        "(56,78)~"
+        "(56,78)~",
       )
       ()
     })
 
     describe("delete", () => {
       // 2-tuple, no blanks
-      t(
-        "deleting ( from a filled 2-tuple does nothing",
-        tuple2WithNoBlank,
-        ~pos=0,
-        del,
-        "~(56,78)"
-      )
+      t("deleting ( from a filled 2-tuple does nothing", tuple2WithNoBlank, ~pos=0, del, "~(56,78)")
       t(
         "deleting ) from a filled 2-tuple just moves cursor left",
         tuple2WithNoBlank,
         ~pos=7,
         bs,
-        "(56,78~)"
+        "(56,78~)",
       )
       t(
         "deleting , from a filled 2-tuple leaves only the first item",
         tuple2WithNoBlank, // (56,78)
         ~pos=4, // at the ,
         bs,
-        "56~"
+        "56~",
       )
 
       // 2-tuple, first blank
@@ -4201,21 +4204,21 @@ let run = () => {
         tuple2WithFirstBlank,
         ~pos=0,
         del,
-        "~78"
+        "~78",
       )
       t(
         "deleting ) from a 2-tuple with first value blank just moves the cursor to left of )",
         tuple2WithFirstBlank,
         ~pos=8, // just after )
         bs,
-        "(___,78~)"
+        "(___,78~)",
       )
       t(
         "deleting , from a 2-tuple with first value blank converts to a blank",
         tuple2WithFirstBlank,
         ~pos=4, // just after ,
         del,
-        "~___"
+        "~___",
       )
 
       // 2-tuple, second blank
@@ -4224,21 +4227,21 @@ let run = () => {
         tuple2WithSecondBlank,
         ~pos=0,
         del,
-        "~56"
+        "~56",
       )
       t(
         "deleting ) from a 2-tuple with second value blank just moves the cursor left",
         tuple2WithSecondBlank,
         ~pos=7, // just before )
         del,
-        "(56,___~)"
+        "(56,___~)",
       )
       t(
         "deleting , from a 2-tuple with second value blank converts to the non-blank value",
         tuple2WithSecondBlank,
         ~pos=3, // just before ,
         del,
-        "56~"
+        "56~",
       )
 
       // 2-tuple, both blank
@@ -4247,21 +4250,21 @@ let run = () => {
         tuple2WithBothBlank,
         ~pos=0,
         del,
-        "~___"
+        "~___",
       )
       t(
         "deleting ) from a blank 2-tuple just moves the cursor left",
         tuple2WithBothBlank,
         ~pos=9,
         bs,
-        "(___,___~)"
+        "(___,___~)",
       )
       t(
         "deleting , from a blank 2-tuple replaces the tuple with a blank",
         tuple2WithBothBlank,
         ~pos=5,
         bs,
-        "~___"
+        "~___",
       )
 
       // 3-tuple, no blanks
@@ -4270,28 +4273,28 @@ let run = () => {
         tuple3WithNoBlanks,
         ~pos=0,
         del,
-        "~(56,78,56)"
+        "~(56,78,56)",
       )
       t(
         "deleting ) from a filled 3-tuple just moves cursor left",
         tuple3WithNoBlanks,
         ~pos=10, // just after )
         bs,
-        "(56,78,56~)"
+        "(56,78,56~)",
       )
       t(
         "deleting first , from a filled 3-tuple removes 2nd item",
         tuple3WithNoBlanks,
         ~pos=3, // just before ,
         del,
-        "(56~,56)"
+        "(56~,56)",
       )
       t(
         "deleting second , from a filled 3-tuple removes 3rd item",
         tuple3WithNoBlanks,
         ~pos=6, // just before ,
         del,
-        "(56,78~)"
+        "(56,78~)",
       )
 
       // 3-tuple, first blank
@@ -4300,28 +4303,28 @@ let run = () => {
         tuple3WithFirstBlank,
         ~pos=0,
         del,
-        "~(___,78,56)"
+        "~(___,78,56)",
       )
       t(
         "deleting first , from a 3-tuple with first item blank removes 2nd item",
         tuple3WithFirstBlank,
         ~pos=4, // just before ,
         del,
-        "(~___,56)"
+        "(~___,56)",
       )
       t(
         "deleting second , from a 3-tuple with first item blank removes 3rd item",
         tuple3WithFirstBlank,
         ~pos=8, // just after ,
         bs,
-        "(___,78~)"
+        "(___,78~)",
       )
       t(
         "deleting ) from a 3-tuple with first item blank just moves cursor left",
         tuple3WithFirstBlank,
         ~pos=11, // just after )
         bs,
-        "(___,78,56~)"
+        "(___,78,56~)",
       )
 
       // 3-tuple, second blank
@@ -4330,28 +4333,28 @@ let run = () => {
         tuple3WithSecondBlank,
         ~pos=0,
         del,
-        "~(56,___,78)"
+        "~(56,___,78)",
       )
       t(
         "deleting first , from a 3-tuple with the second item blank removes the blank",
         tuple3WithSecondBlank,
         ~pos=3, // just before ,
         del,
-        "(56~,78)"
+        "(56~,78)",
       )
       t(
         "deleting second , from a 3-tuple with the second item blank removes 3rd item",
         tuple3WithSecondBlank, // (56,___,78)
         ~pos=7, // just before ,
         del,
-        "(56,~___)"
+        "(56,~___)",
       )
       t(
         "deleting ) from a 3-tuple with the second item blank just moves cursor left",
         tuple3WithSecondBlank,
         ~pos=11, // just after )
         bs,
-        "(56,___,78~)"
+        "(56,___,78~)",
       )
 
       // 3-tuple, third blank `(56,78,___)`
@@ -4360,28 +4363,28 @@ let run = () => {
         tuple3WithThirdBlank,
         ~pos=0,
         del,
-        "~(56,78,___)"
+        "~(56,78,___)",
       )
       t(
         "deleting first , from a 3-tuple with the third item blank removes the second item",
         tuple3WithThirdBlank,
         ~pos=3, // just before ,
         del,
-        "(56~,___)" // or maybe 1char to the right of this
+        "(56~,___)", // or maybe 1char to the right of this
       )
       t(
         "deleting second , from a 3-tuple with the third item blank removes the blank",
         tuple3WithThirdBlank,
         ~pos=7, // just after ,
         bs,
-        "(56,78~)"
+        "(56,78~)",
       )
       t(
         "deleting ) from a 3-tuple with the third item blank just moves the cursor left",
         tuple3WithThirdBlank,
         ~pos=11, // just after )
         bs,
-        "(56,78,___~)"
+        "(56,78,___~)",
       )
 
       // 3-tuple, first non-blank `(56,___,___)`
@@ -4390,28 +4393,28 @@ let run = () => {
         tuple3WithFirstFilled,
         ~pos=0,
         del,
-        "~56"
+        "~56",
       )
       t(
         "deleting first , from a 3-tuple with only first item filled ___",
         tuple3WithFirstFilled,
         ~pos=3, // just before ,
         del,
-        "(56~,___)"
+        "(56~,___)",
       )
       t(
         "deleting second , from a 3-tuple with only first item filled ___",
         tuple3WithFirstFilled,
         ~pos=8, // just after ,
         bs,
-        "(56,~___)"
+        "(56,~___)",
       )
       t(
         "deleting ) from a 3-tuple with only first item filled just moves cursor left",
         tuple3WithFirstFilled,
         ~pos=12, // just after )
         bs,
-        "(56,___,___~)"
+        "(56,___,___~)",
       )
 
       // 3-tuple, second non-blank `(___,56,___)`
@@ -4420,28 +4423,28 @@ let run = () => {
         tuple3WithSecondFilled,
         ~pos=0,
         del,
-        "~56"
+        "~56",
       )
       t(
         "deleting first , from a 3-tuple with only second item filled removes the second item",
         tuple3WithSecondFilled,
         ~pos=4, // just before ,
         del,
-        "(~___,___)"
+        "(~___,___)",
       )
       t(
         "deleting second , from a 3-tuple with only second item filled removes the ending blank",
         tuple3WithSecondFilled,
         ~pos=8, // just after ,
         bs,
-        "(___,56~)"
+        "(___,56~)",
       )
       t(
         "deleting ) from a 3-tuple with only second item filled just moves the cursor left",
         tuple3WithSecondFilled,
         ~pos=12, // just after )
         bs,
-        "(___,56,___~)"
+        "(___,56,___~)",
       )
 
       // 3-tuple, third non-blank `(___,___,56)`
@@ -4450,28 +4453,28 @@ let run = () => {
         tuple3WithThirdFilled,
         ~pos=0,
         del,
-        "~56"
+        "~56",
       )
       t(
         "deleting first , from a 3-tuple with only third item filled removes the second blank",
         tuple3WithThirdFilled,
         ~pos=4, // just before ,
         del,
-        "(~___,56)"
+        "(~___,56)",
       )
       t(
         "deleting second , from a 3-tuple with only third item filled removes the filled item",
         tuple3WithThirdFilled,
         ~pos=9, // just after ,
         bs,
-        "(___,~___)"
+        "(___,~___)",
       )
       t(
         "deleting ) from a 3-tuple with only third item filled just moves the cursor left",
         tuple3WithThirdFilled,
         ~pos=12, // just after )
         bs,
-        "(___,___,56~)"
+        "(___,___,56~)",
       )
 
       // 3-tuple, all blank `(___,___,___)`
@@ -4480,28 +4483,28 @@ let run = () => {
         tuple3WithAllBlank,
         ~pos=0,
         del,
-        "~___"
+        "~___",
       )
       t(
         "deleting first , from a 3-tuple of all blanks removes the second blank",
         tuple3WithAllBlank,
         ~pos=4, // just before ,
         del,
-        "(~___,___)"
+        "(~___,___)",
       )
       t(
         "deleting second , from a 3-tuple of all blanks removes the third blank",
         tuple3WithAllBlank,
         ~pos=9, // just after ,
         bs,
-        "(___,~___)"
+        "(___,~___)",
       )
       t(
         "deleting ) from a 3-tuple of all blanks just moves left",
         tuple3WithAllBlank,
         ~pos=13, // just after )
         bs,
-        "(___,___,___~)" // I could see this instead turning into `~___`
+        "(___,___,___~)", // I could see this instead turning into `~___`
       )
       ()
     })
@@ -4893,11 +4896,7 @@ let run = () => {
     t(
       "autocomplete for field autocommits",
       ~clone=false,
-      let'(
-        "x",
-        partial("body", fieldAccess(EVariable(fakeID1, "request"), "longfield")),
-        b,
-      ),
+      let'("x", partial("body", fieldAccess(EVariable(fakeID1, "request"), "longfield")), b),
       // Right should make it commit
       ~pos=20,
       key(K.Right),
@@ -4906,11 +4905,7 @@ let run = () => {
     t(
       "down works on autocomplete for fields",
       ~clone=false,
-      let'(
-        "x",
-        partial("body", fieldAccess(EVariable(fakeID1, "request"), "longfield")),
-        b,
-      ),
+      let'("x", partial("body", fieldAccess(EVariable(fakeID1, "request"), "longfield")), b),
       ~pos=16,
       keys(list{K.Down, K.Enter}),
       "let x = request.formBody~\n___",
@@ -4919,11 +4914,7 @@ let run = () => {
       "autocomplete for field is committed by dot",
       ~clone=false,
       ~expectsPartial=true,
-      EPartial(
-        gid(),
-        "bod",
-        EFieldAccess(gid(), EVariable(fakeID1, "request"), "longfield"),
-      ),
+      EPartial(gid(), "bod", EFieldAccess(gid(), EVariable(fakeID1, "request"), "longfield")),
       // Dot should select the autocomplete
       ~pos=11,
       ins("."),
@@ -4998,7 +4989,7 @@ let run = () => {
       let ast = let'("request", aShortInt, aPartialVar)
       let h = FluidUtils.h(ast)
       let m = {...defaultTestModel, handlers: Handlers.fromList(list{h})}
-      let tlid = h.hTLID
+      let tlid = h.tlid
       expect({
         let (_, newState, _) = updateMsg(
           m,
@@ -5019,7 +5010,7 @@ let run = () => {
       let ast = binop("+", aShortInt, b)
       let h = FluidUtils.h(ast)
       let m = {...defaultTestModel, handlers: Handlers.fromList(list{h})}
-      let tlid = h.hTLID
+      let tlid = h.tlid
       expect({
         let (_, newState, _) = updateMsg(
           m,
@@ -5189,7 +5180,7 @@ let run = () => {
           let h = FluidUtils.h(FluidAST.toExpr(astInfo.ast))
           let m = {...defaultTestModel, handlers: Handlers.fromList(list{h})}
 
-          updateAutocomplete(m, h.hTLID, astInfo)
+          updateAutocomplete(m, h.tlid, astInfo)
         })
         |> updateMouseClick(0)
         |> (

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -78,7 +78,7 @@ let defaultToplevel = TLHandler({
     name: Blank(gid()),
     modifier: Blank(gid()),
   },
-  hTLID: defaultTLID,
+  tlid: defaultTLID,
   pos: Defaults.origin,
 })
 
@@ -117,7 +117,7 @@ let aHandler = (
   | Some(name) => B.newF(name)
   }
   let spec: PT.Handler.Spec.t = {space: space, name: B.new_(), modifier: B.new_()}
-  {ast: FluidAST.ofExpr(expr), spec: spec, hTLID: tlid, pos: {x: 0, y: 0}}
+  {ast: FluidAST.ofExpr(expr), spec: spec, tlid: tlid, pos: {x: 0, y: 0}}
 }
 
 let aFunction = (~tlid=defaultTLID, ~expr=defaultExpr, ()): PT.UserFunction.t => {

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -106,12 +106,17 @@ let defaultFullQuery = (~tl=defaultToplevel, ac: AC.t, queryString: string): AC.
   {tl: tl, ti: ti, fieldList: list{}, pipedDval: None, queryString: queryString}
 }
 
-let aHandler = (~tlid=defaultTLID, ~expr=defaultExpr, ~space: option<string>=None, ()): handler => {
+let aHandler = (
+  ~tlid=defaultTLID,
+  ~expr=defaultExpr,
+  ~space: option<string>=None,
+  (),
+): PT.Handler.t => {
   let space = switch space {
   | None => B.new_()
   | Some(name) => B.newF(name)
   }
-  let spec = {space: space, name: B.new_(), modifier: B.new_()}
+  let spec: PT.Handler.Spec.t = {space: space, name: B.new_(), modifier: B.new_()}
   {ast: FluidAST.ofExpr(expr), spec: spec, hTLID: tlid, pos: {x: 0, y: 0}}
 }
 

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -37,7 +37,7 @@ let execute_roundtrip = (ast: fluidExpr) => {
     {
       ...defaultTestModel,
       handlers: Handlers.fromList(list{h}),
-      cursorState: FluidEntering(h.hTLID),
+      cursorState: FluidEntering(h.tlid),
       fluidState: {
         ...defaultTestState,
         selectionStart: Some(0),
@@ -75,7 +75,7 @@ let run = () => {
       ...defaultTestModel,
       handlers: Handlers.fromList(list{h}),
       functions: Functions.update(defaultFunctionsProps, defaultTestModel.functions),
-      cursorState: FluidEntering(h.hTLID),
+      cursorState: FluidEntering(h.tlid),
       fluidState: {
         ...defaultTestState,
         selectionStart: Some(start),
@@ -201,7 +201,7 @@ let run = () => {
       let preCopyModel = {
         ...defaultTestModel,
         handlers: Handlers.fromList(list{h}),
-        cursorState: FluidEntering(h.hTLID),
+        cursorState: FluidEntering(h.tlid),
         fluidState: {
           ...defaultTestState,
           selectionStart: Some(start),
@@ -1201,14 +1201,14 @@ let run = () => {
       b,
       (0, 0),
       "(12,34)",
-      "(12,34)~"
+      "(12,34)~",
     )
     testPasteText(
       "pasting a 3-tuple from clipboard on a blank should paste it",
       b,
       (0, 0),
       "(12,34,56)",
-      "(12,34,56)~"
+      "(12,34,56)~",
     )
 
     ()

--- a/client/test/TestFluidCommands.res
+++ b/client/test/TestFluidCommands.res
@@ -10,7 +10,7 @@ let makeTL = ast => TLHandler({
     name: Blank(gid()),
     modifier: Blank(gid()),
   },
-  hTLID: TLID.fromInt(7),
+  tlid: TLID.fromInt(7),
   pos: Defaults.origin,
 })
 

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -18,7 +18,7 @@ let pToString = Printer.pToString
 
 let h = (expr): PT.Handler.t => {
   ast: FluidAST.ofExpr(expr),
-  hTLID: TLID.fromInt(7),
+  tlid: TLID.fromInt(7),
   spec: {
     space: BlankOr.newF("HTTP"),
     name: BlankOr.newF("/test"),
@@ -77,7 +77,7 @@ let run = () => {
 
       let astInfo = Fluid.updateAutocomplete(m, TLID.fromInt(7), astInfo)
       List.fold(inputs, ~initial=astInfo, ~f=(astInfo: ASTInfo.t, input) =>
-        Fluid.updateMsg'(m, h.hTLID, astInfo, FluidInputEvent(input))
+        Fluid.updateMsg'(m, h.tlid, astInfo, FluidInputEvent(input))
       )
     }
 

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -16,7 +16,7 @@ let eToTestString = Printer.eToTestString
 
 let pToString = Printer.pToString
 
-let h = expr => {
+let h = (expr): PT.Handler.t => {
   ast: FluidAST.ofExpr(expr),
   hTLID: TLID.fromInt(7),
   spec: {

--- a/client/test/TestIntrospect.res
+++ b/client/test/TestIntrospect.res
@@ -14,7 +14,7 @@ let run = () => {
         name: B.newF("processOrder"),
         modifier: B.new_(),
       },
-      hTLID: h1tlid,
+      tlid: h1tlid,
       pos: {x: 0, y: 0},
     }
 
@@ -29,7 +29,7 @@ let run = () => {
         name: B.newF("/hello"),
         modifier: B.newF("GET"),
       },
-      hTLID: h2tlid,
+      tlid: h2tlid,
       pos: {x: 0, y: 0},
     }
 
@@ -43,7 +43,7 @@ let run = () => {
     }
 
     let dbs = TD.fromList(list{(dbdata.tlid, dbdata)})
-    let handlers = TD.fromList(list{(h1data.hTLID, h1data), (h2data.hTLID, h2data)})
+    let handlers = TD.fromList(list{(h1data.tlid, h1data), (h2data.tlid, h2data)})
 
     test("dbsByName", () =>
       expect(dbsByName(dbs)) |> toEqual(Map.add(~key="Books", ~value=dbtlid, Map.String.empty))

--- a/client/test/TestIntrospect.res
+++ b/client/test/TestIntrospect.res
@@ -7,7 +7,7 @@ module B = BlankOr
 let run = () => {
   describe("Introspect", () => {
     let h1tlid = gtlid()
-    let h1data = {
+    let h1data: PT.Handler.t = {
       ast: FluidAST.ofExpr(EBlank(gid())),
       spec: {
         space: B.newF("WORKER"),
@@ -20,7 +20,7 @@ let run = () => {
 
     let h2tlid = gtlid()
     let dbRefID = gid()
-    let h2data = {
+    let h2data: PT.Handler.t = {
       ast: FluidAST.ofExpr(
         EFnCall(gid(), "DB::deleteAll_v1", list{EVariable(dbRefID, "Books")}, NoRail),
       ),

--- a/client/test/TestIntrospect.res
+++ b/client/test/TestIntrospect.res
@@ -75,7 +75,7 @@ let run = () => {
     test("tlidsToUpdateUsage", () => {
       let fntlid = gtlid()
       let ops = list{
-        SetHandler(h1tlid, {x: 0, y: 0}, h1data),
+        PT.Op.SetHandler(h1tlid, {x: 0, y: 0}, h1data),
         SetExpr(h1tlid, gid(), EBlank(gid())),
         SetFunction({
           tlid: fntlid,

--- a/client/test/TestPage.res
+++ b/client/test/TestPage.res
@@ -21,7 +21,7 @@ let aHandler = (
   | None => B.new_()
   | Some(name) => B.newF(name)
   }
-  let spec = {space: space, name: B.new_(), modifier: B.new_()}
+  let spec: PT.Handler.Spec.t = {space: space, name: B.new_(), modifier: B.new_()}
   TLHandler({ast: FluidAST.ofExpr(expr), spec: spec, hTLID: tlid, pos: pos})
 }
 

--- a/client/test/TestPage.res
+++ b/client/test/TestPage.res
@@ -22,7 +22,7 @@ let aHandler = (
   | Some(name) => B.newF(name)
   }
   let spec: PT.Handler.Spec.t = {space: space, name: B.new_(), modifier: B.new_()}
-  TLHandler({ast: FluidAST.ofExpr(expr), spec: spec, hTLID: tlid, pos: pos})
+  TLHandler({ast: FluidAST.ofExpr(expr), spec: spec, tlid: tlid, pos: pos})
 }
 
 let run = () => {

--- a/client/test/TestRefactor.res
+++ b/client/test/TestRefactor.res
@@ -64,7 +64,7 @@ let sampleFunctions: list<RT.BuiltInFn.t> = {
 let defaultTLID = TLID.fromInt(7)
 
 let defaultHandler: PT.Handler.t = {
-  hTLID: defaultTLID,
+  tlid: defaultTLID,
   pos: {x: 0, y: 0},
   ast: FluidAST.ofExpr(EBlank(gid())),
   spec: {space: B.newF("HTTP"), name: B.newF("/src"), modifier: B.newF("POST")},
@@ -203,7 +203,7 @@ let run = () => {
           name: B.newF("/src"),
           modifier: B.newF("POST"),
         },
-        hTLID: TLID.fromInt(5),
+        tlid: TLID.fromInt(5),
         pos: {x: 0, y: 0},
       }
 
@@ -246,7 +246,7 @@ let run = () => {
           name: B.newF("/src"),
           modifier: B.newF("POST"),
         },
-        hTLID: defaultTLID,
+        tlid: defaultTLID,
         pos: {x: 0, y: 0},
       }
 
@@ -330,9 +330,9 @@ let run = () => {
   })
   describe("extractVarInAst", () => {
     let modelAndTl = (ast: FluidAST.t) => {
-      let hTLID = defaultTLID
+      let tlid = defaultTLID
       let tl: PT.Handler.t = {
-        hTLID: hTLID,
+        tlid: tlid,
         ast: ast,
         pos: {x: 0, y: 0},
         spec: {
@@ -345,7 +345,7 @@ let run = () => {
       let m = {
         ...D.defaultModel,
         functions: Functions.empty |> Functions.setBuiltins(sampleFunctions, defaultFunctionsProps),
-        handlers: list{(hTLID, tl)} |> TLID.Dict.fromList,
+        handlers: list{(tlid, tl)} |> TLID.Dict.fromList,
         fluidState: {...Defaults.defaultFluidState, ac: FluidAutocomplete.init},
       }
 

--- a/client/test/TestRefactor.res
+++ b/client/test/TestRefactor.res
@@ -63,7 +63,7 @@ let sampleFunctions: list<RT.BuiltInFn.t> = {
 
 let defaultTLID = TLID.fromInt(7)
 
-let defaultHandler = {
+let defaultHandler: PT.Handler.t = {
   hTLID: defaultTLID,
   pos: {x: 0, y: 0},
   ast: FluidAST.ofExpr(EBlank(gid())),
@@ -196,7 +196,7 @@ let run = () => {
     }
 
     test("datastore renamed, handler updates variable", () => {
-      let h = {
+      let h: PT.Handler.t = {
         ast: FluidAST.ofExpr(EVariable(gid(), "ElmCode")),
         spec: {
           space: B.newF("HTTP"),
@@ -239,7 +239,7 @@ let run = () => {
       expect(res) |> toEqual(true)
     })
     test("datastore renamed, handler does not change", () => {
-      let h = {
+      let h: PT.Handler.t = {
         ast: FluidAST.ofExpr(EVariable(gid(), "request")),
         spec: {
           space: B.newF("HTTP"),
@@ -331,7 +331,7 @@ let run = () => {
   describe("extractVarInAst", () => {
     let modelAndTl = (ast: FluidAST.t) => {
       let hTLID = defaultTLID
-      let tl = {
+      let tl: PT.Handler.t = {
         hTLID: hTLID,
         ast: ast,
         pos: {x: 0, y: 0},

--- a/client/test/TestRefactor.res
+++ b/client/test/TestRefactor.res
@@ -227,7 +227,7 @@ let run = () => {
       }
 
       let ops = R.renameDBReferences(model, "ElmCode", "WeirdCode")
-      let res = switch List.sortBy(~f=Encoders.tlidOf, ops) {
+      let res = switch List.sortBy(~f=PT.Op.tlidOf, ops) {
       | list{SetHandler(_, _, h), SetFunction(f)} =>
         switch (FluidAST.toExpr(h.ast), FluidAST.toExpr(f.ast)) {
         | (EVariable(_, "WeirdCode"), EVariable(_, "WeirdCode")) => true

--- a/client/test/TestUserfn.res
+++ b/client/test/TestUserfn.res
@@ -25,7 +25,7 @@ let aHandler = (
   | Some(name) => B.newF(name)
   }
   let spec: PT.Handler.Spec.t = {space: space, name: B.new_(), modifier: B.new_()}
-  TLHandler({ast: FluidAST.ofExpr(expr), spec: spec, hTLID: tlid, pos: pos})
+  TLHandler({ast: FluidAST.ofExpr(expr), spec: spec, tlid: tlid, pos: pos})
 }
 
 let aFn = (

--- a/client/test/TestUserfn.res
+++ b/client/test/TestUserfn.res
@@ -24,7 +24,7 @@ let aHandler = (
   | None => B.new_()
   | Some(name) => B.newF(name)
   }
-  let spec = {space: space, name: B.new_(), modifier: B.new_()}
+  let spec: PT.Handler.Spec.t = {space: space, name: B.new_(), modifier: B.new_()}
   TLHandler({ast: FluidAST.ofExpr(expr), spec: spec, hTLID: tlid, pos: pos})
 }
 


### PR DESCRIPTION
Continuation of #4284 and #4283. Completes the following tasks:

- move ops to a module in programtypes
- move tlidOf to Ops module
- put handler in a module in ProgramTypes
- remove the field prefixes used by handler