### PR TITLE
A number of fixes related to lambdas

### DIFF
--- a/client/src/analysis/Runtime.res
+++ b/client/src/analysis/Runtime.res
@@ -33,12 +33,6 @@ let stripQuotes = (s: string): string => {
   s
 }
 
-let isComplete = (dv: RT.Dval.t): bool =>
-  switch dv {
-  | DError(_) | DIncomplete(_) => false
-  | _ => true
-  }
-
 let parseBasicDval = (str): RT.Dval.t => {
   open Json_decode_extended
   oneOf(
@@ -151,8 +145,7 @@ let rec toRepr_ = (oldIndent: int, dv: RT.Dval.t): string => {
   | DPassword(s) => wrap(s)
   | DFnVal(Lambda({parameters: _, body: _, _})) => // TODO: show relevant symtable entries
     "TODO"
-  | DFnVal(FnName(_)) => // TODO: show relevant symtable entries
-    "TODO"
+  | DFnVal(FnName(_)) => "TODO"
   // FluidPrinter.eToHumanString(ELambda(gid(), parameters, body))
   | DIncomplete(_) => asType
   | DHttpResponse(Redirect(url)) => "302 " ++ url
@@ -223,11 +216,10 @@ let sampleInputValue = (tl: toplevel): AnalysisTypes.InputValueDict.t =>
   |> Belt.Map.String.fromArray
 
 let inputValueAsString = (tl: toplevel, iv: AnalysisTypes.InputValueDict.t): string => {
-  let dval = /* Merge sample + trace, preferring trace.
-   *
-   * This ensures newly added parameters show as incomplete.
-   * */
-  Belt.Map.String.merge(sampleInputValue(tl), iv, (_key, sampleVal, traceVal) =>
+  // Merge sample + trace, preferring trace.
+  // This ensures newly added parameters show as incomplete.
+
+  let dval = Belt.Map.String.merge(sampleInputValue(tl), iv, (_key, sampleVal, traceVal) =>
     switch (sampleVal, traceVal) {
     | (None, None) => None
     | (Some(v), None) => Some(v)

--- a/client/src/analysis/Runtime.res
+++ b/client/src/analysis/Runtime.res
@@ -55,7 +55,8 @@ let toRepr = (dval: RT.Dval.t): string => {
     | DNull => "null"
     | DFnVal(Lambda({parameters, body, _})) =>
       // TODO: show relevant symtable entries
-      RuntimeTokenizer.eToHumanString(parameters, body)
+      let params = parameters->List.map(~f=Tuple2.second)->List.join(~sep=", ")
+      "\\" ++ params ++ " -> " ++ RuntimeTokenizer.eToHumanString(body)
     | DFnVal(FnName(_)) => "TODO"
     | DIncomplete(_) => justType
     | DError(_, msg) => `<error: ${msg}>`

--- a/client/src/analysis/Runtime.res
+++ b/client/src/analysis/Runtime.res
@@ -53,10 +53,10 @@ let toRepr = (dval: RT.Dval.t): string => {
     | DBool(false) => "false"
     | DFloat(f) => Js.Float.toString(f)
     | DNull => "null"
-    | DFnVal(Lambda({parameters: _, body: _, _})) => // TODO: show relevant symtable entries
-      "TODO"
+    | DFnVal(Lambda({parameters, body, _})) =>
+      // TODO: show relevant symtable entries
+      RuntimeTokenizer.eToHumanString(parameters, body)
     | DFnVal(FnName(_)) => "TODO"
-    // FluidPrinter.eToHumanString(ELambda(gid(), parameters, body))
     | DIncomplete(_) => justType
     | DError(_, msg) => `<error: ${msg}>`
     | DDate(s) => wrap(s)
@@ -98,8 +98,6 @@ let toRepr = (dval: RT.Dval.t): string => {
     | DResult(Ok(dv_)) => "Ok " ++ toRepr_(indent, dv_)
     | DResult(Error(dv_)) => "Error " ++ toRepr_(indent, dv_)
     | DErrorRail(dv_) => wrap(toRepr_(indent, dv_))
-    // TODO: newlines and indentation
-
     | DBytes(s) => "<Bytes: length=" ++ (Bytes.length(s) |> string_of_int) ++ ">"
     }
   }

--- a/client/src/analysis/Runtime.res
+++ b/client/src/analysis/Runtime.res
@@ -33,117 +33,78 @@ let stripQuotes = (s: string): string => {
   s
 }
 
-// Copied from Dval.to_repr in backend code, but that's terrible and it should
-// be recopied from to_developer_repr_v0
-let rec toRepr_ = (oldIndent: int, dv: RT.Dval.t): string => {
-  let wrap = value => "<" ++ ((dv |> RT.Dval.toType |> DType.tipe2str) ++ (": " ++ (value ++ ">")))
-  let asType = "<" ++ ((dv |> RT.Dval.toType |> DType.tipe2str) ++ ">")
-  let nl = "\n" ++ String.repeat(~count=oldIndent, " ")
-  let inl = "\n" ++ String.repeat(~count=oldIndent + 2, " ")
-  let indent = oldIndent + 2
-  let objToString = l =>
-    l
-    |> List.map(~f=((k, v)) => k ++ (": " ++ toRepr_(indent, v)))
-    |> String.join(~sep="," ++ inl)
-    |> (s => "{" ++ (inl ++ (s ++ (nl ++ "}"))))
+// This should be kept sync with backend DvalReprDeveloper.toRepr
+let toRepr = (dval: RT.Dval.t): string => {
+  let rec toRepr_ = (indent: int, dv: RT.Dval.t): string => {
+    let makeSpaces = len => String.repeat(~count=len, " ")
+    let nl = "\n" ++ makeSpaces(indent)
+    let inl = "\n" ++ makeSpaces(indent + 2)
+    let indent = indent + 2
+    let typename = dv->RT.Dval.toType->DType.tipe2str
+    let wrap = str => `<${typename}: ${str}>`
+    let justType = `<${typename}>`
 
-  switch dv {
-  | DInt(i) => Int64.to_string(i)
-  | DFloat(f) => Js.Float.toString(f)
-  | DStr(s) => "\"" ++ (s ++ "\"")
-  | DBool(true) => "true"
-  | DBool(false) => "false"
-  | DChar(c) => "'" ++ (c ++ "'")
-  | DNull => "null"
-  | DDate(s) => wrap(s)
-  | DDB(s) => wrap(s)
-  | DUuid(s) => wrap(s)
-  | DError(_, s) =>
-    open Json.Decode
-    let decoder = (j): exception_ => {
-      short: field("short", string, j),
-      long: field("long", optional(string), j),
-      exceptionTipe: field("tipe", string, j),
-      actual: field("actual", optional(string), j),
-      actualType: field("actual_tipe", optional(string), j),
-      expected: field("expected", optional(string), j),
-      result: field("result", optional(string), j),
-      resultType: field("result_tipe", optional(string), j),
-      info: field("info", strDict(string), j),
-      workarounds: field("workarounds", list(string), j),
-    }
+    switch dv {
+    | DPassword(_) => "<password>"
+    | DStr(s) => `"${s}"`
+    | DChar(c) => `'${c}'`
+    | DInt(i) => Int64.to_string(i)
+    | DBool(true) => "true"
+    | DBool(false) => "false"
+    | DFloat(f) => Js.Float.toString(f)
+    | DNull => "null"
+    | DFnVal(Lambda({parameters: _, body: _, _})) => // TODO: show relevant symtable entries
+      "TODO"
+    | DFnVal(FnName(_)) => "TODO"
+    // FluidPrinter.eToHumanString(ELambda(gid(), parameters, body))
+    | DIncomplete(_) => justType
+    | DError(_, msg) => `<error: ${msg}>`
+    | DDate(s) => wrap(s)
+    | DDB(s) => wrap(s)
+    | DUuid(s) => wrap(s)
+    | DHttpResponse(Redirect(url)) => "302 " ++ url
+    | DHttpResponse(Response(code, headers, hdv)) =>
+      let headerString =
+        headers
+        |> List.map(~f=((k, v)) => k ++ ": " ++ v)
+        |> String.join(~sep=", ")
+        |> (s => "{ " ++ s ++ " }")
+      Int64.to_string(code) ++ " " ++ headerString ++ nl ++ toRepr_(indent, hdv)
+    | DList(l) =>
+      if l == list{} {
+        "[]"
+      } else {
+        let elems = Js.Array.joinWith(", ", l->List.map(~f=toRepr_(indent))->List.toArray)
+        `[${inl}${elems}${nl}]`
+      }
+    | DTuple(first, second, theRest) =>
+      let exprs = list{first, second, ...theRest}
+      "(" ++ (String.join(~sep=", ", List.map(~f=toRepr_(indent), exprs)) ++ ")")
+    | DObj(o) =>
+      if Belt.Map.String.isEmpty(o) {
+        "{}"
+      } else {
+        let strs =
+          o
+          |> Belt.Map.String.toList
+          |> List.map(~f=((key, value)) => key ++ ": " ++ toRepr_(indent, value))
 
-    let maybe = (name, m) =>
-      switch m {
-      | Some("") | None => ""
-      | Some(s) => "\n  " ++ (name ++ (": " ++ s))
+        let elems = String.join(~sep=`, ${inl}`, strs)
+        `{${inl}${elems}${nl}}`
       }
 
-    try s
-    |> decodeString(decoder)
-    |> Result.toOption
-    |> Option.map(~f=e =>
-      "An error occurred: \n  " ++
-      (e.short ++
-      (maybe("message", e.long) ++
-      (maybe("actual value", e.actual) ++
-      (maybe("actual type", e.actualType) ++
-      (maybe("expected", e.expected) ++
-      (maybe("result", e.result) ++
-      (maybe("result type", e.resultType) ++
-      (if e.info == Map.String.empty {
-        ""
-      } else {
-        ", info: " ++ Map.toString(e.info)
-      } ++
-      (if e.workarounds == list{} {
-        ""
-      } else {
-        ", workarounds: [" ++ (String.join(~sep="", e.workarounds) ++ "]")
-      } ++
-      if e.exceptionTipe == "code" {
-        ""
-      } else {
-        "\n  error type: " ++ e.exceptionTipe
-      })))))))))
-    )
-    |> Option.unwrap(~default=wrap(s)) catch {
-    | _ => wrap(s)
-    }
-  | DPassword(s) => wrap(s)
-  | DFnVal(Lambda({parameters: _, body: _, _})) => // TODO: show relevant symtable entries
-    "TODO"
-  | DFnVal(FnName(_)) => "TODO"
-  // FluidPrinter.eToHumanString(ELambda(gid(), parameters, body))
-  | DIncomplete(_) => asType
-  | DHttpResponse(Redirect(url)) => "302 " ++ url
-  | DHttpResponse(Response(code, hs, dv_)) =>
-    let headers = objToString(List.map(~f=Tuple2.mapSecond(~f=s => RT.Dval.DStr(s)), hs))
-    Int64.to_string(code) ++ " " ++ headers ++ nl ++ toRepr(dv_)
-  | DOption(None) => "Nothing"
-  | DOption(Some(dv_)) => "Just " ++ toRepr(dv_)
-  | DResult(Ok(dv_)) => "Ok " ++ toRepr(dv_)
-  | DResult(Error(dv_)) => "Error " ++ toRepr(dv_)
-  | DErrorRail(dv_) => wrap(toRepr(dv_))
-  // TODO: newlines and indentation
-  | DList(l) =>
-    switch l {
-    | list{} => "[]"
-    | list{DObj(_), ..._} =>
-      "[" ++
-      (inl ++
-      (String.join(~sep=inl ++ ", ", List.map(~f=toRepr_(indent), l)) ++ (nl ++ "]")))
-    | l => "[ " ++ (String.join(~sep=", ", List.map(~f=toRepr_(indent), l)) ++ " ]")
-    }
-  | DTuple(first, second, theRest) =>
-    let exprs = list{first, second, ...theRest}
-    "(" ++ (String.join(~sep=", ", List.map(~f=toRepr_(indent), exprs)) ++ ")")
-  | DObj(o) => objToString(Belt.Map.String.toList(o))
-  | DBytes(s) => "<Bytes: length=" ++ (Bytes.length(s) |> string_of_int) ++ ">"
-  }
-}
+    | DOption(None) => "Nothing"
+    | DOption(Some(dv_)) => "Just " ++ toRepr_(indent, dv_)
+    | DResult(Ok(dv_)) => "Ok " ++ toRepr_(indent, dv_)
+    | DResult(Error(dv_)) => "Error " ++ toRepr_(indent, dv_)
+    | DErrorRail(dv_) => wrap(toRepr_(indent, dv_))
+    // TODO: newlines and indentation
 
-and toRepr = (dv: RT.Dval.t): string => toRepr_(0, dv)
+    | DBytes(s) => "<Bytes: length=" ++ (Bytes.length(s) |> string_of_int) ++ ">"
+    }
+  }
+  toRepr_(0, dval)
+}
 
 // TODO: copied from Libexecution/http.ml
 let route_variables = (route: string): list<string> => {

--- a/client/src/analysis/Runtime.res
+++ b/client/src/analysis/Runtime.res
@@ -33,38 +33,6 @@ let stripQuotes = (s: string): string => {
   s
 }
 
-let parseBasicDval = (str): RT.Dval.t => {
-  open Json_decode_extended
-  oneOf(
-    list{
-      map(x => RT.Dval.DInt(x), int64),
-      map(x => RT.Dval.DFloat(x), float'),
-      map(x => RT.Dval.DBool(x), bool),
-      nullAs(RT.Dval.DNull),
-      map(x => RT.Dval.DStr(x), string),
-    },
-    str,
-  )
-}
-
-let parseDvalLiteral = (str: string): option<RT.Dval.t> =>
-  switch String.toList(str) {
-  | list{'\'', c, '\''} => Some(DChar(String.fromList(list{c})))
-  | list{'"', ...rest} =>
-    if List.last(rest) == Some('"') {
-      List.initial(rest)
-      |> Option.unwrap(~default=list{})
-      |> String.fromList
-      |> (x => Some(RT.Dval.DStr(x)))
-    } else {
-      None
-    }
-  | _ =>
-    try Some(parseBasicDval(Json.parseOrRaise(str))) catch {
-    | _ => None
-    }
-  }
-
 // Copied from Dval.to_repr in backend code, but that's terrible and it should
 // be recopied from to_developer_repr_v0
 let rec toRepr_ = (oldIndent: int, dv: RT.Dval.t): string => {

--- a/client/src/analysis/RuntimeTokenizer.res
+++ b/client/src/analysis/RuntimeTokenizer.res
@@ -1,9 +1,8 @@
 open Prelude
 module Expr = RuntimeTypes.Expr
 
-// --------------------------------------
-// Convert FluidExpressions to tokenInfos
-// --------------------------------------
+/// This is a copy of the FluidTokenizer, adapted for RuntimeTypes. It just uses
+/// strings instead of tokens, and has some features removed (eg multiline strings)
 
 module Builder = {
   type t = {
@@ -34,13 +33,13 @@ module Builder = {
 
   let lineLimit = 120
 
-  let strLimit = 40
-
   let listLimit = 60
 
-  // # of items in a tuple before we should wrap
+  // # of chars in a tuple before we should wrap
   let tupleLimit = 60
+
   let makeSpaces = len => String.repeat(~count=len, " ")
+
   let add = (token: string, b: t): t => {
     let tokenLength = token |> String.length
     let (newTokens, xPos) = // Add new tokens on the front

--- a/client/src/analysis/RuntimeTokenizer.res
+++ b/client/src/analysis/RuntimeTokenizer.res
@@ -1,0 +1,917 @@
+open Prelude
+module T = FluidToken
+module Expr = ProgramTypes.Expr
+module E = FluidExpression
+module Pattern = FluidPattern
+
+open FluidTypes.Token
+type tokenInfo = FluidTypes.TokenInfo.t
+type fluidToken = FluidTypes.Token.t
+type fluidState = AppTypes.fluidState
+
+type featureFlagTokenization =
+  | @ocaml.doc(" FeatureFlagOnlyDisabled is used in the main editor panel to only
+          * show the flag's old code ")
+  FeatureFlagOnlyDisabled
+
+  | @ocaml.doc(" FeatureFlagConditionAndEnabled is used in the secondary editor
+          * panel for editing a flag's condition and new code ")
+  FeatureFlagConditionAndEnabled
+
+// --------------------------------------
+// Convert FluidExpressions to tokenInfos
+// --------------------------------------
+
+module Builder = {
+  type t = {
+    @ocaml.doc(" [tokens] list is kept reversed while being built up, as adding
+            * things to the front of the list is an order of magnitude faster.
+            * We were having large slowdowns on large handlers before this. ")
+    tokens: list<fluidToken>,
+    @ocaml.doc(" [indent] tracks the indent after a newline ")
+    indent: int,
+    @ocaml.doc(" [xPos] tracks the indent for nesting.
+            * `None` indicates it's ready to go after a newline ")
+    xPos: option<int>,
+    ffTokenization: featureFlagTokenization,
+  }
+
+  let rec endsInNewline = (b: t): bool =>
+    // The latest token is on the front
+    switch b.tokens {
+    | list{TNewline(_), ..._} => true
+    | list{TIndent(_), ...tail} => endsInNewline({...b, tokens: tail})
+    | _ => false
+    }
+
+  let empty = {
+    tokens: list{},
+    xPos: Some(0),
+    indent: 0,
+    ffTokenization: FeatureFlagOnlyDisabled,
+  }
+
+  let lineLimit = 120
+
+  let strLimit = 40
+
+  let listLimit = 60
+
+  /* * # of items in a tuple before we should wrap */
+  let tupleLimit = 60
+
+  let add = (token: fluidToken, b: t): t => {
+    let tokenLength = token |> T.toText |> String.length
+    let (newTokens, xPos) = // Add new tokens on the front
+    if endsInNewline(b) {
+      (
+        if b.indent != 0 {
+          list{token, TIndent(b.indent), ...b.tokens}
+        } else {
+          list{token, ...b.tokens}
+        },
+        Some(b.indent + tokenLength),
+      )
+    } else {
+      let newXPos = switch token {
+      | TNewline(_) => None
+      | _ =>
+        let old = Option.unwrap(b.xPos, ~default=b.indent)
+        Some(old + tokenLength)
+      }
+
+      (list{token, ...b.tokens}, newXPos)
+    }
+
+    {...b, tokens: newTokens, xPos: xPos}
+  }
+
+  let addIf = (cond: bool, token: fluidToken, b: t): t =>
+    if cond {
+      add(token, b)
+    } else {
+      b
+    }
+
+  /* Take a list of 'a, and iterate through them, adding them to `b` by
+   * calling `f` on them */
+  let addIter = (xs: list<'a>, ~f: (int, 'a, t) => t, b: t): t =>
+    List.fold(xs, ~initial=(b, 0), ~f=((b, i), x) => (f(i, x, b), i + 1)) |> Tuple2.first
+
+  let addMany = (tokens: list<fluidToken>, b: t): t =>
+    List.fold(tokens, ~initial=b, ~f=(acc, t) => add(t, acc))
+
+  @ocaml.doc(" [indentBy ~ident ~f b] calls [f] with a modified [b] having additional
+    * indentation by [indent] characters (that is, b.indent + ~indent), then
+    * returns the result of that [f b] invocation with the original indent of
+    * [b] restored. ")
+  let indentBy = (~indent: int, ~f: t => t, b: t): t => {
+    let oldIndent = b.indent
+    {...b, indent: b.indent + indent} |> f |> (b => {...b, indent: oldIndent})
+  }
+
+  let addNested = (~f: t => t, b: t): t => {
+    let oldIndent = b.indent
+    let newIndent = Option.unwrap(~default=b.indent, b.xPos)
+    {...b, indent: newIndent} |> f |> (b => {...b, indent: oldIndent})
+  }
+
+  let addNewlineIfNeeded = (nlInfo: option<(id, id, option<int>)>, b: t): t =>
+    if endsInNewline(b) {
+      b
+    } else {
+      add(TNewline(nlInfo), b)
+    }
+
+  let asTokens = (b: t): list<fluidToken> =>
+    // Tokens are stored reversed
+    List.reverse(b.tokens)
+}
+
+// TODO: rename to `patternToTokens``
+let rec patternToToken = (matchID: id, p: FluidPattern.t, ~idx: int): list<fluidToken> => {
+  open FluidTypes.Token
+  switch p {
+  | PVariable(id, name) => list{TPatternVariable(matchID, id, name, idx)}
+  | PConstructor(id, name, args) =>
+    let args = List.map(args, ~f=a => list{TSep(id, None), ...patternToToken(matchID, a, ~idx)})
+
+    List.flatten(list{list{TPatternConstructorName(matchID, id, name, idx)}, ...args})
+  | PInteger(id, i) => list{TPatternInteger(matchID, id, i, idx)}
+  | PBool(id, b) =>
+    if b {
+      list{TPatternTrue(matchID, id, idx)}
+    } else {
+      list{TPatternFalse(matchID, id, idx)}
+    }
+  | PString(id, str) => list{
+      TPatternString({matchID: matchID, patternID: id, str: str, branchIdx: idx}),
+    }
+  | PCharacter(_) => recover("pchar not supported in patternToToken", list{})
+  | PFloat(id, sign, whole, fraction) =>
+    let whole = switch sign {
+    | Positive => whole
+    | Negative => "-" ++ whole
+    }
+    let whole = if whole == "" {
+      list{}
+    } else {
+      list{TPatternFloatWhole(matchID, id, whole, idx)}
+    }
+    let fraction = if fraction == "" {
+      list{}
+    } else {
+      list{TPatternFloatFractional(matchID, id, fraction, idx)}
+    }
+
+    Belt.List.concatMany([whole, list{TPatternFloatPoint(matchID, id, idx)}, fraction])
+  | PNull(id) => list{TPatternNullToken(matchID, id, idx)}
+  | PBlank(id) => list{TPatternBlank(matchID, id, idx)}
+  | PTuple(id, first, second, theRest) =>
+    let subPatterns = list{first, second, ...theRest}
+
+    let subPatternCount = List.length(subPatterns)
+
+    let middlePart =
+      subPatterns
+      |> List.mapWithIndex(~f=(i, p) => {
+        let isLastPattern = i == subPatternCount - 1
+        let subpatternTokens = patternToToken(matchID, p, ~idx)
+
+        if isLastPattern {
+          subpatternTokens
+        } else {
+          List.append(subpatternTokens, list{TPatternTupleComma(matchID, id, i)})
+        }
+      })
+      |> List.flatten
+
+    List.flatten(list{
+      list{TPatternTupleOpen(matchID, id)},
+      middlePart,
+      list{TPatternTupleClose(matchID, id)},
+    })
+  }
+}
+
+let rec toTokens' = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
+  open Builder
+  let ghostPartial = (id, newName, oldName) => {
+    let ghostSuffix = String.dropLeft(~count=String.length(newName), oldName)
+    if ghostSuffix == "" {
+      list{}
+    } else {
+      list{TPartialGhost(id, ghostSuffix, None)}
+    }
+  }
+
+  /* placeholderFor = (id * string * int)
+   * id: id of the placeholder-containing expr
+   * string: name of the placeholder-containing expr
+   * int: index of the placeholder within the expr's parameters
+   */
+  let nest = (
+    ~placeholderFor: option<(id, string, int)>=None,
+    ~indent,
+    e: E.t,
+    b: Builder.t,
+  ): Builder.t => {
+    let tokensFn = b =>
+      switch (e, placeholderFor) {
+      | (EBlank(id), Some(fnID, fnname, pos)) =>
+        let name =
+          Functions.global()
+          |> Functions.findByStr(fnname)
+          |> Option.andThen(~f=(fn: Function.t) => List.getAt(~index=pos, fn.fnParameters))
+          |> Option.map(~f=(p: Function.parameter): Placeholder.t => {
+            name: p.paramName,
+            tipe: DType.tipe2str(p.paramTipe),
+          })
+
+        switch name {
+        | None => toTokens'(e, b)
+        | Some(placeholder) =>
+          add(
+            TPlaceholder({
+              blankID: id,
+              parentBlockID: Some(fnID),
+              placeholder: placeholder,
+              fnID: fnID,
+            }),
+            b,
+          )
+        }
+      | _ => toTokens'(e, b)
+      }
+
+    b |> indentBy(~indent, ~f=addNested(~f=tokensFn))
+  }
+
+  let addArgs = (name: string, id: id, args: list<E.t>, b: Builder.t): Builder.t => {
+    let (args, offset) = switch args {
+    | list{EPipeTarget(_), ...args} => (args, 1)
+    | _ => (args, 0)
+    }
+
+    let reflow = {
+      let tokens =
+        args
+        |> List.map(~f=a => toTokens'(a, Builder.empty))
+        |> List.map(~f=Builder.asTokens)
+        |> List.flatten
+
+      let length =
+        (tokens |> List.map(~f=\">>"(T.toText, String.length)))->List.sum(module(Int))
+        |> \"+" /* separators, including at the front */(List.length(args))
+        |> \"+"(Option.unwrap(~default=0, b.xPos))
+
+      let tooLong = length > lineLimit
+      let needsNewlineBreak =
+        // newlines aren't disruptive in the last argument
+        args
+        |> List.initial
+        |> Option.unwrap(~default=list{})
+        |> List.map(~f=a => toTokens'(a, Builder.empty))
+        |> List.map(~f=Builder.asTokens)
+        |> List.flatten
+        |> List.any(~f=x =>
+          switch x {
+          | TNewline(_) => true
+          | _ => false
+          }
+        )
+
+      tooLong || needsNewlineBreak
+    }
+
+    b |> addIter(args, ~f=(i, e, b) =>
+      if reflow {
+        b
+        |> addNewlineIfNeeded(Some(id, id, Some(offset + i)))
+        |> nest(~indent=2, ~placeholderFor=Some(id, name, offset + i), e)
+      } else {
+        b
+        |> add(TSep(E.toID(e), None))
+        |> nest(~indent=0, ~placeholderFor=Some(id, name, offset + i), e)
+      }
+    )
+  }
+
+  switch e {
+  | EInteger(id, i) => b |> add(TInteger(id, i, parentID))
+  | EBool(id, bool') =>
+    b |> add(
+      if bool' {
+        TTrue(id, parentID)
+      } else {
+        TFalse(id, parentID)
+      },
+    )
+  | ENull(id) => b |> add(TNullToken(id, parentID))
+  | EFloat(id, sign, whole, fraction) =>
+    let whole = switch sign {
+    | Positive => whole
+    | Negative => "-" ++ whole
+    }
+    let whole = if whole == "" {
+      list{}
+    } else {
+      list{TFloatWhole(id, whole, parentID)}
+    }
+
+    let fraction = if fraction == "" {
+      list{}
+    } else {
+      list{TFloatFractional(id, fraction, parentID)}
+    }
+
+    b |> addMany(Belt.List.concatMany([whole, list{TFloatPoint(id, parentID)}, fraction]))
+  | EBlank(id) => b |> add(TBlank(id, parentID))
+  | ELet(id, lhs, rhs, next) =>
+    let rhsID = E.toID(rhs)
+    b
+    |> add(TLetKeyword(id, rhsID, parentID))
+    |> add(TLetVarName(id, rhsID, lhs, parentID))
+    |> add(TLetAssignment(id, rhsID, parentID))
+    |> addNested(~f=toTokens'(rhs))
+    |> addNewlineIfNeeded(Some(E.toID(next), id, None))
+    |> addNested(~f=toTokens'(next))
+  | ECharacter(id, _) =>
+    recover("tokenizing echaracter is not supported", b |> add(TBlank(id, parentID)))
+  | EString(id, str) =>
+    let strings = if String.length(str) > strLimit {
+      String.segment(~size=strLimit, str)
+    } else {
+      list{str}
+    }
+
+    switch strings {
+    | list{} => add(TString(id, "", parentID), b)
+    | list{starting, ...rest} =>
+      switch List.reverse(rest) {
+      | list{} => add(TString(id, str, parentID), b)
+      | list{ending, ...revrest} =>
+        b |> addNested(~f=b => {
+          let endingOffset = strLimit * (List.length(revrest) + 1)
+          b
+          |> add(TStringMLStart(id, starting, 0, str))
+          |> add(TNewline(None))
+          |> addIter(List.reverse(revrest), ~f=(i, s, b) =>
+            b |> add(TStringMLMiddle(id, s, strLimit * (i + 1), str)) |> add(TNewline(None))
+          )
+          |> add(TStringMLEnd(id, ending, endingOffset, str))
+        })
+      }
+    }
+  | EIf(id, cond, if', else') =>
+    b
+    |> add(TIfKeyword(id, parentID))
+    |> addNested(~f=toTokens'(cond))
+    |> addNewlineIfNeeded(None)
+    |> add(TIfThenKeyword(id, parentID))
+    |> addNewlineIfNeeded(Some(E.toID(if'), id, None))
+    |> nest(~indent=2, if')
+    |> addNewlineIfNeeded(None)
+    |> add(TIfElseKeyword(id, parentID))
+    |> add(TNewline(Some(E.toID(else'), id, None)))
+    |> nest(~indent=2, else')
+  | EBinOp(id, op, lexpr, rexpr, _ster) =>
+    let op = PT.InfixStdlibFnName.toString(op)
+    let start = b =>
+      switch lexpr {
+      | EPipeTarget(_) => b
+      | _ =>
+        b
+        |> nest(~indent=0, ~placeholderFor=Some(id, op, 0), lexpr)
+        |> add(TSep(E.toID(lexpr), parentID))
+      }
+
+    b
+    |> start
+    |> addMany(list{TBinOp(id, op, parentID), TSep(id, parentID)})
+    |> nest(~indent=0, ~placeholderFor=Some(id, op, 1), rexpr)
+  | EPartial(id, newName, EBinOp(_, oldName, lexpr, rexpr, _ster)) =>
+    let oldName = PT.InfixStdlibFnName.toString(oldName)
+    let ghost = ghostPartial(id, newName, FluidUtil.ghostPartialName(oldName))
+
+    let start = b =>
+      switch lexpr {
+      | EPipeTarget(_) => b
+      | _ =>
+        b
+        |> nest(~indent=0, ~placeholderFor=Some(id, oldName, 0), lexpr)
+        |> add(TSep(E.toID(lexpr), parentID))
+      }
+
+    b
+    |> start
+    |> add(TPartial(id, newName, parentID))
+    |> addMany(ghost)
+    |> add(TSep(id, parentID))
+    |> nest(~indent=2, ~placeholderFor=Some(id, oldName, 1), rexpr)
+  | EFnCall(id, fnName, args, ster) =>
+    let fnNameStr = FQFnName.toString(fnName)
+    let displayName = FluidUtil.fnDisplayName(fnNameStr)
+    let versionDisplayName = FluidUtil.versionDisplayName(fnNameStr)
+    let partialName = FluidUtil.fnDisplayNameWithVersion(fnNameStr)
+    let versionToken = if versionDisplayName == "" {
+      list{}
+    } else {
+      list{TFnVersion(id, partialName, versionDisplayName, fnNameStr)}
+    }
+
+    b
+    |> add(TFnName(id, partialName, displayName, fnNameStr, ster))
+    |> addMany(versionToken)
+    |> addArgs(FQFnName.toString(fnName), id, args)
+  | EPartial(id, newName, EFnCall(_, oldName, args, _)) =>
+    let oldName = FQFnName.toString(oldName)
+    let partial = TPartial(id, newName, parentID)
+    let newText = T.toText(partial)
+    let oldText = FluidUtil.ghostPartialName(oldName)
+    let ghost = ghostPartial(id, newText, oldText)
+    b |> add(partial) |> addMany(ghost) |> addArgs(oldName, id, args)
+  | EConstructor(id, name, exprs) =>
+    b |> add(TConstructorName(id, name)) |> addArgs(name, id, exprs)
+  | EPartial(id, newName, EConstructor(_, oldName, exprs)) =>
+    let partial = TPartial(id, newName, parentID)
+    let newText = T.toText(partial)
+    let ghost = ghostPartial(id, newText, oldName)
+    b |> add(partial) |> addMany(ghost) |> addArgs(oldName, id, exprs)
+  | EFieldAccess(id, expr, fieldname) =>
+    let lhsid = E.toID(expr)
+    b
+    |> addNested(~f=toTokens'(expr, ~parentID))
+    |> addMany(list{TFieldOp(id, lhsid, parentID), TFieldName(id, lhsid, fieldname, parentID)})
+  | EPartial(id, newFieldname, EFieldAccess(faID, expr, oldFieldname)) =>
+    let lhsid = E.toID(expr)
+    let partial = TFieldPartial(id, faID, lhsid, newFieldname, parentID)
+    let newText = T.toText(partial)
+    let ghost = ghostPartial(id, newText, oldFieldname)
+    b
+    |> addNested(~f=toTokens'(expr))
+    |> addMany(list{TFieldOp(id, E.toID(expr), parentID), partial})
+    |> addMany(ghost)
+  | EVariable(id, name) => b |> add(TVariable(id, name, parentID))
+  | ELambda(id, names, body) =>
+    let isLast = i => i == List.length(names) - 1
+    b
+    |> add(TLambdaSymbol(id, parentID))
+    |> addIter(names, ~f=(i, (aid, name), b) =>
+      b
+      |> add(TLambdaVar(id, aid, i, name, parentID))
+      |> addIf(!isLast(i), TLambdaComma(id, i, parentID))
+      |> addIf(!isLast(i), TSep(aid, parentID))
+    )
+    |> add(TLambdaArrow(id, parentID))
+    |> nest(~indent=2, body)
+  | EList(id, exprs) =>
+    /* With each iteration of the list, we calculate the new line length if
+     * we were to add this new item. If the new line length exceeds the
+     * limit, then we add a new line token and an indent by 1 first, before
+     * adding the tokenized item to the builder. */
+    let lastIndex = List.length(exprs) - 1
+    let xOffset = b.xPos |> Option.unwrap(~default=0)
+    let pid = if lastIndex == -1 {
+      None
+    } else {
+      Some(id)
+    }
+    b
+    |> add(TListOpen(id, pid))
+    |> addIter(exprs, ~f=(i, e, b') => {
+      let currentLineLength = {
+        let commaWidth = if i != lastIndex {
+          1
+        } else {
+          0
+        }
+        toTokens'(e, b').xPos
+        |> Option.map(~f=x => x - xOffset + commaWidth)
+        |> Option.unwrap(~default=commaWidth)
+      }
+
+      // Even if first element overflows, don't put it in a new line
+      let isOverLimit = i > 0 && currentLineLength > listLimit
+      // Indent after newlines to match the '[ '
+      let indent = if isOverLimit {
+        1
+      } else {
+        0
+      }
+      b'
+      |> addIf(isOverLimit, TNewline(None))
+      |> indentBy(~indent, ~f=b' =>
+        b'
+        |> addNested(~f=toTokens'(~parentID=Some(id), e))
+        |> addIf(i != lastIndex, TListComma(id, i))
+      )
+    })
+    |> add(TListClose(id, pid))
+  | ETuple(id, first, second, theRest) =>
+    let exprs = list{first, second, ...theRest}
+
+    // With each item of the tuple, we calculate the new line length if we were
+    // to add this new item. If the new line length exceeds the limit, then we
+    // add a new line token and an indent by 1 first, before adding the
+    // tokenized item to the builder.
+
+    // TODO or we could define isLastElement, and pass the itemIndex as a param
+    // (I think this would be make the code more clear.)
+    let lastIndex = List.length(exprs) - 1
+
+    let xOffset = b.xPos |> Option.unwrap(~default=0)
+
+    b
+    |> add(TTupleOpen(id))
+    |> addIter(exprs, ~f=(i, e, b') => {
+      let currentLineLength = {
+        let commaWidth = if i != lastIndex {
+          1
+        } else {
+          0
+        }
+        toTokens'(e, b').xPos
+        |> Option.map(~f=x => x - xOffset + commaWidth)
+        |> Option.unwrap(~default=commaWidth)
+      }
+
+      let isNotFirstElement = i > 0
+      let isOverLimit = currentLineLength > tupleLimit
+
+      // Even if first element overflows, don't put it in a new line
+      let shouldIndent = isNotFirstElement && isOverLimit
+
+      // Indent after newlines to match the '( '
+      let indent = if shouldIndent {
+        1
+      } else {
+        0
+      }
+
+      b'
+      |> addIf(shouldIndent, TNewline(None))
+      |> indentBy(~indent, ~f=b' =>
+        b'
+        |> addNested(~f=toTokens'(~parentID=Some(id), e))
+        |> addIf(i != lastIndex, TTupleComma(id, i))
+      )
+    })
+    |> add(TTupleClose(id))
+  | ERecord(id, fields) =>
+    if fields == list{} {
+      b |> addMany(list{TRecordOpen(id, None), TRecordClose(id, None)})
+    } else {
+      let parentBlockID = Some(id)
+      b
+      |> add(TRecordOpen(id, parentBlockID))
+      |> indentBy(~indent=2, ~f=b =>
+        addIter(fields, b, ~f=(i, (fieldName, expr), b) => {
+          let exprID = E.toID(expr)
+          b
+          |> addNewlineIfNeeded(Some(id, id, Some(i)))
+          |> add(
+            TRecordFieldname({
+              recordID: id,
+              exprID: exprID,
+              index: i,
+              fieldName: fieldName,
+              parentBlockID: parentBlockID,
+            }),
+          )
+          |> add(TRecordSep(id, i, exprID))
+          |> addNested(~f=toTokens'(~parentID=Some(id), expr))
+        })
+      )
+      |> addMany(list{
+        TNewline(Some(id, id, Some(List.length(fields)))),
+        TRecordClose(id, parentBlockID),
+      })
+    }
+  | EPipe(id, e1, e2, rest) =>
+    let length = 2 + List.length(rest)
+    b
+    // First entry
+    |> addNested(~f=toTokens'(e1))
+    |> addNewlineIfNeeded(Some(E.toID(e1), id, Some(0)))
+    // Second entry is same as rest
+    |> add(TPipe(id, 0, length, parentID))
+    |> addNested(~f=toTokens'(~parentID, e2))
+    |> addNewlineIfNeeded(Some(E.toID(e2), id, Some(1)))
+    // Rest of entries
+    |> addIter(rest, ~f=(i, e, b) =>
+      b
+      |> add(TPipe(id, i + 1, length, parentID))
+      |> addNested(~f=toTokens'(~parentID, e))
+      |> addNewlineIfNeeded(Some(E.toID(e), id, Some(i + 2)))
+    )
+    |> addNewlineIfNeeded(Some(id, id, Some(2 + List.length(rest))))
+
+  | EPipeTarget(_) => recover("should never be making tokens for EPipeTarget", ~debug=e, b)
+  | EMatch(id, mexpr, pairs) =>
+    b
+    |> add(TMatchKeyword(id))
+    |> addNested(~f=toTokens'(mexpr))
+    |> indentBy(~indent=2, ~f=b =>
+      b
+      |> addIter(pairs, ~f=(i, (pattern, expr), b) =>
+        b
+        |> addNewlineIfNeeded(Some(id, id, Some(i)))
+        |> addMany(patternToToken(id, pattern, ~idx=i))
+        |> add(
+          TMatchBranchArrow({
+            matchID: id,
+            patternID: Pattern.toID(pattern),
+            index: i,
+          }),
+        )
+        |> addNested(~f=toTokens'(expr))
+      )
+      |> addNewlineIfNeeded(Some(id, id, Some(List.length(pairs))))
+    )
+  | EPartial(id, str, _) => b |> add(TPartial(id, str, parentID))
+  | ERightPartial(id, newOp, expr) =>
+    b
+    |> addNested(~f=toTokens'(expr))
+    |> addMany(list{TSep(id, parentID), TRightPartial(id, newOp, parentID)})
+  | ELeftPartial(id, str, expr) =>
+    b |> add(TLeftPartial(id, str, parentID)) |> addNested(~f=toTokens'(expr))
+  | EFeatureFlag(id, _name, cond, disabled, enabled) =>
+    /* Feature flag tokens are displayed in two different editor panels, so
+     * they are built differently depending on the current builder option. */
+    switch b.ffTokenization {
+    | FeatureFlagOnlyDisabled => b |> addNested(~f=toTokens'(disabled))
+    | FeatureFlagConditionAndEnabled =>
+      b
+      |> add(TFlagWhenKeyword(id))
+      |> addNested(~f=toTokens'(cond))
+      |> addNewlineIfNeeded(None)
+      |> add(TFlagEnabledKeyword(id))
+      |> addNewlineIfNeeded(Some(E.toID(enabled), id, None))
+      |> nest(~indent=2, enabled)
+    }
+  }
+}
+
+let infoize = (tokens): list<tokenInfo> => {
+  let (row, col, pos) = (ref(0), ref(0), ref(0))
+  List.map(tokens, ~f=token => {
+    let length = String.length(T.toText(token))
+    let ti: tokenInfo = {
+      token: token,
+      startRow: row.contents,
+      startCol: col.contents,
+      startPos: pos.contents,
+      endPos: pos.contents + length,
+      length: length,
+    }
+
+    switch token {
+    | TNewline(_) =>
+      row := row.contents + 1
+      col := 0
+    | _ => col := col.contents + length
+    }
+    pos := pos.contents + length
+    ti
+  })
+}
+
+let validateTokens = (tokens: list<fluidToken>): list<fluidToken> => {
+  List.forEach(tokens, ~f=t => {
+    asserT("invalid token", String.length(T.toText(t)) > 0, ~debug=t)
+    ()
+  })
+  tokens
+}
+
+// Remove artifacts of the token generation process
+let tidy = (tokens: list<fluidToken>): list<fluidToken> =>
+  tokens |> List.filter(~f=x =>
+    switch x {
+    | TIndent(0) => false
+    | _ => true
+    }
+  )
+
+let tokenizeWithFFTokenization = (
+  ffTokenization: featureFlagTokenization,
+  e: FluidExpression.t,
+): list<tokenInfo> =>
+  {...Builder.empty, ffTokenization: ffTokenization}
+  |> toTokens'(e)
+  |> Builder.asTokens
+  |> tidy
+  |> validateTokens
+  |> infoize
+
+let tokenize: E.t => list<FluidToken.tokenInfo> = tokenizeWithFFTokenization(
+  FeatureFlagOnlyDisabled,
+)
+
+let tokensForEditor = (e: FluidTypes.Editor.t, ast: FluidAST.t): list<FluidToken.tokenInfo> =>
+  switch e {
+  | NoEditor => list{}
+  | MainEditor(_) => tokenize(FluidAST.toExpr(ast))
+  | FeatureFlagEditor(_, id) =>
+    FluidAST.find(id, ast)
+    |> Option.map(~f=tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled))
+    |> recoverOpt(
+      "could not find expression id = " ++ (ID.toString(id) ++ " when tokenizing FF editor"),
+      ~default=list{},
+    )
+  }
+
+let tokenizeForEditor = (e: FluidTypes.Editor.t, expr: FluidExpression.t): list<
+  FluidToken.tokenInfo,
+> =>
+  switch e {
+  | NoEditor => list{}
+  | MainEditor(_) => tokenize(expr)
+  | FeatureFlagEditor(_) => tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled, expr)
+  }
+
+// --------------------------------------
+// ASTInfo
+// --------------------------------------
+type tokenInfos = list<T.tokenInfo>
+
+type neighbour =
+  | L(T.t, T.tokenInfo)
+  | R(T.t, T.tokenInfo)
+  | No
+
+let rec getTokensAtPosition = (~prev=None, ~pos: int, tokens: tokenInfos): (
+  option<T.tokenInfo>,
+  option<T.tokenInfo>,
+  option<T.tokenInfo>,
+) => {
+  // Get the next token and the remaining tokens, skipping indents.
+  let rec getNextToken = (infos: tokenInfos): (option<T.tokenInfo>, tokenInfos) =>
+    switch infos {
+    | list{ti, ...rest} =>
+      if T.isSkippable(ti.token) {
+        getNextToken(rest)
+      } else {
+        (Some(ti), rest)
+      }
+    | list{} => (None, list{})
+    }
+
+  switch getNextToken(tokens) {
+  | (None, _remaining) => (prev, None, None)
+  | (Some(current), remaining) =>
+    if current.endPos > pos {
+      let (next, _) = getNextToken(remaining)
+      (prev, Some(current), next)
+    } else {
+      getTokensAtPosition(~prev=Some(current), ~pos, remaining)
+    }
+  }
+}
+
+let getNeighbours = (~pos: int, tokens: tokenInfos): (
+  neighbour,
+  neighbour,
+  option<T.tokenInfo>,
+) => {
+  let (mPrev, mCurrent, mNext) = getTokensAtPosition(~pos, tokens)
+  let toTheRight = switch mCurrent {
+  | Some(current) => R(current.token, current)
+  | _ => No
+  }
+
+  // The token directly before the cursor (skipping whitespace)
+  let toTheLeft = switch (mPrev, mCurrent) {
+  | (Some(prev), _) if prev.endPos >= pos => L(prev.token, prev)
+  // The left might be separated by whitespace
+  | (Some(prev), Some(current)) if current.startPos >= pos => L(prev.token, prev)
+  | (None, Some(current)) if current.startPos < pos =>
+    // We could be in the middle of a token
+    L(current.token, current)
+  | (None, _) => No
+  | (_, Some(current)) => L(current.token, current)
+  | (Some(prev), None) =>
+    // Last position in the ast
+    L(prev.token, prev)
+  }
+
+  (toTheLeft, toTheRight, mNext)
+}
+
+let getTokenNotWhitespace = (tokens: tokenInfos, s: AppTypes.fluidState): option<T.tokenInfo> => {
+  let (left, right, _) = getNeighbours(~pos=s.newPos, tokens)
+  switch (left, right) {
+  | (L(_, lti), R(TNewline(_), _)) => Some(lti)
+  | (L(lt, lti), _) if T.isTextToken(lt) => Some(lti)
+  | (_, R(_, rti)) => Some(rti)
+  | (L(_, lti), _) => Some(lti)
+  | _ => None
+  }
+}
+
+let getToken' = (tokens: tokenInfos, s: AppTypes.fluidState): option<T.tokenInfo> => {
+  let (toTheLeft, toTheRight, _) = getNeighbours(~pos=s.newPos, tokens)
+
+  /* The algorithm that decides what token on when a certain key is pressed is
+   * in updateKey. It's pretty complex and it tells us what token a keystroke
+   * should apply to. For all other places that need to know what token we're
+   * on, this attemps to approximate that.
+
+   * The cursor at newPos is either in a token (eg 3 chars into "myFunction"),
+   * or between two tokens (eg 1 char into "4 + 2").
+
+   * If we're between two tokens, we decide by looking at whether the left
+   * token is a text token. If it is, it's likely that we're just typing.
+   * Otherwise, the important token is probably the right token.
+   *
+   * Example: `4 + 2`, when the cursor is at position: 0): 4 is to the right,
+   * nothing to the left. Choose 4 1): 4 is a text token to the left, choose 4
+   * 2): the token to the left is not a text token (it's a TSep), so choose +
+   * 3): + is a text token to the left, choose + 4): 2 is to the right, nothing
+   * to the left. Choose 2 5): 2 is a text token to the left, choose 2
+   *
+   * Reminder that this is an approximation. If we find bugs we may need to go
+   * much deeper.
+ */
+  switch (toTheLeft, toTheRight) {
+  | (L(_, ti), _) if T.isTextToken(ti.token) => Some(ti)
+  | (_, R(_, ti)) => Some(ti)
+  | (L(_, ti), _) => Some(ti)
+  | _ => None
+  }
+}
+
+module ASTInfo = {
+  type t = {
+    ast: FluidAST.t,
+    state: AppTypes.fluidState,
+    mainTokenInfos: tokenInfos,
+    featureFlagTokenInfos: list<(id, tokenInfos)>,
+  }
+
+  let setAST = (ast: FluidAST.t, astInfo: t): t =>
+    if astInfo.ast == ast {
+      astInfo
+    } else {
+      let mainTokenInfos = tokenize(FluidAST.toExpr(ast))
+      let featureFlagTokenInfos =
+        ast
+        |> FluidAST.getFeatureFlags
+        |> List.map(~f=expr => (
+          E.toID(expr),
+          tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled, expr),
+        ))
+
+      {
+        ...astInfo,
+        ast: ast,
+        mainTokenInfos: mainTokenInfos,
+        featureFlagTokenInfos: featureFlagTokenInfos,
+      }
+    }
+
+  let ffTokenInfosFor = (ffid: id, astInfo: t): option<tokenInfos> =>
+    List.find(astInfo.featureFlagTokenInfos, ~f=((id, _)) => ffid == id) |> Option.map(
+      ~f=Tuple2.second,
+    )
+
+  // Get the correct tokenInfos for the activeEditor
+  let activeTokenInfos = (astInfo: t): tokenInfos =>
+    switch astInfo.state.activeEditor {
+    | NoEditor => list{}
+    | MainEditor(_) => astInfo.mainTokenInfos
+    | FeatureFlagEditor(_, ffid) => ffTokenInfosFor(ffid, astInfo) |> Option.unwrap(~default=list{})
+    }
+
+  let modifyState = (~f: fluidState => fluidState, astInfo: t): t => {
+    ...astInfo,
+    state: f(astInfo.state),
+  }
+
+  let getToken = (astInfo: t): option<T.tokenInfo> =>
+    getToken'(activeTokenInfos(astInfo), astInfo.state)
+
+  let getTokenNotWhitespace = (astInfo: t): option<T.tokenInfo> =>
+    getTokenNotWhitespace(activeTokenInfos(astInfo), astInfo.state)
+
+  let emptyFor = (state: fluidState): t => {
+    ast: FluidAST.ofExpr(Expr.EBlank(gid())),
+    state: state,
+    mainTokenInfos: list{},
+    featureFlagTokenInfos: list{},
+  }
+
+  let make = (ast: FluidAST.t, s: fluidState): t => emptyFor(s) |> setAST(ast)
+
+  let exprOfActiveEditor = (astInfo: t): FluidExpression.t =>
+    switch astInfo.state.activeEditor {
+    | NoEditor => recover("exprOfActiveEditor - none exists", FluidAST.toExpr(astInfo.ast))
+    | MainEditor(_) => FluidAST.toExpr(astInfo.ast)
+    | FeatureFlagEditor(_, id) =>
+      FluidAST.find(id, astInfo.ast) |> recoverOpt(
+        "exprOfActiveEditor - cannot find expression for editor",
+        ~default=FluidAST.toExpr(astInfo.ast),
+      )
+    }
+}

--- a/client/src/analysis/RuntimeTokenizer.res
+++ b/client/src/analysis/RuntimeTokenizer.res
@@ -230,7 +230,8 @@ let rec toTokens' = (e: Expr.t, b: Builder.t): Builder.t => {
     |> add("\n")
     |> nest(~indent=2, else')
   | EFQFnValue(_, name) => b |> add(FQFnName.toString(name))
-  | EApply(_, e, args, _, _) => b |> addNested(~f=toTokens'(e)) |> addArgs(args)
+  | EApply(_, e, args, _, _) =>
+    b |> add("(") |> addNested(~f=toTokens'(e)) |> addArgs(args) |> add(")")
   | EConstructor(_, name, exprs) => b |> add(name) |> addArgs(exprs)
   | EFieldAccess(_, expr, fieldname) =>
     b |> addNested(~f=toTokens'(expr)) |> addMany(list{".", fieldname})

--- a/client/src/analysis/RuntimeTokenizer.res
+++ b/client/src/analysis/RuntimeTokenizer.res
@@ -339,7 +339,7 @@ let rec toTokens' = (e: Expr.t, b: Builder.t): Builder.t => {
     }
   | EMatch(id, mexpr, pairs) =>
     b
-    |> add("matc h")
+    |> add("match")
     |> addNested(~f=toTokens'(mexpr))
     |> indentBy(~indent=2, ~f=b =>
       b

--- a/client/src/analysis/RuntimeTokenizer.res
+++ b/client/src/analysis/RuntimeTokenizer.res
@@ -1,22 +1,5 @@
 open Prelude
-module T = FluidToken
-module Expr = ProgramTypes.Expr
-module E = FluidExpression
-module Pattern = FluidPattern
-
-open FluidTypes.Token
-type tokenInfo = FluidTypes.TokenInfo.t
-type fluidToken = FluidTypes.Token.t
-type fluidState = AppTypes.fluidState
-
-type featureFlagTokenization =
-  | @ocaml.doc(" FeatureFlagOnlyDisabled is used in the main editor panel to only
-          * show the flag's old code ")
-  FeatureFlagOnlyDisabled
-
-  | @ocaml.doc(" FeatureFlagConditionAndEnabled is used in the secondary editor
-          * panel for editing a flag's condition and new code ")
-  FeatureFlagConditionAndEnabled
+module Expr = RuntimeTypes.Expr
 
 // --------------------------------------
 // Convert FluidExpressions to tokenInfos
@@ -27,20 +10,19 @@ module Builder = {
     @ocaml.doc(" [tokens] list is kept reversed while being built up, as adding
             * things to the front of the list is an order of magnitude faster.
             * We were having large slowdowns on large handlers before this. ")
-    tokens: list<fluidToken>,
+    tokens: list<string>,
     @ocaml.doc(" [indent] tracks the indent after a newline ")
     indent: int,
     @ocaml.doc(" [xPos] tracks the indent for nesting.
             * `None` indicates it's ready to go after a newline ")
     xPos: option<int>,
-    ffTokenization: featureFlagTokenization,
   }
 
   let rec endsInNewline = (b: t): bool =>
     // The latest token is on the front
     switch b.tokens {
-    | list{TNewline(_), ..._} => true
-    | list{TIndent(_), ...tail} => endsInNewline({...b, tokens: tail})
+    | list{"\n", ..._} => true
+    | list{"  ", ...tail} => endsInNewline({...b, tokens: tail})
     | _ => false
     }
 
@@ -48,7 +30,6 @@ module Builder = {
     tokens: list{},
     xPos: Some(0),
     indent: 0,
-    ffTokenization: FeatureFlagOnlyDisabled,
   }
 
   let lineLimit = 120
@@ -57,16 +38,16 @@ module Builder = {
 
   let listLimit = 60
 
-  /* * # of items in a tuple before we should wrap */
+  // # of items in a tuple before we should wrap
   let tupleLimit = 60
-
-  let add = (token: fluidToken, b: t): t => {
-    let tokenLength = token |> T.toText |> String.length
+  let makeSpaces = len => String.repeat(~count=len, " ")
+  let add = (token: string, b: t): t => {
+    let tokenLength = token |> String.length
     let (newTokens, xPos) = // Add new tokens on the front
     if endsInNewline(b) {
       (
         if b.indent != 0 {
-          list{token, TIndent(b.indent), ...b.tokens}
+          list{token, makeSpaces(b.indent), ...b.tokens}
         } else {
           list{token, ...b.tokens}
         },
@@ -74,7 +55,7 @@ module Builder = {
       )
     } else {
       let newXPos = switch token {
-      | TNewline(_) => None
+      | "\n" => None
       | _ =>
         let old = Option.unwrap(b.xPos, ~default=b.indent)
         Some(old + tokenLength)
@@ -86,7 +67,7 @@ module Builder = {
     {...b, tokens: newTokens, xPos: xPos}
   }
 
-  let addIf = (cond: bool, token: fluidToken, b: t): t =>
+  let addIf = (cond: bool, token: string, b: t): t =>
     if cond {
       add(token, b)
     } else {
@@ -98,7 +79,7 @@ module Builder = {
   let addIter = (xs: list<'a>, ~f: (int, 'a, t) => t, b: t): t =>
     List.fold(xs, ~initial=(b, 0), ~f=((b, i), x) => (f(i, x, b), i + 1)) |> Tuple2.first
 
-  let addMany = (tokens: list<fluidToken>, b: t): t =>
+  let addMany = (tokens: list<string>, b: t): t =>
     List.fold(tokens, ~initial=b, ~f=(acc, t) => add(t, acc))
 
   @ocaml.doc(" [indentBy ~ident ~f b] calls [f] with a modified [b] having additional
@@ -116,58 +97,43 @@ module Builder = {
     {...b, indent: newIndent} |> f |> (b => {...b, indent: oldIndent})
   }
 
-  let addNewlineIfNeeded = (nlInfo: option<(id, id, option<int>)>, b: t): t =>
+  let addNewlineIfNeeded = (b: t): t =>
     if endsInNewline(b) {
       b
     } else {
-      add(TNewline(nlInfo), b)
+      add("\n", b)
     }
 
-  let asTokens = (b: t): list<fluidToken> =>
+  let asTokens = (b: t): list<string> =>
     // Tokens are stored reversed
-    List.reverse(b.tokens)
+    b.tokens->List.reverse
+
+  let toString = (b: t): string =>
+    // Tokens are stored reversed
+    b.tokens->List.reverse->List.join(~sep="")
 }
 
-// TODO: rename to `patternToTokens``
-let rec patternToToken = (matchID: id, p: FluidPattern.t, ~idx: int): list<fluidToken> => {
-  open FluidTypes.Token
+let rec patternToTokens = (matchID: id, p: RuntimeTypes.Pattern.t, ~idx: int): list<string> => {
   switch p {
-  | PVariable(id, name) => list{TPatternVariable(matchID, id, name, idx)}
-  | PConstructor(id, name, args) =>
-    let args = List.map(args, ~f=a => list{TSep(id, None), ...patternToToken(matchID, a, ~idx)})
+  | PVariable(_, name) => list{name}
+  | PConstructor(_, name, args) =>
+    let args = List.map(args, ~f=a => list{" ", ...patternToTokens(matchID, a, ~idx)})
 
-    List.flatten(list{list{TPatternConstructorName(matchID, id, name, idx)}, ...args})
-  | PInteger(id, i) => list{TPatternInteger(matchID, id, i, idx)}
-  | PBool(id, b) =>
+    List.flatten(list{list{name}, ...args})
+  | PInteger(_, i) => list{Int64.to_string(i)}
+  | PBool(_, b) =>
     if b {
-      list{TPatternTrue(matchID, id, idx)}
+      list{"true"}
     } else {
-      list{TPatternFalse(matchID, id, idx)}
+      list{"false"}
     }
-  | PString(id, str) => list{
-      TPatternString({matchID: matchID, patternID: id, str: str, branchIdx: idx}),
-    }
-  | PCharacter(_) => recover("pchar not supported in patternToToken", list{})
-  | PFloat(id, sign, whole, fraction) =>
-    let whole = switch sign {
-    | Positive => whole
-    | Negative => "-" ++ whole
-    }
-    let whole = if whole == "" {
-      list{}
-    } else {
-      list{TPatternFloatWhole(matchID, id, whole, idx)}
-    }
-    let fraction = if fraction == "" {
-      list{}
-    } else {
-      list{TPatternFloatFractional(matchID, id, fraction, idx)}
-    }
+  | PString(_, str) => list{"\"", str, "\""}
+  | PCharacter(_, c) => list{"'", c, "'"}
+  | PFloat(_, f) => list{Float.to_string(f)}
 
-    Belt.List.concatMany([whole, list{TPatternFloatPoint(matchID, id, idx)}, fraction])
-  | PNull(id) => list{TPatternNullToken(matchID, id, idx)}
-  | PBlank(id) => list{TPatternBlank(matchID, id, idx)}
-  | PTuple(id, first, second, theRest) =>
+  | PNull(_) => list{"null"}
+  | PBlank(_) => list{"___"}
+  | PTuple(_, first, second, theRest) =>
     let subPatterns = list{first, second, ...theRest}
 
     let subPatternCount = List.length(subPatterns)
@@ -176,83 +142,28 @@ let rec patternToToken = (matchID: id, p: FluidPattern.t, ~idx: int): list<fluid
       subPatterns
       |> List.mapWithIndex(~f=(i, p) => {
         let isLastPattern = i == subPatternCount - 1
-        let subpatternTokens = patternToToken(matchID, p, ~idx)
+        let subpatternTokens = patternToTokens(matchID, p, ~idx)
 
         if isLastPattern {
           subpatternTokens
         } else {
-          List.append(subpatternTokens, list{TPatternTupleComma(matchID, id, i)})
+          List.append(subpatternTokens, list{", "})
         }
       })
       |> List.flatten
 
-    List.flatten(list{
-      list{TPatternTupleOpen(matchID, id)},
-      middlePart,
-      list{TPatternTupleClose(matchID, id)},
-    })
+    List.flatten(list{list{"("}, middlePart, list{")"}})
   }
 }
 
-let rec toTokens' = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
+let rec toTokens' = (e: Expr.t, b: Builder.t): Builder.t => {
   open Builder
-  let ghostPartial = (id, newName, oldName) => {
-    let ghostSuffix = String.dropLeft(~count=String.length(newName), oldName)
-    if ghostSuffix == "" {
-      list{}
-    } else {
-      list{TPartialGhost(id, ghostSuffix, None)}
-    }
+
+  let nest = (~indent, e: Expr.t, b: Builder.t): Builder.t => {
+    b |> indentBy(~indent, ~f=addNested(~f=toTokens'(e)))
   }
 
-  /* placeholderFor = (id * string * int)
-   * id: id of the placeholder-containing expr
-   * string: name of the placeholder-containing expr
-   * int: index of the placeholder within the expr's parameters
-   */
-  let nest = (
-    ~placeholderFor: option<(id, string, int)>=None,
-    ~indent,
-    e: E.t,
-    b: Builder.t,
-  ): Builder.t => {
-    let tokensFn = b =>
-      switch (e, placeholderFor) {
-      | (EBlank(id), Some(fnID, fnname, pos)) =>
-        let name =
-          Functions.global()
-          |> Functions.findByStr(fnname)
-          |> Option.andThen(~f=(fn: Function.t) => List.getAt(~index=pos, fn.fnParameters))
-          |> Option.map(~f=(p: Function.parameter): Placeholder.t => {
-            name: p.paramName,
-            tipe: DType.tipe2str(p.paramTipe),
-          })
-
-        switch name {
-        | None => toTokens'(e, b)
-        | Some(placeholder) =>
-          add(
-            TPlaceholder({
-              blankID: id,
-              parentBlockID: Some(fnID),
-              placeholder: placeholder,
-              fnID: fnID,
-            }),
-            b,
-          )
-        }
-      | _ => toTokens'(e, b)
-      }
-
-    b |> indentBy(~indent, ~f=addNested(~f=tokensFn))
-  }
-
-  let addArgs = (name: string, id: id, args: list<E.t>, b: Builder.t): Builder.t => {
-    let (args, offset) = switch args {
-    | list{EPipeTarget(_), ...args} => (args, 1)
-    | _ => (args, 0)
-    }
-
+  let addArgs = (args: list<Expr.t>, b: Builder.t): Builder.t => {
     let reflow = {
       let tokens =
         args
@@ -261,7 +172,7 @@ let rec toTokens' = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
         |> List.flatten
 
       let length =
-        (tokens |> List.map(~f=\">>"(T.toText, String.length)))->List.sum(module(Int))
+        (tokens |> List.map(~f=String.length))->List.sum(module(Int))
         |> \"+" /* separators, including at the front */(List.length(args))
         |> \"+"(Option.unwrap(~default=0, b.xPos))
 
@@ -274,211 +185,74 @@ let rec toTokens' = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
         |> List.map(~f=a => toTokens'(a, Builder.empty))
         |> List.map(~f=Builder.asTokens)
         |> List.flatten
-        |> List.any(~f=x =>
-          switch x {
-          | TNewline(_) => true
-          | _ => false
-          }
-        )
+        |> List.any(~f=String.includes(~substring="\n"))
 
       tooLong || needsNewlineBreak
     }
 
-    b |> addIter(args, ~f=(i, e, b) =>
+    b |> addIter(args, ~f=(_, e, b) =>
       if reflow {
-        b
-        |> addNewlineIfNeeded(Some(id, id, Some(offset + i)))
-        |> nest(~indent=2, ~placeholderFor=Some(id, name, offset + i), e)
+        b |> addNewlineIfNeeded |> nest(~indent=2, e)
       } else {
-        b
-        |> add(TSep(E.toID(e), None))
-        |> nest(~indent=0, ~placeholderFor=Some(id, name, offset + i), e)
+        b |> add(" ") |> nest(~indent=0, e)
       }
     )
   }
 
   switch e {
-  | EInteger(id, i) => b |> add(TInteger(id, i, parentID))
-  | EBool(id, bool') =>
-    b |> add(
-      if bool' {
-        TTrue(id, parentID)
-      } else {
-        TFalse(id, parentID)
-      },
-    )
-  | ENull(id) => b |> add(TNullToken(id, parentID))
-  | EFloat(id, sign, whole, fraction) =>
-    let whole = switch sign {
-    | Positive => whole
-    | Negative => "-" ++ whole
-    }
-    let whole = if whole == "" {
-      list{}
-    } else {
-      list{TFloatWhole(id, whole, parentID)}
-    }
-
-    let fraction = if fraction == "" {
-      list{}
-    } else {
-      list{TFloatFractional(id, fraction, parentID)}
-    }
-
-    b |> addMany(Belt.List.concatMany([whole, list{TFloatPoint(id, parentID)}, fraction]))
-  | EBlank(id) => b |> add(TBlank(id, parentID))
-  | ELet(id, lhs, rhs, next) =>
-    let rhsID = E.toID(rhs)
+  | EInteger(_, i) => b |> add(Int64.to_string(i))
+  | EBool(_, true) => b |> add("true")
+  | EBool(_, false) => b |> add("false")
+  | ENull(_) => b |> add("null")
+  | EFloat(_, f) => b |> add(Float.to_string(f))
+  | EBlank(_) => b |> add("___")
+  | ELet(_, lhs, rhs, next) =>
     b
-    |> add(TLetKeyword(id, rhsID, parentID))
-    |> add(TLetVarName(id, rhsID, lhs, parentID))
-    |> add(TLetAssignment(id, rhsID, parentID))
+    |> add("let ")
+    |> add(lhs)
+    |> add(" ")
     |> addNested(~f=toTokens'(rhs))
-    |> addNewlineIfNeeded(Some(E.toID(next), id, None))
+    |> addNewlineIfNeeded
     |> addNested(~f=toTokens'(next))
-  | ECharacter(id, _) =>
-    recover("tokenizing echaracter is not supported", b |> add(TBlank(id, parentID)))
-  | EString(id, str) =>
-    let strings = if String.length(str) > strLimit {
-      String.segment(~size=strLimit, str)
-    } else {
-      list{str}
-    }
+  | ECharacter(_, c) => b |> add("'") |> add(c) |> add("'")
+  | EString(_, str) => b |> add("\"") |> add(str) |> add("\'")
 
-    switch strings {
-    | list{} => add(TString(id, "", parentID), b)
-    | list{starting, ...rest} =>
-      switch List.reverse(rest) {
-      | list{} => add(TString(id, str, parentID), b)
-      | list{ending, ...revrest} =>
-        b |> addNested(~f=b => {
-          let endingOffset = strLimit * (List.length(revrest) + 1)
-          b
-          |> add(TStringMLStart(id, starting, 0, str))
-          |> add(TNewline(None))
-          |> addIter(List.reverse(revrest), ~f=(i, s, b) =>
-            b |> add(TStringMLMiddle(id, s, strLimit * (i + 1), str)) |> add(TNewline(None))
-          )
-          |> add(TStringMLEnd(id, ending, endingOffset, str))
-        })
-      }
-    }
-  | EIf(id, cond, if', else') =>
+  | EIf(_, cond, if', else') =>
     b
-    |> add(TIfKeyword(id, parentID))
+    |> add("if ")
     |> addNested(~f=toTokens'(cond))
-    |> addNewlineIfNeeded(None)
-    |> add(TIfThenKeyword(id, parentID))
-    |> addNewlineIfNeeded(Some(E.toID(if'), id, None))
+    |> addNewlineIfNeeded
+    |> add("then")
+    |> addNewlineIfNeeded
     |> nest(~indent=2, if')
-    |> addNewlineIfNeeded(None)
-    |> add(TIfElseKeyword(id, parentID))
-    |> add(TNewline(Some(E.toID(else'), id, None)))
+    |> addNewlineIfNeeded
+    |> add("else")
+    |> add("\n")
     |> nest(~indent=2, else')
-  | EBinOp(id, op, lexpr, rexpr, _ster) =>
-    let op = PT.InfixStdlibFnName.toString(op)
-    let start = b =>
-      switch lexpr {
-      | EPipeTarget(_) => b
-      | _ =>
-        b
-        |> nest(~indent=0, ~placeholderFor=Some(id, op, 0), lexpr)
-        |> add(TSep(E.toID(lexpr), parentID))
-      }
-
-    b
-    |> start
-    |> addMany(list{TBinOp(id, op, parentID), TSep(id, parentID)})
-    |> nest(~indent=0, ~placeholderFor=Some(id, op, 1), rexpr)
-  | EPartial(id, newName, EBinOp(_, oldName, lexpr, rexpr, _ster)) =>
-    let oldName = PT.InfixStdlibFnName.toString(oldName)
-    let ghost = ghostPartial(id, newName, FluidUtil.ghostPartialName(oldName))
-
-    let start = b =>
-      switch lexpr {
-      | EPipeTarget(_) => b
-      | _ =>
-        b
-        |> nest(~indent=0, ~placeholderFor=Some(id, oldName, 0), lexpr)
-        |> add(TSep(E.toID(lexpr), parentID))
-      }
-
-    b
-    |> start
-    |> add(TPartial(id, newName, parentID))
-    |> addMany(ghost)
-    |> add(TSep(id, parentID))
-    |> nest(~indent=2, ~placeholderFor=Some(id, oldName, 1), rexpr)
-  | EFnCall(id, fnName, args, ster) =>
-    let fnNameStr = FQFnName.toString(fnName)
-    let displayName = FluidUtil.fnDisplayName(fnNameStr)
-    let versionDisplayName = FluidUtil.versionDisplayName(fnNameStr)
-    let partialName = FluidUtil.fnDisplayNameWithVersion(fnNameStr)
-    let versionToken = if versionDisplayName == "" {
-      list{}
-    } else {
-      list{TFnVersion(id, partialName, versionDisplayName, fnNameStr)}
-    }
-
-    b
-    |> add(TFnName(id, partialName, displayName, fnNameStr, ster))
-    |> addMany(versionToken)
-    |> addArgs(FQFnName.toString(fnName), id, args)
-  | EPartial(id, newName, EFnCall(_, oldName, args, _)) =>
-    let oldName = FQFnName.toString(oldName)
-    let partial = TPartial(id, newName, parentID)
-    let newText = T.toText(partial)
-    let oldText = FluidUtil.ghostPartialName(oldName)
-    let ghost = ghostPartial(id, newText, oldText)
-    b |> add(partial) |> addMany(ghost) |> addArgs(oldName, id, args)
-  | EConstructor(id, name, exprs) =>
-    b |> add(TConstructorName(id, name)) |> addArgs(name, id, exprs)
-  | EPartial(id, newName, EConstructor(_, oldName, exprs)) =>
-    let partial = TPartial(id, newName, parentID)
-    let newText = T.toText(partial)
-    let ghost = ghostPartial(id, newText, oldName)
-    b |> add(partial) |> addMany(ghost) |> addArgs(oldName, id, exprs)
-  | EFieldAccess(id, expr, fieldname) =>
-    let lhsid = E.toID(expr)
-    b
-    |> addNested(~f=toTokens'(expr, ~parentID))
-    |> addMany(list{TFieldOp(id, lhsid, parentID), TFieldName(id, lhsid, fieldname, parentID)})
-  | EPartial(id, newFieldname, EFieldAccess(faID, expr, oldFieldname)) =>
-    let lhsid = E.toID(expr)
-    let partial = TFieldPartial(id, faID, lhsid, newFieldname, parentID)
-    let newText = T.toText(partial)
-    let ghost = ghostPartial(id, newText, oldFieldname)
-    b
-    |> addNested(~f=toTokens'(expr))
-    |> addMany(list{TFieldOp(id, E.toID(expr), parentID), partial})
-    |> addMany(ghost)
-  | EVariable(id, name) => b |> add(TVariable(id, name, parentID))
-  | ELambda(id, names, body) =>
+  | EFQFnValue(_, name) => b |> add(FQFnName.toString(name))
+  | EApply(_, e, args, _, _) => b |> addNested(~f=toTokens'(e)) |> addArgs(args)
+  | EConstructor(_, name, exprs) => b |> add(name) |> addArgs(exprs)
+  | EFieldAccess(_, expr, fieldname) =>
+    b |> addNested(~f=toTokens'(expr)) |> addMany(list{".", fieldname})
+  | EVariable(_, name) => b |> add(name)
+  | ELambda(_, names, body) =>
     let isLast = i => i == List.length(names) - 1
     b
-    |> add(TLambdaSymbol(id, parentID))
-    |> addIter(names, ~f=(i, (aid, name), b) =>
-      b
-      |> add(TLambdaVar(id, aid, i, name, parentID))
-      |> addIf(!isLast(i), TLambdaComma(id, i, parentID))
-      |> addIf(!isLast(i), TSep(aid, parentID))
+    |> add("\\")
+    |> addIter(names, ~f=(i, (_, name), b) =>
+      b |> add(name) |> addIf(!isLast(i), ",") |> addIf(!isLast(i), " ")
     )
-    |> add(TLambdaArrow(id, parentID))
+    |> add("->")
     |> nest(~indent=2, body)
-  | EList(id, exprs) =>
+  | EList(_, exprs) =>
     /* With each iteration of the list, we calculate the new line length if
      * we were to add this new item. If the new line length exceeds the
      * limit, then we add a new line token and an indent by 1 first, before
      * adding the tokenized item to the builder. */
     let lastIndex = List.length(exprs) - 1
     let xOffset = b.xPos |> Option.unwrap(~default=0)
-    let pid = if lastIndex == -1 {
-      None
-    } else {
-      Some(id)
-    }
     b
-    |> add(TListOpen(id, pid))
+    |> add("[")
     |> addIter(exprs, ~f=(i, e, b') => {
       let currentLineLength = {
         let commaWidth = if i != lastIndex {
@@ -500,15 +274,11 @@ let rec toTokens' = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
         0
       }
       b'
-      |> addIf(isOverLimit, TNewline(None))
-      |> indentBy(~indent, ~f=b' =>
-        b'
-        |> addNested(~f=toTokens'(~parentID=Some(id), e))
-        |> addIf(i != lastIndex, TListComma(id, i))
-      )
+      |> addIf(isOverLimit, "\n")
+      |> indentBy(~indent, ~f=b' => b' |> addNested(~f=toTokens'(e)) |> addIf(i != lastIndex, ", "))
     })
-    |> add(TListClose(id, pid))
-  | ETuple(id, first, second, theRest) =>
+    |> add("]")
+  | ETuple(_, first, second, theRest) =>
     let exprs = list{first, second, ...theRest}
 
     // With each item of the tuple, we calculate the new line length if we were
@@ -523,7 +293,7 @@ let rec toTokens' = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
     let xOffset = b.xPos |> Option.unwrap(~default=0)
 
     b
-    |> add(TTupleOpen(id))
+    |> add("(")
     |> addIter(exprs, ~f=(i, e, b') => {
       let currentLineLength = {
         let commaWidth = if i != lastIndex {
@@ -550,368 +320,49 @@ let rec toTokens' = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
       }
 
       b'
-      |> addIf(shouldIndent, TNewline(None))
-      |> indentBy(~indent, ~f=b' =>
-        b'
-        |> addNested(~f=toTokens'(~parentID=Some(id), e))
-        |> addIf(i != lastIndex, TTupleComma(id, i))
-      )
+      |> addIf(shouldIndent, "\n")
+      |> indentBy(~indent, ~f=b' => b' |> addNested(~f=toTokens'(e)) |> addIf(i != lastIndex, ", "))
     })
-    |> add(TTupleClose(id))
-  | ERecord(id, fields) =>
+    |> add(")")
+  | ERecord(_, fields) =>
     if fields == list{} {
-      b |> addMany(list{TRecordOpen(id, None), TRecordClose(id, None)})
+      b |> add("{}")
     } else {
-      let parentBlockID = Some(id)
       b
-      |> add(TRecordOpen(id, parentBlockID))
+      |> add("{")
       |> indentBy(~indent=2, ~f=b =>
-        addIter(fields, b, ~f=(i, (fieldName, expr), b) => {
-          let exprID = E.toID(expr)
-          b
-          |> addNewlineIfNeeded(Some(id, id, Some(i)))
-          |> add(
-            TRecordFieldname({
-              recordID: id,
-              exprID: exprID,
-              index: i,
-              fieldName: fieldName,
-              parentBlockID: parentBlockID,
-            }),
-          )
-          |> add(TRecordSep(id, i, exprID))
-          |> addNested(~f=toTokens'(~parentID=Some(id), expr))
+        addIter(fields, b, ~f=(_, (fieldName, expr), b) => {
+          b |> addNewlineIfNeeded |> add(fieldName) |> add(": ") |> addNested(~f=toTokens'(expr))
         })
       )
-      |> addMany(list{
-        TNewline(Some(id, id, Some(List.length(fields)))),
-        TRecordClose(id, parentBlockID),
-      })
+      |> addMany(list{"\n", "}"})
     }
-  | EPipe(id, e1, e2, rest) =>
-    let length = 2 + List.length(rest)
-    b
-    // First entry
-    |> addNested(~f=toTokens'(e1))
-    |> addNewlineIfNeeded(Some(E.toID(e1), id, Some(0)))
-    // Second entry is same as rest
-    |> add(TPipe(id, 0, length, parentID))
-    |> addNested(~f=toTokens'(~parentID, e2))
-    |> addNewlineIfNeeded(Some(E.toID(e2), id, Some(1)))
-    // Rest of entries
-    |> addIter(rest, ~f=(i, e, b) =>
-      b
-      |> add(TPipe(id, i + 1, length, parentID))
-      |> addNested(~f=toTokens'(~parentID, e))
-      |> addNewlineIfNeeded(Some(E.toID(e), id, Some(i + 2)))
-    )
-    |> addNewlineIfNeeded(Some(id, id, Some(2 + List.length(rest))))
-
-  | EPipeTarget(_) => recover("should never be making tokens for EPipeTarget", ~debug=e, b)
   | EMatch(id, mexpr, pairs) =>
     b
-    |> add(TMatchKeyword(id))
+    |> add("matc h")
     |> addNested(~f=toTokens'(mexpr))
     |> indentBy(~indent=2, ~f=b =>
       b
       |> addIter(pairs, ~f=(i, (pattern, expr), b) =>
         b
-        |> addNewlineIfNeeded(Some(id, id, Some(i)))
-        |> addMany(patternToToken(id, pattern, ~idx=i))
-        |> add(
-          TMatchBranchArrow({
-            matchID: id,
-            patternID: Pattern.toID(pattern),
-            index: i,
-          }),
-        )
+        |> addNewlineIfNeeded
+        |> addMany(patternToTokens(id, pattern, ~idx=i))
+        |> add(" -> ")
         |> addNested(~f=toTokens'(expr))
       )
-      |> addNewlineIfNeeded(Some(id, id, Some(List.length(pairs))))
+      |> addNewlineIfNeeded
     )
-  | EPartial(id, str, _) => b |> add(TPartial(id, str, parentID))
-  | ERightPartial(id, newOp, expr) =>
+  | EFeatureFlag(_, cond, _disabled, enabled) =>
     b
-    |> addNested(~f=toTokens'(expr))
-    |> addMany(list{TSep(id, parentID), TRightPartial(id, newOp, parentID)})
-  | ELeftPartial(id, str, expr) =>
-    b |> add(TLeftPartial(id, str, parentID)) |> addNested(~f=toTokens'(expr))
-  | EFeatureFlag(id, _name, cond, disabled, enabled) =>
-    /* Feature flag tokens are displayed in two different editor panels, so
-     * they are built differently depending on the current builder option. */
-    switch b.ffTokenization {
-    | FeatureFlagOnlyDisabled => b |> addNested(~f=toTokens'(disabled))
-    | FeatureFlagConditionAndEnabled =>
-      b
-      |> add(TFlagWhenKeyword(id))
-      |> addNested(~f=toTokens'(cond))
-      |> addNewlineIfNeeded(None)
-      |> add(TFlagEnabledKeyword(id))
-      |> addNewlineIfNeeded(Some(E.toID(enabled), id, None))
-      |> nest(~indent=2, enabled)
-    }
+    |> add("when")
+    |> addNested(~f=toTokens'(cond))
+    |> addNewlineIfNeeded
+    |> add("enabled")
+    |> addNewlineIfNeeded
+    |> nest(~indent=2, enabled)
   }
 }
 
-let infoize = (tokens): list<tokenInfo> => {
-  let (row, col, pos) = (ref(0), ref(0), ref(0))
-  List.map(tokens, ~f=token => {
-    let length = String.length(T.toText(token))
-    let ti: tokenInfo = {
-      token: token,
-      startRow: row.contents,
-      startCol: col.contents,
-      startPos: pos.contents,
-      endPos: pos.contents + length,
-      length: length,
-    }
-
-    switch token {
-    | TNewline(_) =>
-      row := row.contents + 1
-      col := 0
-    | _ => col := col.contents + length
-    }
-    pos := pos.contents + length
-    ti
-  })
-}
-
-let validateTokens = (tokens: list<fluidToken>): list<fluidToken> => {
-  List.forEach(tokens, ~f=t => {
-    asserT("invalid token", String.length(T.toText(t)) > 0, ~debug=t)
-    ()
-  })
-  tokens
-}
-
-// Remove artifacts of the token generation process
-let tidy = (tokens: list<fluidToken>): list<fluidToken> =>
-  tokens |> List.filter(~f=x =>
-    switch x {
-    | TIndent(0) => false
-    | _ => true
-    }
-  )
-
-let tokenizeWithFFTokenization = (
-  ffTokenization: featureFlagTokenization,
-  e: FluidExpression.t,
-): list<tokenInfo> =>
-  {...Builder.empty, ffTokenization: ffTokenization}
-  |> toTokens'(e)
-  |> Builder.asTokens
-  |> tidy
-  |> validateTokens
-  |> infoize
-
-let tokenize: E.t => list<FluidToken.tokenInfo> = tokenizeWithFFTokenization(
-  FeatureFlagOnlyDisabled,
-)
-
-let tokensForEditor = (e: FluidTypes.Editor.t, ast: FluidAST.t): list<FluidToken.tokenInfo> =>
-  switch e {
-  | NoEditor => list{}
-  | MainEditor(_) => tokenize(FluidAST.toExpr(ast))
-  | FeatureFlagEditor(_, id) =>
-    FluidAST.find(id, ast)
-    |> Option.map(~f=tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled))
-    |> recoverOpt(
-      "could not find expression id = " ++ (ID.toString(id) ++ " when tokenizing FF editor"),
-      ~default=list{},
-    )
-  }
-
-let tokenizeForEditor = (e: FluidTypes.Editor.t, expr: FluidExpression.t): list<
-  FluidToken.tokenInfo,
-> =>
-  switch e {
-  | NoEditor => list{}
-  | MainEditor(_) => tokenize(expr)
-  | FeatureFlagEditor(_) => tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled, expr)
-  }
-
-// --------------------------------------
-// ASTInfo
-// --------------------------------------
-type tokenInfos = list<T.tokenInfo>
-
-type neighbour =
-  | L(T.t, T.tokenInfo)
-  | R(T.t, T.tokenInfo)
-  | No
-
-let rec getTokensAtPosition = (~prev=None, ~pos: int, tokens: tokenInfos): (
-  option<T.tokenInfo>,
-  option<T.tokenInfo>,
-  option<T.tokenInfo>,
-) => {
-  // Get the next token and the remaining tokens, skipping indents.
-  let rec getNextToken = (infos: tokenInfos): (option<T.tokenInfo>, tokenInfos) =>
-    switch infos {
-    | list{ti, ...rest} =>
-      if T.isSkippable(ti.token) {
-        getNextToken(rest)
-      } else {
-        (Some(ti), rest)
-      }
-    | list{} => (None, list{})
-    }
-
-  switch getNextToken(tokens) {
-  | (None, _remaining) => (prev, None, None)
-  | (Some(current), remaining) =>
-    if current.endPos > pos {
-      let (next, _) = getNextToken(remaining)
-      (prev, Some(current), next)
-    } else {
-      getTokensAtPosition(~prev=Some(current), ~pos, remaining)
-    }
-  }
-}
-
-let getNeighbours = (~pos: int, tokens: tokenInfos): (
-  neighbour,
-  neighbour,
-  option<T.tokenInfo>,
-) => {
-  let (mPrev, mCurrent, mNext) = getTokensAtPosition(~pos, tokens)
-  let toTheRight = switch mCurrent {
-  | Some(current) => R(current.token, current)
-  | _ => No
-  }
-
-  // The token directly before the cursor (skipping whitespace)
-  let toTheLeft = switch (mPrev, mCurrent) {
-  | (Some(prev), _) if prev.endPos >= pos => L(prev.token, prev)
-  // The left might be separated by whitespace
-  | (Some(prev), Some(current)) if current.startPos >= pos => L(prev.token, prev)
-  | (None, Some(current)) if current.startPos < pos =>
-    // We could be in the middle of a token
-    L(current.token, current)
-  | (None, _) => No
-  | (_, Some(current)) => L(current.token, current)
-  | (Some(prev), None) =>
-    // Last position in the ast
-    L(prev.token, prev)
-  }
-
-  (toTheLeft, toTheRight, mNext)
-}
-
-let getTokenNotWhitespace = (tokens: tokenInfos, s: AppTypes.fluidState): option<T.tokenInfo> => {
-  let (left, right, _) = getNeighbours(~pos=s.newPos, tokens)
-  switch (left, right) {
-  | (L(_, lti), R(TNewline(_), _)) => Some(lti)
-  | (L(lt, lti), _) if T.isTextToken(lt) => Some(lti)
-  | (_, R(_, rti)) => Some(rti)
-  | (L(_, lti), _) => Some(lti)
-  | _ => None
-  }
-}
-
-let getToken' = (tokens: tokenInfos, s: AppTypes.fluidState): option<T.tokenInfo> => {
-  let (toTheLeft, toTheRight, _) = getNeighbours(~pos=s.newPos, tokens)
-
-  /* The algorithm that decides what token on when a certain key is pressed is
-   * in updateKey. It's pretty complex and it tells us what token a keystroke
-   * should apply to. For all other places that need to know what token we're
-   * on, this attemps to approximate that.
-
-   * The cursor at newPos is either in a token (eg 3 chars into "myFunction"),
-   * or between two tokens (eg 1 char into "4 + 2").
-
-   * If we're between two tokens, we decide by looking at whether the left
-   * token is a text token. If it is, it's likely that we're just typing.
-   * Otherwise, the important token is probably the right token.
-   *
-   * Example: `4 + 2`, when the cursor is at position: 0): 4 is to the right,
-   * nothing to the left. Choose 4 1): 4 is a text token to the left, choose 4
-   * 2): the token to the left is not a text token (it's a TSep), so choose +
-   * 3): + is a text token to the left, choose + 4): 2 is to the right, nothing
-   * to the left. Choose 2 5): 2 is a text token to the left, choose 2
-   *
-   * Reminder that this is an approximation. If we find bugs we may need to go
-   * much deeper.
- */
-  switch (toTheLeft, toTheRight) {
-  | (L(_, ti), _) if T.isTextToken(ti.token) => Some(ti)
-  | (_, R(_, ti)) => Some(ti)
-  | (L(_, ti), _) => Some(ti)
-  | _ => None
-  }
-}
-
-module ASTInfo = {
-  type t = {
-    ast: FluidAST.t,
-    state: AppTypes.fluidState,
-    mainTokenInfos: tokenInfos,
-    featureFlagTokenInfos: list<(id, tokenInfos)>,
-  }
-
-  let setAST = (ast: FluidAST.t, astInfo: t): t =>
-    if astInfo.ast == ast {
-      astInfo
-    } else {
-      let mainTokenInfos = tokenize(FluidAST.toExpr(ast))
-      let featureFlagTokenInfos =
-        ast
-        |> FluidAST.getFeatureFlags
-        |> List.map(~f=expr => (
-          E.toID(expr),
-          tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled, expr),
-        ))
-
-      {
-        ...astInfo,
-        ast: ast,
-        mainTokenInfos: mainTokenInfos,
-        featureFlagTokenInfos: featureFlagTokenInfos,
-      }
-    }
-
-  let ffTokenInfosFor = (ffid: id, astInfo: t): option<tokenInfos> =>
-    List.find(astInfo.featureFlagTokenInfos, ~f=((id, _)) => ffid == id) |> Option.map(
-      ~f=Tuple2.second,
-    )
-
-  // Get the correct tokenInfos for the activeEditor
-  let activeTokenInfos = (astInfo: t): tokenInfos =>
-    switch astInfo.state.activeEditor {
-    | NoEditor => list{}
-    | MainEditor(_) => astInfo.mainTokenInfos
-    | FeatureFlagEditor(_, ffid) => ffTokenInfosFor(ffid, astInfo) |> Option.unwrap(~default=list{})
-    }
-
-  let modifyState = (~f: fluidState => fluidState, astInfo: t): t => {
-    ...astInfo,
-    state: f(astInfo.state),
-  }
-
-  let getToken = (astInfo: t): option<T.tokenInfo> =>
-    getToken'(activeTokenInfos(astInfo), astInfo.state)
-
-  let getTokenNotWhitespace = (astInfo: t): option<T.tokenInfo> =>
-    getTokenNotWhitespace(activeTokenInfos(astInfo), astInfo.state)
-
-  let emptyFor = (state: fluidState): t => {
-    ast: FluidAST.ofExpr(Expr.EBlank(gid())),
-    state: state,
-    mainTokenInfos: list{},
-    featureFlagTokenInfos: list{},
-  }
-
-  let make = (ast: FluidAST.t, s: fluidState): t => emptyFor(s) |> setAST(ast)
-
-  let exprOfActiveEditor = (astInfo: t): FluidExpression.t =>
-    switch astInfo.state.activeEditor {
-    | NoEditor => recover("exprOfActiveEditor - none exists", FluidAST.toExpr(astInfo.ast))
-    | MainEditor(_) => FluidAST.toExpr(astInfo.ast)
-    | FeatureFlagEditor(_, id) =>
-      FluidAST.find(id, astInfo.ast) |> recoverOpt(
-        "exprOfActiveEditor - cannot find expression for editor",
-        ~default=FluidAST.toExpr(astInfo.ast),
-      )
-    }
+let eToHumanString = (e: RuntimeTypes.Expr.t) => {
+  toTokens'(e, Builder.empty) |> Builder.toString
 }

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -2247,13 +2247,13 @@ let acToExpr = (entry: AC.item): option<(E.t, CT.t)> => {
   | FACVariable(name, _) =>
     let vID = gid()
     Some(EVariable(vID, name), {astRef: ARVariable(vID), offset: String.length(name)})
-  | FACLiteral("true") =>
+  | FACLiteral(LBool(true)) =>
     let bID = gid()
     Some(EBool(bID, true), {astRef: ARBool(bID), offset: String.length("true")})
-  | FACLiteral("false") =>
+  | FACLiteral(LBool(false)) =>
     let bID = gid()
     Some(EBool(bID, false), {astRef: ARBool(bID), offset: String.length("false")})
-  | FACLiteral("null") =>
+  | FACLiteral(LNull) =>
     let nID = gid()
     Some(ENull(nID), {astRef: ARNull(nID), offset: String.length("null")})
   | FACConstructorName(name, argCount) =>
@@ -2269,7 +2269,6 @@ let acToExpr = (entry: AC.item): option<(E.t, CT.t)> => {
         offset: String.length(fieldname),
       },
     )
-  | FACLiteral(_) => recover("invalid literal in autocomplete", ~debug=entry, None)
   | FACPattern(_) =>
     // This only works for exprs
     None

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -57,7 +57,7 @@ module Builder = {
 
   let listLimit = 60
 
-  /* * # of items in a tuple before we should wrap */
+  // # of chars in a tuple before we should wrap
   let tupleLimit = 60
 
   let add = (token: fluidToken, b: t): t => {

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -184,12 +184,17 @@ module AutoComplete = {
     | KPipe
 
   @ppx.deriving(show({with_path: false}))
+  type rec literalItem =
+    | LNull
+    | LBool(bool)
+
+  @ppx.deriving(show({with_path: false}))
   type rec item =
     | FACFunction(Function.t)
     | FACConstructorName(string, int)
     | FACField(string)
     | FACVariable(string, option<RuntimeTypes.Dval.t>)
-    | FACLiteral(string)
+    | FACLiteral(literalItem)
     | FACKeyword(keyword)
     | FACPattern(patternItem)
     | FACCreateFunction(string, TLID.t, ID.t)

--- a/client/src/toplevels/ViewDB.res
+++ b/client/src/toplevels/ViewDB.res
@@ -26,7 +26,7 @@ let viewDbCount = (stats: dbStats): Html.html<msg> =>
     },
   )
 
-let viewDbLatestEntry = (stats: dbStats): Html.html<msg> => {
+let viewDbLatestEntry = (stats: dbStats, tlid: TLID.t, secrets: list<string>): Html.html<msg> => {
   let title = Html.div(
     list{Attrs.class'("title")},
     list{
@@ -43,7 +43,10 @@ let viewDbLatestEntry = (stats: dbStats): Html.html<msg> => {
       list{Attrs.class'("dbexample")},
       list{
         Html.div(list{Attrs.class'("key")}, list{Html.text(key ++ ":")}),
-        Html.div(list{Attrs.class'("value")}, list{Html.text(Runtime.toRepr(example))}),
+        Html.div(
+          list{Attrs.class'("value")},
+          FluidView.viewDval(example, tlid, secrets, ~canCopy=true),
+        ),
       },
     )
   | None => Vdom.noNode
@@ -55,7 +58,7 @@ let viewDbLatestEntry = (stats: dbStats): Html.html<msg> => {
 let viewDBData = (vp: viewProps, db: PT.DB.t): Html.html<msg> =>
   switch Map.get(~key=TLID.toString(db.tlid), vp.dbStats) {
   | Some(stats) if CursorState.tlidOf(vp.cursorState) == Some(db.tlid) =>
-    let liveVal = viewDbLatestEntry(stats)
+    let liveVal = viewDbLatestEntry(stats, db.tlid, vp.secretValues)
     let count = viewDbCount(stats)
     Html.div(list{Attrs.class'("dbdata")}, list{count, liveVal})
   | _ => Vdom.noNode

--- a/client/src/toplevels/ViewData.res
+++ b/client/src/toplevels/ViewData.res
@@ -109,7 +109,7 @@ let viewTrace = (
       let asString = if String.length(asString) == 0 {
         "No input parameters"
       } else {
-        Util.hideSecrets(vp.secretValues, asString)
+        Util.hideSecrets(asString, vp.secretValues)
       }
 
       Html.div(list{Vdom.noProp}, list{Html.text(asString)})

--- a/client/src/util/Util.res
+++ b/client/src/util/Util.res
@@ -261,7 +261,7 @@ let obscureString = (s: string): string => {
   redactedLeft ++ visibleRight
 }
 
-let hideSecrets = (secretValues: list<string>, s: string): string =>
+let hideSecrets = (s: string, secretValues: list<string>): string =>
   List.fold(secretValues, ~initial=s, ~f=(buildingStr, secretVal) =>
     /* We are doing this instead of Regex.replace because it fails secretValues with regex characters
      And Js.String.replace only replaces the first found string. */

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -344,7 +344,7 @@ let run = () => {
         )
       )
       test("null works", () =>
-        expect(acFor(m) |> setQuery("nu") |> AC.highlighted) |> toEqual(Some(FACLiteral("null")))
+        expect(acFor(m) |> setQuery("nu") |> AC.highlighted) |> toEqual(Some(FACLiteral(LNull)))
       )
       test("Ok works", () =>
         expect(acFor(m) |> setQuery("Ok") |> AC.highlighted) |> toEqual(
@@ -357,13 +357,19 @@ let run = () => {
         )
       )
       test("true works", () =>
-        expect(acFor(m) |> setQuery("tr") |> AC.highlighted) |> toEqual(Some(FACLiteral("true")))
+        expect(acFor(m) |> setQuery("tr") |> AC.highlighted) |> toEqual(
+          Some(FACLiteral(LBool(true))),
+        )
       )
       test("case insensitive true works", () =>
-        expect(acFor(m) |> setQuery("tR") |> AC.highlighted) |> toEqual(Some(FACLiteral("true")))
+        expect(acFor(m) |> setQuery("tR") |> AC.highlighted) |> toEqual(
+          Some(FACLiteral(LBool(true))),
+        )
       )
       test("false works", () =>
-        expect(acFor(m) |> setQuery("fa") |> AC.highlighted) |> toEqual(Some(FACLiteral("false")))
+        expect(acFor(m) |> setQuery("fa") |> AC.highlighted) |> toEqual(
+          Some(FACLiteral(LBool(false))),
+        )
       )
       test("if works", () =>
         expect(acFor(m) |> setQuery("if") |> AC.highlighted) |> toEqual(Some(FACKeyword(KIf)))

--- a/client/test/TestUtils.res
+++ b/client/test/TestUtils.res
@@ -19,29 +19,29 @@ let run = () => {
   describe("hideSecrets", () => {
     let secrets = list{"abc[123]-\\bunnies", "XSUYD-JFKJWD-NKFADS"}
     test("replaces a secret", () =>
-      expect(hideSecrets(secrets, "XSUYD-JFKJWD-NKFADS")) |> toEqual("XXXXXXXXXXXXXXXFADS")
+      expect(hideSecrets("XSUYD-JFKJWD-NKFADS", secrets)) |> toEqual("XXXXXXXXXXXXXXXFADS")
     )
     test("replaces a in substring", () =>
-      expect(hideSecrets(secrets, "Bearer XSUYD-JFKJWD-NKFADS")) |> toEqual(
+      expect(hideSecrets("Bearer XSUYD-JFKJWD-NKFADS", secrets)) |> toEqual(
         "Bearer XXXXXXXXXXXXXXXFADS",
       )
     )
     test("replaces secret with regex like characters", () =>
-      expect(hideSecrets(secrets, "abc[123]-\\bunnies")) |> toEqual("XXXXXXXXXXXXXnies")
+      expect(hideSecrets("abc[123]-\\bunnies", secrets)) |> toEqual("XXXXXXXXXXXXXnies")
     )
     test("replaces all of the same secret", () =>
       expect(
         hideSecrets(
-          secrets,
           "{ \"token\" : \"XSUYD-JFKJWD-NKFADS\", \"auth\" : \"XSUYD-JFKJWD-NKFADS\" }",
+          secrets,
         ),
       ) |> toEqual("{ \"token\" : \"XXXXXXXXXXXXXXXFADS\", \"auth\" : \"XXXXXXXXXXXXXXXFADS\" }")
     )
     test("replaces multiple different secrets", () =>
       expect(
         hideSecrets(
-          secrets,
           "{ \"token\" : \"XSUYD-JFKJWD-NKFADS\", \"secret\" : \"abc[123]-\\bunnies\" }",
+          secrets,
         ),
       ) |> toEqual("{ \"token\" : \"XXXXXXXXXXXXXXXFADS\", \"secret\" : \"XXXXXXXXXXXXXnies\" }")
     )

--- a/docs/dblock-serialization.md
+++ b/docs/dblock-serialization.md
@@ -1,4 +1,4 @@
-In Jan, 2020, we changed the dblock internal representation.
+In Jan 2020, we changed the dblock internal representation.
 
 Before, it was a partially applied, in-memory only, OCaml representation,
 which was not possible to serialize.

--- a/fsharp-backend/testfiles/execution/float.tests
+++ b/fsharp-backend/testfiles/execution/float.tests
@@ -119,5 +119,5 @@ Float.sqrt_v0 0.0 = 0.0
 Float.subtract_v0 1.0 0.2 = 0.8
 
 Float.sum_v0 [1.0;0.2] = 1.2
-Float.sum_v0 [1.0;"a"] = Test.typeError_v0 "Expected the argument `a` to be a list of floats, but it was `[ \n  1., \"a\"\n]`"
+Float.sum_v0 [1.0;"a"] = Test.typeError_v0 "Expected the argument `a` to be a list of floats, but it was `[\n  1., \"a\"\n]`"
 Test.nan_v0 != Test.nan_v0

--- a/fsharp-backend/testfiles/execution/int.tests
+++ b/fsharp-backend/testfiles/execution/int.tests
@@ -168,7 +168,7 @@ Int.divide_v0 1 0 = Test.typeError_v0 "Division by zero"
 (List.range_v0 1 5) |> List.map_v0 (fun x -> Int.random_v1 20 10) |> List.map_v0 (fun x -> (x >= 10) && (x <= 20)) = [true; true; true; true; true]
 
 Int.sum_v0 [1;2] = 3
-Int.sum_v0 [1.0;2] = Test.typeError_v0 "Expected the argument `a` to be a list of ints, but it was `[ \n  1., 2\n]`"
+Int.sum_v0 [1.0;2] = Test.typeError_v0 "Expected the argument `a` to be a list of ints, but it was `[\n  1., 2\n]`"
 
 
 Int.parse_v0 "0" = Ok 0

--- a/fsharp-backend/testfiles/execution/list.tests
+++ b/fsharp-backend/testfiles/execution/list.tests
@@ -224,7 +224,7 @@ List.sort_v0 [] = []
 
 List.sortByComparator_v0 [3;1;2] (fun a b -> 0.1) = Error "Expected `fn` to return -1, 0, 1, but it returned `0.1`"
 List.sortByComparator_v0 [3;1;2] (fun a b -> 3) = Error "Expected `fn` to return -1, 0, 1, but it returned `3`"
-List.sortByComparator_v0 [Test.typeError "㧑༷釺";1;2;3] (fun a b -> 1) = Error "Expected `fn` to return -1, 0, 1, but it returned `<error>`"
+List.sortByComparator_v0 [Test.typeError "㧑༷釺";1;2;3] (fun a b -> 1) = Error "Expected `fn` to return -1, 0, 1, but it returned `<error: 㧑༷釺>`"
 List.sortByComparator_v0 [3;1;2] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [ 1; 2; 3 ]
 List.sortByComparator_v0 [] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok []
 List.sortByComparator_v0 [3;1;2;67;3;-1;6;3;5;6;2;5;63;2;3;5;-1;-1;-1] (fun a b -> if Int.lessThan_v0 a b then -1 else 1) = Ok [-1; -1; -1; -1; 1; 2; 2; 2; 3; 3; 3; 3; 5; 5; 5; 6; 6; 63; 67]
@@ -254,7 +254,7 @@ List.uniqueBy_v0 [7;42;7;2;10] (fun x -> x) = [ 2; 7; 10; 42 ]
 List.uniqueBy_v0 [] (fun x -> x) = []
 
 List.unzip_v0 [[1;10];10;[3;30]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `10`. It is of type Int instead of `List`"
-List.unzip_v0 [[1;10];[2;20];[3;30;40]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `[ \n  3, 30, 40\n]`. It has length 3 but should have length 2"
+List.unzip_v0 [[1;10];[2;20];[3;30;40]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `[\n  3, 30, 40\n]`. It has length 3 but should have length 2"
 List.unzip_v0 [[]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `[]`. It has length 0 but should have length 2"
 List.unzip_v0 [[1;10];[2;20];[3;30]] = [ [ 1; 2; 3 ]; [ 10; 20; 30 ] ]
 List.unzip_v0 [[10;6]] = [[10],[6]]

--- a/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
+++ b/fsharp-backend/tests/Tests/DvalRepr.Tests.fs
@@ -72,8 +72,8 @@ let testToDeveloperRepr =
           RT.DFloat(-0.0), "-0."
           RT.DFloat(infinity), "inf"
           RT.DTuple(RT.DInt 1, RT.DInt 2, [ RT.DInt 3 ]), "(\n  1, 2, 3\n)"
-          RT.DObj(Map.ofList [ "", RT.DNull ]), "{ \n  : null\n}"
-          RT.DList [ RT.DNull ], "[ \n  null\n]" ] ]
+          RT.DObj(Map.ofList [ "", RT.DNull ]), "{\n  : null\n}"
+          RT.DList [ RT.DNull ], "[\n  null\n]" ] ]
 
 let testToEnduserReadable =
   testMany


### PR DESCRIPTION
- make AST debugging representation a little bit clearer
- ensure lambda arguments are always traced (so they don't spin)
- use better defaults for lambda preview execution (with test)
- refactor autocomplete literals (allows removing some dead code)
- refactor to catch a few places secrets weren't hidden
- make backend and frontend toRepr implementations match
- remove some dumb stuff from the backend DvalReprDeveloper format
- make a copy of the FluidTokenizer for runtimeTypes, and use it to display lambda live values (see below)

<img width="763" alt="Screen Shot 2022-09-07 at 9 19 41 AM" src="https://user-images.githubusercontent.com/181762/188888447-62103469-5f6b-4eec-a4d3-fcc8f0fd9764.png">