### PR TITLE
Move away from gsutil

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,14 @@ version: 2.1
 executors:
   simple-executor:
     docker:
-      - image: cimg/base:2021.12
+      - image: cimg/base:2022.10
   in-container:
     working_directory: ~/app
     environment:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:dcf86ff
+      - image: darklang/dark-base:b7819f8
 
 commands:
   show-large-files-and-directories:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,7 @@ commands:
   ##########################
   deploy-lock-remove-on-fail:
     steps:
-      # Can only be used from in-container executors as it needs gsutil. Though that
-      # could be installed if we needed to:
-      # https://cloud.google.com/storage/docs/gsutil_install
+      # Can only be used from in-container executors as it needs gcloud
       - auth-with-gcp-on-fail
       - run:
           name: Remove deploy lock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:
           keys:
-            - v14-fsharp-backend-{{ checksum "../checksum" }}
+            - v15-fsharp-backend-{{ checksum "../checksum" }}
             # Fails often enough that it's better not to have a fallback
       - show-large-files-and-directories
       # For tests
@@ -327,7 +327,7 @@ jobs:
           paths:
             - fsharp-backend/Build/obj
             - /home/dark/.nuget
-          key: v14-fsharp-backend-{{ checksum "../checksum" }}
+          key: v15-fsharp-backend-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - store_test_results: { path: rundir/test_results }
       - slack-notify-job-failure
@@ -348,7 +348,7 @@ jobs:
       - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
       - restore_cache:
           keys:
-            - v3-fsharp-blazor-{{ checksum "../checksum" }}
+            - v4-fsharp-blazor-{{ checksum "../checksum" }}
             # Fails often enough that it's better not to have a fallback
       - show-large-files-and-directories
       - run: ./scripts/build/_dotnet-wrapper tool restore
@@ -367,7 +367,7 @@ jobs:
           paths:
             - fsharp-backend/Build/obj
             - /home/dark/.nuget
-          key: v3-fsharp-blazor-{{ checksum "../checksum" }}
+          key: v4-fsharp-blazor-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
       - slack-notify-job-failure
       - deploy-lock-remove-on-fail

--- a/Dockerfile
+++ b/Dockerfile
@@ -292,7 +292,7 @@ RUN \
 # Kubeconform - for linting k8s files
 ############################
 RUN \
-  VERSION=v0.4.13 \
+  VERSION=v0.4.14 \
   && wget -P tmp_install_folder/ https://github.com/yannh/kubeconform/releases/download/$VERSION/kubeconform-linux-amd64.tar.gz \
   && tar xvf tmp_install_folder/kubeconform-linux-amd64.tar.gz -C  tmp_install_folder \
   && sudo cp tmp_install_folder/kubeconform /usr/bin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -301,10 +301,10 @@ RUN \
 ####################################
 # Honeytail and honeymarker installs
 ####################################
-RUN wget -q https://honeycomb.io/download/honeytail/v1.6.1/honeytail_1.6.1_amd64.deb && \
-      echo 'd099dd50b8446926be7a011eb4b98ed5bf07e5e7a4f9fce8015fe2147492833c  honeytail_1.6.1_amd64.deb' | sha256sum -c && \
-      sudo dpkg -i honeytail_1.6.1_amd64.deb && \
-      rm honeytail_1.6.1_amd64.deb
+RUN wget -q https://honeycomb.io/download/honeytail/v1.8.1/honeytail_1.8.1_amd64.deb && \
+      echo '971ba06886c5436927a17f8494fe518084a385cb9b9b28e541296d658eb5cc8d  honeytail_1.8.1_amd64.deb' | sha256sum -c && \
+      sudo dpkg -i honeytail_1.8.1_amd64.deb && \
+      rm honeytail_1.8.1_amd64.deb
 
 RUN wget -q https://honeycomb.io/download/honeymarker/linux/honeymarker_1.9_amd64.deb && \
       echo '5aa10dd42f4f369c9463a8c8a361e46058339e6273055600ddad50e1bcdf2149  honeymarker_1.9_amd64.deb' | sha256sum -c && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,23 +258,7 @@ ENV PUBSUB_EMULATOR_HOST=0.0.0.0:8085
 
 # GKE
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
-
-# crcmod for gsutil; this gets us the compiled (faster), not pure Python
-# (slower) crcmod, as described in `gsutil help crcmod`
-#
-# It requires that python3-pip, python3-dev, python3-setuptools, and gcc be
-# installed. You'll also need CLOUDSDK_PYTHON=python3 to be set when you use
-# gsutil. (Which the ENV line handles.)
-#
-# The last line greps to confirm that gsutil has a compiled crcmod.
-# Possible failure modes; missing deps above (-pip, -dev, -setuptools, gcc); a
-# pre-installed crcmod that needs to be uninstalled first.  Added that because
-# this install is a bit brittle, and it's easy to invisibly install the pure
-# Python crcmod.
 ENV CLOUDSDK_PYTHON=python3
