### PR TITLE
Hide the error - it doesnt seem to break anything afaict

### DIFF
--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1742,6 +1742,7 @@ let update_ = (msg: msg, m: model): modification => {
   | JSError(msg) =>
     // https://github.com/dotnet/runtime/issues/70286
     // This is a problem in .Net 6, so let's ignore it for now
+    // DOTNET7TODO: this error shouldn't happen anymore
     let ignorable =
       msg->String.includes(
         ~substring="System.ArgumentNullException: Value cannot be null. (Parameter 'key')",


### PR DESCRIPTION
This hides the error from https://github.com/darklang/dark/issues/4161#issuecomment-1237454993

I tried finding the cause as error makes it look like there's a null being added to a dictionary somewhere during analysis. However, I couldn't find any dictionary of the right type, and I did some printf debugging that also didn't turn up anything, so I think this is happening in the framework.

Given the error doesn't seem to break anything, maybe the best approach is to ignore it for now.