### PR TITLE
Backspacing fixes

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -3064,24 +3064,23 @@ let doExplicitBackspace = (currCaretTarget: CT.t, ast: FluidAST.t): (FluidAST.t,
       // If the expr is empty and thus can be removed
       mkEBlank()
     | (ARMatch(_, MPKeyword), EMatch(_, cond, pairs)) =>
-      // If there is exactly one expression, and no patterns or condition, then
-      // convert to that. We use a result<option<expr>,unit> for the results:
+      // If there is exactly one expression (including the condition), and no patterns, then
+      // convert to that. We use a result<expr,unit> to track this:
       // - Error() means too many expressions/patterns exist
-      // - Ok(Some(expr)) means an appropriate expression was found
-      // - Ok(None) means nothing appropriate was found.
-      let newExpr = pairs->List.fold(~initial=Ok(Some(cond)), ~f=(acc, pair) => {
+      // - Ok(EBlank) means only blanks found so far
+      // - Ok(expr) means an appropriate expression was found
+      let newExpr = pairs->List.fold(~initial=Ok(cond), ~f=(acc, pair) => {
         switch (acc, pair) {
         | (Error(), _) => acc
         | (_, (PBlank(_), EBlank(_))) => acc
-        | (Ok(Some(EBlank(_))), (PBlank(_), expr)) => Ok(Some(expr))
-        | (Ok(Some(_)), (PBlank(_), _)) => Error() // more than one Expr found
-        | (Ok(None), (PBlank(_), expr)) => Ok(Some(expr))
+        | (Ok(EBlank(_)), (PBlank(_), expr)) => Ok(expr)
+        | (Ok(_), (PBlank(_), _)) => Error() // more than one Expr found
         | _ => Error()
         }
       })
       switch newExpr {
-      | Ok(Some(expr)) => Some(Expr(expr), caretTargetForStartOfExpr'(expr))
-      | Ok(None) => mkEBlank() // Nothing here, so make it blank
+      | Ok(EBlank(_)) => mkEBlank() // Nothing here, so make it blank
+      | Ok(expr) => Some(Expr(expr), caretTargetForStartOfExpr'(expr))
       | Error() => None // Too much stuff, so don't change
       }
     | (ARLet(_, LPKeyword), ELet(_))

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -3063,6 +3063,11 @@ let doExplicitBackspace = (currCaretTarget: CT.t, ast: FluidAST.t): (FluidAST.t,
     | (ARLambda(_, LBPSymbol), ELambda(_, _, EBlank(_))) =>
       // If the expr is empty and thus can be removed
       mkEBlank()
+    // If with exactly one expression can become that expression
+    | (ARIf(_, IPIfKeyword), EIf(_, expr, EBlank(_), EBlank(_)))
+    | (ARIf(_, IPIfKeyword), EIf(_, EBlank(_), expr, EBlank(_)))
+    | (ARIf(_, IPIfKeyword), EIf(_, EBlank(_), EBlank(_), expr)) =>
+      Some(Expr(expr), caretTargetForStartOfExpr'(expr))
     | (ARMatch(_, MPKeyword), EMatch(_, cond, pairs)) =>
       // If there is exactly one expression (including the condition), and no patterns, then
       // convert to that. We use a result<expr,unit> to track this:

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -3063,6 +3063,9 @@ let doExplicitBackspace = (currCaretTarget: CT.t, ast: FluidAST.t): (FluidAST.t,
     | (ARLambda(_, LBPSymbol), ELambda(_, _, EBlank(_))) =>
       // If the expr is empty and thus can be removed
       mkEBlank()
+    | (ARLambda(_, LBPSymbol), ELambda(_, _, expr)) =>
+      // Othewise just convert to the expr
+      Some(Expr(expr), caretTargetForStartOfExpr'(expr))
     // If with exactly one expression can become that expression
     | (ARIf(_, IPIfKeyword), EIf(_, expr, EBlank(_), EBlank(_)))
     | (ARIf(_, IPIfKeyword), EIf(_, EBlank(_), expr, EBlank(_)))
@@ -3089,8 +3092,7 @@ let doExplicitBackspace = (currCaretTarget: CT.t, ast: FluidAST.t): (FluidAST.t,
       | Error() => None // Too much stuff, so don't change
       }
     | (ARLet(_, LPKeyword), ELet(_))
-    | (ARIf(_, IPIfKeyword), EIf(_))
-    | (ARLambda(_, LBPSymbol), ELambda(_)) =>
+    | (ARIf(_, IPIfKeyword), EIf(_)) =>
       // keywords of "non-empty" exprs shouldn't be deletable at all
       None
 

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -144,7 +144,12 @@ let emptyMatchWithTwoPatterns = {
   EMatch(mID, b, list{(PBlank(gid()), b), (PBlank(gid()), b)})
 }
 
-let matchWithPatterns = {
+let matchWithTwoPatterns = {
+  let mID = gid()
+  EMatch(mID, b, list{(PInteger(gid(), 3L), b), (PInteger(gid(), 4L), b)})
+}
+
+let matchWithPattern = {
   let mID = gid()
   EMatch(mID, b, list{(PInteger(gid(), 3L), b)})
 }

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -282,6 +282,10 @@ let aShortVar = EVariable(gid(), "v")
 // ----------------
 let emptyIf = EIf(gid(), b, b, b)
 
+let ifOnlyCond = EIf(gid(), five, b, b)
+let ifOnlyThen = EIf(gid(), b, five, b)
+let ifOnlyElse = EIf(gid(), b, b, five)
+
 let plainIf = EIf(gid(), EInteger(gid(), 5L), EInteger(gid(), 6L), EInteger(gid(), 7L))
 
 let nestedIf = EIf(

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -154,6 +154,11 @@ let matchWithConstructorPattern = {
   EMatch(mID, b, list{(PConstructor(gid(), "Just", list{}), b)})
 }
 
+let matchWithOneExpr = (expr: t) => {
+  let mID = gid()
+  EMatch(mID, b, list{(PBlank(gid()), expr)})
+}
+
 let matchWithBinding = (bindingName: string, expr: t) => {
   let mID = gid()
   EMatch(mID, b, list{(PVariable(gid(), bindingName), expr)})

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -139,6 +139,11 @@ let emptyMatch = {
   EMatch(mID, b, list{(PBlank(gid()), b)})
 }
 
+let matchWithCond = (cond: t) => {
+  let mID = gid()
+  EMatch(mID, cond, list{(PBlank(gid()), b)})
+}
+
 let emptyMatchWithTwoPatterns = {
   let mID = gid()
   EMatch(mID, b, list{(PBlank(gid()), b), (PBlank(gid()), b)})

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2858,6 +2858,7 @@ let run = () => {
     t("move back over match", emptyMatch, ~pos=6, key(K.Left), "~match ___\n  *** -> ___\n")
     t("move forward over match", emptyMatch, ~pos=0, key(K.Right), "match ~___\n  *** -> ___\n")
     t("bs over empty match", emptyMatch, ~pos=6, bs, "~___")
+    t("bs over empty match with cond", matchWithCond(five), ~pos=6, bs, "~5")
     t("bs over empty match with 2 patterns", emptyMatchWithTwoPatterns, ~pos=6, bs, "~___")
     t("bs over match with 1 pattern", matchWithPattern, ~pos=6, bs, "match ~___\n  3 -> ___\n")
     t(
@@ -2869,6 +2870,7 @@ let run = () => {
     )
     t("bs over match with 1 blank pattern", matchWithOneExpr(five), ~pos=6, bs, "~5")
     t("del over empty match", emptyMatch, ~pos=0, del, "~___")
+    t("del over empty match with cond", matchWithCond(five), ~pos=0, del, "~5")
     t("del over empty match with 2 patterns", emptyMatchWithTwoPatterns, ~pos=0, del, "~___")
     t("del over match with 1 pattern", matchWithPattern, ~pos=0, del, "~match ___\n  3 -> ___\n")
     t(

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2860,6 +2860,7 @@ let run = () => {
     t("bs over empty match", emptyMatch, ~pos=6, bs, "~___")
     t("bs over empty match with 2 patterns", emptyMatchWithTwoPatterns, ~pos=6, bs, "~___")
     t("bs over match with 2 patterns", matchWithPatterns, ~pos=6, bs, "match ~___\n  3 -> ___\n")
+    t("bs over match with 1 blank pattern", matchWithOneExpr(five), ~pos=6, bs, "~5")
     t("del over empty match", emptyMatch, ~pos=0, del, "~___")
     t("del over empty match with 2 patterns", emptyMatchWithTwoPatterns, ~pos=0, del, "~___")
     t("del over match with 2 patterns", matchWithPatterns, ~pos=0, del, "~match ___\n  3 -> ___\n")

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2859,11 +2859,26 @@ let run = () => {
     t("move forward over match", emptyMatch, ~pos=0, key(K.Right), "match ~___\n  *** -> ___\n")
     t("bs over empty match", emptyMatch, ~pos=6, bs, "~___")
     t("bs over empty match with 2 patterns", emptyMatchWithTwoPatterns, ~pos=6, bs, "~___")
-    t("bs over match with 2 patterns", matchWithPatterns, ~pos=6, bs, "match ~___\n  3 -> ___\n")
+    t("bs over match with 1 pattern", matchWithPattern, ~pos=6, bs, "match ~___\n  3 -> ___\n")
+    t(
+      "bs over match with 2 patterns",
+      matchWithTwoPatterns,
+      ~pos=6,
+      bs,
+      "match ~___\n  3 -> ___\n  4 -> ___\n",
+    )
     t("bs over match with 1 blank pattern", matchWithOneExpr(five), ~pos=6, bs, "~5")
     t("del over empty match", emptyMatch, ~pos=0, del, "~___")
     t("del over empty match with 2 patterns", emptyMatchWithTwoPatterns, ~pos=0, del, "~___")
-    t("del over match with 2 patterns", matchWithPatterns, ~pos=0, del, "~match ___\n  3 -> ___\n")
+    t("del over match with 1 pattern", matchWithPattern, ~pos=0, del, "~match ___\n  3 -> ___\n")
+    t(
+      "del over match with 2 patterns",
+      matchWithTwoPatterns,
+      ~pos=0,
+      del,
+      "~match ___\n  3 -> ___\n  4 -> ___\n",
+    )
+    t("del over match with 1 blank pattern", matchWithOneExpr(five), ~pos=0, del, "~5")
     t(
       "del constructor in match pattern",
       matchWithConstructorPattern,
@@ -2926,7 +2941,7 @@ let run = () => {
     )
     t(
       "enter at the end of the cond creates a new row",
-      matchWithPatterns,
+      matchWithPattern,
       ~pos=9,
       enter,
       "match ___\n  ~*** -> ___\n  3 -> ___\n",
@@ -2975,7 +2990,7 @@ let run = () => {
     )
     t(
       "enter at the start of a row creates a new row",
-      matchWithPatterns,
+      matchWithPattern,
       ~pos=12,
       enter,
       "match ___\n  *** -> ___\n  ~3 -> ___\n",

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2656,9 +2656,9 @@ let run = () => {
     // end type -> to move through a lambda
     t("bs over lambda symbol", aLambda, ~pos=1, bs, "~___")
     t("insert space in lambda", aLambda, ~pos=1, key(K.Space), "\\~*** -> ___")
-    t("bs non-empty lambda symbol", nonEmptyLambda, ~pos=1, bs, "\\~*** -> 5")
+    t("bs non-empty lambda symbol", nonEmptyLambda, ~pos=1, bs, "~5")
     t("del lambda symbol", aLambda, ~pos=0, del, "~___")
-    t("del non-empty lambda symbol", nonEmptyLambda, ~pos=0, del, "~\\*** -> 5")
+    t("del non-empty lambda symbol", nonEmptyLambda, ~pos=0, del, "~5")
     t(
       "insert changes occurence of binding var",
       lambdaWithUsedBinding("binding"),

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -3675,6 +3675,13 @@ let run = () => {
     t("bs over indent 1", plainIf, ~pos=12, bs, "if 5\nthen~\n  6\nelse\n  7")
     t("bs over indent 2", plainIf, ~pos=21, bs, "if 5\nthen\n  6\nelse~\n  7")
     t("bs over empty if", emptyIf, ~pos=2, bs, "~___")
+    t("bs over if with cond", ifOnlyCond, ~pos=2, bs, "~5")
+    t("bs over if with then", ifOnlyThen, ~pos=2, bs, "~5")
+    t("bs over if with else", ifOnlyElse, ~pos=2, bs, "~5")
+    t("del over empty if", emptyIf, ~pos=0, del, "~___")
+    t("del over if with cond", ifOnlyCond, ~pos=0, del, "~5")
+    t("del over if with then", ifOnlyThen, ~pos=0, del, "~5")
+    t("del over if with else", ifOnlyElse, ~pos=0, del, "~5")
     t(
       "move to front of line 1",
       plainIf,


### PR DESCRIPTION
When backspacing over the keyword of an expr, when that expr has contents, intentionally does nothing.

This changes it in the case that the expression contains exactly one expression.

![2022-09-07 13 25 25](https://user-images.githubusercontent.com/181762/188941656-b0a584be-d115-41cc-a956-28b79646fa89.gif)
