### PR TITLE
When url changes, update "open-in-new-window"

### DIFF
--- a/client/src/toplevels/ViewHandler.res
+++ b/client/src/toplevels/ViewHandler.res
@@ -150,7 +150,7 @@ let viewMenu = (vp: viewProps, spec: PT.Handler.Spec.t): Html.html<msg> => {
         let url = externalLink(vp, name)
         let newTabAction: TLMenu.menuItem = {
           title: "Open in new tab",
-          key: "new-tab-",
+          key: `new-tab-${url}`,
           icon: Some("external-link-alt"),
           action: _ => NewTabFromTLMenu(url, tlid),
           disableMsg: None,


### PR DESCRIPTION
The key did not have the url in it, and so the DOM did not update when the url changed.