### PR TITLE
Preload initial APIs

### DIFF
--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -11,6 +11,31 @@ let clientVersionHeader = (m: model): Tea_http.header => Header(
   m.buildHash,
 )
 
+let apiCallGETNoParams = (
+  m: model,
+  ~decoder: Js.Json.t => 'resulttype,
+  ~callback: Tea.Result.t<'resulttype, Tea.Http.error<string>> => msg,
+  endpoint: string,
+): cmd => {
+  let url = apiRoot ++ Tea.Http.encodeUri(m.canvasName) ++ endpoint
+  let request = Tea.Http.request({
+    method': "GET",
+    headers: list{
+      Header("Content-type", "application/json"),
+      Header("X-CSRF-Token", m.csrfToken),
+      clientVersionHeader(m),
+    },
+    url: url,
+    body: Web.XMLHttpRequest.EmptyBody,
+    expect: Tea.Http.expectStringResponse(Decoders.wrapExpect(decoder)),
+    timeout: None,
+    withCredentials: false,
+  })
+
+  Tea.Http.send(callback, request)
+}
+
+
 let apiCallNoParams = (
   m: model,
   ~decoder: Js.Json.t => 'resulttype,
@@ -134,7 +159,7 @@ let uploadFn = (m: model, params: APIPackages.UploadFn.Params.t): cmd =>
   )
 
 let loadPackages = (m: model): cmd =>
-  apiCallNoParams(
+  apiCallGETNoParams(
     m,
     "/v1/packages",
     ~decoder=APIPackages.AllPackages.decode,
@@ -210,7 +235,7 @@ let insertSecret = (m: model, params: APISecrets.Insert.Params.t): cmd =>
   )
 
 let initialLoad = (m: model, focus: AppTypes.Focus.t): cmd =>
-  apiCallNoParams(
+  apiCallGETNoParams(
     m,
     "/v1/initial_load",
     ~decoder=APIInitialLoad.decode,

--- a/fsharp-backend/src/ApiServer/ApiServer.fs
+++ b/fsharp-backend/src/ApiServer/ApiServer.fs
@@ -74,6 +74,11 @@ let addRoutes
   let std = standardMiddleware
   let html = htmlMiddleware
 
+  let clientJsonGETApi name perm f =
+    let handler = clientJsonHandler f
+    let route = $"/api/{{canvasName}}/{name}"
+    addRoute "GET" route std perm handler
+
   let clientJsonApi name perm f =
     let handler = clientJsonHandler f
     let route = $"/api/{{canvasName}}/{name}"
@@ -113,8 +118,10 @@ let addRoutes
   clientJsonApi "get_unlocked_dbs" R DBs.Unlocked.get
   clientJsonApi "get_worker_stats" R Workers.WorkerStats.getStats
   clientJsonApi "v1/initial_load" R InitialLoad.V1.initialLoad
+  clientJsonGETApi "v1/initial_load" R InitialLoad.V1.initialLoad
   clientJsonApi "v1/insert_secret" RW Secrets.InsertV1.insert
   clientJsonApi "v1/packages" R (Packages.ListV1.packages packages)
+  clientJsonGETApi "v1/packages" R (Packages.ListV1.packages packages)
   // CLEANUP: packages/upload_function
   // CLEANUP: save_test handler
   clientJsonApi "v1/trigger_handler" RW Execution.HandlerV1.trigger

--- a/fsharp-backend/src/ApiServer/Templates/ui.html
+++ b/fsharp-backend/src/ApiServer/Templates/ui.html
@@ -46,6 +46,12 @@
       href="//{{STATIC}}/app.js"
       crossorigin="anonymous"
     />
+    <link rel="preload" href="/api/{{CANVAS_NAME}}/v1/packages" as="fetch" />
+    <link
+      rel="preload"
+      href="/api/{{CANVAS_NAME}}/v1/initial_load"
+      as="fetch"
+    />
 
     <!-- Actually load the files -->
     <link


### PR DESCRIPTION
This is a fun little performance hack - let's preload initial_load and packages API calls!

Note, only the last commit is new here.

There's a brief window here where someone might be loading an API call that doesn't exist (on old servers), but it'll be brief, only affect loading the editor for the first time, and be easy to resolve by refreshing, so probably fine to ship this in one PR.