-RUN sudo pip3 install -U --no-cache-dir -U crcmod \
-  && ((gsutil version -l | grep compiled.crcmod:.True) \
-      || (echo "Compiled crcmod not installed." && false))
 
 ############################
 # Pip packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,7 +183,7 @@ ENV LC_ALL en_US.UTF-8
 ############################
 # Frontend
 ############################
-RUN sudo npm install -g prettier@2.5.1
+RUN sudo npm install -g prettier@2.7.1
 
 # Esy is currently a nightmare. Upgrading to esy 6.6 is stalled because:
 # - esy 6.6 copies from ~/.esy to _esy, and in our container, that copy is

--- a/Dockerfile
+++ b/Dockerfile
@@ -267,8 +267,8 @@ RUN sudo pip3 install --no-cache-dir yq yamllint
 ENV PATH "$PATH:/home/dark/.local/bin"
 
 RUN pip3 install git+https://github.com/pbiggar/watchgod.git@b74cd7ec064ebc7b4263dc532c7c97e046002bef
-# Formatting
 
+# Formatting
 RUN pip3 install yapf==0.32.0
 
 ####################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # as part of that build. Search for DOCKERFILE_REPO for where to make that
 # change.
 
-FROM ubuntu:20.04@sha256:7cc0576c7c0ec2384de5cbf245f41567e922aab1b075f3e8ad565f508032df17 as dark-base
+FROM ubuntu:20.04@sha256:e722c7335fdd0ce77044ab5942cb1fbd2b5f60d1f5416acfcdb0814b2baf7898 as dark-base
 
 ENV FORCE_BUILD 3
 

--- a/docs/production/static-assets.md
+++ b/docs/production/static-assets.md
@@ -1,18 +1,20 @@
-# Static Assets Notes
+# Darklang.com Static Assets Notes
+
+_Note: this is about how we store assets for darklang.com, not how customers use assets (though we should move to using the customer solution)_
 
 We're storing static assets in a google backend bucket now, which is then
 fronted by a gcloud loadbalancer (which does the CDN work).
 
 Of note:
 
-- gcloud can do "decompressive transcoding", which means that what we upload must
+- gcp can do "decompressive transcoding", which means that what we upload must
   already be gzipped, and the 'Content-Encoding: gzip' header attached (see:
   `scripts/deployment/_push-assets-to-cdn` script for details). Assuming that is done,
-  gcloud cloud cdn will handle sending either gzipped or decompressed files depending
+  google cloud cdn will handle sending either gzipped or decompressed files depending
   on whether the request headers include 'Content-Encoding: gzip'.
-  - NOTE: if you do one but not the other (`gsutil cp -h 'Content-Encoding: gzip'`,
+  - NOTE: if you do one but not the other (`gcloud storage cp --content-encoding gzip`,
     but with decompressed files), Chrome will give you CONTENT_ENCODING errors. To fix:
-    re-upload with `gsutil cp` and bust the cache in GCloud Console. You are not likely
+    re-upload with `gcloud storage cp` and bust the cache in GCloud Console. You are not likely
     to run into this, because `scripts/deployment/_push-assets-to-cdn` does the work.
 - The bucket must send appropriate Access-Control-Allow-Origin headers, or the
   browser won't be able to load some things. (We've seen this with
@@ -30,7 +32,7 @@ Of note:
 ]
 ```
 
-and attach it to the bucket: `gsutil cors set cors.json gsutil://<bucket_name>`.
+and attach it to the bucket: `gcloud storage buckets update --set-cors-file cors.json gs://<bucket_name>`.
 
 - If we add more origins, obviously this document (and the CORS policy) will
   need to be updated.

--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -12,23 +12,22 @@ import time
 ROOT_OF_FILES = "backend/static/"
 BUCKET = "gs://darklang-static-assets"
 
