### PR TITLE
Add StdLib fns for Tuples

### DIFF
--- a/fsharp-backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
+++ b/fsharp-backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
@@ -27,7 +27,8 @@
     <Compile Include="LibOption.fs" />
     <Compile Include="LibResult.fs" />
     <Compile Include="LibString.fs" />
-    <Compile Include="LibTuple.fs" />
+    <Compile Include="LibTuple2.fs" />
+    <Compile Include="LibTuple3.fs" />
     <Compile Include="LibUuid.fs" />
     <Compile Include="LibCrypto.fs" />
     <Compile Include="LibHttpClientAuth.fs" />

--- a/fsharp-backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
+++ b/fsharp-backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="LibOption.fs" />
     <Compile Include="LibResult.fs" />
     <Compile Include="LibString.fs" />
+    <Compile Include="LibTuple.fs" />
     <Compile Include="LibUuid.fs" />
     <Compile Include="LibCrypto.fs" />
     <Compile Include="LibHttpClientAuth.fs" />

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -42,6 +42,21 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "Tuple2" "swap" 0
+      parameters =
+        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "b", TVariable "a", [])
+      description = "Returns a 2-tuple with the elements swapped."
+      fn =
+        (function
+        | state, [ DTuple (first, second, []) ] ->
+          Ply(DTuple (second, first, []))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
     // Tuple3
     { name = fn "Tuple3" "first" 0
       parameters =

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -13,16 +13,15 @@ let err (str : string) = Ply(Dval.errStr str)
 let incorrectArgs = Errors.incorrectArgs
 
 let fns : List<BuiltInFn> =
-  [ { name = fn "Tuple2" "first" 0
-      parameters = [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+  [ // Tuple2
+    { name = fn "Tuple2" "first" 0
+      parameters =
+        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "a"
-      description =
-        // TODO: improve this text
-        "Returns the first part of a 2-tuple."
+      description = "Returns the first part of a 2-tuple."
       fn =
         (function
-        | state, [ DTuple (first, _second, []) ] ->
-          Ply(first)
+        | state, [ DTuple (first, _second, []) ] -> Ply(first)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -30,15 +29,65 @@ let fns : List<BuiltInFn> =
 
 
     { name = fn "Tuple2" "second" 0
-      parameters = [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      parameters =
+        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "b"
-      description =
-        // TODO: improve this text
-        "Returns the second part of a 2-tuple."
+      description = "Returns the second part of a 2-tuple."
       fn =
         (function
-        | state, [ DTuple (_first, second, []) ] ->
-          Ply(second)
+        | state, [ DTuple (_first, second, []) ] -> Ply(second)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    // Tuple3
+    { name = fn "Tuple3" "first" 0
+      parameters =
+        [ Param.make
+            "tuple"
+            (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
+            "" ]
+      returnType = TVariable "a"
+      description = "Returns the first part of a 3-tuple."
+      fn =
+        (function
+        | state, [ DTuple (first, _second, [ _third ]) ] -> Ply(first)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple3" "second" 0
+      parameters =
+        [ Param.make
+            "tuple"
+            (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
+            "" ]
+      returnType = TVariable "b"
+      description = "Returns the second part of a 3-tuple."
+      fn =
+        (function
+        | state, [ DTuple (_first, second, [ _third ]) ] -> Ply(second)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple3" "third" 0
+      parameters =
+        [ Param.make
+            "tuple"
+            (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
+            "" ]
+      returnType = TVariable "c"
+      description = "Returns the third part of a 3-tuple."
+      fn =
+        (function
+        | state, [ DTuple (_first, _second, [ third ]) ] -> Ply(third)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -4,6 +4,8 @@ open Prelude
 open LibExecution.RuntimeTypes
 open LibExecution.VendoredTablecloth
 
+module Interpreter = LibExecution.Interpreter
+
 module Errors = LibExecution.Errors
 
 let fn = FQFnName.stdlibFnName
@@ -65,6 +67,30 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [ DTuple (first, second, []) ] -> Ply(DTuple(second, first, []))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "mapFirst" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fn"
+            (TFn([ TVariable "a" ], TVariable "c"))
+            ""
+            [ "val" ]
+          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "c", TVariable "b", [])
+      description = "Transform the first value in a 3-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fn; DTuple (first, second, []) ] ->
+          uply {
+            let! newFirst =
+              Interpreter.applyFnVal state (id 0) fn [ first ] NotInPipe NoRail
+            return DTuple(newFirst, second, [])
+          }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -14,6 +14,21 @@ let incorrectArgs = Errors.incorrectArgs
 
 let fns : List<BuiltInFn> =
   [ // Tuple2
+    { name = fn "Tuple2" "pair" 0
+      parameters =
+        [ Param.make "first" (TVariable "a") ""
+          Param.make "second" (TVariable "b") "" ]
+      returnType = TTuple(TVariable "a", TVariable "b", [])
+      description = "Returns a new 2-tuple with the given values."
+      fn =
+        (function
+        | state, [ first; second ] -> Ply(DTuple(first, second, []))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
     { name = fn "Tuple2" "first" 0
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
@@ -49,8 +64,7 @@ let fns : List<BuiltInFn> =
       description = "Returns a 2-tuple with the elements swapped."
       fn =
         (function
-        | state, [ DTuple (first, second, []) ] ->
-          Ply(DTuple (second, first, []))
+        | state, [ DTuple (first, second, []) ] -> Ply(DTuple(second, first, []))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -12,4 +12,34 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = Errors.incorrectArgs
 
-let fns : List<BuiltInFn> = []
+let fns : List<BuiltInFn> =
+  [ { name = fn "Tuple2" "first" 0
+      parameters = [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TVariable "a"
+      description =
+        // TODO: improve this text
+        "Returns the first part of a 2-tuple."
+      fn =
+        (function
+        | state, [ DTuple (first, _second, []) ] ->
+          Ply(first)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "second" 0
+      parameters = [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TVariable "b"
+      description =
+        // TODO: improve this text
+        "Returns the second part of a 2-tuple."
+      fn =
+        (function
+        | state, [ DTuple (_first, second, []) ] ->
+          Ply(second)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated } ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -33,7 +33,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "a"
-      description = "Returns the first part of a 2-tuple."
+      description = "Returns the first value of a 2-tuple."
       fn =
         (function
         | state, [ DTuple (first, _second, []) ] -> Ply(first)
@@ -47,7 +47,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "b"
-      description = "Returns the second part of a 2-tuple."
+      description = "Returns the second value of a 2-tuple."
       fn =
         (function
         | state, [ DTuple (_first, second, []) ] -> Ply(second)
@@ -79,7 +79,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "a"
-      description = "Returns the first part of a 3-tuple."
+      description = "Returns the first value of a 3-tuple."
       fn =
         (function
         | state, [ DTuple (first, _second, [ _third ]) ] -> Ply(first)
@@ -96,7 +96,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "b"
-      description = "Returns the second part of a 3-tuple."
+      description = "Returns the second value of a 3-tuple."
       fn =
         (function
         | state, [ DTuple (_first, second, [ _third ]) ] -> Ply(second)
@@ -113,7 +113,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "c"
-      description = "Returns the third part of a 3-tuple."
+      description = "Returns the third value of a 3-tuple."
       fn =
         (function
         | state, [ DTuple (_first, _second, [ third ]) ] -> Ply(third)

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -82,7 +82,7 @@ let fns : List<BuiltInFn> =
             [ "val" ]
           Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "c", TVariable "b", [])
-      description = "Transform the first value in a 3-tuple."
+      description = "Transform the first value in a 2-tuple."
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, []) ] ->
@@ -90,6 +90,65 @@ let fns : List<BuiltInFn> =
             let! newFirst =
               Interpreter.applyFnVal state (id 0) fn [ first ] NotInPipe NoRail
             return DTuple(newFirst, second, [])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "mapSecond" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fn"
+            (TFn([ TVariable "b" ], TVariable "c"))
+            ""
+            [ "val" ]
+          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "a", TVariable "c", [])
+      description = "Transform the second value in a 2-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fn; DTuple (first, second, []) ] ->
+          uply {
+            let! newSecond =
+              Interpreter.applyFnVal state (id 0) fn [ second ] NotInPipe NoRail
+            return DTuple(first, newSecond, [])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "mapBoth" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fnFirst"
+            (TFn([ TVariable "a" ], TVariable "c"))
+            "used to map the first value in the tuple"
+            [ "val" ]
+
+          Param.makeWithArgs
+            "fnSecond"
+            (TFn([ TVariable "b" ], TVariable "d"))
+            "used to map the second value in the tuple"
+            [ "val" ]
+
+          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "c", TVariable "d", [])
+      description = "Transform both values in a 2-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fnFst; DFnVal fnSnd; DTuple (first, second, []) ] ->
+          uply {
+            let! newFirst =
+              Interpreter.applyFnVal state (id 0) fnFst [ first ] NotInPipe NoRail
+
+            let! newSecond =
+              Interpreter.applyFnVal state (id 0) fnSnd [ second ] NotInPipe NoRail
+
+            return DTuple(newFirst, newSecond, [])
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -1,0 +1,15 @@
+module LibExecutionStdLib.LibTuple
+
+open Prelude
+open LibExecution.RuntimeTypes
+open LibExecution.VendoredTablecloth
+
+module Errors = LibExecution.Errors
+
+let fn = FQFnName.stdlibFnName
+
+let err (str : string) = Ply(Dval.errStr str)
+
+let incorrectArgs = Errors.incorrectArgs
+
+let fns : List<BuiltInFn> = []

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple.fs
@@ -14,6 +14,8 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = Errors.incorrectArgs
 
+// TODO consider breaking this into `tuple2fns` and `tuple3fns` in-code,
+// and then `let fns = tuple2fns @ tuple3fns. (may help with legibility?)
 let fns : List<BuiltInFn> =
   [ // Tuple2
     { name = fn "Tuple2" "pair" 0
@@ -202,6 +204,144 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [ DTuple (_first, _second, [ third ]) ] -> Ply(third)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple3" "mapFirst" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fn"
+            (TFn([ TVariable "a" ], TVariable "d"))
+            ""
+            [ "val" ]
+          Param.make
+            "tuple"
+            (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
+            "" ]
+      returnType = TTuple(TVariable "d", TVariable "b", [ TVariable "c" ])
+      description = "Transform the first value in a 3-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
+          uply {
+            let! newFirst =
+              Interpreter.applyFnVal state (id 0) fn [ first ] NotInPipe NoRail
+            return DTuple(newFirst, second, [ third ])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple3" "mapSecond" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fn"
+            (TFn([ TVariable "b" ], TVariable "d"))
+            ""
+            [ "val" ]
+          Param.make
+            "tuple"
+            (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
+            "" ]
+      returnType = TTuple(TVariable "a", TVariable "d", [ TVariable "c" ])
+      description = "Transform the second value in a 3-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
+          uply {
+            let! newSecond =
+              Interpreter.applyFnVal state (id 0) fn [ second ] NotInPipe NoRail
+            return DTuple(first, newSecond, [ third ])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple3" "mapThird" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fn"
+            (TFn([ TVariable "c" ], TVariable "d"))
+            ""
+            [ "val" ]
+          Param.make
+            "tuple"
+            (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
+            "" ]
+      returnType = TTuple(TVariable "a", TVariable "b", [ TVariable "d" ])
+      description = "Transform the third value in a 3-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
+          uply {
+            let! newThird =
+              Interpreter.applyFnVal state (id 0) fn [ third ] NotInPipe NoRail
+            return DTuple(first, second, [ newThird ])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple3" "mapAllThree" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fnFirst"
+            (TFn([ TVariable "a" ], TVariable "d"))
+            "used to map the first value in the tuple"
+            [ "val" ]
+
+          Param.makeWithArgs
+            "fnSecond"
+            (TFn([ TVariable "b" ], TVariable "e"))
+            "used to map the second value in the tuple"
+            [ "val" ]
+
+          Param.makeWithArgs
+            "fnThird"
+            (TFn([ TVariable "c" ], TVariable "f"))
+            "used to map the third value in the tuple"
+            [ "val" ]
+
+          Param.make
+            "tuple"
+            (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
+            "" ]
+      returnType = TTuple(TVariable "d", TVariable "e", [ TVariable "f" ])
+      description = "Transform all values in a 3-tuple."
+      fn =
+        (function
+        | state,
+          [ DFnVal fnFirst
+            DFnVal fnSecond
+            DFnVal fnThird
+            DTuple (first, second, [ third ]) ] ->
+          uply {
+            let! newFirst =
+              Interpreter.applyFnVal state (id 0) fnFirst [ first ] NotInPipe NoRail
+
+            let! newSecond =
+              Interpreter.applyFnVal
+                state
+                (id 0)
+                fnSecond
+                [ second ]
+                NotInPipe
+                NoRail
+
+            let! newThird =
+              Interpreter.applyFnVal state (id 0) fnThird [ third ] NotInPipe NoRail
+
+            return DTuple(newFirst, newSecond, [ newThird ])
+          }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
@@ -23,7 +23,7 @@ let fns : List<BuiltInFn> =
         [ Param.make "first" (TVariable "a") ""
           Param.make "second" (TVariable "b") "" ]
       returnType = TTuple(TVariable "a", TVariable "b", [])
-      description = "Returns a 2-tuple with the given values."
+      description = "Returns a 2-tuple with the given values"
       fn =
         (function
         | state, [ first; second ] -> Ply(DTuple(first, second, []))
@@ -37,7 +37,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "a"
-      description = "Returns the first value of a 2-tuple."
+      description = "Returns the first value of a 2-tuple"
       fn =
         (function
         | state, [ DTuple (first, _second, []) ] -> Ply(first)
@@ -51,7 +51,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "b"
-      description = "Returns the second value of a 2-tuple."
+      description = "Returns the second value of a 2-tuple"
       fn =
         (function
         | state, [ DTuple (_first, second, []) ] -> Ply(second)
@@ -65,7 +65,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "b", TVariable "a", [])
-      description = "Returns a 2-tuple with the elements swapped."
+      description = "Returns a 2-tuple with the elements swapped"
       fn =
         (function
         | state, [ DTuple (first, second, []) ] -> Ply(DTuple(second, first, []))
@@ -84,7 +84,7 @@ let fns : List<BuiltInFn> =
             [ "val" ]
           Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "c", TVariable "b", [])
-      description = "Transform the first value in a 2-tuple."
+      description = "Transform the first value in a 2-tuple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, []) ] ->
@@ -108,7 +108,7 @@ let fns : List<BuiltInFn> =
             [ "val" ]
           Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "a", TVariable "c", [])
-      description = "Transform the second value in a 2-tuple."
+      description = "Transform the second value in a 2-tuple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, []) ] ->
@@ -139,7 +139,7 @@ let fns : List<BuiltInFn> =
 
           Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "c", TVariable "d", [])
-      description = "Transform both values in a 2-tuple."
+      description = "Transform both values in a 2-tuple"
       fn =
         (function
         | state, [ DFnVal fnFst; DFnVal fnSnd; DTuple (first, second, []) ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
@@ -1,0 +1,158 @@
+/// StdLib functions to create and utilize tuples with 2 elements
+module LibExecutionStdLib.LibTuple2
+
+open Prelude
+open LibExecution.RuntimeTypes
+open LibExecution.VendoredTablecloth
+
+module Interpreter = LibExecution.Interpreter
+
+module Errors = LibExecution.Errors
+
+let fn = FQFnName.stdlibFnName
+
+let err (str : string) = Ply(Dval.errStr str)
+
+let incorrectArgs = Errors.incorrectArgs
+
+// TODO consider breaking this into `tuple2fns` and `tuple3fns` in-code,
+// and then `let fns = tuple2fns @ tuple3fns. (may help with legibility?)
+let fns : List<BuiltInFn> =
+  [ { name = fn "Tuple2" "create" 0
+      parameters =
+        [ Param.make "first" (TVariable "a") ""
+          Param.make "second" (TVariable "b") "" ]
+      returnType = TTuple(TVariable "a", TVariable "b", [])
+      description = "Returns a 2-tuple with the given values."
+      fn =
+        (function
+        | state, [ first; second ] -> Ply(DTuple(first, second, []))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "first" 0
+      parameters =
+        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TVariable "a"
+      description = "Returns the first value of a 2-tuple."
+      fn =
+        (function
+        | state, [ DTuple (first, _second, []) ] -> Ply(first)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "second" 0
+      parameters =
+        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TVariable "b"
+      description = "Returns the second value of a 2-tuple."
+      fn =
+        (function
+        | state, [ DTuple (_first, second, []) ] -> Ply(second)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "swap" 0
+      parameters =
+        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "b", TVariable "a", [])
+      description = "Returns a 2-tuple with the elements swapped."
+      fn =
+        (function
+        | state, [ DTuple (first, second, []) ] -> Ply(DTuple(second, first, []))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "mapFirst" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fn"
+            (TFn([ TVariable "a" ], TVariable "c"))
+            ""
+            [ "val" ]
+          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "c", TVariable "b", [])
+      description = "Transform the first value in a 2-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fn; DTuple (first, second, []) ] ->
+          uply {
+            let! newFirst =
+              Interpreter.applyFnVal state (id 0) fn [ first ] NotInPipe NoRail
+            return DTuple(newFirst, second, [])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "mapSecond" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fn"
+            (TFn([ TVariable "b" ], TVariable "c"))
+            ""
+            [ "val" ]
+          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "a", TVariable "c", [])
+      description = "Transform the second value in a 2-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fn; DTuple (first, second, []) ] ->
+          uply {
+            let! newSecond =
+              Interpreter.applyFnVal state (id 0) fn [ second ] NotInPipe NoRail
+            return DTuple(first, newSecond, [])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Tuple2" "mapBoth" 0
+      parameters =
+        [ Param.makeWithArgs
+            "fnFirst"
+            (TFn([ TVariable "a" ], TVariable "c"))
+            "used to map the first value in the tuple"
+            [ "val" ]
+
+          Param.makeWithArgs
+            "fnSecond"
+            (TFn([ TVariable "b" ], TVariable "d"))
+            "used to map the second value in the tuple"
+            [ "val" ]
+
+          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
+      returnType = TTuple(TVariable "c", TVariable "d", [])
+      description = "Transform both values in a 2-tuple."
+      fn =
+        (function
+        | state, [ DFnVal fnFst; DFnVal fnSnd; DTuple (first, second, []) ] ->
+          uply {
+            let! newFirst =
+              Interpreter.applyFnVal state (id 0) fnFst [ first ] NotInPipe NoRail
+
+            let! newSecond =
+              Interpreter.applyFnVal state (id 0) fnSnd [ second ] NotInPipe NoRail
+
+            return DTuple(newFirst, newSecond, [])
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated } ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
@@ -15,8 +15,6 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = Errors.incorrectArgs
 
-// TODO consider breaking this into `tuple2fns` and `tuple3fns` in-code,
-// and then `let fns = tuple2fns @ tuple3fns. (may help with legibility?)
 let fns : List<BuiltInFn> =
   [ { name = fn "Tuple2" "create" 0
       parameters =

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
@@ -23,7 +23,7 @@ let fns : List<BuiltInFn> =
         [ Param.make "first" (TVariable "a") ""
           Param.make "second" (TVariable "b") "" ]
       returnType = TTuple(TVariable "a", TVariable "b", [])
-      description = "Returns a 2-tuple with the given values"
+      description = "Returns a pair with the given values"
       fn =
         (function
         | state, [ first; second ] -> Ply(DTuple(first, second, []))
@@ -37,7 +37,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "a"
-      description = "Returns the first value of a 2-tuple"
+      description = "Returns the first value of a pair"
       fn =
         (function
         | state, [ DTuple (first, _second, []) ] -> Ply(first)
@@ -51,7 +51,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TVariable "b"
-      description = "Returns the second value of a 2-tuple"
+      description = "Returns the second value of a pair"
       fn =
         (function
         | state, [ DTuple (_first, second, []) ] -> Ply(second)
@@ -65,7 +65,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "b", TVariable "a", [])
-      description = "Returns a 2-tuple with the elements swapped"
+      description = "Returns a pair with the elements swapped"
       fn =
         (function
         | state, [ DTuple (first, second, []) ] -> Ply(DTuple(second, first, []))
@@ -84,7 +84,7 @@ let fns : List<BuiltInFn> =
             [ "val" ]
           Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "c", TVariable "b", [])
-      description = "Transform the first value in a 2-tuple"
+      description = "Transform the first value in a pair"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, []) ] ->
@@ -108,7 +108,7 @@ let fns : List<BuiltInFn> =
             [ "val" ]
           Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "a", TVariable "c", [])
-      description = "Transform the second value in a 2-tuple"
+      description = "Transform the second value in a pair"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, []) ] ->
@@ -139,7 +139,7 @@ let fns : List<BuiltInFn> =
 
           Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
       returnType = TTuple(TVariable "c", TVariable "d", [])
-      description = "Transform both values in a 2-tuple"
+      description = "Transform both values in a pair"
       fn =
         (function
         | state, [ DFnVal fnFst; DFnVal fnSnd; DTuple (first, second, []) ] ->

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
@@ -24,7 +24,7 @@ let fns : List<BuiltInFn> =
           Param.make "second" (TVariable "b") ""
           Param.make "third" (TVariable "c") "" ]
       returnType = TTuple(TVariable "a", TVariable "b", [ TVariable "c" ])
-      description = "Returns a 3-tuple with the given values."
+      description = "Returns a 3-tuple with the given values"
       fn =
         (function
         | state, [ first; second; third ] -> Ply(DTuple(first, second, [ third ]))
@@ -41,7 +41,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "a"
-      description = "Returns the first value of a 3-tuple."
+      description = "Returns the first value of a 3-tuple"
       fn =
         (function
         | state, [ DTuple (first, _second, [ _third ]) ] -> Ply(first)
@@ -58,7 +58,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "b"
-      description = "Returns the second value of a 3-tuple."
+      description = "Returns the second value of a 3-tuple"
       fn =
         (function
         | state, [ DTuple (_first, second, [ _third ]) ] -> Ply(second)
@@ -75,7 +75,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "c"
-      description = "Returns the third value of a 3-tuple."
+      description = "Returns the third value of a 3-tuple"
       fn =
         (function
         | state, [ DTuple (_first, _second, [ third ]) ] -> Ply(third)
@@ -97,7 +97,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "d", TVariable "b", [ TVariable "c" ])
-      description = "Transform the first value in a 3-tuple."
+      description = "Transform the first value in a 3-tuple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
@@ -124,7 +124,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "a", TVariable "d", [ TVariable "c" ])
-      description = "Transform the second value in a 3-tuple."
+      description = "Transform the second value in a 3-tuple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
@@ -151,7 +151,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "a", TVariable "b", [ TVariable "d" ])
-      description = "Transform the third value in a 3-tuple."
+      description = "Transform the third value in a 3-tuple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
@@ -191,7 +191,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "d", TVariable "e", [ TVariable "f" ])
-      description = "Transform all values in a 3-tuple."
+      description = "Transform all values in a 3-tuple"
       fn =
         (function
         | state,

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
@@ -15,8 +15,6 @@ let err (str : string) = Ply(Dval.errStr str)
 
 let incorrectArgs = Errors.incorrectArgs
 
-// TODO consider breaking this into `tuple2fns` and `tuple3fns` in-code,
-// and then `let fns = tuple2fns @ tuple3fns. (may help with legibility?)
 let fns : List<BuiltInFn> =
   [ { name = fn "Tuple3" "create" 0
       parameters =

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
@@ -24,7 +24,7 @@ let fns : List<BuiltInFn> =
           Param.make "second" (TVariable "b") ""
           Param.make "third" (TVariable "c") "" ]
       returnType = TTuple(TVariable "a", TVariable "b", [ TVariable "c" ])
-      description = "Returns a 3-tuple with the given values"
+      description = "Returns a triple with the given values"
       fn =
         (function
         | state, [ first; second; third ] -> Ply(DTuple(first, second, [ third ]))
@@ -41,7 +41,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "a"
-      description = "Returns the first value of a 3-tuple"
+      description = "Returns the first value of a triple"
       fn =
         (function
         | state, [ DTuple (first, _second, [ _third ]) ] -> Ply(first)
@@ -58,7 +58,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "b"
-      description = "Returns the second value of a 3-tuple"
+      description = "Returns the second value of a triple"
       fn =
         (function
         | state, [ DTuple (_first, second, [ _third ]) ] -> Ply(second)
@@ -75,7 +75,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TVariable "c"
-      description = "Returns the third value of a 3-tuple"
+      description = "Returns the third value of a triple"
       fn =
         (function
         | state, [ DTuple (_first, _second, [ third ]) ] -> Ply(third)
@@ -97,7 +97,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "d", TVariable "b", [ TVariable "c" ])
-      description = "Transform the first value in a 3-tuple"
+      description = "Transform the first value in a triple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
@@ -124,7 +124,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "a", TVariable "d", [ TVariable "c" ])
-      description = "Transform the second value in a 3-tuple"
+      description = "Transform the second value in a triple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
@@ -151,7 +151,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "a", TVariable "b", [ TVariable "d" ])
-      description = "Transform the third value in a 3-tuple"
+      description = "Transform the third value in a triple"
       fn =
         (function
         | state, [ DFnVal fn; DTuple (first, second, [ third ]) ] ->
@@ -191,7 +191,7 @@ let fns : List<BuiltInFn> =
             (TTuple(TVariable "a", TVariable "b", [ TVariable "c" ]))
             "" ]
       returnType = TTuple(TVariable "d", TVariable "e", [ TVariable "f" ])
-      description = "Transform all values in a 3-tuple"
+      description = "Transform all values in a triple"
       fn =
         (function
         | state,

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
@@ -1,4 +1,5 @@
-module LibExecutionStdLib.LibTuple
+/// StdLib functions to create and utilize tuples with 3 elements
+module LibExecutionStdLib.LibTuple3
 
 open Prelude
 open LibExecution.RuntimeTypes
@@ -17,148 +18,22 @@ let incorrectArgs = Errors.incorrectArgs
 // TODO consider breaking this into `tuple2fns` and `tuple3fns` in-code,
 // and then `let fns = tuple2fns @ tuple3fns. (may help with legibility?)
 let fns : List<BuiltInFn> =
-  [ // Tuple2
-    { name = fn "Tuple2" "pair" 0
+  [ { name = fn "Tuple3" "create" 0
       parameters =
         [ Param.make "first" (TVariable "a") ""
-          Param.make "second" (TVariable "b") "" ]
-      returnType = TTuple(TVariable "a", TVariable "b", [])
-      description = "Returns a new 2-tuple with the given values."
+          Param.make "second" (TVariable "b") ""
+          Param.make "third" (TVariable "c") "" ]
+      returnType = TTuple(TVariable "a", TVariable "b", [ TVariable "c" ])
+      description = "Returns a 3-tuple with the given values."
       fn =
         (function
-        | state, [ first; second ] -> Ply(DTuple(first, second, []))
+        | state, [ first; second; third ] -> Ply(DTuple(first, second, [ third ]))
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated = NotDeprecated }
 
 
-    { name = fn "Tuple2" "first" 0
-      parameters =
-        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
-      returnType = TVariable "a"
-      description = "Returns the first value of a 2-tuple."
-      fn =
-        (function
-        | state, [ DTuple (first, _second, []) ] -> Ply(first)
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "Tuple2" "second" 0
-      parameters =
-        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
-      returnType = TVariable "b"
-      description = "Returns the second value of a 2-tuple."
-      fn =
-        (function
-        | state, [ DTuple (_first, second, []) ] -> Ply(second)
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "Tuple2" "swap" 0
-      parameters =
-        [ Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
-      returnType = TTuple(TVariable "b", TVariable "a", [])
-      description = "Returns a 2-tuple with the elements swapped."
-      fn =
-        (function
-        | state, [ DTuple (first, second, []) ] -> Ply(DTuple(second, first, []))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "Tuple2" "mapFirst" 0
-      parameters =
-        [ Param.makeWithArgs
-            "fn"
-            (TFn([ TVariable "a" ], TVariable "c"))
-            ""
-            [ "val" ]
-          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
-      returnType = TTuple(TVariable "c", TVariable "b", [])
-      description = "Transform the first value in a 2-tuple."
-      fn =
-        (function
-        | state, [ DFnVal fn; DTuple (first, second, []) ] ->
-          uply {
-            let! newFirst =
-              Interpreter.applyFnVal state (id 0) fn [ first ] NotInPipe NoRail
-            return DTuple(newFirst, second, [])
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "Tuple2" "mapSecond" 0
-      parameters =
-        [ Param.makeWithArgs
-            "fn"
-            (TFn([ TVariable "b" ], TVariable "c"))
-            ""
-            [ "val" ]
-          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
-      returnType = TTuple(TVariable "a", TVariable "c", [])
-      description = "Transform the second value in a 2-tuple."
-      fn =
-        (function
-        | state, [ DFnVal fn; DTuple (first, second, []) ] ->
-          uply {
-            let! newSecond =
-              Interpreter.applyFnVal state (id 0) fn [ second ] NotInPipe NoRail
-            return DTuple(first, newSecond, [])
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "Tuple2" "mapBoth" 0
-      parameters =
-        [ Param.makeWithArgs
-            "fnFirst"
-            (TFn([ TVariable "a" ], TVariable "c"))
-            "used to map the first value in the tuple"
-            [ "val" ]
-
-          Param.makeWithArgs
-            "fnSecond"
-            (TFn([ TVariable "b" ], TVariable "d"))
-            "used to map the second value in the tuple"
-            [ "val" ]
-
-          Param.make "tuple" (TTuple(TVariable "a", TVariable "b", [])) "" ]
-      returnType = TTuple(TVariable "c", TVariable "d", [])
-      description = "Transform both values in a 2-tuple."
-      fn =
-        (function
-        | state, [ DFnVal fnFst; DFnVal fnSnd; DTuple (first, second, []) ] ->
-          uply {
-            let! newFirst =
-              Interpreter.applyFnVal state (id 0) fnFst [ first ] NotInPipe NoRail
-
-            let! newSecond =
-              Interpreter.applyFnVal state (id 0) fnSnd [ second ] NotInPipe NoRail
-
-            return DTuple(newFirst, newSecond, [])
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    // Tuple3
     { name = fn "Tuple3" "first" 0
       parameters =
         [ Param.make

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -45,7 +45,8 @@ let prefixFns : List<BuiltInFn> =
     LibOption.fns
     LibResult.fns
     LibCrypto.fns
-    LibString.fns ]
+    LibString.fns
+    LibTuple.fns ]
   |> List.concat
   |> renameFunctions renames
 

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -46,7 +46,8 @@ let prefixFns : List<BuiltInFn> =
     LibResult.fns
     LibCrypto.fns
     LibString.fns
-    LibTuple.fns ]
+    LibTuple2.fns
+    LibTuple3.fns ]
   |> List.concat
   |> renameFunctions renames
 

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -1,7 +1,19 @@
-Tuple2.first (1, 2) = 1
+// Tuple2
+
 Tuple2.first ("one", 2) = "one"
 Tuple2.first (1, "two") = 1
 
-Tuple2.second (1, 2) = 2
 Tuple2.second ("one", 2) = 2
 Tuple2.second (1, "two") = "two"
+
+
+// Tuple3
+
+Tuple3.first (1, "two", 3.14) = 1
+Tuple3.first ("one", 2, "pi") = "one"
+
+Tuple3.second (1, "two", 3.14) = "two"
+Tuple3.second ("one", 2, "pi") = 2
+
+Tuple3.third (1, "two", 3.14) = 3.14
+Tuple3.third ("one", 2, "pi") = "pi"

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -1,0 +1,7 @@
+Tuple2.first (1, 2) = 1
+Tuple2.first ("one", 2) = "one"
+Tuple2.first (1, "two") = 1
+
+Tuple2.second (1, 2) = 2
+Tuple2.second ("one", 2) = 2
+Tuple2.second (1, "two") = "two"

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -13,6 +13,16 @@ Tuple2.swap (1, "two") = ("two", 1)
 
 Tuple2.swap(Tuple2.swap ("two swaps", "back to original")) = ("two swaps", "back to original")
 
+Tuple2.mapFirst (fun x -> String.toUppercase_v1 x) ("one", 2) = ("ONE", 2)
+Tuple2.mapFirst (fun x -> x - 2) (1, "two") = (-1, "two")
+
+//Tuple2.mapSecond (TODO) ("one", 2) = ("one", TODO)
+//Tuple2.mapSecond (TODO) (1, "two") = (1, TODO)
+
+//Tuple2.mapBoth (TODO) ("one", 2) = (TODO, TODO)
+//Tuple2.mapBoth (TODO) (1, "two") = (TODO, TODO)
+
+
 
 // Tuple3
 
@@ -24,3 +34,16 @@ Tuple3.second ("one", 2, "pi") = 2
 
 Tuple3.third (1, "two", 3.14) = 3.14
 Tuple3.third ("one", 2, "pi") = "pi"
+
+
+//Tuple3.mapFirst (TODO) ("one", 2, "pi") = (TODO, 2, "pi")
+//Tuple3.mapFirst (TODO) (1, "two", "3.14") = (TODO, "two", 3.14)
+
+//Tuple3.mapSecond (TODO) ("one", 2, "pi") = ("one", TODO, "pi")
+//Tuple3.mapSecond (TODO) (1, "two", 3.14) = (1, TODO, 3.14)
+
+//Tuple3.mapThird (TODO) ("one", 2, "pi") = ("one", 2, TODO)
+//Tuple3.mapThird (TODO) (1, "two", 3.14) = (1, "two", TODO)
+
+//Tuple3.mapAllThree (TODO) ("one", 2, "pi") = (TODO, TODO, TODO)
+//Tuple3.mapAllThree (TODO) (1, "two", 3.14) = (TODO, TODO, TODO)

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -8,10 +8,12 @@ Tuple2.first (1, "two") = 1
 Tuple2.second ("one", 2) = 2
 Tuple2.second (1, "two") = "two"
 
+
 Tuple2.swap ("one", 2) = (2, "one")
 Tuple2.swap (1, "two") = ("two", 1)
 
 Tuple2.swap(Tuple2.swap ("two swaps", "back to original")) = ("two swaps", "back to original")
+
 
 Tuple2.mapFirst (fun x -> String.toUppercase_v1 x) ("one", 2) = ("ONE", 2)
 Tuple2.mapFirst (fun x -> x - 2) (1, "two") = (-1, "two")
@@ -36,14 +38,14 @@ Tuple3.third (1, "two", 3.14) = 3.14
 Tuple3.third ("one", 2, "pi") = "pi"
 
 
-//Tuple3.mapFirst (TODO) ("one", 2, "pi") = (TODO, 2, "pi")
-//Tuple3.mapFirst (TODO) (1, "two", "3.14") = (TODO, "two", 3.14)
+Tuple3.mapFirst (fun x -> String.toUppercase_v1 x) ("one", 2, "pi") = ("ONE", 2, "pi")
+Tuple3.mapFirst (fun x -> x - 2) (1, "two", 3.14) = (-1, "two", 3.14)
 
-//Tuple3.mapSecond (TODO) ("one", 2, "pi") = ("one", TODO, "pi")
-//Tuple3.mapSecond (TODO) (1, "two", 3.14) = (1, TODO, 3.14)
+Tuple3.mapSecond (fun x -> x - 2) ("one", 2, "pi") = ("one", 0, "pi")
+Tuple3.mapSecond (fun x -> String.toUppercase_v1 x) (1, "two", 3.14) = (1, "TWO", 3.14)
 
-//Tuple3.mapThird (TODO) ("one", 2, "pi") = ("one", 2, TODO)
-//Tuple3.mapThird (TODO) (1, "two", 3.14) = (1, "two", TODO)
+Tuple3.mapThird (fun x -> String.toUppercase_v1 x) ("one", 2, "pi") = ("one", 2, "PI")
+Tuple3.mapThird (fun x -> Float.roundDown_v0 x) (1, "two", 3.14) = (1, "two", 3)
 
-//Tuple3.mapAllThree (TODO) ("one", 2, "pi") = (TODO, TODO, TODO)
-//Tuple3.mapAllThree (TODO) (1, "two", 3.14) = (TODO, TODO, TODO)
+Tuple3.mapAllThree (fun x -> String.toUppercase_v1 x) (fun x -> x - 2) (fun x -> String.toUppercase_v1 x) ("one", 2, "pi") = ("ONE", 0, "PI")
+Tuple3.mapAllThree (fun x -> x - 2) (fun x -> String.toUppercase_v1 x) (fun x -> Float.roundDown_v0 x) (1, "two", 3.14) = (-1, "TWO", 3)

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -6,6 +6,11 @@ Tuple2.first (1, "two") = 1
 Tuple2.second ("one", 2) = 2
 Tuple2.second (1, "two") = "two"
 
+Tuple2.swap ("one", 2) = (2, "one")
+Tuple2.swap (1, "two") = ("two", 1)
+
+Tuple2.swap(Tuple2.swap ("two swaps", "back to original")) = ("two swaps", "back to original")
+
 
 // Tuple3
 

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -4,51 +4,37 @@ Tuple2.create 1 "two" = (1, "two")
 
 Tuple2.first ("one", 2) = "one"
 Tuple2.first (1, "two") = 1
-
 Tuple2.second ("one", 2) = 2
 Tuple2.second (1, "two") = "two"
 
-
 Tuple2.swap ("one", 2) = (2, "one")
 Tuple2.swap (1, "two") = ("two", 1)
-
 Tuple2.swap(Tuple2.swap ("two swaps", "back to original")) = ("two swaps", "back to original")
-
 
 Tuple2.mapFirst (fun x -> String.toUppercase_v1 x) ("one", 2) = ("ONE", 2)
 Tuple2.mapFirst (fun x -> x - 2) (1, "two") = (-1, "two")
-
 Tuple2.mapSecond (fun x -> x - 2) ("one", 2) = ("one", 0)
 Tuple2.mapSecond (fun x -> String.toUppercase_v1 x) (1, "two") = (1, "TWO")
-
 Tuple2.mapBoth (fun x -> String.toUppercase_v1 x) (fun x -> x - 2) ("one", 2) = ("ONE", 0)
 Tuple2.mapBoth (fun x -> x - 2) (fun x -> String.toUppercase_v1 x) (1, "two") = (-1, "TWO")
 
 
-
 // Tuple3
-
 Tuple3.create "one" 2 "pi" = ("one", 2, "pi")
 Tuple3.create 1 "two" 3.14 = (1, "two", 3.14)
 
 Tuple3.first (1, "two", 3.14) = 1
 Tuple3.first ("one", 2, "pi") = "one"
-
 Tuple3.second (1, "two", 3.14) = "two"
 Tuple3.second ("one", 2, "pi") = 2
-
 Tuple3.third (1, "two", 3.14) = 3.14
 Tuple3.third ("one", 2, "pi") = "pi"
 
-
 Tuple3.mapFirst (fun x -> String.toUppercase_v1 x) ("one", 2, "pi") = ("ONE", 2, "pi")
 Tuple3.mapFirst (fun x -> x - 2) (1, "two", 3.14) = (-1, "two", 3.14)
-
 Tuple3.mapSecond (fun x -> x - 2) ("one", 2, "pi") = ("one", 0, "pi")
 Tuple3.mapSecond (fun x -> String.toUppercase_v1 x) (1, "two", 3.14) = (1, "TWO", 3.14)
-
 Tuple3.mapThird (fun x -> String.toUppercase_v1 x) ("one", 2, "pi") = ("one", 2, "PI")
 Tuple3.mapThird (fun x -> Float.roundDown_v0 x) (1, "two", 3.14) = (1, "two", 3)
-
 Tuple3.mapAllThree (fun x -> String.toUppercase_v1 x) (fun x -> x - 2) (fun x -> String.toUppercase_v1 x) ("one", 2, "pi") = ("ONE", 0, "PI")
 Tuple3.mapAllThree (fun x -> x - 2) (fun x -> String.toUppercase_v1 x) (fun x -> Float.roundDown_v0 x) (1, "two", 3.14) = (-1, "TWO", 3)

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -1,6 +1,6 @@
 // Tuple2
-Tuple2.pair "one" 2 = ("one", 2)
-Tuple2.pair 1 "two" = (1, "two")
+Tuple2.create "one" 2 = ("one", 2)
+Tuple2.create 1 "two" = (1, "two")
 
 Tuple2.first ("one", 2) = "one"
 Tuple2.first (1, "two") = 1
@@ -27,6 +27,9 @@ Tuple2.mapBoth (fun x -> x - 2) (fun x -> String.toUppercase_v1 x) (1, "two") = 
 
 
 // Tuple3
+
+Tuple3.create "one" 2 "pi" = ("one", 2, "pi")
+Tuple3.create 1 "two" 3.14 = (1, "two", 3.14)
 
 Tuple3.first (1, "two", 3.14) = 1
 Tuple3.first ("one", 2, "pi") = "one"

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -1,4 +1,6 @@
 // Tuple2
+Tuple2.pair "one" 2 = ("one", 2)
+Tuple2.pair 1 "two" = (1, "two")
 
 Tuple2.first ("one", 2) = "one"
 Tuple2.first (1, "two") = 1

--- a/fsharp-backend/tests/testfiles/tuple.tests
+++ b/fsharp-backend/tests/testfiles/tuple.tests
@@ -16,11 +16,11 @@ Tuple2.swap(Tuple2.swap ("two swaps", "back to original")) = ("two swaps", "back
 Tuple2.mapFirst (fun x -> String.toUppercase_v1 x) ("one", 2) = ("ONE", 2)
 Tuple2.mapFirst (fun x -> x - 2) (1, "two") = (-1, "two")
 
-//Tuple2.mapSecond (TODO) ("one", 2) = ("one", TODO)
-//Tuple2.mapSecond (TODO) (1, "two") = (1, TODO)
+Tuple2.mapSecond (fun x -> x - 2) ("one", 2) = ("one", 0)
+Tuple2.mapSecond (fun x -> String.toUppercase_v1 x) (1, "two") = (1, "TWO")
 
-//Tuple2.mapBoth (TODO) ("one", 2) = (TODO, TODO)
-//Tuple2.mapBoth (TODO) (1, "two") = (TODO, TODO)
+Tuple2.mapBoth (fun x -> String.toUppercase_v1 x) (fun x -> x - 2) ("one", 2) = ("ONE", 0)
+Tuple2.mapBoth (fun x -> x - 2) (fun x -> String.toUppercase_v1 x) (1, "two") = (-1, "TWO")
 
 
 


### PR DESCRIPTION
This will resolve #3309, and is a part of #4265.

This adds the following stdlib fns:
- `Tuple2::pair`
- `Tuple2::first`
- `Tuple2::second`
- `Tuple2::swap`
- `Tuple2::mapFirst`
- `Tuple2::mapSecond`
- `Tuple2::mapBoth`
- `Tuple3::first`
- `Tuple3::second`
- `Tuple3::third`
- `Tuple3::mapFirst`
- `Tuple3::mapSecond`
- `Tuple3::mapThird`
- `Tuple3::mapAllThree`