### PR TITLE
Disable Tuple2:: and Tuple3:: fns

### DIFF
--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple2.fs
@@ -28,7 +28,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple2" "first" 0
@@ -42,7 +42,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple2" "second" 0
@@ -56,7 +56,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple2" "swap" 0
@@ -70,7 +70,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple2" "mapFirst" 0
@@ -94,7 +94,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple2" "mapSecond" 0
@@ -118,7 +118,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple2" "mapBoth" 0
@@ -153,4 +153,4 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated } ]
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") } ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibTuple3.fs
@@ -29,7 +29,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple3" "first" 0
@@ -46,7 +46,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple3" "second" 0
@@ -63,7 +63,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple3" "third" 0
@@ -80,7 +80,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple3" "mapFirst" 0
@@ -107,7 +107,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple3" "mapSecond" 0
@@ -134,7 +134,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple3" "mapThird" 0
@@ -161,7 +161,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated }
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") }
 
 
     { name = fn "Tuple3" "mapAllThree" 0
@@ -218,4 +218,4 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
-      deprecated = NotDeprecated } ]
+      deprecated = DeprecatedBecause("Added prematurely; this will be re-added.") } ]


### PR DESCRIPTION
While I disabled the creation of tuples in Fluid, I forgot that tuples could be created by way of Tuple2::create and Tuple3::create. This disables those functions for now.