### PR TITLE
Rename String::toFloat to Float::parse

### DIFF
--- a/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
@@ -351,4 +351,25 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
+      deprecated = NotDeprecated }
+
+    { name = fn "Float" "parse" 1
+      parameters = [ Param.make "s" TStr "" ]
+      returnType = TResult(TFloat, TStr)
+      description = "Returns the <type float> value of the <type string>"
+      fn =
+        (function
+        | _, [ DStr s ] ->
+          (try
+            float (s) |> DFloat |> Ok |> DResult |> Ply
+           with
+           | e ->
+             "Expected a string representation of an IEEE float"
+             |> DStr
+             |> Error
+             |> DResult
+             |> Ply)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
       deprecated = NotDeprecated } ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibFloat.fs
@@ -353,7 +353,7 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated }
 
-    { name = fn "Float" "parse" 1
+    { name = fn "Float" "parse" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TResult(TFloat, TStr)
       description = "Returns the <type float> value of the <type string>"

--- a/fsharp-backend/src/LibExecutionStdLib/LibString.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibString.fs
@@ -259,28 +259,6 @@ let fns : List<BuiltInFn> =
       deprecated = ReplacedBy(fn "String" "toFloat" 1) }
 
 
-    { name = fn "String" "toFloat" 1
-      parameters = [ Param.make "s" TStr "" ]
-      returnType = TResult(TFloat, TStr)
-      description = "Returns the <type float> value of the <type string>"
-      fn =
-        (function
-        | _, [ DStr s ] ->
-          (try
-            float (s) |> DFloat |> Ok |> DResult |> Ply
-           with
-           | e ->
-             "Expected a string representation of an IEEE float"
-             |> DStr
-             |> Error
-             |> DResult
-             |> Ply)
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
     { name = fn "String" "toUppercase" 0
       parameters = [ Param.make "s" TStr "" ]
       returnType = TStr

--- a/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/StdLib.fs
@@ -22,7 +22,8 @@ let renames =
     fn "Object" "toJSON" 1, fn "Dict" "toJSON" 0
     fn "Date" "subtract" 0, fn "Date" "subtractSeconds" 0
     fn "List" "contains" 0, fn "List" "member" 0
-    fn "String" "toUUID" 1, fn "Uuid" "parse" 0 ]
+    fn "String" "toUUID" 1, fn "Uuid" "parse" 0
+    fn "String" "toFloat" 1, fn "Float" "parse" 0 ]
 
 
 let prefixFns : List<BuiltInFn> =

--- a/fsharp-backend/testfiles/execution/float.tests
+++ b/fsharp-backend/testfiles/execution/float.tests
@@ -104,6 +104,16 @@ Float.min_v0 2147483647.0 00000000.000 = 0.0
 
 Float.multiply_v0 26.0 0.5 = 13.0
 
+Float.parse_v0 "1.5" = Ok 1.5
+Float.parse_v0 "0.0" = Ok 0.0
+Float.parse_v0 "-0.5" = Ok -0.5
+Float.parse_v0 "+0.5" = Ok 0.5
+Float.parse_v0 ".5" = Ok 0.5
+Float.parse_v0 "-55555555555555555555555555555.5" = Ok -55555555555555555555555555555.5
+Float.parse_v0 "-141s" = Error "Expected a string representation of an IEEE float"
+Float.parse_v0 "" = Error "Expected a string representation of an IEEE float"
+//Float.parse_v0 "0xffffffffffffffff" = Ok 1.844674407e+19
+
 Float.power_v0 4.0 -0.5 = 0.5
 Float.power_v0 4.0 0.5 = 2.0
 


### PR DESCRIPTION
Changelog:

```
Standard library:
- rename `String::toFloat_v1` to `Float::parse_v0`
```

Fixes #4503 
 