### PR TITLE
Add Cloud Run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:89294ed
+      - image: darklang/dark-base:f68d6ec
 
 commands:
   show-large-files-and-directories:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,8 @@
     "ms-python.python",
     "ms-azuretools.vscode-docker",
     "editorconfig.editorconfig",
-    "chenglou92.rescript-vscode@1.1.3"
+    "chenglou92.rescript-vscode@1.1.3",
+    "hashicorp.terraform"
   ],
 
   /////////////////////////////////////////////////

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ backend/tests/**/obj
 backend/.paket/load/
 .fake
 
+# Terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+
 ###############
 # Deployment
 ###############

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN curl -sSL https://nginx.org/keys/nginx_signing.key | apt-key add -
-
+RUN curl -sSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 
 # We want postgres 9.6, but it is not in later ubuntus
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
@@ -77,6 +77,8 @@ RUN echo "deb-src https://deb.nodesource.com/node_14.x jammy main" >> /etc/apt/s
 
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN echo "deb [arch=${TARGETARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
+RUN echo "deb https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list
 
 # Mostly, we use the generic version. However, for things in production we want
 # to pin the exact package version so that we don't have any surprises.  As a
@@ -114,6 +116,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       google-cloud-sdk \
       google-cloud-sdk-pubsub-emulator \
       google-cloud-sdk-gke-gcloud-auth-plugin \
+      terraform \
       jq \
       vim \
       unzip \

--- a/scripts/build/compile
+++ b/scripts/build/compile
@@ -140,6 +140,12 @@ def yamllint(f):
   return result
 
 
+def terraform_validate():
+  start = time.time()
+  result = run_backend(start, "cd tf && terraform validate")
+  return result
+
+
 def shipit_validate(f):
   start = time.time()
   return run_backend(start, f"scripts/deployment/shipit validate {f}")
@@ -327,6 +333,7 @@ class Should:
     self.shellcheck = []
     self.yamllint = []
     self.shipit_validate = []
+    self.terraform_validate = False
 
 
 def execute(should):
@@ -432,6 +439,9 @@ def execute(should):
     if not all([shipit_validate(f) for f in should.shipit_validate]):
       success = False
 
+  if should.terraform_validate:
+    if not terraform_validate(): success = False
+
   return success
 
 
@@ -513,6 +523,9 @@ def mark(should, f):
 
   elif ("/services/" in f and "shipit.yaml" in f):
     should.shipit_validate += [f]
+
+  elif ("/tf/" in f and ".tf" in f):
+    should.terraform_validate = True
 
   elif ("/scripts/deployment/requirements.txt" in f):
     should.pip_install = True

