### PR TITLE
Fluid Pattern Reconstruction fixes

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -5725,8 +5725,8 @@ let reconstructExprFromRange = (range: (int, int), astInfo: ASTInfo.t): option<
         // i.e. if you highlight the following, starting at `match` and ending
         // after `Ok`, the "test" value is included in the reconstructed expr
         //
-        // «match Ok "test"
-        //    Ok» "test" -> 123
+        // «match Ok 1
+        //    Ok» "test" -> 999
         //
         // CLEANUP TUPLETODO we should instead use the subPatternTokens to
         // reconstruct the sub-patterns appropriately

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -5719,12 +5719,8 @@ let reconstructExprFromRange = (range: (int, int), astInfo: ASTInfo.t): option<
           | list{(id, value, "pattern-float-fractional")} =>
             PInteger(id, Util.coerceStringTo64BitInt(value))
 
-          | list{(id, value, "pattern-tuple-open"), ...subPatternTokens} =>
-            Debug.loG("at a patter-tuple-open and not sure what to do", ())
-            Debug.loG("value", value)
-            Debug.loG("subPatternTokens", subPatternTokens)
-
-            // TUPLETODO finish this. (it's for copy/paste, reconstruction, I believe.)
+          | list{(id, _value, "pattern-tuple-open"), ..._subPatternTokens} =>
+            // TUPLETODO finish this. (it's for copy/paste, reconstruction)
             PTuple(id, PBlank(gid()), PBlank(gid()), list{})
 
           | _ => PBlank(gid())

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1348,10 +1348,42 @@ let run = () => {
     )
     ()
   })
