### PR TITLE
Stick to gsutil

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:b7819f8
+      - image: darklang/dark-base:8fb190f
 
 commands:
   show-large-files-and-directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,23 @@ ENV PUBSUB_EMULATOR_HOST=0.0.0.0:8085
 
 # GKE
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
+
+# crcmod for gsutil; this gets us the compiled (faster), not pure Python
+# (slower) crcmod, as described in `gsutil help crcmod`
+#
+# It requires that python3-pip, python3-dev, python3-setuptools, and gcc be
+# installed. You'll also need CLOUDSDK_PYTHON=python3 to be set when you use
+# gsutil. (Which the ENV line handles.)
+#
+# The last line greps to confirm that gsutil has a compiled crcmod.
+# Possible failure modes; missing deps above (-pip, -dev, -setuptools, gcc); a
+# pre-installed crcmod that needs to be uninstalled first.  Added that because
+# this install is a bit brittle, and it's easy to invisibly install the pure
+# Python crcmod.
 ENV CLOUDSDK_PYTHON=python3
+RUN sudo pip3 install -U --no-cache-dir -U crcmod \
+  && ((gsutil version -l | grep compiled.crcmod:.True) \
+      || (echo "Compiled crcmod not installed." && false))
 
 ############################
 # Pip packages

--- a/docs/production/static-assets.md
+++ b/docs/production/static-assets.md
@@ -7,15 +7,6 @@ fronted by a gcloud loadbalancer (which does the CDN work).
 
 Of note:
 
-- gcp can do "decompressive transcoding", which means that what we upload must
-  already be gzipped, and the 'Content-Encoding: gzip' header attached (see:
-  `scripts/deployment/_push-assets-to-cdn` script for details). Assuming that is done,
-  google cloud cdn will handle sending either gzipped or decompressed files depending
-  on whether the request headers include 'Content-Encoding: gzip'.
-  - NOTE: if you do one but not the other (`gcloud storage cp --content-encoding gzip`,
-    but with decompressed files), Chrome will give you CONTENT_ENCODING errors. To fix:
-    re-upload with `gcloud storage cp` and bust the cache in GCloud Console. You are not likely
-    to run into this, because `scripts/deployment/_push-assets-to-cdn` does the work.
 - The bucket must send appropriate Access-Control-Allow-Origin headers, or the
   browser won't be able to load some things. (We've seen this with
   `vendor/fontawesome-*/css/all.css`, and with `*.{woff,ttf}`.) - To fix: create a file

--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -151,14 +151,34 @@ for f in static_files_to_copy:
 for mimetype in mimetypes_to_process:
   mimetype_subfolder = get_mimetype_temp_dir(mimetype)
   start = time.time()
-  command = f'''gcloud storage cp \
-    --content-type ${mimetype} \
-    --content-encoding gzip \
-    --cache-control public \
-    --no-clobber \
-    --recursive \
-    . "{BUCKET}"
-    '''
+
+  # Unfortunately, gzip-local overrides the cache-control header, so this doesn't work
+  # See discussion in https://issuetracker.google.com/issues/252956852
+  # So let's just stick to gsutil for now
+  # A better option in future is to use dynamic compression: https://cloud.google.com/cdn/docs/dynamic-compression
+  # command = f'''gcloud storage cp \
+  #   --content-type {mimetype} \
+  #   --cache-control "public, no-transform" \
+  #   --gzip-local \
+  #   --no-clobber \
+  #   --recursive \
+  #   . "{BUCKET}"
+  #   '''
+
+  # - global gsutil args
+  #   -h: set header
+  #   -m: Upload assets in parallel, within call
+  # - `cp`-specific args
+  #   -Z: Uploaded file is served as zipped. Also adds 'no-transform' to Cache-Control header
+  #   -n: Don't overwrite
+  #   -r: Copy recursively
+  start = time.time()
+  command = f'''gsutil \
+    -h "Content-Type:{mimetype}" \
+    -h "Cache-Control:public" \
+    -m \
+    cp -Z -n -r . "{BUCKET}"
+  '''
 
   result = subprocess.run(command,
                           shell=True,
@@ -174,5 +194,6 @@ for mimetype in mimetypes_to_process:
   print(f"Uploaded dir {mimetype_subfolder} for mimetype {mimetype} in {elapsed}s")
 
 # Wrap up
-shutil.rmtree(temp_dir, ignore_errors=True)
+print("temp_dir", temp_dir)
+# shutil.rmtree(temp_dir, ignore_errors=True)
 print("Done!")

--- a/scripts/deployment/_push-assets-to-cdn
+++ b/scripts/deployment/_push-assets-to-cdn
@@ -194,6 +194,5 @@ for mimetype in mimetypes_to_process:
   print(f"Uploaded dir {mimetype_subfolder} for mimetype {mimetype} in {elapsed}s")
 
 # Wrap up
-print("temp_dir", temp_dir)
-# shutil.rmtree(temp_dir, ignore_errors=True)
+shutil.rmtree(temp_dir, ignore_errors=True)
 print("Done!")


### PR DESCRIPTION
No changelog

I tried to improve the speed of deploys by switching to `gcloud storage cp` from `gsutil cp`, but ended up breaking things. So this goes back to the old one.

- [x] TODO: revert dockerfile