-# This script's goal is to gather all of our static assets in `backend/static/`
-# and upload them to GCP via `gsutil cp`, with the correct Content-Type. Some
-# files should maintain their exact name (e.g. vendor assets), and others
-# should have their contents' hash injected into their name, as expected by
-# `etags.json`.
+# This script's goal is to gather all of our static assets in `backend/static/` and
+# upload them to GCP using gcloud, with the correct Content-Type. Some files should
+# maintain their exact name (e.g. vendor assets), and others should have their
+# contents' hash injected into their name, as expected by `etags.json`.
 #
-# As we want to upload with the correct content types, which `gsutil cp` allows
-# via a `-h "Content-Type: {mimetype}"` argument, we must make a call to the
-# tool once per Content-Type. We must also ensure we maintain relative file
-# paths when uploaded. (i.e. backend/static/blazor/blazor.js should end up at
-# {BUCKET}/blazor/blazor-HASH.js).
+# As we want to upload with the correct content types, which `gcloud storage cp`
+# allows, we must make a call to the tool once per Content-Type. We must also ensure
+# we maintain relative file paths when uploaded. (i.e.
+# backend/static/blazor/blazor.js should end up at {BUCKET}/blazor/blazor-HASH.js).
 #
-# Inconveniently, `gsutil cp` doesn't provide a way to pass in a list of
-# (local path/name, remote path/name) pairs, making it tricky to do rename
-# transforms. We get around this by creating a temp folder per content-type
-# and rather than providing a list of files, we provide such a directory, and
-# include the `-r` (recursive) argument, along with the Content-Type
+# TODO: reevaluate now that we use `gcloud storage cp`
+# Inconveniently, `gsutil cp` doesn't provide a way to pass in a list of (local
+# path/name, remote path/name) pairs, making it tricky to do rename transforms. We
+# get around this by creating a temp folder per content-type and rather than
+# providing a list of files, we provide such a directory, and include the `-r`
+# (recursive) argument, along with the Content-Type
 #
 # The algorithm of this script is:
 # - gather a list of all files in `backend/static/`
@@ -37,7 +36,7 @@ BUCKET = "gs://darklang-static-assets"
 # - copy all relevant files from `backend/static/` to the appropriate
 #   Content-Type -specific subfolder of our temp directory, renaming
 #   some files to have the hashes from etags.json in their file name
-# - call `gsutil cp -r` per Content-Type -specific directory
+# - call `gcloud storage cp -r` per Content-Type -specific directory
 
 
 # Exists because we can't make folders named like "application/json"
@@ -113,7 +112,7 @@ def should_hash(filename):
 
 # Create a local temp directory, with a subfolder per Content-Type relevant,
 # and copy our files to such, respecting relative location.
-# We'll later call `gsutil cp` per-folder with a `-r` (recursive) flag.
+# We'll later call `gcloud storage cp` per-folder with a `-r` (recursive) flag.
 temp_dir = tempfile.gettempdir() + "/static-assets"
 shutil.rmtree(temp_dir, ignore_errors=True)
 
@@ -148,32 +147,27 @@ for f in static_files_to_copy:
 
   shutil.copy(f, target)
 
-# Copy the files to CDN - one `gsutil cp` call per Content-Type
+# Copy the files to CDN - one `gcloud storage cp` call per Content-Type
 for mimetype in mimetypes_to_process:
   mimetype_subfolder = get_mimetype_temp_dir(mimetype)
-  # Prepare a `gsutil cp` call
-  # - global gsutil args
-  #   -h: set header
-  #   -m: Upload assets in parallel, within call
-  # - `cp`-specific args
-  #   -Z: Uploaded file is served as zipped. Also adds 'no-transform' to Cache-Control header
-  #   -n: Don't overwrite
-  #   -r: Copy recursively
   start = time.time()
