### PR TITLE
Use tailwind 3.2 nested groups

### DIFF
--- a/client/src/canvas/ViewSidebar.res
+++ b/client/src/canvas/ViewSidebar.res
@@ -446,7 +446,7 @@ let viewEntry = (m: model, e: entry): Html.html<msg> => {
       ~key=e.name ++ "-plus",
       ~icon="plus-circle",
       ~style=%twc(
-        "ml-1.5 group-sidebar-addbutton-hover:text-sidebar-hover inline-block text-grey8"
+        "ml-1.5 group-hover/sidebar-addbutton:text-sidebar-hover inline-block text-grey8"
       ),
       msg,
     )
@@ -512,7 +512,7 @@ let viewEntry = (m: model, e: entry): Html.html<msg> => {
     | SendMsg(_) | DoNothing | Destination(_) => Vdom.noProp
     }
 
-    Html.span(list{tw(%twc("group inline-block group-sidebar-addbutton w-full")), action}, contents)
+    Html.span(list{tw(%twc("group inline-block group/sidebar-addbutton w-full")), action}, contents)
   }
 
   // This prevents the delete button appearing
@@ -583,7 +583,7 @@ let viewToplevelCategory = (
       }
 
       let style = %twc(
-        "text-grey5 duration-200 text-2xl group-sidebar-category-hover:text-3xl pr-1 w-full h-9 text-center box-border"
+        "text-grey5 duration-200 text-2xl group-hover/sidebar-category:text-3xl pr-1 w-full h-9 text-center box-border"
       )
 
       Html.div(
@@ -604,14 +604,14 @@ let viewToplevelCategory = (
   }
 
   Html.div(
-    list{tw(%twc("pb-5 text-center relative group-sidebar-category"))},
+    list{tw(%twc("pb-5 text-center relative group/sidebar-category"))},
     list{
       sidebarIcon,
       Html.div(
         list{
           tw(
             %twc(
-              "absolute -top-5 left-14 pt-1.5 pb-3 px-2.5 box-border min-w-[20rem] max-w-[40rem] max-h-96 bg-sidebar-bg shadow-[2px_2px_2px_0_var(--black1)] z-[1] overflow-y-scroll w-max text-left hidden group-sidebar-category-hover:block"
+              "absolute -top-5 left-14 pt-1.5 pb-3 px-2.5 box-border min-w-[20rem] max-w-[40rem] max-h-96 bg-sidebar-bg shadow-[2px_2px_2px_0_var(--black1)] z-[1] overflow-y-scroll w-max text-left hidden group-hover/sidebar-category:block"
             ),
           ),
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3063,12 +3063,6 @@
         }
       }
     },
-    "tailwindcss-labeled-groups": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss-labeled-groups/-/tailwindcss-labeled-groups-0.0.2.tgz",
-      "integrity": "sha512-leOVv9h2K9WDHoXPXVBOmTJgWECVkpVFc/hjrwuqGUEtNxvRvuOtCjenu9ppY+pJtky5INJUqDCNa8pS3AbYmw==",
-      "dev": true
-    },
     "thenby": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "ppx-deriving": "44.2.0",
     "sass": "^1.55.0",
     "tailwind-scrollbar": "^2.0.1",
-    "tailwindcss": "^3.2.0",
-    "tailwindcss-labeled-groups": "^0.0.2"
+    "tailwindcss": "^3.2.0"
   },
   "dependencies": {
     "@fullstory/browser": "^1.6.2",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -83,13 +83,5 @@ module.exports = {
     // the other reset css used, so disable it.
     preflight: false,
   },
-  plugins: [
-    require("tailwind-scrollbar")({ nocompatible: true }),
-    require("tailwindcss-labeled-groups")([
-      // This allows us have overlapping and nested groups. Each time you need a
-      // group, create a new one with a contextual name
-      "sidebar-category",
-      "sidebar-addbutton",
-    ]),
-  ],
+  plugins: [require("tailwind-scrollbar")({ nocompatible: true })],
 };


### PR DESCRIPTION
No changelog


New feature I saw in the dependabot changelog. Seems much nicer, and always better to use a first-class thing rather than a plugin. We also no longer need to declare them, so they're easier to use.