### PR TITLE
Don't let cert-manager pods prevent us from scaling down

### DIFF
--- a/services/custom-domains-darklang/cert-manager-issuer.yaml
+++ b/services/custom-domains-darklang/cert-manager-issuer.yaml
@@ -23,3 +23,7 @@ spec:
       - http01:
           ingress:
             name: darkcustomdomain-tls-ingress
+            podTemplate:
+              metadata:
+                annotations:
+                  cluster-autoscaler.kubernetes.io/safe-to-evict: "true"


### PR DESCRIPTION
Changelog:

```
Internal changes:
- don't let cert-manager prevent us from scaling down
```

Cert-manager pods aren't marked as safe-to-evict in k8s, so the GKE autoscheduler will do a bad job of scaling down when it sees them (if someone has a domain added or changes their domain's DNS).

As a result, we've been running with 6 VMs, when we could reasonably have been running with 4.


```
dark@dark-dev:~/app$ kubectl explain issuer.spec.acme.solvers.http01.ingress.podTemplate
KIND:     Issuer
VERSION:  cert-manager.io/v1

RESOURCE: podTemplate <Object>

DESCRIPTION:
     Optional pod template used to configure the ACME challenge solver pods used
     for HTTP01 challenges.

FIELDS:
   metadata	<Object>
     ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the
     'labels' and 'annotations' fields may be set. If labels or annotations
     overlap with in-built values, the values here will override the in-built
     values.
```