### PR TITLE
Add List::partition_v0 stdlib fn

### DIFF
--- a/client/src/analysis/Functions.res
+++ b/client/src/analysis/Functions.res
@@ -137,7 +137,10 @@ let calculateAllowedFunctionsList = (props: props, t: t): list<Function.t> => {
     let isNonExperimentalOrOptedIn = (f: Function.t): bool =>
       // TUPLETODO remove this filter when the experimental setting is removed
       switch f.name {
-      | Stdlib(fnName) if String.startsWith(~prefix="Tuple", fnName.module_) => props.allowTuples
+      | Stdlib(fnName)
+        if String.startsWith(~prefix="Tuple", fnName.module_) ||
+        (fnName.module_ == "List" && fnName.function == "partition") =>
+        props.allowTuples
       | _ => true
       }
 

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -1230,17 +1230,20 @@ module Ply =
         return List.rev filtered
       }
 
-    let partitionSequentially (f : 'a -> Ply<bool>) (list : List<'a>) : Ply<List<'a> * List<'a>> =
+    let partitionSequentially
+      (f : 'a -> Ply<bool>)
+      (list : List<'a>)
+      : Ply<List<'a> * List<'a>> =
       uply {
         let! (a, b) =
           List.fold
             (fun (accum : Ply<List<'a> * List<'a>>) (arg : 'a) ->
               uply {
-                let! (a : List<'a>, b: List<'a>) = accum
+                let! (a : List<'a>, b : List<'a>) = accum
                 let! keep = f arg
                 return (if keep then (arg :: a, b) else (a, arg :: b))
               })
-            (Ply (([], [])))
+            (Ply(([], [])))
             list
 
         return (List.rev a, List.rev b)

--- a/fsharp-backend/src/Prelude/Prelude.fs
+++ b/fsharp-backend/src/Prelude/Prelude.fs
@@ -1230,25 +1230,6 @@ module Ply =
         return List.rev filtered
       }
 
-    let partitionSequentially
-      (f : 'a -> Ply<bool>)
-      (list : List<'a>)
-      : Ply<List<'a> * List<'a>> =
-      uply {
-        let! (a, b) =
-          List.fold
-            (fun (accum : Ply<List<'a> * List<'a>>) (arg : 'a) ->
-              uply {
-                let! (a : List<'a>, b : List<'a>) = accum
-                let! keep = f arg
-                return (if keep then (arg :: a, b) else (a, arg :: b))
-              })
-            (Ply(([], [])))
-            list
-
-        return (List.rev a, List.rev b)
-      }
-
     let iterSequentially (f : 'a -> Ply<unit>) (list : List<'a>) : Ply<unit> =
       List.fold
         (fun (accum : Ply<unit>) (arg : 'a) ->

--- a/fsharp-backend/testfiles/execution/list.tests
+++ b/fsharp-backend/testfiles/execution/list.tests
@@ -186,13 +186,13 @@ List.member_v0 [1;2;3] 2 = true
 List.member_v0 [1;2;3] 4 = false
 List.member_v0 [] 1 = false
 
-List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> Nothing | 2 -> false | 3 -> true) = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `Nothing`", [])
-List.partition_v0 [true;false;true] (fun item -> "a") = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `\"a\"`", [])
-List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> blank | 3 -> true) = (blank, [])
-List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> false | 3 -> true) = ([ 1; 3 ], [2])
 List.partition_v0 [-20; 5; 9;] (fun x -> x > 0) = ([5; 9], [-20])
 List.partition_v0 [] (fun item -> true) = ([], [])
 List.partition_v0 [] (fun item -> "a") = ([], [])
+List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> false | 3 -> true) = ([ 1; 3 ], [2])
+List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> blank | 3 -> true) = ([ 1; 3 ], [2])
+List.partition_v0 [true;false;true] (fun item -> "a") = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `\"a\"`", [])
+List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> Nothing | 2 -> false | 3 -> true) = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `Nothing`", [])
 
 List.pushBack_v0 [2;3] 1 = [2;3;1]
 List.pushBack_v0 [] 1 = [1]

--- a/fsharp-backend/testfiles/execution/list.tests
+++ b/fsharp-backend/testfiles/execution/list.tests
@@ -190,7 +190,7 @@ List.partition_v0 [-20; 5; 9;] (fun x -> x > 0) = ([5; 9], [-20])
 List.partition_v0 [] (fun item -> true) = ([], [])
 List.partition_v0 [] (fun item -> "a") = ([], [])
 List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> false | 3 -> true) = ([ 1; 3 ], [2])
-List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> blank | 3 -> true) = ([ 1; 3 ], [2])
+List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> blank | 3 -> true) = blank
 List.partition_v0 [true;false;true] (fun item -> "a") = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `\"a\"`", [])
 List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> Nothing | 2 -> false | 3 -> true) = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `Nothing`", [])
 

--- a/fsharp-backend/testfiles/execution/list.tests
+++ b/fsharp-backend/testfiles/execution/list.tests
@@ -186,6 +186,14 @@ List.member_v0 [1;2;3] 2 = true
 List.member_v0 [1;2;3] 4 = false
 List.member_v0 [] 1 = false
 
+List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> Nothing | 2 -> false | 3 -> true) = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `Nothing`", [])
+List.partition_v0 [true;false;true] (fun item -> "a") = (Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `\"a\"`", [])
+List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> blank | 3 -> true) = (blank, [])
+List.partition_v0 [1;2;3] (fun item -> match item with | 1 -> true | 2 -> false | 3 -> true) = ([ 1; 3 ], [2])
+List.partition_v0 [-20; 5; 9;] (fun x -> x > 0) = ([5; 9], [-20])
+List.partition_v0 [] (fun item -> true) = ([], [])
+List.partition_v0 [] (fun item -> "a") = ([], [])
+
 List.pushBack_v0 [2;3] 1 = [2;3;1]
 List.pushBack_v0 [] 1 = [1]
 


### PR DESCRIPTION
Changelog:

```
Standard library
- add `List::partition_v0` function to split a list into 2 lists
```

---

I was recently reaching for this function and found that we didn't have it.
For now, it's hidden behind our experimental tuple usage editor setting.