### PR TITLE
Include given metadata when printing exceptions

### DIFF
--- a/backend/src/Prelude/Prelude.fs
+++ b/backend/src/Prelude/Prelude.fs
@@ -351,6 +351,7 @@ let rec printException'
   (e : exn)
   : unit =
   print $"{prefix}: error: {e.Message}"
+  printMetadata prefix metadata
   printMetadata prefix (Exception.toMetadata e)
   print $"{prefix}: exceptionType: {e.GetType()}"
   print $"{prefix}: {e.StackTrace}"


### PR DESCRIPTION
No changelog

I noticed that we've been ignoring the `metadata` arg of `Prelude.printException`.
This is mostly only relevant for local development or emergencies when we can't reach Rollbar, but figured it's worth fixing.