### PR TITLE
Fix ssl-cert-snakeoil.key permission denied

### DIFF
--- a/scripts/devcontainer/_start-background-services
+++ b/scripts/devcontainer/_start-background-services
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+sudo chmod 766 /etc/ssl/private
+sudo chown postgres:postgres /etc/ssl/private/ssl-cert-snakeoil.key
+
 for name in "${@}"; do
   if [[ $name == postgresql ]]; then
     # for some reason, uncommenting the equivalent line in the Dockerfile doesn't do the
@@ -9,7 +12,12 @@ for name in "${@}"; do
     LA="listen_addresses = '*'"
     echo "$LA" | sudo tee -a /etc/postgresql/9.6/main/postgresql.conf
   fi
-
+  sudo mkdir /etc/ssl/private-copy
+  sudo mv /etc/ssl/private/* /etc/ssl/private-copy/
+  sudo rm -r /etc/ssl/private
+  sudo mv /etc/ssl/private-copy /etc/ssl/private
+  sudo chmod -R 0700 /etc/ssl/private
+  sudo chown -R postgres /etc/ssl/private
   echo "--------------------------"
   echo "--  Starting $name"
   echo "--------------------------"


### PR DESCRIPTION
Changelog:

```
Area of change
- Add some `chmod` and `chown` in the **scripts/devcontainer/_start-background-services**
```

alternatively:

No changelog

## What is the problem/goal being addressed?
Not sure if it's always happen, but I got this postgresql related error when trying to run `scripts/builder --compile --watch --test`

```
UTC FATAL: could not access private key file "/etc/ssl/private/ssl-cert-snakeoil.key": Permission denied
```

## What is the solution to this problem?

It sounds a lot like that's a [really tricky](https://stackoverflow.com/questions/34209661/fatal-could-not-access-private-key-file-etc-ssl-private-ssl-cert-snakeoil-key) issue, inspired by [this crazy solution](https://github.com/puntonim/docker-postgresql93/issues/2), finally I made it.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?

I just added some `chmod` and `chown` in the **scripts/devcontainer/_start-background-services**, I believe it won't have any other product impacts.

## How are you sure this works/how was this tested?
I didn't test it, but after adding this shell commands, I got `-- Initial compile succeeded` finally.

## What is the reversion plan if this fails after shipping?
Just rollback this script.

## Has this information been included in the comments?
No, since it's an one-off script.