### PR TITLE
Add some Char functions

### DIFF
--- a/client/src/forms/Autocomplete.res
+++ b/client/src/forms/Autocomplete.res
@@ -561,6 +561,7 @@ let allowedParamTypes = list{
   TStr,
   TBool,
   TFloat,
+  TChar,
   TDict(DType.any),
   TList(DType.any),
   DType.any,

--- a/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
@@ -105,7 +105,10 @@ let fns : List<BuiltInFn> =
       description = "Return whether <param c> is a lowercase character."
       fn =
         function
-        | _, [ DChar c ] -> Ply(DBool(c.ToLower() = c && c.ToUpper() <> c))
+        | _, [ DChar c ] ->
+          // If we just check that the uppercase value of the char is the same, then
+          // chars that are not letters would be incorrectly reported as uppercase
+          Ply(DBool(c.ToLower() = c && c.ToUpper() <> c))
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
@@ -118,7 +121,10 @@ let fns : List<BuiltInFn> =
       description = "Return whether <param c> is an uppercase character."
       fn =
         function
-        | _, [ DChar c ] -> Ply(DBool(c.ToUpper() = c && c.ToLower() <> c))
+        | _, [ DChar c ] ->
+          // If we just check that the uppercase value of the char is the same, then
+          // chars that are not letters would be incorrectly reported as uppercase
+          Ply(DBool(c.ToUpper() = c && c.ToLower() <> c))
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplementedTODO
       previewable = Pure

--- a/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
@@ -68,4 +68,58 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
       deprecated =
-        DeprecatedBecause("used an old Character type that no longer exists") } ]
+        DeprecatedBecause("used an old Character type that no longer exists") }
+
+
+    { name = fn "Char" "toUppercase" 1
+      parameters = [ Param.make "c" TChar "" ]
+      returnType = TChar
+      description =
+        "Return the uppercase value of <param c>. If <param c> does not have an uppercase value, returns <param c>"
+      fn =
+        function
+        | _, [ DChar c ] -> Ply(DChar(c.ToUpper()))
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Char" "toLowercase" 1
+      parameters = [ Param.make "c" TChar "" ]
+      returnType = TChar
+      description =
+        "Return the lowercase value of <param c>. If <param c> does not have a lowercase value, returns <param c>"
+      fn =
+        function
+        | _, [ DChar c ] -> Ply(DChar(c.ToLower()))
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Char" "isLowercase" 0
+      parameters = [ Param.make "c" TChar "" ]
+      returnType = TBool
+      description = "Return whether <param c> is a lowercase character."
+      fn =
+        function
+        | _, [ DChar c ] -> Ply(DBool(c.ToLower() = c && c.ToUpper() <> c))
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Char" "isUppercase" 0
+      parameters = [ Param.make "c" TChar "" ]
+      returnType = TBool
+      description = "Return whether <param c> is an uppercase character."
+      fn =
+        function
+        | _, [ DChar c ] -> Ply(DBool(c.ToUpper() = c && c.ToLower() <> c))
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated } ]

--- a/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
+++ b/fsharp-backend/src/LibExecutionStdLib/LibChar.fs
@@ -122,4 +122,51 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplementedTODO
       previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Char" "isDigit" 0
+      parameters = [ Param.make "c" TChar "" ]
+      returnType = TBool
+      description = "Return whether <param c> is a digit (that is, the digits 0-9)"
+      fn =
+        function
+        | _, [ DChar c ] ->
+          (if c.Length = 1 then System.Char.IsDigit(c[0]) else false) |> DBool |> Ply
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Char" "isASCIILetter" 0
+      parameters = [ Param.make "c" TChar "" ]
+      returnType = TBool
+      description = "Return whether <param c> is an ASCII letter"
+      fn =
+        function
+        | _, [ DChar c ] ->
+          (if c.Length = 1 then
+             System.Char.IsAscii c[0] && System.Char.IsLetter c[0]
+           else
+             false)
+          |> DBool
+          |> Ply
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Char" "isASCII" 0
+      parameters = [ Param.make "c" TChar "" ]
+      returnType = TBool
+      description = "Return whether <param c> is a valid ASCII character"
+      fn =
+        function
+        | _, [ DChar c ] ->
+          (if c.Length = 1 then System.Char.IsAscii c[0] else false) |> DBool |> Ply
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplementedTODO
+      previewable = Pure
       deprecated = NotDeprecated } ]

