### PR TITLE
Allow floats where the whole number part is empty

### DIFF
--- a/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -44,7 +44,9 @@ module Pattern =
     | PT.PBool (id, b) -> RT.PBool(id, b)
     | PT.PCharacter (id, c) -> RT.PCharacter(id, c)
     | PT.PString (id, s) -> RT.PString(id, s)
-    | PT.PFloat (id, s, w, f) -> RT.PFloat(id, makeFloat s w f)
+    | PT.PFloat (id, s, w, f) ->
+      let w = if w = "" then "0" else w
+      RT.PFloat(id, makeFloat s w f)
     | PT.PNull id -> RT.PNull id
     | PT.PBlank id -> RT.PBlank id
 
@@ -58,6 +60,8 @@ module Expr =
     | PT.EInteger (id, num) -> RT.EInteger(id, num)
     | PT.EString (id, str) -> RT.EString(id, str)
     | PT.EFloat (id, sign, whole, fraction) ->
+      let whole = if whole = "" then "0" else whole
+      let fraction = if fraction = "" then "0" else fraction
       RT.EFloat(id, makeFloat sign whole fraction)
     | PT.EBool (id, b) -> RT.EBool(id, b)
     | PT.ENull id -> RT.ENull id

--- a/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/fsharp-backend/tests/Tests/ProgramTypes.Tests.fs
@@ -157,6 +157,22 @@ let testPipesToRuntimeTypes =
     Expect.equalExprIgnoringIDs actual expected
   }
 
+let testProgramTypesToRuntimeTypes =
+  let b = PT.EBlank(8UL)
+  let rb = RT.EBlank(8UL)
+  testMany
+    "program types to runtime types"
+    PT2RT.Expr.toRT
+    [ PT.EFloat(7UL, Positive, "", "0"), RT.EFloat(7UL, 0.0)
+      PT.EFloat(7UL, Positive, "0", ""), RT.EFloat(7UL, 0.0)
+      PT.EFloat(7UL, Positive, "", ""), RT.EFloat(7UL, 0.0)
+      (PT.EMatch(9UL, b, [ PT.Pattern.PFloat(5UL, Positive, "", ""), b ]),
+       RT.EMatch(9UL, rb, [ RT.Pattern.PFloat(5UL, 0.0), rb ]))
+      (PT.EMatch(9UL, b, [ PT.Pattern.PFloat(5UL, Positive, "0", ""), b ]),
+       RT.EMatch(9UL, rb, [ RT.Pattern.PFloat(5UL, 0.0), rb ]))
+      (PT.EMatch(9UL, b, [ PT.Pattern.PFloat(5UL, Positive, "", "0"), b ]),
+       RT.EMatch(9UL, rb, [ RT.Pattern.PFloat(5UL, 0.0), rb ])) ]
+
 // We didn't use a special infix type in serialized types, so check it converts OK
 let testInfixSerializedTypesToProgramTypes =
   testMany
@@ -241,6 +257,7 @@ let tests =
     "ProgramTypes"
     [ parseTests
       testPipesToRuntimeTypes
+      testProgramTypesToRuntimeTypes
       ptFQFnName
       testInfixSerializedTypesToProgramTypes
       testInfixProgramTypesToSerializedTypes


### PR DESCRIPTION
![2022-08-06 17 00 31](https://user-images.githubusercontent.com/181762/183265874-db219d10-102d-483b-b199-fa12f297637c.gif)

Allow deleting the whole part of a float. The client allowed it, and the server would save it, but there would be a runtime exception.