-  gsutil_command = f'''gsutil \
-    -h "Content-Type:{mimetype}" \
-    -h "Cache-Control:public" \
-    -m \
-    cp -Z -n -r . "{BUCKET}"
+  command = f'''gcloud storage cp \
+    --content-type ${mimetype}" \
+    --content-encoding gzip \
+    --cache-control public \
+    --no-clobber \
+    --recursive \
+    . "{BUCKET}"
     '''
 
-  result = subprocess.run(gsutil_command, shell=True, cwd=mimetype_subfolder, capture_output=True)
-  # Note: checking stderr won't work here, as gsutil sends non-error logs to
-  # stderr by default. We could add a `-q` flag to avoid this, but the logs are
-  # useful in local debugging, so let's check the returncode instead.
-  # https://github.com/GoogleCloudPlatform/gsutil/issues/116#issuecomment-13929972
+  result = subprocess.run(command,
+                          shell=True,
+                          cwd=mimetype_subfolder,
+                          capture_output=True)
   if result.returncode != 0:
-    print(f"Failed to upload {mimetype_subfolder} to CDN bucket {BUCKET}. Failed with {result.returncode} {result.stderr}.")
+    print(
+        f"Failed to upload {mimetype_subfolder} to CDN bucket {BUCKET}. Failed with {result.returncode} {result.stderr}."
+    )
     sys.exit(1)
 
   elapsed = (time.time() - start)

--- a/scripts/deployment/deploy-lock-all-clear
+++ b/scripts/deployment/deploy-lock-all-clear
@@ -7,4 +7,4 @@ set -euo pipefail
 
 DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
 
-gsutil rm "${DEPLOY_LOCK_BUCKET}/*"
+gcloud storage rm "${DEPLOY_LOCK_BUCKET}/*"

--- a/scripts/deployment/deploy-lock-all-list
+++ b/scripts/deployment/deploy-lock-all-list
@@ -7,4 +7,4 @@ set -euo pipefail
 
 DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
 
-gsutil ls ${DEPLOY_LOCK_BUCKET}/ | sed 's!.*/!!'
+gcloud storage ls ${DEPLOY_LOCK_BUCKET}/ | sed 's!.*/!!'

--- a/scripts/deployment/deploy-lock-one-add
+++ b/scripts/deployment/deploy-lock-one-add
@@ -12,5 +12,5 @@ touch "$LOCKFILE_NAME"
 
 echo "Adding lock file with id ${LOCKFILE_NAME}"
 
-gsutil cp "${LOCKFILE_NAME}" "${DEPLOY_LOCK_BUCKET}"
+gcloud storage cp "${LOCKFILE_NAME}" "${DEPLOY_LOCK_BUCKET}"
 rm "$LOCKFILE_NAME"

--- a/scripts/deployment/deploy-lock-one-remove
+++ b/scripts/deployment/deploy-lock-one-remove
@@ -8,4 +8,4 @@ set -euo pipefail
 DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
 LOCKFILE_NAME=$(./scripts/deployment/deploy-lock-one-get-name)
 
-gsutil rm -f "${DEPLOY_LOCK_BUCKET}/${LOCKFILE_NAME}"
+gcloud storage rm "${DEPLOY_LOCK_BUCKET}/${LOCKFILE_NAME}"

--- a/scripts/production/create-download-gcp-db-bucket
+++ b/scripts/production/create-download-gcp-db-bucket
@@ -10,7 +10,7 @@ BUCKET=gs://download-gcp-db
 ###########################
 echo "Creating bucket"
 ###########################
-gsutil mb -c regional -l us-west1 "$BUCKET"
+gcloud storage buckets create --default-storage-class regional --location us-west1 "$BUCKET"
 
 ###########################
 echo "Adding cloud sql permissions"

--- a/scripts/production/download-gcp-db
+++ b/scripts/production/download-gcp-db
@@ -7,7 +7,7 @@ set -euo pipefail
 DB=prodclone
 
 # get list | drop last file | drop all columns except filename | sort to get latest | get first | trim whitespace
-GSFILENAME="$(gsutil ls -l gs://download-gcp-db/sqldump_*.gz | head -n-1 | cut -d" " -f5- | sort -r | head -n1 | awk '{$1=$1;print}')"
+GSFILENAME="$(gcloud storage ls -l gs://download-gcp-db/sqldump_*.gz | head -n-1 | cut -d" " -f5- | sort -r | head -n1 | awk '{$1=$1;print}')"
 echo "Using latest DB export: ${GSFILENAME}"
 
 FILENAME="${GSFILENAME//gs:\/\/download-gcp-db\//}"
@@ -16,7 +16,7 @@ LOGFILE="${FILENAME}.log"
 ###########################
 echo "Downloading $GSFILENAME contents"
 ###########################
-gsutil cp "$GSFILENAME" "$FILENAME"
+gcloud storage cp "$GSFILENAME" "$FILENAME"
 
 ###########################
 echo "Dropping existing DB $DB (killing existing connections)"


### PR DESCRIPTION
Changelog:

```
Internal:

- Use gcloud storage commands instead of gsutil for deployment
```

Google cloud has a separate tool called `gsutil`, which we use to deploy darklang.com assets and also for the deploy lock. However, it's a little annoying as the tool requires us to install a python module to have reasonably fast deployment.

They recently released a new component to gcloud which replaces this: `gcloud storage`. It means we don't need the python module and it's also supposedly much much faster.

Also updates some dependencies in the dev container