--- a/fsharp-backend/testfiles/execution/char.tests
+++ b/fsharp-backend/testfiles/execution/char.tests
@@ -11,11 +11,6 @@ Char.toASCIIChar_v0 1 = Test.typeError_v0 "Char::toASCIIChar was removed from Da
 Char.toLowercase_v0 "A" = Test.typeError_v0 "Char::toLowercase was removed from Dark"
 Char.toUppercase_v0 "A" = Test.typeError_v0 "Char::toUppercase was removed from Dark"
 
-// Char.toASCIICode_v1 'a' = Just 60
-// Char.toASCIICode_v1 '😂' = Nothing
-
-// Char.fromASCIICode_v1 60 = Just 'a'
-// Char.fromASCIICode_v1 123544523 = Nothing
 
 Char.toLowercase_v1 'A' = 'a'
 Char.toLowercase_v1 'a' = 'a'
@@ -94,6 +89,7 @@ Char.isASCII_v0 'ჾ' = false
 Char.isASCII_v0 'Ჾ' = false
 Char.isASCII_v0 ' ' = true
 Char.isASCII_v0 '\t' = true
+
 
 Char.isDigit_v0 'a' = false
 Char.isDigit_v0 'A' = false

--- a/fsharp-backend/testfiles/execution/char.tests
+++ b/fsharp-backend/testfiles/execution/char.tests
@@ -1,3 +1,11 @@
+[fn.smiley null:any]
+((String.toList_v1 "😂") |> List.head_v2_ster)
+
+[fn.hand null:any]
+((String.toList_v1 "✋🏿") |> List.head_v2_ster)
+
+[tests.all]
+
 Char.toASCIICode_v0 "a" = Test.typeError_v0 "Char::toASCIICode was removed from Dark"
 Char.toASCIIChar_v0 1 = Test.typeError_v0 "Char::toASCIIChar was removed from Dark"
 Char.toLowercase_v0 "A" = Test.typeError_v0 "Char::toLowercase was removed from Dark"
@@ -13,11 +21,11 @@ Char.toLowercase_v1 'A' = 'a'
 Char.toLowercase_v1 'a' = 'a'
 Char.toLowercase_v1 'Á' = 'á'
 Char.toLowercase_v1 '3' = '3'
-Char.toLowercase_v1 '😄' = '😄'
+Char.toLowercase_v1 (smiley null) = smiley null
 Char.toLowercase_v1 'Ż' = 'ż'
 Char.toLowercase_v1 'Ó' = 'ó'
 Char.toLowercase_v1 'Ł' = 'ł'
-Char.toLowercase_v1 '✋🏿' = '✋🏿'
+Char.toLowercase_v1 (hand null) = hand null
 Char.toLowercase_v1 'Ჾ' = 'ჾ'
 Char.toLowercase_v1 'ჾ' = 'ჾ'
 
@@ -25,11 +33,11 @@ Char.toUppercase_v1 'a' = 'A'
 Char.toUppercase_v1 'A' = 'A'
 Char.toUppercase_v1 'á' = 'Á'
 Char.toUppercase_v1 '3' = '3'
-Char.toUppercase_v1 '😄' = '😄'
+Char.toUppercase_v1 (smiley null) = smiley null
 Char.toUppercase_v1 'ż' = 'Ż'
 Char.toUppercase_v1 'ó' = 'Ó'
 Char.toUppercase_v1 'ł' = 'Ł'
-Char.toUppercase_v1 '✋🏿' = '✋🏿'
+Char.toUppercase_v1 (hand null) = hand null
 Char.toUppercase_v1 'ჾ' = 'Ჾ'
 Char.toUppercase_v1 'Ჾ' = 'Ჾ'
 
@@ -38,14 +46,14 @@ Char.isLowercase_v0 'A' = false
 Char.isLowercase_v0 'á' = true
 Char.isLowercase_v0 'Á' = false
 Char.isLowercase_v0 '3' = false
-Char.isLowercase_v0 '😄' = false
+Char.isLowercase_v0 (smiley null) = false
 Char.isLowercase_v0 'ż' = true
 Char.isLowercase_v0 'Ż' = false
 Char.isLowercase_v0 'ó' = true
 Char.isLowercase_v0 'Ó' = false
 Char.isLowercase_v0 'ł' = true
 Char.isLowercase_v0 'Ł' = false
