### PR TITLE
Allow non-admins to view in-Editor debugger

### DIFF
--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -1187,6 +1187,7 @@ module Model = {
       orgCanvasList: list{},
       loading: false,
       privacy: {recordConsent: None},
+      isContributor: false
     },
     insertSecretModal: SecretTypes.defaultInsertModal,
   }

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -566,12 +566,6 @@ module IntegrationTests = {
 }
 
 module EditorSettings = {
-  @ppx.deriving(show({with_path: false}))
-  type rec ffIsExpanded = bool
-
-  @ppx.deriving(show({with_path: false}))
-  type rec flagsVS = Tc.Map.String.t<ffIsExpanded>
-
   // Editor settings are global settings on the editor. Initially, these are
   // only things that contributors use for debugging - in the future they could
   // be extended to non-contributor editor settings (such as theming).

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -587,16 +587,8 @@ module EditorSettings = {
     let decode = (j: Js.Json.t): t => {
       open Json_decode_extended
       {
-        showHandlerASTs: withDefault(
-          false,
-          field("editorSettings", field("showHandlerASTs", bool)),
-          j,
-        ),
-        showFluidDebugger: withDefault(
-          false,
-          field("editorSettings", field("showFluidDebugger", bool)),
-          j,
-        ),
+        showHandlerASTs: withDefault(false, field("showHandlerASTs", bool), j),
+        showFluidDebugger: withDefault(false, field("showFluidDebugger", bool), j),
       }
     }
     let default: t = {
@@ -621,7 +613,6 @@ module EditorSettings = {
   let decode = (j): t => {
     open Json_decode_extended
     {
-      // todo: do I really need to reference 'editorSettings' here
       runTimers: withDefault(true, field("runTimers", bool), j),
       contributorSettings: optional(field("contributorSettings", ContributorSettings.decode), j)
     }

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -590,6 +590,22 @@ module EditorSettings = {
       ("showFluidDebugger", bool(es.showFluidDebugger)),
     })
   }
+  let decode = (j): t => {
+    open Json_decode_extended
+    {
+      runTimers: withDefault(true, field("editorSettings", field("runTimers", bool)), j),
+      showHandlerASTs: withDefault(
+        false,
+        field("editorSettings", field("showHandlerASTs", bool)),
+        j,
+      ),
+      showFluidDebugger: withDefault(
+        false,
+        field("editorSettings", field("showFluidDebugger", bool)),
+        j,
+      ),
+    }
+  }
   let default: t = {runTimers: true, showHandlerASTs: false, showFluidDebugger: false}
 }
 
@@ -687,19 +703,7 @@ module SavedSettings = {
     // always use withDefault or optional because the field might be missing due
     // to old editors or new fields.
     {
-      editorSettings: {
-        runTimers: withDefault(true, field("editorSettings", field("runTimers", bool)), j),
-        showHandlerASTs: withDefault(
-          false,
-          field("editorSettings", field("showHandlerASTs", bool)),
-          j,
-        ),
-        showFluidDebugger: withDefault(
-          false,
-          field("editorSettings", field("showFluidDebugger", bool)),
-          j,
-        ),
-      },
+      editorSettings: withDefault(EditorSettings.default, field("editorSettings", EditorSettings.decode), j),
       cursorState: withDefault(CursorState.Deselected, field("cursorState", CursorState.decode), j),
       tlTraceIDs: withDefault(TLID.Dict.empty, field("tlTraceIDs", TLID.Dict.decode(string)), j),
       handlerProps: withDefault(

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -572,9 +572,9 @@ module EditorSettings = {
   @ppx.deriving(show({with_path: false}))
   type rec flagsVS = Tc.Map.String.t<ffIsExpanded>
 
-  // Editor settings are global settings on the editor. Initially, these are only
-  // things that admins use for debugging - in the future they could be extended to
-  // actual editor settings
+  // Editor settings are global settings on the editor. Initially, these are
+  // only things that contributors use for debugging - in the future they could
+  // be extended to non-contributor editor settings (such as theming).
   @ppx.deriving(show({with_path: false}))
   type rec t = {
     showFluidDebugger: bool,

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1404,7 +1404,7 @@ let update_ = (msg: msg, m: model): modification => {
         m => {
           let settingsView = SettingsView.update(
             m.settingsView,
-            SetSettingsView(r.canvasList, m.username, r.orgs, r.orgCanvasList),
+            SetSettingsView(r.canvasList, m.username, r.orgs, r.orgCanvasList, Option.isSome(m.editorSettings.contributorSettings)),
           )
 
           (

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -286,7 +286,7 @@ let tlCacheKey = (m: model, tl) => {
       props,
       menuIsOpen,
       workerSchedule,
-      m.editorSettings.showHandlerASTs,
+      AppTypes.EditorSettings.contribSettingsOrDefault(m.editorSettings).showHandlerASTs,
       m.tooltipState.userTutorial,
     )
   }
@@ -712,7 +712,8 @@ let view = (m: model): Html.html<msg> => {
   let activeAvatars = Avatar.viewAllAvatars(m.avatarsList)
   let ast = TL.selectedAST(m) |> Option.unwrap(~default=FluidAST.ofExpr(EBlank(gid())))
 
-  let fluidStatus = if m.editorSettings.showFluidDebugger {
+  let showFluidDebugger = AppTypes.EditorSettings.contribSettingsOrDefault(m.editorSettings).showFluidDebugger
+  let fluidStatus = if showFluidDebugger {
     list{FluidDebugger.view(m, ast)}
   } else {
     list{Vdom.noNode}

--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -1022,13 +1022,14 @@ let adminDebuggerView = (m: model): Html.html<msg> => {
   let toggleFluidDebugger = Html.div(
     list{
       ViewUtils.eventNoPropagation(~key="tt", "mouseup", _ => ToggleEditorSetting(
-        es => {...es, showFluidDebugger: !es.showFluidDebugger},
+        es => AppTypes.EditorSettings.withUpdatedContribSettings(es, ~f=cs => {...cs, showFluidDebugger: !cs.showFluidDebugger})
       )),
+
       Html.class'("checkbox-row"),
     },
     list{
       Html.input'(
-        list{Html.type'("checkbox"), Html.checked(m.editorSettings.showFluidDebugger)},
+        list{Html.type'("checkbox"), Html.checked(AppTypes.EditorSettings.contribSettingsOrDefault(m.editorSettings).showFluidDebugger)},
         list{},
       ),
       Html.label(list{}, list{Html.text("Show Fluid Debugger")}),
@@ -1038,13 +1039,13 @@ let adminDebuggerView = (m: model): Html.html<msg> => {
   let toggleHandlerASTs = Html.div(
     list{
       ViewUtils.eventNoPropagation(~key="tgast", "mouseup", _ => ToggleEditorSetting(
-        es => {...es, showHandlerASTs: !es.showHandlerASTs},
+        es => AppTypes.EditorSettings.withUpdatedContribSettings(es, ~f=cs => {...cs, showHandlerASTs: !cs.showHandlerASTs})
       )),
       Html.class'("checkbox-row"),
     },
     list{
       Html.input'(
-        list{Html.type'("checkbox"), Html.checked(m.editorSettings.showHandlerASTs)},
+        list{Html.type'("checkbox"), Html.checked(AppTypes.EditorSettings.contribSettingsOrDefault(m.editorSettings).showHandlerASTs)},
         list{},
       ),
       Html.label(list{}, list{Html.text("Show Handler ASTs")}),

--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -1157,7 +1157,7 @@ let viewSidebar_ = (m: model): Html.html<msg> => {
   | _ => false
   }
 
-  let showAdminDebugger = if !isDetailed && m.isAdmin {
+  let showContributorDebugger = if !isDetailed && Option.isSome(m.editorSettings.contributorSettings) {
     adminDebuggerView(m)
   } else {
     Vdom.noNode
@@ -1167,7 +1167,7 @@ let viewSidebar_ = (m: model): Html.html<msg> => {
   let content = {
     let categories = Belt.List.concat(
       List.map(~f=viewCategory(m), cats),
-      list{secretsView, viewDeployStats(m), showAdminDebugger},
+      list{secretsView, viewDeployStats(m), showContributorDebugger},
     )
 
     Html.div(

--- a/client/src/components/SettingsViewTypes.res
+++ b/client/src/components/SettingsViewTypes.res
@@ -20,6 +20,7 @@ and settingsTab =
   | UserSettings
   | InviteUser(inviteFields)
   | Privacy
+  | Editor
 
 @ppx.deriving(show)
 type rec inviteFormMessage = {
@@ -40,12 +41,13 @@ type rec settingsViewState = {
   orgCanvasList: list<string> /* This is org canvases, not orgs themselves */,
   loading: bool,
   privacy: privacySettings,
+  isContributor: bool
 }
 
 @ppx.deriving(show)
 type rec settingsMsg =
   | CloseSettingsView(settingsTab)
-  | SetSettingsView(@opaque (list<string>, string, list<string>, list<string>))
+  | SetSettingsView(@opaque (list<string>, string, list<string>, list<string>, bool))
   | OpenSettingsView(settingsTab)
   | SwitchSettingsTabs(settingsTab)
   | UpdateInviteForm(string)
@@ -54,6 +56,7 @@ type rec settingsMsg =
   TriggerSendInviteCallback(Tea.Result.t<unit, @opaque Tea.Http.error<string>>)
   | InitRecordConsent(option<bool>)
   | SetRecordConsent(bool)
+  | SetIsContributor(bool)
 
 let settingsTabToText = (tab: settingsTab): string =>
   switch tab {
@@ -61,6 +64,7 @@ let settingsTabToText = (tab: settingsTab): string =>
   | UserSettings => "canvases"
   | InviteUser(_) => "share"
   | Privacy => "privacy"
+  | Editor => "editor"
   }
 
 let defaultInviteFields: inviteFields = {email: {value: "", error: None}}
@@ -71,5 +75,6 @@ let settingsTabFromText = (tab: string): settingsTab =>
   | "canvases" => UserSettings
   | "share" => InviteUser(defaultInviteFields)
   | "privacy" => Privacy
+  | "editor" => Editor
   | _ => UserSettings
   }

--- a/client/src/util/ViewUtils.res
+++ b/client/src/util/ViewUtils.res
@@ -152,7 +152,7 @@ let createVS = (m: AppTypes.model, tl: toplevel): viewProps => {
     | TLPmFunc(_) | TLDB(_) | TLTipe(_) => false
     },
     fnProps: m.currentUserFn,
-    showHandlerASTs: m.editorSettings.showHandlerASTs,
+    showHandlerASTs: AppTypes.EditorSettings.contribSettingsOrDefault(m.editorSettings).showHandlerASTs,
     secretValues: m.secrets |> List.map(~f=SecretTypes.getSecretValue),
   }
 }


### PR DESCRIPTION
When working on Dark features, namely when adjusting how Fluid responds to my keyboard input, I keep reaching for the in-Editor Dark debugging experience currently only exposed to 'admins' (right now, that's just Paul). I've been locally getting around this restriction by editing `Ui.fs`, setting myself as an admin there.

This PR aims at exposing that functionality to anyone who marks themselves as a 'dark developer'. I'd like to use it in prod, both to diagnose my own Dark canvases, as well as potentially use the feature when diagnosing other users' issues.

Changes made:
- A new "Editor" tab has been added to the settings modal, with a single radio button.
- the `editorSettings` model has been changed - it no longer houses the `runTimers`, `showHandlerASTs`, and `showFluidDebugger` variables directly, but now rather houses these in a `option<darkDev>` field under `editorSettings`.
- the sidebar debugger previously used a lot of vertical space in displaying the environment - now each key/value pair just takes up one line (unless it overflows)
  ![image](https://user-images.githubusercontent.com/906686/182189090-8ab6b44f-1474-4e24-8f80-44ff8cbd9847.png)
- the `SAVE STATE FOR INTEGRATION TEST` feature no longer worked (since the OCaml->F# port?), so has been disabled (by commenting out relevant code).