### PR TITLE
Remove errant quote

### DIFF
--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -152,7 +152,7 @@ for mimetype in mimetypes_to_process:
   mimetype_subfolder = get_mimetype_temp_dir(mimetype)
   start = time.time()
   command = f'''gcloud storage cp \
-    --content-type ${mimetype}" \
+    --content-type ${mimetype} \
     --content-encoding gzip \
     --cache-control public \
     --no-clobber \


### PR DESCRIPTION
I believe that this is what [broke some deploys yesterday](https://app.circleci.com/pipelines/github/darklang/dark/4231/workflows/55546e52-b4b1-48bb-ab32-65ad97806eff/jobs/43940).

[This commit](https://github.com/darklang/dark/commit/3ad6c3d28b956fa63fd7f18788777721950a46ee) introduced an errant `"`