### PR TITLE
Fix for WSL users with a space in their username

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -117,7 +117,7 @@
   // doesn't have bash, which is needed to interpolate string values here
   "initializeCommand": [
     "./scripts/devcontainer/_initialize-vscode",
-    "${localEnv:USERPROFILE}${localEnv:HOME}"
+    "\"${localEnv:USERPROFILE}${localEnv:HOME}\""
   ],
 
   // Run one build-server, and keep it running for the life of the

--- a/scripts/devcontainer/_initialize-vscode
+++ b/scripts/devcontainer/_initialize-vscode
@@ -6,7 +6,7 @@
 # must run in vscode's default docker container.
 
 if [ -z "$WSLENV" ]; then
-  home=$1
+  home="$1"
 else
   home=$(wslpath $1)
 fi


### PR DESCRIPTION
Changelog:

```
Contributor experience
- Fix error when initializing devcontainer when username has a space
```
