### PR TITLE
Move to later version of bs-tea

### DIFF
--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -609,6 +609,7 @@ module Msg = {
   type rec t<'model, 'modification> =
     | IgnoreMsg(/* debug string so you know where it came from */ string)
     | IgnoreMouseUp // for nothingMouseEvent
+    | RenderEvent
     | FluidMsg(FluidTypes.Msg.t<'model, 'modification>)
     | AppMouseDown(MouseEvent.t)
     | @printer(opaque("AppMouseDrag")) AppMouseDrag(Tea.Mouse.position)

--- a/client/src/app/CursorState.res
+++ b/client/src/app/CursorState.res
@@ -39,23 +39,23 @@ let focusEntry = (m: AppTypes.Model.t): AppTypes.cmd =>
 // Based on Tea_html_cmds, applies offset after focus
 let focusWithOffset = (id, offset) =>
   Tea.Cmd.call(_ => {
-    let ecb = _ignored =>
-      switch Js.Nullable.toOption(Web.Document.getElementById(id)) {
-      | None =>
-        // Do not report this error, it's not a problem
-        Js.log(("Attempted to focus a non-existant element of: ", id))
-      | Some(elem) =>
-        // We have to focus after setting range, or the cursor will vanish when the offset is 0
-        elem["setSelectionRange"](offset, offset)
-        Web.Node.focus(elem)
-        ()
+    let ecb = _ignored => {
+      let elem =
+        Webapi.Dom.document
+        ->Webapi.Dom.Document.getElementById(id)
+        ->Belt.Option.flatMap(Webapi.Dom.HtmlInputElement.ofElement)
+      switch elem {
+      | Some(input) =>
+        input->Webapi.Dom.HtmlInputElement.setSelectionRange(offset, offset)
+        input->Webapi.Dom.HtmlInputElement.focus
+      | None => ()
       }
+    }
 
     // One to get out of the current render frame
-    let cb = _ignored => ignore(Web.Window.requestAnimationFrame(ecb))
+    let cb = _ignored => ignore(Webapi.requestAnimationFrame(ecb))
     // And another to properly focus
-    ignore(Web.Window.requestAnimationFrame(cb))
-    ()
+    ignore(Webapi.requestAnimationFrame(cb))
   })
 
 let focusEntryWithOffset = (m: AppTypes.model, offset: int): AppTypes.cmd =>

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -2051,8 +2051,12 @@ let update_ = (msg: msg, m: model): modification => {
     Model.updateErrorMod(Error.set("Successfully uploaded function"))
   | SecretMsg(msg) => InsertSecret.update(msg)
   | RenderEvent =>
-    Fluid.renderCallback(m)
-    NoChange
+    ReplaceAllModificationsWithThisOne(
+      m => {
+        Fluid.renderCallback(m)
+        (m, Cmd.none)
+      },
+    )
   }
 }
 
@@ -2119,7 +2123,8 @@ let subscriptions = (m: model): Tea.Sub.t<msg> => {
   | _ => list{}
   }
 
-  let renderSubs = list{Tea.Ex.render_event(AppTypes.Msg.RenderEvent)}
+  let rand = Random.int(10000000)->Int.to_string
+  let renderSubs = list{Tea.Ex.render_event(~key="renderEvent" ++ rand, AppTypes.Msg.RenderEvent)}
 
   let windowMouseSubs = list{
     BrowserSubscriptions.Window.Mouse.ups(~key="win_mouse_up", event => WindowMouseUp(event)),

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -2050,6 +2050,9 @@ let update_ = (msg: msg, m: model): modification => {
   | UploadFnAPICallback(_, Ok(_)) =>
     Model.updateErrorMod(Error.set("Successfully uploaded function"))
   | SecretMsg(msg) => InsertSecret.update(msg)
+  | RenderEvent =>
+    Fluid.renderCallback(m)
+    NoChange
   }
 }
 
@@ -2115,6 +2118,8 @@ let subscriptions = (m: model): Tea.Sub.t<msg> => {
     list{BrowserSubscriptions.DarkMouse.moves(~key, event => AppMouseDrag(event))}
   | _ => list{}
   }
+
+  let renderSubs = list{Tea.Ex.render_event(AppTypes.Msg.RenderEvent)}
 
   let windowMouseSubs = list{
     BrowserSubscriptions.Window.Mouse.ups(~key="win_mouse_up", event => WindowMouseUp(event)),
@@ -2196,6 +2201,7 @@ let subscriptions = (m: model): Tea.Sub.t<msg> => {
       clipboardSubs,
       dragSubs,
       timers,
+      renderSubs,
       visibility,
       onError,
       mousewheelSubs,

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -2205,12 +2205,11 @@ let subscriptions = (m: model): Tea.Sub.t<msg> => {
 }
 
 let debugging = {
-  let prog = Tea.Debug.debug(
+  let prog = Tea.Debug.debug_program(
     AppTypes.show_msg,
     {
       init: a => init(a, Tea.Navigation.getLocation()),
       view: View.view,
-      renderCallback: Fluid.renderCallback,
       update: update,
       subscriptions: subscriptions,
       shutdown: _ => Cmd.none,
@@ -2224,7 +2223,6 @@ let debugging = {
       init: myInit,
       update: prog.update,
       view: prog.view,
-      renderCallback: prog.renderCallback,
       subscriptions: prog.subscriptions,
       shutdown: prog.shutdown,
     },
@@ -2236,7 +2234,6 @@ let normal = {
     init: init,
     view: View.view,
     update: update,
-    renderCallback: Fluid.renderCallback,
     subscriptions: subscriptions,
     shutdown: _ => Cmd.none,
   }

--- a/client/src/fluid/FluidEditorView.res
+++ b/client/src/fluid/FluidEditorView.res
@@ -322,9 +322,9 @@ let toHtml = (p: props, duplicatedRecordFields: list<(id, Set.String.t)>): list<
 
 let tokensView = (p: props): Html.html<msg> => {
   let tlidStr = TLID.toString(p.tlid)
-  let textInputListeners = /* the command palette is inside div.fluid-editor but has it's own input
-   * handling, so don't do normal fluid input stuff if it's open */
-  if FluidCommands.isOpened(p.fluidState.cp) {
+  // the command palette is inside div.fluid-editor but has it's own input
+  // handling, so don't do normal fluid input stuff if it's open
+  let textInputListeners = if FluidCommands.isOpened(p.fluidState.cp) {
     (Attrs.noProp, Attrs.noProp, Attrs.noProp)
   } else {
     (
@@ -424,8 +424,6 @@ let tokensView = (p: props): Html.html<msg> => {
   }
 
   Html.div(
-    // disable grammarly crashes
-
     Belt.List.concatMany([
       list{
         idAttr,
@@ -433,6 +431,7 @@ let tokensView = (p: props): Html.html<msg> => {
         Vdom.prop("contentEditable", "true"),
         Attrs.autofocus(true),
         Vdom.attribute("", "spellcheck", "false"),
+        // disable grammarly crashes
         Vdom.attribute("", "data-gramm", "false"),
       },
       clickHandlers,

--- a/client/src/forms/Entry.res
+++ b/client/src/forms/Entry.res
@@ -86,7 +86,7 @@ let preorderWalkUntil = (~f: Dom.Node.t => bool, node: Dom.Node.t): unit => {
   |> ignore
 }
 
-@ocaml.doc(" getFluidSelectionRange returns the [begin, end] indices of the last
+@ocaml.doc("getFluidSelectionRange returns the [begin, end] indices of the last
   * selection/caret placement within a fluid editor.
   *
   * If there has been no selection/caret placement or if the selected nodes are
@@ -125,10 +125,9 @@ let getFluidSelectionRange = (): option<(int, int)> => {
           if focusNode === node {
             focusIdx := Some(cursor.contents)
           }
-          /* If node is not a leaf, then advance cursor. This is
-           * probably a span or other container element. We'll see the
-           * actual text node later, and we don't want to double-count
-           * the textContent. */
+          // If node is not a leaf, then advance cursor. This is probably a span or
+          // other container element. We'll see the actual text node later, and we
+          // don't want to double-count the textContent.
           if !(Node.firstChild(node) |> Option.is_some) {
             cursor := cursor.contents + (node |> Node.textContent |> String.length)
           }
@@ -159,7 +158,7 @@ let getFluidCaretPos = (): option<int> =>
   | None => None
   }
 
-@ocaml.doc(" setFluidSelectionRange([beginIdx, endIdx]) attempts to select the passed
+@ocaml.doc("setFluidSelectionRange([beginIdx, endIdx]) attempts to select the passed
   * region in the currently selected fluid editor, if there is one.
   * If beginIdx == endIdx, it sets the caret position (0-width selection).
   *

--- a/client/src/forms/Entry.res
+++ b/client/src/forms/Entry.res
@@ -234,8 +234,6 @@ let setFluidSelectionRange = (beginIdx: int, endIdx: int): unit => {
   |> ignore
 }
 
-let setFluidCaret = (idx: int): unit => setFluidSelectionRange(idx, idx)
-
 type browserPlatform =
   | Mac
   | Linux

--- a/client/src/util/Native.res
+++ b/client/src/util/Native.res
@@ -64,22 +64,25 @@ module OffsetEstimator = {
    * TODO: It's a super hacky estimate based on our common screen size at Dark and the default
    * font size and should be replaced with a proper implementation. But it's done us
    * okay so far. */
-  let estimateClickOffset = (elementID: string, event: MouseEvent.t): option<int> =>
-    switch Js.Nullable.toOption(Web_document.getElementById(elementID)) {
+  let estimateClickOffset = (elementID: string, event: MouseEvent.t): option<int> => {
+    open Webapi.Dom
+    let elem = document->Document.getElementById(elementID)
+    switch elem {
     | Some(elem) =>
-      let rect = elem["getBoundingClientRect"]()
+      let rect = elem->Element.getBoundingClientRect
       if (
-        event.mePos.vy >= int_of_float(rect["top"]) &&
-          (event.mePos.vy <= int_of_float(rect["bottom"]) &&
-          (event.mePos.vx >= int_of_float(rect["left"]) &&
-            event.mePos.vx <= int_of_float(rect["right"])))
+        event.mePos.vy >= int_of_float(rect->DomRect.top) &&
+          (event.mePos.vy <= int_of_float(rect->DomRect.bottom) &&
+          (event.mePos.vx >= int_of_float(rect->DomRect.left) &&
+            event.mePos.vx <= int_of_float(rect->DomRect.right)))
       ) {
-        Some((event.mePos.vx - int_of_float(rect["left"])) / 8)
+        Some((event.mePos.vx - int_of_float(rect->DomRect.left)) / 8)
       } else {
         None
       }
     | None => None
     }
+  }
 }
 
 module Random = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,8 +566,8 @@
       }
     },
     "bucklescript-tea": {
-      "version": "git+ssh://git@github.com/darklang/bucklescript-tea.git#63963ffee701b8f30ed99cce7483682193731eb9",
-      "from": "bucklescript-tea@darklang/bucklescript-tea#master"
+      "version": "github:pbiggar/rescript-tea#83e738cdcd9d4031b6feeb5d5da8e666dabc292d",
+      "from": "github:pbiggar/rescript-tea#83e738cdcd9d4031b6feeb5d5da8e666dabc292d"
     },
     "buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bs-fetch": "0.6.2",
     "bs-uuid": "0.3.1",
     "rescript-webapi": "0.6.1",
-    "bucklescript-tea": "darklang/bucklescript-tea#master",
+    "bucklescript-tea": "pbiggar/rescript-tea#83e738cdcd9d4031b6feeb5d5da8e666dabc292d",
     "clipboard-copy": "4.0.1",
     "domready": "1.0.8",
     "minimist": ">=1.2.7",


### PR DESCRIPTION
No changelog

Fixes #4413.

This moves off our abandoned fork of bucklescript-tea, to a much newer (but still not latest) version of our new fork, rescript-tea.

renderCallback was never accepted upstream, and they went with a much nicer approach using subscriptions. Some other functions were only in our fork and so I moved them to rescript-webapi instead (which is what should happen for all our uses of Tea.Node).