### PR TITLE
Fix package params (+ rename "tipe")

### DIFF
--- a/client/src/analysis/Analysis.res
+++ b/client/src/analysis/Analysis.res
@@ -130,10 +130,10 @@ let getLiveValue' = (analysisStore: AnalysisTypes.analysisStore, id: id): option
 let getLiveValue = (m: model, id: id, traceID: traceID): option<RT.Dval.t> =>
   getLiveValue'(getStoredAnalysis(m, traceID), id)
 
-let getTipeOf' = (analysisStore: AnalysisTypes.analysisStore, id: id): option<DType.t> =>
+let getTypeOf' = (analysisStore: AnalysisTypes.analysisStore, id: id): option<DType.t> =>
   getLiveValue'(analysisStore, id) |> Option.map(~f=RT.Dval.toType)
 
-let getTipeOf = (m: model, id: id, traceID: traceID): option<DType.t> =>
+let getTypeOf = (m: model, id: id, traceID: traceID): option<DType.t> =>
   getLiveValue(m, id, traceID) |> Option.map(~f=RT.Dval.toType)
 
 let getArguments = (m: model, tl: toplevel, callerID: id, traceID: traceID): option<
@@ -188,7 +188,7 @@ let getAvailableVarnames = (m: model, tl: toplevel, id: id, traceID: traceID): l
   switch tl {
   | TLHandler(h) => Belt.List.concatMany([varsFor(h.ast), glob, inputVariables])
   | TLFunc(fn) => Belt.List.concatMany([varsFor(fn.body), glob, inputVariables])
-  | TLPmFunc(_) | TLDB(_) | TLTipe(_) => list{}
+  | TLPmFunc(_) | TLDB(_) | TLType(_) => list{}
   }
 }
 
@@ -430,7 +430,7 @@ let requestTrace = (~force=false, m, tlid, traceID): (model, AppTypes.cmd) => {
   let should =
     // DBs + Types dont have traces
     TL.get(m, tlid)
-    |> Option.map(~f=tl => !(TL.isDB(tl) || TL.isUserTipe(tl)))
+    |> Option.map(~f=tl => !(TL.isDB(tl) || TL.isUserType(tl)))
     |> Option.unwrap(~default=false)
 
   if should {

--- a/client/src/analysis/Runtime.res
+++ b/client/src/analysis/Runtime.res
@@ -133,7 +133,7 @@ let inputVariables = (tl: toplevel): list<string> =>
     | UnknownHandler(_) => list{"request", "event"}
     }
   | TLFunc(f) => f.parameters |> List.filterMap(~f=(p: PT.UserFunction.Parameter.t) => Some(p.name))
-  | TLTipe(_) | TLDB(_) | TLPmFunc(_) => list{}
+  | TLType(_) | TLDB(_) | TLPmFunc(_) => list{}
   }
 
 let sampleInputValue = (tl: toplevel): AnalysisTypes.InputValueDict.t =>