-Char.isLowercase_v0 '✋🏿' = false
+Char.isLowercase_v0 (hand null) = false
 Char.isLowercase_v0 'ჾ' = true
 Char.isLowercase_v0 'Ჾ' = false
 
@@ -54,14 +62,14 @@ Char.isUppercase_v0 'A' = true
 Char.isUppercase_v0 'á' = false
 Char.isUppercase_v0 'Á' = true
 Char.isUppercase_v0 '3' = false
-Char.isUppercase_v0 '😄' = false
+Char.isUppercase_v0 (smiley null) = false
 Char.isUppercase_v0 'ż' = false
 Char.isUppercase_v0 'Ż' = true
 Char.isUppercase_v0 'ó' = false
 Char.isUppercase_v0 'Ó' = true
 Char.isUppercase_v0 'ł' = false
 Char.isUppercase_v0 'Ł' = true
-Char.isUppercase_v0 '✋🏿' = false
+Char.isUppercase_v0 (hand null) = false
 Char.isUppercase_v0 'ჾ' = false
 Char.isUppercase_v0 'Ჾ' = true
 

--- a/fsharp-backend/testfiles/execution/char.tests
+++ b/fsharp-backend/testfiles/execution/char.tests
@@ -29,6 +29,7 @@ Char.toLowercase_v1 (hand null) = hand null
 Char.toLowercase_v1 'Ჾ' = 'ჾ'
 Char.toLowercase_v1 'ჾ' = 'ჾ'
 
+
 Char.toUppercase_v1 'a' = 'A'
 Char.toUppercase_v1 'A' = 'A'
 Char.toUppercase_v1 'á' = 'Á'
@@ -40,6 +41,7 @@ Char.toUppercase_v1 'ł' = 'Ł'
 Char.toUppercase_v1 (hand null) = hand null
 Char.toUppercase_v1 'ჾ' = 'Ჾ'
 Char.toUppercase_v1 'Ჾ' = 'Ჾ'
+
 
 Char.isLowercase_v0 'a' = true
 Char.isLowercase_v0 'A' = false
@@ -56,6 +58,7 @@ Char.isLowercase_v0 'Ł' = false
 Char.isLowercase_v0 (hand null) = false
 Char.isLowercase_v0 'ჾ' = true
 Char.isLowercase_v0 'Ჾ' = false
+
 
 Char.isUppercase_v0 'a' = false
 Char.isUppercase_v0 'A' = true
@@ -74,14 +77,70 @@ Char.isUppercase_v0 'ჾ' = false
 Char.isUppercase_v0 'Ჾ' = true
 
 
+Char.isASCII_v0 'a' = true
+Char.isASCII_v0 'A' = true
+Char.isASCII_v0 'á' = false
+Char.isASCII_v0 'Á' = false
+Char.isASCII_v0 '3' = true
+Char.isASCII_v0 (smiley null) = false
+Char.isASCII_v0 'ż' = false
+Char.isASCII_v0 'Ż' = false
+Char.isASCII_v0 'ó' = false
+Char.isASCII_v0 'Ó' = false
+Char.isASCII_v0 'ł' = false
+Char.isASCII_v0 'Ł' = false
+Char.isASCII_v0 (hand null) = false
+Char.isASCII_v0 'ჾ' = false
+Char.isASCII_v0 'Ჾ' = false
+Char.isASCII_v0 ' ' = true
+Char.isASCII_v0 '\t' = true
 
