### PR TITLE
Be less specific to catch another error

### DIFF
--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1764,9 +1764,7 @@ let update_ = (msg: msg, m: model): modification => {
     // This is a problem in .Net 6, so let's ignore it for now
     // DOTNET7TODO: this error shouldn't happen anymore
     let ignorable =
-      msg->String.includes(
-        ~substring="System.ArgumentNullException: Value cannot be null. (Parameter 'key')",
-      ) &&
+      msg->String.includes(~substring="System.ArgumentNullException") &&
       msg->String.includes(~substring="System.Collections.Generic.Dictionary") &&
       msg->String.includes(~substring="ReleaseJSOwnedObjectByGCHandle") &&
       msg->String.includes(~substring="Remove")


### PR DESCRIPTION
We previously hid an error from the GC in .NET analysis which seemed harmless, but we didn't catch all cases. The following error still got through:

> Error in JS: Uncaught Error: System.ArgumentNullException: ArgumentNull_Generic Arg_ParamName_Name, key
   at System.Collections.Generic.Dictionary`2[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].Remove(Object )
   at System.Runtime.InteropServices.JavaScript.Runtime.ReleaseJSOwnedObjectByGCHandle(Int32 gcHandle)

Make the rule to ignore it more generic to catch this one too