### PR TITLE
Show selected fn doc, not the doc of the fn it's an argument of

### DIFF
--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -202,8 +202,8 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
 
       acFnDocString
       |> Option.orElse(cmdDocString)
-      |> Option.orElse(selectedParamDocString)
       |> Option.orElse(selectedFnDocString)
+      |> Option.orElse(selectedParamDocString)
       |> Option.unwrap(~default=Vdom.noNode)
     | _ => Vdom.noNode
     }


### PR DESCRIPTION
Changelog:

```
Autocomplete
- When using nested function calls, display documentation for the nested function
```

As I recall, we chose the old order to prioritize more detailed documentation, so for example if you have `a 5|` it would show the docs for `a` with parameter info. However, if we have `a (b| c)` it would prioritize showing docs for `a` instead of `b`.

I need to do a little more testing to make sure this doesn't make other things worse. Maybe I'll add some tests.