-// isAscii
-// isAsciiLetter
-// isAsciiAlphanumberic
-// isdigit
-// toCode
-// fromCode
-// ishexdigit
-// isoctaldigit
-// String.getAt
-// String.map
+
+// create test cases for isASCIILetter
+
+Char.isDigit_v0 'a' = false
+Char.isDigit_v0 'A' = false
+Char.isDigit_v0 'á' = false
+Char.isDigit_v0 'Á' = false
+Char.isDigit_v0 '0' = true
+Char.isDigit_v0 '1' = true
+Char.isDigit_v0 '2' = true
+Char.isDigit_v0 '3' = true
+Char.isDigit_v0 '4' = true
+Char.isDigit_v0 '5' = true
+Char.isDigit_v0 '6' = true
+Char.isDigit_v0 '7' = true
+Char.isDigit_v0 '8' = true
+Char.isDigit_v0 '9' = true
+Char.isDigit_v0 (smiley null) = false
+Char.isDigit_v0 'ż' = false
+Char.isDigit_v0 'Ż' = false
+Char.isDigit_v0 'ó' = false
+Char.isDigit_v0 'Ó' = false
+Char.isDigit_v0 'ł' = false
+Char.isDigit_v0 'Ł' = false
+Char.isDigit_v0 (hand null) = false
+Char.isDigit_v0 'ჾ' = false
+Char.isDigit_v0 'Ჾ' = false
+Char.isDigit_v0 ' ' = false
+Char.isDigit_v0 '\t' = false
+
+
+Char.isASCIILetter_v0 'a' = true
+Char.isASCIILetter_v0 'A' = true
+Char.isASCIILetter_v0 'á' = false
+Char.isASCIILetter_v0 'Á' = false
+Char.isASCIILetter_v0 '3' = false
+Char.isASCIILetter_v0 ',' = false
+Char.isASCIILetter_v0 (smiley null) = false
+Char.isASCIILetter_v0 'ż' = false
+Char.isASCIILetter_v0 'Ż' = false
+Char.isASCIILetter_v0 'ó' = false
+Char.isASCIILetter_v0 'Ó' = false
+Char.isASCIILetter_v0 'ł' = false
+Char.isASCIILetter_v0 'Ł' = false
+Char.isASCIILetter_v0 (hand null) = false
+Char.isASCIILetter_v0 'ჾ' = false
+Char.isASCIILetter_v0 'Ჾ' = false
+Char.isASCIILetter_v0 ' ' = false
+Char.isASCIILetter_v0 '\t' = false

--- a/fsharp-backend/testfiles/execution/char.tests
+++ b/fsharp-backend/testfiles/execution/char.tests
@@ -72,25 +72,6 @@ Char.isUppercase_v0 'ჾ' = false
 Char.isUppercase_v0 'Ჾ' = true
 
 
-Char.isASCII_v0 'a' = true
-Char.isASCII_v0 'A' = true
-Char.isASCII_v0 'á' = false
-Char.isASCII_v0 'Á' = false
-Char.isASCII_v0 '3' = true
-Char.isASCII_v0 (smiley null) = false
-Char.isASCII_v0 'ż' = false
-Char.isASCII_v0 'Ż' = false
-Char.isASCII_v0 'ó' = false
-Char.isASCII_v0 'Ó' = false
-Char.isASCII_v0 'ł' = false
-Char.isASCII_v0 'Ł' = false
-Char.isASCII_v0 (hand null) = false
-Char.isASCII_v0 'ჾ' = false
-Char.isASCII_v0 'Ჾ' = false
-Char.isASCII_v0 ' ' = true
-Char.isASCII_v0 '\t' = true
-
-
 Char.isDigit_v0 'a' = false
 Char.isDigit_v0 'A' = false
 Char.isDigit_v0 'á' = false
@@ -137,3 +118,22 @@ Char.isASCIILetter_v0 'ჾ' = false
 Char.isASCIILetter_v0 'Ჾ' = false
 Char.isASCIILetter_v0 ' ' = false
 Char.isASCIILetter_v0 '\t' = false
+
+
+Char.isASCII_v0 'a' = true
+Char.isASCII_v0 'A' = true
+Char.isASCII_v0 'á' = false
+Char.isASCII_v0 'Á' = false
+Char.isASCII_v0 '3' = true
+Char.isASCII_v0 (smiley null) = false
+Char.isASCII_v0 'ż' = false
+Char.isASCII_v0 'Ż' = false
+Char.isASCII_v0 'ó' = false
+Char.isASCII_v0 'Ó' = false
+Char.isASCII_v0 'ł' = false
+Char.isASCII_v0 'Ł' = false
+Char.isASCII_v0 (hand null) = false
+Char.isASCII_v0 'ჾ' = false
+Char.isASCII_v0 'Ჾ' = false
+Char.isASCII_v0 ' ' = true
+Char.isASCII_v0 '\t' = true

--- a/fsharp-backend/testfiles/execution/char.tests
+++ b/fsharp-backend/testfiles/execution/char.tests
@@ -95,9 +95,6 @@ Char.isASCII_v0 'Ჾ' = false
 Char.isASCII_v0 ' ' = true
 Char.isASCII_v0 '\t' = true
 
-
-// create test cases for isASCIILetter
-
 Char.isDigit_v0 'a' = false
 Char.isDigit_v0 'A' = false
 Char.isDigit_v0 'á' = false

