### PR TITLE
Print timedout tests in Playwright

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -5,19 +5,19 @@
   "requires": true,
   "dependencies": {
     "@playwright/test": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
-      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
+      "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.27.1"
+        "playwright-core": "1.26.1"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.27.1",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-          "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
+          "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
           "dev": true
         }
       }
@@ -29,18 +29,18 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.27.1.tgz",
-      "integrity": "sha512-xXYZ7m36yTtC+oFgqH0eTgullGztKSRMb4yuwLPl8IYSmgBM88QiB+3IWb1mRIC9/NNwcgbG0RwtFlg+EAFQHQ==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.1.tgz",
+      "integrity": "sha512-WQmEdCgYYe8jOEkhkW9QLcK0PB+w1RZztBLYIT10MEEsENYg251cU0IzebDINreQsUt+HCwwRhtdz4weH9ICcQ==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.27.1"
+        "playwright-core": "1.26.1"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.27.1",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
-          "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
+          "version": "1.26.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
+          "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
           "dev": true
         }
       }

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -5,42 +5,42 @@
   "requires": true,
   "dependencies": {
     "@playwright/test": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-      "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.26.1"
+        "playwright-core": "1.27.1"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.26.1",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-          "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+          "version": "1.27.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+          "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
           "dev": true
         }
       }
     },
     "@types/node": {
-      "version": "18.8.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.1.tgz",
-      "integrity": "sha512-vuYaNuEIbOYLTLUAJh50ezEbvxrD43iby+lpUA2aa148Nh5kX/AVO/9m1Ahmbux2iU5uxJTNF9g2Y+31uml7RQ==",
+      "version": "18.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
+      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
       "dev": true
     },
     "playwright": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.26.1.tgz",
-      "integrity": "sha512-WQmEdCgYYe8jOEkhkW9QLcK0PB+w1RZztBLYIT10MEEsENYg251cU0IzebDINreQsUt+HCwwRhtdz4weH9ICcQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.27.1.tgz",
+      "integrity": "sha512-xXYZ7m36yTtC+oFgqH0eTgullGztKSRMb4yuwLPl8IYSmgBM88QiB+3IWb1mRIC9/NNwcgbG0RwtFlg+EAFQHQ==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.26.1"
+        "playwright-core": "1.27.1"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.26.1",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-          "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+          "version": "1.27.1",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+          "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
           "dev": true
         }
       }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "author": "",
   "devDependencies": {
-    "@playwright/test": "1.26.1",
-    "playwright": "1.26.1"
+    "@playwright/test": "1.27.1",
+    "playwright": "1.27.1"
   },
   "dependencies": {}
 }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "author": "",
   "devDependencies": {
-    "@playwright/test": "1.27.1",
-    "playwright": "1.27.1"
+    "@playwright/test": "1.26.1",
+    "playwright": "1.26.1"
   },
   "dependencies": {}
 }

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -98,7 +98,7 @@ fi
 echo "Starting playwright"
 integration-tests/node_modules/.bin/playwright --version
 
-BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" DEBUG=pw:test integration-tests/node_modules/.bin/playwright \
+BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" integration-tests/node_modules/.bin/playwright \
   test \
   $DEBUG_MODE_FLAG \
   --workers "$CONCURRENCY" \

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -97,6 +97,7 @@ fi
 ######################
 echo "Starting playwright"
 integration-tests/node_modules/.bin/playwright --version
+set +e # We're going to use this error code
 BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" integration-tests/node_modules/.bin/playwright \
   test \
   $DEBUG_MODE_FLAG \

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -107,3 +107,14 @@ BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" integration-tests/node_modules
   --output "rundir/integration-tests/" \
   --retries "$RETRIES" \
   --config integration-tests/playwright.config.ts
+
+STATUS=$?
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "Playwright tests failed"
+  echo "The following tests were skipped and shouldn't have been (if the integration test timed out, these are likely culprits):"
+  cat rundir/test_results/integration_tests.json | jq -r '.suites[0].suites[0].specs[] | select( .tests[0].results[0].status == "skipped") | .title ' | sort
+
+  exit $STATUS
+fi
+

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -108,6 +108,8 @@ BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" integration-tests/node_modules
   --retries "$RETRIES" \
   --config integration-tests/playwright.config.ts
 
+set -x
+
 STATUS=$?
 
 if [[ $STATUS -ne 0 ]]; then

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -97,8 +97,11 @@ fi
 ######################
 echo "Starting playwright"
 integration-tests/node_modules/.bin/playwright --version
+
+set -x
 set +e # We're going to use this error code
-BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" integration-tests/node_modules/.bin/playwright \
+
+BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" DEBUG=pw:test integration-tests/node_modules/.bin/playwright \
   test \
   $DEBUG_MODE_FLAG \
   --workers "$CONCURRENCY" \
@@ -108,8 +111,6 @@ BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" integration-tests/node_modules
   --output "rundir/integration-tests/" \
   --retries "$RETRIES" \
   --config integration-tests/playwright.config.ts
-
-set -x
 
 STATUS=$?
 

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -98,7 +98,6 @@ fi
 echo "Starting playwright"
 integration-tests/node_modules/.bin/playwright --version
 
-set -x
 set +e # Don't fail immediately - we want to list skipped files
 BASE_URL="$BASE_URL" BWD_BASE_URL="$BWD_BASE_URL" integration-tests/node_modules/.bin/playwright \
   test \
@@ -117,8 +116,7 @@ STATUS=$? # Save the playwright exit code
 SKIPPED=$(cat rundir/test_results/integration_tests.json | jq -r '.suites[0].suites[0].specs[] | select( .tests[0].results[0].status == "skipped") | .title ' | sort)
 
 if [[ "$SKIPPED" != "" ]]; then
-  echo "Playwright tests failed"
-  echo "The following tests were skipped and shouldn't have been (if the integration test timed out, these are likely culprits):"
+  echo "Playwright skipped these tests and shouldn't have (if the integration test timed out, these are likely culprits):"
   echo "$SKIPPED"
   exit 1
 fi


### PR DESCRIPTION
No changelog

When integration tests timeout, it's hard to know the cause. This searches through the json output to find the tests which were skipped, which I take to mean "were not complete when timed out".

We shouldn't really need this, as the test should a) fail after it's own timeout and b) be reported after the global timeout imo, but those aren't happening, so here we are.

I've reported these to playwright as well: https://github.com/microsoft/playwright/issues/18250 and https://github.com/microsoft/playwright/issues/18248

