### PR TITLE
Add "allow tuples" contributor setting

### DIFF
--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1999,6 +1999,7 @@ let update_ = (msg: msg, m: model): modification => {
 
         | Some(ContributingIntent(SettingsContributing.Intent.UseAssetsIntent()))
         | Some(ContributingIntent(SettingsContributing.Intent.GeneralIntent()))
+        | Some(ContributingIntent(SettingsContributing.Intent.InProgressFeaturesIntent()))
         | Some(InviteIntent(None))
         | None => (m, Cmd.none)
         }

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1998,7 +1998,7 @@ let update_ = (msg: msg, m: model): modification => {
         | Some(CloseSettings) => (m, Cmd.none)->CCC.setPage(Architecture)->CCC.setPanning(true)
 
         | Some(ContributingIntent(SettingsContributing.Intent.UseAssetsIntent()))
-        | Some(ContributingIntent(SettingsContributing.Intent.ToolsIntent()))
+        | Some(ContributingIntent(SettingsContributing.Intent.GeneralIntent()))
         | Some(InviteIntent(None))
         | None => (m, Cmd.none)
         }

--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -1140,7 +1140,7 @@ let viewSidebar_ = (m: model): Html.html<msg> => {
   | _ => false
   }
 
-  let showAdminDebugger = if !isDetailed && m.settings.contributingSettings.tools.showSidebarPanel {
+  let showAdminDebugger = if !isDetailed && m.settings.contributingSettings.general.showSidebarDebuggerPanel {
     adminDebuggerView(m)
   } else {
     Vdom.noNode
@@ -1205,7 +1205,7 @@ let rtCacheKey = (m: model) =>
     m.tooltipState.tooltipSource,
     m.secrets,
     m.functions.packageFunctions |> Map.mapValues(~f=(t: PT.Package.Fn.t) => t.name.owner),
-    m.settings.contributingSettings.tools.showSidebarPanel,
+    m.settings.contributingSettings.general.showSidebarDebuggerPanel,
   ) |> Option.some
 
 let viewSidebar = m => ViewCache.cache1m(rtCacheKey, viewSidebar_, m)

--- a/client/src/components/Settings/SettingsContributing.res
+++ b/client/src/components/Settings/SettingsContributing.res
@@ -327,9 +327,12 @@ let default = {
   inProgressFeatures: InProgressFeatures.default
 }
 
-let toSaved = ({general, _}: t) => {
+let toSaved = (s: t) => {
   open Json.Encode
-  object_(list{("general", General.toSaved(general))})
+  object_(list{
+    ("general", General.toSaved(s.general)),
+    ("inProgressFeatures", InProgressFeatures.toSaved(s.inProgressFeatures))
+  })
 }
 
 let fromSaved = (j: Js.Json.t) => {
@@ -337,6 +340,7 @@ let fromSaved = (j: Js.Json.t) => {
   {
     ...default,
     general: field("general", General.fromSaved, j),
+    inProgressFeatures: field("inProgressFeatures", InProgressFeatures.fromSaved, j),
   }
 }
 

--- a/client/src/components/Settings/SettingsContributingView.res
+++ b/client/src/components/Settings/SettingsContributingView.res
@@ -67,11 +67,11 @@ let viewAllowTuples = (allowTuples: bool): Html.html<AppTypes.msg> => {
 }
 
 let viewGeneral = (s: T.General.t): list<Html.html<AppTypes.msg>> => {
-  list{viewSidebarDebuggerToggle(s.showSidebarDebuggerPanel)}
+  list{C.sectionHeading("General", None), viewSidebarDebuggerToggle(s.showSidebarDebuggerPanel)}
 }
 
 let viewInProgressFeatures = (s: T.InProgressFeatures.t): list<Html.html<AppTypes.msg>> => {
-  list{viewAllowTuples(s.allowTuples)}
+  list{C.sectionHeading("In-Progress Features", None),viewAllowTuples(s.allowTuples)}
 }
 
 let viewTunnelSectionHeader = {
@@ -142,15 +142,19 @@ let viewTunnelToggle = (s: T.UseAssets.t): Html.html<AppTypes.msg> => {
   C.settingRow("Use tunneled assets", ~info=None, ~error=None, list{toggle})
 }
 
+let viewTunnelSection = (s: T.t): list<Html.html<AppTypes.msg>> => {
+  Belt.List.concatMany([
+    viewTunnelSectionHeader,
+    list{viewTunnelHost(s.tunnelHost)},
+    list{viewTunnelToggle(s.useAssets)}
+  ])
+}
+
 let view = (s: T.t): list<Html.html<AppTypes.msg>> => {
   Belt.List.concatMany([
     list{viewIntroText},
-    list{C.sectionHeading("General", None)},
     viewGeneral(s.general),
-    list{C.sectionHeading("In-Progress Features", None)},
     viewInProgressFeatures(s.inProgressFeatures),
-    viewTunnelSectionHeader,
-    list{viewTunnelHost(s.tunnelHost)},
-    list{viewTunnelToggle(s.useAssets)},
+    viewTunnelSection(s)
   ])
 }

--- a/client/src/components/Settings/SettingsContributingView.res
+++ b/client/src/components/Settings/SettingsContributingView.res
@@ -39,11 +39,9 @@ let viewSidebarDebuggerToggle = (showSidebarDebuggerPanel: bool): Html.html<AppT
     )
     C.toggleButton(attr, showSidebarDebuggerPanel)
   }
-  let info = Some(
-    "Show a menu in the (closed) sidebar with debugging options. These are
+  let info = Some("Show a menu in the (closed) sidebar with debugging options. These are
     useful when working on the Darklang client (note they are not typically
-    useful for writing Darklang code)",
-  )
+    useful for writing Darklang code)")
   C.settingRow("Show debugging options", ~info, ~error=None, list{toggle})
 }
 
@@ -54,25 +52,26 @@ let viewAllowTuples = (allowTuples: bool): Html.html<AppTypes.msg> => {
       "click",
       _ => Msg.SettingsMsg(
         Settings.ContributingMsg(
-          SettingsContributing.GeneralMsg(T.General.SetTuplesAllowed(!allowTuples)),
+          SettingsContributing.InProgressFeaturesMsg(
+            T.InProgressFeatures.SetTuplesAllowed(!allowTuples),
+          ),
         ),
       ),
     )
     C.toggleButton(attr, allowTuples)
   }