--- a/fsharp-backend/testfiles/execution/char.tests
+++ b/fsharp-backend/testfiles/execution/char.tests
@@ -2,3 +2,78 @@ Char.toASCIICode_v0 "a" = Test.typeError_v0 "Char::toASCIICode was removed from 
 Char.toASCIIChar_v0 1 = Test.typeError_v0 "Char::toASCIIChar was removed from Dark"
 Char.toLowercase_v0 "A" = Test.typeError_v0 "Char::toLowercase was removed from Dark"
 Char.toUppercase_v0 "A" = Test.typeError_v0 "Char::toUppercase was removed from Dark"
+
+// Char.toASCIICode_v1 'a' = Just 60
+// Char.toASCIICode_v1 '😂' = Nothing
+
+// Char.fromASCIICode_v1 60 = Just 'a'
+// Char.fromASCIICode_v1 123544523 = Nothing
+
+Char.toLowercase_v1 'A' = 'a'
+Char.toLowercase_v1 'a' = 'a'
+Char.toLowercase_v1 'Á' = 'á'
+Char.toLowercase_v1 '3' = '3'
+Char.toLowercase_v1 '😄' = '😄'
+Char.toLowercase_v1 'Ż' = 'ż'
+Char.toLowercase_v1 'Ó' = 'ó'
+Char.toLowercase_v1 'Ł' = 'ł'
+Char.toLowercase_v1 '✋🏿' = '✋🏿'
+Char.toLowercase_v1 'Ჾ' = 'ჾ'
+Char.toLowercase_v1 'ჾ' = 'ჾ'
+
+Char.toUppercase_v1 'a' = 'A'
+Char.toUppercase_v1 'A' = 'A'
+Char.toUppercase_v1 'á' = 'Á'
+Char.toUppercase_v1 '3' = '3'
+Char.toUppercase_v1 '😄' = '😄'
+Char.toUppercase_v1 'ż' = 'Ż'
+Char.toUppercase_v1 'ó' = 'Ó'
+Char.toUppercase_v1 'ł' = 'Ł'
+Char.toUppercase_v1 '✋🏿' = '✋🏿'
+Char.toUppercase_v1 'ჾ' = 'Ჾ'
+Char.toUppercase_v1 'Ჾ' = 'Ჾ'
+
+Char.isLowercase_v0 'a' = true
+Char.isLowercase_v0 'A' = false
+Char.isLowercase_v0 'á' = true
+Char.isLowercase_v0 'Á' = false
+Char.isLowercase_v0 '3' = false
+Char.isLowercase_v0 '😄' = false
+Char.isLowercase_v0 'ż' = true
+Char.isLowercase_v0 'Ż' = false
+Char.isLowercase_v0 'ó' = true
+Char.isLowercase_v0 'Ó' = false
+Char.isLowercase_v0 'ł' = true
+Char.isLowercase_v0 'Ł' = false
+Char.isLowercase_v0 '✋🏿' = false
+Char.isLowercase_v0 'ჾ' = true
+Char.isLowercase_v0 'Ჾ' = false
+
+Char.isUppercase_v0 'a' = false
+Char.isUppercase_v0 'A' = true
+Char.isUppercase_v0 'á' = false
+Char.isUppercase_v0 'Á' = true
+Char.isUppercase_v0 '3' = false
+Char.isUppercase_v0 '😄' = false
+Char.isUppercase_v0 'ż' = false
+Char.isUppercase_v0 'Ż' = true
+Char.isUppercase_v0 'ó' = false
+Char.isUppercase_v0 'Ó' = true
+Char.isUppercase_v0 'ł' = false
+Char.isUppercase_v0 'Ł' = true
+Char.isUppercase_v0 '✋🏿' = false
+Char.isUppercase_v0 'ჾ' = false
+Char.isUppercase_v0 'Ჾ' = true
+
+
+
+// isAscii
+// isAsciiLetter
+// isAsciiAlphanumberic
+// isdigit
+// toCode
+// fromCode
+// ishexdigit
+// isoctaldigit
+// String.getAt
+// String.map


### PR DESCRIPTION
Changelog:

```
Standard Library
- Add functions that operate on characters: `Char::isUppercase_v0`, `Char::isLowercase_v0`, `Char::toUppercase_v1`, `Char::toLowercase_v1`, `Char::isDigit_v0`, `Char::isASCII_v0`, and `Char::isASCIILetter_v0` 

Editor
- Allow using `Char` as a function parameter type and return type
```

Fixes #4625 
