### PR TITLE
Switch Presence URL to dark-editor canvas

### DIFF
--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -220,7 +220,7 @@ let integration = (m: model, name: string): Tea.Cmd.t<msg> =>
   )
 
 let sendPresence = (m: model, av: avatarModelMessage): Tea.Cmd.t<msg> => {
-  let url = "https://presence.darklang.com/presence"
+  let url = "https://editor.darklang.com/presence"
   let request = postJson(
     ~headers=list{clientVersionHeader(m)},
     ~withCredentials=true,
@@ -232,9 +232,9 @@ let sendPresence = (m: model, av: avatarModelMessage): Tea.Cmd.t<msg> => {
 
   /* If origin is https://darklang.com, then we're in prod (or ngrok, running
    * against prod) and
-   * presence.darklang.com's CORS rules will allow this request. If not, we're
+   * editor.darklang.com's CORS rules will allow this request. If not, we're
    * in local, and both CORS and auth (session, canvas_id) will not work against
-   * presence.darklang.com. By putting the conditional here instead of at the
+   * editor.darklang.com. By putting the conditional here instead of at the
    * beginning of the function, we still exercise the message and request
    * generating code locally. */
   if m.origin == "https://darklang.com" {

--- a/docs/production/what-to-do-if-something-goes-wrong.md
+++ b/docs/production/what-to-do-if-something-goes-wrong.md
@@ -186,6 +186,6 @@ These can be rolled back: `kubectl rollout undo ...` TODO
 
 ## Other services:
 
-- user signup happen on the ops-adduser canvas (accounts.darklang.com)
+- user signup happen on the `ops-adduser` canvas (accounts.darklang.com)
 - user signin happens via login.darklang.com
-- presence notifcations are on the ops-presence canvas (presence.darklang.com)
+- presence notifications are on the `dark-editor` canvas (editor.darklang.com)


### PR DESCRIPTION
This is the final step of, and will resolve #4266.

Functionality has been ported from `ops-presence` to `dark-editor`. Some minor changes have been made to the `/presence` endpoint code, to account for the "cors feature" of Dark (which we plan to deprecate) being enabled in `ops-presence` but not in `dark-editor`.

I've tested this locally, and all seems good.