--- a/client/src/analysis/Runtime.res
+++ b/client/src/analysis/Runtime.res
@@ -40,7 +40,7 @@ let toRepr = (dval: RT.Dval.t): string => {
     let nl = "\n" ++ makeSpaces(indent)
     let inl = "\n" ++ makeSpaces(indent + 2)
     let indent = indent + 2
-    let typename = dv->RT.Dval.toType->DType.tipe2str
+    let typename = dv->RT.Dval.toType->DType.type2str
     let wrap = str => `<${typename}: ${str}>`
     let justType = `<${typename}>`
 

--- a/client/src/api/APIError.res
+++ b/client/src/api/APIError.res
@@ -83,7 +83,7 @@ let parseResponse = (body: Http.responseBody): string => {
   |> Option.map(~f=({
     short,
     long,
-    exceptionTipe,
+    exceptionType,
     actual,
     actualType,
     expected,
@@ -93,7 +93,7 @@ let parseResponse = (body: Http.responseBody): string => {
     workarounds,
   }) =>
     " (" ++
-    (exceptionTipe ++
+    (exceptionType ++
     ("): " ++
     (short ++
     (maybe("message", long) ++

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -102,10 +102,10 @@ module AutoComplete = {
     // User functions
     | ACFnName(string)
     | ACParamName(string)
-    | ACParamTipe(DType.t)
-    | ACReturnTipe(DType.t)
+    | ACParamType(DType.t)
+    | ACReturnType(DType.t)
     // User types
-    | ACTypeFieldTipe(DType.t)
+    | ACTypeFieldType(DType.t)
     | ACTypeName(string)
     | ACTypeFieldName(string)
 
@@ -888,7 +888,7 @@ module Model = {
     csrfToken: string,
     usedDBs: Tc.Map.String.t<int>,
     usedFns: Tc.Map.String.t<int>,
-    usedTipes: Tc.Map.String.t<int>,
+    usedTypes: Tc.Map.String.t<int>,
     handlerProps: TLID.Dict.t<HandlerProperty.t>,
     staticDeploys: list<StaticAssets.Deploy.t>,
     /* tlRefersTo : to answer the question "what TLs does this TL refer to". eg
@@ -971,7 +971,7 @@ module Model = {
     csrfToken: Defaults.unsetCSRF,
     usedDBs: Tc.Map.String.empty,
     usedFns: Tc.Map.String.empty,
-    usedTipes: Tc.Map.String.empty,
+    usedTypes: Tc.Map.String.empty,
     handlerProps: TLID.Dict.empty,
     staticDeploys: list{},
     tlRefersTo: TLID.Dict.empty,

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -364,7 +364,7 @@ let rec updateMod = (mod_: modification, (m, cmd): (model, AppTypes.cmd)): (
         | Some(TLDB(db)) => DB.upsert(newM, db)
         | Some(TLHandler(h)) => Handlers.upsert(newM, h)
         | Some(TLFunc(func)) => UserFunctions.upsert(newM, func)
-        | Some(TLPmFunc(_)) | Some(TLTipe(_)) | None => newM
+        | Some(TLPmFunc(_)) | Some(TLType(_)) | None => newM
         }
       | None => newM
       }
@@ -444,7 +444,7 @@ let rec updateMod = (mod_: modification, (m, cmd): (model, AppTypes.cmd)): (
       ) = switch p {
       | STTopLevelRoot =>
         switch TL.get(m, tlid) {
-        | Some(TLDB(_)) | Some(TLTipe(_)) => (Selecting(tlid, None), None)
+        | Some(TLDB(_)) | Some(TLType(_)) => (Selecting(tlid, None), None)
         | Some(TLFunc(_)) | Some(TLHandler(_)) => (FluidEntering(tlid), None)
         | Some(TLPmFunc(_)) => (Selecting(tlid, None), None)
         | None => (Deselected, None)
@@ -717,7 +717,7 @@ let rec updateMod = (mod_: modification, (m, cmd): (model, AppTypes.cmd)): (
           m2
         } else {
           TL.get(m, tlid)
-          |> Option.andThen(~f=TL.asUserTipe)
+          |> Option.andThen(~f=TL.asUserType)
           |> Option.map(~f=UserTypes.upsert(m2))
           |> Option.unwrap(~default=m2)
         }
@@ -1130,7 +1130,7 @@ let update_ = (msg: msg, m: model): modification => {
     if event.button == Defaults.leftButton {
       let tl = TL.get(m, targetTLID)
       switch tl {
-      | Some(TLPmFunc(_)) | Some(TLFunc(_)) | Some(TLTipe(_)) | None => NoChange
+      | Some(TLPmFunc(_)) | Some(TLFunc(_)) | Some(TLType(_)) | None => NoChange
       | Some(TLHandler(_)) | Some(TLDB(_)) => DragTL(targetTLID, event.mePos, false, m.cursorState)
       }
     } else {
@@ -1262,7 +1262,7 @@ let update_ = (msg: msg, m: model): modification => {
     | None => NoChange
     }
   | DeleteUserTypeField(tipetlid, field) =>
-    switch TL.get(m, tipetlid) |> Option.andThen(~f=TL.asUserTipe) {
+    switch TL.get(m, tipetlid) |> Option.andThen(~f=TL.asUserType) {
     | Some(tipe) =>
       let replacement = UserTypes.removeField(tipe, field)
       AddOps(list{SetType(replacement)}, FocusNext(tipe.tlid, None))

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1261,11 +1261,11 @@ let update_ = (msg: msg, m: model): modification => {
       Refactor.addFunctionParameter(m, uf, nextId)
     | None => NoChange
     }
-  | DeleteUserTypeField(tipetlid, field) =>
-    switch TL.get(m, tipetlid) |> Option.andThen(~f=TL.asUserType) {
-    | Some(tipe) =>
-      let replacement = UserTypes.removeField(tipe, field)
-      AddOps(list{SetType(replacement)}, FocusNext(tipe.tlid, None))
+  | DeleteUserTypeField(typetlid, field) =>
+    switch TL.get(m, typetlid) |> Option.andThen(~f=TL.asUserType) {
+    | Some(typ) =>
+      let replacement = UserTypes.removeField(typ, field)
+      AddOps(list{SetType(replacement)}, FocusNext(typ.tlid, None))
     | None => NoChange
     }
   | ToplevelDelete(tlid) =>
@@ -1868,10 +1868,10 @@ let update_ = (msg: msg, m: model): modification => {
     Refactor.createNewDB(m, None, center)
   | CreateFunction => Refactor.createNewFunction(m, None)
   | CreateType =>
-    let tipe = Refactor.generateEmptyUserType()
+    let typ = Refactor.generateEmptyUserType()
     Many(list{
-      AddOps(list{SetType(tipe)}, FocusNothing),
-      MakeCmd(Url.navigateTo(FocusedType(tipe.tlid))),
+      AddOps(list{SetType(typ)}, FocusNothing),
+      MakeCmd(Url.navigateTo(FocusedType(typ.tlid))),
     })
   | EnablePanning(pan) => ReplaceAllModificationsWithThisOne(Viewport.enablePan(pan))
   | ClipboardCopyEvent(e) =>

--- a/client/src/canvas/Url.res
+++ b/client/src/canvas/Url.res
@@ -85,13 +85,13 @@ let parseLocation = (loc: Web.Location.location): option<page> => {
   let handler = () =>
     getTLID("handler")->Option.map(~f=tlid => Page.FocusedHandler(tlid, trace, true))
   let db = () => getTLID("db")->Option.map(~f=tlid => Page.FocusedDB(tlid, true))
-  let tipe = () => getTLID("type")->Option.map(~f=tlid => Page.FocusedType(tlid))
+  let typ = () => getTLID("type")->Option.map(~f=tlid => Page.FocusedType(tlid))
 
   fn()
   |> Option.orElse(pmfn())
   |> Option.orElse(handler())
   |> Option.orElse(db())
-  |> Option.orElse(tipe())
+  |> Option.orElse(typ())
   |> Option.orElse(settingModal())
   |> Option.orElse(architecture())
 }

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -51,7 +51,7 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
       ViewData.viewData(vs),
       false,
     )
-  | TLTipe(t) => (list{ViewUserType.viewUserTipe(vs, t)}, list{}, false)
+  | TLType(t) => (list{ViewUserType.viewUserType(vs, t)}, list{}, false)
   }
 
   let usages = ViewIntrospect.allUsagesView(tlid, vs.usedInRefs, vs.refersToRefs)
@@ -298,7 +298,7 @@ let tlCacheKeyDB = (m: model, tl) => {
   }
 }
 
-let tlCacheKeyTipe = (m: model, tl) => {
+let tlCacheKeyType = (m: model, tl) => {
   let tlid = TL.id(tl)
   if Some(tlid) == CursorState.tlidOf(m.cursorState) {
     None
@@ -310,7 +310,7 @@ let tlCacheKeyTipe = (m: model, tl) => {
 
 let viewTL = (m, tl) =>
   switch tl {
-  | TLTipe(_) => ViewCache.cache2m(tlCacheKeyTipe, viewTL_, m, tl)
+  | TLType(_) => ViewCache.cache2m(tlCacheKeyType, viewTL_, m, tl)
   | TLDB(_) => ViewCache.cache2m(tlCacheKeyDB, viewTL_, m, tl)
   | TLPmFunc(_) | TLFunc(_) | TLHandler(_) => ViewCache.cache2m(tlCacheKey, viewTL_, m, tl)
   }

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -366,7 +366,7 @@ let viewCanvas = (m: model): Html.html<msg> => {
     }
   | FocusedType(tlid) =>
     switch Map.get(~key=tlid, m.userTypes) {
-    | Some(tipe) => list{viewTL(m, TL.utToTL(tipe))}
+    | Some(typ) => list{viewTL(m, TL.utToTL(typ))}
     | None => list{}
     }
   }

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -177,7 +177,7 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
 
         switch paramAndFnDesc {
         | Some(Some(param), f) =>
-          let header = param.name ++ ": " ++ DType.tipe2str(param.typ)
+          let header = param.name ++ ": " ++ DType.type2str(param.typ)
 
           Some(
             viewDoc(

--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -293,7 +293,7 @@ let userTypeCategory = (m: model, types: list<PT.UserType.t>): category => {
       Entry({
         name: typ.name,
         identifier: Tlid(typ.tlid),
-        uses: Some(Refactor.tipeUseCount(m, typ.name)),
+        uses: Some(Refactor.typeUseCount(m, typ.name)),
         minusButton: minusButton,
         killAction: Some(DeleteUserTypeForever(typ.tlid)),
         onClick: Destination(FocusedType(typ.tlid)),

--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -273,30 +273,30 @@ let userFunctionCategory = (m: model, ufs: list<PT.UserFunction.t>): category =>
   }
 }
 
-let userTipeCategory = (m: model, tipes: list<PT.UserType.t>): category => {
-  let tipes = tipes |> List.filter(~f=(ut: PT.UserType.t) => ut.name != "")
+let userTypeCategory = (m: model, types: list<PT.UserType.t>): category => {
+  let types = types |> List.filter(~f=(ut: PT.UserType.t) => ut.name != "")
   {
-    count: List.length(tipes),
+    count: List.length(types),
     name: "Types",
     emptyName: "Types",
     plusButton: Some(CreateType),
     iconAction: None,
     icon: Icons.darkIcon("types"),
     tooltip: None,
-    entries: List.map(tipes, ~f=tipe => {
-      let minusButton = if Refactor.usedTipe(m, tipe.name) {
+    entries: List.map(types, ~f=typ => {
+      let minusButton = if Refactor.usedType(m, typ.name) {
         None
       } else {
-        Some(Msg.DeleteUserType(tipe.tlid))
+        Some(Msg.DeleteUserType(typ.tlid))
       }
 
       Entry({
-        name: tipe.name,
-        identifier: Tlid(tipe.tlid),
-        uses: Some(Refactor.tipeUseCount(m, tipe.name)),
+        name: typ.name,
+        identifier: Tlid(typ.tlid),
+        uses: Some(Refactor.tipeUseCount(m, typ.name)),
         minusButton: minusButton,
-        killAction: Some(DeleteUserTypeForever(tipe.tlid)),
-        onClick: Destination(FocusedType(tipe.tlid)),
+        killAction: Some(DeleteUserTypeForever(typ.tlid)),
+        onClick: Destination(FocusedType(typ.tlid)),
         plusButton: None,
         verb: None,
       })
@@ -308,12 +308,12 @@ let standardCategories = (m, hs, dbs, ufns, types) => {
   let hs = hs |> Map.values |> List.sortBy(~f=tl => TL.sortkey(TLHandler(tl)))
   let dbs = dbs |> Map.values |> List.sortBy(~f=tl => TL.sortkey(TLDB(tl)))
   let ufns = ufns |> Map.values |> List.sortBy(~f=tl => TL.sortkey(TLFunc(tl)))
-  let types = types |> Map.values |> List.sortBy(~f=tl => TL.sortkey(TLTipe(tl)))
+  let types = types |> Map.values |> List.sortBy(~f=tl => TL.sortkey(TLType(tl)))
 
   // We want to hide user defined types for users who arent already using them
   // since there is currently no way to use them other than as a function param.
   // we should show user defined types once the user can use them more
-  let types = types == list{} ? list{} : list{userTipeCategory(m, types)}
+  let types = types == list{} ? list{} : list{userTypeCategory(m, types)}
 
   list{
     httpCategory(hs),
@@ -967,7 +967,7 @@ let rtCacheKey = (m: model) =>
     m.unlockedDBs,
     m.usedDBs,
     m.usedFns,
-    m.usedTipes,
+    m.usedTypes,
     CursorState.tlidOf(m.cursorState),
     m.environment,
     m.editorSettings,

--- a/client/src/components/FnParams.res
+++ b/client/src/components/FnParams.res
@@ -116,9 +116,9 @@ let viewKillParameterBtn = (uf: PT.UserFunction.t, p: PT.UserFunction.Parameter.
 let viewParamName = (~classes: list<string>, vp: viewProps, v: BlankOr.t<string>): Html.html<msg> =>
   ViewBlankOr.viewText(~enterable=true, ~classes, ParamName, vp, v)
 
-let viewParamTipe = (~classes: list<string>, vp: viewProps, v: BlankOr.t<DType.t>): Html.html<
+let viewParamType = (~classes: list<string>, vp: viewProps, v: BlankOr.t<DType.t>): Html.html<
   msg,
-> => ViewBlankOr.viewTipe(~classes, ~enterable=true, ParamTipe, vp, v)
+> => ViewBlankOr.viewType(~classes, ~enterable=true, ParamType, vp, v)
 
 let jsDragStart: Web.Node.event => unit = %raw(
   "function(e){ e.dataTransfer.setData('text/plain', e.target.innerHTML); e.dataTransfer.effectAllowed = 'move'; }"
@@ -219,7 +219,7 @@ let viewParam = (
       list{
         killParamBtn,
         viewParamName(vp, ~classes=list{"name"}, B.fromStringID(p.name, p.nameID)),
-        viewParamTipe(vp, ~classes=list{"type"}, B.fromOptionID(p.typ, p.typeID)),
+        viewParamType(vp, ~classes=list{"type"}, B.fromOptionID(p.typ, p.typeID)),
         dragIcon,
       },
     )

--- a/client/src/core/DType.res
+++ b/client/src/core/DType.res
@@ -28,7 +28,7 @@ type rec t =
 
 let any = TVariable("any")
 
-let rec tipe2str = (t: t): string =>
+let rec type2str = (t: t): string =>
   switch t {
   | TVariable(_) => "Any"
   | TInt => "Int"
@@ -51,7 +51,7 @@ let rec tipe2str = (t: t): string =>
   | TUuid => "UUID"
   | TErrorRail => "ErrorRail"
   | TResult(_) => "Result"
-  | TDbList(a) => "[" ++ (tipe2str(a) ++ "]")
+  | TDbList(a) => "[" ++ (type2str(a) ++ "]")
   | TUserType(name, _) => name
   | TBytes => "Bytes"
   | TRecord(_) => "Record"

--- a/client/src/core/Decoders.res
+++ b/client/src/core/Decoders.res
@@ -8,7 +8,7 @@ open Json.Decode
 let exception_ = (j): exception_ => {
   short: field("short", string, j),
   long: field("long", optional(string), j),
-  exceptionTipe: field("tipe", string, j),
+  exceptionType: field("tipe", string, j),
   actual: field("actual", optional(string), j),
   actualType: field("actual_tipe", optional(string), j),
   expected: field("expected", optional(string), j),

--- a/client/src/core/Function.res
+++ b/client/src/core/Function.res
@@ -57,7 +57,7 @@ let fromUserFn = (f: ProgramTypes.UserFunction.t): option<t> => {
 let fromPkgFn = (pkgFn: ProgramTypes.Package.Fn.t): t => {
   let paramOfPkgFnParam = (pkgFnParam: ProgramTypes.Package.Parameter.t): BuiltInFn.Param.t => {
     name: pkgFnParam.name,
-    typ: pkgFnParam.tipe,
+    typ: pkgFnParam.typ,
     description: pkgFnParam.description,
     args: list{},
   }

--- a/client/src/core/ProgramTypes.res
+++ b/client/src/core/ProgramTypes.res
@@ -896,7 +896,7 @@ module Op = {
     | AddDBCol(t, cn, ct) => ev("AddDBCol", list{tlid(t), id(cn), id(ct)})
     | SetDBColName(t, i, name) => ev("SetDBColName", list{tlid(t), id(i), string(name)})
     | ChangeDBColName(t, i, name) => ev("ChangeDBColName", list{tlid(t), id(i), string(name)})
-    | SetDBColType(t, i, tipe) => ev("SetDBColType", list{tlid(t), id(i), string(tipe)})
+    | SetDBColType(t, i, typ) => ev("SetDBColType", list{tlid(t), id(i), string(typ)})
     | ChangeDBColType(t, i, name) => ev("ChangeDBColType", list{tlid(t), id(i), string(name)})
     | DeleteDBCol(t, i) => ev("DeleteDBCol", list{tlid(t), id(i)})
     | TLSavepoint(t) => ev("TLSavepoint", list{tlid(t)})
@@ -932,11 +932,8 @@ module Op = {
           "ChangeDBColName",
           variant3((t, i, name) => ChangeDBColName(t, i, name), tlid, id, string),
         ),
-        ("SetDBColType", variant3((t, i, tipe) => SetDBColType(t, i, tipe), tlid, id, string)),
-        (
-          "ChangeDBColType",
-          variant3((t, i, tipe) => ChangeDBColType(t, i, tipe), tlid, id, string),
-        ),
+        ("SetDBColType", variant3((t, i, typ) => SetDBColType(t, i, typ), tlid, id, string)),
+        ("ChangeDBColType", variant3((t, i, typ) => ChangeDBColType(t, i, typ), tlid, id, string)),
         ("DeleteDBCol", variant2((t, i) => DeleteDBCol(t, i), tlid, id)),
         ("TLSavepoint", variant1(t => TLSavepoint(t), tlid)),
         ("UndoTL", variant1(t => UndoTL(t), tlid)),
@@ -964,14 +961,14 @@ module Package = {
     @ppx.deriving(show({with_path: false}))
     type rec t = {
       name: string,
-      tipe: DType.t,
+      typ: DType.t,
       description: string,
     }
     let decode = (j: Js.Json.t): t => {
       open Json.Decode
       {
         name: field("name", string, j),
-        tipe: field("typ", DType.decode, j),
+        typ: field("typ", DType.decode, j),
         description: field("description", string, j),
       }
     }
@@ -979,7 +976,7 @@ module Package = {
       open Json.Encode
       object_(list{
         ("name", string(p.name)),
-        ("typ", DType.encode(p.tipe)),
+        ("typ", DType.encode(p.typ)),
         ("description", string(p.description)),
       })
     }

--- a/client/src/core/Types.res
+++ b/client/src/core/Types.res
@@ -47,7 +47,7 @@ let opaque = (msg, fmt, _) => {
 type rec exception_ = {
   short: string,
   long: option<string>,
-  exceptionTipe: string,
+  exceptionType: string,
   actual: option<string>,
   actualType: option<string>,
   result: option<string>,
@@ -92,12 +92,12 @@ and blankOrData =
   | PDBColName(BlankOr.t<string>)
   | PDBColType(BlankOr.t<DType.t>)
   | PFnName(BlankOr.t<string>)
-  | PFnReturnTipe(BlankOr.t<DType.t>) // CLEANUP rename
+  | PFnReturnType(BlankOr.t<DType.t>) // CLEANUP rename
   | PParamName(BlankOr.t<string>)
-  | PParamTipe(BlankOr.t<DType.t>)
+  | PParamType(BlankOr.t<DType.t>)
   | PTypeName(BlankOr.t<string>)
   | PTypeFieldName(BlankOr.t<string>)
-  | PTypeFieldTipe(BlankOr.t<DType.t>) // CLEANUP rename
+  | PTypeFieldType(BlankOr.t<DType.t>) // CLEANUP rename
 
 @ppx.deriving(show({with_path: false}))
 and blankOrType =
@@ -108,12 +108,12 @@ and blankOrType =
   | DBColName
   | DBColType
   | FnName
-  | FnReturnTipe
+  | FnReturnType
   | ParamName
-  | ParamTipe
+  | ParamType
   | TypeName
   | TypeFieldName
-  | TypeFieldTipe
+  | TypeFieldType
 
 // ----------------------
 // Toplevels
@@ -144,7 +144,7 @@ and toplevel =
   | TLDB(PT.DB.t)
   | TLPmFunc(PT.Package.Fn.t)
   | TLFunc(PT.UserFunction.t)
-  | TLTipe(PT.UserType.t)
+  | TLType(PT.UserType.t)
 
 and packageFns = TLID.Dict.t<PT.Package.Fn.t>
 

--- a/client/src/fluid/Commands.res
+++ b/client/src/fluid/Commands.res
@@ -111,13 +111,13 @@ let commands: list<AppTypes.fluidCmd> = {
       commandName: "create-type",
       action: (m, tl, id) => {
         let tlid = TL.id(tl)
-        let tipe =
+        let typ =
           Analysis.getSelectedTraceID(m, tlid)
           |> Option.andThen(~f=Analysis.getLiveValue(m, id))
           |> Refactor.generateUserType
 
-        switch tipe {
-        | Ok(tipe) => AddOps(list{SetType(tipe)}, FocusNext(tipe.tlid, Some(tipe.nameID)))
+        switch typ {
+        | Ok(typ) => AddOps(list{SetType(typ)}, FocusNext(typ.tlid, Some(typ.nameID)))
         | Error(s) => Model.updateErrorMod(Error.set("Can't create-type: " ++ s))
         }
       },

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -1505,10 +1505,10 @@ let replacePartialWithArguments = (props: props, ~newExpr: E.t, id: id, ast: Flu
     p2: option<(string, string, E.t, int)>,
   ): compareParamsResult =>
     switch (p1, p2) {
-    | (Some(name, tipe, _, index), Some(name', tipe', _, index')) =>
-      if name == name' && tipe == tipe' {
+    | (Some(name, typ, _, index), Some(name', typ', _, index')) =>
+      if name == name' && typ == typ' {
         CPAligned
-      } else if tipe == tipe' && index == index' {
+      } else if typ == typ' && index == index' {
         CPTypeAndPositionMatched
       } else {
         CPNothingMatched
@@ -1592,9 +1592,9 @@ let replacePartialWithArguments = (props: props, ~newExpr: E.t, id: id, ast: Flu
           | (Some(index), _) | (None, Some(index)) =>
             let np = List.getAt(~index, newParams)
             switch (np, p) {
-            | (Some(Some(name, tipe, _, index)), Some(_, _, expr, _)) =>
+            | (Some(Some(name, typ, _, index)), Some(_, _, expr, _)) =>
               // Assign new param position index with old param info
-              Left(Some(name, tipe, expr, index))
+              Left(Some(name, typ, expr, index))
             | _ => Right(p)
             }
           | (None, None) => Right(p)

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -1446,7 +1446,7 @@ let replacePartialWithArguments = (props: props, ~newExpr: E.t, id: id, ast: Flu
       |> Option.andThen(~f=(fn: Function.t) => List.getAt(~index, fn.parameters))
       |> Option.map(~f=(p: RuntimeTypes.BuiltInFn.Param.t) => (
         p.name,
-        DType.tipe2str(p.typ),
+        DType.type2str(p.typ),
         List.getAt(~index, varExprs) |> Option.unwrap(~default=EBlank(gid())),
         index,
       ))
@@ -1638,7 +1638,7 @@ let replacePartialWithArguments = (props: props, ~newExpr: E.t, id: id, ast: Flu
         let oldParams = existingExprs |> List.mapWithIndex(~f=(i, p) => {
           // create ugly automatic variable name
           let name = "var_" ++ string_of_int(DUtil.random())
-          (name, DType.tipe2str(DType.any), p, i)
+          (name, DType.type2str(DType.any), p, i)
         })
 
         (wrapWithLets(~expr=newExpr, oldParams), ctForExpr(newExpr))

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -100,15 +100,15 @@ let asTypeStrings = (item: item): (list<string>, string) =>
   | FACFunction(f) =>
     f.parameters
     |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
-    |> List.map(~f=DType.tipe2str)
-    |> (s => (s, DType.tipe2str(f.returnType)))
+    |> List.map(~f=DType.type2str)
+    |> (s => (s, DType.type2str(f.returnType)))
   | FACField(_) => (list{}, "field")
   | FACVariable(_, odv) =>
     odv
-    |> Option.map(~f=(dv: RT.Dval.t) => dv |> RT.Dval.toType |> DType.tipe2str)
+    |> Option.map(~f=(dv: RT.Dval.t) => dv |> RT.Dval.toType |> DType.type2str)
     |> Option.unwrap(~default="variable")
     |> (r => (list{}, r))
-  | FACSecret(_, dv) => (list{}, dv |> RT.Dval.toType |> DType.tipe2str)
+  | FACSecret(_, dv) => (list{}, dv |> RT.Dval.toType |> DType.type2str)
   | FACDatastore(_) => (list{}, "datastore")
   | FACMatchPattern(_, FMPAVariable(_)) => (list{}, "variable")
   | FACConstructorName(name, _) | FACMatchPattern(_, FMPAConstructor(name, _)) =>
@@ -693,9 +693,9 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
     let acFirstArgType = asTypeStrings(item) |> Tuple2.first |> List.head
     let typeInfo = switch acFirstArgType {
     | None => list{Html.text(" takes no arguments.")}
-    | Some(tipeStr) => list{
+    | Some(typeStr) => list{
         Html.text(" takes a "),
-        Html.span(list{Attrs.class'("type")}, list{Html.text(tipeStr)}),
+        Html.span(list{Attrs.class'("type")}, list{Html.text(typeStr)}),
         Html.text(" as its first argument."),
       }
     }
@@ -705,7 +705,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
       list{
         Html.span(list{Attrs.class'("err")}, list{Html.text("Type error: ")}),
         Html.text("A value of type "),
-        Html.span(list{Attrs.class'("type")}, list{Html.text(DType.tipe2str(typ))}),
+        Html.span(list{Attrs.class'("type")}, list{Html.text(DType.type2str(typ))}),
         Html.text(" is being piped into this function call, but "),
         Html.span(list{Attrs.class'("fn")}, list{Html.text(acFunction)}),
         ...typeInfo,
@@ -725,7 +725,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
         Html.text(" expects "),
         Html.span(list{Attrs.class'("param")}, list{Html.text(paramName)}),
         Html.text(" to be a "),
-        Html.span(list{Attrs.class'("type")}, list{Html.text(DType.tipe2str(returnType))}),
+        Html.span(list{Attrs.class'("type")}, list{Html.text(DType.type2str(returnType))}),
         Html.text(", but "),
         Html.span(list{Attrs.class'("fn")}, list{Html.text(acFunction)}),
         Html.text(" returns a "),
@@ -749,7 +749,7 @@ let documentationForFunction = (
     list{Attrs.class("returnType")},
     list{
       Html.text("Returns: "),
-      Html.span(list{Attrs.class("type")}, list{Html.text(DType.tipe2str(f.returnType))}),
+      Html.span(list{Attrs.class("type")}, list{Html.text(DType.type2str(f.returnType))}),
     },
   )
 

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -122,12 +122,12 @@ let asTypeStrings = (item: item): (list<string>, string) =>
       (list{}, "unknown")
     }
   | FACLiteral(lit) =>
-    let tipe = switch lit {
+    let typ = switch lit {
     | LNull => "null"
     | LBool(_) => "bool"
     }
 
-    (list{}, tipe ++ " literal")
+    (list{}, typ ++ " literal")
   | FACMatchPattern(_, FMPABool(_)) => (list{}, "boolean literal")
   | FACKeyword(_) => (list{}, "keyword")
   | FACMatchPattern(_, FMPANull) => (list{}, "null")
@@ -277,7 +277,7 @@ let typeCheck = (
   item: item,
 ): data => {
   let valid: data = {item: item, validity: FACItemValid}
-  let invalidFirstArg = tipe => {FT.AutoComplete.item: item, validity: FACItemInvalidPipedArg(tipe)}
+  let invalidFirstArg = typ => {FT.AutoComplete.item: item, validity: FACItemInvalidPipedArg(typ)}
   let invalidReturnType = {
     FT.AutoComplete.item: item,
     validity: FACItemInvalidReturnType(expectedReturnType),
@@ -688,7 +688,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
   let _validity = validity
   switch validity {
   | FACItemValid => Vdom.noNode
-  | FACItemInvalidPipedArg(tipe) =>
+  | FACItemInvalidPipedArg(typ) =>
     let acFunction = asName(item)
     let acFirstArgType = asTypeStrings(item) |> Tuple2.first |> List.head
     let typeInfo = switch acFirstArgType {
@@ -705,7 +705,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
       list{
         Html.span(list{Attrs.class'("err")}, list{Html.text("Type error: ")}),
         Html.text("A value of type "),
-        Html.span(list{Attrs.class'("type")}, list{Html.text(DType.tipe2str(tipe))}),
+        Html.span(list{Attrs.class'("type")}, list{Html.text(DType.tipe2str(typ))}),
         Html.text(" is being piped into this function call, but "),
         Html.span(list{Attrs.class'("fn")}, list{Html.text(acFunction)}),
         ...typeInfo,

--- a/client/src/fluid/FluidEditorView.res
+++ b/client/src/fluid/FluidEditorView.res
@@ -443,7 +443,7 @@ let tokensView = (p: props): Html.html<msg> => {
 }
 
 let viewErrorIndicator = (p: props, ti: FluidToken.tokenInfo): Html.html<msg> => {
-  let returnTipe = (name: string) =>
+  let returnType = (name: string) =>
     Functions.findByStr(name, p.functions)
     |> Option.map(~f=(fn: Function.t) => fn.returnType)
     |> Option.unwrap(~default=DType.any)
@@ -459,7 +459,7 @@ let viewErrorIndicator = (p: props, ti: FluidToken.tokenInfo): Html.html<msg> =>
   switch ti.token {
   | TFnName(id, _, _, fnName, Rail) =>
     let offset = string_of_int(ti.startRow) ++ "rem"
-    let icon = switch (returnTipe(fnName), liveValue(id)) {
+    let icon = switch (returnType(fnName), liveValue(id)) {
     | (TResult(_), Some(DErrorRail(DResult(Error(_))))) => Icons.darkIcon("result-error")
     | (TResult(_), v) if isEvalSuccess(v) => Icons.darkIcon("result-ok")
     | (TOption(_), Some(DErrorRail(DOption(None)))) => Icons.darkIcon("option-nothing")

--- a/client/src/fluid/FluidToken.res
+++ b/client/src/fluid/FluidToken.res
@@ -536,7 +536,7 @@ let toText = (t: t): string => {
   | TFalse(_) => "false"
   | TNullToken(_) => "null"
   | TBlank(_) => "   "
-  | TPlaceholder({placeholder: {name, tipe}, _}) => " " ++ (name ++ (" : " ++ (tipe ++ " ")))
+  | TPlaceholder({placeholder: {name, typ}, _}) => " " ++ (name ++ (" : " ++ (typ ++ " ")))
   | TPartial(_, _, str, _) => shouldntBeEmpty(str)
   | TRightPartial(_, str, _) => shouldntBeEmpty(str)
   | TLeftPartial(_, str, _) => shouldntBeEmpty(str)
@@ -604,8 +604,8 @@ let toText = (t: t): string => {
 
 let toTestText = (t: t): string => {
   let result = switch t {
-  | TPlaceholder({placeholder: {name, tipe}, _}) =>
-    let count = 1 + String.length(name) + 3 + String.length(tipe) + 1
+  | TPlaceholder({placeholder: {name, typ}, _}) =>
+    let count = 1 + String.length(name) + 3 + String.length(typ) + 1
     Caml.String.make(count, '_')
   | TBlank(_) => "___"
   | TPartialGhost(_, _, str, _) =>

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -279,7 +279,7 @@ let rec exprToTokens = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
           |> Option.andThen(~f=(fn: Function.t) => List.getAt(~index=pos, fn.parameters))
           |> Option.map(~f=(p: RuntimeTypes.BuiltInFn.Param.t): Placeholder.t => {
             name: p.name,
-            typ: DType.tipe2str(p.typ),
+            typ: DType.type2str(p.typ),
           })
 
         switch name {

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -279,7 +279,7 @@ let rec exprToTokens = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
           |> Option.andThen(~f=(fn: Function.t) => List.getAt(~index=pos, fn.parameters))
           |> Option.map(~f=(p: RuntimeTypes.BuiltInFn.Param.t): Placeholder.t => {
             name: p.name,
-            tipe: DType.tipe2str(p.typ),
+            typ: DType.tipe2str(p.typ),
           })
 
         switch name {

--- a/client/src/fluid/FluidTypes.res
+++ b/client/src/fluid/FluidTypes.res
@@ -32,7 +32,7 @@ module Token = {
     @ppx.deriving(show({with_path: false}))
     type rec t = {
       name: string,
-      tipe: string,
+      typ: string,
     }
   }
 

--- a/client/src/fluid/FluidView.res
+++ b/client/src/fluid/FluidView.res
@@ -293,7 +293,7 @@ let viewReturnValue = (vp: ViewUtils.viewProps, dragEvents: ViewUtils.domEventLi
               },
             )
           }
-        | (_, TLPmFunc(_)) | (_, TLHandler(_)) | (_, TLDB(_)) | (_, TLTipe(_)) => Vdom.noNode
+        | (_, TLPmFunc(_)) | (_, TLHandler(_)) | (_, TLDB(_)) | (_, TLType(_)) => Vdom.noNode
         }
       }
 

--- a/client/src/fluid/FluidView.res
+++ b/client/src/fluid/FluidView.res
@@ -272,8 +272,8 @@ let viewReturnValue = (vp: ViewUtils.viewProps, dragEvents: ViewUtils.domEventLi
           if Runtime.isCompatible(actualType, declaredType) {
             Vdom.noNode
           } else {
-            let actualTypeString = DType.tipe2str(actualType)
-            let declaredTypeString = DType.tipe2str(declaredType)
+            let actualTypeString = DType.type2str(actualType)
+            let declaredTypeString = DType.type2str(declaredType)
             Html.div(
               list{warningAttr},
               list{

--- a/client/src/fluid/Refactor.res
+++ b/client/src/fluid/Refactor.res
@@ -15,11 +15,11 @@ let generateFnName = (_: unit): string => "fn_" ++ (() |> Util.random |> string_
 
 let generateTypeName = (): string => "Type_" ++ (() |> Util.random |> string_of_int)
 
-let convertType = (tipe: DType.t): DType.t =>
-  switch tipe {
+let convertType = (typ: DType.t): DType.t =>
+  switch typ {
   | TIncomplete => DType.any
   | TError => DType.any
-  | _ => tipe
+  | _ => typ
   }
 
 // Call f on calls to uf across the whole AST
@@ -123,7 +123,7 @@ let isRailable = (m: model, name: FQFnName.t) =>
   |> Option.unwrap(~default=false)
 
 let putOnRail = (m: model, tl: toplevel, id: id): modification =>
-  // Only toggle onto rail iff. return tipe is TOption or TResult
+  // Only toggle onto rail iff. return typ is TOption or TResult
   TL.modifyASTMod(tl, ~f=ast =>
     FluidAST.update(id, ast, ~f=x =>
       switch x {
@@ -203,7 +203,7 @@ let extractFunction = (m: model, tl: toplevel, id: id): modification => {
     let newAST = FluidAST.replace(~replacement, id, ast)
     let astOp = TL.setASTMod(tl, newAST)
     let params = List.map(freeVars, ~f=((id, name_)) => {
-      let tipe =
+      let typ =
         Analysis.getSelectedTraceID(m, tlid)
         |> Option.andThen(~f=Analysis.getTypeOf(m, id))
         |> Option.unwrap(~default=DType.any)
@@ -212,7 +212,7 @@ let extractFunction = (m: model, tl: toplevel, id: id): modification => {
       {
         PT.UserFunction.Parameter.name: name_,
         nameID: gid(),
-        typ: Some(tipe),
+        typ: Some(typ),
         typeID: gid(),
         description: "",
       }
@@ -440,7 +440,7 @@ let generateUserType = (dv: option<RT.Dval.t>): Result.t<PT.UserType.t, string> 
          * Dates, but we decided that today is not that day. See
          * discussion at
          * https://dark-inc.slack.com/archives/C7MFHVDDW/p1562878578176700
-         * let tipe = v |> coerceType in
+         * let typ = v |> coerceType in
          */
         {PT.UserType.RecordField.name: k, nameID: gid(), typ: Some(typ), typeID: gid()}
       })

--- a/client/src/fluid/Refactor.res
+++ b/client/src/fluid/Refactor.res
@@ -297,10 +297,10 @@ let fnUseCount = (m: model, name: string): int =>
 
 let usedFn = (m: model, name: string): bool => fnUseCount(m, name) != 0
 
-let tipeUseCount = (m: model, name: string): int =>
+let typeUseCount = (m: model, name: string): int =>
   Map.get(m.usedTypes, ~key=name) |> Option.unwrap(~default=0)
 
-let usedType = (m: model, name: string): bool => tipeUseCount(m, name) != 0
+let usedType = (m: model, name: string): bool => typeUseCount(m, name) != 0
 
 let dbUseCount = (m: model, name: string): int =>
   Map.get(m.usedDBs, ~key=name) |> Option.unwrap(~default=0)
@@ -413,14 +413,14 @@ let generateEmptyFunction = (_: unit): PT.UserFunction.t => {
 }
 
 let generateEmptyUserType = (): PT.UserType.t => {
-  let tipeName = generateTypeName()
+  let typeName = generateTypeName()
   let tlid = gtlid()
   let definition = PT.UserType.Definition.Record(list{
     {name: "", nameID: gid(), typ: None, typeID: gid()},
   })
   {
     tlid: tlid,
-    name: tipeName,
+    name: typeName,
     nameID: gid(),
     version: 0,
     definition: definition,

--- a/client/src/forms/Autocomplete.res
+++ b/client/src/forms/Autocomplete.res
@@ -84,8 +84,8 @@ let asName = (aci: A.item): string =>
   | ACCronName(name) => name
   | ACCronTiming(timing) => timing
   | ACEventSpace(space) => space
-  | ACDBColType(tipe) => tipe
-  | ACParamType(tipe) => DType.tipe2str(tipe)
+  | ACDBColType(typ) => typ
+  | ACParamType(typ) => DType.tipe2str(typ)
   | ACDBName(name) => name
   | ACDBColName(name)
   | ACEventModifier(name)
@@ -93,7 +93,7 @@ let asName = (aci: A.item): string =>
   | ACParamName(name)
   | ACTypeName(name)
   | ACTypeFieldName(name) => name
-  | ACReturnType(tipe) | ACTypeFieldType(tipe) => DType.tipe2str(tipe)
+  | ACReturnType(typ) | ACTypeFieldType(typ) => DType.tipe2str(typ)
   }
 
 let asTypeString = (item: A.item): string =>
@@ -115,8 +115,8 @@ let asTypeString = (item: A.item): string =>
   | ACParamName(_) => "param name"
   | ACTypeName(_) => "type name"
   | ACTypeFieldName(_) => "type field name"
-  | ACReturnType(tipe) | ACTypeFieldType(tipe) =>
-    switch tipe {
+  | ACReturnType(typ) | ACTypeFieldType(typ) =>
+    switch typ {
     | TUserType(_, v) => "version " ++ string_of_int(v)
     | _ => "builtin"
     }
@@ -522,7 +522,7 @@ let tlGotoName = (tl: toplevel): string =>
   | TLHandler(h) => "Jump to handler: " ++ handlerDisplayName(h)
   | TLDB(db) => "Jump to DB: " ++ db.name
   | TLPmFunc(_) | TLFunc(_) => recover("can't goto function", ~debug=tl, "<invalid state>")
-  | TLType(_) => recover("can't goto tipe ", ~debug=tl, "<invalid state>")
+  | TLType(_) => recover("can't goto typ ", ~debug=tl, "<invalid state>")
   }
 
 let tlDestinations = (m: model): list<A.item> => {
@@ -545,7 +545,7 @@ let tlDestinations = (m: model): list<A.item> => {
 // Create the list
 // ------------------------------------
 
-/* Types from Types.tipe that aren't included:
+/* Types from Types.typ that aren't included:
   - TChar: TODO include once Characters are more easily add-able within code
   - TNull: trying to get rid of this, so don't spread it
   - TIncomplete: makes no sense to pass to a function
@@ -807,9 +807,9 @@ let documentationForItem = (aci: A.item): option<list<Vdom.t<'a>>> => {
   | ACCronName(_) => simpleDoc("Name of your CRON job")
   | ACHTTPRoute(name) => simpleDoc("Handle HTTP requests made to " ++ name)
   | ACDBName(name) => simpleDoc("Set the DB's name to " ++ name)
-  | ACDBColType(tipe) => simpleDoc("This field will be a " ++ tipe)
-  | ACParamType(tipe) => simpleDoc("This parameter will be a " ++ DType.tipe2str(tipe))
-  | ACTypeFieldType(tipe) => simpleDoc("This parameter will be a " ++ DType.tipe2str(tipe))
+  | ACDBColType(typ) => simpleDoc("This field will be a " ++ typ)
+  | ACParamType(typ) => simpleDoc("This parameter will be a " ++ DType.tipe2str(typ))
+  | ACTypeFieldType(typ) => simpleDoc("This parameter will be a " ++ DType.tipe2str(typ))
   | ACDBColName(name) => simpleDoc("Set the DB's column name to" ++ name)
   | ACEventModifier(name) => simpleDoc("Set event modifier to " ++ name)
   | ACFnName(fnName) => simpleDoc("Set function name to " ++ fnName)

--- a/client/src/forms/Autocomplete.res
+++ b/client/src/forms/Autocomplete.res
@@ -85,7 +85,7 @@ let asName = (aci: A.item): string =>
   | ACCronTiming(timing) => timing
   | ACEventSpace(space) => space
   | ACDBColType(typ) => typ
-  | ACParamType(typ) => DType.tipe2str(typ)
+  | ACParamType(typ) => DType.type2str(typ)
   | ACDBName(name) => name
   | ACDBColName(name)
   | ACEventModifier(name)
@@ -93,7 +93,7 @@ let asName = (aci: A.item): string =>
   | ACParamName(name)
   | ACTypeName(name)
   | ACTypeFieldName(name) => name
-  | ACReturnType(typ) | ACTypeFieldType(typ) => DType.tipe2str(typ)
+  | ACReturnType(typ) | ACTypeFieldType(typ) => DType.type2str(typ)
   }
 
 let asTypeString = (item: A.item): string =>
@@ -808,8 +808,8 @@ let documentationForItem = (aci: A.item): option<list<Vdom.t<'a>>> => {
   | ACHTTPRoute(name) => simpleDoc("Handle HTTP requests made to " ++ name)
   | ACDBName(name) => simpleDoc("Set the DB's name to " ++ name)
   | ACDBColType(typ) => simpleDoc("This field will be a " ++ typ)
-  | ACParamType(typ) => simpleDoc("This parameter will be a " ++ DType.tipe2str(typ))
-  | ACTypeFieldType(typ) => simpleDoc("This parameter will be a " ++ DType.tipe2str(typ))
+  | ACParamType(typ) => simpleDoc("This parameter will be a " ++ DType.type2str(typ))
+  | ACTypeFieldType(typ) => simpleDoc("This parameter will be a " ++ DType.type2str(typ))
   | ACDBColName(name) => simpleDoc("Set the DB's column name to" ++ name)
   | ACEventModifier(name) => simpleDoc("Set event modifier to " ++ name)
   | ACFnName(fnName) => simpleDoc("Set function name to " ++ fnName)

--- a/client/src/forms/BlankOrData.res
+++ b/client/src/forms/BlankOrData.res
@@ -6,12 +6,12 @@ type rec t =
   | PDBColName(BlankOr.t<string>)
   | PDBColType(BlankOr.t<string>)
   | PFnName(BlankOr.t<string>)
-  | PFnReturnTipe(BlankOr.t<DType.t>)
+  | PFnReturnType(BlankOr.t<DType.t>)
   | PParamName(BlankOr.t<string>)
-  | PParamTipe(BlankOr.t<DType.t>)
+  | PParamType(BlankOr.t<DType.t>)
   | PTypeName(BlankOr.t<string>)
   | PTypeFieldName(BlankOr.t<string>)
-  | PTypeFieldTipe(BlankOr.t<DType.t>)
+  | PTypeFieldType(BlankOr.t<DType.t>)
 
 let decode = (j: Js.Json.t): t => {
   open Json_decode_extended
@@ -26,9 +26,9 @@ let decode = (j: Js.Json.t): t => {
       ("PDBColType", dv1(x => PDBColType(x), BlankOr.decode(string))),
       ("PFnName", dv1(x => PFnName(x), BlankOr.decode(string))),
       ("PParamName", dv1(x => PParamName(x), BlankOr.decode(string))),
-      ("PParamTipe", dv1(x => PParamTipe(x), BlankOr.decode(DType.decode))),
+      ("PParamTipe", dv1(x => PParamType(x), BlankOr.decode(DType.decode))),
       ("PTypeFieldName", dv1(x => PTypeFieldName(x), BlankOr.decode(string))),
-      ("PTypeFieldTipe", dv1(x => PTypeFieldTipe(x), BlankOr.decode(DType.decode))),
+      ("PTypeFieldTipe", dv1(x => PTypeFieldType(x), BlankOr.decode(DType.decode))),
     },
     j,
   )
@@ -45,11 +45,11 @@ let encode = (bd: t): Js.Json.t => {
   | PDBColName(colname) => ev("PDBColName", list{BlankOr.encode(string, colname)})
   | PDBColType(coltype) => ev("PDBColType", list{BlankOr.encode(string, coltype)})
   | PFnName(msg) => ev("PFnName", list{BlankOr.encode(string, msg)})
-  | PFnReturnTipe(msg) => ev("PFnReturnTipe", list{BlankOr.encode(DType.encode, msg)})
+  | PFnReturnType(msg) => ev("PFnReturnTipe", list{BlankOr.encode(DType.encode, msg)})
   | PParamName(msg) => ev("PParamName", list{BlankOr.encode(string, msg)})
-  | PParamTipe(msg) => ev("PParamTipe", list{BlankOr.encode(DType.encode, msg)})
+  | PParamType(msg) => ev("PParamTipe", list{BlankOr.encode(DType.encode, msg)})
   | PTypeName(n) => ev("PTypeName", list{BlankOr.encode(string, n)})
   | PTypeFieldName(n) => ev("PTypeFieldName", list{BlankOr.encode(string, n)})
-  | PTypeFieldTipe(t) => ev("PTypeFieldTipe", list{BlankOr.encode(DType.encode, t)})
+  | PTypeFieldType(t) => ev("PTypeFieldTipe", list{BlankOr.encode(DType.encode, t)})
   }
 }

--- a/client/src/forms/Entry.res
+++ b/client/src/forms/Entry.res
@@ -585,9 +585,9 @@ let submitACItem = (
           wrapNew(list{SetFunction(new_), ...changedNames}, newPD)
         }
 
-      | (PFnReturnType(_), ACReturnType(tipe), _) => replace(PFnReturnType(F(id, tipe)))
+      | (PFnReturnType(_), ACReturnType(typ), _) => replace(PFnReturnType(F(id, typ)))
       | (PParamName(_), ACParamName(value), _) => replace(PParamName(F(id, value)))
-      | (PParamType(_), ACParamType(tipe), _) => replace(PParamType(F(id, tipe)))
+      | (PParamType(_), ACParamType(typ), _) => replace(PParamType(F(id, typ)))
       | (PTypeName(_), ACTypeName(value), TLType(old)) =>
         if List.member(~value, UserTypes.allNames(m.userTypes)) {
           Model.updateErrorMod(Error.set("There is already a Type named " ++ value))
@@ -598,7 +598,7 @@ let submitACItem = (
           wrapNew(list{SetType(new_), ...changedNames}, newPD)
         }
       | (PTypeFieldName(_), ACTypeFieldName(value), _) => replace(PTypeFieldName(F(id, value)))
-      | (PTypeFieldType(_), ACTypeFieldType(tipe), _) => replace(PTypeFieldType(F(id, tipe)))
+      | (PTypeFieldType(_), ACTypeFieldType(typ), _) => replace(PTypeFieldType(F(id, typ)))
       | (pd, item, _) =>
         ReplaceAllModificationsWithThisOne(
           m => {

--- a/client/src/forms/Entry.res
+++ b/client/src/forms/Entry.res
@@ -464,7 +464,7 @@ let submitACItem = (
           AddOps(list{RenameDBname(tlid, value), ...varrefs}, FocusNothing)
         }
       | (PDBColType(ct), ACDBColType(value), TLDB(_)) =>
-        if B.toOption(ct) |> Option.map(~f=DType.tipe2str) == Some(value) {
+        if B.toOption(ct) |> Option.map(~f=DType.type2str) == Some(value) {
           // TODO: I think this should actually be STCaret with a target indicating the end of the ac item?
           Select(tlid, STID(id))
         } else if B.isBlank(ct) {

--- a/client/src/forms/Entry.res
+++ b/client/src/forms/Entry.res
@@ -383,15 +383,15 @@ let validate = (tl: toplevel, pd: blankOrData, value: string): option<string> =>
     } else {
       v(AC.fnNameValidator, "function name")
     }
-  | PFnReturnTipe(_) => v(AC.paramTypeValidator, "return type")
+  | PFnReturnType(_) => v(AC.paramTypeValidator, "return type")
   | PParamName(oldParam) =>
     v(AC.paramNameValidator, "param name") |> Option.orElse(
       AC.validateFnParamNameFree(tl, oldParam, value),
     )
-  | PParamTipe(_) => v(AC.paramTypeValidator, "param type")
+  | PParamType(_) => v(AC.paramTypeValidator, "param type")
   | PTypeName(_) => v(AC.typeNameValidator, "type name")
   | PTypeFieldName(_) => v(AC.fieldNameValidator, "type field name")
-  | PTypeFieldTipe(_) => v(AC.paramTypeValidator, "type field type")
+  | PTypeFieldType(_) => v(AC.paramTypeValidator, "type field type")
   }
 }
 
@@ -439,7 +439,7 @@ let submitACItem = (
           switch newtl {
           | TLHandler(h) => wrapNew(list{SetHandler(tlid, h.pos, h)}, next)
           | TLFunc(f) => wrapNew(list{SetFunction(f)}, next)
-          | TLTipe(t) => wrapNew(list{SetType(t)}, next)
+          | TLType(t) => wrapNew(list{SetType(t)}, next)
           | TLPmFunc(_) => recover("no vars in pmfn", ~debug=tl, Mod.NoChange)
           | TLDB(_) => recover("no vars in DBs", ~debug=tl, Mod.NoChange)
           }
@@ -585,20 +585,20 @@ let submitACItem = (
           wrapNew(list{SetFunction(new_), ...changedNames}, newPD)
         }
 
-      | (PFnReturnTipe(_), ACReturnTipe(tipe), _) => replace(PFnReturnTipe(F(id, tipe)))
+      | (PFnReturnType(_), ACReturnType(tipe), _) => replace(PFnReturnType(F(id, tipe)))
       | (PParamName(_), ACParamName(value), _) => replace(PParamName(F(id, value)))
-      | (PParamTipe(_), ACParamTipe(tipe), _) => replace(PParamTipe(F(id, tipe)))
-      | (PTypeName(_), ACTypeName(value), TLTipe(old)) =>
+      | (PParamType(_), ACParamType(tipe), _) => replace(PParamType(F(id, tipe)))
+      | (PTypeName(_), ACTypeName(value), TLType(old)) =>
         if List.member(~value, UserTypes.allNames(m.userTypes)) {
           Model.updateErrorMod(Error.set("There is already a Type named " ++ value))
         } else {
           let newPD = PTypeName(F(id, value))
           let new_ = UserTypes.replace(pd, newPD, old)
-          let changedNames = Refactor.renameUserTipe(m, old, new_)
+          let changedNames = Refactor.renameUserType(m, old, new_)
           wrapNew(list{SetType(new_), ...changedNames}, newPD)
         }
       | (PTypeFieldName(_), ACTypeFieldName(value), _) => replace(PTypeFieldName(F(id, value)))
-      | (PTypeFieldTipe(_), ACTypeFieldTipe(tipe), _) => replace(PTypeFieldTipe(F(id, tipe)))
+      | (PTypeFieldType(_), ACTypeFieldType(tipe), _) => replace(PTypeFieldType(F(id, tipe)))
       | (pd, item, _) =>
         ReplaceAllModificationsWithThisOne(
           m => {

--- a/client/src/forms/KeyPress.res
+++ b/client/src/forms/KeyPress.res
@@ -90,13 +90,13 @@ let defaultHandler = (event: Keyboard.keyEvent, m: AppTypes.model): modification
         // if we're selecting a toplevel only, deselect.
         | None => Deselect
         }
-      | (Key.Enter, Some(TLTipe(t) as tl)) if event.shiftKey =>
+      | (Key.Enter, Some(TLType(t) as tl)) if event.shiftKey =>
         switch mId {
         | Some(id) =>
           switch TL.find(tl, id) {
           | Some(PTypeName(_))
           | Some(PTypeFieldName(_))
-          | Some(PTypeFieldTipe(_)) =>
+          | Some(PTypeFieldType(_)) =>
             let replacement = UserTypes.extend(t)
             AddOps(list{SetType(replacement)}, FocusNext(tlid, Some(id)))
           | _ => NoChange
@@ -110,7 +110,7 @@ let defaultHandler = (event: Keyboard.keyEvent, m: AppTypes.model): modification
         switch mId {
         | Some(id) =>
           switch TL.find(tl, id) {
-          | Some(PParamTipe(_)) | Some(PParamName(_)) | Some(PFnName(_)) =>
+          | Some(PParamType(_)) | Some(PParamName(_)) | Some(PFnName(_)) =>
             Refactor.addFunctionParameter(m, f, id)
           | _ => NoChange
           }

--- a/client/src/forms/Pointer.res
+++ b/client/src/forms/Pointer.res
@@ -16,12 +16,12 @@ let typeOf = (pd: blankOrData): blankOrType =>
   | PDBColName(_) => DBColName
   | PDBColType(_) => DBColType
   | PFnName(_) => FnName
-  | PFnReturnTipe(_) => FnReturnTipe
+  | PFnReturnType(_) => FnReturnType
   | PParamName(_) => ParamName
-  | PParamTipe(_) => ParamTipe
+  | PParamType(_) => ParamType
   | PTypeName(_) => TypeName
   | PTypeFieldName(_) => TypeFieldName
-  | PTypeFieldTipe(_) => TypeFieldTipe
+  | PTypeFieldType(_) => TypeFieldType
   }
 
 let toID = (pd: blankOrData): id =>
@@ -33,12 +33,12 @@ let toID = (pd: blankOrData): id =>
   | PDBColName(d) => B.toID(d)
   | PDBColType(d) => B.toID(d)
   | PFnName(d) => B.toID(d)
-  | PFnReturnTipe(d) => B.toID(d)
+  | PFnReturnType(d) => B.toID(d)
   | PParamName(d) => B.toID(d)
-  | PParamTipe(d) => B.toID(d)
+  | PParamType(d) => B.toID(d)
   | PTypeName(d) => B.toID(d)
   | PTypeFieldName(d) => B.toID(d)
-  | PTypeFieldTipe(d) => B.toID(d)
+  | PTypeFieldType(d) => B.toID(d)
   }
 
 let isBlank = (pd: blankOrData): bool =>
@@ -54,9 +54,9 @@ let isBlank = (pd: blankOrData): bool =>
   | PTypeFieldName(str) =>
     B.isBlank(str)
   | PDBColType(t)
-  | PFnReturnTipe(t)
-  | PTypeFieldTipe(t)
-  | PParamTipe(t) =>
+  | PFnReturnType(t)
+  | PTypeFieldType(t)
+  | PParamType(t) =>
     B.isBlank(t)
   }
 
@@ -73,7 +73,7 @@ let toContent = (pd: blankOrData): string => {
   | PTypeName(d)
   | PTypeFieldName(d) =>
     bs2s(d)
-  | PFnReturnTipe(d) | PParamTipe(d) | PTypeFieldTipe(d) | PDBColType(d) =>
+  | PFnReturnType(d) | PParamType(d) | PTypeFieldType(d) | PDBColType(d) =>
     d |> B.toOption |> Option.map(~f=DType.tipe2str) |> Option.unwrap(~default="")
   }
 }

--- a/client/src/forms/Pointer.res
+++ b/client/src/forms/Pointer.res
@@ -74,6 +74,6 @@ let toContent = (pd: blankOrData): string => {
   | PTypeFieldName(d) =>
     bs2s(d)
   | PFnReturnType(d) | PParamType(d) | PTypeFieldType(d) | PDBColType(d) =>
-    d |> B.toOption |> Option.map(~f=DType.tipe2str) |> Option.unwrap(~default="")
+    d |> B.toOption |> Option.map(~f=DType.type2str) |> Option.unwrap(~default="")
   }
 }

--- a/client/src/forms/ViewBlankOr.res
+++ b/client/src/forms/ViewBlankOr.res
@@ -93,12 +93,12 @@ let placeHolderFor = (vp: ViewUtils.viewProps, pt: blankOrType): string =>
   | DBColName => "db field name"
   | DBColType => "db type"
   | FnName => "function name"
-  | FnReturnTipe => "return type"
+  | FnReturnType => "return type"
   | ParamName => "param name"
-  | ParamTipe => "param type"
+  | ParamType => "param type"
   | TypeName => "type name"
   | TypeFieldName => "field name"
-  | TypeFieldTipe => "field type"
+  | TypeFieldType => "field type"
   }
 
 let viewBlankOr = (
@@ -147,7 +147,7 @@ let viewText = (
   str: BlankOr.t<string>,
 ): Html.html<msg> => viewBlankOr(~enterable, ~classes, Html.text, pt, vp, str)
 
-let viewTipe = (
+let viewType = (
   ~enterable: bool,
   ~classes: list<string>,
   pt: blankOrType,

--- a/client/src/forms/ViewBlankOr.res
+++ b/client/src/forms/ViewBlankOr.res
@@ -154,6 +154,6 @@ let viewType = (
   vp: ViewUtils.viewProps,
   str: BlankOr.t<DType.t>,
 ): Html.html<msg> => {
-  let fn = t => Html.text(DType.tipe2str(t))
+  let fn = t => Html.text(DType.type2str(t))
   viewBlankOr(~enterable, ~classes, fn, pt, vp, str)
 }

--- a/client/src/package/PackageManager.res
+++ b/client/src/package/PackageManager.res
@@ -3,14 +3,14 @@ open Prelude
 let pmParamsToUserFnParams = (p: PT.Package.Parameter.t): PT.UserFunction.Parameter.t => {
   name: p.name,
   nameID: ID.generate(),
-  typ: Some(p.tipe),
+  typ: Some(p.typ),
   typeID: ID.generate(),
   description: p.description,
 }
 
 let paramData = (pfp: PT.Package.Parameter.t): list<blankOrData> => {
   let paramName = BlankOr.newF(pfp.name)
-  let paramType = BlankOr.newF(pfp.tipe)
+  let paramType = BlankOr.newF(pfp.typ)
   list{PParamName(paramName), PParamType(paramType)}
 }
 

--- a/client/src/package/PackageManager.res
+++ b/client/src/package/PackageManager.res
@@ -10,8 +10,8 @@ let pmParamsToUserFnParams = (p: PT.Package.Parameter.t): PT.UserFunction.Parame
 
 let paramData = (pfp: PT.Package.Parameter.t): list<blankOrData> => {
   let paramName = BlankOr.newF(pfp.name)
-  let paramTipe = BlankOr.newF(pfp.tipe)
-  list{PParamName(paramName), PParamTipe(paramTipe)}
+  let paramType = BlankOr.newF(pfp.tipe)
+  list{PParamName(paramName), PParamType(paramType)}
 }
 
 let allParamData = (pmf: PT.Package.Fn.t): list<blankOrData> =>

--- a/client/src/package/PackageManager.res
+++ b/client/src/package/PackageManager.res
@@ -1,9 +1,9 @@
 open Prelude
 
 let pmParamsToUserFnParams = (p: PT.Package.Parameter.t): PT.UserFunction.Parameter.t => {
-  name: "",
+  name: p.name,
   nameID: ID.generate(),
-  typ: None,
+  typ: Some(p.tipe),
   typeID: ID.generate(),
   description: p.description,
 }

--- a/client/src/toplevels/Introspect.res
+++ b/client/src/toplevels/Introspect.res
@@ -5,7 +5,7 @@ module TD = TLID.Dict
 
 let keyForHandlerSpec = (space: string, name: string): string => space ++ (":" ++ name)
 
-let keyForTipe = (name: string, version: int): string => name ++ (":" ++ Int.toString(version))
+let keyForType = (name: string, version: int): string => name ++ (":" ++ Int.toString(version))
 
 let dbsByName = (dbs: TD.t<PT.DB.t>): Map.String.t<TLID.t> =>
   dbs
@@ -47,7 +47,7 @@ let tipesByName = (uts: TD.t<PT.UserType.t>): Map.String.t<TLID.t> =>
   |> Map.mapValues(~f=(ut: PT.UserType.t) => {
     let name = ut.name
     let version = ut.version
-    let key = keyForTipe(name, version)
+    let key = keyForType(name, version)
     (key, ut.tlid)
   })
   |> Map.String.fromList
@@ -177,7 +177,7 @@ let findUsagesInFunctionParams = (tipes: Map.String.t<TLID.t>, fn: PT.UserFuncti
   |> List.filterMap(~f=(p: PT.UserFunction.Parameter.t) =>
     p.typ
     |> Option.map(~f=DType.tipe2str)
-    |> Option.map(~f=t => keyForTipe(t, version))
+    |> Option.map(~f=t => keyForType(t, version))
     |> Option.andThen(~f=key => Map.get(~key, tipes))
     |> Option.thenAlso(~f=_ => Some(p.typeID))
   )

--- a/client/src/toplevels/Introspect.res
+++ b/client/src/toplevels/Introspect.res
@@ -42,7 +42,7 @@ let packageFunctionsByName = (fns: TD.t<PT.Package.Fn.t>): Map.String.t<TLID.t> 
   |> Map.mapValues(~f=(fn: PT.Package.Fn.t) => (FQFnName.PackageFnName.toString(fn.name), fn.tlid))
   |> Map.String.fromList
 
-let tipesByName = (uts: TD.t<PT.UserType.t>): Map.String.t<TLID.t> =>
+let typesByName = (uts: TD.t<PT.UserType.t>): Map.String.t<TLID.t> =>
   uts
   |> Map.mapValues(~f=(ut: PT.UserType.t) => {
     let name = ut.name
@@ -167,18 +167,18 @@ let findUsagesInAST = (
   )
   |> List.map(~f=((usedIn, id)) => {refersTo: tlid, usedIn: usedIn, id: id})
 
-let findUsagesInFunctionParams = (tipes: Map.String.t<TLID.t>, fn: PT.UserFunction.t): list<
+let findUsagesInFunctionParams = (types: Map.String.t<TLID.t>, fn: PT.UserFunction.t): list<
   usage,
 > => {
   // Versions are slightly aspirational, and we don't have them in most of
-  // the places we use tipes, including here
+  // the places we use types, including here
   let version = 0
   fn.parameters
   |> List.filterMap(~f=(p: PT.UserFunction.Parameter.t) =>
     p.typ
-    |> Option.map(~f=DType.tipe2str)
+    |> Option.map(~f=DType.type2str)
     |> Option.map(~f=t => keyForType(t, version))
-    |> Option.andThen(~f=key => Map.get(~key, tipes))
+    |> Option.andThen(~f=key => Map.get(~key, types))
     |> Option.thenAlso(~f=_ => Some(p.typeID))
   )
   |> List.map(~f=((usedIn, id)) => {refersTo: fn.tlid, usedIn: usedIn, id: id})
@@ -190,7 +190,7 @@ let getUsageFor = (
   ~handlers: Map.String.t<TLID.t>,
   ~functions: Map.String.t<TLID.t>,
   ~packageFunctions: Map.String.t<TLID.t>,
-  ~tipes: Map.String.t<TLID.t>,
+  ~types: Map.String.t<TLID.t>,
 ): list<usage> => {
   let astUsages =
     TL.getAST(tl)
@@ -201,10 +201,10 @@ let getUsageFor = (
 
   let fnUsages =
     TL.asUserFunction(tl)
-    |> Option.map(~f=findUsagesInFunctionParams(tipes))
+    |> Option.map(~f=findUsagesInFunctionParams(types))
     |> Option.unwrap(~default=list{})
 
-  // TODO: tipes in other tipes
+  // TODO: types in other types
   Belt.List.concat(astUsages, fnUsages)
 }
 
@@ -213,7 +213,7 @@ let refreshUsages = (m: AppTypes.model, tlids: list<TLID.t>): AppTypes.model => 
   let handlers = handlersByName(m.handlers)
   let functions = functionsByName(m.userFunctions)
   let packageFunctions = packageFunctionsByName(m.functions.packageFunctions)
-  let tipes = tipesByName(m.userTypes)
+  let types = typesByName(m.userTypes)
   /* We need to overwrite the already-stored results for the passed-in TLIDs.
    * So we clear tlRefers for these tlids, and remove them from the inner set
    * of tlUsedIn. */
@@ -227,7 +227,7 @@ let refreshUsages = (m: AppTypes.model, tlids: list<TLID.t>): AppTypes.model => 
     |> List.filterMap(~f=tlid => {
       let tl = TL.get(m, tlid)
       Option.map(tl, ~f=tl =>
-        getUsageFor(tl, ~datastores, ~handlers, ~functions, ~packageFunctions, ~tipes)
+        getUsageFor(tl, ~datastores, ~handlers, ~functions, ~packageFunctions, ~types)
       )
     })
     |> List.flatten

--- a/client/src/toplevels/Toplevel.res
+++ b/client/src/toplevels/Toplevel.res
@@ -50,7 +50,7 @@ let pos = tl =>
   | TLDB(db) => db.pos
   | TLPmFunc(f) => recover("no pos in a func", ~debug=f.tlid, ({x: 0, y: 0}: Pos.t))
   | TLFunc(f) => recover("no pos in a func", ~debug=f.tlid, ({x: 0, y: 0}: Pos.t))
-  | TLType(t) => recover("no pos in a tipe", ~debug=t.tlid, ({x: 0, y: 0}: Pos.t))
+  | TLType(t) => recover("no pos in a typ", ~debug=t.tlid, ({x: 0, y: 0}: Pos.t))
   }
 
 let remove = (m: model, tl: toplevel): model => {
@@ -278,10 +278,10 @@ let replace = (p: blankOrData, replacement: blankOrData, tl: toplevel): toplevel
     }
   | PTypeName(_) | PTypeFieldName(_) | PTypeFieldType(_) =>
     switch asUserType(tl) {
-    | Some(tipe) =>
-      let newTL = UserTypes.replace(p, replacement, tipe)
+    | Some(typ) =>
+      let newTL = UserTypes.replace(p, replacement, typ)
       TLType(newTL)
-    | _ => recover("Changing tipe metadata on non-tipe", ~debug=replacement, tl)
+    | _ => recover("Changing typ metadata on non-typ", ~debug=replacement, tl)
     }
   }
 }

--- a/client/src/toplevels/Toplevel.res
+++ b/client/src/toplevels/Toplevel.res
@@ -18,7 +18,7 @@ let name = (tl: toplevel): string =>
   | TLDB(db) => "DB: " ++ db.name
   | TLPmFunc(fn) => "Package Manager Func: " ++ FQFnName.PackageFnName.toString(fn.name)
   | TLFunc(f) => "Func: " ++ f.name
-  | TLTipe(t) => "Type: " ++ t.name
+  | TLType(t) => "Type: " ++ t.name
   }
 
 let sortkey = (tl: toplevel): string =>
@@ -32,7 +32,7 @@ let sortkey = (tl: toplevel): string =>
   | TLDB(db) => db.name
   | TLPmFunc(f) => FQFnName.PackageFnName.toString(f.name)
   | TLFunc(f) => f.name
-  | TLTipe(t) => t.name
+  | TLType(t) => t.name
   }
 
 let id = tl =>
@@ -41,7 +41,7 @@ let id = tl =>
   | TLDB(db) => db.tlid
   | TLFunc(f) => f.tlid
   | TLPmFunc(f) => f.tlid
-  | TLTipe(t) => t.tlid
+  | TLType(t) => t.tlid
   }
 
 let pos = tl =>
@@ -50,7 +50,7 @@ let pos = tl =>
   | TLDB(db) => db.pos
   | TLPmFunc(f) => recover("no pos in a func", ~debug=f.tlid, ({x: 0, y: 0}: Pos.t))
   | TLFunc(f) => recover("no pos in a func", ~debug=f.tlid, ({x: 0, y: 0}: Pos.t))
-  | TLTipe(t) => recover("no pos in a tipe", ~debug=t.tlid, ({x: 0, y: 0}: Pos.t))
+  | TLType(t) => recover("no pos in a tipe", ~debug=t.tlid, ({x: 0, y: 0}: Pos.t))
   }
 
 let remove = (m: model, tl: toplevel): model => {
@@ -59,7 +59,7 @@ let remove = (m: model, tl: toplevel): model => {
   | TLHandler(h) => Handlers.remove(m, h)
   | TLDB(db) => DB.remove(m, db)
   | TLFunc(f) => UserFunctions.remove(m, f)
-  | TLTipe(ut) => UserTypes.remove(m, ut)
+  | TLType(ut) => UserTypes.remove(m, ut)
   | TLPmFunc(_) => // Cannot remove a package manager function
     m
   }
@@ -84,7 +84,7 @@ let ufToTL = (uf: PT.UserFunction.t): toplevel => TLFunc(uf)
 
 let pmfToTL = (pmf: PT.Package.Fn.t): toplevel => TLPmFunc(pmf)
 
-let utToTL = (ut: PT.UserType.t): toplevel => TLTipe(ut)
+let utToTL = (ut: PT.UserType.t): toplevel => TLType(ut)
 
 let asUserFunction = (tl: toplevel): option<PT.UserFunction.t> =>
   switch tl {
@@ -92,9 +92,9 @@ let asUserFunction = (tl: toplevel): option<PT.UserFunction.t> =>
   | _ => None
   }
 
-let asUserTipe = (tl: toplevel): option<PT.UserType.t> =>
+let asUserType = (tl: toplevel): option<PT.UserType.t> =>
   switch tl {
-  | TLTipe(t) => Some(t)
+  | TLType(t) => Some(t)
   | _ => None
   }
 
@@ -104,9 +104,9 @@ let isUserFunction = (tl: toplevel): bool =>
   | _ => false
   }
 
-let isUserTipe = (tl: toplevel): bool =>
+let isUserType = (tl: toplevel): bool =>
   switch tl {
-  | TLTipe(_) => true
+  | TLType(_) => true
   | _ => false
   }
 
@@ -180,7 +180,7 @@ let toOp = (tl: toplevel): list<PT.Op.t> =>
   switch tl {
   | TLHandler(h) => list{SetHandler(h.tlid, h.pos, h)}
   | TLFunc(fn) => list{SetFunction(fn)}
-  | TLTipe(t) => list{SetType(t)}
+  | TLType(t) => list{SetType(t)}
   | TLPmFunc(_) => recover("Package Manager functions are not editable", ~debug=id(tl), list{})
   | TLDB(_) => recover("This isn't how datastore ops work", ~debug=id(tl), list{})
   }
@@ -194,7 +194,7 @@ let blankOrData = (tl: toplevel): list<blankOrData> =>
   | TLDB(db) => DB.blankOrData(db)
   | TLPmFunc(f) => PackageManager.blankOrData(f)
   | TLFunc(f) => UserFunctions.blankOrData(f)
-  | TLTipe(t) => UserTypes.blankOrData(t)
+  | TLType(t) => UserTypes.blankOrData(t)
   }
 
 let isValidBlankOrID = (tl: toplevel, id: id): bool =>
@@ -216,7 +216,7 @@ let setAST = (tl: toplevel, newAST: FluidAST.t): toplevel =>
   switch tl {
   | TLHandler(h) => TLHandler({...h, ast: newAST})
   | TLFunc(uf) => TLFunc({...uf, body: newAST})
-  | TLDB(_) | TLTipe(_) | TLPmFunc(_) => tl
+  | TLDB(_) | TLType(_) | TLPmFunc(_) => tl
   }
 
 let withAST = (m: model, tlid: TLID.t, ast: FluidAST.t): model => {
@@ -248,7 +248,7 @@ let setASTMod = (~ops=list{}, tl: toplevel, ast: FluidAST.t): AppTypes.modificat
       AddOps(Belt.List.concat(ops, list{SetFunction({...f, body: ast})}), FocusNoChange)
     }
   | TLPmFunc(_) => recover("cannot change ast in package manager", ~debug=tl, Mod.NoChange)
-  | TLTipe(_) => recover("no ast in Tipes", ~debug=tl, Mod.NoChange)
+  | TLType(_) => recover("no ast in Types", ~debug=tl, Mod.NoChange)
   | TLDB(_) => recover("no ast in DBs", ~debug=tl, Mod.NoChange)
   }
 
@@ -269,18 +269,18 @@ let replace = (p: blankOrData, replacement: blankOrData, tl: toplevel): toplevel
     | _ => recover("Changing handler metadata on non-handler", ~debug=replacement, tl)
     }
   | PDBName(_) | PDBColType(_) | PDBColName(_) => tl
-  | PFnName(_) | PFnReturnTipe(_) | PParamName(_) | PParamTipe(_) =>
+  | PFnName(_) | PFnReturnType(_) | PParamName(_) | PParamType(_) =>
     switch asUserFunction(tl) {
     | Some(fn) =>
       let newFn = UserFunctions.replaceMetadataField(p, replacement, fn)
       TLFunc(newFn)
     | _ => recover("Changing fn metadata on non-fn", ~debug=replacement, tl)
     }
-  | PTypeName(_) | PTypeFieldName(_) | PTypeFieldTipe(_) =>
-    switch asUserTipe(tl) {
+  | PTypeName(_) | PTypeFieldName(_) | PTypeFieldType(_) =>
+    switch asUserType(tl) {
     | Some(tipe) =>
       let newTL = UserTypes.replace(p, replacement, tipe)
-      TLTipe(newTL)
+      TLType(newTL)
     | _ => recover("Changing tipe metadata on non-tipe", ~debug=replacement, tl)
     }
   }
@@ -336,7 +336,7 @@ let asPage = (tl: toplevel, center: bool): AppTypes.Page.t =>
   | TLHandler(_) => FocusedHandler(id(tl), None, center)
   | TLDB(_) => FocusedDB(id(tl), center)
   | TLPmFunc(_) | TLFunc(_) => FocusedFn(id(tl), None)
-  | TLTipe(_) => FocusedType(id(tl))
+  | TLType(_) => FocusedType(id(tl))
   }
 
 let selected = (m: model): option<toplevel> =>

--- a/client/src/toplevels/UserFunctions.res
+++ b/client/src/toplevels/UserFunctions.res
@@ -171,12 +171,12 @@ let replaceParamType = (
   }
 }
 
