### PR TITLE
Put cursor at _start_ of blank pattern when removing elements, not end

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -1258,8 +1258,7 @@ let rec caretTargetForEndOfPattern = (pattern: fluidPattern): CT.t =>
       offset: String.length(frac),
     }
   | PNull(id) => {astRef: ARPattern(id, PPNull), offset: String.length("null")}
-  | PBlank(id) => // Consider changing this from 3 to 0 if we don't want blanks to have two spots
-    {astRef: ARPattern(id, PPBlank), offset: 3}
+  | PBlank(id) => {astRef: ARPattern(id, PPBlank), offset: 0}
   }
 
 /* caretTargetForBeginningOfMatchBranch returns a caretTarget representing caret

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -3006,14 +3006,14 @@ let run = () => {
       emptyMatchWithTwoPatterns,
       ~pos=29,
       bs,
-      "match ___\n  *** -> ___\n  ***~ -> ___\n",
+      "match ___\n  *** -> ___\n  ~*** -> ___\n",
     )
     t(
       "backspacing second matchSep ( -> |) -> moves to end of pattern",
       emptyMatchWithTwoPatterns,
       ~pos=32,
       bs,
-      "match ___\n  *** -> ___\n  ***~ -> ___\n",
+      "match ___\n  *** -> ___\n  ~*** -> ___\n",
     )
     t(
       "ctrl+left 2 times from end moves to first blank",

--- a/client/test/TestFluidPattern.res
+++ b/client/test/TestFluidPattern.res
@@ -466,7 +466,8 @@ let run = () => {
         insert("5"),
         ("(5,***)", 2),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
+      // TUPLETODO discrepency between pat and expr behaviour
+      // t(
       //   "inserting before a tuple is no-op",
       //   tuplePattern2WithBothBlank,
       //
@@ -559,7 +560,8 @@ let run = () => {
         insert(","),
         ("(\"a,b\",\"cd\",\"ef\")", 4),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
+      // TUPLETODO discrepency between pat and expr behaviour
+      // t(
       //   "close bracket at end of tuple is swallowed",
       //   tuplePattern2WithNoBlank,
       //   ~pos=6, // right before closing )
@@ -606,13 +608,13 @@ let run = () => {
         bs,
         ("(***,78)", 7),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting , from a 2-tuple with first value blank converts to a blank",
-      //   tuplePattern2WithFirstBlank,
-      //   ~pos=4, // just after ,
-      //   del,
-      //   ("***", 0),
-      // )
+      t(
+        "deleting , from a 2-tuple with first value blank converts to a blank",
+        tuplePattern2WithFirstBlank,
+        ~pos=4, // just after ,
+        del,
+        ("***", 0),
+      )
 
       // 2-tuple, second blank
       t(
@@ -650,13 +652,13 @@ let run = () => {
         bs,
         ("(***,***)", 8),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting , from a blank 2-tuple replaces the tuple with a blank",
-      //   tuplePattern2WithBothBlank,
-      //   ~pos=5,
-      //   bs,
-      //   ("***", 0),
-      // )
+      t(
+        "deleting , from a blank 2-tuple pattern replaces the tuple with a blank",
+        tuplePattern2WithBothBlank,
+        ~pos=5,
+        bs,
+        ("***", 0),
+      )
 
       // 3-tuple, no blanks
       t(
@@ -694,13 +696,13 @@ let run = () => {
         del,
         ("(***,78,56)", 0),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting first , from a 3-tuple with first item blank removes 2nd item",
-      //   tuplePattern3WithFirstBlank,
-      //   ~pos=4, // just before ,
-      //   del,
-      //   ("(***,56)", 1),
-      // )
+      t(
+        "deleting first , from a 3-tuple with first item blank removes 2nd item",
+        tuplePattern3WithFirstBlank,
+        ~pos=4, // just before ,
+        del,
+        ("(***,56)", 1),
+      )
       t(
         "deleting second , from a 3-tuple with first item blank removes 3rd item",
         tuplePattern3WithFirstBlank,
@@ -730,13 +732,13 @@ let run = () => {
         del,
         ("(56,78)", 3),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting second , from a 3-tuple with the second item blank removes 3rd item",
-      //   tuplePattern3WithSecondBlank, // (56,***,78)
-      //   ~pos=7, // just before ,
-      //   del,
-      //   ("(56,***)", 4),
-      // )
+      t(
+        "deleting second , from a 3-tuple with the second item blank removes 3rd item",
+        tuplePattern3WithSecondBlank, // (56,***,78)
+        ~pos=7, // just before ,
+        del,
+        ("(56,***)", 4),
+      )
       t(
         "deleting ) from a 3-tuple with the second item blank just moves cursor left",
         tuplePattern3WithSecondBlank,
@@ -788,13 +790,13 @@ let run = () => {
         del,
         ("(56,***)", 3),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting second , from a 3-tuple with only first item filled ***",
-      //   tuplePattern3WithFirstFilled,
-      //   ~pos=8, // just after ,
-      //   bs,
-      //   ("(56,***)", 4),
-      // )
+      t(
+        "deleting second , from a 3-tuple with only first item filled ***",
+        tuplePattern3WithFirstFilled,
+        ~pos=8, // just after ,
+        bs,
+        ("(56,***)", 4),
+      )
       t(
         "deleting ) from a 3-tuple with only first item filled just moves cursor left",
         tuplePattern3WithFirstFilled,
@@ -810,13 +812,13 @@ let run = () => {
         del,
         ("56", 0),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting first , from a 3-tuple with only second item filled removes the second item",
-      //   tuplePattern3WithSecondFilled,
-      //   ~pos=4, // just before ,
-      //   del,
-      //   ("(***,***)", 1),
-      // )
+      t(
+        "deleting first , from a 3-tuple with only second item filled removes the second item",
+        tuplePattern3WithSecondFilled,
+        ~pos=4, // just before ,
+        del,
+        ("(***,***)", 1),
+      )
       t(
         "deleting second , from a 3-tuple with only second item filled removes the ending blank",
         tuplePattern3WithSecondFilled,
@@ -839,14 +841,15 @@ let run = () => {
         del,
         ("56", 0),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting first , from a 3-tuple with only third item filled removes the second blank",
-      //   tuplePattern3WithThirdFilled,
-      //   ~pos=4, // just before ,
-      //   del,
-      //   ("(***,56)", 1),
-      // )
-      // t( TUPLETODO discrepency between pat and expr behaviour
+      t(
+        "deleting first , from a 3-tuple with only third item filled removes the second blank",
+        tuplePattern3WithThirdFilled,
+        ~pos=4, // just before ,
+        del,
+        ("(***,56)", 1),
+      )
+      // TUPLETODO discrepency between pat and expr behaviour
+      // t(
       //   "deleting second , from a 3-tuple with only third item filled removes the filled item",
       //   tuplePattern3WithThirdFilled,
       //   ~pos=9, // just after ,
@@ -868,14 +871,15 @@ let run = () => {
         del,
         ("***", 0),
       )
-      // t( TUPLETODO discrepency between pat and expr behaviour
-      //   "deleting first , from a 3-tuple of all blanks removes the second blank",
-      //   tuplePattern3WithAllBlank,
-      //   ~pos=4, // just before ,
-      //   del,
-      //   ("(***,***)", 1),
-      // )
-      // t( TUPLETODO discrepency between pat and expr behaviour
+      t(
+        "deleting first , from a 3-tuple of all blanks removes the second blank",
+        tuplePattern3WithAllBlank,
+        ~pos=4, // just before ,
+        del,
+        ("(***,***)", 1),
+      )
+      // TUPLETODO discrepency between pat and expr behaviour
+      // t(
       //   "deleting second , from a 3-tuple of all blanks removes the third blank",
       //   tuplePattern3WithAllBlank,
       //   ~pos=9, // just after ,


### PR DESCRIPTION
Given the Dark code `let x = (___,|2,3)`, hitting `backspace` changes it to `let x = (|___,3)`, with the cursor at the _start_ of the blank.

The equivalent, for the tuple match pattern, was different. It turned:
```
match (1,2)
  (___,|2,3) -> ___
```

into
```
match (1,2)
  (|___,3) -> ___
```

This was done by updating `caretTargetForEndOfPattern` to `offset` the cursor position by `0` rather than by `3`.
There was a relevant note in place, and this seemed an appropriate time to follow the note.