### PR TITLE
Use CaretTargets to handle deleting selection

### DIFF
--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -652,14 +652,12 @@ let doDown = (~pos: int, astInfo: ASTInfo.t): ASTInfo.t => {
 // Movement with CaretTarget
 // ****************************
 
-/* posFromCaretTarget returns the position in the token stream corresponding to
-   the passed caretTarget within the passed ast. We expect to succeed in finding
-   the target. If we cannot, we `recover` and return the current caret pos
-   as a fallback.
+@ocaml.doc("returns the position in the token stream corresponding to the passed
+  caretTarget within the passed ast. We expect to succeed in finding the target.
 
-   This is useful for determining the precise position to which the caret should
-   jump after a transformation. */
-let posFromCaretTarget = (ct: CT.t, astInfo: ASTInfo.t): int => {
+  This is useful for determining the precise position to which the caret should jump
+  after a transformation.")
+let posFromCaretTargetMaybe = (ct: CT.t, astInfo: ASTInfo.t): option<int> => {
   /* Essentially we're using List.findMap to map a function that
    * matches across astref,token combinations (exhaustively matching astref but not token)
    * to determine the corresponding caretPos.
@@ -677,6 +675,7 @@ let posFromCaretTarget = (ct: CT.t, astInfo: ASTInfo.t): int => {
     between an ASTRef and a token. It does not make sense for ASTRefs that scan across
     multiple tokens (eg Multiline Strings) */
   let posForTi = (ti: T.tokenInfo): option<int> => Some(ti.startPos + min(ct.offset, ti.length))
+
   let clampedPosForTi = (ti: T.tokenInfo, pos): option<int> => Some(
     ti.startPos + max(0, min(pos, ti.length)),
   )
@@ -862,12 +861,19 @@ let posFromCaretTarget = (ct: CT.t, astInfo: ASTInfo.t): int => {
     | (ARInvalid, _) => None
     }
 
-  let newPosMaybe =
-    ASTInfo.activeTokenInfos(astInfo) |> List.findMap(~f=ti =>
-      targetAndTokenInfoToMaybeCaretPos((ct, ti))
-    )
+  ASTInfo.activeTokenInfos(astInfo) |> List.findMap(~f=ti =>
+    targetAndTokenInfoToMaybeCaretPos((ct, ti))
+  )
+}
 
-  switch newPosMaybe {
+@ocaml.doc("returns the position in the token stream corresponding to the passed
+  caretTarget within the passed ast. We expect to succeed in finding the target. If
+  we cannot, we `recover` and return the current caret pos as a fallback.
+
+  This is useful for determining the precise position to which the caret should jump
+  after a transformation.")
+let posFromCaretTarget = (ct: CT.t, astInfo: ASTInfo.t): int =>
+  switch posFromCaretTargetMaybe(ct, astInfo) {
   | Some(newPos) => newPos
   | None =>
     recover(
@@ -876,7 +882,6 @@ let posFromCaretTarget = (ct: CT.t, astInfo: ASTInfo.t): int => {
       astInfo.state.newPos,
     )
   }
-}
 
 @ocaml.doc(" moveToCaretTarget returns a modified fluidState with newPos set to reflect
     the caretTarget. ")
@@ -985,6 +990,9 @@ let caretTargetFromTokenInfo = (pos: int, ti: T.tokenInfo): option<CT.t> => {
   }
 }
 
+@ocaml.doc("Gets the caret target for a pos within a list of tokens. Ignores
+  whitespace tokens, and favors tokens 'to the right' of the pos, in cases where two
+  tokens surround the position.")
 let caretTargetForNextNonWhitespaceToken = (~pos, tokens: tokenInfos): option<CT.t> => {
   let rec getNextWS = tokens =>
     switch tokens {
@@ -999,6 +1007,35 @@ let caretTargetForNextNonWhitespaceToken = (~pos, tokens: tokenInfos): option<CT
 
   getNextWS(tokens)
 }
+
+@ocaml.doc("Gets the caret target for a pos within a list of tokens. Ignores
+  whitespace tokens, and favors tokens 'to the left' of the pos, in cases where two
+  tokens surround the position.")
+let caretTargetForCurrentNonWhitespaceToken = (~pos, tokens: tokenInfos): option<CT.t> =>
+  List.fold(
+    ~initial=None,
+    ~f=(ct, ti) => {
+      if T.isWhitespace(ti.token) {
+        // ignore non-AST formatting/whitespace tokens
+        ct
+      } else if ti.endPos < pos {
+        // if the token ends before the current 'pos', reference the end of the token
+        caretTargetFromTokenInfo(ti.endPos, ti)
+      } else if ti.startPos < pos {
+        // if the token _surrounds_ the caret, reference the current position within that token
+        caretTargetFromTokenInfo(pos, ti)
+      } else if ti.startPos == pos && Option.isNone(ct) {
+        // if the token starts at the current position, reference it only if we
+        // don't yet have a CT chosen. it's generally best to favor referencing
+        // tokens to the left of the cursor.
+        caretTargetFromTokenInfo(pos, ti)
+      } else {
+        // token is 'to the right' of pos; ignore
+        ct
+      }
+    },
+    tokens,
+  )
 
 @ocaml.doc(" moveToAstRef returns a modified fluidState with newPos set to reflect
     the targeted astRef.
@@ -4971,19 +5008,25 @@ and updateKey = (
   {...newAstInfo, ast: newAST}
 }
 
-/* deleteCaretRange is equivalent to pressing backspace starting from the
- * larger of the two caret positions until the caret reaches the smaller of the
- * caret positions or can no longer move.
- *
- * XXX(JULIAN): This actually moves the caret to the larger side of the range
- * and backspaces until the beginning, which means this hijacks the caret in
- * the state. */
+@ocaml.doc("This is equivalent to pressing backspace starting from the larger of the
+  two caret positions until the caret reaches the smaller of the caret positions or
+  can no longer move.
+
+  Note: This actually moves the caret to the larger side of the range and backspaces
+  until the beginning, which means this hijacks the caret in the state.")
 and deleteCaretRange = (
   props: FluidTypes.Props.t,
   caretRange: (int, int),
   origInfo: ASTInfo.t,
 ): ASTInfo.t => {
   let (rangeStart, rangeEnd) = orderRangeFromSmallToBig(caretRange)
+
+  // algorithm: backspace until we 'reach' this caret target
+  let caretTargetToEndOn = caretTargetForCurrentNonWhitespaceToken(
+    ~pos=rangeStart,
+    ASTInfo.activeTokenInfos(origInfo),
+  )
+
   let origInfo = ASTInfo.modifyState(origInfo, ~f=s => {
     ...s,
     newPos: rangeEnd,
@@ -4991,20 +5034,53 @@ and deleteCaretRange = (
     selectionStart: None,
   })
 
-  let oldInfo = ref(origInfo)
-  let nothingChanged = ref(false)
-  while !nothingChanged.contents && oldInfo.contents.state.newPos > rangeStart {
-    let newInfo = updateKey(props, DeleteContentBackward, oldInfo.contents)
-    if (
-      newInfo.state.newPos == oldInfo.contents.state.newPos && newInfo.ast == oldInfo.contents.ast
-    ) {
-      // stop if nothing changed--guarantees loop termination
-      nothingChanged := true
-    } else {
-      oldInfo := newInfo
+  let result = ref(origInfo)
+  let shouldStop = ref(false)
+
+  if rangeStart == rangeEnd {
+    // don't bother backspacing if our cursor is nothing is actually 'selected'
+    shouldStop := true
+  }
+
+  switch caretTargetToEndOn {
+  | None => ()
+
+  | Some(caretTargetToEndOn) =>
+    while !shouldStop.contents {
+      let newInfo = updateKey(props, DeleteContentBackward, result.contents)
+
+      let caretTargetToEndOnStillInScope =
+        posFromCaretTargetMaybe(caretTargetToEndOn, newInfo)->Option.isSome
+
+      let hasReachedCaretTargetToEndOn = {
+        let newCaretTarget = caretTargetForCurrentNonWhitespaceToken(
+          ~pos=newInfo.state.newPos,
+          ASTInfo.activeTokenInfos(newInfo),
+        )
+        switch newCaretTarget {
+        | None => false
+        | Some(newCaretTarget) => newCaretTarget == caretTargetToEndOn
+        }
+      }
+
+      if (
+        newInfo.state.newPos == result.contents.state.newPos && newInfo.ast == result.contents.ast
+      ) {
+        // stop if nothing changed - guarantees loop termination
+        shouldStop := true
+      } else if !caretTargetToEndOnStillInScope && newInfo.state.newPos <= rangeStart {
+        result := newInfo
+        shouldStop := true
+      } else if hasReachedCaretTargetToEndOn {
+        result := newInfo
+        shouldStop := true
+      } else {
+        result := newInfo
+      }
     }
   }
-  oldInfo.contents
+
+  result.contents
 }
 
 /* deleteSelection is equivalent to pressing backspace starting from the larger of the two caret positions

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2224,7 +2224,7 @@ let run = () => {
       aFnCallWithVersion,
       ~pos=12,
       inputs(list{DeleteWordForward}),
-      "DB::getAllv1 ___________________~",
+      "DB::getAllv1 ~___________________",
     )
     let string40 = "0123456789abcdefghij0123456789abcdefghij"
     let string80 = string40 ++ string40
@@ -2852,7 +2852,7 @@ let run = () => {
       aConstructor,
       ~pos=4,
       inputs(list{DeleteWordForward}),
-      "Just ___~",
+      "Just ~___",
     )
     t(
       ~expectsPartial=true,

--- a/client/test/TestFluid.res
+++ b/client/test/TestFluid.res
@@ -2224,7 +2224,7 @@ let run = () => {
       aFnCallWithVersion,
       ~pos=12,
       inputs(list{DeleteWordForward}),
-      "DB::getAllv1 ~___________________",
+      "DB::getAllv1 ___________________~",
     )
     let string40 = "0123456789abcdefghij0123456789abcdefghij"
     let string80 = string40 ++ string40
@@ -2852,7 +2852,7 @@ let run = () => {
       aConstructor,
       ~pos=4,
       inputs(list{DeleteWordForward}),
-      "Just ~___",
+      "Just ___~",
     )
     t(
       ~expectsPartial=true,

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -951,10 +951,29 @@ let run = () => {
       if'(bool(true), str("then body"), str("else body")),
       (12, 31),
       (
-        "if true\nthen\n  ~___\nelse\n  \"else body\"",
+        "if true\nthen~\n  ___\nelse\n  \"else body\"",
         "if ___\nthen\n  \"then body\"\nelse\n  ___",
       ),
     )
+    testCut(
+      "cutting the tail end of an if expr where surrounding tuple is removed as we delete",
+      tuple(if'(bool(true), str("then body"), str("else body")), bool(true), list{}),
+      (35, 53), // from `else|` to `tr|ue`
+      ("if true\nthen\n  \"then body\"\nelse~\n  ___", "(\"else body\",tr)"),
+    )
+    // TODO fix this test.
+    // The tuple surroundin the selection is removed as we backspace.
+    // Due to this, the 'else' we're referencing moves (indentation), so we stop
+    // deleting early.
+    // Initially, the plan is to delete until '4 characters after the end of the `else`'
+    // But with the tuple being removed, we want to end at '3 chars after the end of the `else`',
+    // and currently have no good way to 'learn' this along the way.
+    // testCut(
+    //   "same thing as above but we end just before the else branch's string expr",,
+    //   tuple(if'(bool(true), str("then body"), str("else body")), bool(true), list{}),
+    //   (39, 53), // from `|"else body"` to `tr|ue`
+    //   ("if true\nthen\n  \"then body\"\nelse\n  ~___", "(\"else body\",tr)"),
+    // )
     testCut(
       "cutting just the else body adds the else expression to clipboard",
       if'(bool(true), str("then body"), str("else body")),

--- a/client/test/TestFluidClipboard.res
+++ b/client/test/TestFluidClipboard.res
@@ -951,7 +951,7 @@ let run = () => {
       if'(bool(true), str("then body"), str("else body")),
       (12, 31),
       (
-        "if true\nthen~\n  ___\nelse\n  \"else body\"",
+        "if true\nthen\n  ~___\nelse\n  \"else body\"",
         "if ___\nthen\n  \"then body\"\nelse\n  ___",
       ),
     )
@@ -1233,12 +1233,12 @@ let run = () => {
       (5, 11),
       "(\"lo\",12)",
     )
-    // testCut( // TUPLETODO fix results - somehow an extra 'l' is being included.
-    //   "cutting halfway between tuple parts leaves a partial tuple and copies the data selected to clipboard",
-    //   tuple(str("hello"), int(1234), list{}), // ("hello",1234)
-    //   (5, 11),
-    //   ("(\"hel~\")", "(\"lo\",12)"),
-    // )
+    testCut(
+      "cutting halfway between tuple parts leaves a partial tuple and copies the data selected to clipboard",
+      tuple(str("hello"), int(1234), list{}), // ("hello",1234)
+      (5, 11),
+      ("\"hel~\"", "(\"lo\",12)"),
+    )
 
     // surrounding separators (1|,2,|3)
     testCopy(


### PR DESCRIPTION
Changelog:

```
Editor improvements:
- deleting a selected range of code is now more accurate
```

This will fix #4264

Our process to delete a "selection" of Dark code is currently pretty naive, and we're trying to make it much more solid and correct.

Currently, `Fluid.deleteCaretRange` deletes from the end of the selection to the start of the selection character by character.
In order to determine when to stop deleting, it checks for:
- is the 'current' position `<=` the selection's start pos? If so, we're done.
- has the last 'delete' done anything (changed our pos or changed the AST)? if not, stop, so we don't loop forever.

This falls short in situations where the position changes throughout the deletion process.
For example, consider if you start with the AST `(123, 456)` and select `(12|3, 4|56)`. Throughout the deletion (upon deleting the `,`), the second part of the tuple is deleted, which results in the tuple being ripped out, replacing the tuple with a simple `123`. When this happens, the position of `12|3` is suddenly `2` where it used to be `3`, and we end up deleting too little.

Here's a showcase of the bug:
![old](https://user-images.githubusercontent.com/906686/195380448-ff097fc4-45e8-4ca6-9ad3-4e04d3bee744.gif)

To resolve this, we should use CaretTargets - they refer to offsets of tokenizations of AST parts, and should be generally stable throughout the deletion loop.

With the fix, this is what happens when you `cut` in the same scenario:

![new](https://user-images.githubusercontent.com/906686/195380682-b7d2e986-87d0-46e5-bda5-88029041371b.gif)

---

It was tricky to ensure we had no regressions, but there are many tests around Fluid reconstruction which steered this away from a few wrong paths