### PR TITLE
Allow pressing enter in more expression bodies

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -5001,9 +5001,14 @@ let rec updateKey = (
       |> moveToAstRef(ARRecord(parentId, RPFieldname(idx + 1)))
     | _ => astInfo
     }
-  /*
-   * Caret at very beginning of tokens or at beginning of non-special line. */
+  // Caret at very beginning of a nested expr - exception: don't do it in the middle
+  // of the preeceding syntax token
+  | (Keypress({key: K.Enter, _}), L(TMatchBranchArrow(_), _), R(TMatchBranchArrow(_), _))
+  | (Keypress({key: K.Enter, _}), L(TLambdaArrow(_), _), R(TLambdaArrow(_), _)) => astInfo
+  // Caret at very beginning of tokens or at beginning of non-special line.
   | (Keypress({key: K.Enter, _}), No, R(t, _))
+  | (Keypress({key: K.Enter, _}), L(TMatchBranchArrow(_), _), R(t, _))
+  | (Keypress({key: K.Enter, _}), L(TLambdaArrow(_), _), R(t, _))
   | (Keypress({key: K.Enter, _}), L(TNewline(_), _), R(t, _)) =>
     /* In some cases, like |1 + 2, we want to wrap the parent expr (in this case the binop) in a let.
      * This has to be recursive to handle variations on |1*2 + 3.

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2793,7 +2793,14 @@ let run = () => {
       bs,
       "\\aVar, bVar~ -> aVar + ___ * bVar",
     )
-    ()
+    t("enter in lambda arrow does nothing", lambdaWithTwoBindings, ~pos=7, enter, "\\x, y -~> ___")
+    t(
+      "enter after lambda arrow inserts let",
+      lambdaWithTwoBindings,
+      ~pos=9,
+      enter,
+      "\\x, y -> let *** = ___\n         ~___",
+    )
   })
   describe("Variables", () => {
     t(~expectsPartial=true, "insert middle of variable", aVar, ~pos=5, ins("c"), "variac~ble")
@@ -2950,6 +2957,20 @@ let run = () => {
       ~pos=39,
       enter,
       "let a = match ___\n          *** -> ___\nlet *** = ___\n~5",
+    )
+    t(
+      "enter at beginning of match expr body adds let, not match row",
+      matchWithBinding("a", five),
+      ~pos=17,
+      enter,
+      "match ___\n  a -> let *** = ___\n       ~5\n",
+    )
+    t(
+      "enter in a match arrow does nothing",
+      matchWithBinding("a", five),
+      ~pos=15,
+      enter,
+      "match ___\n  a -~> 5\n",
     )
     t(
       "enter at the start of a row creates a new row",
@@ -4013,7 +4034,7 @@ let run = () => {
     )
     ()
   })
-  
+
   describe("Tuples", () => {
     describe("render", () => {
       t("blank tuple", tuple2WithBothBlank, render, "~(___,___)")

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2759,28 +2759,28 @@ let run = () => {
       "\\x,~ y -> ___",
     )
     t(
-      "ctrl+left twice over lamda from beg moves to beg of first param",
+      "ctrl+left twice over lambda from beg moves to beg of first param",
       lambdaWithTwoBindings,
       ~pos=1,
       keys(list{K.GoToStartOfWord(DropSelection), K.GoToStartOfWord(DropSelection)}),
       "~\\x, y -> ___",
     )
     t(
-      "ctrl+right twice over lamda from beg moves to last blank",
+      "ctrl+right twice over lambda from beg moves to last blank",
       lambdaWithTwoBindings,
       ~pos=1,
       keys(list{K.GoToEndOfWord(DropSelection), K.GoToEndOfWord(DropSelection)}),
       "\\x, y~ -> ___",
     )
     t(
-      "ctrl+left twice over lamda from end moves to end of second param",
+      "ctrl+left twice over lambda from end moves to end of second param",
       lambdaWithTwoBindings,
       ~pos=12,
       keys(list{K.GoToStartOfWord(DropSelection), K.GoToStartOfWord(DropSelection)}),
       "\\x, ~y -> ___",
     )
     t(
-      "ctrl+right twice over lamda from end doesnt move",
+      "ctrl+right twice over lambda from end doesnt move",
       lambdaWithTwoBindings,
       ~pos=12,
       keys(list{K.GoToEndOfWord(DropSelection), K.GoToEndOfWord(DropSelection)}),

--- a/fsharp-backend/tests/TestUtils/TestUtils.fs
+++ b/fsharp-backend/tests/TestUtils/TestUtils.fs
@@ -745,7 +745,7 @@ module Expect =
     | DErrorRail l, DErrorRail r -> de ("ErrorRail" :: path) l r
     | DFnVal (Lambda l1), DFnVal (Lambda l2) ->
       let vals l = List.map Tuple2.second l
-      check ("lamdaVars" :: path) (vals l1.parameters) (vals l2.parameters)
+      check ("lambdaVars" :: path) (vals l1.parameters) (vals l2.parameters)
       check ("symbtable" :: path) l1.symtable l2.symtable // TODO: use dvalEquality
       exprEqualityBaseFn false path l1.body l2.body errorFn
     | DStr _, DStr _ -> check path (debugDval actual) (debugDval expected)


### PR DESCRIPTION
When you're at the start of an expressions, pressing enter should insert a new line (which at the moment means a let). That mostly works, but there were two places it didn't:

## lambda bodies

![2022-09-01 09 31 44](https://user-images.githubusercontent.com/181762/187926655-55def644-a1f4-4a56-b4ed-436080eea027.gif)


## match pattern expression bodies

![2022-09-01 09 32 13](https://user-images.githubusercontent.com/181762/187926685-bba62e8c-d5bb-45ae-8631-226c22b6b882.gif)


