### PR TITLE
Use IDs more

### DIFF
--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -986,28 +986,6 @@ let fns : List<BuiltInFn> =
       deprecated = ReplacedBy(fn "String" "toUUID" 1) }
 
 
-    { name = fn "String" "toUUID" 1
-      parameters = [ Param.make "uuid" TStr "" ]
-      returnType = TResult(TUuid, TStr)
-      description =
-        "Parse a <type UUID> of form {{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}}"
-      fn =
-        (function
-        | _, [ DStr s ] ->
-          match Guid.TryParse s with
-          | true, x -> x |> DUuid |> Ok |> DResult |> Ply
-          | _ ->
-            "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-            |> DStr
-            |> Error
-            |> DResult
-            |> Ply
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
     { name = fn "String" "isSubstring" 0
       parameters =
         [ Param.make "searchingFor" TStr ""; Param.make "lookingIn" TStr "" ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibUuid.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibUuid.fs
@@ -31,4 +31,28 @@ let fns : List<BuiltInFn> =
       // similarly to Date::now, it's not particularly fun for this to change
       // when live programming
       previewable = Impure
-      deprecated = NotDeprecated } ]
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Uuid" "parse" 0
+      parameters = [ Param.make "uuid" TStr "" ]
+      returnType = TResult(TUuid, TStr)
+      description =
+        "Parse a <type UUID> of form {{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}}"
+      fn =
+        (function
+        | _, [ DStr s ] ->
+          match System.Guid.TryParse s with
+          | true, x -> x |> DUuid |> Ok |> DResult |> Ply
+          | _ ->
+            "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+            |> DStr
+            |> Error
+            |> DResult
+            |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+    ]

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -21,7 +21,8 @@ let renames =
     fn "Object" "merge" 0, fn "Dict" "merge" 0
     fn "Object" "toJSON" 1, fn "Dict" "toJSON" 0
     fn "Date" "subtract" 0, fn "Date" "subtractSeconds" 0
-    fn "List" "contains" 0, fn "List" "member" 0 ]
+    fn "List" "contains" 0, fn "List" "member" 0
+    fn "String" "toUUID" 1, fn "Uuid" "parse" 0 ]
 
 
 let prefixFns : List<BuiltInFn> =

--- a/fsharp-backend/testfiles/execution/internal.tests
+++ b/fsharp-backend/testfiles/execution/internal.tests
@@ -76,7 +76,7 @@ DarkInternal.getOrgList Test.getUserID = []
 // DarkInternal.getAllCanvases = []
 
 // ---------------
-// permissions
+// check permission
 // ---------------
 [test.checkPermission with none]
 (let user1 = ("cpnuser1" ++ (String.random 5)) |> String.toLowercase_v1
@@ -87,7 +87,7 @@ DarkInternal.getOrgList Test.getUserID = []
  let _ = DarkInternal.insertUser_v2_ster user2 user2Email "cpn test user2" {}
  let startingPermission = DarkInternal.checkPermission_v0 user1 user2
  let _ = DarkInternal.grant_v0_ster user1 user2 "" in
- [DarkInternal.checkPermission_v0 user1 user2; startingPermission] ) = ["" ; ""]
+ (DarkInternal.checkPermission_v0 user1 user2, startingPermission) ) = ("" , "")
 
 [test.checkPermission with r]
 (let user1 = ("cpruser1" ++ (String.random 5)) |> String.toLowercase_v1
@@ -98,9 +98,9 @@ DarkInternal.getOrgList Test.getUserID = []
  let _ = DarkInternal.insertUser_v2_ster user2 user2Email "cpr test user2" {}
  let startingPermission = DarkInternal.checkPermission_v0 user1 user2
  let _ = DarkInternal.grant_v0_ster user1 user2 "r" in
- [DarkInternal.checkPermission_v0 user1 user2; startingPermission] ) = ["r" ; ""]
+ (DarkInternal.checkPermission_v0 user1 user2, startingPermission) ) = ("r" , "")
 
