### PR TITLE
Make match arrows match the style of other arrows

### DIFF
--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -305,6 +305,7 @@ $ff-color: adjust-hue($purple, -40deg);
     margin-right: 0.11px;
   }
 
+  .fluid-match-branch-arrow,
   .fluid-lambda-symbol,
   .fluid-lambda-var,
   .fluid-lambda-arrow {
@@ -409,11 +410,12 @@ $ff-color: adjust-hue($purple, -40deg);
     position: relative;
   }
 
+  .fluid-match-branch-arrow,
   .fluid-binop,
   .fluid-pipe-symbol,
   .fluid-lambda-arrow {
-    /* Fira Code renders slightly larger than Mono in some circumstances, and
-     * we don't want our symbols to be taller than our text. */
+    // Fira Code renders slightly larger than Mono in some circumstances, and
+    // we don't want our symbols to be taller than our text.
     font-size: 90%;
     font-family: "Fira Code", monospace;
   }


### PR DESCRIPTION
Before:

<img width="365" alt="Screen Shot 2022-09-01 at 9 48 16 AM" src="https://user-images.githubusercontent.com/181762/187930327-02f150cb-cec6-44ac-ac54-dd971b5b8250.png">


After:

<img width="365" alt="Screen Shot 2022-09-01 at 9 44 51 AM" src="https://user-images.githubusercontent.com/181762/187929549-5f47a52d-3cbf-4a52-a29c-4673ed08114c.png">
