### PR TITLE
Add Fluid tests around the Tuple match pattern

### DIFF
--- a/client/src/fluid/FluidShortcuts.res
+++ b/client/src/fluid/FluidShortcuts.res
@@ -138,7 +138,6 @@ let pNull = (~id=gid(), ()): FluidPattern.t => PNull(id)
 
 let pBlank = (~id=gid(), ()): FluidPattern.t => PBlank(id)
 
-// TUPLETODO use this in tests
 let pTuple = (
   ~id=gid(),
   first: FluidPattern.t,

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -334,10 +334,6 @@ module State = {
 
 module FluidSettings = {
   type t = {allowTuples: bool}
-
-  let default = {
-    allowTuples: false,
-  }
 }
 
 // TODO: Consider renaming to 'Environment'

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -1,10 +1,12 @@
 open Prelude
 open ProgramTypes.Expr
+module P = ProgramTypes.Pattern
 
 // ----------------
 // Shortcuts
 // ----------------
 let b = FluidExpression.newB()
+let bPat = ProgramTypes.Pattern.PBlank(gid())
 
 open FluidShortcuts
 
@@ -189,6 +191,68 @@ let nestedMatch = {
   let mID = gid()
   EMatch(mID, b, list{(PBlank(gid()), emptyMatch)})
 }
+
+// ----------------
+// Match _Patterns_
+// ----------------
+let fiftySixPat = P.PInteger(gid(), 56L)
+let seventyEightPat = P.PInteger(gid(), 78L)
+
+let tuplePattern2WithNoBlank = pTuple(fiftySixPat, seventyEightPat, list{})
+let tuplePattern2WithBothBlank = pTuple(bPat, bPat, list{})
+let tuplePattern2WithFirstBlank = pTuple(bPat, seventyEightPat, list{})
+let tuplePattern2WithSecondBlank = pTuple(fiftySixPat, bPat, list{})
+
+let tuplePattern3WithNoBlanks = pTuple(fiftySixPat, seventyEightPat, list{fiftySixPat})
+let tuplePattern3WithAllBlank = pTuple(bPat, bPat, list{bPat})
+
+let tuplePattern3WithFirstBlank = pTuple(bPat, seventyEightPat, list{fiftySixPat})
+let tuplePattern3WithSecondBlank = pTuple(fiftySixPat, bPat, list{seventyEightPat})
+let tuplePattern3WithThirdBlank = pTuple(fiftySixPat, seventyEightPat, list{bPat})
+
+let tuplePattern3WithFirstFilled = pTuple(fiftySixPat, bPat, list{bPat})
+let tuplePattern3WithSecondFilled = pTuple(bPat, fiftySixPat, list{bPat})
+let tuplePattern3WithThirdFilled = pTuple(bPat, bPat, list{fiftySixPat})
+
+let tuplePattern6 = pTuple(
+  fiftySixPat,
+  seventyEightPat,
+  list{fiftySixPat, seventyEightPat, fiftySixPat, seventyEightPat},
+)
+
+let tuplePattern3WithStrs = pTuple(pString("ab"), pString("cd"), list{pString("ef")})
+
+let tuplePatternHuge = pTuple(
+  fiftySixPat,
+  seventyEightPat,
+  list{
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+    seventyEightPat,
+    fiftySixPat,
+  },
+)
 
 // ----------------
 // Variables
@@ -832,7 +896,9 @@ let defaultFunctionsProps: Functions.props = {
 
 let defaultTestProps: FluidTypes.Props.t = {
   functions: Functions.empty |> Functions.setBuiltins(defaultTestFunctions, defaultFunctionsProps),
-  settings: FluidTypes.FluidSettings.default,
+  settings: {
+    allowTuples: SettingsContributing.InProgressFeatures.default.allowTuples,
+  },
 }
 
 let fakeID1 = ID.fromInt(77777771)

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -49,7 +49,7 @@ type fluidState = AppTypes.fluidState
  *
  * expectsPartial
  *   By default, tests expect zero partials in the result. When passed
- *   ~expectPartial:true, the test will assert that the result /does/ include
+ *   ~expectsPartial:true, the test will assert that the result /does/ include
  *   a partial.
  *
  * debug

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -5,10 +5,11 @@ module K = FluidKeyboard
 module TL = Toplevel
 open ProgramTypes.Pattern
 open ProgramTypes.Expr
+open FluidTestData
 
-/* These tests should be synced with the subset of tests in fluid_test.ml that
- * makes sense for patterns. See the extensive docs there for how this all
- * works. */
+// These tests should be synced with the subset of tests in TestFluid.res that
+// makes sense for patterns. See the extensive docs there for how this all
+// works.
 
 let eToStructure = Printer.eToStructure
 
@@ -23,8 +24,43 @@ let h = (expr): PT.Handler.t => {
   pos: {x: 0, y: 0},
 }
 
+let mID = gid()
+
+module TestCase = {
+  type t = {
+    ast: ProgramTypes.Expr.t,
+    state: AppTypes.fluidState,
+    pos: int,
+    pat: FluidPattern.t,
+    debug: bool,
+  }
+
+  let init = (~debug=false, ~pos=0, originalPat: FluidPattern.t): t => {
+    let ast = EMatch(mID, EBlank(gid()), list{(originalPat, EBlank(gid()))})
+
+    let state = {
+      {
+        ...defaultTestState,
+        oldPos: pos,
+        newPos: pos,
+      }
+    }
+
+    {
+      pat: originalPat,
+      pos: pos,
+      ast: ast,
+      state: state,
+      debug: debug,
+    }
+  }
+}
+
+module TestResult = {
+  type t = (string, int)
+}
+
 let run = () => {
-  let mID = gid()
   let aStr = PString(gid(), "some string")
 
   let emptyStr = PString(gid(), "")
@@ -40,22 +76,18 @@ let run = () => {
   let falseBool = PBool(gid(), false)
   let aNull = PNull(gid())
   let five = PInteger(gid(), 5L)
-  // let fiftySix = PInteger (mID, gid (), 56) in
-  // let seventyEight = PInteger (gid (), 78) in
+  // let fiftySix = PInteger (mID, gid (), 56)
+  // let seventyEight = PInteger (gid (), 78)
   let b = () => PBlank(gid())
-  // let aPartialVar = FPPartial (gid (), "req") in
+  //let aPartialVar = FPPartial (gid (), "req")
   let aVar = PVariable(gid(), "variable")
   let aShortVar = PVariable(gid(), "v")
   let aConstructor = PConstructor(gid(), "Just", list{b()})
-  let process = (
-    ~debug: bool,
-    inputs: list<FluidTypes.Msg.inputEvent>,
-    pos: int,
-    pat: FluidPattern.t,
-  ): (string, int) => {
-    let ast = EMatch(mID, EBlank(gid()), list{(pat, EBlank(gid()))})
+
+  let process = (inputs: list<FluidTypes.Msg.inputEvent>, tc: TestCase.t): TestResult.t => {
+    // the extra chars caused by the `match` that wraps the pattern under test
     let extra = 12
-    let pos = pos + extra
+    let pos = tc.pos + extra
     let s = {
       ...FluidTestData.defaultTestState,
       ac: AC.init,
@@ -63,11 +95,11 @@ let run = () => {
       newPos: pos,
     }
 
-    if debug {
+    if tc.debug {
       Js.log2("state before ", FluidUtils.debugState(s))
-      Js.log2("pattern before", eToStructure(ast))
+      Js.log2("pattern before", eToStructure(tc.ast))
     }
-    let astInfo = Fluid.ASTInfo.make(FluidAST.ofExpr(ast), s)
+    let astInfo = Fluid.ASTInfo.make(FluidAST.ofExpr(tc.ast), s)
 
     let result = {
       let h = FluidUtils.h(FluidAST.toExpr(astInfo.ast))
@@ -84,7 +116,7 @@ let run = () => {
     | _ => failwith("can't match: " ++ eToTestString(FluidAST.toExpr(result.ast)))
     }
 
-    if debug {
+    if tc.debug {
       Js.log2("state after", FluidUtils.debugState(result.state))
       Js.log2("pattern after", eToStructure(FluidAST.toExpr(result.ast)))
     }
@@ -99,236 +131,231 @@ let run = () => {
     ctrlKey: false,
   })
 
-  let del = (~debug=false, pos: int, pat: fluidPattern): (string, int) =>
-    process(~debug, list{DeleteContentForward}, pos, pat)
+  let del = (case: TestCase.t): TestResult.t => process(list{DeleteContentForward}, case)
 
-  let bs = (~debug=false, pos: int, pat: fluidPattern): (string, int) =>
-    process(~debug, list{DeleteContentBackward}, pos, pat)
+  let bs = (case: TestCase.t): TestResult.t => process(list{DeleteContentBackward}, case)
 
-  let space = (~debug=false, pos: int, pat: fluidPattern): (string, int) =>
-    process(~debug, list{keypress(K.Space)}, pos, pat)
+  let press = (key: K.key, case: TestCase.t): TestResult.t => process(list{keypress(key)}, case)
 
-  // let tab (pos : int) (pat : fluidPattern) : string * int =
-  // process [K.Tab] pos pat
-  // in
-  // let shiftTab (pos : int) (pat : fluidPattern) : string * int =
-  // process [K.ShiftTab] pos pat
-  // in
-  let press = (~debug=false, key: K.key, pos: int, pat: fluidPattern): (string, int) =>
-    process(~debug, list{keypress(key)}, pos, pat)
+  let space = (case: TestCase.t): TestResult.t => process(list{keypress(K.Space)}, case)
 
-  let inputs = (
-    ~debug=false,
-    inputs: list<FluidTypes.Msg.inputEvent>,
-    pos: int,
-    pat: fluidPattern,
-  ): (string, int) => process(~debug, inputs, pos, pat)
+  // let tab = (case: TestCase.t): TestResult.t => process(list{keypress(K.Tab)}, case)
 
-  let insert = (~debug=false, s: string, pos: int, pat: fluidPattern): (string, int) =>
-    process(~debug, list{InsertText(s)}, pos, pat)
+  // let shiftTab = (case: TestCase.t): TestResult.t => process(list{keypress(K.ShiftTab)}, case)
+
+  let inputs = (inputs: list<FluidTypes.Msg.inputEvent>, case: TestCase.t): TestResult.t =>
+    process(inputs, case)
+
+  let insert = (s: string, case: TestCase.t): TestResult.t => process(list{InsertText(s)}, case)
 
   let blank = "***"
+
   let t = (
+    ~pos=0,
     name: string,
-    initial: fluidPattern,
-    fn: fluidPattern => (string, int),
-    expected: (string, int),
-  ) =>
-    test(
+    pat: fluidPattern,
+    fn: TestCase.t => TestResult.t,
+    expected: TestResult.t,
+  ) => {
+    let testName =
       name ++
       (" - `" ++
-      ((pToString(initial) |> Regex.replace(~re=Regex.regex("\n"), ~repl=" ")) ++ "`")),
-      () => expect(fn(initial)) |> toEqual(expected),
-    )
+      ((pToString(pat) |> Regex.replace(~re=Regex.regex("\n"), ~repl=" ")) ++ "`"))
+
+    let case = TestCase.init(~pos, pat)
+
+    test(testName, () => expect(fn(case)) |> toEqual(expected))
+  }
 
   describe("Strings", () => {
-    t("insert mid string", aStr, insert("c", 3), ("\"socme string\"", 4))
-    t("del mid string", aStr, del(3), ("\"soe string\"", 3))
-    t("bs mid string", aStr, bs(4), ("\"soe string\"", 3))
-    t("insert empty string", emptyStr, insert("c", 1), ("\"c\"", 2))
-    t("del empty string", emptyStr, del(1), ("\"\"", 1))
-    t("del empty string from outside", emptyStr, del(0), (blank, 0))
-    t("bs empty string", emptyStr, bs(1), (blank, 0))
-    t("bs outside empty string", emptyStr, bs(2), ("\"\"", 1))
-    t("bs near-empty string", oneCharStr, bs(2), ("\"\"", 1))
-    t("del near-empty string", oneCharStr, del(1), ("\"\"", 1))
-    t("insert outside string", aStr, insert("c", 0), ("\"some string\"", 0))
-    t("del outside string", aStr, del(0), ("\"some string\"", 0))
-    t("bs outside string", aStr, bs(0), ("\"some string\"", 0))
-    t("insert start of string", aStr, insert("c", 1), ("\"csome string\"", 2))
-    t("del start of string", aStr, del(1), ("\"ome string\"", 1))
-    t("bs start of string", aStr, bs(1), ("\"some string\"", 0))
-    t("insert end of string", aStr, insert("c", 12), ("\"some stringc\"", 13))
-    t("del end of string", aStr, del(12), ("\"some string\"", 12))
-    t("bs end of string", aStr, bs(12), ("\"some strin\"", 11))
-    t("insert after end", aStr, insert("c", 13), ("\"some string\"", 13))
-    t("del after end of string", aStr, del(13), ("\"some string\"", 13))
-    t("bs after end", aStr, bs(13), ("\"some string\"", 12))
-    t("insert space in string", aStr, space(3), ("\"so me string\"", 4))
-    t("del space in string", aStr, del(5), ("\"somestring\"", 5))
-    t("bs space in string", aStr, bs(6), ("\"somestring\"", 5))
-    t("final quote is swallowed", aStr, insert("\"", 12), ("\"some string\"", 13))
+    t("insert mid string", aStr, ~pos=3, insert("c"), ("\"socme string\"", 4))
+    t("del mid string", aStr, ~pos=3, del, ("\"soe string\"", 3))
+    t("bs mid string", ~pos=4, aStr, bs, ("\"soe string\"", 3))
+    t("insert empty string", ~pos=1, emptyStr, insert("c"), ("\"c\"", 2))
+    t("del empty string", ~pos=1, emptyStr, del, ("\"\"", 1))
+    t("del empty string from outside", ~pos=0, emptyStr, del, (blank, 0))
+    t("bs empty string", emptyStr, ~pos=1, bs, (blank, 0))
+    t("bs outside empty string", emptyStr, ~pos=2, bs, ("\"\"", 1))
+    t("bs near-empty string", oneCharStr, ~pos=2, bs, ("\"\"", 1))
+    t("del near-empty string", oneCharStr, ~pos=1, del, ("\"\"", 1))
+    t("insert outside string", aStr, ~pos=0, insert("c"), ("\"some string\"", 0))
+    t("del outside string", aStr, ~pos=0, del, ("\"some string\"", 0))
+    t("bs outside string", aStr, ~pos=0, bs, ("\"some string\"", 0))
+    t("insert start of string", aStr, ~pos=1, insert("c"), ("\"csome string\"", 2))
+    t("del start of string", aStr, ~pos=1, del, ("\"ome string\"", 1))
+    t("bs start of string", aStr, ~pos=1, bs, ("\"some string\"", 0))
+    t("insert end of string", aStr, ~pos=12, insert("c"), ("\"some stringc\"", 13))
+    t("del end of string", aStr, ~pos=12, del, ("\"some string\"", 12))
+    t("bs end of string", aStr, ~pos=12, bs, ("\"some strin\"", 11))
+    t("insert after end", aStr, ~pos=13, insert("c"), ("\"some string\"", 13))
+    t("del after end of string", aStr, ~pos=13, del, ("\"some string\"", 13))
+    t("bs after end", aStr, ~pos=13, bs, ("\"some string\"", 12))
+    t("insert space in string", aStr, ~pos=3, space, ("\"so me string\"", 4))
+    t("del space in string", aStr, ~pos=5, del, ("\"somestring\"", 5))
+    t("bs space in string", aStr, ~pos=6, bs, ("\"somestring\"", 5))
+    t("final quote is swallowed", aStr, ~pos=12, insert("\""), ("\"some string\"", 13))
     ()
   })
   describe("Integers", () => {
-    t("insert 0 at front ", anInt, insert("0", 0), ("12345", 0))
-    t("insert at end of short", aShortInt, insert("2", 1), ("12", 2))
-    t("insert not a number", anInt, insert("c", 0), ("12345", 0))
-    t("insert start of number", anInt, insert("5", 0), ("512345", 1))
-    t("del start of number", anInt, del(0), ("2345", 0))
-    t("bs start of number", anInt, bs(0), ("12345", 0))
-    t("insert end of number", anInt, insert("0", 5), ("123450", 6))
-    t("del end of number", anInt, del(5), ("12345", 5))
-    t("bs end of number", anInt, bs(5), ("1234", 4))
-    t("insert number at scale", aHugeInt, insert("9", 5), ("3000090000000000000", 6))
-    t("insert number at scale", aHugeInt, insert("9", 0), ("930000000000000000", 1))
-    t("insert number at scale", aHugeInt, insert("9", 19), ("3000000000000000000", 19))
+    t("insert 0 at front ", anInt, ~pos=0, insert("0"), ("12345", 0))
+    t("insert at end of short", aShortInt, ~pos=1, insert("2"), ("12", 2))
+    t("insert not a number", anInt, ~pos=0, insert("c"), ("12345", 0))
+    t("insert start of number", anInt, ~pos=0, insert("5"), ("512345", 1))
+    t("del start of number", anInt, ~pos=0, del, ("2345", 0))
+    t("bs start of number", anInt, ~pos=0, bs, ("12345", 0))
+    t("insert end of number", anInt, ~pos=5, insert("0"), ("123450", 6))
+    t("del end of number", anInt, ~pos=5, del, ("12345", 5))
+    t("bs end of number", anInt, ~pos=5, bs, ("1234", 4))
+    t("insert number at scale", aHugeInt, ~pos=5, insert("9"), ("3000090000000000000", 6))
+    t("insert number at scale", aHugeInt, ~pos=0, insert("9"), ("930000000000000000", 1))
+    t("insert number at scale", aHugeInt, ~pos=19, insert("9"), ("3000000000000000000", 19))
     let oneShorterThanMax63BitInt = PInteger(gid(), 922337203685477580L)
 
     t(
       "insert number at scale",
       oneShorterThanMax63BitInt,
-      insert("7", 18),
+      ~pos=18,
+      insert("7"),
       ("9223372036854775807", 19),
     )
     t(
       "insert number at scale",
       oneShorterThanMax63BitInt,
-      insert("9", 18),
+      ~pos=18,
+      insert("9"),
       ("922337203685477580", 18),
     )
     ()
   })
   describe("Floats", () => {
-    t("insert . converts to float - end", anInt, insert(".", 5), ("12345.", 6))
-    t("insert . converts to float - middle", anInt, insert(".", 3), ("123.45", 4))
-    t("insert . converts to float - start", anInt, insert(".", 0), (".12345", 1))
-    t("insert . converts to float - short", aShortInt, insert(".", 1), ("1.", 2))
-    t("continue after adding dot", aPartialFloat, insert("2", 2), ("1.2", 3))
-    t("insert zero in whole - start", aFloat, insert("0", 0), ("123.456", 0))
-    t("insert int in whole - start", aFloat, insert("9", 0), ("9123.456", 1))
-    t("insert int in whole - middle", aFloat, insert("0", 1), ("1023.456", 2))
-    t("insert int in whole - end", aFloat, insert("0", 3), ("1230.456", 4))
-    t("insert int in fraction - start", aFloat, insert("0", 4), ("123.0456", 5))
-    t("insert int in fraction - middle", aFloat, insert("0", 6), ("123.4506", 7))
-    t("insert int in fraction - end", aFloat, insert("0", 7), ("123.4560", 8))
-    t("insert non-int in whole", aFloat, insert("c", 2), ("123.456", 2))
-    t("insert non-int in fraction", aFloat, insert("c", 6), ("123.456", 6))
-    t("del dot", aFloat, del(3), ("123456", 3))
-    t("del dot at scale", aHugeFloat, del(9), ("123456789123456789", 9))
+    t("insert . converts to float - end", anInt, ~pos=5, insert("."), ("12345.", 6))
+    t("insert . converts to float - middle", anInt, ~pos=3, insert("."), ("123.45", 4))
+    t("insert . converts to float - start", anInt, ~pos=0, insert("."), (".12345", 1))
+    t("insert . converts to float - short", aShortInt, ~pos=1, insert("."), ("1.", 2))
+    t("continue after adding dot", aPartialFloat, ~pos=2, insert("2"), ("1.2", 3))
+    t("insert zero in whole - start", aFloat, ~pos=0, insert("0"), ("123.456", 0))
+    t("insert int in whole - start", aFloat, ~pos=0, insert("9"), ("9123.456", 1))
+    t("insert int in whole - middle", aFloat, ~pos=1, insert("0"), ("1023.456", 2))
+    t("insert int in whole - end", aFloat, ~pos=3, insert("0"), ("1230.456", 4))
+    t("insert int in fraction - start", aFloat, ~pos=4, insert("0"), ("123.0456", 5))
+    t("insert int in fraction - middle", aFloat, ~pos=6, insert("0"), ("123.4506", 7))
+    t("insert int in fraction - end", aFloat, ~pos=7, insert("0"), ("123.4560", 8))
+    t("insert non-int in whole", aFloat, ~pos=2, insert("c"), ("123.456", 2))
+    t("insert non-int in fraction", aFloat, ~pos=6, insert("c"), ("123.456", 6))
+    t("del dot", aFloat, ~pos=3, del, ("123456", 3))
+    t("del dot at scale", aHugeFloat, ~pos=9, del, ("123456789123456789", 9))
+
     let maxPosIntWithDot = PFloat(gid(), Positive, "9223372036854775", "807")
     let maxPosIntPlus1WithDot = PFloat(gid(), Positive, "9223372036854775", "808")
 
-    t("del dot at limit1", maxPosIntWithDot, del(16), ("9223372036854775807", 16))
-    t("del dot at limit2", maxPosIntPlus1WithDot, del(16), ("922337203685477580", 16))
-    t("del start of whole", aFloat, del(0), ("23.456", 0))
-    t("del middle of whole", aFloat, del(1), ("13.456", 1))
-    t("del end of whole", aFloat, del(2), ("12.456", 2))
-    t("del start of fraction", aFloat, del(4), ("123.56", 4))
-    t("del middle of fraction", aFloat, del(5), ("123.46", 5))
-    t("del end of fraction", aFloat, del(6), ("123.45", 6))
-    t("del dot converts to int", aFloat, del(3), ("123456", 3))
-    t("del dot converts to int, no fraction", aPartialFloat, del(1), ("1", 1))
-    t("bs dot", aFloat, bs(4), ("123456", 3))
-    t("bs frac of float", aShortFloat, bs(3), ("1.", 2))
-    t("bs whole of float", aShortFloat, bs(1), (".2", 0))
-    t("bs dot at scale", aHugeFloat, bs(10), ("123456789123456789", 9))
-    t("bs dot at limit1", maxPosIntWithDot, bs(17), ("9223372036854775807", 16))
-    t("bs dot at limit2", maxPosIntPlus1WithDot, bs(17), ("922337203685477580", 16))
-    t("bs start of whole", aFloat, bs(1), ("23.456", 0))
-    t("bs middle of whole", aFloat, bs(2), ("13.456", 1))
-    t("bs end of whole", aFloat, bs(3), ("12.456", 2))
-    t("bs start of fraction", aFloat, bs(5), ("123.56", 4))
-    t("bs middle of fraction", aFloat, bs(6), ("123.46", 5))
-    t("bs end of fraction", aFloat, bs(7), ("123.45", 6))
-    t("bs dot converts to int", aFloat, bs(4), ("123456", 3))
-    t("bs dot converts to int, no fraction", aPartialFloat, bs(2), ("1", 1))
-    t("continue after adding dot", aPartialFloat, insert("2", 2), ("1.2", 3))
+    t("del dot at limit1", maxPosIntWithDot, ~pos=16, del, ("9223372036854775807", 16))
+    t("del dot at limit2", maxPosIntPlus1WithDot, ~pos=16, del, ("922337203685477580", 16))
+    t("del start of whole", aFloat, ~pos=0, del, ("23.456", 0))
+    t("del middle of whole", aFloat, ~pos=1, del, ("13.456", 1))
+    t("del end of whole", aFloat, ~pos=2, del, ("12.456", 2))
+    t("del start of fraction", aFloat, ~pos=4, del, ("123.56", 4))
+    t("del middle of fraction", aFloat, ~pos=5, del, ("123.46", 5))
+    t("del end of fraction", aFloat, ~pos=6, del, ("123.45", 6))
+    t("del dot converts to int", aFloat, ~pos=3, del, ("123456", 3))
+    t("del dot converts to int, no fraction", aPartialFloat, ~pos=1, del, ("1", 1))
+    t("bs dot", aFloat, ~pos=4, bs, ("123456", 3))
+    t("bs frac of float", aShortFloat, ~pos=3, bs, ("1.", 2))
+    t("bs whole of float", aShortFloat, ~pos=1, bs, (".2", 0))
+    t("bs dot at scale", aHugeFloat, ~pos=10, bs, ("123456789123456789", 9))
+    t("bs dot at limit1", maxPosIntWithDot, ~pos=17, bs, ("9223372036854775807", 16))
+    t("bs dot at limit2", maxPosIntPlus1WithDot, ~pos=17, bs, ("922337203685477580", 16))
+    t("bs start of whole", aFloat, ~pos=1, bs, ("23.456", 0))
+    t("bs middle of whole", aFloat, ~pos=2, bs, ("13.456", 1))
+    t("bs end of whole", aFloat, ~pos=3, bs, ("12.456", 2))
+    t("bs start of fraction", aFloat, ~pos=5, bs, ("123.56", 4))
+    t("bs middle of fraction", aFloat, ~pos=6, bs, ("123.46", 5))
+    t("bs end of fraction", aFloat, ~pos=7, bs, ("123.45", 6))
+    t("bs dot converts to int", aFloat, ~pos=4, bs, ("123456", 3))
+    t("bs dot converts to int, no fraction", aPartialFloat, ~pos=2, bs, ("1", 1))
+    t("continue after adding dot", aPartialFloat, ~pos=2, insert("2"), ("1.2", 3))
     ()
   })
   describe("Bools", () => {
-    t("insert start of true", trueBool, insert("c", 0), ("ctrue", 1))
-    t("del start of true", trueBool, del(0), ("rue", 0))
-    t("bs start of true", trueBool, bs(0), ("true", 0))
-    t("insert end of true", trueBool, insert("0", 4), ("true0", 5))
-    t("del end of true", trueBool, del(4), ("true", 4))
-    t("bs end of true", trueBool, bs(4), ("tru", 3))
-    t("insert middle of true", trueBool, insert("0", 2), ("tr0ue", 3))
-    t("del middle of true", trueBool, del(2), ("tre", 2))
-    t("bs middle of true", trueBool, bs(2), ("tue", 1))
-    t("insert start of false", falseBool, insert("c", 0), ("cfalse", 1))
-    t("del start of false", falseBool, del(0), ("alse", 0))
-    t("bs start of false", falseBool, bs(0), ("false", 0))
-    t("insert end of false", falseBool, insert("0", 5), ("false0", 6))
-    t("del end of false", falseBool, del(5), ("false", 5))
-    t("bs end of false", falseBool, bs(5), ("fals", 4))
-    t("insert middle of false", falseBool, insert("0", 2), ("fa0lse", 3))
-    t("del middle of false", falseBool, del(2), ("fase", 2))
-    t("bs middle of false", falseBool, bs(2), ("flse", 1))
+    t("insert start of true", trueBool, ~pos=0, insert("c"), ("ctrue", 1))
+    t("del start of true", trueBool, ~pos=0, del, ("rue", 0))
+    t("bs start of true", trueBool, ~pos=0, bs, ("true", 0))
+    t("insert end of true", trueBool, ~pos=4, insert("0"), ("true0", 5))
+    t("del end of true", trueBool, ~pos=4, del, ("true", 4))
+    t("bs end of true", trueBool, ~pos=4, bs, ("tru", 3))
+    t("insert middle of true", trueBool, ~pos=2, insert("0"), ("tr0ue", 3))
+    t("del middle of true", trueBool, ~pos=2, del, ("tre", 2))
+    t("bs middle of true", trueBool, ~pos=2, bs, ("tue", 1))
+    t("insert start of false", falseBool, ~pos=0, insert("c"), ("cfalse", 1))
+    t("del start of false", falseBool, ~pos=0, del, ("alse", 0))
+    t("bs start of false", falseBool, ~pos=0, bs, ("false", 0))
+    t("insert end of false", falseBool, ~pos=5, insert("0"), ("false0", 6))
+    t("del end of false", falseBool, ~pos=5, del, ("false", 5))
+    t("bs end of false", falseBool, ~pos=5, bs, ("fals", 4))
+    t("insert middle of false", falseBool, ~pos=2, insert("0"), ("fa0lse", 3))
+    t("del middle of false", falseBool, ~pos=2, del, ("fase", 2))
+    t("bs middle of false", falseBool, ~pos=2, bs, ("flse", 1))
     ()
   })
   describe("Nulls", () => {
-    t("insert start of null", aNull, insert("c", 0), ("cnull", 1))
-    t("del start of null", aNull, del(0), ("ull", 0))
-    t("bs start of null", aNull, bs(0), ("null", 0))
-    t("insert end of null", aNull, insert("0", 4), ("null0", 5))
-    t("del end of null", aNull, del(4), ("null", 4))
-    t("bs end of null", aNull, bs(4), ("nul", 3))
-    t("insert middle of null", aNull, insert("0", 2), ("nu0ll", 3))
-    t("del middle of null", aNull, del(2), ("nul", 2))
-    t("bs middle of null", aNull, bs(2), ("nll", 1))
+    t("insert start of null", aNull, ~pos=0, insert("c"), ("cnull", 1))
+    t("del start of null", aNull, ~pos=0, del, ("ull", 0))
+    t("bs start of null", aNull, ~pos=0, bs, ("null", 0))
+    t("insert end of null", aNull, ~pos=4, insert("0"), ("null0", 5))
+    t("del end of null", aNull, ~pos=4, del, ("null", 4))
+    t("bs end of null", aNull, ~pos=4, bs, ("nul", 3))
+    t("insert middle of null", aNull, ~pos=2, insert("0"), ("nu0ll", 3))
+    t("del middle of null", aNull, ~pos=2, del, ("nul", 2))
+    t("bs middle of null", aNull, ~pos=2, bs, ("nll", 1))
     ()
   })
   describe("Blanks", () => {
-    t("insert middle of blank->string", b(), insert("\"", 3), ("\"\"", 1))
-    t("del middle of blank->blank", b(), del(3), (blank, 3))
-    t("bs middle of blank->blank", b(), bs(3), (blank, 0))
-    t("insert blank->string", b(), insert("\"", 0), ("\"\"", 1))
-    t("del blank->string", emptyStr, del(0), (blank, 0))
-    t("bs blank->string", emptyStr, bs(1), (blank, 0))
-    t("insert blank->int", b(), insert("5", 0), ("5", 1))
-    t("insert blank->int", b(), insert("0", 0), ("0", 1))
-    t("del int->blank ", five, del(0), (blank, 0))
-    t("bs int->blank ", five, bs(1), (blank, 0))
-    t("insert end of blank->int", b(), insert("5", 1), ("5", 1))
-    t("insert partial", b(), insert("t", 0), ("t", 1))
+    t("insert middle of blank->string", b(), ~pos=3, insert("\""), ("\"\"", 1))
+    t("del middle of blank->blank", b(), ~pos=3, del, (blank, 3))
+    t("bs middle of blank->blank", b(), ~pos=3, bs, (blank, 0))
+    t("insert blank->string", b(), ~pos=0, insert("\""), ("\"\"", 1))
+    t("del blank->string", emptyStr, ~pos=0, del, (blank, 0))
+    t("bs blank->string", emptyStr, ~pos=1, bs, (blank, 0))
+    t("insert blank->int", b(), ~pos=0, insert("5"), ("5", 1))
+    t("insert blank->int", b(), ~pos=0, insert("0"), ("0", 1))
+    t("del int->blank ", five, ~pos=0, del, (blank, 0))
+    t("bs int->blank ", five, ~pos=1, bs, (blank, 0))
+    t("insert end of blank->int", b(), ~pos=1, insert("5"), ("5", 1))
+    t("insert partial", b(), ~pos=0, insert("t"), ("t", 1))
     t(
       "backspacing your way through a partial finishes",
       trueBool,
-      inputs(
-        list{
-          DeleteContentBackward,
-          DeleteContentBackward,
-          DeleteContentBackward,
-          DeleteContentBackward,
-          keypress(K.Left),
-        },
-        4,
-      ),
+      ~pos=4,
+      inputs(list{
+        DeleteContentBackward,
+        DeleteContentBackward,
+        DeleteContentBackward,
+        DeleteContentBackward,
+        keypress(K.Left),
+      }),
       ("***", 0),
     )
-    t("insert blank->space", b(), press(K.Space, 0), (blank, 0))
+    t("insert blank->space", b(), ~pos=0, press(K.Space), (blank, 0))
     ()
   })
   describe("Variables", () => {
-    t("insert middle of variable", aVar, insert("c", 5), ("variacble", 6))
-    t("del middle of variable", aVar, del(5), ("variale", 5))
-    t("insert capital works", aVar, insert("A", 5), ("variaAble", 6))
-    t("can't insert invalid", aVar, insert("$", 5), ("variable", 5))
-    t("del variable", aShortVar, del(0), (blank, 0))
-    t("del long variable", aVar, del(0), ("ariable", 0))
-    t("del mid variable", aVar, del(6), ("variabe", 6))
-    t("bs variable", aShortVar, bs(1), (blank, 0))
-    t("bs mid variable", aVar, bs(8), ("variabl", 7))
-    t("bs mid variable", aVar, bs(6), ("variale", 5))
+    t("insert middle of variable", aVar, ~pos=5, insert("c"), ("variacble", 6))
+    t("del middle of variable", aVar, ~pos=5, del, ("variale", 5))
+    t("insert capital works", aVar, ~pos=5, insert("A"), ("variaAble", 6))
+    t("can't insert invalid", aVar, ~pos=5, insert("$"), ("variable", 5))
+    t("del variable", aShortVar, ~pos=0, del, (blank, 0))
+    t("del long variable", aVar, ~pos=0, del, ("ariable", 0))
+    t("del mid variable", aVar, ~pos=6, del, ("variabe", 6))
+    t("bs variable", aShortVar, ~pos=1, bs, (blank, 0))
+    t("bs mid variable", aVar, ~pos=8, bs, ("variabl", 7))
+    t("bs mid variable", aVar, ~pos=6, bs, ("variale", 5))
     ()
   })
   describe("Constructors", () => {
-    t("arguments work in constructors", aConstructor, insert("t", 5), ("Just t", 6))
-    t("int arguments work in constructors", aConstructor, insert("5", 5), ("Just 5", 6))
-    t("bs on a constructor deletes", aConstructor, bs(4), ("Jus", 3))
-    t("del on a constructor deletes", aConstructor, del(0), ("ust", 0))
-    t("space on a constructor blank does nothing", aConstructor, space(5), ("Just ***", 5))
+    t("arguments work in constructors", aConstructor, ~pos=5, insert("t"), ("Just t", 6))
+    t("int arguments work in constructors", aConstructor, ~pos=5, insert("5"), ("Just 5", 6))
+    t("bs on a constructor deletes", aConstructor, ~pos=4, bs, ("Jus", 3))
+    t("del on a constructor deletes", aConstructor, del, ("ust", 0))
+    t("space on a constructor blank does nothing", aConstructor, ~pos=5, space, ("Just ***", 5))
     /* TODO: test renaming constructors.
      * It's not too useful yet because there's only 4 constructors and,
      * hence, unlikely that anyone will rename them this way.

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -180,14 +180,14 @@ let run = () => {
     t("bs mid string", ~pos=4, aStr, bs, ("\"soe string\"", 3))
     t("insert empty string", ~pos=1, emptyStr, insert("c"), ("\"c\"", 2))
     t("del empty string", ~pos=1, emptyStr, del, ("\"\"", 1))
-    t("del empty string from outside", ~pos=0, emptyStr, del, (blank, 0))
+    t("del empty string from outside", emptyStr, del, (blank, 0))
     t("bs empty string", emptyStr, ~pos=1, bs, (blank, 0))
     t("bs outside empty string", emptyStr, ~pos=2, bs, ("\"\"", 1))
     t("bs near-empty string", oneCharStr, ~pos=2, bs, ("\"\"", 1))
     t("del near-empty string", oneCharStr, ~pos=1, del, ("\"\"", 1))
-    t("insert outside string", aStr, ~pos=0, insert("c"), ("\"some string\"", 0))
-    t("del outside string", aStr, ~pos=0, del, ("\"some string\"", 0))
-    t("bs outside string", aStr, ~pos=0, bs, ("\"some string\"", 0))
+    t("insert outside string", aStr, insert("c"), ("\"some string\"", 0))
+    t("del outside string", aStr, del, ("\"some string\"", 0))
+    t("bs outside string", aStr, bs, ("\"some string\"", 0))
     t("insert start of string", aStr, ~pos=1, insert("c"), ("\"csome string\"", 2))
     t("del start of string", aStr, ~pos=1, del, ("\"ome string\"", 1))
     t("bs start of string", aStr, ~pos=1, bs, ("\"some string\"", 0))
@@ -204,17 +204,18 @@ let run = () => {
     ()
   })
   describe("Integers", () => {
-    t("insert 0 at front ", anInt, ~pos=0, insert("0"), ("12345", 0))
+    t("render int", anInt, render, ("12345", 0))
+    t("insert 0 at front ", anInt, insert("0"), ("12345", 0))
     t("insert at end of short", aShortInt, ~pos=1, insert("2"), ("12", 2))
-    t("insert not a number", anInt, ~pos=0, insert("c"), ("12345", 0))
-    t("insert start of number", anInt, ~pos=0, insert("5"), ("512345", 1))
-    t("del start of number", anInt, ~pos=0, del, ("2345", 0))
-    t("bs start of number", anInt, ~pos=0, bs, ("12345", 0))
+    t("insert not a number", anInt, insert("c"), ("12345", 0))
+    t("insert start of number", anInt, insert("5"), ("512345", 1))
+    t("del start of number", anInt, del, ("2345", 0))
+    t("bs start of number", anInt, bs, ("12345", 0))
     t("insert end of number", anInt, ~pos=5, insert("0"), ("123450", 6))
     t("del end of number", anInt, ~pos=5, del, ("12345", 5))
     t("bs end of number", anInt, ~pos=5, bs, ("1234", 4))
     t("insert number at scale", aHugeInt, ~pos=5, insert("9"), ("3000090000000000000", 6))
-    t("insert number at scale", aHugeInt, ~pos=0, insert("9"), ("930000000000000000", 1))
+    t("insert number at scale", aHugeInt, insert("9"), ("930000000000000000", 1))
     t("insert number at scale", aHugeInt, ~pos=19, insert("9"), ("3000000000000000000", 19))
     let oneShorterThanMax63BitInt = PInteger(gid(), 922337203685477580L)
 
@@ -237,11 +238,11 @@ let run = () => {
   describe("Floats", () => {
     t("insert . converts to float - end", anInt, ~pos=5, insert("."), ("12345.", 6))
     t("insert . converts to float - middle", anInt, ~pos=3, insert("."), ("123.45", 4))
-    t("insert . converts to float - start", anInt, ~pos=0, insert("."), (".12345", 1))
+    t("insert . converts to float - start", anInt, insert("."), (".12345", 1))
     t("insert . converts to float - short", aShortInt, ~pos=1, insert("."), ("1.", 2))
     t("continue after adding dot", aPartialFloat, ~pos=2, insert("2"), ("1.2", 3))
-    t("insert zero in whole - start", aFloat, ~pos=0, insert("0"), ("123.456", 0))
-    t("insert int in whole - start", aFloat, ~pos=0, insert("9"), ("9123.456", 1))
+    t("insert zero in whole - start", aFloat, insert("0"), ("123.456", 0))
+    t("insert int in whole - start", aFloat, insert("9"), ("9123.456", 1))
     t("insert int in whole - middle", aFloat, ~pos=1, insert("0"), ("1023.456", 2))
     t("insert int in whole - end", aFloat, ~pos=3, insert("0"), ("1230.456", 4))
     t("insert int in fraction - start", aFloat, ~pos=4, insert("0"), ("123.0456", 5))
@@ -257,7 +258,7 @@ let run = () => {
 
     t("del dot at limit1", maxPosIntWithDot, ~pos=16, del, ("9223372036854775807", 16))
     t("del dot at limit2", maxPosIntPlus1WithDot, ~pos=16, del, ("922337203685477580", 16))
-    t("del start of whole", aFloat, ~pos=0, del, ("23.456", 0))
+    t("del start of whole", aFloat, del, ("23.456", 0))
     t("del middle of whole", aFloat, ~pos=1, del, ("13.456", 1))
     t("del end of whole", aFloat, ~pos=2, del, ("12.456", 2))
     t("del start of fraction", aFloat, ~pos=4, del, ("123.56", 4))
@@ -283,18 +284,18 @@ let run = () => {
     ()
   })
   describe("Bools", () => {
-    t("insert start of true", trueBool, ~pos=0, insert("c"), ("ctrue", 1))
-    t("del start of true", trueBool, ~pos=0, del, ("rue", 0))
-    t("bs start of true", trueBool, ~pos=0, bs, ("true", 0))
+    t("insert start of true", trueBool, insert("c"), ("ctrue", 1))
+    t("del start of true", trueBool, del, ("rue", 0))
+    t("bs start of true", trueBool, bs, ("true", 0))
     t("insert end of true", trueBool, ~pos=4, insert("0"), ("true0", 5))
     t("del end of true", trueBool, ~pos=4, del, ("true", 4))
     t("bs end of true", trueBool, ~pos=4, bs, ("tru", 3))
     t("insert middle of true", trueBool, ~pos=2, insert("0"), ("tr0ue", 3))
     t("del middle of true", trueBool, ~pos=2, del, ("tre", 2))
     t("bs middle of true", trueBool, ~pos=2, bs, ("tue", 1))
-    t("insert start of false", falseBool, ~pos=0, insert("c"), ("cfalse", 1))
-    t("del start of false", falseBool, ~pos=0, del, ("alse", 0))
-    t("bs start of false", falseBool, ~pos=0, bs, ("false", 0))
+    t("insert start of false", falseBool, insert("c"), ("cfalse", 1))
+    t("del start of false", falseBool, del, ("alse", 0))
+    t("bs start of false", falseBool, bs, ("false", 0))
     t("insert end of false", falseBool, ~pos=5, insert("0"), ("false0", 6))
     t("del end of false", falseBool, ~pos=5, del, ("false", 5))
     t("bs end of false", falseBool, ~pos=5, bs, ("fals", 4))
@@ -304,9 +305,9 @@ let run = () => {
     ()
   })
   describe("Nulls", () => {
-    t("insert start of null", aNull, ~pos=0, insert("c"), ("cnull", 1))
-    t("del start of null", aNull, ~pos=0, del, ("ull", 0))
-    t("bs start of null", aNull, ~pos=0, bs, ("null", 0))
+    t("insert start of null", aNull, insert("c"), ("cnull", 1))
+    t("del start of null", aNull, del, ("ull", 0))
+    t("bs start of null", aNull, bs, ("null", 0))
     t("insert end of null", aNull, ~pos=4, insert("0"), ("null0", 5))
     t("del end of null", aNull, ~pos=4, del, ("null", 4))
     t("bs end of null", aNull, ~pos=4, bs, ("nul", 3))
@@ -319,15 +320,15 @@ let run = () => {
     t("insert middle of blank->string", b(), ~pos=3, insert("\""), ("\"\"", 1))
     t("del middle of blank->blank", b(), ~pos=3, del, (blank, 3))
     t("bs middle of blank->blank", b(), ~pos=3, bs, (blank, 0))
-    t("insert blank->string", b(), ~pos=0, insert("\""), ("\"\"", 1))
-    t("del blank->string", emptyStr, ~pos=0, del, (blank, 0))
+    t("insert blank->string", b(), insert("\""), ("\"\"", 1))
+    t("del blank->string", emptyStr, del, (blank, 0))
     t("bs blank->string", emptyStr, ~pos=1, bs, (blank, 0))
-    t("insert blank->int", b(), ~pos=0, insert("5"), ("5", 1))
-    t("insert blank->int", b(), ~pos=0, insert("0"), ("0", 1))
-    t("del int->blank ", five, ~pos=0, del, (blank, 0))
+    t("insert blank->int", b(), insert("5"), ("5", 1))
+    t("insert blank->int", b(), insert("0"), ("0", 1))
+    t("del int->blank ", five, del, (blank, 0))
     t("bs int->blank ", five, ~pos=1, bs, (blank, 0))
     t("insert end of blank->int", b(), ~pos=1, insert("5"), ("5", 1))
-    t("insert partial", b(), ~pos=0, insert("t"), ("t", 1))
+    t("insert partial", b(), insert("t"), ("t", 1))
     t(
       "backspacing your way through a partial finishes",
       trueBool,
@@ -341,7 +342,7 @@ let run = () => {
       }),
       ("***", 0),
     )
-    t("insert blank->space", b(), ~pos=0, press(K.Space), (blank, 0))
+    t("insert blank->space", b(), press(K.Space), (blank, 0))
     ()
   })
   describe("Variables", () => {
@@ -349,8 +350,8 @@ let run = () => {
     t("del middle of variable", aVar, ~pos=5, del, ("variale", 5))
     t("insert capital works", aVar, ~pos=5, insert("A"), ("variaAble", 6))
     t("can't insert invalid", aVar, ~pos=5, insert("$"), ("variable", 5))
-    t("del variable", aShortVar, ~pos=0, del, (blank, 0))
-    t("del long variable", aVar, ~pos=0, del, ("ariable", 0))
+    t("del variable", aShortVar, del, (blank, 0))
+    t("del long variable", aVar, del, ("ariable", 0))
     t("del mid variable", aVar, ~pos=6, del, ("variabe", 6))
     t("bs variable", aShortVar, ~pos=1, bs, (blank, 0))
     t("bs mid variable", aVar, ~pos=8, bs, ("variabl", 7))
@@ -370,542 +371,527 @@ let run = () => {
      * constructor are randomly generated and would be hard to test */
     ()
   })
-
-  describe("Patterns", () => {
-    describe("Tuple Patterns", () => {
-      // TUPLETODO add a test for the bug you found. fix it.
-      // TUPLETODO other tests (copy/paste/reconstruction)
-      describe("render", () => {
-        t("blank tuple pattern", tuplePattern2WithBothBlank, render, ("(***,***)", 0))
-        t("simple tuple pattern", tuplePattern2WithNoBlank, render, ("(56,78)", 0))
-        // t( //TUPLETODO
-        //   "a very long tuple pattern wraps",
-        //   match'(b, list{(tuplePatternHuge, b)}),
-        //   render,
-        //   "~match ___\n (56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,\n 56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78) -> ___\n",
-        // )
-        // t(
-        //   "a tuple of long floats does not break upon wrap",
-        //   match'(
-        //     b,
-        //     list{
-        //       (
-        //         pTuple(
-        //           PFloat(
-        //             gid(),
-        //             Positive,
-        //             "4611686018427387",
-        //             "12345678901234567989048290381902830912830912830912830912309128901234567890123456789",
-        //           ),
-        //           PFloat(
-        //             gid(),
-        //             Positive,
-        //             "4611686018427387",
-        //             "1234567890183918309183091809183091283019832345678901234567890123456789",
-        //           ),
-        //           list{PFloat(gid(), Positive, "4611686018427387", "123456")},
-        //         ),
-        //         b,
-        //       ),
-        //     },
-        //   ),
-        //   render,
-        //   "~match ___\n (4611686018427387.12345678901234567989048290381902830912830912830912830912309128901234567890123456789,\n 4611686018427387.1234567890183918309183091809183091283019832345678901234567890123456789,\n 4611686018427387.123456) -> ___\n",
-        // )
-        ()
-      })
-
-      describe("navigate", () => {
-        // t( // TUPLETODO we need some special code for this. it works with tuple Exprs
-        //   "ctrl+left at the beginning of tuple pattern item moves to beginning of next tuple item",
-        //   match'(
-        //     b,
-        //     list{
-        //       (
-        //         pTuple(
-        //           fiftySixPat,
-        //           seventyEightPat,
-        //           list{fiftySixPat, seventyEightPat, fiftySixPat, seventyEightPat},
-        //         ),
-        //         b,
-        //       ),
-        //     },
-        //   ),
-        //   ~pos=22, // after the third comma, before the 2nd 78
-        //   ctrlLeft,
-        //   "match ___\n  (56,78,~56,78,56,78) -> ___\n",
-        // )
-        // t(
-        //   "ctrl+right at the end of tuple item moves to end of next tuple item",
-        //   match'(b, list{(tuplePattern6, b)}),
-        //   ~pos=16,
-        //   ctrlRight,
-        //   "match ___\n  (56,78,56~,78,56,78) -> ___\n",
-        // )
-        ()
-      })
-
-      if defaultTestProps.settings.allowTuples {
-        describe("create", () => {
-          t("create tuple pattern", bPat, insert("("), ("(***,***)", 1))
-
-          t(
-            "create and fill in tuple pattern",
-            bPat,
-            insertMany(list{"(", "1", ",", "2", ")"}),
-            ("(1,2)", 4), // aha, this caught a bug!
-          )
-          ()
-        })
-      }
-
-      describe("insert", () => {
-        t(
-          "insert into empty tuple inserts",
-          tuplePattern2WithBothBlank,
-          ~pos=1,
-          insert("5"),
-          ("(5,***)", 2),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "inserting before a tuple is no-op",
-        //   tuplePattern2WithBothBlank,
-        //   ~pos=0,
-        //   insert("5"),
-        //   ("(***,***)", 0),
-        // )
-        t(
-          "insert space into tuple does nothing",
-          tuplePattern2WithNoBlank,
-          ~pos=6, // right before closing )
-          press(K.Space),
-          ("(56,78)", 6),
-        )
-        t(
-          "insert separator after opening parens creates blank",
-          pTuple(pInt(1), pInt(2), list{pInt(3)}),
-          ~pos=1, // after the (
-          insert(","),
-          ("(***,1,2,3)", 1),
-        )
-        t(
-          "insert separator before closing parens creates blank",
-          pTuple(pInt(1), pInt(2), list{pInt(3)}), // (1,2,3)
-          ~pos=6, // before the )
-          insert(","),
-          ("(1,2,3,***)", 7),
-        )
-        t(
-          "insert separator after separator creates blank",
-          pTuple(pInt(1), pInt(2), list{pInt(3)}), // (1,2,3)
-          ~pos=5, // after the second comma
-          insert(","),
-          ("(1,2,***,3)", 5),
-        )
-        t(
-          "inserting space into simple tuple does nothing",
-          tuplePattern2WithNoBlank,
-          ~pos=3,
-          press(K.Space),
-          ("(56,78)", 3),
-        )
-        t(
-          "insert separator before item creates blank",
-          tuplePattern2WithNoBlank,
-          ~pos=1,
-          insert(","),
-          ("(***,56,78)", 1),
-        )
-        t(
-          "insert separator after item creates blank",
-          tuplePattern2WithNoBlank,
-          ~pos=6, // after 78
-          insert(","),
-          ("(56,78,***)", 7),
-        )
-        t(
-          "insert , in string in tuple types ,",
-          pTuple(pString("01234567890123456789012345678901234567890"), fiftySixPat, list{}),
-          ~pos=42, // right before the last 0
-          insert(","),
-          ("(\"0123456789012345678901234567890123456789,0\",56)", 43),
-        )
-
-        t(
-          "insert separator just before another skips over it",
-          tuplePattern2WithNoBlank,
-          ~pos=3, // before the first comma
-          insert(","),
-          ("(56,78)", 4),
-        )
-        t(
-          "insert separator just after another creates blank",
-          tuplePattern2WithNoBlank,
-          ~pos=4, // just after the comma
-          insert(","),
-          ("(56,***,78)", 4),
-        )
-
-        t(
-          "insert separator mid int does nothing special ",
-          tuplePattern2WithNoBlank,
-          ~pos=2, // halfway through `56`
-          insert(","),
-          ("(56,78)", 2),
-        )
-        t(
-          "insert separator mid string does nothing special ",
-          tuplePattern3WithStrs,
-          ~pos=3, // in between the a and b of the first str
-          insert(","),
-          ("(\"a,b\",\"cd\",\"ef\")", 4),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "close bracket at end of tuple is swallowed",
-        //   tuplePattern2WithNoBlank,
-        //   ~pos=6, // right before closing )
-        //   insert(")"),
-        //   ("(56,78)", 7),
-        // )
-        ()
-      })
-
-      describe("delete", () => {
-        // 2-tuple, no blanks
-        t(
-          "deleting ( from a filled 2-tuple does nothing",
-          tuplePattern2WithNoBlank,
-          ~pos=0,
-          del,
-          ("(56,78)", 0),
-        )
-        t(
-          "deleting ) from a filled 2-tuple just moves cursor left",
-          tuplePattern2WithNoBlank,
-          ~pos=7,
-          bs,
-          ("(56,78)", 6),
-        )
-        t(
-          "deleting , from a filled 2-tuple leaves only the first item",
-          tuplePattern2WithNoBlank, // (56,78)
-          ~pos=4, // at the ,
-          bs,
-          ("56", 2),
-        )
-
-        // 2-tuple, first blank
-        t(
-          "deleting ( from a 2-tuple with first value blank converts to the non-blank value",
-          tuplePattern2WithFirstBlank,
-          ~pos=0,
-          del,
-          ("78", 0),
-        )
-        t(
-          "deleting ) from a 2-tuple with first value blank just moves the cursor to left of )",
-          tuplePattern2WithFirstBlank,
-          ~pos=8, // just after )
-          bs,
-          ("(***,78)", 7),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting , from a 2-tuple with first value blank converts to a blank",
-        //   tuplePattern2WithFirstBlank,
-        //   ~pos=4, // just after ,
-        //   del,
-        //   ("***", 0),
-        // )
-
-        // 2-tuple, second blank
-        t(
-          "deleting ( from a 2-tuple with second value blank converts to the non-blank value",
-          tuplePattern2WithSecondBlank,
-          ~pos=0,
-          del,
-          ("56", 0),
-        )
-        t(
-          "deleting ) from a 2-tuple with second value blank just moves the cursor left",
-          tuplePattern2WithSecondBlank,
-          ~pos=7, // just before )
-          del,
-          ("(56,***)", 7),
-        )
-        t(
-          "deleting , from a 2-tuple with second value blank converts to the non-blank value",
-          tuplePattern2WithSecondBlank,
-          ~pos=3, // just before ,
-          del,
-          ("56", 2),
-        )
-
-        // 2-tuple, both blank
-        t(
-          "deleting ( from a blank 2-tuple converts to blank",
-          tuplePattern2WithBothBlank,
-          ~pos=0,
-          del,
-          ("***", 0),
-        )
-        t(
-          "deleting ) from a blank 2-tuple just moves the cursor left",
-          tuplePattern2WithBothBlank,
-          ~pos=9,
-          bs,
-          ("(***,***)", 8),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting , from a blank 2-tuple replaces the tuple with a blank",
-        //   tuplePattern2WithBothBlank,
-        //   ~pos=5,
-        //   bs,
-        //   ("***", 0),
-        // )
-
-        // 3-tuple, no blanks
-        t(
-          "deleting ( from a filled 3-tuple does nothing",
-          tuplePattern3WithNoBlanks,
-          ~pos=0,
-          del,
-          ("(56,78,56)", 0),
-        )
-        t(
-          "deleting ) from a filled 3-tuple just moves cursor left",
-          tuplePattern3WithNoBlanks,
-          ~pos=10, // just after )
-          bs,
-          ("(56,78,56)", 9),
-        )
-        t(
-          "deleting first , from a filled 3-tuple removes 2nd item",
-          tuplePattern3WithNoBlanks,
-          ~pos=3, // just before ,
-          del,
-          ("(56,56)", 3),
-        )
-        t(
-          "deleting second , from a filled 3-tuple removes 3rd item",
-          tuplePattern3WithNoBlanks,
-          ~pos=6, // just before ,
-          del,
-          ("(56,78)", 6),
-        )
-
-        // 3-tuple, first blank
-        t(
-          "deleting ( from a 3-tuple with first item blank does nothing",
-          tuplePattern3WithFirstBlank,
-          ~pos=0,
-          del,
-          ("(***,78,56)", 0),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting first , from a 3-tuple with first item blank removes 2nd item",
-        //   tuplePattern3WithFirstBlank,
-        //   ~pos=4, // just before ,
-        //   del,
-        //   ("(***,56)", 1),
-        // )
-        t(
-          "deleting second , from a 3-tuple with first item blank removes 3rd item",
-          tuplePattern3WithFirstBlank,
-          ~pos=8, // just after ,
-          bs,
-          ("(***,78)", 7),
-        )
-        t(
-          "deleting ) from a 3-tuple with first item blank just moves cursor left",
-          tuplePattern3WithFirstBlank,
-          ~pos=11, // just after )
-          bs,
-          ("(***,78,56)", 10),
-        )
-
-        // 3-tuple, second blank
-        t(
-          "deleting ( from a 3-tuple with the second item blank does nothing",
-          tuplePattern3WithSecondBlank,
-          ~pos=0,
-          del,
-          ("(56,***,78)", 0),
-        )
-        t(
-          "deleting first , from a 3-tuple with the second item blank removes the blank",
-          tuplePattern3WithSecondBlank,
-          ~pos=3, // just before ,
-          del,
-          ("(56,78)", 3),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting second , from a 3-tuple with the second item blank removes 3rd item",
-        //   tuplePattern3WithSecondBlank, // (56,***,78)
-        //   ~pos=7, // just before ,
-        //   del,
-        //   ("(56,***)", 4),
-        // )
-        t(
-          "deleting ) from a 3-tuple with the second item blank just moves cursor left",
-          tuplePattern3WithSecondBlank,
-          ~pos=11, // just after )
-          bs,
-          ("(56,***,78)", 10),
-        )
-
-        // 3-tuple, third blank `(56,78,___)`
-        t(
-          "deleting ( from a 3-tuple with the third item blank does nothing",
-          tuplePattern3WithThirdBlank,
-          ~pos=0,
-          del,
-          ("(56,78,***)", 0),
-        )
-        t(
-          "deleting first , from a 3-tuple with the third item blank removes the second item",
-          tuplePattern3WithThirdBlank,
-          ~pos=3, // just before ,
-          del,
-          ("(56,***)", 3), // or maybe 1char to the right of this
-        )
-        t(
-          "deleting second , from a 3-tuple with the third item blank removes the blank",
-          tuplePattern3WithThirdBlank,
-          ~pos=7, // just after ,
-          bs,
-          ("(56,78)", 6),
-        )
-        t(
-          "deleting ) from a 3-tuple with the third item blank just moves the cursor left",
-          tuplePattern3WithThirdBlank,
-          ~pos=11, // just after )
-          bs,
-          ("(56,78,***)", 10),
-        )
-
-        // 3-tuple, first non-blank `(56,___,___)`
-        t(
-          "deleting ( from a 3-tuple with only first item replaces it with that item",
-          tuplePattern3WithFirstFilled,
-          ~pos=0,
-          del,
-          ("56", 0),
-        )
-        t(
-          "deleting first , from a 3-tuple with only first item filled ___",
-          tuplePattern3WithFirstFilled,
-          ~pos=3, // just before ,
-          del,
-          ("(56,***)", 3),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting second , from a 3-tuple with only first item filled ___",
-        //   tuplePattern3WithFirstFilled,
-        //   ~pos=8, // just after ,
-        //   bs,
-        //   ("(56,***)", 4),
-        // )
-        t(
-          "deleting ) from a 3-tuple with only first item filled just moves cursor left",
-          tuplePattern3WithFirstFilled,
-          ~pos=12, // just after )
-          bs,
-          ("(56,***,***)", 11),
-        )
-
-        // 3-tuple, second non-blank `(___,56,___)`
-        t(
-          "deleting ( from a 3-tuple with only second item filled replaces the tuple with the item",
-          tuplePattern3WithSecondFilled,
-          ~pos=0,
-          del,
-          ("56", 0),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting first , from a 3-tuple with only second item filled removes the second item",
-        //   tuplePattern3WithSecondFilled,
-        //   ~pos=4, // just before ,
-        //   del,
-        //   ("(***,***)", 1),
-        // )
-        t(
-          "deleting second , from a 3-tuple with only second item filled removes the ending blank",
-          tuplePattern3WithSecondFilled,
-          ~pos=8, // just after ,
-          bs,
-          ("(***,56)", 7),
-        )
-        t(
-          "deleting ) from a 3-tuple with only second item filled just moves the cursor left",
-          tuplePattern3WithSecondFilled,
-          ~pos=12, // just after )
-          bs,
-          ("(***,56,***)", 11),
-        )
-
-        // 3-tuple, third non-blank `(___,___,56)`
-        t(
-          "deleting ( from a 3-tuple with only third item filled replaces the tuple with the item",
-          tuplePattern3WithThirdFilled,
-          ~pos=0,
-          del,
-          ("56", 0),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting first , from a 3-tuple with only third item filled removes the second blank",
-        //   tuplePattern3WithThirdFilled,
-        //   ~pos=4, // just before ,
-        //   del,
-        //   ("(***,56)", 1),
-        // )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting second , from a 3-tuple with only third item filled removes the filled item",
-        //   tuplePattern3WithThirdFilled,
-        //   ~pos=9, // just after ,
-        //   bs,
-        //   ("(***,***)", 5),
-        // )
-        t(
-          "deleting ) from a 3-tuple with only third item filled just moves the cursor left",
-          tuplePattern3WithThirdFilled,
-          ~pos=12, // just after )
-          bs,
-          ("(***,***,56)", 11),
-        )
-
-        // 3-tuple, all blank `(***,***,***)`
-        t(
-          "deleting ( from a 3-tuple of all blanks replaces the tuple with a blank",
-          tuplePattern3WithAllBlank,
-          ~pos=0,
-          del,
-          ("***", 0),
-        )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting first , from a 3-tuple of all blanks removes the second blank",
-        //   tuplePattern3WithAllBlank,
-        //   ~pos=4, // just before ,
-        //   del,
-        //   ("(***,***)", 1),
-        // )
-        // t( TUPLETODO discrepency between pat and expr behaviour
-        //   "deleting second , from a 3-tuple of all blanks removes the third blank",
-        //   tuplePattern3WithAllBlank,
-        //   ~pos=9, // just after ,
-        //   bs,
-        //   ("(***,***)", 5),
-        // )
-        t(
-          "deleting ) from a 3-tuple of all blanks just moves left",
-          tuplePattern3WithAllBlank,
-          ~pos=13, // just after )
-          bs,
-          ("(***,***,***)", 12), // I could see this instead turning into `~___`
-        )
-        ()
-      })
+  describe("Tuples", () => {
+    // TUPLETODO add a test for the bug you found. fix it.
+    // TUPLETODO other tests (copy/paste/reconstruction)
+    describe("render", () => {
+      t("blank tuple pattern", tuplePattern2WithBothBlank, render, ("(***,***)", 0))
+      t("simple tuple pattern", tuplePattern2WithNoBlank, render, ("(56,78)", 0))
+      // t( //TUPLETODO
+      //   "a very long tuple pattern wraps",
+      //   match'(b, list{(tuplePatternHuge, b)}),
+      //   render,
+      //   "~match ___\n (56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,\n 56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,78,56,\n 78,56,78,56,78,56,78,56,78,56,78) -> ___\n",
+      // )
+      // t(
+      //   "a tuple of long floats does not break upon wrap",
+      //   match'(
+      //     b,
+      //     list{
+      //       (
+      //         pTuple(
+      //           PFloat(
+      //             gid(),
+      //             Positive,
+      //             "4611686018427387",
+      //             "12345678901234567989048290381902830912830912830912830912309128901234567890123456789",
+      //           ),
+      //           PFloat(
+      //             gid(),
+      //             Positive,
+      //             "4611686018427387",
+      //             "1234567890183918309183091809183091283019832345678901234567890123456789",
+      //           ),
+      //           list{PFloat(gid(), Positive, "4611686018427387", "123456")},
+      //         ),
+      //         b,
+      //       ),
+      //     },
+      //   ),
+      //   render,
+      //   "~match ___\n (4611686018427387.12345678901234567989048290381902830912830912830912830912309128901234567890123456789,\n 4611686018427387.1234567890183918309183091809183091283019832345678901234567890123456789,\n 4611686018427387.123456) -> ___\n",
+      // )
       ()
     })
+
+    describe("navigate", () => {
+      // t( // TUPLETODO we need some special code for this. it works with tuple Exprs
+      //   "ctrl+left at the beginning of tuple pattern item moves to beginning of next tuple item",
+      //   match'(
+      //     b,
+      //     list{
+      //       (
+      //         pTuple(
+      //           fiftySixPat,
+      //           seventyEightPat,
+      //           list{fiftySixPat, seventyEightPat, fiftySixPat, seventyEightPat},
+      //         ),
+      //         b,
+      //       ),
+      //     },
+      //   ),
+      //   ~pos=22, // after the third comma, before the 2nd 78
+      //   ctrlLeft,
+      //   "match ___\n  (56,78,~56,78,56,78) -> ___\n",
+      // )
+      // t(
+      //   "ctrl+right at the end of tuple item moves to end of next tuple item",
+      //   match'(b, list{(tuplePattern6, b)}),
+      //   ~pos=16,
+      //   ctrlRight,
+      //   "match ___\n  (56,78,56~,78,56,78) -> ___\n",
+      // )
+      ()
+    })
+
+    if defaultTestProps.settings.allowTuples {
+      describe("create", () => {
+        t("create tuple pattern", bPat, insert("("), ("(***,***)", 1))
+
+        t(
+          "create and fill in tuple pattern",
+          bPat,
+          insertMany(list{"(", "1", ",", "2", ")"}),
+          ("(1,2)", 4), // aha, this caught a bug!
+        )
+        ()
+      })
+    }
+
+    describe("insert", () => {
+      t(
+        "insert into empty tuple inserts",
+        tuplePattern2WithBothBlank,
+        ~pos=1,
+        insert("5"),
+        ("(5,***)", 2),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "inserting before a tuple is no-op",
+      //   tuplePattern2WithBothBlank,
+      //
+      //   insert("5"),
+      //   ("(***,***)", 0),
+      // )
+      t(
+        "insert space into tuple does nothing",
+        tuplePattern2WithNoBlank,
+        ~pos=6, // right before closing )
+        press(K.Space),
+        ("(56,78)", 6),
+      )
+      t(
+        "insert separator after opening parens creates blank",
+        pTuple(pInt(1), pInt(2), list{pInt(3)}),
+        ~pos=1, // after the (
+        insert(","),
+        ("(***,1,2,3)", 1),
+      )
+      t(
+        "insert separator before closing parens creates blank",
+        pTuple(pInt(1), pInt(2), list{pInt(3)}), // (1,2,3)
+        ~pos=6, // before the )
+        insert(","),
+        ("(1,2,3,***)", 7),
+      )
+      t(
+        "insert separator after separator creates blank",
+        pTuple(pInt(1), pInt(2), list{pInt(3)}), // (1,2,3)
+        ~pos=5, // after the second comma
+        insert(","),
+        ("(1,2,***,3)", 5),
+      )
+      t(
+        "inserting space into simple tuple does nothing",
+        tuplePattern2WithNoBlank,
+        ~pos=3,
+        press(K.Space),
+        ("(56,78)", 3),
+      )
+      t(
+        "insert separator before item creates blank",
+        tuplePattern2WithNoBlank,
+        ~pos=1,
+        insert(","),
+        ("(***,56,78)", 1),
+      )
+      t(
+        "insert separator after item creates blank",
+        tuplePattern2WithNoBlank,
+        ~pos=6, // after 78
+        insert(","),
+        ("(56,78,***)", 7),
+      )
+      t(
+        "insert , in string in tuple types ,",
+        pTuple(pString("01234567890123456789012345678901234567890"), fiftySixPat, list{}),
+        ~pos=42, // right before the last 0
+        insert(","),
+        ("(\"0123456789012345678901234567890123456789,0\",56)", 43),
+      )
+
+      t(
+        "insert separator just before another skips over it",
+        tuplePattern2WithNoBlank,
+        ~pos=3, // before the first comma
+        insert(","),
+        ("(56,78)", 4),
+      )
+      t(
+        "insert separator just after another creates blank",
+        tuplePattern2WithNoBlank,
+        ~pos=4, // just after the comma
+        insert(","),
+        ("(56,***,78)", 4),
+      )
+
+      t(
+        "insert separator mid int does nothing special ",
+        tuplePattern2WithNoBlank,
+        ~pos=2, // halfway through `56`
+        insert(","),
+        ("(56,78)", 2),
+      )
+      t(
+        "insert separator mid string does nothing special ",
+        tuplePattern3WithStrs,
+        ~pos=3, // in between the a and b of the first str
+        insert(","),
+        ("(\"a,b\",\"cd\",\"ef\")", 4),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "close bracket at end of tuple is swallowed",
+      //   tuplePattern2WithNoBlank,
+      //   ~pos=6, // right before closing )
+      //   insert(")"),
+      //   ("(56,78)", 7),
+      // )
+      ()
+    })
+
+    describe("delete", () => {
+      // 2-tuple, no blanks
+      t(
+        "deleting ( from a filled 2-tuple does nothing",
+        tuplePattern2WithNoBlank,
+        del,
+        ("(56,78)", 0),
+      )
+      t(
+        "deleting ) from a filled 2-tuple just moves cursor left",
+        tuplePattern2WithNoBlank,
+        ~pos=7,
+        bs,
+        ("(56,78)", 6),
+      )
+      t(
+        "deleting , from a filled 2-tuple leaves only the first item",
+        tuplePattern2WithNoBlank, // (56,78)
+        ~pos=4, // at the ,
+        bs,
+        ("56", 2),
+      )
+
+      // 2-tuple, first blank
+      t(
+        "deleting ( from a 2-tuple with first value blank converts to the non-blank value",
+        tuplePattern2WithFirstBlank,
+        del,
+        ("78", 0),
+      )
+      t(
+        "deleting ) from a 2-tuple with first value blank just moves the cursor to left of )",
+        tuplePattern2WithFirstBlank,
+        ~pos=8, // just after )
+        bs,
+        ("(***,78)", 7),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting , from a 2-tuple with first value blank converts to a blank",
+      //   tuplePattern2WithFirstBlank,
+      //   ~pos=4, // just after ,
+      //   del,
+      //   ("***", 0),
+      // )
+
+      // 2-tuple, second blank
+      t(
+        "deleting ( from a 2-tuple with second value blank converts to the non-blank value",
+        tuplePattern2WithSecondBlank,
+        del,
+        ("56", 0),
+      )
+      t(
+        "deleting ) from a 2-tuple with second value blank just moves the cursor left",
+        tuplePattern2WithSecondBlank,
+        ~pos=7, // just before )
+        del,
+        ("(56,***)", 7),
+      )
+      t(
+        "deleting , from a 2-tuple with second value blank converts to the non-blank value",
+        tuplePattern2WithSecondBlank,
+        ~pos=3, // just before ,
+        del,
+        ("56", 2),
+      )
+
+      // 2-tuple, both blank
+      t(
+        "deleting ( from a blank 2-tuple converts to blank",
+        tuplePattern2WithBothBlank,
+        del,
+        ("***", 0),
+      )
+      t(
+        "deleting ) from a blank 2-tuple just moves the cursor left",
+        tuplePattern2WithBothBlank,
+        ~pos=9,
+        bs,
+        ("(***,***)", 8),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting , from a blank 2-tuple replaces the tuple with a blank",
+      //   tuplePattern2WithBothBlank,
+      //   ~pos=5,
+      //   bs,
+      //   ("***", 0),
+      // )
+
+      // 3-tuple, no blanks
+      t(
+        "deleting ( from a filled 3-tuple does nothing",
+        tuplePattern3WithNoBlanks,
+        del,
+        ("(56,78,56)", 0),
+      )
+      t(
+        "deleting ) from a filled 3-tuple just moves cursor left",
+        tuplePattern3WithNoBlanks,
+        ~pos=10, // just after )
+        bs,
+        ("(56,78,56)", 9),
+      )
+      t(
+        "deleting first , from a filled 3-tuple removes 2nd item",
+        tuplePattern3WithNoBlanks,
+        ~pos=3, // just before ,
+        del,
+        ("(56,56)", 3),
+      )
+      t(
+        "deleting second , from a filled 3-tuple removes 3rd item",
+        tuplePattern3WithNoBlanks,
+        ~pos=6, // just before ,
+        del,
+        ("(56,78)", 6),
+      )
+
+      // 3-tuple, first blank
+      t(
+        "deleting ( from a 3-tuple with first item blank does nothing",
+        tuplePattern3WithFirstBlank,
+        del,
+        ("(***,78,56)", 0),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting first , from a 3-tuple with first item blank removes 2nd item",
+      //   tuplePattern3WithFirstBlank,
+      //   ~pos=4, // just before ,
+      //   del,
+      //   ("(***,56)", 1),
+      // )
+      t(
+        "deleting second , from a 3-tuple with first item blank removes 3rd item",
+        tuplePattern3WithFirstBlank,
+        ~pos=8, // just after ,
+        bs,
+        ("(***,78)", 7),
+      )
+      t(
+        "deleting ) from a 3-tuple with first item blank just moves cursor left",
+        tuplePattern3WithFirstBlank,
+        ~pos=11, // just after )
+        bs,
+        ("(***,78,56)", 10),
+      )
+
+      // 3-tuple, second blank
+      t(
+        "deleting ( from a 3-tuple with the second item blank does nothing",
+        tuplePattern3WithSecondBlank,
+        del,
+        ("(56,***,78)", 0),
+      )
+      t(
+        "deleting first , from a 3-tuple with the second item blank removes the blank",
+        tuplePattern3WithSecondBlank,
+        ~pos=3, // just before ,
+        del,
+        ("(56,78)", 3),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting second , from a 3-tuple with the second item blank removes 3rd item",
+      //   tuplePattern3WithSecondBlank, // (56,***,78)
+      //   ~pos=7, // just before ,
+      //   del,
+      //   ("(56,***)", 4),
+      // )
+      t(
+        "deleting ) from a 3-tuple with the second item blank just moves cursor left",
+        tuplePattern3WithSecondBlank,
+        ~pos=11, // just after )
+        bs,
+        ("(56,***,78)", 10),
+      )
+
+      // 3-tuple, third blank `(56,78,***)`
+      t(
+        "deleting ( from a 3-tuple with the third item blank does nothing",
+        tuplePattern3WithThirdBlank,
+        del,
+        ("(56,78,***)", 0),
+      )
+      t(
+        "deleting first , from a 3-tuple with the third item blank removes the second item",
+        tuplePattern3WithThirdBlank,
+        ~pos=3, // just before ,
+        del,
+        ("(56,***)", 3), // or maybe 1char to the right of this
+      )
+      t(
+        "deleting second , from a 3-tuple with the third item blank removes the blank",
+        tuplePattern3WithThirdBlank,
+        ~pos=7, // just after ,
+        bs,
+        ("(56,78)", 6),
+      )
+      t(
+        "deleting ) from a 3-tuple with the third item blank just moves the cursor left",
+        tuplePattern3WithThirdBlank,
+        ~pos=11, // just after )
+        bs,
+        ("(56,78,***)", 10),
+      )
+
+      // 3-tuple, first non-blank `(56,***,***)`
+      t(
+        "deleting ( from a 3-tuple with only first item replaces it with that item",
+        tuplePattern3WithFirstFilled,
+        del,
+        ("56", 0),
+      )
+      t(
+        "deleting first , from a 3-tuple with only first item filled ***",
+        tuplePattern3WithFirstFilled,
+        ~pos=3, // just before ,
+        del,
+        ("(56,***)", 3),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting second , from a 3-tuple with only first item filled ***",
+      //   tuplePattern3WithFirstFilled,
+      //   ~pos=8, // just after ,
+      //   bs,
+      //   ("(56,***)", 4),
+      // )
+      t(
+        "deleting ) from a 3-tuple with only first item filled just moves cursor left",
+        tuplePattern3WithFirstFilled,
+        ~pos=12, // just after )
+        bs,
+        ("(56,***,***)", 11),
+      )
+
+      // 3-tuple, second non-blank `(***,56,***)`
+      t(
+        "deleting ( from a 3-tuple with only second item filled replaces the tuple with the item",
+        tuplePattern3WithSecondFilled,
+        del,
+        ("56", 0),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting first , from a 3-tuple with only second item filled removes the second item",
+      //   tuplePattern3WithSecondFilled,
+      //   ~pos=4, // just before ,
+      //   del,
+      //   ("(***,***)", 1),
+      // )
+      t(
+        "deleting second , from a 3-tuple with only second item filled removes the ending blank",
+        tuplePattern3WithSecondFilled,
+        ~pos=8, // just after ,
+        bs,
+        ("(***,56)", 7),
+      )
+      t(
+        "deleting ) from a 3-tuple with only second item filled just moves the cursor left",
+        tuplePattern3WithSecondFilled,
+        ~pos=12, // just after )
+        bs,
+        ("(***,56,***)", 11),
+      )
+
+      // 3-tuple, third non-blank `(***,***,56)`
+      t(
+        "deleting ( from a 3-tuple with only third item filled replaces the tuple with the item",
+        tuplePattern3WithThirdFilled,
+        del,
+        ("56", 0),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting first , from a 3-tuple with only third item filled removes the second blank",
+      //   tuplePattern3WithThirdFilled,
+      //   ~pos=4, // just before ,
+      //   del,
+      //   ("(***,56)", 1),
+      // )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting second , from a 3-tuple with only third item filled removes the filled item",
+      //   tuplePattern3WithThirdFilled,
+      //   ~pos=9, // just after ,
+      //   bs,
+      //   ("(***,***)", 5),
+      // )
+      t(
+        "deleting ) from a 3-tuple with only third item filled just moves the cursor left",
+        tuplePattern3WithThirdFilled,
+        ~pos=12, // just after )
+        bs,
+        ("(***,***,56)", 11),
+      )
+
+      // 3-tuple, all blank `(***,***,***)`
+      t(
+        "deleting ( from a 3-tuple of all blanks replaces the tuple with a blank",
+        tuplePattern3WithAllBlank,
+        del,
+        ("***", 0),
+      )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting first , from a 3-tuple of all blanks removes the second blank",
+      //   tuplePattern3WithAllBlank,
+      //   ~pos=4, // just before ,
+      //   del,
+      //   ("(***,***)", 1),
+      // )
+      // t( TUPLETODO discrepency between pat and expr behaviour
+      //   "deleting second , from a 3-tuple of all blanks removes the third blank",
+      //   tuplePattern3WithAllBlank,
+      //   ~pos=9, // just after ,
+      //   bs,
+      //   ("(***,***)", 5),
+      // )
+      t(
+        "deleting ) from a 3-tuple of all blanks just moves left",
+        tuplePattern3WithAllBlank,
+        ~pos=13, // just after )
+        bs,
+        ("(***,***,***)", 12), // I could see this instead turning into `~***`
+      )
+      ()
+    })
+    ()
   })
   ()
 }

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -373,7 +373,6 @@ let run = () => {
 
   describe("Patterns", () => {
     describe("Tuple Patterns", () => {
-      // TUPLETODO uncomment and correct all of these tests.
       // TUPLETODO add a test for the bug you found. fix it.
       // TUPLETODO other tests (copy/paste/reconstruction)
       describe("render", () => {
@@ -468,7 +467,7 @@ let run = () => {
           insert("5"),
           ("(5,***)", 2),
         )
-        // t( TUPLETODO bug found
+        // t( TUPLETODO discrepency between pat and expr behaviour
         //   "inserting before a tuple is no-op",
         //   tuplePattern2WithBothBlank,
         //   ~pos=0,
@@ -561,7 +560,7 @@ let run = () => {
           insert(","),
           ("(\"a,b\",\"cd\",\"ef\")", 4),
         )
-        // t( // TUPLETODO
+        // t( TUPLETODO discrepency between pat and expr behaviour
         //   "close bracket at end of tuple is swallowed",
         //   tuplePattern2WithNoBlank,
         //   ~pos=6, // right before closing )
@@ -571,340 +570,340 @@ let run = () => {
         ()
       })
 
-      // describe("delete", () => {
-      //   // 2-tuple, no blanks
-      //   t(
-      //     "deleting ( from a filled 2-tuple does nothing",
-      //     tuple2WithNoBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~(56,78)",
-      //   )
-      //   t(
-      //     "deleting ) from a filled 2-tuple just moves cursor left",
-      //     tuple2WithNoBlank,
-      //     ~pos=7,
-      //     bs,
-      //     "(56,78~)",
-      //   )
-      //   t(
-      //     "deleting , from a filled 2-tuple leaves only the first item",
-      //     tuple2WithNoBlank, // (56,78)
-      //     ~pos=4, // at the ,
-      //     bs,
-      //     "56~",
-      //   )
+      describe("delete", () => {
+        // 2-tuple, no blanks
+        t(
+          "deleting ( from a filled 2-tuple does nothing",
+          tuplePattern2WithNoBlank,
+          ~pos=0,
+          del,
+          ("(56,78)", 0),
+        )
+        t(
+          "deleting ) from a filled 2-tuple just moves cursor left",
+          tuplePattern2WithNoBlank,
+          ~pos=7,
+          bs,
+          ("(56,78)", 6),
+        )
+        t(
+          "deleting , from a filled 2-tuple leaves only the first item",
+          tuplePattern2WithNoBlank, // (56,78)
+          ~pos=4, // at the ,
+          bs,
+          ("56", 2),
+        )
 
-      //   // 2-tuple, first blank
-      //   t(
-      //     "deleting ( from a 2-tuple with first value blank converts to the non-blank value",
-      //     tuple2WithFirstBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~78",
-      //   )
-      //   t(
-      //     "deleting ) from a 2-tuple with first value blank just moves the cursor to left of )",
-      //     tuple2WithFirstBlank,
-      //     ~pos=8, // just after )
-      //     bs,
-      //     "(___,78~)",
-      //   )
-      //   t(
-      //     "deleting , from a 2-tuple with first value blank converts to a blank",
-      //     tuple2WithFirstBlank,
-      //     ~pos=4, // just after ,
-      //     del,
-      //     "~___",
-      //   )
+        // 2-tuple, first blank
+        t(
+          "deleting ( from a 2-tuple with first value blank converts to the non-blank value",
+          tuplePattern2WithFirstBlank,
+          ~pos=0,
+          del,
+          ("78", 0),
+        )
+        t(
+          "deleting ) from a 2-tuple with first value blank just moves the cursor to left of )",
+          tuplePattern2WithFirstBlank,
+          ~pos=8, // just after )
+          bs,
+          ("(***,78)", 7),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting , from a 2-tuple with first value blank converts to a blank",
+        //   tuplePattern2WithFirstBlank,
+        //   ~pos=4, // just after ,
+        //   del,
+        //   ("***", 0),
+        // )
 
-      //   // 2-tuple, second blank
-      //   t(
-      //     "deleting ( from a 2-tuple with second value blank converts to the non-blank value",
-      //     tuple2WithSecondBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~56",
-      //   )
-      //   t(
-      //     "deleting ) from a 2-tuple with second value blank just moves the cursor left",
-      //     tuple2WithSecondBlank,
-      //     ~pos=7, // just before )
-      //     del,
-      //     "(56,___~)",
-      //   )
-      //   t(
-      //     "deleting , from a 2-tuple with second value blank converts to the non-blank value",
-      //     tuple2WithSecondBlank,
-      //     ~pos=3, // just before ,
-      //     del,
-      //     "56~",
-      //   )
+        // 2-tuple, second blank
+        t(
+          "deleting ( from a 2-tuple with second value blank converts to the non-blank value",
+          tuplePattern2WithSecondBlank,
+          ~pos=0,
+          del,
+          ("56", 0),
+        )
+        t(
+          "deleting ) from a 2-tuple with second value blank just moves the cursor left",
+          tuplePattern2WithSecondBlank,
+          ~pos=7, // just before )
+          del,
+          ("(56,***)", 7),
+        )
+        t(
+          "deleting , from a 2-tuple with second value blank converts to the non-blank value",
+          tuplePattern2WithSecondBlank,
+          ~pos=3, // just before ,
+          del,
+          ("56", 2),
+        )
 
-      //   // 2-tuple, both blank
-      //   t(
-      //     "deleting ( from a blank 2-tuple converts to blank",
-      //     tuple2WithBothBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~___",
-      //   )
-      //   t(
-      //     "deleting ) from a blank 2-tuple just moves the cursor left",
-      //     tuple2WithBothBlank,
-      //     ~pos=9,
-      //     bs,
-      //     "(___,___~)",
-      //   )
-      //   t(
-      //     "deleting , from a blank 2-tuple replaces the tuple with a blank",
-      //     tuple2WithBothBlank,
-      //     ~pos=5,
-      //     bs,
-      //     "~___",
-      //   )
+        // 2-tuple, both blank
+        t(
+          "deleting ( from a blank 2-tuple converts to blank",
+          tuplePattern2WithBothBlank,
+          ~pos=0,
+          del,
+          ("***", 0),
+        )
+        t(
+          "deleting ) from a blank 2-tuple just moves the cursor left",
+          tuplePattern2WithBothBlank,
+          ~pos=9,
+          bs,
+          ("(***,***)", 8),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting , from a blank 2-tuple replaces the tuple with a blank",
+        //   tuplePattern2WithBothBlank,
+        //   ~pos=5,
+        //   bs,
+        //   ("***", 0),
+        // )
 
-      //   // 3-tuple, no blanks
-      //   t(
-      //     "deleting ( from a filled 3-tuple does nothing",
-      //     tuple3WithNoBlanks,
-      //     ~pos=0,
-      //     del,
-      //     "~(56,78,56)",
-      //   )
-      //   t(
-      //     "deleting ) from a filled 3-tuple just moves cursor left",
-      //     tuple3WithNoBlanks,
-      //     ~pos=10, // just after )
-      //     bs,
-      //     "(56,78,56~)",
-      //   )
-      //   t(
-      //     "deleting first , from a filled 3-tuple removes 2nd item",
-      //     tuple3WithNoBlanks,
-      //     ~pos=3, // just before ,
-      //     del,
-      //     "(56~,56)",
-      //   )
-      //   t(
-      //     "deleting second , from a filled 3-tuple removes 3rd item",
-      //     tuple3WithNoBlanks,
-      //     ~pos=6, // just before ,
-      //     del,
-      //     "(56,78~)",
-      //   )
+        // 3-tuple, no blanks
+        t(
+          "deleting ( from a filled 3-tuple does nothing",
+          tuplePattern3WithNoBlanks,
+          ~pos=0,
+          del,
+          ("(56,78,56)", 0),
+        )
+        t(
+          "deleting ) from a filled 3-tuple just moves cursor left",
+          tuplePattern3WithNoBlanks,
+          ~pos=10, // just after )
+          bs,
+          ("(56,78,56)", 9),
+        )
+        t(
+          "deleting first , from a filled 3-tuple removes 2nd item",
+          tuplePattern3WithNoBlanks,
+          ~pos=3, // just before ,
+          del,
+          ("(56,56)", 3),
+        )
+        t(
+          "deleting second , from a filled 3-tuple removes 3rd item",
+          tuplePattern3WithNoBlanks,
+          ~pos=6, // just before ,
+          del,
+          ("(56,78)", 6),
+        )
 
-      //   // 3-tuple, first blank
-      //   t(
-      //     "deleting ( from a 3-tuple with first item blank does nothing",
-      //     tuple3WithFirstBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~(___,78,56)",
-      //   )
-      //   t(
-      //     "deleting first , from a 3-tuple with first item blank removes 2nd item",
-      //     tuple3WithFirstBlank,
-      //     ~pos=4, // just before ,
-      //     del,
-      //     "(~___,56)",
-      //   )
-      //   t(
-      //     "deleting second , from a 3-tuple with first item blank removes 3rd item",
-      //     tuple3WithFirstBlank,
-      //     ~pos=8, // just after ,
-      //     bs,
-      //     "(___,78~)",
-      //   )
-      //   t(
-      //     "deleting ) from a 3-tuple with first item blank just moves cursor left",
-      //     tuple3WithFirstBlank,
-      //     ~pos=11, // just after )
-      //     bs,
-      //     "(___,78,56~)",
-      //   )
+        // 3-tuple, first blank
+        t(
+          "deleting ( from a 3-tuple with first item blank does nothing",
+          tuplePattern3WithFirstBlank,
+          ~pos=0,
+          del,
+          ("(***,78,56)", 0),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting first , from a 3-tuple with first item blank removes 2nd item",
+        //   tuplePattern3WithFirstBlank,
+        //   ~pos=4, // just before ,
+        //   del,
+        //   ("(***,56)", 1),
+        // )
+        t(
+          "deleting second , from a 3-tuple with first item blank removes 3rd item",
+          tuplePattern3WithFirstBlank,
+          ~pos=8, // just after ,
+          bs,
+          ("(***,78)", 7),
+        )
+        t(
+          "deleting ) from a 3-tuple with first item blank just moves cursor left",
+          tuplePattern3WithFirstBlank,
+          ~pos=11, // just after )
+          bs,
+          ("(***,78,56)", 10),
+        )
 
-      //   // 3-tuple, second blank
-      //   t(
-      //     "deleting ( from a 3-tuple with the second item blank does nothing",
-      //     tuple3WithSecondBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~(56,___,78)",
-      //   )
-      //   t(
-      //     "deleting first , from a 3-tuple with the second item blank removes the blank",
-      //     tuple3WithSecondBlank,
-      //     ~pos=3, // just before ,
-      //     del,
-      //     "(56~,78)",
-      //   )
-      //   t(
-      //     "deleting second , from a 3-tuple with the second item blank removes 3rd item",
-      //     tuple3WithSecondBlank, // (56,___,78)
-      //     ~pos=7, // just before ,
-      //     del,
-      //     "(56,~___)",
-      //   )
-      //   t(
-      //     "deleting ) from a 3-tuple with the second item blank just moves cursor left",
-      //     tuple3WithSecondBlank,
-      //     ~pos=11, // just after )
-      //     bs,
-      //     "(56,___,78~)",
-      //   )
+        // 3-tuple, second blank
+        t(
+          "deleting ( from a 3-tuple with the second item blank does nothing",
+          tuplePattern3WithSecondBlank,
+          ~pos=0,
+          del,
+          ("(56,***,78)", 0),
+        )
+        t(
+          "deleting first , from a 3-tuple with the second item blank removes the blank",
+          tuplePattern3WithSecondBlank,
+          ~pos=3, // just before ,
+          del,
+          ("(56,78)", 3),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting second , from a 3-tuple with the second item blank removes 3rd item",
+        //   tuplePattern3WithSecondBlank, // (56,***,78)
+        //   ~pos=7, // just before ,
+        //   del,
+        //   ("(56,***)", 4),
+        // )
+        t(
+          "deleting ) from a 3-tuple with the second item blank just moves cursor left",
+          tuplePattern3WithSecondBlank,
+          ~pos=11, // just after )
+          bs,
+          ("(56,***,78)", 10),
+        )
 
-      //   // 3-tuple, third blank `(56,78,___)`
-      //   t(
-      //     "deleting ( from a 3-tuple with the third item blank does nothing",
-      //     tuple3WithThirdBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~(56,78,___)",
-      //   )
-      //   t(
-      //     "deleting first , from a 3-tuple with the third item blank removes the second item",
-      //     tuple3WithThirdBlank,
-      //     ~pos=3, // just before ,
-      //     del,
-      //     "(56~,___)", // or maybe 1char to the right of this
-      //   )
-      //   t(
-      //     "deleting second , from a 3-tuple with the third item blank removes the blank",
-      //     tuple3WithThirdBlank,
-      //     ~pos=7, // just after ,
-      //     bs,
-      //     "(56,78~)",
-      //   )
-      //   t(
-      //     "deleting ) from a 3-tuple with the third item blank just moves the cursor left",
-      //     tuple3WithThirdBlank,
-      //     ~pos=11, // just after )
-      //     bs,
-      //     "(56,78,___~)",
-      //   )
+        // 3-tuple, third blank `(56,78,___)`
+        t(
+          "deleting ( from a 3-tuple with the third item blank does nothing",
+          tuplePattern3WithThirdBlank,
+          ~pos=0,
+          del,
+          ("(56,78,***)", 0),
+        )
+        t(
+          "deleting first , from a 3-tuple with the third item blank removes the second item",
+          tuplePattern3WithThirdBlank,
+          ~pos=3, // just before ,
+          del,
+          ("(56,***)", 3), // or maybe 1char to the right of this
+        )
+        t(
+          "deleting second , from a 3-tuple with the third item blank removes the blank",
+          tuplePattern3WithThirdBlank,
+          ~pos=7, // just after ,
+          bs,
+          ("(56,78)", 6),
+        )
+        t(
+          "deleting ) from a 3-tuple with the third item blank just moves the cursor left",
+          tuplePattern3WithThirdBlank,
+          ~pos=11, // just after )
+          bs,
+          ("(56,78,***)", 10),
+        )
 
-      //   // 3-tuple, first non-blank `(56,___,___)`
-      //   t(
-      //     "deleting ( from a 3-tuple with only first item replaces it with that item",
-      //     tuple3WithFirstFilled,
-      //     ~pos=0,
-      //     del,
-      //     "~56",
-      //   )
-      //   t(
-      //     "deleting first , from a 3-tuple with only first item filled ___",
-      //     tuple3WithFirstFilled,
-      //     ~pos=3, // just before ,
-      //     del,
-      //     "(56~,___)",
-      //   )
-      //   t(
-      //     "deleting second , from a 3-tuple with only first item filled ___",
-      //     tuple3WithFirstFilled,
-      //     ~pos=8, // just after ,
-      //     bs,
-      //     "(56,~___)",
-      //   )
-      //   t(
-      //     "deleting ) from a 3-tuple with only first item filled just moves cursor left",
-      //     tuple3WithFirstFilled,
-      //     ~pos=12, // just after )
-      //     bs,
-      //     "(56,___,___~)",
-      //   )
+        // 3-tuple, first non-blank `(56,___,___)`
+        t(
+          "deleting ( from a 3-tuple with only first item replaces it with that item",
+          tuplePattern3WithFirstFilled,
+          ~pos=0,
+          del,
+          ("56", 0),
+        )
+        t(
+          "deleting first , from a 3-tuple with only first item filled ___",
+          tuplePattern3WithFirstFilled,
+          ~pos=3, // just before ,
+          del,
+          ("(56,***)", 3),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting second , from a 3-tuple with only first item filled ___",
+        //   tuplePattern3WithFirstFilled,
+        //   ~pos=8, // just after ,
+        //   bs,
+        //   ("(56,***)", 4),
+        // )
+        t(
+          "deleting ) from a 3-tuple with only first item filled just moves cursor left",
+          tuplePattern3WithFirstFilled,
+          ~pos=12, // just after )
+          bs,
+          ("(56,***,***)", 11),
+        )
 
-      //   // 3-tuple, second non-blank `(___,56,___)`
-      //   t(
-      //     "deleting ( from a 3-tuple with only second item filled replaces the tuple with the item",
-      //     tuple3WithSecondFilled,
-      //     ~pos=0,
-      //     del,
-      //     "~56",
-      //   )
-      //   t(
-      //     "deleting first , from a 3-tuple with only second item filled removes the second item",
-      //     tuple3WithSecondFilled,
-      //     ~pos=4, // just before ,
-      //     del,
-      //     "(~___,___)",
-      //   )
-      //   t(
-      //     "deleting second , from a 3-tuple with only second item filled removes the ending blank",
-      //     tuple3WithSecondFilled,
-      //     ~pos=8, // just after ,
-      //     bs,
-      //     "(___,56~)",
-      //   )
-      //   t(
-      //     "deleting ) from a 3-tuple with only second item filled just moves the cursor left",
-      //     tuple3WithSecondFilled,
-      //     ~pos=12, // just after )
-      //     bs,
-      //     "(___,56,___~)",
-      //   )
+        // 3-tuple, second non-blank `(___,56,___)`
+        t(
+          "deleting ( from a 3-tuple with only second item filled replaces the tuple with the item",
+          tuplePattern3WithSecondFilled,
+          ~pos=0,
+          del,
+          ("56", 0),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting first , from a 3-tuple with only second item filled removes the second item",
+        //   tuplePattern3WithSecondFilled,
+        //   ~pos=4, // just before ,
+        //   del,
+        //   ("(***,***)", 1),
+        // )
+        t(
+          "deleting second , from a 3-tuple with only second item filled removes the ending blank",
+          tuplePattern3WithSecondFilled,
+          ~pos=8, // just after ,
+          bs,
+          ("(***,56)", 7),
+        )
+        t(
+          "deleting ) from a 3-tuple with only second item filled just moves the cursor left",
+          tuplePattern3WithSecondFilled,
+          ~pos=12, // just after )
+          bs,
+          ("(***,56,***)", 11),
+        )
 
-      //   // 3-tuple, third non-blank `(___,___,56)`
-      //   t(
-      //     "deleting ( from a 3-tuple with only third item filled replaces the tuple with the item",
-      //     tuple3WithThirdFilled,
-      //     ~pos=0,
-      //     del,
-      //     "~56",
-      //   )
-      //   t(
-      //     "deleting first , from a 3-tuple with only third item filled removes the second blank",
-      //     tuple3WithThirdFilled,
-      //     ~pos=4, // just before ,
-      //     del,
-      //     "(~___,56)",
-      //   )
-      //   t(
-      //     "deleting second , from a 3-tuple with only third item filled removes the filled item",
-      //     tuple3WithThirdFilled,
-      //     ~pos=9, // just after ,
-      //     bs,
-      //     "(___,~___)",
-      //   )
-      //   t(
-      //     "deleting ) from a 3-tuple with only third item filled just moves the cursor left",
-      //     tuple3WithThirdFilled,
-      //     ~pos=12, // just after )
-      //     bs,
-      //     "(___,___,56~)",
-      //   )
+        // 3-tuple, third non-blank `(___,___,56)`
+        t(
+          "deleting ( from a 3-tuple with only third item filled replaces the tuple with the item",
+          tuplePattern3WithThirdFilled,
+          ~pos=0,
+          del,
+          ("56", 0),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting first , from a 3-tuple with only third item filled removes the second blank",
+        //   tuplePattern3WithThirdFilled,
+        //   ~pos=4, // just before ,
+        //   del,
+        //   ("(***,56)", 1),
+        // )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting second , from a 3-tuple with only third item filled removes the filled item",
+        //   tuplePattern3WithThirdFilled,
+        //   ~pos=9, // just after ,
+        //   bs,
+        //   ("(***,***)", 5),
+        // )
+        t(
+          "deleting ) from a 3-tuple with only third item filled just moves the cursor left",
+          tuplePattern3WithThirdFilled,
+          ~pos=12, // just after )
+          bs,
+          ("(***,***,56)", 11),
+        )
 
-      //   // 3-tuple, all blank `(___,___,___)`
-      //   t(
-      //     "deleting ( from a 3-tuple of all blanks replaces the tuple with a blank",
-      //     tuple3WithAllBlank,
-      //     ~pos=0,
-      //     del,
-      //     "~___",
-      //   )
-      //   t(
-      //     "deleting first , from a 3-tuple of all blanks removes the second blank",
-      //     tuple3WithAllBlank,
-      //     ~pos=4, // just before ,
-      //     del,
-      //     "(~___,___)",
-      //   )
-      //   t(
-      //     "deleting second , from a 3-tuple of all blanks removes the third blank",
-      //     tuple3WithAllBlank,
-      //     ~pos=9, // just after ,
-      //     bs,
-      //     "(___,~___)",
-      //   )
-      //   t(
-      //     "deleting ) from a 3-tuple of all blanks just moves left",
-      //     tuple3WithAllBlank,
-      //     ~pos=13, // just after )
-      //     bs,
-      //     "(___,___,___~)", // I could see this instead turning into `~___`
-      //   )
-      //   ()
-      // })
+        // 3-tuple, all blank `(***,***,***)`
+        t(
+          "deleting ( from a 3-tuple of all blanks replaces the tuple with a blank",
+          tuplePattern3WithAllBlank,
+          ~pos=0,
+          del,
+          ("***", 0),
+        )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting first , from a 3-tuple of all blanks removes the second blank",
+        //   tuplePattern3WithAllBlank,
+        //   ~pos=4, // just before ,
+        //   del,
+        //   ("(***,***)", 1),
+        // )
+        // t( TUPLETODO discrepency between pat and expr behaviour
+        //   "deleting second , from a 3-tuple of all blanks removes the third blank",
+        //   tuplePattern3WithAllBlank,
+        //   ~pos=9, // just after ,
+        //   bs,
+        //   ("(***,***)", 5),
+        // )
+        t(
+          "deleting ) from a 3-tuple of all blanks just moves left",
+          tuplePattern3WithAllBlank,
+          ~pos=13, // just after )
+          bs,
+          ("(***,***,***)", 12), // I could see this instead turning into `~___`
+        )
+        ()
+      })
       ()
     })
   })


### PR DESCRIPTION
This replaces #4434 - the tests are now in `TestFluidPattern`, which has been updated to support tests that only `render`.