### PR TITLE
Allow tuple patterns to be expanded with ,

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -757,10 +757,10 @@ let posFromCaretTarget = (ct: CT.t, astInfo: ASTInfo.t): int => {
     | (ARFloat(id, FPFractional), TFloatFractional(id', _, _)) if id == id' =>
       posForTi(ti)
 
-    | (ARPattern(id, PPTuple(TPOpen)), TPatternTupleOpen(id'))
-    | (ARPattern(id, PPTuple(TPClose)), TPatternTupleClose(id')) if id == id' =>
+    | (ARPattern(id, PPTuple(TPOpen)), TPatternTupleOpen(_, id'))
+    | (ARPattern(id, PPTuple(TPClose)), TPatternTupleClose(_, id')) if id == id' =>
       posForTi(ti)
-    | (ARPattern(id, PPTuple(TPComma(idx))), TPatternTupleComma(id', idx')) if id == id' && idx == idx' =>
+    | (ARPattern(id, PPTuple(TPComma(idx))), TPatternTupleComma(_, id', idx')) if id == id' && idx == idx' =>
       posForTi(ti)
 
     /*
@@ -981,11 +981,11 @@ let caretTargetFromTokenInfo = (pos: int, ti: T.tokenInfo): option<CT.t> => {
   | TPatternFloatPoint(_, id, _) => Some({astRef: ARPattern(id, PPFloat(FPPoint)), offset: offset})
   | TPatternFloatFractional(_, id, _, _) =>
     Some({astRef: ARPattern(id, PPFloat(FPFractional)), offset: offset})
-  | TPatternTupleOpen(id) =>
+  | TPatternTupleOpen(_, id) =>
     Some({astRef: ARPattern(id, PPTuple(TPOpen)), offset: offset})
-  | TPatternTupleClose(id) =>
+  | TPatternTupleClose(_, id) =>
     Some({astRef: ARPattern(id, PPTuple(TPClose)), offset: offset})
-  | TPatternTupleComma(id, idx) =>
+  | TPatternTupleComma(_, id, idx) =>
     Some({astRef: ARPattern(id, PPTuple(TPComma(idx))), offset: offset})
   | TPatternBlank(_, id, _) => Some({astRef: ARPattern(id, PPBlank), offset: offset})
 

--- a/client/src/fluid/FluidAST.res
+++ b/client/src/fluid/FluidAST.res
@@ -19,25 +19,17 @@ let ofExpr = e => Root(e)
 
 let toID = (Root(e)) => E.toID(e)
 
-let map = (~f: E.t => E.t, ast: t): t => toExpr(ast) |> f |> ofExpr
-
-let replace = (~replacement: E.t, target: id, ast: t): t =>
-  map(ast, ~f=E.replace(~replacement, target))
-
-let update = (~failIfMissing=true, ~f: E.t => E.t, target: id, ast: t): t =>
-  map(ast, ~f=E.update(~failIfMissing, ~f, target))
+let ids = (ast: t): list<id> => toExpr(ast) |> E.ids
 
 let filter = (ast: t, ~f: E.t => bool): list<E.t> => toExpr(ast) |> E.filter(~f)
-
-let blanks = (ast: t): list<E.t> => toExpr(ast) |> E.blanks
-
-let ids = (ast: t): list<id> => toExpr(ast) |> E.ids
 
 let find = (target: id, ast: t): option<E.t> => toExpr(ast) |> E.find(target)
 
 let findParent = (target: id, ast: t): option<E.t> => toExpr(ast) |> E.findParent(target)
 
 let ancestors = (target: id, ast: t): list<E.t> => toExpr(ast) |> E.ancestors(target)
+
+let blanks = (ast: t): list<E.t> => toExpr(ast) |> E.blanks
 
 let getFeatureFlags = (ast: t): list<E.t> =>
   filter(ast, ~f=x =>
@@ -47,9 +39,17 @@ let getFeatureFlags = (ast: t): list<E.t> =>
     }
   )
 
-let clone = map(~f=E.clone)
-
 let testEqualIgnoringIds = (a: t, b: t): bool => E.testEqualIgnoringIds(toExpr(a), toExpr(b))
+
+let map = (~f: E.t => E.t, ast: t): t => toExpr(ast) |> f |> ofExpr
+
+let replace = (~replacement: E.t, target: id, ast: t): t =>
+  map(ast, ~f=E.replace(~replacement, target))
+
+let update = (~failIfMissing=true, ~f: E.t => E.t, target: id, ast: t): t =>
+  map(ast, ~f=E.update(~failIfMissing, ~f, target))
+
+let clone = map(~f=E.clone)
 
 let updatePattern = (
   ~f: fluidPattern => fluidPattern,

--- a/client/src/fluid/FluidAST.resi
+++ b/client/src/fluid/FluidAST.resi
@@ -103,3 +103,12 @@ let clone: t => t
   *
   * Find the implementation in the FluidExpression function of the same name. ")
 let testEqualIgnoringIds: (t, t) => bool
+
+let updatePattern: (
+  ~f: FluidPattern.t => FluidPattern.t,
+  ID.t,
+  ID.t,
+  t,
+) => t
+
+let replacePattern: (~newPat: FluidPattern.t, ID.t, ID.t, t) => t

--- a/client/src/fluid/FluidPattern.res
+++ b/client/src/fluid/FluidPattern.res
@@ -119,6 +119,22 @@ let rec preTraversal = (~f: t => t, pattern: t): t => {
   }
 }
 
+// TODO: this feels like a dupe of either the above or below - remove in favor of such?
+let recurse = (~f: t => t, pat: t): t =>
+  switch pat {
+  | PInteger(_)
+  | PBlank(_)
+  | PString(_)
+  | PCharacter(_)
+  | PVariable(_)
+  | PBool(_)
+  | PNull(_)
+  | PFloat(_) => pat
+  | PConstructor(id, name, pats) => PConstructor(id, name, List.map(~f, pats))
+  | PTuple(id, first, second, theRest) =>
+    PTuple(id, f(first), f(second), List.map(~f, theRest))
+  }
+
 let rec postTraversal = (~f: t => t, pattern: t): t => {
   let r = postTraversal(~f)
   let result = switch pattern {

--- a/client/src/fluid/FluidPattern.resi
+++ b/client/src/fluid/FluidPattern.resi
@@ -30,3 +30,6 @@ let preTraversal: (~f: t => t, t) => t
   * replaced by [f p]. After calling [f], the result is NOT recursed into; if
   * this isn't what you want call preTraversal. ")
 let postTraversal: (~f: t => t, t) => t
+
+@ocaml.doc("TODO is this a dupe?")
+let recurse: (~f: t => t, t) => t

--- a/client/src/fluid/FluidToken.res
+++ b/client/src/fluid/FluidToken.res
@@ -70,9 +70,9 @@ let tid = (t: t): id =>
   | TPatternFloatWhole(_, id, _, _)
   | TPatternFloatPoint(_, id, _)
   | TPatternFloatFractional(_, id, _, _)
-  | TPatternTupleOpen(id)
-  | TPatternTupleClose(id)
-  | TPatternTupleComma(id, _)
+  | TPatternTupleOpen(_, id)
+  | TPatternTupleClose(_, id)
+  | TPatternTupleComma(_, id, _)
 
   | TSep(id, _)
   | TParenOpen(id)
@@ -979,9 +979,12 @@ let matchesContent = (t1: t, t2: t): bool =>
   | (TPatternFloatFractional(p1, id1, val1, ind1), TPatternFloatFractional(p2, id2, val2, ind2)) =>
     p1 == p2 && (id1 == id2 && (val1 == val2 && ind1 == ind2))
 
-  | (TPatternTupleOpen(id1), TPatternTupleOpen(id2)) => id1 == id2
-  | (TPatternTupleClose(id1), TPatternTupleClose(id2)) => id1 == id2
-  | (TPatternTupleComma(id1, ind1), TPatternTupleComma(id2, ind2)) => id1 == id2 && ind1 == ind2
+  | (TPatternTupleOpen(p1, id1), TPatternTupleOpen(p2, id2)) =>
+    p1 == p2 && id1 == id2
+  | (TPatternTupleClose(p1, id1), TPatternTupleClose(p2, id2)) =>
+    p1 == p2 && id1 == id2
+  | (TPatternTupleComma(p1, id1, ind1), TPatternTupleComma(p2, id2, ind2)) =>
+    p1 == p2 && id1 == id2 && ind1 == ind2
 
   | (TIndent(ind1), TIndent(ind2)) => ind1 == ind2
   | (TPlaceholder(d1), TPlaceholder(d2)) =>

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -181,12 +181,12 @@ let rec patternToToken = (matchID: id, p: FluidPattern.t, ~idx: int): list<fluid
         if isLastPattern {
           subpatternTokens
         } else {
-          List.append(subpatternTokens, list{TPatternTupleComma(id, i)})
+          List.append(subpatternTokens, list{TPatternTupleComma(matchID, id, i)})
         }
       })
       |> List.flatten
 
-    List.flatten(list{list{TPatternTupleOpen(id)}, middlePart, list{TPatternTupleClose(id)}})
+    List.flatten(list{list{TPatternTupleOpen(matchID, id)}, middlePart, list{TPatternTupleClose(matchID, id)}})
   }
 }
 

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -139,12 +139,12 @@ module Token = {
     | TPatternFloatWhole(ID.t, ID.t, string, int)
     | TPatternFloatPoint(ID.t, ID.t, int)
     | TPatternFloatFractional(ID.t, ID.t, string, int)
-    
+
     | TPatternBlank(ID.t, ID.t, int)
 
-    | TPatternTupleOpen(ID.t)
-    | TPatternTupleComma(ID.t, int)
-    | TPatternTupleClose(ID.t)
+    | TPatternTupleOpen(ID.t, ID.t)
+    | TPatternTupleComma(ID.t, ID.t, int)
+    | TPatternTupleClose(ID.t, ID.t)
 
     | TConstructorName(ID.t, string)
 


### PR DESCRIPTION
This is part of https://github.com/darklang/dark/issues/4427

Prior to this, tuple patterns were restricted to 2 elements - , keystrokes within them did nothing.

This replaces #4431.

- [ ] consider if FluidPattern.recurse is a duplicate of preTraversal or postTraversal
  consider removing it. if not, improve the code commentary around it.