### PR TITLE
Remove unused emptyHandler bindings from APIOps.fs

### DIFF
--- a/fsharp-backend/src/ApiServer/Api/APIOps.fs
+++ b/fsharp-backend/src/ApiServer/Api/APIOps.fs
@@ -89,7 +89,6 @@ module V0 =
 
       let c = C.fromOplist canvasInfo oldOps newOps
 
-
       t.next "to-frontend"
       let toplevels = C.toplevels c
       let deletedToplevels = C.deletedToplevels c
@@ -104,15 +103,6 @@ module V0 =
           deleted_user_functions = dFns
           user_tipes = types
           deleted_user_tipes = dTypes }
-
-      let emptyHandler (tlid : tlid) : PT.Toplevel.T =
-        let ids : PT.Handler.ids =
-          { moduleID = gid (); nameID = gid (); modifierID = gid () }
-        PT.Toplevel.TLHandler
-          { pos = { x = 0; y = 0 }
-            tlid = tlid
-            ast = PT.EBlank(gid ())
-            spec = PT.Handler.HTTP("", "", ids) }
 
 
       t.next "save-to-disk"
@@ -242,16 +232,6 @@ module V1 =
           deleted_user_functions = Map.values c.deletedUserFunctions
           user_tipes = Map.values c.userTypes
           deleted_user_tipes = Map.values c.deletedUserTypes }
-
-      let emptyHandler (tlid : tlid) : PT.Toplevel.T =
-        let ids : PT.Handler.ids =
-          { moduleID = gid (); nameID = gid (); modifierID = gid () }
-        PT.Toplevel.TLHandler
-          { pos = { x = 0; y = 0 }
-            tlid = tlid
-            ast = PT.EBlank(gid ())
-            spec = PT.Handler.HTTP("", "", ids) }
-
 
       t.next "save-to-disk"
       // work out the result before we save it, in case it has a


### PR DESCRIPTION
I noticed that these bindings were unused; removed now.