### PR TITLE
Fix List::all parameter list

### DIFF
--- a/fsharp-backend/src/LibExecution/RuntimeTypes.fs
+++ b/fsharp-backend/src/LibExecution/RuntimeTypes.fs
@@ -331,6 +331,11 @@ and DType =
   | TFn of List<DType> * DType // replaces TLambda
   | TRecord of List<string * DType>
 
+  member this.isFn() : bool =
+    match this with
+    | TFn _ -> true
+    | _ -> false
+
   // This string was created in the very old days, and is barely used anymore
   member this.toOldString() : string =
     // Used in DB::schema_v0, to save type in honeycomb after queue execution
@@ -379,6 +384,7 @@ and Param =
     description : string }
 
   static member make (name : string) (typ : DType) (description : string) : Param =
+    assert_ "make called on TFn" [ "name", name ] (not (typ.isFn ()))
     { name = name; typ = typ; description = description; blockArgs = [] }
 
   static member makeWithArgs
@@ -387,6 +393,7 @@ and Param =
     (description : string)
     (blockArgs : List<string>)
     : Param =
+    assert_ "makeWithArgs not called on TFn" [ "name", name ] (typ.isFn ())
     { name = name; typ = typ; description = description; blockArgs = blockArgs }
 
 /// Functions for working with Dark runtime expressions

--- a/fsharp-backend/src/LibExecutionStdLib/LibList.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibList.fs
@@ -772,10 +772,11 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "all" 0
       parameters =
         [ Param.make "list" (TList varA) ""
-          Param.make
+          Param.makeWithArgs
             "fn"
             (TFn([ varA ], TBool))
-            "Function to be applied on all list elements;" ]
+            "Function to be applied on all list elements"
+            [ "val" ] ]
       returnType = TBool
       description =
         "Return {{true}} if all elements in the list meet the function's criteria, else {{false}}"


### PR DESCRIPTION
Changelog:

```
Standard Library
- fix lambda argument names for `List::all_v0`

Internal improvements
- add assertion that all standard library functions that take lambdas have default names provided for the lambda arguments
```