### PR TITLE
Add DarkInternal::serverBuildHash fn that returns the git hash of the server's current deploy

### DIFF
--- a/backend/src/BackendOnlyStdLib/LibDarkInternal.fs
+++ b/backend/src/BackendOnlyStdLib/LibDarkInternal.fs
@@ -668,7 +668,6 @@ that's already taken, returns an error."
       deprecated = NotDeprecated }
 
 
-
     { name = fn "DarkInternal" "newSessionForUsername" 0
       parameters = [ Param.make "username" TStr "" ]
       returnType = TResult(TStr, TStr)
@@ -893,6 +892,19 @@ human-readable data."
               do! StaticAssets.deleteStaticAssetDeploy canvasID deployHash
               return DNull
             }
+          | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "DarkInternal" "serverBuildHash" 0
+      parameters = []
+      returnType = TStr
+      description = "Returns the git hash of the server's current deploy"
+      fn =
+        internalFn (function
+          | _, [] -> uply { return DStr LibService.Config.buildHash }
           | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/testfiles/execution/internal.tests
+++ b/backend/testfiles/execution/internal.tests
@@ -3,8 +3,22 @@
 // ---------------
 // Misc
 // ---------------
+[tests.misc]
+
+[test.correct number of tables]
 Dict.size_v0 DarkInternal.getAndLogTableSizes_v0 = 24
+
+[test.allFunctions has many functions]
 (List.length_v0 DarkInternal.allFunctions_v0 > 290) = true
+
+[test.server build hash]
+(match DarkInternal.serverBuildHash_v0 with
+ // in local dev, the value is "dev"
+ | "dev" -> true
+ // in ci, "circleci"
+ | "circleci" -> true
+ // otherwise it's the first 7 chars of the git hash
+ | hash -> (String.length hash) = 7)
 
 // ---------------
 // Grants


### PR DESCRIPTION
Changelog:

```
Internal
- add internal function that returns the git hash of the server's current/latest deploy
```

This is to support #4648 - with this fn exposed, an endpoint in `dark-editor` may be defined to expose the current deploy version, which the `client` may then call out to, in order to see if it's at the latest build.

Questions for review:
- is `LibService.Config.buildHash` something we can/should rely on? Locally, it returns just `"dev"` but I understand it will contain the actual hash outside of local development.
- should the function instead be `::buildHash` or `::buildVersion` or `::latestBuild` or something else?
- I haven't written tests around this. I could test that it returns `"dev"`? Not sure what's best here.