### PR TITLE
Try a fresh cache each week for .net

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,8 @@ jobs:
       # TODO: think through an alternative or more nuanced approach.
       #- run: git restore-mtime
       - setup-app
-      - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
+      # The date is used to get a fresh cache each week
+      - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json <(date +"%U%Y") > ../checksum
       - restore_cache:
           keys:
             - v15-fsharp-backend-{{ checksum "../checksum" }}
@@ -345,7 +346,8 @@ jobs:
       # rebuilt.
       - run: git restore-mtime
       - setup-app
-      - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json > ../checksum
+      # The date is used to get a fresh cache each week
+      - run: shasum fsharp-backend/paket.lock fsharp-backend/global.json <(date +"%U%Y") > ../checksum
       - restore_cache:
           keys:
             - v4-fsharp-blazor-{{ checksum "../checksum" }}


### PR DESCRIPTION
No changelog

Try to speed up the build. The .net cache can get stale, so use a new one each week. That will slow down the first build of the week, but I expect this to shave a minute or two off all subsequent builds