-let usesOfType = (tipename: string, version: int, uf: PT.UserFunction.t): list<blankOrData> =>
+let usesOfType = (typename: string, version: int, uf: PT.UserFunction.t): list<blankOrData> =>
   uf
   |> allParamData
   |> List.filterMap(~f=p =>
     switch p {
-    | PParamType(F(_, TUserType(n, v))) as pd if n == tipename && v == version => Some(pd)
+    | PParamType(F(_, TUserType(n, v))) as pd if n == typename && v == version => Some(pd)
     | _ => None
     }
   )

--- a/client/src/toplevels/UserFunctions.res
+++ b/client/src/toplevels/UserFunctions.res
@@ -38,7 +38,7 @@ let sameName = (name: string, uf: PT.UserFunction.t): bool => uf.name == name
 
 let paramData = (ufp: PT.UserFunction.Parameter.t): list<blankOrData> => list{
   PParamName(BlankOr.fromStringID(ufp.name, ufp.nameID)),
-  PParamTipe(BlankOr.fromOptionID(ufp.typ, ufp.typeID)),
+  PParamType(BlankOr.fromOptionID(ufp.typ, ufp.typeID)),
 }
 
 let allParamData = (uf: PT.UserFunction.t): list<blankOrData> =>
@@ -46,7 +46,7 @@ let allParamData = (uf: PT.UserFunction.t): list<blankOrData> =>
 
 let blankOrData = (uf: PT.UserFunction.t): list<blankOrData> => list{
   PFnName(BlankOr.fromStringID(uf.name, uf.nameID)),
-  PFnReturnTipe(F(uf.returnTypeID, uf.returnType)),
+  PFnReturnType(F(uf.returnTypeID, uf.returnType)),
   ...allParamData(uf),
 }
 
