### PR TITLE
Fix the uneven spacing due to ligatured arrows

### DIFF
--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -310,7 +310,6 @@ $ff-color: adjust-hue($purple, -40deg);
   .fluid-lambda-var,
   .fluid-lambda-arrow {
     color: $orange;
-
   }
 
   .fluid-match-branch-arrow,

--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -310,6 +310,15 @@ $ff-color: adjust-hue($purple, -40deg);
   .fluid-lambda-var,
   .fluid-lambda-arrow {
     color: $orange;
+
+  }
+
+  .fluid-match-branch-arrow,
+  .fluid-lambda-arrow {
+    // The ligature is 28px wide but we need it to be 32px to keep things lined up appropriately.
+    width: 28px;
+    padding-left: 2px;
+    padding-right: 2px;
   }
 
   .fluid-placeholder {


### PR DESCRIPTION
Note the position of the "l" in `let`

Before:

<img width="373" alt="Screen Shot 2022-09-05 at 4 18 41 PM" src="https://user-images.githubusercontent.com/181762/188509196-fac631c5-5cd4-4603-86d4-50acbfe13bad.png">

After:
<img width="368" alt="Screen Shot 2022-09-05 at 4 18 06 PM" src="https://user-images.githubusercontent.com/181762/188509195-010915c8-485d-4499-bda1-fccbde0239a5.png">