### PR TITLE
Fix preload of API calls

### DIFF
--- a/fsharp-backend/src/ApiServer/Templates/ui.html
+++ b/fsharp-backend/src/ApiServer/Templates/ui.html
@@ -15,8 +15,8 @@
     <link rel="preconnect" href="https://cdnjs.cloudflare.com/" crossorigin />
     <link rel="preconnect" href="https://fonts.gstatic.com/" />
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
-    <link rel="preconnect" href="//{STATIC}/" />
-    <link rel="preconnect" href="//{STATIC}/" crossorigin />
+    <link rel="preconnect" href="//{{STATIC}}/" />
+    <link rel="preconnect" href="//{{STATIC}}/" crossorigin />
 
     <!-- Preload all files async -->
     <link
@@ -46,11 +46,19 @@
       href="//{{STATIC}}/app.js"
       crossorigin="anonymous"
     />
-    <link rel="preload" href="/api/{{CANVAS_NAME}}/v1/packages" as="fetch" />
+    <!-- Preloading there API calls is very delicate, they must match exactly and we
+    have very limited control over the headers -->
+    <link
+      rel="preload"
+      href="/api/{{CANVAS_NAME}}/v1/packages"
+      as="fetch"
+      crossorigin
+    />
     <link
       rel="preload"
       href="/api/{{CANVAS_NAME}}/v1/initial_load"
       as="fetch"
+      crossorigin
     />
 
     <!-- Actually load the files -->


### PR DESCRIPTION
Changelog:

```
Editor
- preload first API requests to load the editor faster
```

I had thought this worked but evidently the headers were wrong, which the devtools reported.

<img width="937" alt="Screen Shot 2022-11-01 at 11 05 57 AM" src="https://user-images.githubusercontent.com/181762/199266241-df1e3287-97ff-4a73-a769-4527e36b5cb1.png">

You can see packages being loaded twice:
<img width="958" alt="Screen Shot 2022-11-01 at 11 05 28 AM" src="https://user-images.githubusercontent.com/181762/199266240-1c82d71e-7093-466b-b2ae-3a3452d48429.png">

