### PR TITLE
Don't fail while handling exception

### DIFF
--- a/fsharp-backend/tests/Tests/HttpClient.Tests.fs
+++ b/fsharp-backend/tests/Tests/HttpClient.Tests.fs
@@ -276,7 +276,7 @@ let runTestHandler (ctx : HttpContext) : Task<HttpContext> =
                    || v.Contains "us-ascii" then
                   transcodeToLatin1 <- true
 
-              BwdServer.Server.setHeader ctx k v)
+              BwdServer.Server.setResponseHeader ctx k v)
             testCase.result.headers
 
           let data =


### PR DESCRIPTION
It is possible to throw exception during `BwdServer.runDarkHandler`, but after the Http body has started to be written back to the client. Our attempt to create an error response after this point cause an exception.

This is the cause of https://rollbar.com/darkops/darklang/items/3471/, which has the message "Headers are read-only, response has already started.".

This adds logging for the actual exception, and prevents throwing the extra exception.

