### PR TITLE
Refresh client hourly when inactive

### DIFF
--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -261,6 +261,39 @@ let saveTest = (m: model): cmd =>
     x,
   ))
 
+let fetchServerBuildHash = (m: model): cmd => {
+  let url = "https://editor.darklang.com/latest-backend-build-hash"
+
+  let request = Tea.Http.request({
+    method: "POST",
+    headers: list{clientVersionHeader(m), Header("X-CSRF-Token", m.csrfToken)},
+    url: url,
+    body: Web.XMLHttpRequest.EmptyBody,
+    expect: Tea.Http.expectStringResponse(Decoders.wrapExpect(Json.Decode.string)),
+    timeout: None,
+    withCredentials: false,
+  })
+
+  // If origin is https://darklang.com, then we're in prod (or ngrok, running against
+  // prod) and editor.darklang.com's CORS rules will allow this request. If not,
+  // we're in local, and both CORS and auth (session, canvas_id) will not work
+  // against editor.darklang.com. By putting the conditional here instead of at the
+  // beginning of the function, we still exercise the message and request generating
+  // code locally.
+  if m.origin == "https://darklang.com" {
+    // TODO: test this locally.
+    Tea.Http.send(serverBuildHash =>
+      switch serverBuildHash {
+      | Ok(serverBuildHash) => AppTypes.Msg.RefreshClientIfOutdated(serverBuildHash)
+      | Error(_err) => AppTypes.Msg.IgnoreMsg("TODO")
+      }
+    , request)
+  } else {
+    Tea.Cmd.msg(AppTypes.Msg.RefreshClientIfOutdated("not-dev-go-refresh"))
+    //Tea.Cmd.msg(AppTypes.Msg.IgnoreMsg("TODO"))
+  }
+}
+
 let integration = (m: model, name: string): cmd =>
   apiCallPreloaded(
     m,

--- a/client/src/api/API.res
+++ b/client/src/api/API.res
@@ -265,8 +265,8 @@ let fetchServerBuildHash = (m: model): cmd => {
   let url = "https://editor.darklang.com/latest-backend-build-hash"
 
   let request = Tea.Http.request({
-    method: "POST",
-    headers: list{clientVersionHeader(m), Header("X-CSRF-Token", m.csrfToken)},
+    method: "GET",
+    headers: list{clientVersionHeader(m)},
     url: url,
     body: Web.XMLHttpRequest.EmptyBody,
     expect: Tea.Http.expectStringResponse(Decoders.wrapExpect(Json.Decode.string)),
@@ -281,16 +281,9 @@ let fetchServerBuildHash = (m: model): cmd => {
   // beginning of the function, we still exercise the message and request generating
   // code locally.
   if m.origin == "https://darklang.com" {
-    // TODO: test this locally.
-    Tea.Http.send(serverBuildHash =>
-      switch serverBuildHash {
-      | Ok(serverBuildHash) => AppTypes.Msg.RefreshClientIfOutdated(serverBuildHash)
-      | Error(_err) => AppTypes.Msg.IgnoreMsg("TODO")
-      }
-    , request)
+    Tea.Http.send(serverBuildHash => AppTypes.Msg.RefreshClientIfOutdated(serverBuildHash), request)
   } else {
-    Tea.Cmd.msg(AppTypes.Msg.RefreshClientIfOutdated("not-dev-go-refresh"))
-    //Tea.Cmd.msg(AppTypes.Msg.IgnoreMsg("TODO"))
+    Tea.Cmd.none
   }
 }
 

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -1083,6 +1083,8 @@ module Model = {
     browserId: string,
     buildHash: string,
     lastReload: option<Js.Date.t>,
+    @ocaml.doc("When the page was last active/visible")
+    lastActive: option<Js.Date.t>,
     opCtrs: Tc.Map.String.t<int>,
     clientOpCtrId: string,
     permission: option<AccountTypes.Permission.t>,
@@ -1154,6 +1156,7 @@ module Model = {
     buildHash: "",
     username: "defaultUsername",
     lastReload: None,
+    lastActive: None,
     permission: None,
     showTopbar: true,
     toast: Toast.default,

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -734,7 +734,7 @@ module Msg = {
     | UpdateHeapio(Types.heapioTrack)
     | SettingsMsg(Settings.msg)
     | SecretMsg(SecretTypes.msg)
-    | RefreshClientIfOutdated(string)
+    | RefreshClientIfOutdated(result<string, Types.httpError>)
 
   let toDebugString = (msg: t<'model, 'cmd>): string =>
     switch msg {

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -1083,8 +1083,6 @@ module Model = {
     browserId: string,
     buildHash: string,
     lastReload: option<Js.Date.t>,
-    @ocaml.doc("When the page was last active/visible")
-    lastActive: option<Js.Date.t>,
     opCtrs: Tc.Map.String.t<int>,
     clientOpCtrId: string,
     permission: option<AccountTypes.Permission.t>,
@@ -1156,7 +1154,6 @@ module Model = {
     buildHash: "",
     username: "defaultUsername",
     lastReload: None,
-    lastActive: None,
     permission: None,
     showTopbar: true,
     toast: Toast.default,

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -734,6 +734,7 @@ module Msg = {
     | UpdateHeapio(Types.heapioTrack)
     | SettingsMsg(Settings.msg)
     | SecretMsg(SecretTypes.msg)
+    | RefreshClientIfOutdated(string)
 
   let toDebugString = (msg: t<'model, 'cmd>): string =>
     switch msg {
@@ -839,6 +840,7 @@ module Msg = {
     | SaveTestAPICallback(_) => "SaveTestAPICallback"
     | GetUnlockedDBsAPICallback(_) => "GetUnlockedDBsAPICallback"
     | Get404sAPICallback(_) => "Get404sAPICallback"
+    | RefreshClientIfOutdated(_) => "RefreshClientIfOutdated"
     }
 }
 
@@ -877,6 +879,8 @@ module Modification = {
         'model => ('model, Tea.Cmd.t<Msg.t<'model, t<'model>>>),
       )
 
+    | NoChange
+
     // API Calls
     | AddOps((list<PT.Op.t>, Focus.t))
     | HandleAPIError(APIError.t)
@@ -887,6 +891,7 @@ module Modification = {
     | TriggerHandlerAPICall(TLID.t)
     | UpdateDBStatsAPICall(TLID.t)
     | DeleteToplevelForeverAPICall(TLID.t)
+    | GetServerBuildHash
     // End API Calls
     | Select(TLID.t, tlidSelectTarget)
     | SetHover(TLID.t, Types.idOrTraceID)
@@ -907,7 +912,6 @@ module Modification = {
     | EnterWithOffset(TLID.t, ID.t, int) // Entering a blankOr with a desired caret offset
     | OpenOmnibox(option<Pos.t>) // Open the omnibox
     | UpdateWorkerSchedules(Tc.Map.String.t<AnalysisTypes.WorkerState.t>)
-    | NoChange
     | MakeCmd(Tea.Cmd.t<Msg.t<'model, t<'model>>>)
     | AutocompleteMod(AutoComplete.mod)
     | Many(list<t<'model>>)
@@ -965,6 +969,7 @@ module Modification = {
     | TriggerHandlerAPICall(_) => "TriggerHandlerAPICall"
     | UpdateDBStatsAPICall(_) => "UpdateDBStatsAPICall"
     | DeleteToplevelForeverAPICall(_) => "DeleteToplevelForeverAPICall"
+    | GetServerBuildHash => "GetServerBuildHash"
     | Select(_, _) => "Select"
     | SetHover(_, _) => "SetHover"
     | ClearHover(_, _) => "ClearHover"

--- a/client/src/app/AppTypes.res
+++ b/client/src/app/AppTypes.res
@@ -55,7 +55,7 @@ module CanvasProps = {
 module PageVisibility = {
   @ppx.deriving(show({with_path: false}))
   type rec t =
-    | Hidden
+    | Hidden(Js.Date.t)
     | Visible
 }
 

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -2121,6 +2121,7 @@ let update_ = (msg: msg, m: model): modification => {
   | UploadFnAPICallback(_, Ok(_)) =>
     Model.updateErrorMod(Error.set("Successfully uploaded function"))
   | SecretMsg(msg) => InsertSecret.update(msg)
+
   | RenderEvent =>
     ReplaceAllModificationsWithThisOne(
       "RenderEvent",
@@ -2213,7 +2214,7 @@ let subscriptions = (m: model): Tea.Sub.t<msg> => {
     // only when the page is invisible. Rather, it only prevents us from _starting_
     // the timer until the page is invisible.
     switch m.visibility {
-    | Hidden => list{refreshOutdatedClient}
+    | Hidden(_since) => list{refreshOutdatedClient}
     | Visible => list{
         Tea.Time.every(~key="refresh_analysis", Tea.Time.second, f => AppTypes.Msg.TimerFire(
           RefreshAnalysis,
@@ -2239,7 +2240,7 @@ let subscriptions = (m: model): Tea.Sub.t<msg> => {
       if v {
         PageVisibilityChange(Visible)
       } else {
-        PageVisibilityChange(Hidden)
+        PageVisibilityChange(Hidden(Js.Date.now() |> Js.Date.fromFloat))
       }
     ),
   }

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -2134,12 +2134,12 @@ let update_ = (msg: msg, m: model): modification => {
     Model.updateErrorMod(Error.set("Successfully uploaded function"))
   | SecretMsg(msg) => InsertSecret.update(msg)
 
-  | RefreshClientIfOutdated(serverHash) =>
+  | RefreshClientIfOutdated(Error(_err)) => NoChange
+  | RefreshClientIfOutdated(Ok(serverHash)) =>
     let hasBeenInactiveForPastHour = switch m.visibility {
     | Visible => false
     | Hidden(since) =>
-      // TODO: switch back to an hour (60.) ago rather than a minute (1.) ago
-      let oneHourAgo = Js.Date.now() -. 1.0 *. 60.0 *. 1000.0 |> Js.Date.fromFloat
+      let oneHourAgo = Js.Date.now() -. 60.0 *. 60.0 *. 1000.0 |> Js.Date.fromFloat
       since < oneHourAgo
     }
 
@@ -2156,8 +2156,7 @@ let update_ = (msg: msg, m: model): modification => {
     let hashesMatch = m.buildHash == serverHash
 
     if hasBeenInactiveForPastHour && isPageSafelyRefreshable && !hashesMatch {
-      //Webapi.Dom.location->Webapi.Dom.Location.reload
-      Debug.loG("(fake-refreshing)", ())
+      Webapi.Dom.location->Webapi.Dom.Location.reload
     }
 
     NoChange

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -2276,11 +2276,11 @@ let subscriptions = (m: model): Tea.Sub.t<msg> => {
   }
 
   let visibility = list{
-    BrowserSubscriptions.Window.OnFocusChange.listen(~key="window_on_focus_change", v =>
-      if !v {
-        PageVisibilityChange(Visible)
-      } else {
+    BrowserSubscriptions.Window.OnFocusChange.listen(~key="window_on_focus_change", hidden =>
+      if hidden {
         PageVisibilityChange(Hidden(Js.Date.now() |> Js.Date.fromFloat))
+      } else {
+        PageVisibilityChange(Visible)
       }
     ),
   }

--- a/client/src/app/Main.res
+++ b/client/src/app/Main.res
@@ -1832,8 +1832,8 @@ let update_ = (msg: msg, m: model): modification => {
   | TimerFire(action, _) =>
     switch action {
     | RefreshAnalysis =>
-      let getUnlockedDBs = // Small optimization
-      if Map.length(m.dbs) > 0 {
+      // Small optimization - only refresh unlocked DBs if there's at least 1 known
+      let getUnlockedDBs = if !Map.isEmpty(m.dbs) {
         GetUnlockedDBsAPICall
       } else {
         NoChange

--- a/client/src/components/Settings/SettingsContributingView.res
+++ b/client/src/components/Settings/SettingsContributingView.res
@@ -82,7 +82,13 @@ let viewTunnelSectionHeader = {
       Html.a(list{Attrs.href("https://localtunnel.me")}, list{Html.text("localtunnel")}),
       Html.text(" or "),
       Html.a(list{Attrs.href("https://ngrok.com")}, list{Html.text("ngrok")}),
-      Html.text(") to use your local client against the Darklang production API"),
+      Html.text(") to use your local client against the Darklang production API. "),
+      Html.text("See the "),
+      Html.a(
+        list{Attrs.href("https://docs.darklang.com/contributing/client-asset-tunnelling")},
+        list{Html.text("contributor docs")},
+      ),
+      Html.text(" for instructions."),
     }),
   }
 }

--- a/client/src/core/Types.res
+++ b/client/src/core/Types.res
@@ -138,6 +138,7 @@ and timerAction =
   | RefreshAnalysis
   | RefreshAvatars
   | CheckUrlHashPosition
+  | CheckIfClientIsOutdated
 
 and traceID = string
 


### PR DESCRIPTION
Changelog:

```
Editor
- refresh the editor when it is outdated and inactive
```

How this works:
- `appsupport.js` listens for changes in whether the page is in focus or not, with `windowFocusChange`
- upon change of hidden/visible, it sends a message to a `BrowserSubscription` in ReScript land, which in turn triggers a `PageVisibilityChange` `Msg`
- that triggers a `PageVisibilityChange` `Msg`, which results in an update to a `pageVisibility` field in our main `model`
  - new: the 'hidden' variant of `PageVisibility` now has a `since` field in it, which is used to track how long it's been since a page became hidden
- separately, a timer runs every minute, triggering a `CheckIfClientIsOutdated` `Msg`; that results in an API call being made to a new endpoint in `dark-editor`, made possible by #4649:
  ![image](https://user-images.githubusercontent.com/906686/210249661-dee0b4bb-5fca-466c-8d4a-d9deaf034547.png) 
- when the result of that API (the hash) is returned, we assess a few variables, and refresh the page if all are true:
  - the client hash and the server hash don't match (i.e. the client is out of date)
  - the page is 'safe to refresh'[1]
  - the page is not currently in focus, and has been 'hidden' for at least an hour

[1] later, we can/should expand this criteria - currently, only the `Architecture` and `FocusedPackageManagerFn` pages are considered safely refreshable

I ran into some confusion when trying to tunnel my static assets in prod, so wrote some external docs in `darklang/docs`, and referenced those in the relevant portion of the Contributor settings.