--- a/tf/.terraform.lock.hcl
+++ b/tf/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.47.0"
+  constraints = ">= 3.3.0"
+  hashes = [
+    "h1:JXAoKJbm79Uo19YVObJCJcKPtNYBGVF+tQ91PtVIvt0=",
+    "zh:030359653ee8e3a7a0ec30f06f7ac0d2bf5cb8bf895d06155646114fa13766e5",
+    "zh:14b18f549466eb99cac08fd2d89c8df3591cc3688c9e5ed12fb4a957482d0e2d",
+    "zh:3a9b9d1878f4004a7fee0ab8f8dea600307ad75a872f591590f704bf504b25af",
+    "zh:412b809bc61a74857912da5c2e9deddf5edf2eb883999ffb29573146ca12097b",
+    "zh:456372baa4fbb397f2d67fa291a15d216937e24dd1c05a66d6484ca2e24829e8",
+    "zh:69dc08f0e8eb672a8be11070b4ebb319b4a1725d928498607a0534a65089f3ef",
+    "zh:bc582257b94b0d2bd225b829016963580c681b09b0545c474420a27909b53fea",
+    "zh:bf1a8bf7e54f3e709d6323bdd12b5bf5cce3b245414f8aa09cb1860aa98f407d",
+    "zh:dc322cd105f3d0d0268e75a646f45471158ac668ed665309483f19c16385783b",
+    "zh:ee3b36c484dd4aea0855300e325fe31eee067eeb759192cee3ccad6fae45f610",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f58ac64cc632d80243c2a97a009c44e8b7672adbab11cce488a77a7efeca33f0",
+  ]
+}

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -1,0 +1,107 @@
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    google = "4.47.0"
+  }
+}
+
+provider "google" {
+  project = "balmy-ground-195100"
+  region  = "us-west1"
+}
+
+# main.tf
+
+# Enables the Cloud Run API
+# resource "google_project_service" "run_api" {
+#   service = "run.googleapis.com"
+
+#   disable_on_destroy = true
+# }
+
+
+resource "google_cloud_run_service" "run_service" {
+  name     = "bwdserver"
+  location = "us-west1"
+
+  template {
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/minScale" : "1"
+        "autoscaling.knative.dev/maxScale" : "10"
+        "run.googleapis.com/cloudsql-instances" : "balmy-ground-195100:us-west1:dark-west"
+        "run.googleapis.com/startup-cpu-boost" : "true"
+      }
+    }
+
+    spec {
+      container_concurrency = 0
+      timeout_seconds       = 300
+      service_account_name  = "cloud-run-runner@balmy-ground-195100.iam.gserviceaccount.com"
+      containers {
+        image = "gcr.io/balmy-ground-195100/gcp-fsharp-bwdserver@sha256:7e91876469db2b8a21a176308e54d8a61147976ab83251d896fee4fb2d63ba77"
+        ports {
+          name           = "http1"
+          container_port = 11001
+        }
+        resources {
+          limits = {
+            cpu    = "2.0"
+            memory = "6000Mi"
+          }
+        }
+        # startup_probe {
+        #   initial_delay_seconds = 0
+        #   timeout_seconds = 1
+        #   period_seconds = 3
+        #   failure_threshold = 1
+        #   tcp_socket {
+        #     port = 8080
+        #   }
+        # }
+        # liveness_probe {
+        #   http_get {
+        #     path = "/"
+        #   }
+        # }
+
+        # secrets
+        dynamic "env" {
+          for_each = var.service_secrets
+          content {
+            name = env.key
+            value_from {
+              secret_key_ref {
+                name = env.value
+                key  = "latest"
+              }
+            }
+          }
+        }
+
+        # Env vars
+        dynamic "env" {
+          for_each = var.service_env_vars
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  # Waits for the Cloud Run API to be enabled
+  # depends_on = [google_project_service.run_api]
+}
+
+output "service_url" {
+  value = google_cloud_run_service.run_service.status[0].url
+}

--- a/tf/service_env_vars.tf
+++ b/tf/service_env_vars.tf
@@ -1,0 +1,138 @@
+variable "service_env_vars" {
+  type = map(string)
+  default = {
+    # Root directories
+    "DARK_CONFIG_RUNDIR"   = "/home/dark/gcp-rundir"
+    "DARK_CONFIG_ROOT_DIR" = "/home/dark"
+
+    # Important dirs
+    "DARK_CONFIG_TEMPLATES_DIR"  = "/home/dark/templates"
+    "DARK_CONFIG_WEBROOT_DIR"    = "/home/dark/webroot/static"
+    "DARK_CONFIG_MIGRATIONS_DIR" = "/home/dark/migrations"
+
+    # Ports
+
+    ## ApiServer
+    "DARK_CONFIG_APISERVER_NGINX_PORT"      = "9000"
+    "DARK_CONFIG_APISERVER_BACKEND_PORT"    = "9001"
+    "DARK_CONFIG_APISERVER_KUBERNETES_PORT" = "9002"
+
+    ## BwdServer
+    "DARK_CONFIG_BWDSERVER_BACKEND_PORT"    = "11001"
+    "DARK_CONFIG_BWDSERVER_KUBERNETES_PORT" = "11002"
+
+    ## CronChecker
+    "DARK_CONFIG_CRONCHECKER_KUBERNETES_PORT" = "12002"
+
+    ## QueueWorker
+    "DARK_CONFIG_QUEUEWORKER_KUBERNETES_PORT" = "13002"
+
+    "DARK_CONFIG_ALLOW_TEST_ROUTES"     = "n"
+    "DARK_CONFIG_TRIGGER_QUEUE_WORKERS" = "y"
+    "DARK_CONFIG_TRIGGER_CRONS"         = "y"
+    "DARK_CONFIG_PAUSE_BETWEEN_CRONS"   = "0"
+    "DARK_CONFIG_CREATE_ACCOUNTS"       = "n"
+    "DARK_CONFIG_USE_HTTPS"             = "y"
+
+    "DARK_CONFIG_APISERVER_SERVE_STATIC_CONTENT" = "n"
+    "DARK_CONFIG_APISERVER_HOST"                 = "darklang.com"
+    "DARK_CONFIG_APISERVER_STATIC_HOST"          = "static.darklang.com"
+    "DARK_CONFIG_COOKIE_DOMAIN"                  = ".darklang.com"
+    "DARK_CONFIG_BWDSERVER_HOST"                 = "builtwithdark.com"
+
+    # Serialization
+    "DARK_CONFIG_SERIALIZATION_GENERATE_TEST_DATA" = "n"
+    "DARK_CONFIG_SERIALIZATION_CHECK_TYPES"        = "n"
+    "DARK_CONFIG_SERIALIZATION_HEALTH_CHECK_HOSTS" = "dark-editor,ops-adduser,ops-corpsite,ops-login,sample-crud"
+
+    # Logging
+    "DARK_CONFIG_ENV_DISPLAY_NAME" = "production"
+
+    # Rollbar
+    "DARK_CONFIG_ROLLBAR_ENABLED"          = "y"
+    "DARK_CONFIG_ROLLBAR_ENVIRONMENT"      = "production"
+    "DARK_CONFIG_ROLLBAR_POST_CLIENT_ITEM" = "c7af77e991aa4edd80cf6a576c1e42f5"
+    # "#DARK_CONFIG_ROLLBAR_POST_SERVER_ITEM" = "k8s"
+
+    # Honeycomb
+    "DARK_CONFIG_TELEMETRY_EXPORTER" = "honeycomb"
+    # "#DARK_CONFIG_HONEYCOMB_API_KEY"     = "k8s"
+    "DARK_CONFIG_HONEYCOMB_DATASET_NAME" = "kubernetes-bwd-ocaml"
+    "DARK_CONFIG_HONEYCOMB_API_ENDPOINT" = "https://api.honeycomb.io:443"
+
+    # Launchdarkly - https://app.launchdarkly.com/settings/projects/default/environments
+    # "DARK_CONFIG_LAUNCHDARKLY_SDK_API_KEY"   = "k8s"
+    "DARK_CONFIG_LAUNCHDARKLY_CLIENT_SIDE_ID" = "627162f9b2bab01530ddc355"
+
+    # Feature flag defaults
+    "DARK_CONFIG_TRACE_SAMPLING_RULE_DEFAULT" = "sample-none"
+
+    # DB
+    "DARK_CONFIG_DB_DBNAME" = "postgres"
+    "DARK_CONFIG_DB_HOST"   = "/cloudsql/balmy-ground-195100:us-west1:dark-west"
+    # DARK_CONFIG_DB_USER: k8s
+    # DARK_CONFIG_DB_PASSWORD: k8s
+    "DARK_CONFIG_DB_POOL_SIZE" = "20"
+
+    # Queue / pubsub
+    "DARK_CONFIG_QUEUE_PUBSUB_PROJECT_ID"        = "balmy-ground-195100"
+    "DARK_CONFIG_QUEUE_PUBSUB_TOPIC_NAME"        = "topic-queueworker-1"
+    "DARK_CONFIG_QUEUE_PUBSUB_SUBSCRIPTION_NAME" = "subscription-queueworker-1"
+    "DARK_CONFIG_QUEUE_PUBSUB_CREATE_TOPIC"      = "n"
+    # DARK_CONFIG_QUEUE_PUBSUB_CREDENTIALS: k8s
+
+    # Httpclient
+    "DARK_CONFIG_HTTPCLIENT_TUNNEL_PROXY_URL" = "socks5://tunnel2-service.darklang:1080"
+
+    # Publicly accessible domain
+    "DARK_CONFIG_PUBLIC_DOMAIN" = "localhost"
+
+    # Pusher
+    # DARK_CONFIG_PUSHER_APP_ID: k8s
+    # DARK_CONFIG_PUSHER_KEY: k8s
+    # DARK_CONFIG_PUSHER_SECRET: k8s
+    # DARK_CONFIG_PUSHER_CLUSTER: k8s
+
+    # Heap analytics
+    "DARK_CONFIG_HEAPIO_ID" = "477722926"
+
+    # Static assets
+    "DARK_CONFIG_STATIC_ASSETS_SALT_SUFFIX" = "production"
+
+    # Other
+    "DARK_CONFIG_BROWSER_RELOAD_ENABLED"           = "n"
+    "DARK_CONFIG_HASH_STATIC_FILENAMES"            = "y"
+    "DARK_CONFIG_USE_LOGIN_DARKLANG_COM_FOR_LOGIN" = "y"
+
+    # Getting started canvas
+    "DARK_CONFIG_GETTING_STARTED_CANVAS_NAME"   = "crud"
+    "DARK_CONFIG_GETTING_STARTED_CANVAS_SOURCE" = "sample-crud"
+  }
+}
+
+variable "service_secrets" {
+  type = map(string)
+  default = {
+    # rollbar
+    "DARK_CONFIG_ROLLBAR_POST_SERVER_ITEM" = "rollbar-post-token"
+
+    # launchdarkly
+    "DARK_CONFIG_LAUNCHDARKLY_SDK_API_KEY" = "launchdarkly-sdk-api-key"
+
+    # pusher
+    "DARK_CONFIG_PUSHER_APP_ID"  = "pusher-app-id"
+    "DARK_CONFIG_PUSHER_KEY"     = "pusher-key"
+    "DARK_CONFIG_PUSHER_SECRET"  = "pusher-secret"
+    "DARK_CONFIG_PUSHER_CLUSTER" = "pusher-cluster"
+
+    # database
+    "DARK_CONFIG_DB_USER"     = "cloudsql-username"
+    "DARK_CONFIG_DB_PASSWORD" = "cloudsql-password"
+
+    # honeycomb
+    "DARK_CONFIG_HONEYCOMB_API_KEY" = "honeycomb-api-key"
+
+    # PubSub - service account JSON file
+    "DARK_CONFIG_QUEUE_PUBSUB_CREDENTIALS" = "queue-pubsub-credentials"
+  }
+}


### PR DESCRIPTION
No changelog (changes aren't effected yet)

We'd like to move away from kubernetes, and Google Cloud Run is a great option for that:
- does everything we need with minimal config
- only bills when CPU is in use
- autoscales
- no control plane to manage/upgrade

This is the start of the setting it up - I have it working in practice with these settings, but still more testing and stuff before it's ready to put it into production. This doesn't do any deployment, and users can't reach this.

- adds terraform
- adds terraform config to run bwdserver in cloud run
- creates an file with env vars and secrets that should replace config/gke-builtwithdark (can be used for queues as well)

This should be safe to merge as it's not actually connected to anything userfacing.

Remaining work is in #4663.


