### PR TITLE
Tone down the string background a bit

### DIFF
--- a/client/styles/_fluid.scss
+++ b/client/styles/_fluid.scss
@@ -303,7 +303,7 @@ $ff-color: adjust-hue($purple, -40deg);
   .fluid-string-ml,
   .fluid-string,
   .fluid-pattern-string {
-    background-color: #462d4c31;
+    background-color: #462d4c17;
   }
 
   // Part of the same problem, making space for it.


### PR DESCRIPTION
I think I overdid it with the string background color. This turns it down by about half. It's still there, just more subtle. It still provides a little contrast against the background so you can see spaces on it, it just no longer overwhelms the entire handler.

Before:

<img width="543" alt="Screen Shot 2022-09-18 at 9 32 22 AM" src="https://user-images.githubusercontent.com/181762/190904974-754550d0-5a9c-410c-969c-b3a23133ee20.png">

After:
<img width="605" alt="Screen Shot 2022-09-18 at 9 33 56 AM" src="https://user-images.githubusercontent.com/181762/190904975-276ea41d-5880-460f-b68f-fedc70b1a0e1.png">