-  let info = Some(
-    "Tuples are currently being added to the Dark language - with this setting
-    on, you'll be able to use tuples in your Dark code before the user
-    experience around them is stable.",
-  )
+  let info = Some("Tuples are currently being added to the Dark language - with
+    this setting on, you'll be able to use tuples in your Dark code before the
+    user experience around them is stable.")
   C.settingRow("Enable tuples", ~info, ~error=None, list{toggle})
 }
 
-let viewGeneral = (ui: T.General.t): list<Html.html<AppTypes.msg>> => {
-  list{
-    viewSidebarDebuggerToggle(ui.showSidebarDebuggerPanel),
-    viewAllowTuples(ui.allowTuples)
-  }
+let viewGeneral = (s: T.General.t): list<Html.html<AppTypes.msg>> => {
+  list{viewSidebarDebuggerToggle(s.showSidebarDebuggerPanel)}
+}
+
+let viewInProgressFeatures = (s: T.InProgressFeatures.t): list<Html.html<AppTypes.msg>> => {
+  list{viewAllowTuples(s.allowTuples)}
 }
 
 let viewTunnelSectionHeader = {
@@ -148,6 +147,8 @@ let view = (s: T.t): list<Html.html<AppTypes.msg>> => {
     list{viewIntroText},
     list{C.sectionHeading("General", None)},
     viewGeneral(s.general),
+    list{C.sectionHeading("In-Progress Features", None)},
+    viewInProgressFeatures(s.inProgressFeatures),
     viewTunnelSectionHeader,
     list{viewTunnelHost(s.tunnelHost)},
     list{viewTunnelToggle(s.useAssets)},

--- a/client/src/components/Settings/SettingsContributingView.res
+++ b/client/src/components/Settings/SettingsContributingView.res
@@ -26,23 +26,53 @@ let viewIntroText = {
   )
 }
 
-let viewTools = (ui: T.Tools.t): Html.html<AppTypes.msg> => {
+let viewSidebarDebuggerToggle = (showSidebarDebuggerPanel: bool): Html.html<AppTypes.msg> => {
   let toggle = {
     let attr = EventListeners.eventNoPropagation(
-      ~key=`toggle-settings-${string_of_bool(ui.showSidebarPanel)}`,
+      ~key=`toggle-sidebar-debugger-${string_of_bool(showSidebarDebuggerPanel)}`,
       "click",
       _ => Msg.SettingsMsg(
         Settings.ContributingMsg(
-          SettingsContributing.ToolsMsg(T.Tools.SetSidebarPanel(!ui.showSidebarPanel)),
+          SettingsContributing.GeneralMsg(T.General.SetSidebarPanel(!showSidebarDebuggerPanel)),
         ),
       ),
     )
-    C.toggleButton(attr, ui.showSidebarPanel)
+    C.toggleButton(attr, showSidebarDebuggerPanel)
   }
   let info = Some(
-    "Show a menu in the (closed) sidebar with debugging options. These are useful when working on the Darklang client (note they are not typically useful for writing Darklang code)",
+    "Show a menu in the (closed) sidebar with debugging options. These are
+    useful when working on the Darklang client (note they are not typically
+    useful for writing Darklang code)",
   )
   C.settingRow("Show debugging options", ~info, ~error=None, list{toggle})
+}
+
+let viewAllowTuples = (allowTuples: bool): Html.html<AppTypes.msg> => {
+  let toggle = {
+    let attr = EventListeners.eventNoPropagation(
+      ~key=`toggle-allow-tuples-${string_of_bool(allowTuples)}`,
+      "click",
+      _ => Msg.SettingsMsg(
+        Settings.ContributingMsg(
+          SettingsContributing.GeneralMsg(T.General.SetTuplesAllowed(!allowTuples)),
+        ),
+      ),
+    )
+    C.toggleButton(attr, allowTuples)
+  }
+  let info = Some(
+    "Tuples are currently being added to the Dark language - with this setting
+    on, you'll be able to use tuples in your Dark code before the user
+    experience around them is stable.",
+  )
+  C.settingRow("Enable tuples", ~info, ~error=None, list{toggle})
+}
+
+let viewGeneral = (ui: T.General.t): list<Html.html<AppTypes.msg>> => {
+  list{
+    viewSidebarDebuggerToggle(ui.showSidebarDebuggerPanel),
+    viewAllowTuples(ui.allowTuples)
+  }
 }
 
 let viewTunnelSectionHeader = {
@@ -116,8 +146,8 @@ let viewTunnelToggle = (s: T.UseAssets.t): Html.html<AppTypes.msg> => {
 let view = (s: T.t): list<Html.html<AppTypes.msg>> => {
   Belt.List.concatMany([
     list{viewIntroText},
-    list{C.sectionHeading("Tools", None)},
-    list{viewTools(s.tools)},
+    list{C.sectionHeading("General", None)},
+    viewGeneral(s.general),
     viewTunnelSectionHeader,
     list{viewTunnelHost(s.tunnelHost)},
     list{viewTunnelToggle(s.useAssets)},

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -823,7 +823,6 @@ module ASTInfo = {
     state: AppTypes.fluidState,
     mainTokenInfos: tokenInfos,
     featureFlagTokenInfos: list<(id, tokenInfos)>,
-    props: FluidTypes.Props.t,
   }
 
   let setAST = (ast: FluidAST.t, astInfo: t): t =>
@@ -871,16 +870,15 @@ module ASTInfo = {
   let getTokenNotWhitespace = (astInfo: t): option<T.tokenInfo> =>
     getTokenNotWhitespace(activeTokenInfos(astInfo), astInfo.state)
 
-  let emptyFor = (props: FluidTypes.Props.t, state: fluidState): t => {
+  let emptyFor = (state: fluidState): t => {
     ast: FluidAST.ofExpr(Expr.EBlank(gid())),
     state: state,
     mainTokenInfos: list{},
     featureFlagTokenInfos: list{},
-    props: props,
   }
 
-  let make = (props: FluidTypes.Props.t, ast: FluidAST.t, s: fluidState): t =>
-    emptyFor(props, s) |> setAST(ast)
+  let make = (ast: FluidAST.t, s: fluidState): t =>
+    emptyFor(s) |> setAST(ast)
 
   let exprOfActiveEditor = (astInfo: t): FluidExpression.t =>
     switch astInfo.state.activeEditor {

--- a/client/src/fluid/FluidTokenizer.resi
+++ b/client/src/fluid/FluidTokenizer.resi
@@ -60,7 +60,6 @@ module ASTInfo: {
     state: AppTypes.fluidState,
     mainTokenInfos: list<FluidToken.tokenInfo>,
     featureFlagTokenInfos: list<(ID.t, list<FluidToken.tokenInfo>)>,
-    props: FluidTypes.Props.t,
   }
 
   let setAST: (FluidAST.t, t) => t
@@ -75,9 +74,9 @@ module ASTInfo: {
 
   let getTokenNotWhitespace: t => option<FluidToken.tokenInfo>
 
-  let emptyFor: (FluidTypes.Props.t, AppTypes.fluidState) => t
+  let emptyFor: (AppTypes.fluidState) => t
 
-  let make: (FluidTypes.Props.t, FluidAST.t, AppTypes.fluidState) => t
+  let make: (FluidAST.t, AppTypes.fluidState) => t
 
   let exprOfActiveEditor: t => FluidExpression.t
 }

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -330,6 +330,7 @@ module FluidSettings = {
   }
 }
 
+// TODO: Consider renaming to 'Environment'
 module Props = {
   type rec t = {
     functions: Functions.t,

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -320,9 +320,21 @@ module State = {
   }
 }
 
+
+module FluidSettings = {
+  type t = {
+    allowTuples: bool
+  }
+
+  let default = {
+    allowTuples: false
+  }
+}
+
+
 module Props = {
   type rec t = {
     functions: Functions.t,
-    settings: Settings.t,
+    settings: FluidSettings.t,
   }
 }

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -320,7 +320,6 @@ module State = {
   }
 }
 
-
 module FluidSettings = {
   type t = {
     allowTuples: bool
@@ -330,7 +329,6 @@ module FluidSettings = {
     allowTuples: false
   }
 }
-
 
 module Props = {
   type rec t = {

--- a/client/src/fluid/FluidUtil.res
+++ b/client/src/fluid/FluidUtil.res
@@ -3,7 +3,7 @@ open Prelude
 let propsFromModel = (m: AppTypes.model): FluidTypes.Props.t => {
   functions: m.functions,
   settings: {
-    allowTuples: m.settings.contributingSettings.general.allowTuples
+    allowTuples: m.settings.contributingSettings.inProgressFeatures.allowTuples
   },
 }
 

--- a/client/src/fluid/FluidUtil.res
+++ b/client/src/fluid/FluidUtil.res
@@ -2,7 +2,9 @@ open Prelude
 
 let propsFromModel = (m: AppTypes.model): FluidTypes.Props.t => {
   functions: m.functions,
-  settings: m.settings,
+  settings: {
+    allowTuples: m.settings.contributingSettings.general.allowTuples
+  },
 }
 
 let orderRangeFromSmallToBig = ((rangeBegin, rangeEnd): (int, int)): (int, int) =>

--- a/client/src/ui/ViewUtils.res
+++ b/client/src/ui/ViewUtils.res
@@ -67,9 +67,6 @@ let createVS = (m: AppTypes.model, tl: toplevel): viewProps => {
       ~default=Loadable.NotInitialized,
     )
 
-  // TODO: env
-  //let props = FluidUtil.propsFromModel(m)
-
   let astInfo = ASTInfo.make(ast, m.fluidState)
   {
     tl: tl,

--- a/client/src/ui/ViewUtils.res
+++ b/client/src/ui/ViewUtils.res
@@ -67,8 +67,10 @@ let createVS = (m: AppTypes.model, tl: toplevel): viewProps => {
       ~default=Loadable.NotInitialized,
     )
 
-  let props = FluidUtil.propsFromModel(m)
-  let astInfo = ASTInfo.make(props, ast, m.fluidState)
+  // TODO: env
+  //let props = FluidUtil.propsFromModel(m)
+
+  let astInfo = ASTInfo.make(ast, m.fluidState)
   {
     tl: tl,
     astInfo: astInfo,

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -832,10 +832,7 @@ let defaultFunctionsProps: Functions.props = {
 
 let defaultTestProps: FluidTypes.Props.t = {
   functions: Functions.empty |> Functions.setBuiltins(defaultTestFunctions, defaultFunctionsProps),
-  settings: {
-    //...FluidTypes.FluidSettings.default,
-    allowTuples: true
-  }
+  settings: FluidTypes.FluidSettings.default
 }
 
 let fakeID1 = ID.fromInt(77777771)

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -832,7 +832,10 @@ let defaultFunctionsProps: Functions.props = {
 
 let defaultTestProps: FluidTypes.Props.t = {
   functions: Functions.empty |> Functions.setBuiltins(defaultTestFunctions, defaultFunctionsProps),
-  settings: Settings.default,
+  settings: {
+    //...FluidTypes.FluidSettings.default,
+    allowTuples: true
+  }
 }
 
 let fakeID1 = ID.fromInt(77777771)

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -4069,13 +4069,11 @@ let run = () => {
       ()
     })
 
-    if Fluid.allowUserToCreateTuple {
-      describe("create", () => {
-        t("create tuple", b, ~pos=0, ins("("), "(~___,___)")
-        t("create and fill in tuple", b, ~pos=0, insMany(list{"(", "1", ",", "2", ")"}), "(1,2)~")
-        ()
-      })
-    }
+    describe("create", () => {
+      t("create tuple", b, ~pos=0, ins("("), "(~___,___)")
+      t("create and fill in tuple", b, ~pos=0, insMany(list{"(", "1", ",", "2", ")"}), "(1,2)~")
+      ()
+    })
     describe("insert", () => {
       t("insert into empty tuple inserts", tuple2WithBothBlank, ~pos=1, ins("5"), "(5~,___)")
       t("inserting before a tuple is no-op", tuple2WithBothBlank, ~pos=0, ins("5"), "~(___,___)")

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -404,7 +404,7 @@ let process = (inputs: list<FluidTypes.Msg.inputEvent>, tc: TestCase.t): TestRes
     Js.log2("state before ", FluidUtils.debugState(tc.state))
     Js.log2("expr before", FluidAST.toExpr(tc.ast) |> FluidPrinter.eToStructure(~includeIDs=true))
   }
-  let result = Fluid.ASTInfo.make(defaultTestProps, tc.ast, tc.state) |> processMsg(inputs)
+  let result = Fluid.ASTInfo.make(tc.ast, tc.state) |> processMsg(inputs)
 
   let resultAST = FluidAST.map(result.ast, ~f=x =>
     switch x {
@@ -534,7 +534,7 @@ let tStruct = (
   test(name, () => {
     let state = {...defaultTestState, oldPos: pos, newPos: pos, selectionStart: None}
 
-    let astInfo = Fluid.ASTInfo.make(defaultTestProps, FluidAST.ofExpr(ast), state)
+    let astInfo = Fluid.ASTInfo.make(FluidAST.ofExpr(ast), state)
 
     let astInfo = processMsg(inputs, astInfo)
     expect(FluidAST.toExpr(astInfo.ast))
@@ -4069,11 +4069,13 @@ let run = () => {
       ()
     })
 
-    describe("create", () => {
-      t("create tuple", b, ~pos=0, ins("("), "(~___,___)")
-      t("create and fill in tuple", b, ~pos=0, insMany(list{"(", "1", ",", "2", ")"}), "(1,2)~")
-      ()
-    })
+    if defaultTestProps.settings.allowTuples {
+      describe("create", () => {
+        t("create tuple", b, ~pos=0, ins("("), "(~___,___)")
+        t("create and fill in tuple", b, ~pos=0, insMany(list{"(", "1", ",", "2", ")"}), "(1,2)~")
+        ()
+      })
+    }
     describe("insert", () => {
       t("insert into empty tuple inserts", tuple2WithBothBlank, ~pos=1, ins("5"), "(5~,___)")
       t("inserting before a tuple is no-op", tuple2WithBothBlank, ~pos=0, ins("5"), "~(___,___)")
@@ -5035,9 +5037,9 @@ let run = () => {
     test("backspace on partial will open AC if query matches", () => {
       let ast = FluidAST.ofExpr(let'("request", aShortInt, aPartialVar))
       let astInfo =
-        ASTInfo.make(defaultTestProps, ast, defaultTestState)
+        ASTInfo.make(ast, defaultTestState)
         |> moveTo(19)
-        |> updateKey(keypress(K.Down))
+        |> updateKey(defaultTestProps, keypress(K.Down))
         |> processMsg(list{DeleteContentBackward})
 
       let result = ASTInfo.activeTokenInfos(astInfo) |> Printer.tokensToString
@@ -5062,7 +5064,7 @@ let run = () => {
     let tokens = FluidTokenizer.tokenize(compoundExpr)
     let len = tokens |> List.map(~f=(ti: T.tokenInfo) => ti.token) |> length
     let ast = compoundExpr |> FluidAST.ofExpr
-    let astInfo = ASTInfo.make(defaultTestProps, ast, defaultTestState)
+    let astInfo = ASTInfo.make(ast, defaultTestState)
     test("gridFor - 1", () => expect(gridFor(~pos=116, tokens)) |> toEqual({row: 2, col: 2}))
     test("gridFor - 2", () => expect(gridFor(~pos=70, tokens)) |> toEqual({row: 0, col: 70}))
     test("gridFor - 3", () => expect(gridFor(~pos=129, tokens)) |> toEqual({row: 2, col: 15}))
@@ -5163,18 +5165,18 @@ let run = () => {
       expect(
         astInfo
         |> moveTo(143)
-        |> updateKey(keypress(K.Up))
-        |> updateKey(keypress(K.Up))
-        |> updateKey(keypress(K.Up))
+        |> updateKey(defaultTestProps, keypress(K.Up))
+        |> updateKey(defaultTestProps, keypress(K.Up))
+        |> updateKey(defaultTestProps, keypress(K.Up))
         |> (astInfo => astInfo.state.newPos),
       ) |> toEqual(13)
     )
     test("down goes through the autocomplete", () =>
       expect(
         moveTo(14, astInfo)
-        |> updateKey(keypress(K.Down))
-        |> updateKey(keypress(K.Down))
-        |> updateKey(keypress(K.Down))
+        |> updateKey(defaultTestProps, keypress(K.Down))
+        |> updateKey(defaultTestProps, keypress(K.Down))
+        |> updateKey(defaultTestProps, keypress(K.Down))
         |> (astInfo => astInfo.state.newPos),
       ) |> toEqual(144)
     )
@@ -5189,7 +5191,7 @@ let run = () => {
 
           updateAutocomplete(m, h.tlid, astInfo)
         })
-        |> updateMouseClick(0)
+        |> updateMouseClick(defaultTestProps, 0)
         |> (
           astInfo =>
             switch FluidAST.toExpr(astInfo.ast) {
@@ -5231,19 +5233,19 @@ let run = () => {
     )
     test("escape hides autocomplete", () =>
       expect(
-        ASTInfo.make(defaultTestProps, FluidAST.ofExpr(b), s)
+        ASTInfo.make(FluidAST.ofExpr(b), s)
         |> moveTo(0)
-        |> updateKey(InsertText("r"))
-        |> updateKey(keypress(K.Escape))
+        |> updateKey(defaultTestProps, InsertText("r"))
+        |> updateKey(defaultTestProps, keypress(K.Escape))
         |> (astInfo => astInfo.state.ac.index),
       ) |> toEqual(None)
     )
     test("right/left brings back autocomplete", () => {
-      let astInfo = ASTInfo.make(defaultTestProps, FluidAST.ofExpr(b), s)
+      let astInfo = ASTInfo.make(FluidAST.ofExpr(b), s)
       expect(
         moveTo(0, astInfo)
-        |> updateKey(InsertText("r"))
-        |> updateKey(keypress(K.Escape))
+        |> updateKey(defaultTestProps, InsertText("r"))
+        |> updateKey(defaultTestProps, keypress(K.Escape))
         |> (astInfo => astInfo.state.ac.index),
       ) |> toEqual(None)
     })

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -195,7 +195,6 @@ let acFor = (~tlid=defaultTLID, ~pos=0, m: AppTypes.model): AC.t => {
     |> Option.andThen(~f=TL.getAST)
     |> Option.andThen(~f=ast =>
       Fluid.ASTInfo.make(
-        defaultTestProps,
         ast,
         {...m.fluidState, newPos: pos},
       ) |> Fluid.ASTInfo.getToken

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -67,7 +67,7 @@ let run = () => {
       Js.log2("state before ", FluidUtils.debugState(s))
       Js.log2("pattern before", eToStructure(ast))
     }
-    let astInfo = Fluid.ASTInfo.make(FluidTestData.defaultTestProps, FluidAST.ofExpr(ast), s)
+    let astInfo = Fluid.ASTInfo.make(FluidAST.ofExpr(ast), s)
 
     let result = {
       let h = FluidUtils.h(FluidAST.toExpr(astInfo.ast))

--- a/client/test/TestFluidSelection.res
+++ b/client/test/TestFluidSelection.res
@@ -9,7 +9,7 @@ open ProgramTypes.Expr
 
 let run = () => {
   describe("getSelectedExprID", () => {
-    let aiFor = (ast, s) => ASTInfo.make(defaultTestProps, FluidAST.ofExpr(ast), s)
+    let aiFor = (ast, s) => ASTInfo.make(FluidAST.ofExpr(ast), s)
     test("nothing selected", () => {
       let s = {...defaultTestState, newPos: 2}
       let ast = plainIf

--- a/client/test/TestViewBlankor.res
+++ b/client/test/TestViewBlankor.res
@@ -22,7 +22,6 @@ let run = () => {
       let vp: ViewUtils.viewProps = {
         tl: tl,
         astInfo: FluidTokenizer.ASTInfo.make(
-          FluidTestData.defaultTestProps,
           FluidAST.ofExpr(ast),
           FluidTypes.State.default,
         ),


### PR DESCRIPTION
Problems I'm solving for:
- I'm tired of flipping this hardcoded flag on/off when I'm developing Tuple stuff
- I'd like others to be able to use Tuples and provide feedback without having to pull the Dark source code and flip the hardcoded flag

What this does:
- renames the "Tools" section of Contributor Settings to "General"
- adds a new "Allow Tuples" setting to the Contributor Settings
  use _it_ rather than the hardcoded `bool` value to determine if Fluid should allow Tuples to be created

![image](https://user-images.githubusercontent.com/906686/187494039-f24ef3af-7cc8-4595-a3e9-333776547b7f.png)

---

Outstanding problem:

- [ ] Updating the setting doesn't take immediate effect.

The settings being updated doesn't seem to propogate to Fluid immediately, so a refresh is currently required for the tuple setting to take effect. This is likely due to the `ViewUtils.createVS` fn being called so rarely (i.e. only when the TLID or something big is changing).