-[test.checkPermission with r]
+[test.checkPermission with rw]
 (let user1 = ("cprwuser1" ++ (String.random 5)) |> String.toLowercase_v1
  let user2 = ("cprwuser2" ++ (String.random 5)) |> String.toLowercase_v1
  let user1Email = user1 ++ "-test@darklang.com"
@@ -109,7 +109,51 @@ DarkInternal.getOrgList Test.getUserID = []
  let _ = DarkInternal.insertUser_v2_ster user2 user2Email "cprw test user2" {}
  let startingPermission = DarkInternal.checkPermission_v0 user1 user2
  let _ = DarkInternal.grant_v0_ster user1 user2 "rw" in
- [DarkInternal.checkPermission_v0 user1 user2; startingPermission] ) = ["rw" ; ""]
+ (DarkInternal.checkPermission_v0 user1 user2, startingPermission) ) = ("rw" , "")
+
+// ---------------
+// get permission
+// ---------------
+[test.getPermission with none]
+(let user1 = ("gpnuser1" ++ (String.random 5)) |> String.toLowercase_v1
+ let user2 = ("gpnuser2" ++ (String.random 5)) |> String.toLowercase_v1
+ let user1Email = user1 ++ "-test@darklang.com"
+ let user2Email = user2 ++ "-test@darklang.com"
+ let _ = DarkInternal.insertUser_v2_ster user1 user1Email "gpn test user1" {}
+ let _ = DarkInternal.insertUser_v2_ster user2 user2Email "gpn test user2" {}
+ let userID = DarkInternal.getUserID_v0_ster user1
+ let canvasID = Test.createCanvas user2
+ let startingPermission = DarkInternal.getPermission_v0 userID canvasID
+ let _ = DarkInternal.grant_v0_ster user1 user2 "" in
+ (DarkInternal.getPermission_v0 userID canvasID, startingPermission) ) = (Ok "" , Ok "")
+
+[test.getPermission with r]
+(let user1 = ("gpruser1" ++ (String.random 5)) |> String.toLowercase_v1
+ let user2 = ("gpruser2" ++ (String.random 5)) |> String.toLowercase_v1
+ let user1Email = user1 ++ "-test@darklang.com"
+ let user2Email = user2 ++ "-test@darklang.com"
+ let _ = DarkInternal.insertUser_v2_ster user1 user1Email "gpr test user1" {}
+ let _ = DarkInternal.insertUser_v2_ster user2 user2Email "gpr test user2" {}
+ let userID = DarkInternal.getUserID_v0_ster user1
+ let canvasID = Test.createCanvas user2
+ let startingPermission = DarkInternal.getPermission_v0 userID canvasID
+ let _ = DarkInternal.grant_v0_ster user1 user2 "r" in
+ (DarkInternal.getPermission_v0 userID canvasID, startingPermission) ) = (Ok "r" , Ok "")
+
+[test.getPermission with rw]
+(let user1 = ("gprwuser1" ++ (String.random 5)) |> String.toLowercase_v1
+ let user2 = ("gprwuser2" ++ (String.random 5)) |> String.toLowercase_v1
+ let user1Email = user1 ++ "-test@darklang.com"
+ let user2Email = user2 ++ "-test@darklang.com"
+ let _ = DarkInternal.insertUser_v2_ster user1 user1Email "gprw test user1" {}
+ let _ = DarkInternal.insertUser_v2_ster user2 user2Email "gprw test user2" {}
+ let userID = DarkInternal.getUserID_v0_ster user1
+ let canvasID = Test.createCanvas user2
+ let startingPermission = DarkInternal.getPermission_v0 userID canvasID
+ let _ = DarkInternal.grant_v0_ster user1 user2 "rw" in
+ (DarkInternal.getPermission_v0 userID canvasID, startingPermission) ) = (Ok "rw" , Ok "")
+
+
 
 
 // ---------------
@@ -118,9 +162,15 @@ DarkInternal.getOrgList Test.getUserID = []
 [tests.canvasIDOfCanvasName]
 DarkInternal.canvasIdOfCanvasName_v0 "not-a-canvas" = Nothing
 DarkInternal.canvasIdOfCanvasName_v0_ster Test.getCanvasName = toString Test.getCanvasID
+
 DarkInternal.canvasIDOfCanvasName_v0 Test.getCanvasName = Ok (Test.getCanvasID)
 DarkInternal.canvasIDOfCanvasName_v0 "invalid name" = Error "Invalid username 'invalid name' - must be 2-20 lowercase characters, and must start with a letter."
 DarkInternal.canvasIDOfCanvasName_v0 "not-a-real-canvas" = Error "Canvas not found"
+
+[tests.canvasNameOfCanvasID]
+DarkInternal.canvasNameOfCanvasID_v0 (Test.getCanvasID) = Ok (Test.getCanvasName)
+DarkInternal.canvasNameOfCanvasID_v0 (Uuid.parse_v0_ster "7d9e5495-b068-4364-a2cc-3633ab4d13e6") = Error "Canvas not found"
+
 
 // ---------------
 // Secrets

--- a/fsharp-backend/testfiles/execution/uuid.tests
+++ b/fsharp-backend/testfiles/execution/uuid.tests
@@ -1,0 +1,8 @@
+Uuid.parse_v0 "👱🏼" = Error "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+Uuid.parse_v0 "1111111🍇-2222-3333-4444-555555555555" = Error "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+Uuid.parse_v0 "psp-soslsls==" = Error "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+Uuid.parse_v0 "123456" = Error "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+Uuid.parse_v0 "d388ff30-667f-11eb-ae93" = Error "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+Uuid.parse_v0 "d388ff30-667f-11eb-ae93-0242ac13000" = Error "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+Uuid.parse_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d" = Ok (String.toUUID_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
+Uuid.parse_v0 "11111111-2222-3333-4444-555555555555" = Ok (String.toUUID_v0 "11111111-2222-3333-4444-555555555555")

--- a/fsharp-backend/tests/TestUtils/LibTest.fs
+++ b/fsharp-backend/tests/TestUtils/LibTest.fs
@@ -397,6 +397,8 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
+
+
     { name = fn "Test" "getUserID" 0
       parameters = []
       returnType = TUuid
@@ -404,6 +406,24 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [] -> state.program.accountID |> DUuid |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Test" "createCanvas" 0
+      parameters = [ Param.make "canvasName" TStr "" ]
+      returnType = TUuid
+      description = "Create the named canvas and return the IDgg"
+      fn =
+        (function
+        | state, [ DStr canvasName ] ->
+          uply {
+            let! meta =
+              LibBackend.Canvas.getMetaAndCreate (CanvasName.createExn canvasName)
+            return DUuid meta.id
+          }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure


### PR DESCRIPTION
A lot of our internal functions use usernames and canvas names instead of IDs. That can make things a little bit ambiguous, especially in the future if we choose to allow users to rename themselves.

Instead, we want to use canvasIDs and UserID where possible. This ads two functions that help with that. It also renames `String::toUUID` to `Uuid.parse`, which is better naming.