### PR TITLE
Rewrite fluid match pattern reconstruction

### DIFF
--- a/client/src/fluid/FeatureFlags.res
+++ b/client/src/fluid/FeatureFlags.res
@@ -32,7 +32,7 @@ let wrap = (s: AppTypes.fluidState, ast: FluidAST.t, id: id): (option<id>, Fluid
     let flagID = gid()
     let expr = FluidAST.toExpr(ast)
     let isSelectAll = {
-      let tokenInfos = FluidTokenizer.tokenize(Expr(expr))
+      let tokenInfos = FluidTokenizer.tokenizeExpr(expr)
       let (tokenStart, tokenEnd) =
         List.last(tokenInfos)
         |> Option.map(~f=(last: tokenInfo) => (0, last.endPos))

--- a/client/src/fluid/FeatureFlags.res
+++ b/client/src/fluid/FeatureFlags.res
@@ -32,7 +32,7 @@ let wrap = (s: AppTypes.fluidState, ast: FluidAST.t, id: id): (option<id>, Fluid
     let flagID = gid()
     let expr = FluidAST.toExpr(ast)
     let isSelectAll = {
-      let tokenInfos = FluidTokenizer.tokenize(expr)
+      let tokenInfos = FluidTokenizer.tokenize(Expr(expr))
       let (tokenStart, tokenEnd) =
         List.last(tokenInfos)
         |> Option.map(~f=(last: tokenInfo) => (0, last.endPos))

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -5535,7 +5535,7 @@ let reconstructExprFromRange = (astInfo: ASTInfo.t, (startPos, endPos): (int, in
             switch (reconstructMatchPattern(matchID, index, matchPattern), reconstructExpr(expr)) {
             | (Some(mp), Some(expr)) => Some(mp, expr)
             | (Some(mp), None) => Some(mp, None |> orDefaultExpr)
-            | (None, Some(_expr)) => None // todo: reconsider
+            | (None, Some(expr)) => Some(None |> orDefaultMP, expr)
             | (None, None) => None
             }
           })
@@ -5605,7 +5605,7 @@ let reconstructExprFromRange = (astInfo: ASTInfo.t, (startPos, endPos): (int, in
           if newValue == "null" {
             Some(MPNull(id))
           } else {
-            None // TODO: MPPartial
+            Some(MPNull(id)) // TODO: MPPartial
           }
         )
         |> Option.flatten
@@ -5637,7 +5637,7 @@ let reconstructExprFromRange = (astInfo: ASTInfo.t, (startPos, endPos): (int, in
           if newValue == "" {
             None
           } else if newValue != string_of_bool(value) {
-            None // TODO: MPPartial
+            Some(MPBool(id, value)) // TODO: MPPartial
           } else {
             Some(MPBool(id, value))
           }

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -5550,6 +5550,12 @@ let reconstructExprFromRange = (astInfo: ASTInfo.t, (startPos, endPos): (int, in
             }
           })
 
+        // all match exprs should have at least 1 case
+        let newCases = switch newCases {
+        | list{} => list{(None |> orDefaultMP, None |> orDefaultExpr)}
+        | atLeastOneCase => atLeastOneCase
+        }
+
         Some(EMatch(id, newCond, newCases))
       | EFeatureFlag(_, name, cond, disabled, enabled) =>
         // since we don't have any tokens associated with feature flags yet

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -5070,6 +5070,12 @@ let shouldSelect = (key: K.key): bool =>
   | _ => false
   }
 
+let findInfoForToken = (tokenInfos: list<T.tokenInfo>, tok: option<FluidToken.tokenInfo>) =>
+  switch tok {
+  | Some(mpTok) => List.find(tokenInfos, ~f=tk => T.matchesContent(mpTok.token, tk.token))
+  | _ => None
+  }
+
 @ocaml.doc("returns the beginning and end of the range from the expression's
   first and last token by cross-referencing the tokens for the expression with
   the tokens for the whole editor's expr.
@@ -5085,16 +5091,8 @@ let selectionRangeOfExpr = (exprID: id, astInfo: ASTInfo.t): option<(int, int)> 
     |> Option.map(~f=expr => FluidTokenizer.tokenizeExprForEditor(astInfo.state.activeEditor, expr))
     |> Option.unwrap(~default=list{})
 
-  let (exprStartToken, exprEndToken) = (
-    List.head(exprTokens),
-    List.last(exprTokens),
-  ) |> Tuple2.mapAll(~f=(x: option<T.tokenInfo>) =>
-    switch x {
-    | Some(exprTok) =>
-      List.find(containingTokens, ~f=(tk: T.tokenInfo) => T.matchesContent(exprTok.token, tk.token))
-    | _ => None
-    }
-  )
+  let exprStartToken = List.head(exprTokens) |> findInfoForToken(containingTokens)
+  let exprEndToken = List.last(exprTokens) |> findInfoForToken(containingTokens)
 
   switch (exprStartToken, exprEndToken) {
   /* range is from startPos of first token in expr to
@@ -5122,16 +5120,8 @@ let selectionRangeOfMatchPattern = (
     )
     |> Option.unwrap(~default=list{})
 
-  let (mpStartToken, mpEndToken) = (
-    List.head(mpTokens),
-    List.last(mpTokens),
-  ) |> Tuple2.mapAll(~f=(x: option<T.tokenInfo>) =>
-    switch x {
-    | Some(mpTok) =>
-      List.find(containingTokens, ~f=(tk: T.tokenInfo) => T.matchesContent(mpTok.token, tk.token))
-    | _ => None
-    }
-  )
+  let mpStartToken = List.head(mpTokens) |> findInfoForToken(containingTokens)
+  let mpEndToken = List.last(mpTokens) |> findInfoForToken(containingTokens)
 
   // range is from startPos of first token in MP to endPos of last token in MP
   switch (mpStartToken, mpEndToken) {

--- a/client/src/fluid/FluidDebugger.res
+++ b/client/src/fluid/FluidDebugger.res
@@ -10,7 +10,7 @@ module Token = FluidToken
 
 let view = (m: AppTypes.model, ast: FluidAST.t): Html.html<AppTypes.msg> => {
   let s = m.fluidState
-  let tokens = FluidTokenizer.tokenizeForDebugger(m.fluidState.activeEditor, ast)
+  let tokens = FluidTokenizer.tokenizeExprForDebugger(m.fluidState.activeEditor, ast)
   let ddText = txt => Html.dd(list{}, list{Html.text(txt)})
   let dtText = txt => Html.dt(list{}, list{Html.text(txt)})
   let posData = {

--- a/client/src/fluid/FluidDebugger.res
+++ b/client/src/fluid/FluidDebugger.res
@@ -10,7 +10,7 @@ module Token = FluidToken
 
 let view = (m: AppTypes.model, ast: FluidAST.t): Html.html<AppTypes.msg> => {
   let s = m.fluidState
-  let tokens = FluidTokenizer.tokensForEditor(m.fluidState.activeEditor, ast)
+  let tokens = FluidTokenizer.tokenizeForDebugger(m.fluidState.activeEditor, ast)
   let ddText = txt => Html.dd(list{}, list{Html.text(txt)})
   let dtText = txt => Html.dt(list{}, list{Html.text(txt)})
   let posData = {

--- a/client/src/fluid/FluidPrinter.res
+++ b/client/src/fluid/FluidPrinter.res
@@ -13,12 +13,15 @@ let tokensToString = (tis: list<tokenInfo>): string =>
   tis |> List.map(~f=(ti: tokenInfo) => T.toText(ti.token)) |> String.join(~sep="")
 
 let eToTestString = (e: E.t): string =>
-  e |> tokenize |> List.map(~f=(ti: tokenInfo) => T.toTestText(ti.token)) |> String.join(~sep="")
+  E.Expr(e)
+  |> tokenize
+  |> List.map(~f=(ti: tokenInfo) => T.toTestText(ti.token))
+  |> String.join(~sep="")
 
-let eToHumanString = (e: E.t): string => e |> tokenize |> tokensToString
+let eToHumanString = (e: E.t): string => E.Expr(e) |> tokenize |> tokensToString
 
 let eToStructure = (~includeIDs=false, e: E.t): string =>
-  e
+  E.Expr(e)
   |> tokenize
   |> List.map(~f=(ti: tokenInfo) =>
     "<" ++

--- a/client/src/fluid/FluidPrinter.res
+++ b/client/src/fluid/FluidPrinter.res
@@ -13,16 +13,16 @@ let tokensToString = (tis: list<tokenInfo>): string =>
   tis |> List.map(~f=(ti: tokenInfo) => T.toText(ti.token)) |> String.join(~sep="")
 
 let eToTestString = (e: E.t): string =>
-  E.Expr(e)
-  |> tokenize
+  e
+  |> tokenizeExpr
   |> List.map(~f=(ti: tokenInfo) => T.toTestText(ti.token))
   |> String.join(~sep="")
 
-let eToHumanString = (e: E.t): string => E.Expr(e) |> tokenize |> tokensToString
+let eToHumanString = (e: E.t): string => e |> tokenizeExpr |> tokensToString
 
 let eToStructure = (~includeIDs=false, e: E.t): string =>
-  E.Expr(e)
-  |> tokenize
+  e
+  |> tokenizeExpr
   |> List.map(~f=(ti: tokenInfo) =>
     "<" ++
     (T.toTypeName(ti.token) ++

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -746,7 +746,7 @@ let tokenizeWithOptions = (
   switch mpOrExpr {
   | Expr(expr) =>
     {...Builder.empty, ffTokenization: ffTokenization} |> exprToTokens(expr) |> Builder.asTokens
-  | MatchPat(matchId, pat) => matchPatternToTokens(matchId, ~idx=0, pat)
+  | MatchPat(matchId, pat) => matchPatternToTokens(matchId, ~idx=0, pat) // TODO: this is the wrong index!
   }
   |> tidy
   |> validateTokens

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -755,7 +755,19 @@ let tokenize: E.t => list<FluidToken.tokenInfo> = tokenizeWithFFTokenization(
   FeatureFlagOnlyDisabled,
 )
 
-let tokensForEditor = (e: FluidTypes.Editor.t, ast: FluidAST.t): list<FluidToken.tokenInfo> =>
+let tokenizeForEditor = (e: FluidTypes.Editor.t, expr: FluidExpression.t): list<
+  FluidToken.tokenInfo,
+> =>
+  switch e {
+  | NoEditor => list{}
+  | MainEditor(_) => tokenize(expr)
+  | FeatureFlagEditor(_) => tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled, expr)
+  }
+
+// this is only used for FluidDebugger. TODO: consider removing? Not sure why
+// we have this separate tokenizer - when would we have a FF but no expr
+// corresponding to the expr's ID?
+let tokenizeForDebugger = (e: FluidTypes.Editor.t, ast: FluidAST.t): list<FluidToken.tokenInfo> =>
   switch e {
   | NoEditor => list{}
   | MainEditor(_) => tokenize(FluidAST.toExpr(ast))
@@ -766,15 +778,6 @@ let tokensForEditor = (e: FluidTypes.Editor.t, ast: FluidAST.t): list<FluidToken
       "could not find expression id = " ++ (ID.toString(id) ++ " when tokenizing FF editor"),
       ~default=list{},
     )
-  }
-
-let tokenizeForEditor = (e: FluidTypes.Editor.t, expr: FluidExpression.t): list<
-  FluidToken.tokenInfo,
-> =>
-  switch e {
-  | NoEditor => list{}
-  | MainEditor(_) => tokenize(expr)
-  | FeatureFlagEditor(_) => tokenizeWithFFTokenization(FeatureFlagConditionAndEnabled, expr)
   }
 
 // --------------------------------------

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -176,7 +176,7 @@ let tidy = (tokens: list<fluidToken>): list<fluidToken> =>
 // The actual tokenization
 // --------------------------------------
 
-let rec matchPatternToTokens = (matchID: id, mp: FluidMatchPattern.t, ~idx: int): list<
+let rec matchPatternToTokens = (matchID: id, ~idx: int, mp: FluidMatchPattern.t): list<
   fluidToken,
 > => {
   open FluidTypes.Token

--- a/client/src/fluid/FluidTokenizer.resi
+++ b/client/src/fluid/FluidTokenizer.resi
@@ -9,7 +9,7 @@ type featureFlagTokenization =
   fluidTokens.
 
   ~idx is the zero-based index of the match pattern in the enclosing match")
-let matchPatternToTokens: (ID.t, FluidMatchPattern.t, ~idx: int) => list<FluidTypes.Token.t>
+let matchPatternToTokens: (ID.t, ~idx: int, FluidMatchPattern.t) => list<FluidTypes.Token.t>
 
 let tokenize: FluidExpression.t => list<FluidToken.tokenInfo>
 

--- a/client/src/fluid/FluidTokenizer.resi
+++ b/client/src/fluid/FluidTokenizer.resi
@@ -11,10 +11,13 @@ type featureFlagTokenization =
   ~idx is the zero-based index of the match pattern in the enclosing match")
 let matchPatternToTokens: (ID.t, ~idx: int, FluidMatchPattern.t) => list<FluidTypes.Token.t>
 
-let tokenize: FluidExpression.t => list<FluidToken.tokenInfo>
+let tokenize: FluidExpression.fluidMatchPatOrExpr => list<FluidToken.tokenInfo>
 
 @ocaml.doc("returns the given expression, tokenized with the rules of the specified editor")
-let tokenizeForEditor: (FluidTypes.Editor.t, FluidExpression.t) => list<FluidToken.tokenInfo>
+let tokenizeForEditor: (
+  FluidTypes.Editor.t,
+  FluidExpression.fluidMatchPatOrExpr,
+) => list<FluidToken.tokenInfo>
 
 @ocaml.doc("the same as tokenizeForEditor, but for the contributor debugger")
 let tokenizeForDebugger: (FluidTypes.Editor.t, FluidAST.t) => list<FluidToken.tokenInfo>

--- a/client/src/fluid/FluidTokenizer.resi
+++ b/client/src/fluid/FluidTokenizer.resi
@@ -11,16 +11,21 @@ type featureFlagTokenization =
   ~idx is the zero-based index of the match pattern in the enclosing match")
 let matchPatternToTokens: (ID.t, ~idx: int, FluidMatchPattern.t) => list<FluidTypes.Token.t>
 
-let tokenize: FluidExpression.fluidMatchPatOrExpr => list<FluidToken.tokenInfo>
+let tokenizeExpr: FluidExpression.t => list<FluidToken.tokenInfo>
 
 @ocaml.doc("returns the given expression, tokenized with the rules of the specified editor")
-let tokenizeForEditor: (
+let tokenizeExprForEditor: (FluidTypes.Editor.t, FluidExpression.t) => list<FluidToken.tokenInfo>
+
+@ocaml.doc("returns the given match pattern, tokenized with the rules of the specified editor")
+let tokenizeMatchPatternForEditor: (
   FluidTypes.Editor.t,
-  FluidExpression.fluidMatchPatOrExpr,
+  ID.t,
+  int,
+  FluidMatchPattern.t,
 ) => list<FluidToken.tokenInfo>
 
-@ocaml.doc("the same as tokenizeForEditor, but for the contributor debugger")
-let tokenizeForDebugger: (FluidTypes.Editor.t, FluidAST.t) => list<FluidToken.tokenInfo>
+@ocaml.doc("the same as tokenizeExprForEditor, but for the contributor debugger")
+let tokenizeExprForDebugger: (FluidTypes.Editor.t, FluidAST.t) => list<FluidToken.tokenInfo>
 
 let getTokensAtPosition: (
   ~prev: option<FluidToken.tokenInfo>=?,

--- a/client/src/fluid/FluidTokenizer.resi
+++ b/client/src/fluid/FluidTokenizer.resi
@@ -1,31 +1,23 @@
 type featureFlagTokenization =
-  | @ocaml.doc(" FeatureFlagOnlyDisabled is used in the main editor panel to only
-          * show the flag's old code ")
+  | @ocaml.doc("used in the main editor panel to only show the flag's old code ")
   FeatureFlagOnlyDisabled
 
-  | @ocaml.doc(" FeatureFlagConditionAndEnabled is used in the secondary editor
-          * panel for editing a flag's condition and new code ")
+  | @ocaml.doc("used in the secondary editor panel for editing a flag's condition and new code")
   FeatureFlagConditionAndEnabled
-
-let tokenizeWithFFTokenization: (
-  featureFlagTokenization,
-  FluidExpression.t,
-) => list<FluidToken.tokenInfo>
-
-let tokenize: FluidExpression.t => list<FluidToken.tokenInfo>
-
-@ocaml.doc(" returns the tokens that should populate the given editor ")
-let tokensForEditor: (FluidTypes.Editor.t, FluidAST.t) => list<FluidToken.tokenInfo>
-
-@ocaml.doc(" returns the given expression, tokenized with the rules of the specified editor ")
-let tokenizeForEditor: (FluidTypes.Editor.t, FluidExpression.t) => list<FluidToken.tokenInfo>
 
 @@ocaml.text("takes a match pattern `p` and converts it to a list of
   fluidTokens.
 
   ~idx is the zero-based index of the match pattern in the enclosing match")
-
 let matchPatternToTokens: (ID.t, FluidMatchPattern.t, ~idx: int) => list<FluidTypes.Token.t>
+
+let tokenize: FluidExpression.t => list<FluidToken.tokenInfo>
+
+@ocaml.doc("returns the given expression, tokenized with the rules of the specified editor")
+let tokenizeForEditor: (FluidTypes.Editor.t, FluidExpression.t) => list<FluidToken.tokenInfo>
+
+@ocaml.doc("the same as tokenizeForEditor, but for the contributor debugger")
+let tokenizeForDebugger: (FluidTypes.Editor.t, FluidAST.t) => list<FluidToken.tokenInfo>
 
 let getTokensAtPosition: (
   ~prev: option<FluidToken.tokenInfo>=?,

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -126,7 +126,7 @@ module Token = {
     // for all these TMP* variants:
     // - the first id is the match id
     // - the second id is the pattern id
-    // - the final int is the index of the (pattern -> expr)
+    // - the final int is the index of the (pattern, expr) case within the wrapping `match` expr
     | TMPVariable(ID.t, ID.t, string, int)
     | TMPConstructorName(ID.t, ID.t, string, int)
 

--- a/client/test/FluidFuzzer.res
+++ b/client/test/FluidFuzzer.res
@@ -401,9 +401,9 @@ let simplify = (id: id, ast: E.t): E.t =>
   )
 
 let reduce = (test: FuzzTest.t, ast: E.t) => {
-  let runThrough = (msg, reducer, ast) => {
+  let runThrough = (msg, reducer, ast: E.t) => {
     let tokenIDs =
-      ast |> FluidTokenizer.tokenize |> List.map(~f=(ti: T.tokenInfo) => T.tid(ti.token))
+      E.Expr(ast) |> FluidTokenizer.tokenize |> List.map(~f=(ti: T.tokenInfo) => T.tid(ti.token))
 
     let eIDs = ast |> E.filterMap(~f=e => Some(E.toID(e)))
     let ids =

--- a/client/test/FluidFuzzer.res
+++ b/client/test/FluidFuzzer.res
@@ -403,7 +403,7 @@ let simplify = (id: id, ast: E.t): E.t =>
 let reduce = (test: FuzzTest.t, ast: E.t) => {
   let runThrough = (msg, reducer, ast: E.t) => {
     let tokenIDs =
-      E.Expr(ast) |> FluidTokenizer.tokenize |> List.map(~f=(ti: T.tokenInfo) => T.tid(ti.token))
+      ast |> FluidTokenizer.tokenizeExpr |> List.map(~f=(ti: T.tokenInfo) => T.tid(ti.token))
 
     let eIDs = ast |> E.filterMap(~f=e => Some(E.toID(e)))
     let ids =

--- a/client/test/FuzzTests.res
+++ b/client/test/FuzzTests.res
@@ -110,7 +110,7 @@ let encodingRoundtrip: FuzzTest.t = {
 let longLines: FuzzTest.t = {
   name: "no lines above 120 chars",
   check: (~testcase as _, ~newAST, _) => {
-    let allTokens = FluidTokenizer.tokenize(newAST)
+    let allTokens = FluidTokenizer.tokenize(Expr(newAST))
     List.all(allTokens, ~f=ti => ti.startCol + ti.length <= 120)
   },
   ignore: _ => false,

--- a/client/test/FuzzTests.res
+++ b/client/test/FuzzTests.res
@@ -110,7 +110,7 @@ let encodingRoundtrip: FuzzTest.t = {
 let longLines: FuzzTest.t = {
   name: "no lines above 120 chars",
   check: (~testcase as _, ~newAST, _) => {
-    let allTokens = FluidTokenizer.tokenize(Expr(newAST))
+    let allTokens = FluidTokenizer.tokenizeExpr(newAST)
     List.all(allTokens, ~f=ti => ti.startCol + ti.length <= 120)
   },
   ignore: _ => false,

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -223,8 +223,8 @@ module TestCase = {
            *
            * Importantly, we do this on the original expr
            */
-          E.Expr(originalExpr)
-          |> Tokenizer.tokenize
+          originalExpr
+          |> Tokenizer.tokenizeExpr
           |> List.filter(~f=(ti: T.tokenInfo) =>
             FluidToken.isNewline(ti.token) && ti.startPos < pos
           )
@@ -289,7 +289,7 @@ module TestResult = {
   }
 
   let tokenizeResult = (res: t): list<FluidToken.tokenInfo> =>
-    E.Expr(FluidAST.toExpr(res.resultAST)) |> FluidTokenizer.tokenizeForEditor(
+    FluidAST.toExpr(res.resultAST) |> FluidTokenizer.tokenizeExprForEditor(
       res.resultState.activeEditor,
     )
 
@@ -5333,7 +5333,7 @@ let run = () => {
   })
   describe("Movement", () => {
     let s = defaultTestState
-    let tokens = FluidTokenizer.tokenize(E.Expr(compoundExpr))
+    let tokens = FluidTokenizer.tokenizeExpr(compoundExpr)
     let len = tokens |> List.map(~f=(ti: T.tokenInfo) => ti.token) |> length
     let ast = compoundExpr |> FluidAST.ofExpr
     let astInfo = ASTInfo.make(ast, defaultTestState)
@@ -5781,7 +5781,7 @@ let run = () => {
       }
 
       let ast = EString(id, "test")
-      let tokens = tokenize(E.Expr(ast))
+      let tokens = tokenizeExpr(ast)
       expect(getNeighbours(~pos=3, tokens)) |> toEqual((L(token, ti), R(token, ti), Some(nextTI)))
     })
   })

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -223,7 +223,7 @@ module TestCase = {
            *
            * Importantly, we do this on the original expr
            */
-          originalExpr
+          E.Expr(originalExpr)
           |> Tokenizer.tokenize
           |> List.filter(~f=(ti: T.tokenInfo) =>
             FluidToken.isNewline(ti.token) && ti.startPos < pos
@@ -289,7 +289,9 @@ module TestResult = {
   }
 
   let tokenizeResult = (res: t): list<FluidToken.tokenInfo> =>
-    FluidAST.toExpr(res.resultAST) |> FluidTokenizer.tokenizeForEditor(res.resultState.activeEditor)
+    E.Expr(FluidAST.toExpr(res.resultAST)) |> FluidTokenizer.tokenizeForEditor(
+      res.resultState.activeEditor,
+    )
 
   let containsPartials = (res: t): bool =>
     List.any(tokenizeResult(res), ~f=ti =>
@@ -5331,7 +5333,7 @@ let run = () => {
   })
   describe("Movement", () => {
     let s = defaultTestState
-    let tokens = FluidTokenizer.tokenize(compoundExpr)
+    let tokens = FluidTokenizer.tokenize(E.Expr(compoundExpr))
     let len = tokens |> List.map(~f=(ti: T.tokenInfo) => ti.token) |> length
     let ast = compoundExpr |> FluidAST.ofExpr
     let astInfo = ASTInfo.make(ast, defaultTestState)
@@ -5779,7 +5781,7 @@ let run = () => {
       }
 
       let ast = EString(id, "test")
-      let tokens = tokenize(ast)
+      let tokens = tokenize(E.Expr(ast))
       expect(getNeighbours(~pos=3, tokens)) |> toEqual((L(token, ti), R(token, ti), Some(nextTI)))
     })
   })

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -123,8 +123,7 @@ let defaultTokenInfo: FluidToken.tokenInfo = {
 let defaultFullQuery = (~tl=defaultToplevel, ac: AC.t, queryString: string): AC.fullQuery => {
   let ti = switch tl {
   | TLHandler({ast, _}) | TLFunc({body: ast, _}) =>
-    ast
-    |> FluidAST.toExpr
+    FluidExpression.Expr(FluidAST.toExpr(ast))
     |> Printer.tokenize
     |> List.head
     |> Option.unwrap(~default=defaultTokenInfo)

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -123,8 +123,8 @@ let defaultTokenInfo: FluidToken.tokenInfo = {
 let defaultFullQuery = (~tl=defaultToplevel, ac: AC.t, queryString: string): AC.fullQuery => {
   let ti = switch tl {
   | TLHandler({ast, _}) | TLFunc({body: ast, _}) =>
-    FluidExpression.Expr(FluidAST.toExpr(ast))
-    |> Printer.tokenize
+    FluidAST.toExpr(ast)
+    |> Printer.tokenizeExpr
     |> List.head
     |> Option.unwrap(~default=defaultTokenInfo)
   | _ => defaultTokenInfo

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -11,7 +11,7 @@ open FluidShortcuts
 type testResult = (fluidExpr, (string, option<string>), int)
 
 let containsPartials = (res: fluidExpr): bool =>
-  res
+  FluidExpression.Expr(res)
   |> FluidTokenizer.tokenizeForEditor(FluidTypes.Editor.MainEditor(TLID.fromInt(7)))
   |> List.any(~f=(ti: FluidToken.tokenInfo) =>
     switch ti.token {

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -11,8 +11,8 @@ open FluidShortcuts
 type testResult = (fluidExpr, (string, option<string>), int)
 
 let containsPartials = (res: fluidExpr): bool =>
-  FluidExpression.Expr(res)
-  |> FluidTokenizer.tokenizeForEditor(FluidTypes.Editor.MainEditor(TLID.fromInt(7)))
+  res
+  |> FluidTokenizer.tokenizeExprForEditor(FluidTypes.Editor.MainEditor(TLID.fromInt(7)))
   |> List.any(~f=(ti: FluidToken.tokenInfo) =>
     switch ti.token {
     | TRightPartial(_) | TPartial(_) | TFieldPartial(_) => true

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1411,66 +1411,114 @@ let run = () => {
   })
   describe("Match", () => {
     testCopy(
-      "copying a blank match expression works",
+      "copying a single blank match pattern works",
       match'(blank(), list{(mpBlank(), blank())}),
       (0, 22),
       "match ___\n  *** -> ___\n",
     )
+    // todo: copying all cases in a match expression
     testCopy(
-      "copying a match expression with a single integer pattern works",
-      match'(int(123), list{(mpInt(123), str("success"))}),
-      (0, 27),
-      "match 123\n  123 -> \"success\"\n",
-    )
-    testCopy(
-      "copying a match expression with a full constructor pattern works",
-      match'(
-        constructor("Just", list{int(123)}),
-        list{(mpConstructor("Just", list{mpInt(123)}), str("success"))},
-      ),
-      (0, 37),
-      "match Just 123\n  Just 123 -> \"success\"\n",
-    )
-    testCopy(
-      "copying fewer than all cases in a match expression works",
+      "copying fewer than all cases in a match expression",
       match'(int(0), list{(mpInt(123), str("first branch")), (mpInt(456), str("second branch"))}),
       (0, 30), // right after "Just"
       "match 0\n  123 -> \"first branch\"\n",
     )
+    // todo: copying just the expr in a match case (without arrow)
+    // todo: copying just the expr in a match case (with arrow)
+    // todo: copying just the pattern in a match case (without arrow)
+    // todo: copying just the pattern in a match case (with arrow)
+    // todo:
 
-    // CLEANUP this test fails because the impl. assumes we've selected the
-    // subpatterns
-    // testCopy(
-    //   "copying a match expression with a partial constructor pattern works",
-    //   match'(
-    //     constructor("Just", list{int(123)}),
-    //     list{(pConstructor("Just", list{pInt(123)}), str("success"))},
-    //   ),
-    //   (0, 21), // right after "Just"
-    //   "match Just 123\n  Just *** -> ___\n",
-    // )
+    describe("Bool match pattern", () => {
+      // todo: fully selected `true`
+      // todo: fully selected `false`
+      // todo: partially selected `true` (`tr`)
+      // todo: partially selected `false` (`alse`)
+      ()
+    })
 
-    testCopy(
-      "copying a match expression including a full tuple pattern works",
-      match'(
-        tuple(int(1), str("two"), list{int(3)}),
-        list{(mpTuple(mpInt(1), mpString("two"), list{mpInt(3)}), str("success"))},
-      ),
-      (0, 44),
-      "match (1,\"two\",3)\n  (1,\"two\",3) -> \"success\"\n",
-    )
+    describe("Null match pattern", () => {
+      // todo: fullly selected
+      // todo: partially selected (`nul`)
+      ()
+    })
 
-    // CLEANUP TUPLETODO this test fails because the impl. assumes we've
-    // selected the subpatterns
-    // testCopy(
-    //   "copying a match expression including part of a tuple pattern works",
-    //   match'(
-    //     tuple(int(1), str("two"), list{int(3)}),
-    //     list{(pTuple(pInt(1), pString("two"), list{pInt(3)}), str("success"))},
-    //   ),
-    //   (0, 29), // ending just before the '3' in the pattern
-    //   "match (1,\"two\",3)\n  (1,\"two\",***) -> ___\n",
-    // )
+    describe("Character match pattern", () => {
+      // CLEANUP these aren't yet create-able in Fluid
+      ()
+    })
+    describe("String match pattern", () => {
+      // todo: many tests
+      ()
+    })
+
+    describe("Int match pattern", () => {
+      testCopy(
+        "copying a match expression with a single integer pattern works",
+        match'(int(123), list{(mpInt(123), str("success"))}),
+        (0, 27),
+        "match 123\n  123 -> \"success\"\n",
+      )
+      // todo: many more tests
+      ()
+    })
+    describe("Float match pattern", () => {
+      // todo: many tests
+      ()
+    })
+
+    describe("Constructor match pattern", () => {
+      testCopy(
+        "copying a match expression with a full constructor pattern works",
+        match'(
+          constructor("Just", list{int(123)}),
+          list{(mpConstructor("Just", list{mpInt(123)}), str("success"))},
+        ),
+        (0, 37),
+        "match Just 123\n  Just 123 -> \"success\"\n",
+      )
+
+      // CLEANUP this test fails because the impl. assumes we've selected the
+      // subpatterns
+      // testCopy(
+      //   "copying a match expression with a partial constructor pattern works",
+      //   match'(
+      //     constructor("Just", list{int(123)}),
+      //     list{(pConstructor("Just", list{pInt(123)}), str("success"))},
+      //   ),
+      //   (0, 21), // right after "Just"
+      //   "match Just 123\n  Just *** -> ___\n",
+      // )
+
+      // todo: many more tests
+      ()
+    })
+
+    describe("Tuple match pattern", () => {
+      testCopy(
+        "copying a match expression including a full tuple pattern works",
+        match'(
+          tuple(int(1), str("two"), list{int(3)}),
+          list{(mpTuple(mpInt(1), mpString("two"), list{mpInt(3)}), str("success"))},
+        ),
+        (0, 44),
+        "match (1,\"two\",3)\n  (1,\"two\",3) -> \"success\"\n",
+      )
+
+      // CLEANUP TUPLETODO this test fails because the impl. assumes we've
+      // selected the subpatterns
+      // testCopy(
+      //   "copying a match expression including part of a tuple pattern works",
+      //   match'(
+      //     tuple(int(1), str("two"), list{int(3)}),
+      //     list{(pTuple(pInt(1), pString("two"), list{pInt(3)}), str("success"))},
+      //   ),
+      //   (0, 29), // ending just before the '3' in the pattern
+      //   "match (1,\"two\",3)\n  (1,\"two\",***) -> ___\n",
+      // )
+
+      // todo: many more tests
+    })
     ()
   })
   describe("json", () => {

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1476,13 +1476,13 @@ let run = () => {
         "copying a partially selected bool match pattern - true",
         match'(blank(), list{(mpBool(true), blank())}),
         (0, 14), // tr|ue
-        "match ___\n  *** -> ___\n",
+        "match ___\n  true -> ___\n",
       )
       testCopy(
         "copying a partially selected bool match pattern - false",
         match'(blank(), list{(mpBool(false), blank())}),
         (0, 15), // fal|se
-        "match ___\n  *** -> ___\n",
+        "match ___\n  false -> ___\n",
       )
       ()
     })
@@ -1498,7 +1498,7 @@ let run = () => {
         "copying a partially selected null match pattern",
         match'(blank(), list{(mpNull(), blank())}),
         (0, 14), // nu|ll
-        "match ___\n  *** -> ___\n",
+        "match ___\n  null -> ___\n",
       )
       ()
     })

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1410,24 +1410,36 @@ let run = () => {
     ()
   })
   describe("Match", () => {
+    //
+    // First, test the reconstruction of the `match` expr itself
+    //
+
     testCopy(
-      "copying a single blank match pattern works",
+      "copying a single blank match pattern",
       match'(blank(), list{(mpBlank(), blank())}),
       (0, 22),
       "match ___\n  *** -> ___\n",
     )
-    // todo: copying all cases in a match expression
+    testCopy(
+      "copying all cases in a match expression",
+      match'(int(0), list{(mpInt(123), str("first branch")), (mpInt(456), str("second branch"))}),
+      (0, 56), // at the end
+      "match 0\n  123 -> \"first branch\"\n  456 -> \"second branch\"\n",
+    )
     testCopy(
       "copying fewer than all cases in a match expression",
       match'(int(0), list{(mpInt(123), str("first branch")), (mpInt(456), str("second branch"))}),
-      (0, 30), // right after "Just"
+      (0, 31), // at the end of "first branch" (before newline)
       "match 0\n  123 -> \"first branch\"\n",
     )
     // todo: copying just the expr in a match case (without arrow)
     // todo: copying just the expr in a match case (with arrow)
     // todo: copying just the pattern in a match case (without arrow)
     // todo: copying just the pattern in a match case (with arrow)
-    // todo:
+
+    //
+    // Now, test the reconstruction of various 'match patterns'
+    //
 
     describe("Bool match pattern", () => {
       // todo: fully selected `true`
@@ -1454,7 +1466,7 @@ let run = () => {
 
     describe("Int match pattern", () => {
       testCopy(
-        "copying a match expression with a single integer pattern works",
+        "copying a match expr with a single integer pattern",
         match'(int(123), list{(mpInt(123), str("success"))}),
         (0, 27),
         "match 123\n  123 -> \"success\"\n",
@@ -1469,7 +1481,7 @@ let run = () => {
 
     describe("Constructor match pattern", () => {
       testCopy(
-        "copying a match expression with a full constructor pattern works",
+        "copying a match expression with a full constructor pattern",
         match'(
           constructor("Just", list{int(123)}),
           list{(mpConstructor("Just", list{mpInt(123)}), str("success"))},
@@ -1478,7 +1490,7 @@ let run = () => {
         "match Just 123\n  Just 123 -> \"success\"\n",
       )
       testCopy(
-        "copying a match expression with a partial constructor pattern works",
+        "copying a match expression with a partial constructor pattern",
         match'(
           constructor("Just", list{int(123)}),
           list{(mpConstructor("Just", list{mpInt(123)}), str("success"))},
@@ -1493,7 +1505,7 @@ let run = () => {
 
     describe("Tuple match pattern", () => {
       testCopy(
-        "copying a match expression including a full tuple pattern works",
+        "copying a match expression including a full tuple pattern",
         match'(
           tuple(int(1), str("two"), list{int(3)}),
           list{(mpTuple(mpInt(1), mpString("two"), list{mpInt(3)}), str("success"))},
@@ -1502,7 +1514,7 @@ let run = () => {
         "match (1,\"two\",3)\n  (1,\"two\",3) -> \"success\"\n",
       )
       testCopy(
-        "copying a match expression including part of a tuple pattern works",
+        "copying a match expression including part of a tuple pattern",
         match'(
           tuple(int(1), str("two"), list{int(3)}),
           list{(mpTuple(mpInt(1), mpString("two"), list{mpInt(3)}), str("success"))},

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -1477,18 +1477,15 @@ let run = () => {
         (0, 37),
         "match Just 123\n  Just 123 -> \"success\"\n",
       )
-
-      // CLEANUP this test fails because the impl. assumes we've selected the
-      // subpatterns
-      // testCopy(
-      //   "copying a match expression with a partial constructor pattern works",
-      //   match'(
-      //     constructor("Just", list{int(123)}),
-      //     list{(pConstructor("Just", list{pInt(123)}), str("success"))},
-      //   ),
-      //   (0, 21), // right after "Just"
-      //   "match Just 123\n  Just *** -> ___\n",
-      // )
+      testCopy(
+        "copying a match expression with a partial constructor pattern works",
+        match'(
+          constructor("Just", list{int(123)}),
+          list{(mpConstructor("Just", list{mpInt(123)}), str("success"))},
+        ),
+        (0, 21), // right after "Just"
+        "match Just 123\n  Just *** -> ___\n",
+      )
 
       // todo: many more tests
       ()
@@ -1504,18 +1501,15 @@ let run = () => {
         (0, 44),
         "match (1,\"two\",3)\n  (1,\"two\",3) -> \"success\"\n",
       )
-
-      // CLEANUP TUPLETODO this test fails because the impl. assumes we've
-      // selected the subpatterns
-      // testCopy(
-      //   "copying a match expression including part of a tuple pattern works",
-      //   match'(
-      //     tuple(int(1), str("two"), list{int(3)}),
-      //     list{(pTuple(pInt(1), pString("two"), list{pInt(3)}), str("success"))},
-      //   ),
-      //   (0, 29), // ending just before the '3' in the pattern
-      //   "match (1,\"two\",3)\n  (1,\"two\",***) -> ___\n",
-      // )
+      testCopy(
+        "copying a match expression including part of a tuple pattern works",
+        match'(
+          tuple(int(1), str("two"), list{int(3)}),
+          list{(mpTuple(mpInt(1), mpString("two"), list{mpInt(3)}), str("success"))},
+        ),
+        (0, 29), // ending just before the '3' in the pattern
+        "match (1,\"two\",3)\n  (1,\"two\",***) -> ___\n",
+      )
 
       // todo: many more tests
     })

--- a/client/test/TestFluidPrinter.res
+++ b/client/test/TestFluidPrinter.res
@@ -8,7 +8,7 @@ type tokenInfo = FluidTypes.TokenInfo.t
 
 let run = () => {
   let tokensFor = (e: E.t): list<T.t> =>
-    FluidTokenizer.tokenize(e) |> List.map(~f=(ti: tokenInfo) => ti.token)
+    FluidTokenizer.tokenize(Expr(e)) |> List.map(~f=(ti: tokenInfo) => ti.token)
 
   let hasTokenMatch = (~f: T.t => bool, e: E.t) => {
     let tokens = tokensFor(e)

--- a/client/test/TestFluidPrinter.res
+++ b/client/test/TestFluidPrinter.res
@@ -15,7 +15,7 @@ let run = () => {
     expect(List.any(tokens, ~f)) |> toEqual(true)
   }
 
-  describe("toTokens' converts expressions to tokens", () => {
+  describe("exprToTokens converts expressions to tokens", () => {
     test("field access keeps parentBlockID", () => {
       let parentID = gid()
       let expr = E.EList(parentID, list{EFieldAccess(gid(), EVariable(gid(), "obj"), "field")})

--- a/client/test/TestFluidPrinter.res
+++ b/client/test/TestFluidPrinter.res
@@ -8,7 +8,7 @@ type tokenInfo = FluidTypes.TokenInfo.t
 
 let run = () => {
   let tokensFor = (e: E.t): list<T.t> =>
-    FluidTokenizer.tokenize(Expr(e)) |> List.map(~f=(ti: tokenInfo) => ti.token)
+    FluidTokenizer.tokenizeExpr(e) |> List.map(~f=(ti: tokenInfo) => ti.token)
 
   let hasTokenMatch = (~f: T.t => bool, e: E.t) => {
     let tokens = tokensFor(e)

--- a/docs/unittests.md
+++ b/docs/unittests.md
@@ -31,14 +31,13 @@ in `fsharp-backend/tests/FuzzTests`. Run them with `scripts/run-fsharp-fuzzer`.
 To run tests, run `scripts/run-client-tests` or `npm run test` (slower).
 Run `scripts/run-client-tests --help` for options.
 
-Tests are _not_ automatically discovered; they must be added to
-`run` in the file in question to run automatically, and new files
-need to be added to unittest.ml.
+Tests are _not_ automatically discovered; they must be added to `run` in the
+file in question to run automatically, and new files need to be added to
+`unittests.res`.
 
-Our test harness is a tiny homegrown test suite, in
-client/test/tester.ml. We initially used jest; Unfortunately,
-it had such poor performance that a rewrite was faster than
-figuring out why it was bad.
+Our test harness is a tiny homegrown test suite, in `client/test/tester.res`.
+We initially used jest; Unfortunately, it had such poor performance that a
+rewrite was faster than figuring out why it was bad.
 
 ## Integration tests
 


### PR DESCRIPTION
Reconstruction (what happens when you copy/paste some Dark code) of Exprs has been generally solid in Fluid, but the implementation for reconstructing match patterns was hacky, and did not support reconstructing only some of a nested pattern (i.e. if a Tuple pattern or Constructor pattern was partially highlighted when cutting/copying, the whole thing would be reconstructed - even the unselected parts).

This is how it used to operate:
![old](https://user-images.githubusercontent.com/906686/194083731-d6db5d5f-cd4f-4912-909e-419d4f454f7f.gif)

and here's with the fix
![new](https://user-images.githubusercontent.com/906686/194083734-ef204e30-0143-4055-8206-2f091c4a1e88.gif)

---

This broke down as follows:

- in `FluidTokenization.res`, organize the code to have all of the actual 'tokenization' be in one area visually.
- extend tokenization MP inputs (without needing to pass in the wrapping `match` expr)
- rename `FluidTokenization.tokensForEditor` to `.tokenizeForDebugger`
  previously, we had `tokensForEditor` and `tokenizeForEditor` - I found this pretty confusing.
- (goal 1) rewrite implementation to match how we reconstruct exprs (no longer trying to parse directly from the output tokens)
- (goal 2) support reconstructing just _part_ of a nested match pattern

TODOs:
- [x] more tests on reconstructing match patterns, generally
- [x] tests specifically around reconstructing only part of a nested match pattern
- [x] record screen to demonstrate the fix to reconstructing nested match pats (maybe to be copied to changelog)
- [x] ~~based on the below feedback, potentially remove mentions of non-existant `MPPartial`, and just commit to the logic we agree upon.~~ Edit: will leave the comments in, and follow up here soon when MPPartials are implemented.

---

In this re-implementation, I've reached for something like a `MPPartial` a few times - EPartials are used in reconstruction often when we've highlighted just part of a pattern, resulting in a way for the user to 'correct' the reconstructed code. For match pattern reconstruction, I've had to work around this. Would it make sense to add an MPPartial at some point?

In the meantime, here are the cases where I reached for MPPartial:

- when you've highlighted partway through a `Null` pattern
  my thought: reconstruct with a `Null` pattern
- when you've highlighted partway through a `Bool` pattern (with a value of `true` or `false`)
  my thought: reconstruct with the appropriate `Bool` pattern
- when you've highlighted partway through the _name_ in a `Constructor` pattern
  my thought: reconstruct with a `Blank` pattern

What do you think about these cases?

---

When reconstructing a `match`, here's the logic to choose which `cases` should be reconstructed or skipped:
```
let newCases = List.filterMap(cases, ~f=((matchPattern, expr)) => {
  switch (reconstructMatchPattern(matchID, matchPattern), reconstructExpr(expr)) {
  | (Some(mp), Some(expr)) => Some(mp, expr)
  | (Some(mp), None) => Some(mp, None |> orDefaultExpr)
  | (None, Some(_expr)) => None // todo: reconsider
  | (None, None) => None
  }
})
```

This was recently (in a previous PR) written to match some previous logic.
I think this is generally appropriate, but wanted to get some input on the third branch: 
`| (None, Some(_expr)) => None`

If we were able to reconstruct some Expr, but not reconstruct the Match Pattern (i.e. if you select the expr "downwards"), we don't create the new case. I don't think that makes sense - rather, I'd expect us to reconstruct a new `case`, but with a `Blank` pattern. What do you think about this branch?

---

I've lately become increasingly wary of searching for these magic strings `"match-pattern-variable"` within `Fluid.res`. I'm tempted to create a copy of the `FluidTypes.Token.t` which doesn't have the internals, and is a simple DU to use in these cases. That wouldn't help the existing CSS usages of the magic strings, but those are pretty rare anyway.