@@ -58,7 +58,7 @@ let replaceFnReturn = (
   let sId = P.toID(search)
   if uf.returnTypeID == sId {
     switch replacement {
-    | PFnReturnTipe(new_) => {
+    | PFnReturnType(new_) => {
         let (typ, id) = B.toOptionID(new_)
         {
           ...uf,
@@ -135,25 +135,25 @@ let replaceParamName = (
   }
 }
 
-let replaceParamTipe = (
+let replaceParamType = (
   search: blankOrData,
   replacement: blankOrData,
   uf: PT.UserFunction.t,
 ): PT.UserFunction.t => {
   let sId = P.toID(search)
-  let paramTipes =
+  let paramTypes =
     uf
     |> allParamData
     |> List.filterMap(~f=p =>
       switch p {
-      | PParamTipe(t) => Some(t)
+      | PParamType(t) => Some(t)
       | _ => None
       }
     )
 
-  if List.any(~f=p => B.toID(p) == sId, paramTipes) {
+  if List.any(~f=p => B.toID(p) == sId, paramTypes) {
     let newParameters = switch replacement {
-    | PParamTipe(new_) =>
+    | PParamType(new_) =>
       uf.parameters |> List.map(~f=(p: PT.UserFunction.Parameter.t) => {
         if sId == p.typeID {
           let (typ, id) = B.toOptionID(new_)
@@ -171,12 +171,12 @@ let replaceParamTipe = (
   }
 }
 
-let usesOfTipe = (tipename: string, version: int, uf: PT.UserFunction.t): list<blankOrData> =>
+let usesOfType = (tipename: string, version: int, uf: PT.UserFunction.t): list<blankOrData> =>
   uf
   |> allParamData
   |> List.filterMap(~f=p =>
     switch p {
-    | PParamTipe(F(_, TUserType(n, v))) as pd if n == tipename && v == version => Some(pd)
+    | PParamType(F(_, TUserType(n, v))) as pd if n == tipename && v == version => Some(pd)
     | _ => None
     }
   )
@@ -190,7 +190,7 @@ let replaceMetadataField = (
   |> replaceFnName(old, new_)
   |> replaceFnReturn(old, new_)
   |> replaceParamName(old, new_)
-  |> replaceParamTipe(old, new_)
+  |> replaceParamType(old, new_)
 
 let extend = (uf: PT.UserFunction.t): PT.UserFunction.t => {
   let newParam = {

--- a/client/src/toplevels/UserTypes.res
+++ b/client/src/toplevels/UserTypes.res
@@ -18,7 +18,7 @@ let blankOrData = (t: PT.UserType.t): list<blankOrData> => {
           acc,
           list{
             PTypeFieldName(BlankOr.fromStringID(f.name, f.nameID)),
-            PTypeFieldTipe(BlankOr.fromOptionID(f.typ, f.typeID)),
+            PTypeFieldType(BlankOr.fromOptionID(f.typ, f.typeID)),
           },
         ),
       fields,
@@ -79,7 +79,7 @@ let replaceDefinitionElement = (
         }
       } else if f.typeID == sId {
         switch new_ {
-        | PTypeFieldTipe(new) =>
+        | PTypeFieldType(new) =>
           let (typ, typeID) = B.toOptionID(new)
           {...f, typ: typ, typeID: typeID}
         | _ => f

--- a/client/src/toplevels/UserTypes.res
+++ b/client/src/toplevels/UserTypes.res
@@ -54,20 +54,20 @@ let allNames = (tipes: TLID.Dict.t<PT.UserType.t>): list<string> =>
   |> List.filter(~f=(ut: PT.UserType.t) => ut.name != "")
   |> List.map(~f=(ut: PT.UserType.t) => ut.name)
 
-let toTUserType = (tipe: PT.UserType.t): option<DType.t> =>
-  if tipe.name == "" {
+let toTUserType = (typ: PT.UserType.t): option<DType.t> =>
+  if typ.name == "" {
     None
   } else {
-    Some(DType.TUserType(tipe.name, tipe.version))
+    Some(DType.TUserType(typ.name, typ.version))
   }
 
 let replaceDefinitionElement = (
   old: blankOrData,
   new_: blankOrData,
-  tipe: PT.UserType.t,
+  typ: PT.UserType.t,
 ): PT.UserType.t => {
   let sId = P.toID(old)
-  switch tipe.definition {
+  switch typ.definition {
   | Record(fields) =>
     let newFields = fields->List.map(~f=f =>
       if f.nameID == sId {
@@ -89,39 +89,39 @@ let replaceDefinitionElement = (
       }
     )
 
-    {...tipe, definition: Record(newFields)}
+    {...typ, definition: Record(newFields)}
   }
 }
 
-let replaceTypeName = (old: blankOrData, new_: blankOrData, tipe: PT.UserType.t): PT.UserType.t => {
+let replaceTypeName = (old: blankOrData, new_: blankOrData, typ: PT.UserType.t): PT.UserType.t => {
   let sId = P.toID(old)
-  if tipe.nameID == sId {
+  if typ.nameID == sId {
     switch new_ {
-    | PTypeName(F(id, new_)) => {...tipe, name: new_, nameID: id}
-    | PTypeName(Blank(id)) => {...tipe, name: "", nameID: id}
-    | _ => tipe
+    | PTypeName(F(id, new_)) => {...typ, name: new_, nameID: id}
+    | PTypeName(Blank(id)) => {...typ, name: "", nameID: id}
+    | _ => typ
     }
   } else {
-    tipe
+    typ
   }
 }
 
-let replace = (old: blankOrData, new_: blankOrData, tipe: PT.UserType.t): PT.UserType.t =>
-  tipe |> replaceTypeName(old, new_) |> replaceDefinitionElement(old, new_)
+let replace = (old: blankOrData, new_: blankOrData, typ: PT.UserType.t): PT.UserType.t =>
+  typ |> replaceTypeName(old, new_) |> replaceDefinitionElement(old, new_)
 
-let extend = (tipe: PT.UserType.t): PT.UserType.t =>
-  switch tipe.definition {
+let extend = (typ: PT.UserType.t): PT.UserType.t =>
+  switch typ.definition {
   | Record(fields) =>
     let newFields = Belt.List.concat(
       fields,
       list{{name: "", nameID: gid(), typ: None, typeID: gid()}},
     )
-    {...tipe, definition: Record(newFields)}
+    {...typ, definition: Record(newFields)}
   }
 
-let removeField = (tipe: PT.UserType.t, field: PT.UserType.RecordField.t): PT.UserType.t =>
-  switch tipe.definition {
+let removeField = (typ: PT.UserType.t, field: PT.UserType.RecordField.t): PT.UserType.t =>
+  switch typ.definition {
   | Record(fields) =>
     let newFields = List.filter(~f=f => field != f, fields)
-    {...tipe, definition: Record(newFields)}
+    {...typ, definition: Record(newFields)}
   }

--- a/client/src/toplevels/UserTypes.res
+++ b/client/src/toplevels/UserTypes.res
@@ -48,8 +48,8 @@ let remove = (m: model, ut: PT.UserType.t): model => {
 let fromList = (uts: list<PT.UserType.t>): TLID.Dict.t<PT.UserType.t> =>
   uts |> List.map(~f=(ut: PT.UserType.t) => (ut.tlid, ut)) |> TLID.Dict.fromList
 
-let allNames = (tipes: TLID.Dict.t<PT.UserType.t>): list<string> =>
-  tipes
+let allNames = (types: TLID.Dict.t<PT.UserType.t>): list<string> =>
+  types
   |> Map.values
   |> List.filter(~f=(ut: PT.UserType.t) => ut.name != "")
   |> List.map(~f=(ut: PT.UserType.t) => ut.name)

--- a/client/src/toplevels/ViewDB.res
+++ b/client/src/toplevels/ViewDB.res
@@ -133,7 +133,7 @@ let viewDBColType = (
   typeID: ID.t,
 ): Html.html<msg> => {
   let enterable = typ == None || !vp.dbLocked
-  let typ = Option.map(~f=DType.tipe2str, typ)
+  let typ = Option.map(~f=DType.type2str, typ)
   let v = B.fromOptionID(typ, typeID)
   ViewBlankOr.viewText(~enterable, ~classes, DBColType, vp, v)
 }

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -205,7 +205,7 @@ let packageFnView = (
   tlid: TLID.t,
   name: string,
   params: list<PT.Package.Parameter.t>,
-  returnTipe: BlankOr.t<DType.t>,
+  returnType: BlankOr.t<DType.t>,
   direction: string,
 ): Html.html<msg> => {
   // Spec is here: https://www.notion.so/darklang/PM-Function-References-793d95469dfd40d5b01c2271cb8f4a0f
@@ -227,7 +227,7 @@ let packageFnView = (
     list{
       Html.div(list{Attrs.class'("fnheader fnheader-pkg")}, header),
       packageFnParamsView(params),
-      fnReturnTypeView(B.toOption(returnTipe)),
+      fnReturnTypeView(B.toOption(returnType)),
     },
   )
 }
@@ -278,7 +278,7 @@ let renderView = (originalTLID, direction, (tl, originalIDs)) =>
       BlankOr.newF(pFn.returnType),
       direction,
     )
-  | TLTipe({tlid, name, version, _}) if name != "" =>
+  | TLType({tlid, name, version, _}) if name != "" =>
     tipeView(originalTLID, originalIDs, tlid, name, version, direction)
   | _ => Vdom.noNode
   }

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -67,7 +67,7 @@ let packageFnParamsView = (params: list<PT.Package.Parameter.t>): Html.html<msg>
     let name = Html.span(list{Attrs.classList(list{("name", true)})}, list{Html.text(p.name)})
     let ptype = Html.span(
       list{Attrs.classList(list{("type", true)})},
-      list{Html.text(DType.tipe2str(p.tipe))},
+      list{Html.text(DType.tipe2str(p.typ))},
     )
 
     Html.div(list{Attrs.class'("field")}, list{name, ptype})
@@ -248,14 +248,14 @@ let tipeView = (
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.class'("ref-block tipe " ++ direction),
+        Attrs.class'("ref-block typ " ++ direction),
         EventListeners.eventNoPropagation(
-          ~key="ref-tipe-link" ++ TLID.toString(tlid),
+          ~key="ref-typ-link" ++ TLID.toString(tlid),
           "click",
           _ => Msg.GoTo(FocusedType(tlid)),
         ),
       },
-      hoveringRefProps(originTLID, originIDs, ~key="ref-tipe-hover"),
+      hoveringRefProps(originTLID, originIDs, ~key="ref-typ-hover"),
     ),
     list{Html.div(list{Attrs.class'("tipeheader")}, header)},
   )

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -18,7 +18,7 @@ let dbColsView = (cols: list<PT.DB.Col.t>): Html.html<msg> => {
         list{Attrs.class'("field")},
         list{
           Html.div(list{Attrs.class'("name")}, list{Html.text(name)}),
-          Html.div(list{Attrs.class'("type")}, list{Html.text(DType.tipe2str(typ))}),
+          Html.div(list{Attrs.class'("type")}, list{Html.text(DType.type2str(typ))}),
         },
       )
 
@@ -49,7 +49,7 @@ let fnParamsView = (params: list<PT.UserFunction.Parameter.t>): Html.html<msg> =
       list{
         Html.text(
           switch p.typ {
-          | Some(v) => DType.tipe2str(v)
+          | Some(v) => DType.type2str(v)
           | None => "no type"
           },
         ),
@@ -67,7 +67,7 @@ let packageFnParamsView = (params: list<PT.Package.Parameter.t>): Html.html<msg>
     let name = Html.span(list{Attrs.classList(list{("name", true)})}, list{Html.text(p.name)})
     let ptype = Html.span(
       list{Attrs.classList(list{("type", true)})},
-      list{Html.text(DType.tipe2str(p.typ))},
+      list{Html.text(DType.type2str(p.typ))},
     )
 
     Html.div(list{Attrs.class'("field")}, list{name, ptype})
@@ -79,7 +79,7 @@ let packageFnParamsView = (params: list<PT.Package.Parameter.t>): Html.html<msg>
 let fnReturnTypeView = (returnType: option<DType.t>): Html.html<msg> =>
   switch returnType {
   | Some(v) =>
-    let typeStr = DType.tipe2str(v)
+    let typeStr = DType.type2str(v)
     Html.div(
       list{},
       list{Html.text("Returns "), Html.span(list{Attrs.class'("type")}, list{Html.text(typeStr)})},
@@ -232,7 +232,7 @@ let packageFnView = (
   )
 }
 
-let tipeView = (
+let typeView = (
   originTLID: TLID.t,
   originIDs: list<id>,
   tlid: TLID.t,
@@ -242,7 +242,7 @@ let tipeView = (
 ): Html.html<msg> => {
   let header = list{
     Icons.darkIcon("type"),
-    Html.span(list{Attrs.class'("tipename")}, list{Html.text(name)}),
+    Html.span(list{Attrs.class'("typename")}, list{Html.text(name)}),
   }
 
   Html.div(
@@ -257,7 +257,7 @@ let tipeView = (
       },
       hoveringRefProps(originTLID, originIDs, ~key="ref-typ-hover"),
     ),
-    list{Html.div(list{Attrs.class'("tipeheader")}, header)},
+    list{Html.div(list{Attrs.class'("typeheader")}, header)},
   )
 }
 
@@ -279,7 +279,7 @@ let renderView = (originalTLID, direction, (tl, originalIDs)) =>
       direction,
     )
   | TLType({tlid, name, version, _}) if name != "" =>
-    tipeView(originalTLID, originalIDs, tlid, name, version, direction)
+    typeView(originalTLID, originalIDs, tlid, name, version, direction)
   | _ => Vdom.noNode
   }
 

--- a/client/src/toplevels/ViewUserFunction.res
+++ b/client/src/toplevels/ViewUserFunction.res
@@ -211,7 +211,7 @@ let viewMetadata = (vp: viewProps, fn: functionTypes, showFnTooltips: bool): Htm
       list{Attrs.id("fnreturn"), Attrs.class'("col param")},
       list{
         fontAwesome("level-down-alt"),
-        ViewBlankOr.viewTipe(~classes=list{"type"}, ~enterable=true, FnReturnTipe, vp, returnType),
+        ViewBlankOr.viewType(~classes=list{"type"}, ~enterable=true, FnReturnType, vp, returnType),
       },
     )
   }

--- a/client/src/toplevels/ViewUserType.res
+++ b/client/src/toplevels/ViewUserType.res
@@ -13,7 +13,7 @@ let fontAwesome = Icons.fontAwesome
 
 type viewProps = ViewUtils.viewProps
 
-let viewTipeName = (vp: viewProps, t: PT.UserType.t): Html.html<msg> => {
+let viewTypeName = (vp: viewProps, t: PT.UserType.t): Html.html<msg> => {
   let nameField = ViewBlankOr.viewText(
     ~enterable=true,
     ~classes=list{"ut-name"},
@@ -30,7 +30,7 @@ let viewFieldName = (~classes: list<string>, vp: viewProps, v: BlankOr.t<string>
 
 let viewFieldType = (~classes: list<string>, vp: viewProps, v: BlankOr.t<DType.t>): Html.html<
   msg,
-> => ViewBlankOr.viewTipe(~enterable=true, ~classes, TypeFieldTipe, vp, v)
+> => ViewBlankOr.viewType(~enterable=true, ~classes, TypeFieldType, vp, v)
 
 let viewKillFieldBtn = (t: PT.UserType.t, field: PT.UserType.RecordField.t): Html.html<msg> =>
   Html.div(
@@ -45,7 +45,7 @@ let viewKillFieldBtn = (t: PT.UserType.t, field: PT.UserType.RecordField.t): Htm
     list{fontAwesome("times-circle")},
   )
 
-let viewTipeField = (
+let viewTypeField = (
   vp: viewProps,
   t: PT.UserType.t,
   fieldCount: int,
@@ -66,13 +66,13 @@ let viewTipeField = (
   Html.div(list{Attrs.class'("field")}, row)
 }
 
-let viewUserTipe = (vp: viewProps, t: PT.UserType.t): Html.html<msg> =>
+let viewUserType = (vp: viewProps, t: PT.UserType.t): Html.html<msg> =>
   switch t.definition {
   | Record(fields) =>
-    let nameDiv = viewTipeName(vp, t)
+    let nameDiv = viewTypeName(vp, t)
     let fieldDivs = {
       let fieldCount = List.length(fields)
-      Html.div(list{Attrs.class'("fields")}, List.map(~f=viewTipeField(vp, t, fieldCount), fields))
+      Html.div(list{Attrs.class'("fields")}, List.map(~f=viewTypeField(vp, t, fieldCount), fields))
     }
 
     Html.div(list{Attrs.class'("user-type")}, list{nameDiv, fieldDivs})

--- a/client/src/ui/ViewUtils.res
+++ b/client/src/ui/ViewUtils.res
@@ -150,7 +150,7 @@ let createVS = (m: AppTypes.model, tl: toplevel): viewProps => {
       | Some(p) => p.execution == Executing
       | _ => false
       }
-    | TLPmFunc(_) | TLDB(_) | TLTipe(_) => false
+    | TLPmFunc(_) | TLDB(_) | TLType(_) => false
     },
     fnProps: m.currentUserFn,
     showHandlerASTs: m.editorSettings.showHandlerASTs,

--- a/client/styles/_introspect.scss
+++ b/client/styles/_introspect.scss
@@ -69,7 +69,7 @@ $arrow-height: 24px;
   }
 
   .dbheader,
-  .tipeheader,
+  .typeheader,
   .fnheader {
     display: flex;
     width: 100%;
@@ -86,15 +86,15 @@ $arrow-height: 24px;
 
   .fnicon,
   .fnname,
-  .tipeicon,
-  .tipename,
+  .typeicon,
+  .typename,
   .dbheader i.fa,
   .dbname {
     display: inline-block;
   }
 
   .fnicon,
-  .tipeicon,
+  .typeicon,
   .dbheader i.fa {
     color: $hover-foreground;
     font-size: 14px;
@@ -103,7 +103,7 @@ $arrow-height: 24px;
 
   .fnname,
   .dbname,
-  .tipename {
+  .typename {
     padding-left: 1ch;
   }
 

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -70,9 +70,9 @@ let sampleFunctions: list<RT.BuiltInFn.t> = list{
     DType.TVariable("b"),
   ),
   ("InQuery", "whatever", 0, list{TDict(DType.TVariable("efg"))}, DType.TVariable("x")),
-} |> List.map(~f=((module_, function, version, paramTipes, returnType)): RT.BuiltInFn.t => {
+} |> List.map(~f=((module_, function, version, paramTypes, returnType)): RT.BuiltInFn.t => {
   name: {module_: module_, function: function, version: version},
-  parameters: List.map(paramTipes, ~f=(paramType): RT.BuiltInFn.Param.t => {
+  parameters: List.map(paramTypes, ~f=(paramType): RT.BuiltInFn.Param.t => {
     name: "x",
     typ: paramType,
     args: list{},

--- a/client/test/TestJsonEncoding.res
+++ b/client/test/TestJsonEncoding.res
@@ -122,12 +122,12 @@ let run = () => {
     t("complex", FluidTestData.complexExpr)
   })
 
-  describe("tipe", () => {
+  describe("typ", () => {
     let roundtrip = typ => typ |> DType.encode |> DType.decode
 
-    test("tuple tipe roundtrips", () => {
-      let tipe = DType.TTuple(TInt, TFloat, list{TIncomplete})
-      expect(tipe |> roundtrip) |> toEqual(tipe)
+    test("tuple typ roundtrips", () => {
+      let typ = DType.TTuple(TInt, TFloat, list{TIncomplete})
+      expect(typ |> roundtrip) |> toEqual(typ)
     })
   })
   describe("decode serializations", () => {

--- a/client/test/TestRefactor.res
+++ b/client/test/TestRefactor.res
@@ -329,8 +329,8 @@ let run = () => {
         |> List.sortBy(~f=((k, _)) => k)
 
       let _ = (dobj, expectedFields)
-      let tipe = R.generateUserType(Some(dobj))
-      let fields = switch tipe {
+      let typ = R.generateUserType(Some(dobj))
+      let fields = switch typ {
       | Error(_) => list{}
       | Ok(ut) =>
         switch ut.definition {


### PR DESCRIPTION
We inexplicably dropped parameters names and types when displaying package manager fns.

Also, while I was here I renamed all uses of "tipe" to "typ", unless it was part of a word in which case it became "type" or "Type".

Before:

<img width="521" alt="Screen Shot 2022-10-05 at 8 25 57 PM" src="https://user-images.githubusercontent.com/181762/194189451-c0dd51d0-3284-40fc-abac-0dafcf4fcff6.png">
After:

<img width="486" alt="Screen Shot 2022-10-05 at 8 50 46 PM" src="https://user-images.githubusercontent.com/181762/194189452-cdc00326-43ad-48f5-90c1-e4fa1f0184d1.png">
