### PR TITLE
No-op refactor of QueueWorker

### DIFF
--- a/docs/eventsV2.md
+++ b/docs/eventsV2.md
@@ -10,7 +10,7 @@ Goals:
 
 ## Definitions
 
-- `emit` adding an event to the queue from a Cron handler or the `emit` function
+- `emit`: adding an event to the queue from a Cron handler or the `emit` function
 - `event`: refers to the Dark value `emit`ed into the queue and the metadata around
   it (including what you might call a "job" or "message" in other systems). We say we
   "run the event" when we execute it, or "retry the event" if we requeue it.


### PR DESCRIPTION
Changelog:

```
Internal
- No-op refactor of QueueWorker source
```

I've flattened `QueueWorker.fs` a bit to improve my understanding.
The core logic of `handleEvent` is still all in that fn definition.

I realize this is a bit hard to do a good 'diff' on. Given that, and potential hesitancy for refactoring here generally, what might make sense is to give [the refactored code](https://github.com/StachuDotNet/dark/blob/queueworker-redux/fsharp-backend/src/QueueWorker/QueueWorker.fs) a look in full. If it generally feels like it doesn't increase risk, I can follow up and break this down? Otherwise, I'm fine to keep the structure as it was, and just follow up by adding a few code comments.