### PR TITLE
WIP - fixing reconstruction

### DIFF
--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -93,7 +93,7 @@ let addOp = (m: model, focus: AppTypes.Focus.t, params: APIAddOps.Params.t): cmd
     "/v1/add_op",
     ~decoder=APIAddOps.decode,
     ~encoder=APIAddOps.Params.encode,
-    ~params,
+    ~params={...params, ops: APIAddOps.Params.withSavepoints(params.ops)},
     ~callback=x => AddOpsAPICallback(focus, params, x),
   )
 

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1840,9 +1840,10 @@ let update_ = (msg: msg, m: model): modification => {
       (m: model) => ({...m, toast: {...m.toast, message: Some("Copied!")}}, Cmd.none),
     )
 
-    let (copyData, mod_) = (Fluid.getCopySelection(m), Apply(m => Fluid.update(m, FluidCut)))
+    let clipboardData = Fluid.getCopySelection(m)
+    let  mod_ = Apply(m => Fluid.update(m, FluidCut))
 
-    Many(list{SetClipboardContents(copyData, e), mod_, toast})
+    Many(list{SetClipboardContents(clipboardData, e), mod_, toast})
   | ClipboardCopyLivevalue(lv, pos) =>
     let lv = lv |> Regex.replace(~re=Regex.regex("(^\")|(\"$)"), ~repl="")
     Native.Clipboard.copyToClipboard(lv)

--- a/client/src/core/Encoders.res
+++ b/client/src/core/Encoders.res
@@ -3,20 +3,6 @@ open Json.Encode
 
 // Dark
 
-let ops = (ops: list<PT.Op.t>): Js.Json.t =>
-  list(
-    PT.Op.encode,
-    switch ops {
-    | list{UndoTL(_)} => ops
-    | list{RedoTL(_)} => ops
-    | list{} => ops
-    | _ =>
-      let savepoints = List.map(~f=op => PT.Op.TLSavepoint(PT.Op.tlidOf(op)), ops)
-
-      Belt.List.concat(savepoints, ops)
-    },
-  )
-
 let httpError = (e: Tea.Http.error<string>): Js.Json.t => {
   module Http = Tea.Http
   let responseBody = (r: Http.responseBody) =>

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1188,12 +1188,12 @@ let run = () => {
       (5, 11),
       "(\"lo\",12)",
     )
-    // testCut( // TUPLETODO fix results - somehow an extra 'l' is being included.
-    //   "cutting halfway between tuple parts leaves a partial tuple and copies the data selected to clipboard",
-    //   tuple(str("hello"), int(1234), list{}), // ("hello",1234)
-    //   (5, 11),
-    //   ("(\"hel~\")", "(\"lo\",12)"),
-    // )
+    testCut( // TUPLETODO fix results - somehow an extra 'l' is being included.
+      "cutting halfway between tuple parts leaves a partial tuple and copies the data selected to clipboard",
+      tuple(str("hello"), int(1234), list{}), // ("hello",1234)
+      (5, 11),
+      ("(\"hel~\")", "(\"lo\",12)"),
+    )
 
     // pasting tuples
     testPasteText(

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -696,13 +696,28 @@ test.describe.parallel("Integration Tests", async () => {
   });
 
   test("fluid_undo_redo_happen_exactly_once", async ({ page }) => {
+    // Test that the undos in the test file are respected
+
     await page.waitForSelector(".tl-608699171");
     await page.click(".id-68470584.fluid-category-string");
     await page.waitForSelector(".selected #active-editor");
+
     await expectExactText(page, ".fluid-category-string", '"12345"');
+
     await pressShortcut(page, "z");
     await expectExactText(page, ".fluid-category-string", '"1234"');
+
     await pressShortcut(page, "Shift+z");
+    await expectExactText(page, ".fluid-category-string", '"12345"');
+
+    // Test that savepoints get saved appropriately
+
+    // go to end of expr - the cursor is in the middle of the expr above
+    await pressShortcut(page, "ArrowRight");
+    await page.keyboard.press("6");
+    await expectExactText(page, ".fluid-category-string", '"123456"');
+
+    await pressShortcut(page, "z");
     await expectExactText(page, ".fluid-category-string", '"12345"');
   });
 


### PR DESCRIPTION
given the code
```fsharp
("hello",12345)
```

if I select between the two |s:
```fsharp
("he|llo",12|345)
```

Upon hitting 'delete' I expect the remaining state to be
`"he|"`

The tuple will be killed as the deletions happen, so I expect the 12345 to disappear.
Then, I should have the `"hel"` remaining, and be on the right side of the `e`.

Instead, I get `"hel|"` - one of the "l"s remains.

---

This seems to be because how `deleteCaretRange` works:

https://github.com/darklang/dark/blob/d6d113b9dc99bf8c2401fdd5ce01f4bf40ec2e72/client/src/fluid/Fluid.res#L4930-L4953

- put the cursor at the RHS of the selection (in this case, 10)
- record the 'col' of the LHS of the selection (in this case, 4)
- hit 'backspace' until either:
  - the last backspace changed neither AST nor cursor position
  - the cursor is now at the recorded LHS

because the ( of the tuple is deleted, however, the initial LHS evaluation is sort of invalidated.
The code thinks to go to position 4, but position 4 is eventualy between the 2 "l"s, rater than between "e" and "l".

---

My first attempt here was to rewrite the algorithm pretty dramatically. It works but breaks many other tests - will review and try again tomorrow.