### PR TITLE
Add Savepoints to Ops in Client, to re-support Undo functionality

### DIFF
--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -93,7 +93,7 @@ let addOp = (m: model, focus: AppTypes.Focus.t, params: APIAddOps.Params.t): cmd
     "/v1/add_op",
     ~decoder=APIAddOps.decode,
     ~encoder=APIAddOps.Params.encode,
-    ~params,
+    ~params={...params, ops: APIAddOps.Params.withSavepoints(params.ops)},
     ~callback=x => AddOpsAPICallback(focus, params, x),
   )
 

--- a/client/src/api/APIAddOps.res
+++ b/client/src/api/APIAddOps.res
@@ -33,12 +33,6 @@ module Params = {
     | list{RedoTL(_)} => ops
     | list{} => ops
     | _ =>
-      // CLEANUP should these savepoints be intersperced instead of prepended?
-      // i.e. should `withSavePoints([op1; op2])` result in
-      //   [savepoint; op1; savepoint; op2]
-      // rather than (now)
-      //   [savepoint; savepoint; op1; op2]
-      // ?
       let savepoints = List.map(ops, ~f=op => PT.Op.TLSavepoint(PT.Op.tlidOf(op)))
       Belt.List.concat(savepoints, ops)
     }

--- a/client/src/core/Encoders.res
+++ b/client/src/core/Encoders.res
@@ -3,20 +3,6 @@ open Json.Encode
 
 // Dark
 
-let ops = (ops: list<PT.Op.t>): Js.Json.t =>
-  list(
-    PT.Op.encode,
-    switch ops {
-    | list{UndoTL(_)} => ops
-    | list{RedoTL(_)} => ops
-    | list{} => ops
-    | _ =>
-      let savepoints = List.map(~f=op => PT.Op.TLSavepoint(PT.Op.tlidOf(op)), ops)
-
-      Belt.List.concat(savepoints, ops)
-    },
-  )
-
 let httpError = (e: Tea.Http.error<string>): Js.Json.t => {
   module Http = Tea.Http
   let responseBody = (r: Http.responseBody) =>

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -696,13 +696,28 @@ test.describe.parallel("Integration Tests", async () => {
   });
 
   test("fluid_undo_redo_happen_exactly_once", async ({ page }) => {
+    // Test that the undos in the test file are respected
+
     await page.waitForSelector(".tl-608699171");
     await page.click(".id-68470584.fluid-category-string");
     await page.waitForSelector(".selected #active-editor");
+
     await expectExactText(page, ".fluid-category-string", '"12345"');
+
     await pressShortcut(page, "z");
     await expectExactText(page, ".fluid-category-string", '"1234"');
+
     await pressShortcut(page, "Shift+z");
+    await expectExactText(page, ".fluid-category-string", '"12345"');
+
+    // Test that savepoints get saved appropriately
+
+    // go to end of expr - the cursor is in the middle of the expr above
+    await pressShortcut(page, "ArrowRight");
+    await page.keyboard.press("6");
+    await expectExactText(page, ".fluid-category-string", '"123456"');
+
+    await pressShortcut(page, "z");
     await expectExactText(page, ".fluid-category-string", '"12345"');
   });
 


### PR DESCRIPTION
TLSavepoints haven't been persisted alongside recent ops, as they have prior - this is causing Undo to not work for recently-changed code.

The relevant integration test has been working, because the TLSavepoint ops were persisted in the actual integration test _file_, not part of the tested UX. As such, a follow-up will be to add another integration test that ensures TLSavepoint is added appropriately (or just adjust the existing one).