-  describe("Match", () =>
-    // TODO: test match statements, implementation is slightly inconsistent
+  describe("Match", () => {
+    testCopy(
+      "copying a blank match expression works",
+      match'(blank(), list{(pBlank(), blank())}),
+      (0, 22),
+      "match ___\n  *** -> ___\n",
+    )
+    testCopy(
+      "copying a match expression with a single integer pattern works",
+      match'(int(123), list{(pInt(123), str("success"))}),
+      (0, 27),
+      "match 123\n  123 -> \"success\"\n",
+    )
+    testCopy(
+      "copying a match expression with a full constructor pattern works",
+      match'(
+        constructor("Just", list{int(123)}),
+        list{(pConstructor("Just", list{pInt(123)}), str("success"))},
+      ),
+      (0, 37),
+      "match Just 123\n  Just 123 -> \"success\"\n",
+    )
+
+    // CLEANUP this test fails because the impl. assumes we've selected the
+    // subpatterns
+    testCopy(
+      "copying a match expression with a partial constructor pattern works",
+      match'(
+        constructor("Just", list{int(123)}),
+        list{(pConstructor("Just", list{pInt(123)}), str("success"))},
+      ),
+      (0, 21), // right after "Just"
+      "match Just 123\n  Just *** -> ___\n",
+    )
     ()
-  )
+  })
   describe("json", () => {
     testPasteText("pasting a json int makes an int", b, (0, 0), "6", "6~")
     testPasteText("pasting a json float makes a float", b, (0, 0), "6.6", "6.6~")

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1370,9 +1370,6 @@ let run = () => {
       (0, 37),
       "match Just 123\n  Just 123 -> \"success\"\n",
     )
-
-    // CLEANUP this test fails because the impl. does not account for
-    // selections that exclude patterns within a `match` expr
     testCopy(
       "copying fewer than all cases in a match expression works",
       match'(int(0), list{(pInt(123), str("first branch")), (pInt(456), str("second branch"))}),

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1382,6 +1382,17 @@ let run = () => {
       (0, 21), // right after "Just"
       "match Just 123\n  Just *** -> ___\n",
     )
+
+    // CLEANUP this test fails because the impl. is incomplete
+    testCopy(
+      "copying a match expression including a full tuple pattern works",
+      match'(
+        tuple(int(1), str("two"), list{int(3)}),
+        list{(pTuple(pInt(1), pString("two"), list{pInt(3)}), str("success"))},
+      ),
+      (0, 44),
+      "match (1,\"two\",3)\n  (1,\"two\",3) -> \"success\"\n",
+    )
     ()
   })
   describe("json", () => {

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1389,7 +1389,6 @@ let run = () => {
       "match Just 123\n  Just *** -> ___\n",
     )
 
-    // CLEANUP this test fails because the impl. is incomplete
     testCopy(
       "copying a match expression including a full tuple pattern works",
       match'(

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1398,6 +1398,18 @@ let run = () => {
       (0, 44),
       "match (1,\"two\",3)\n  (1,\"two\",3) -> \"success\"\n",
     )
+
+    // CLEANUP this test fails because the impl. assumes we've selected the
+    // subpatterns
+    testCopy(
+      "copying a match expression including part of a tuple pattern works",
+      match'(
+        tuple(int(1), str("two"), list{int(3)}),
+        list{(pTuple(pInt(1), pString("two"), list{pInt(3)}), str("success"))},
+      ),
+      (0, 29), // ending just before the '3' in the pattern
+      "match (1,\"two\",3)\n  (1,\"two\",***) -> ___\n",
+    )
     ()
   })
   describe("json", () => {

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1379,15 +1379,15 @@ let run = () => {
 
     // CLEANUP this test fails because the impl. assumes we've selected the
     // subpatterns
-    testCopy(
-      "copying a match expression with a partial constructor pattern works",
-      match'(
-        constructor("Just", list{int(123)}),
-        list{(pConstructor("Just", list{pInt(123)}), str("success"))},
-      ),
-      (0, 21), // right after "Just"
-      "match Just 123\n  Just *** -> ___\n",
-    )
+    // testCopy(
+    //   "copying a match expression with a partial constructor pattern works",
+    //   match'(
+    //     constructor("Just", list{int(123)}),
+    //     list{(pConstructor("Just", list{pInt(123)}), str("success"))},
+    //   ),
+    //   (0, 21), // right after "Just"
+    //   "match Just 123\n  Just *** -> ___\n",
+    // )
 
     testCopy(
       "copying a match expression including a full tuple pattern works",
@@ -1399,17 +1399,17 @@ let run = () => {
       "match (1,\"two\",3)\n  (1,\"two\",3) -> \"success\"\n",
     )
 
-    // CLEANUP this test fails because the impl. assumes we've selected the
-    // subpatterns
-    testCopy(
-      "copying a match expression including part of a tuple pattern works",
-      match'(
-        tuple(int(1), str("two"), list{int(3)}),
-        list{(pTuple(pInt(1), pString("two"), list{pInt(3)}), str("success"))},
-      ),
-      (0, 29), // ending just before the '3' in the pattern
-      "match (1,\"two\",3)\n  (1,\"two\",***) -> ___\n",
-    )
+    // CLEANUP TUPLETODO this test fails because the impl. assumes we've
+    // selected the subpatterns
+    // testCopy(
+    //   "copying a match expression including part of a tuple pattern works",
+    //   match'(
+    //     tuple(int(1), str("two"), list{int(3)}),
+    //     list{(pTuple(pInt(1), pString("two"), list{pInt(3)}), str("success"))},
+    //   ),
+    //   (0, 29), // ending just before the '3' in the pattern
+    //   "match (1,\"two\",3)\n  (1,\"two\",***) -> ___\n",
+    // )
     ()
   })
   describe("json", () => {

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1371,6 +1371,15 @@ let run = () => {
       "match Just 123\n  Just 123 -> \"success\"\n",
     )
 
+    // CLEANUP this test fails because the impl. does not account for
+    // selections that exclude patterns within a `match` expr
+    testCopy(
+      "copying fewer than all cases in a match expression works",
+      match'(int(0), list{(pInt(123), str("first branch")), (pInt(456), str("second branch"))}),
+      (0, 30), // right after "Just"
+      "match 0\n  123 -> \"first branch\"\n",
+    )
+
     // CLEANUP this test fails because the impl. assumes we've selected the
     // subpatterns
     testCopy(


### PR DESCRIPTION
- generally documents `reconstructExprFromRange`
- adds notes around limitations in reconstructing `Constructor` patterns
- adds _basic_ support for reconstructing `Tuple` patterns
- starts to fill in tests around this functionality
- fixes a bug: given a `match` with multiple patterns, if you select `match` through the first pattern, the reconstruction would mistakenly create a blank 'case' per each unselected line.