### PR TITLE
Use the same documentation box in autocomplete and when showing docs

### DIFF
--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -156,14 +156,7 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
 
         switch fnAndRail {
         | Some(fn, sendToRail) =>
-          Some(
-            viewDoc(
-              Belt.List.concat(
-                PrettyDocs.convert(fn.description),
-                list{ViewErrorRailDoc.hintForFunction(fn, Some(sendToRail))},
-              ),
-            ),
-          )
+          Some(viewDoc(FluidAutocomplete.documentationForFunction(fn, Some(sendToRail))))
         | None => None
         }
       }
@@ -178,23 +171,23 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
             |> Functions.findByStr(name)
             |> Option.map(~f=(f: Function.t) => {
               let param = f.parameters |> List.getAt(~index)
-              (param, f.description)
+              (param, f)
             })
           )
 
         switch paramAndFnDesc {
-        | Some(param, fnDesc) =>
-          switch param {
-          | Some(pm) =>
-            let header = pm.name ++ (" : " ++ DType.tipe2str(pm.typ))
+        | Some(Some(param), f) =>
+          let header = param.name ++ ": " ++ DType.tipe2str(param.typ)
 
-            Some(
-              viewDoc(
-                Belt.List.concat(PrettyDocs.convert(fnDesc), list{p(header), p(pm.description)}),
+          Some(
+            viewDoc(
+              Belt.List.concat(
+                FluidAutocomplete.documentationForFunction(f, None),
+                list{p(header), p(param.description)},
               ),
-            )
-          | None => None
-          }
+            ),
+          )
+
         | _ => None
         }
       }

--- a/client/src/canvas/ViewErrorRailDoc.res
+++ b/client/src/canvas/ViewErrorRailDoc.res
@@ -4,7 +4,7 @@ open Prelude
 module E = FluidExpression
 open PrettyDocs
 
-@ocaml.doc(" [hintForFunction fn sendToRail] returns a (possibly noNode) DOM node that
+@ocaml.doc("[hintForFunction fn sendToRail] returns a (possibly noNode) DOM node that
  * provides a contextual hint about error-rail usage for the function [fn].
  *
  * The message in the node is customized based on the function return value

--- a/client/src/fluid/FluidAutocomplete.resi
+++ b/client/src/fluid/FluidAutocomplete.resi
@@ -38,6 +38,11 @@ let selectUp: t => t
 
 let selectDown: t => t
 
+let documentationForFunction: (
+  Function.t,
+  option<ProgramTypes.Expr.SendToRail.t>,
+) => list<Tea.Html.html<AppTypes.msg>>
+
 let documentationForItem: data => option<list<Vdom.t<AppTypes.msg>>>
 
 let isOpened: t => bool

--- a/client/styles/_doc.scss
+++ b/client/styles/_doc.scss
@@ -23,7 +23,8 @@
     padding-bottom: 15px;
   }
 
-  .deprecation-reason, .returnType {
+  .deprecation-reason,
+  .returnType {
     padding-top: 15px;
   }
 

--- a/client/styles/_doc.scss
+++ b/client/styles/_doc.scss
@@ -20,10 +20,15 @@
 
   .err {
     color: lighten(saturate($red, 25%), 30%);
+    padding-bottom: 15px;
   }
 
-  .deprecation-reason {
+  .deprecation-reason, .returnType {
     padding-top: 15px;
+  }
+
+  .returnType {
+    color: $grey5;
   }
 
   .cmd {


### PR DESCRIPTION
In both places that docs are used, use the same code to generate them. Also show the return type of a called function.