### PR TITLE
Include dark client version in apiserver rollbars

### DIFF
--- a/backend/src/ApiServer/ApiServer.fs
+++ b/backend/src/ApiServer/ApiServer.fs
@@ -176,6 +176,7 @@ let rollbarCtxToMetadata (ctx : HttpContext) : (Rollbar.Person * Metadata) =
   let clientVersion =
     try
       string ctx.Request.Headers["x-darklang-client-version"]
+      |> String.take 7
     with
     | _ -> null
 

--- a/backend/src/ApiServer/ApiServer.fs
+++ b/backend/src/ApiServer/ApiServer.fs
@@ -175,12 +175,11 @@ let rollbarCtxToMetadata (ctx : HttpContext) : (Rollbar.Person * Metadata) =
 
   let clientVersion =
     try
-      string ctx.Request.Headers["x-darklang-client-version"]
-      |> String.take 7
+      string ctx.Request.Headers["x-darklang-client-version"] |> String.take 7
     with
     | _ -> null
 
-  (person, [ "canvas", canvas; "clientVersion", clientVersion ])
+  (person, [ "canvas", canvas; "client_version", clientVersion ])
 
 let configureApp (packages : Packages) (appBuilder : WebApplication) =
   appBuilder

--- a/backend/src/ApiServer/ApiServer.fs
+++ b/backend/src/ApiServer/ApiServer.fs
@@ -166,12 +166,20 @@ let rollbarCtxToMetadata (ctx : HttpContext) : (Rollbar.Person * Metadata) =
       loadUserInfo ctx |> LibBackend.Account.userInfoToPerson
     with
     | _ -> None
+
   let canvas =
     try
       string (loadCanvasInfo ctx).name
     with
     | _ -> null
-  (person, [ "canvas", canvas ])
+
+  let clientVersion =
+    try
+      string ctx.Request.Headers["x-darklang-client-version"]
+    with
+    | _ -> null
+
+  (person, [ "canvas", canvas; "clientVersion", clientVersion ])
 
 let configureApp (packages : Packages) (appBuilder : WebApplication) =
   appBuilder


### PR DESCRIPTION
Changelog:

```
Internal
- include dark client version in apiserver rollbars
```

![image](https://user-images.githubusercontent.com/906686/207941140-e604389b-a6e9-4d83-97aa-56741eabae60.png)

- [ ] it's a bit long; maybe we should truncate to ~6chars