### PR TITLE
Bugfix: don't allow tuple pattern parts to be overwritten

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -3954,39 +3954,38 @@ let doExplicitInsert = (
       }
 
     | (ARPattern(_, PPTuple(kind)), PTuple(_pID, first, second, theRest)) =>
-      let allPats = list{first, second, ...theRest}
-
-      // CLEANUP TUPLETODO: this feels like it can be reasonably shorter
-
       let elIndex = switch kind {
       | TPOpen => Some(0)
       | TPComma(i) => Some(i + 1)
       | TPClose => None
       }
 
-      switch elIndex {
-      | None => None
-      | Some(elIndex) =>
-        let patternIsBlank =
+      switch (elIndex, handlePatBlank()) {
+      | (Some(elIndex), Some(newPat, newCt)) =>
+        let allPats = list{first, second, ...theRest}
+
+        let shouldReplacePatternAtIndex =
           List.getAt(~index=elIndex, allPats)
           |> Option.map(~f=p => P.isPatternBlank(p))
           |> Option.unwrap(~default=false)
 
-        if patternIsBlank {
-          switch handlePatBlank() {
-          | None => None
-          | Some(newPat, ct) =>
-            let allPatsWithReplacement = allPats |> List.updateAt(~f=_p => newPat, ~index=elIndex)
+        if shouldReplacePatternAtIndex {
+          let allPatsWithReplacement = allPats |> List.updateAt(~f=_p => newPat, ~index=elIndex)
 
-            switch allPatsWithReplacement {
-            | list{first, second, ...theRest} =>
-              Some(E.Pat(mID, PTuple(gid(), first, second, theRest)), ct)
-            | _ => None
-            }
+          switch allPatsWithReplacement {
+          | list{first, second, ...theRest} =>
+            Some(E.Pat(mID, PTuple(gid(), first, second, theRest)), newCt)
+          | _ =>
+            recover(
+              "doPatInsert - unexpected tuple pattern of fewer than 2 elements",
+              ~debug=pat,
+              None,
+            )
           }
         } else {
           None
         }
+      | _ => None
       }
 
     /*

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -3967,16 +3967,25 @@ let doExplicitInsert = (
       switch elIndex {
       | None => None
       | Some(elIndex) =>
-        switch handlePatBlank() {
-        | None => None
-        | Some(newPat, ct) =>
-          let allPatsWithReplacement = allPats |> List.updateAt(~f=_p => newPat, ~index=elIndex)
+        let patternIsBlank =
+          List.getAt(~index=elIndex, allPats)
+          |> Option.map(~f=p => P.isPatternBlank(p))
+          |> Option.unwrap(~default=false)
 
-          switch allPatsWithReplacement {
-          | list{first, second, ...theRest} =>
-            Some(E.Pat(mID, PTuple(gid(), first, second, theRest)), ct)
-          | _ => None
+        if patternIsBlank {
+          switch handlePatBlank() {
+          | None => None
+          | Some(newPat, ct) =>
+            let allPatsWithReplacement = allPats |> List.updateAt(~f=_p => newPat, ~index=elIndex)
+
+            switch allPatsWithReplacement {
+            | list{first, second, ...theRest} =>
+              Some(E.Pat(mID, PTuple(gid(), first, second, theRest)), ct)
+            | _ => None
+            }
           }
+        } else {
+          None
         }
       }
 

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -372,8 +372,6 @@ let run = () => {
     ()
   })
   describe("Tuples", () => {
-    // TUPLETODO add a test for the bug you found. fix it.
-    // TUPLETODO other tests (copy/paste/reconstruction)
     describe("render", () => {
       t("blank tuple pattern", tuplePattern2WithBothBlank, render, ("(***,***)", 0))
       t("simple tuple pattern", tuplePattern2WithNoBlank, render, ("(56,78)", 0))
@@ -566,6 +564,13 @@ let run = () => {
       //   insert(")"),
       //   ("(56,78)", 7),
       // )
+      t(
+        "trying to write over a pattern with another type does nothing",
+        tuplePattern3WithStrs,
+        ~pos=1, // in between the a and b of the first str
+        insert("1"),
+        ("(\"ab\",\"cd\",\"ef\")", 1),
+      )
       ()
     })
 


### PR DESCRIPTION
Given the following code involving a "tuple match pattern":
```
match (1,2)
  (|"one",2) -> "success"
```

with the cursor at the noted spot, typing `1` should do nothing, leaving the cursor in place.

Instead, prior to this change, it would turn into:
```
match (1,2)
  (1|,2) -> "success"
```

Logic has been adjusted to not overwrite non-blank patterns in such a case, and a test around this has been added.