### PR TITLE
Swallow ) input at end of tuple pattern

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -4615,6 +4615,8 @@ let rec updateKey = (
   // Pressing ) to go over the last )
   | (InsertText(")"), _, R(TTupleClose(_), ti)) if pos == ti.endPos - 1 =>
     moveOneRight(pos, astInfo)
+  | (InsertText(")"), _, R(TPatternTupleClose(_), ti)) if pos == ti.endPos - 1 =>
+    moveOneRight(pos, astInfo)
   // Pressing quote to go over the last quote
   | (InsertText("\""), _, R(TPatternString(_), ti))
   | (InsertText("\""), _, R(TString(_), ti))

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -564,6 +564,7 @@ let run = () => {
         ~pos=6, // right before closing )
         insert(")"),
         ("(56,78)", 7),
+      )
       t(
         "trying to write over a pattern with another type does nothing",
         tuplePattern3WithStrs,

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -452,7 +452,7 @@ let run = () => {
           "create and fill in tuple pattern",
           bPat,
           insertMany(list{"(", "1", ",", "2", ")"}),
-          ("(1,2)", 4), // aha, this caught a bug!
+          ("(1,2)", 5),
         )
         ()
       })
@@ -559,13 +559,13 @@ let run = () => {
         insert(","),
         ("(\"a,b\",\"cd\",\"ef\")", 4),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "close bracket at end of tuple is swallowed",
-      //   tuplePattern2WithNoBlank,
-      //   ~pos=6, // right before closing )
-      //   insert(")"),
-      //   ("(56,78)", 7),
-      // )
+      t(
+        "close bracket at end of tuple is swallowed",
+        tuplePattern2WithNoBlank,
+        ~pos=6, // right before closing )
+        insert(")"),
+        ("(56,78)", 7),
+      )
       ()
     })
 


### PR DESCRIPTION
Given this Dark code:

```
match (1,2)
  (1,2|) -> ...
```

, with the cursor at the noted position, a `)` input snow properly skips over the tuple's closing `)`.