### PR TITLE
Redo settings invite

### DIFF
--- a/client/src/appsupport.js
+++ b/client/src/appsupport.js
@@ -483,17 +483,6 @@ function addWheelListener(elem) {
   return listener(elem);
 }
 
-// ---------------------------
-// Validation
-// ---------------------------
-
-var validator = require("validator");
-
-function validateEmail(email) {
-  return validator.isEmail(email);
-}
-window.Dark.validateEmail = validateEmail;
-
 var moment = require("moment");
 
 function formatDate([date, format]) {

--- a/client/src/components/Settings/SettingsInvite.res
+++ b/client/src/components/Settings/SettingsInvite.res
@@ -60,14 +60,14 @@ let setInviter = (state: t, username: string, name: string): t => {
   inviter: {username: username, name: name},
 }
 
-@val @scope("window") @scope("Dark") external validateEmail: string => bool = "validateEmail"
+@module("validator") external validator: string => bool = "isEmail"
 
 let validateEmail = (email: Utils.formField): Utils.formField => {
   let error = {
     let emailVal = email.value
     if String.length(emailVal) == 0 {
       Some("Field Required")
-    } else if !validateEmail(emailVal) {
+    } else if !validator(emailVal) {
       Some("Invalid Email")
     } else {
       None

--- a/client/src/components/Settings/SettingsInviteView.res
+++ b/client/src/components/Settings/SettingsInviteView.res
@@ -11,9 +11,11 @@ module T = SettingsInvite
 
 module C = SettingsViewComponents
 
+let tw = Attrs.class
+
 let view = (state: T.t): list<Html.html<AppTypes.msg>> => {
   let introText = list{
-    Html.h2(list{}, list{Html.text("Share Dark with a friend or colleague")}),
+    C.sectionHeading("Share Dark with a friend or colleague", None),
     Html.p(
       list{},
       list{
@@ -22,14 +24,12 @@ let view = (state: T.t): list<Html.html<AppTypes.msg>> => {
         ),
       },
     ),
-    Html.p(
-      list{},
-      list{
-        Html.text(
-          "Note: This will not add them to any of your existing organizations or canvases.",
-        ),
-      },
-    ),
+  }
+
+  let note = list{
+    C.sectionIntroText(list{
+      Html.text("Note: This will not add them to any of your existing organizations or canvases."),
+    }),
   }
 
   let inviteform = {
@@ -37,14 +37,14 @@ let view = (state: T.t): list<Html.html<AppTypes.msg>> => {
       let btn = if state.loading {
         list{
           Icons.fontAwesome("spinner"),
-          Html.h3(list{Attrs.class(%twc("m-0 pl-2.5"))}, list{Html.text("Loading")}),
+          Html.h4(list{tw(%twc("m-0 pl-2.5"))}, list{Html.text("Sending")}),
         }
       } else {
-        list{Html.h3(list{Attrs.class(%twc("m-0"))}, list{Html.text("Send invite")})}
+        list{Html.h4(list{tw(%twc("m-0"))}, list{Html.text("Invite")})}
       }
 
       C.submitBtn(
-        ~style="ml-2",
+        ~style="",
         Html.Attributes.disabled(state.loading),
         EventListeners.eventNoPropagation(
           ~key="close-settings-modal",
@@ -54,40 +54,34 @@ let view = (state: T.t): list<Html.html<AppTypes.msg>> => {
         btn,
       )
     }
+
+    let field = Html.div(
+      list{},
+      list{
+        C.input(
+          ~loadStatus=LoadStatus.Success(""),
+          ~style="ml-1 w-80",
+          ~attrs=list{
+            Attrs.spellcheck(false),
+            Events.onInput(str => AppTypes.Msg.SettingsMsg(Settings.InviteMsg(T.Update(str)))),
+            Attrs.value(state.email.value),
+          },
+          "",
+        ),
+        C.errorSpan(state.email.error |> Option.unwrap(~default="")),
+      },
+    )
+
     list{
       Html.div(
-        list{Attrs.class(%twc("flex items-center justify-center flex-col"))},
+        list{tw(%twc("flex items-baseline justify-center my-2"))},
         list{
-          Html.div(
-            list{
-              Attrs.class(
-                %twc("flex items-baseline justify-around w-full max-w-lg mt-6 flex-wrap"),
-              ),
-            },
-            list{
-              Html.h3(list{Attrs.class(%twc("m-0"))}, list{Html.text("Email:")}),
-              Html.div(
-                list{},
-                list{
-                  C.emailInput(
-                    ~style="",
-                    ~attrs=list{
-                      Attrs.spellcheck(false),
-                      Events.onInput(str => AppTypes.Msg.SettingsMsg(
-                        Settings.InviteMsg(T.Update(str)),
-                      )),
-                      Attrs.value(state.email.value),
-                    },
-                  ),
-                  C.errorSpan(state.email.error |> Option.unwrap(~default="")),
-                },
-              ),
-            },
-          ),
+          Html.p(list{tw(%twc("text-base mr-3 font-semibold"))}, list{Html.text("Email:")}),
+          field,
           submitBtn,
         },
       ),
     }
   }
-  Belt.List.concat(introText, inviteform)
+  Belt.List.concatMany([introText, inviteform, note])
 }

--- a/client/src/components/Settings/SettingsViewComponents.res
+++ b/client/src/components/Settings/SettingsViewComponents.res
@@ -132,7 +132,7 @@ let submitBtn = (
       Attrs.classes([
         style,
         %twc(
-          "flex items-center justify-center w-auto rounded py-2.5 px-3.5 mt-9 cursor-pointer text-white1 bg-grey2 hover:bg-grey1"
+          "flex items-center justify-center w-auto rounded py-2 px-3 ml-4 mt-2 cursor-pointer text-white1 bg-grey2 hover:bg-grey1"
         ),
       ]),
       loadingState,
@@ -190,24 +190,6 @@ let input = (
         list{},
       ),
       loadingSpinner,
-    },
-  )
-}
-
-let emailInput = (~style="", ~attrs: list<Attrs.property<'msg>>) => {
-  Html.span(
-    list{},
-    list{
-      Html.input'(
-        list{
-          Attrs.classes([
-            style,
-            %twc("bg-black3 py-0 px-2.5 min-h-[35px] min-w-[35ch] caret-grey8 text-white1"),
-          ]),
-          ...List.concat(list{attrs}),
-        },
-        list{},
-      ),
     },
   )
 }


### PR DESCRIPTION
Changelog:

```
Internal 
-  Update the styling of settings invite.
```
**Changes:**
- Some styling changes in settingsInviteView.
- Remove emailInput from components and replace it with the existing input.
- Reuse more components.
- Remove validateEmail function from appsupport and access validator package directly via an external.

**Before -> After**
![Frame 19](https://user-images.githubusercontent.com/87861924/207354553-c7b1cec1-e06b-4abe-b294-28ef35a9190b.png)

This was tested successfully against production. If you want any changes please let me know.

**Note:**
- I definitely did not change 376 files (only 4 files were changed). I got 372 files changed after pulling the latest changes from the remote repo. I wasn't sure if I should commit these. If I did something wrong please let me know and I'll revert these commits.
- Not sure what to put in the changelog.