### PR TITLE
Allow tuple patterns to be expanded with ,

### DIFF
--- a/client/src/fluid/AST.res
+++ b/client/src/fluid/AST.res
@@ -300,7 +300,7 @@ let variablesIn = (ast: E.t): AnalysisTypes.avDict => {
 
 let removePartials = (expr: E.t): E.t =>
   E.postTraversal(
-    ~f=x =>
+    ~fExpr=x =>
       switch x {
       | EPartial(_, _, e)
       | ERightPartial(_, _, e)

--- a/client/src/fluid/AST.res
+++ b/client/src/fluid/AST.res
@@ -265,9 +265,7 @@ let rec sym_exec = (~trace: (E.t, sym_set) => unit, st: sym_set, expr: E.t): uni
         | PVariable(patternID, v) => list{(patternID, v)}
         | PConstructor(_, _, inner) => inner |> List.map(~f=variablesInPattern) |> List.flatten
         | PTuple(_, first, second, theRest) =>
-          list{first, second, ...theRest}
-          |> List.map(~f=variablesInPattern)
-          |> List.flatten
+          list{first, second, ...theRest} |> List.map(~f=variablesInPattern) |> List.flatten
         }
 
       sexe(st, matchExpr)

--- a/client/src/fluid/AST.res
+++ b/client/src/fluid/AST.res
@@ -299,13 +299,16 @@ let variablesIn = (ast: E.t): AnalysisTypes.avDict => {
 }
 
 let removePartials = (expr: E.t): E.t =>
-  E.postTraversal(expr, ~f=x =>
-    switch x {
-    | EPartial(_, _, e)
-    | ERightPartial(_, _, e)
-    | ELeftPartial(_, _, e)
-    | e => e
-    }
+  E.postTraversal(
+    ~f=x =>
+      switch x {
+      | EPartial(_, _, e)
+      | ERightPartial(_, _, e)
+      | ELeftPartial(_, _, e)
+      | e => e
+      },
+    ~fPattern=p => p,
+    expr,
   )
 
 @ocaml.doc(" Reorder function calls which call fnName, moving the argument at [oldPos] to [newPos],

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -2212,7 +2212,6 @@ let insertAtTupleEnd = (~newExpr: E.t, id: id, ast: FluidAST.t): FluidAST.t =>
     ast,
   )
 
-// TUPLETODO these are a WIP
 let insertInTuplePattern = (~index: int, ~newPat: P.t, id: id, ast: FluidAST.t): FluidAST.t =>
   FluidAST.update(
     ~fExpr=e => e,

--- a/client/src/fluid/FluidAST.res
+++ b/client/src/fluid/FluidAST.res
@@ -22,7 +22,7 @@ let replace = (~replacement: E.t, target: id, ast: t): t =>
   map(ast, ~f=E.replace(~replacement, target))
 
 let update = (~failIfMissing=true, ~fExpr: E.t => E.t, target: id, ast: t): t => {
-  map(ast, ~f=E.update(~failIfMissing, ~f=fExpr, target))
+  map(ast, ~f=E.update(~failIfMissing, ~f=fExpr, ~fPattern=p => p, target))
 }
 
 let filter = (ast: t, ~f: E.t => bool): list<E.t> => toExpr(ast) |> E.filter(~f)

--- a/client/src/fluid/FluidAST.res
+++ b/client/src/fluid/FluidAST.res
@@ -23,7 +23,7 @@ let replace = (~replacement: E.t, target: id, ast: t): t =>
   map(ast, ~f=E.replace(~replacement, target))
 
 let update = (~failIfMissing=true, ~fExpr: E.t => E.t, ~fPattern: P.t => P.t, target: id, ast: t): t => {
-  map(ast, ~f=E.update(~failIfMissing, ~f=fExpr, ~fPattern, target))
+  map(ast, ~f=E.update(~failIfMissing, ~fExpr, ~fPattern, target))
 }
 
 let filter = (ast: t, ~f: E.t => bool): list<E.t> => toExpr(ast) |> E.filter(~f)

--- a/client/src/fluid/FluidAST.res
+++ b/client/src/fluid/FluidAST.res
@@ -1,4 +1,5 @@
 module E = FluidExpression
+module P = FluidPattern
 
 open ProgramTypes.AST
 
@@ -21,8 +22,8 @@ let map = (~f: E.t => E.t, ast: t): t => toExpr(ast) |> f |> ofExpr
 let replace = (~replacement: E.t, target: id, ast: t): t =>
   map(ast, ~f=E.replace(~replacement, target))
 
-let update = (~failIfMissing=true, ~fExpr: E.t => E.t, target: id, ast: t): t => {
-  map(ast, ~f=E.update(~failIfMissing, ~f=fExpr, ~fPattern=p => p, target))
+let update = (~failIfMissing=true, ~fExpr: E.t => E.t, ~fPattern: P.t => P.t, target: id, ast: t): t => {
+  map(ast, ~f=E.update(~failIfMissing, ~f=fExpr, ~fPattern, target))
 }
 
 let filter = (ast: t, ~f: E.t => bool): list<E.t> => toExpr(ast) |> E.filter(~f)

--- a/client/src/fluid/FluidAST.res
+++ b/client/src/fluid/FluidAST.res
@@ -21,8 +21,9 @@ let map = (~f: E.t => E.t, ast: t): t => toExpr(ast) |> f |> ofExpr
 let replace = (~replacement: E.t, target: id, ast: t): t =>
   map(ast, ~f=E.replace(~replacement, target))
 
-let update = (~failIfMissing=true, ~f: E.t => E.t, target: id, ast: t): t =>
-  map(ast, ~f=E.update(~failIfMissing, ~f, target))
+let update = (~failIfMissing=true, ~fExpr: E.t => E.t, target: id, ast: t): t => {
+  map(ast, ~f=E.update(~failIfMissing, ~f=fExpr, target))
+}
 
 let filter = (ast: t, ~f: E.t => bool): list<E.t> => toExpr(ast) |> E.filter(~f)
 

--- a/client/src/fluid/FluidAST.resi
+++ b/client/src/fluid/FluidAST.resi
@@ -56,7 +56,7 @@ let replace: (~replacement: FluidExpression.t, ID.t, t) => t
 let update: (
   ~failIfMissing: bool=?,
   ~fExpr: FluidExpression.t => FluidExpression.t,
-  //~fPat: FluidPattern.t => FluidPattern.t,
+  ~fPattern: FluidPattern.t => FluidPattern.t,
   ID.t,
   t,
 ) => t

--- a/client/src/fluid/FluidAST.resi
+++ b/client/src/fluid/FluidAST.resi
@@ -42,17 +42,24 @@ let map: (~f: FluidExpression.t => FluidExpression.t, t) => t
   * See FluidExpression.replace ")
 let replace: (~replacement: FluidExpression.t, ID.t, t) => t
 
-@ocaml.doc(" [update f target ast] recursively searches [ast] for the expression having
-  * an id of [target].
-  *
-  * If found, replaces the expression with the result of [f e] and returns the
-  * new AST. If not found, will asserT before returning the unmodified [ast].
-  *
-  * Passing failIfMissing=false will skip the asserT and silently return an
-  * unmodified AST.
-  *
-  * See FluidExpression.update ")
-let update: (~failIfMissing: bool=?, ~f: FluidExpression.t => FluidExpression.t, ID.t, t) => t
+@ocaml.doc(" [update fExpr fPat target ast] recursively searches [ast] for the
+  expression or pattern having an id of [target].
+
+  If found, replaces the expression/pattern with the result of [f e] and
+  returns the new AST. If not found, will asserT before returning the
+  unmodified [ast].
+
+  Passing failIfMissing=false will skip the asserT and silently return an
+  unmodified AST.
+
+  See FluidExpression.update ")
+let update: (
+  ~failIfMissing: bool=?,
+  ~fExpr: FluidExpression.t => FluidExpression.t,
+  //~fPat: FluidPattern.t => FluidPattern.t,
+  ID.t,
+  t,
+) => t
 
 @ocaml.doc(" [filter ast ~f] recursively calls [f] on every expression within [ast],
   * returning a list of all expressions for which [f e] is true.

--- a/client/src/fluid/FluidCursorTypes.res
+++ b/client/src/fluid/FluidCursorTypes.res
@@ -13,8 +13,7 @@ module AstRef = {
     | FPFractional
 
   @ppx.deriving(show({with_path: false}))
-  type rec astStringPart =
-    | SPOpenQuote
+  type rec astStringPart = SPOpenQuote
 
   @ppx.deriving(show({with_path: false}))
   type rec astLetPart =

--- a/client/src/fluid/FluidExpression.res
+++ b/client/src/fluid/FluidExpression.res
@@ -263,7 +263,8 @@ let rec preTraversal = (~f: t => t, expr: t): t => {
 
 let rec postTraversal = (~f: t => t, ~fPattern: fluidPattern => fluidPattern, expr: t): t => {
   let r = postTraversal(~f, ~fPattern)
-  //let rP = FluidPattern.postTraversal()
+  let rP = FluidPattern.postTraversal(~f=fPattern)
+
   let result = switch expr {
   | EInteger(_)
   | EBlank(_)
@@ -283,7 +284,7 @@ let rec postTraversal = (~f: t => t, ~fPattern: fluidPattern => fluidPattern, ex
   | EList(id, exprs) => EList(id, List.map(~f=r, exprs))
   | ETuple(id, first, second, theRest) => ETuple(id, r(first), r(second), List.map(~f=r, theRest))
   | EMatch(id, mexpr, pairs) =>
-    EMatch(id, r(mexpr), List.map(~f=((pat, expr)) => (pat, r(expr)), pairs))
+    EMatch(id, r(mexpr), List.map(~f=((pat, expr)) => (rP(pat), r(expr)), pairs))
   | ERecord(id, fields) => ERecord(id, List.map(~f=((name, expr)) => (name, r(expr)), fields))
   | EPipe(id, expr1, expr2, exprs) => EPipe(id, r(expr1), r(expr2), List.map(~f=r, exprs))
   | EConstructor(id, name, exprs) => EConstructor(id, name, List.map(~f=r, exprs))
@@ -374,6 +375,14 @@ let update = (
       f(e)
     } else {
       e
+    }
+  }
+  let fPattern = p => {
+    if FluidPattern.toID(p) == target {
+      found := true
+      fPattern(p)
+    } else {
+      p
     }
   }
 

--- a/client/src/fluid/FluidExpression.res
+++ b/client/src/fluid/FluidExpression.res
@@ -94,8 +94,10 @@ let rec findExprOrPat = (target: id, within: fluidPatOrExpr): option<fluidPatOrE
     | PCharacter(pid, _)
     | PString(pid, _) => (pid, list{})
     | PConstructor(pid, _, pats) => (pid, List.map(pats, ~f=p1 => Pat(matchID, p1)))
-    | PTuple(pid, first, second, theRest) =>
-      (pid, List.map(list{first, second, ...theRest}, ~f=p1 => Pat(matchID, p1)))
+    | PTuple(pid, first, second, theRest) => (
+        pid,
+        List.map(list{first, second, ...theRest}, ~f=p1 => Pat(matchID, p1)),
+      )
     }
   }
 

--- a/client/src/fluid/FluidExpression.resi
+++ b/client/src/fluid/FluidExpression.resi
@@ -37,6 +37,7 @@ let preTraversal: (
  * call preTraversal. ")
 let postTraversal: (
   ~f: ProgramTypes.Expr.t => ProgramTypes.Expr.t,
+  ~fPattern: ProgramTypes.Pattern.t => ProgramTypes.Pattern.t,
   ProgramTypes.Expr.t,
 ) => ProgramTypes.Expr.t
 
@@ -99,6 +100,7 @@ let ancestors: (ID.t, ProgramTypes.Expr.t) => list<ProgramTypes.Expr.t>
 let update: (
   ~failIfMissing: bool=?,
   ~f: ProgramTypes.Expr.t => ProgramTypes.Expr.t,
+  ~fPattern: ProgramTypes.Pattern.t => ProgramTypes.Pattern.t,
   ID.t,
   ProgramTypes.Expr.t,
 ) => ProgramTypes.Expr.t

--- a/client/src/fluid/FluidExpression.resi
+++ b/client/src/fluid/FluidExpression.resi
@@ -36,7 +36,7 @@ let preTraversal: (
  * calling [f], the result is NOT recursed into; if this isn't what you want
  * call preTraversal. ")
 let postTraversal: (
-  ~f: ProgramTypes.Expr.t => ProgramTypes.Expr.t,
+  ~fExpr: ProgramTypes.Expr.t => ProgramTypes.Expr.t,
   ~fPattern: ProgramTypes.Pattern.t => ProgramTypes.Pattern.t,
   ProgramTypes.Expr.t,
 ) => ProgramTypes.Expr.t
@@ -99,7 +99,7 @@ let ancestors: (ID.t, ProgramTypes.Expr.t) => list<ProgramTypes.Expr.t>
     If not found, will assertT before returning the unmodified [ast]. ")
 let update: (
   ~failIfMissing: bool=?,
-  ~f: ProgramTypes.Expr.t => ProgramTypes.Expr.t,
+  ~fExpr: ProgramTypes.Expr.t => ProgramTypes.Expr.t,
   ~fPattern: ProgramTypes.Pattern.t => ProgramTypes.Pattern.t,
   ID.t,
   ProgramTypes.Expr.t,

--- a/client/src/fluid/FluidPattern.res
+++ b/client/src/fluid/FluidPattern.res
@@ -21,12 +21,10 @@ let toID = (p: t): id =>
 
 let rec ids = (p: t): list<id> =>
   switch p {
-  | PConstructor(id, _, list) =>
-    list |> List.map(~f=ids) |> List.flatten |> (l => list{id, ...l})
+  | PConstructor(id, _, list) => list |> List.map(~f=ids) |> List.flatten |> (l => list{id, ...l})
 
   | PTuple(id, first, second, theRest) =>
-    list{first, second, ...theRest} |> List.map(~f=ids) |> List.flatten
-    |> (l => list{id, ...l})
+    list{first, second, ...theRest} |> List.map(~f=ids) |> List.flatten |> (l => list{id, ...l})
 
   | PVariable(_)
   | PInteger(_)
@@ -58,7 +56,8 @@ let rec variableNames = (p: t): list<string> =>
   switch p {
   | PVariable(_, name) => list{name}
   | PConstructor(_, _, patterns) => patterns |> List.map(~f=variableNames) |> List.flatten
-  | PTuple(_, first, second, theRest) => list{first, second, ...theRest} |> List.map(~f=variableNames) |> List.flatten
+  | PTuple(_, first, second, theRest) =>
+    list{first, second, ...theRest} |> List.map(~f=variableNames) |> List.flatten
   | PInteger(_) | PBool(_) | PString(_) | PCharacter(_) | PBlank(_) | PNull(_) | PFloat(_) => list{}
   }
 

--- a/client/src/fluid/FluidPrinter.res
+++ b/client/src/fluid/FluidPrinter.res
@@ -35,13 +35,13 @@ let eToStructure = (~includeIDs=false, e: E.t): string =>
 
 let pToString = (p: fluidPattern): string =>
   p
-  |> FluidTokenizer.patternToToken(ID.fromInt(0), ~idx=0)
+  |> FluidTokenizer.patternToTokens(ID.fromInt(0), ~idx=0)
   |> List.map(~f=t => T.toTestText(t))
   |> String.join(~sep="")
 
 let pToStructure = (p: fluidPattern): string =>
   p
-  |> FluidTokenizer.patternToToken(ID.fromInt(0), ~idx=0)
+  |> FluidTokenizer.patternToTokens(ID.fromInt(0), ~idx=0)
   |> List.map(~f=t => "<" ++ (T.toTypeName(t) ++ (":" ++ (T.toText(t) ++ ">"))))
   |> String.join(~sep="")
 

--- a/client/src/fluid/FluidToken.res
+++ b/client/src/fluid/FluidToken.res
@@ -56,7 +56,6 @@ let tid = (t: t): id =>
   | TRecordFieldname({recordID: id, _})
   | TRecordSep(id, _, _)
   | TConstructorName(id, _)
-
   | TMatchBranchArrow({matchID: id, _})
   | TMatchKeyword(id)
   | TPatternBlank(_, id, _)
@@ -73,7 +72,6 @@ let tid = (t: t): id =>
   | TPatternTupleOpen(id)
   | TPatternTupleClose(id)
   | TPatternTupleComma(id, _)
-
   | TSep(id, _)
   | TParenOpen(id)
   | TParenClose(id)
@@ -159,7 +157,6 @@ let parentBlockID = (t: t): option<id> =>
 
   | TFnName(_)
   | TFnVersion(_)
-
   | TMatchKeyword(_)
   | TMatchBranchArrow(_)
   | TPatternVariable(_)
@@ -176,7 +173,6 @@ let parentBlockID = (t: t): option<id> =>
   | TPatternTupleClose(_)
   | TPatternTupleComma(_)
   | TPatternBlank(_)
-
   | TConstructorName(_)
   | TParenOpen(_)
   | TParenClose(_)

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -898,8 +898,7 @@ module ASTInfo = {
     featureFlagTokenInfos: list{},
   }
 
-  let make = (ast: FluidAST.t, s: fluidState): t =>
-    emptyFor(s) |> setAST(ast)
+  let make = (ast: FluidAST.t, s: fluidState): t => emptyFor(s) |> setAST(ast)
 
   let exprOfActiveEditor = (astInfo: t): FluidExpression.t =>
     switch astInfo.state.activeEditor {

--- a/client/src/fluid/FluidTokenizer.resi
+++ b/client/src/fluid/FluidTokenizer.resi
@@ -74,7 +74,7 @@ module ASTInfo: {
 
   let getTokenNotWhitespace: t => option<FluidToken.tokenInfo>
 
-  let emptyFor: (AppTypes.fluidState) => t
+  let emptyFor: AppTypes.fluidState => t
 
   let make: (FluidAST.t, AppTypes.fluidState) => t
 

--- a/client/src/fluid/FluidTokenizer.resi
+++ b/client/src/fluid/FluidTokenizer.resi
@@ -20,12 +20,12 @@ let tokensForEditor: (FluidTypes.Editor.t, FluidAST.t) => list<FluidToken.tokenI
 @ocaml.doc(" returns the given expression, tokenized with the rules of the specified editor ")
 let tokenizeForEditor: (FluidTypes.Editor.t, FluidExpression.t) => list<FluidToken.tokenInfo>
 
-@@ocaml.text(" patternToToken takes a match pattern `p` and converts it to a list of
+@@ocaml.text(" patternToTokens takes a match pattern `p` and converts it to a list of
     fluidTokens.
 
     ~idx is the zero-based index of the pattern in the enclosing match ")
 
-let patternToToken: (ID.t, FluidPattern.t, ~idx: int) => list<FluidTypes.Token.t>
+let patternToTokens: (ID.t, FluidPattern.t, ~idx: int) => list<FluidTypes.Token.t>
 
 let getTokensAtPosition: (
   ~prev: option<FluidToken.tokenInfo>=?,

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -139,7 +139,7 @@ module Token = {
     | TPatternFloatWhole(ID.t, ID.t, string, int)
     | TPatternFloatPoint(ID.t, ID.t, int)
     | TPatternFloatFractional(ID.t, ID.t, string, int)
-    
+
     | TPatternBlank(ID.t, ID.t, int)
 
     | TPatternTupleOpen(ID.t)
@@ -333,12 +333,10 @@ module State = {
 }
 
 module FluidSettings = {
-  type t = {
-    allowTuples: bool
-  }
+  type t = {allowTuples: bool}
 
   let default = {
-    allowTuples: false
+    allowTuples: false,
   }
 }
 

--- a/client/src/fluid/FluidUtil.res
+++ b/client/src/fluid/FluidUtil.res
@@ -3,7 +3,7 @@ open Prelude
 let propsFromModel = (m: AppTypes.model): FluidTypes.Props.t => {
   functions: m.functions,
   settings: {
-    allowTuples: m.settings.contributingSettings.inProgressFeatures.allowTuples
+    allowTuples: m.settings.contributingSettings.inProgressFeatures.allowTuples,
   },
 }
 

--- a/client/src/fluid/Refactor.res
+++ b/client/src/fluid/Refactor.res
@@ -98,7 +98,9 @@ let wrap = (wl: wrapLoc, _: model, tl: toplevel, id: id): AppTypes.modification 
   }
 
   TL.getAST(tl)
-  |> Option.map(~f=\">>"(FluidAST.update(~fExpr=replacement, id), TL.setASTMod(tl)))
+  |> Option.map(
+    ~f=\">>"(FluidAST.update(~fExpr=replacement, ~fPattern=p => p, id), TL.setASTMod(tl)),
+  )
   |> Option.unwrap(~default=Mod.NoChange)
 }
 
@@ -112,7 +114,7 @@ let takeOffRail = (_m: model, tl: toplevel, id: id): modification =>
         | EFnCall(_, name, exprs, Rail) => EFnCall(id, name, exprs, NoRail)
         | e => recover("incorrect id in takeoffRail", e)
         },
-      
+      ~fPattern=p => p,
       id,
     )
     |> TL.setASTMod(tl)
@@ -134,7 +136,7 @@ let putOnRail = (m: model, tl: toplevel, id: id): modification =>
         | EFnCall(_, name, exprs, NoRail) if isRailable(m, name) => EFnCall(id, name, exprs, Rail)
         | e => e
         },
-
+      ~fPattern=p => p,
       id,
       ast,
     )
@@ -182,7 +184,7 @@ let extractVarInAst = (
           switch x {
           | last => ELet(gid(), varname, FluidExpression.clone(e), last)
           },
-
+        ~fPattern=p => p,
         FluidExpression.toID(last),
       )
       |> FluidAST.replace(FluidExpression.toID(e), ~replacement=EVariable(gid(), varname))

--- a/client/test/FluidFuzzer.res
+++ b/client/test/FluidFuzzer.res
@@ -227,7 +227,7 @@ let unwrap = (id: id, ast: E.t): E.t => {
   let childOr = (exprs: list<E.t>) => List.find(exprs, ~f=e => E.toID(e) == id)
 
   E.postTraversal(
-    ~f=e => {
+    ~fExpr=e => {
       let newExpr = switch e {
       | ELet(_, _, rhs, next) => childOr(list{rhs, next})
       | EIf(_, cond, ifexpr, elseexpr) => childOr(list{cond, ifexpr, elseexpr})
@@ -261,7 +261,7 @@ let changeStrings = (id: id, ~f: string => string, ast: E.t): E.t => {
       str
     }
   E.postTraversal(
-    ~f=x =>
+    ~fExpr=x =>
       switch x {
       | ELet(id, name, rhs, next) => ELet(id, fStr(id, name), rhs, next)
       | EFieldAccess(id, expr, fieldname) => EFieldAccess(id, expr, fStr(id, fieldname))
@@ -347,7 +347,7 @@ let shortenNames = (id: id, expr: E.t): E.t =>
 let remove = (id: id, ast: E.t): E.t => {
   let removeFromList = exprs => List.filter(exprs, ~f=e => E.toID(e) != id)
   E.postTraversal(
-    ~f=x =>
+    ~fExpr=x =>
       switch x {
       | e if E.toID(e) == id => EBlank(id)
       | EFnCall(id, name, exprs, ster) => EFnCall(id, name, removeFromList(exprs), ster)
@@ -403,7 +403,7 @@ let remove = (id: id, ast: E.t): E.t => {
 
 let simplify = (id: id, ast: E.t): E.t =>
   E.update(
-    ~f=x =>
+    ~fExpr=x =>
       switch x {
       | EBlank(e) => EBlank(e)
       | _ => EInteger(id, 5L)


### PR DESCRIPTION
This is part of #4427

Prior to this, tuple patterns were restricted to 2 elements - `,` keystrokes within them did nothing.

The blocker here was that we didn't have a great way to update the _patterns_ of Fluid expressions without context of the matchId, in the same `FluidAST.update` fashion as Expr updates are.

This removes that blocker, and implements the expected `,` functionality.

(For situations with a MatchID within context, a few functions are available in Fluid.res itself: `replacePattern` mostly, which uses  `updatePattern` and `recursePattern`. If this PR looks OK directionally, I"ll see about removing those.)

This:
- catches up on some ReScript code formatting that I hadn't performed before
- updates FluidExpression.update to use postTraversal instead of `deprecatedWalk` (preTraversal broke a ton of tests)
- updates FluidExpression.update to take both an `fExpr` as well as a new `fPattern` - extending the functionality to work with Patterns as well as traces.
- for all usages of `update`, ensure the labeled params are before the un-labeled params
- adds `insertInTuplePattern` and `insertAtTuplePatternEnd`, which are the accessory functions driving this whole change
- respect `,` inputs in a tuple match pattern, by adding elements

Some TODOs:
- [ ] get feedback - does this strategy make sense? It feels a bit annoying to pass `fExpr` and `fPattern` all over the place, but likely that's a necesarry annoyance? My other thought here was to update everything to use `fluidPatOrExpr`s, but that didn't pan out well.
- [ ] see if we can remove the `updatePattern` and `recursePattern` within Fluid.res (seems out of place)
- [ ] add tests