### PR TITLE
Use new short-circuiting and/or

### DIFF
--- a/backend/src/LibExecutionStdLib/StdLib.fs
+++ b/backend/src/LibExecutionStdLib/StdLib.fs
@@ -76,11 +76,16 @@ let infixFnMapping : Map<FQFnName.StdlibFnName, (FQFnName.StdlibFnName * Depreca
     ("String", "append", 1), (("", "++"), NotDeprecated)
     ("", "equals", 0), (("", "=="), NotDeprecated)
     ("", "notEquals", 0), (("", "!="), NotDeprecated)
-    // TODO: deprecate when there's a nice way to move from infix fn to language version
-    // ("Bool", "and", 0), (("", "&&"), DeprecatedBecause("Use `&&` instead"))
-    // ("Bool", "or", 0), (("", "||"), DeprecatedBecause("Use `||` instead"))
-    ("Bool", "and", 0), (("", "&&"), NotDeprecated)
-    ("Bool", "or", 0), (("", "||"), NotDeprecated) ]
+    ("Bool", "and", 0),
+    (("", "&&"),
+     DeprecatedBecause(
+       "Use built-in keyword `&&` instead. Use the `convert-to-short-circuiting` command to convert automatically"
+     ))
+    ("Bool", "or", 0),
+    (("", "||"),
+     DeprecatedBecause(
+       "Use built-in keyword `&&` instead. Use the `convert-to-short-circuiting` command to convert automatically"
+     )) ]
   |> List.map (fun ((module_, name, version), ((newMod, opName), deprecation)) ->
     FQFnName.stdlibFnName module_ name version,
     (FQFnName.stdlibFnName newMod opName 0, deprecation))

--- a/backend/src/LibExecutionStdLib/StdLib.fs
+++ b/backend/src/LibExecutionStdLib/StdLib.fs
@@ -84,7 +84,7 @@ let infixFnMapping : Map<FQFnName.StdlibFnName, (FQFnName.StdlibFnName * Depreca
     ("Bool", "or", 0),
     (("", "||"),
      DeprecatedBecause(
-       "Use built-in keyword `&&` instead. Use the `convert-to-short-circuiting` command to convert automatically"
+       "Use built-in keyword `||` instead. Use the `convert-to-short-circuiting` command to convert automatically"
      )) ]
   |> List.map (fun ((module_, name, version), ((newMod, opName), deprecation)) ->
     FQFnName.stdlibFnName module_ name version,

--- a/client/src/components/Settings/SettingsContributing.res
+++ b/client/src/components/Settings/SettingsContributing.res
@@ -254,40 +254,34 @@ module General = {
 // -------------------
 module InProgressFeatures = {
   @ppx.deriving(show)
-  type rec t = {allowTuples: bool, allowShortCircuitingBinops: bool}
+  type rec t = {allowTuples: bool}
 
   @ppx.deriving(show)
-  type rec msg = SetTuplesAllowed(bool) | SetShortCircuitingBinopsAllowed(bool)
+  type rec msg = SetTuplesAllowed(bool)
 
   @ppx.deriving(show)
   type rec intent = unit
 
   let default = {
     allowTuples: false,
-    allowShortCircuitingBinops: false,
   }
 
   let toSaved = (state: t) => {
     open Json.Encode
-    object_(list{
-      ("allowTuples", bool(state.allowTuples)),
-      ("allowShortCircuitingBinops", bool(state.allowShortCircuitingBinops)),
-    })
+    object_(list{("allowTuples", bool(state.allowTuples))})
   }
   let fromSaved = (j: Js.Json.t) => {
     open Json.Decode
     {
       allowTuples: field("allowTuples", bool, j),
-      allowShortCircuitingBinops: field("allowShortCircuitingBinops", bool, j),
     }
   }
 
   let init = () => Tea.Cmd.none
 
-  let update = (state: t, msg: msg): (t, intent) =>
+  let update = (_: t, msg: msg): (t, intent) =>
     switch msg {
-    | SetTuplesAllowed(v) => ({...state, allowTuples: v}, ())
-    | SetShortCircuitingBinopsAllowed(v) => ({...state, allowShortCircuitingBinops: v}, ())
+    | SetTuplesAllowed(v) => ({allowTuples: v}, ())
     }
 }
 

--- a/client/src/components/Settings/SettingsContributingView.res
+++ b/client/src/components/Settings/SettingsContributingView.res
@@ -68,38 +68,12 @@ let viewAllowTuples = (allowTuples: bool): Html.html<AppTypes.msg> => {
   C.settingRow("Enable tuples", ~info, ~error=None, list{toggle})
 }
 
-let viewAllowShortCircuitingBinops = (allow: bool): Html.html<AppTypes.msg> => {
-  let toggle = {
-    let attr = EventListeners.eventNoPropagation(
-      ~key=`toggle-allow-ShortCircuitingBinops-${string_of_bool(allow)}`,
-      "click",
-      _ => Msg.SettingsMsg(
-        Settings.ContributingMsg(
-          SettingsContributing.InProgressFeaturesMsg(
-            T.InProgressFeatures.SetShortCircuitingBinopsAllowed(!allow),
-          ),
-        ),
-      ),
-    )
-    C.toggleButton(attr, allow)
-  }
-
-  let info = Some(
-    "We're currently adding support for || and && operators - the current versions are actually infix functions, and so they execute both arguments always. The new versions will only execute the second argument if the first one allows it. Changing the flag does not change the behavior of existing code - instead when adding new || and && operators, the new short-circuiting versions will be used.",
-  )
-  C.settingRow("Enable short-circuiting || and  && operators", ~info, ~error=None, list{toggle})
-}
-
 let viewGeneral = (s: T.General.t): list<Html.html<AppTypes.msg>> => {
   list{C.sectionHeading("General", None), viewSidebarDebuggerToggle(s.showSidebarDebuggerPanel)}
 }
 
 let viewInProgressFeatures = (s: T.InProgressFeatures.t): list<Html.html<AppTypes.msg>> => {
-  list{
-    C.sectionHeading("In-Progress Features", None),
-    viewAllowTuples(s.allowTuples),
-    viewAllowShortCircuitingBinops(s.allowShortCircuitingBinops),
-  }
+  list{C.sectionHeading("In-Progress Features", None), viewAllowTuples(s.allowTuples)}
 }
 
 let viewTunnelSectionHeader = {

--- a/client/src/fluid/Commands.res
+++ b/client/src/fluid/Commands.res
@@ -46,6 +46,12 @@ let commands: list<AppTypes.fluidCmd> = {
       doc: "Convert the if expression into a match expression",
     },
     {
+      commandName: "convert-to-short-circuiting",
+      action: ShortCircuitingBinOpDeprecation.refactor,
+      shouldShow: (_, _, e) => ShortCircuitingBinOpDeprecation.shouldShow(e),
+      doc: "Convert the && or || expression into the new short-circuiting version",
+    },
+    {
       commandName: "insert-let-above",
       action: Refactor.wrap(Refactor.WLetBody),
       shouldShow: alwaysShow,

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -845,8 +845,26 @@ let rec documentationForItem = ({item, validity}: data): option<list<Vdom.t<'a>>
       "A `match` expression allows you to pattern match on a value, and return different expressions based on many possible conditions",
     )
   | FACKeyword(KPipe) => simpleDoc("Pipe into another expression")
-  | FACKeyword(KAnd) => simpleDoc("A boolean `and`")
-  | FACKeyword(KOr) => simpleDoc("A boolean `or`")
+  | FACKeyword(KAnd) =>
+    Some(
+      List.flatten(list{
+        PrettyDocs.convert("&&"),
+        list{Html.br(list{}), Html.br(list{})},
+        PrettyDocs.convert("Evaluates to {{true}} if both expressions are {{true}}"),
+        list{Html.br(list{}), Html.br(list{})},
+        PrettyDocs.convert("The second expression is only evaluated if the first is {{true}}"),
+      }),
+    )
+  | FACKeyword(KOr) =>
+    Some(
+      List.flatten(list{
+        PrettyDocs.convert("||"),
+        list{Html.br(list{}), Html.br(list{})},
+        PrettyDocs.convert("Evaluates to {{true}} if either expression is {{true}}"),
+        list{Html.br(list{}), Html.br(list{})},
+        PrettyDocs.convert("The second expression is only evaluated if the first is {{false}}"),
+      }),
+    )
   | FACMatchPattern(_, pat) =>
     switch pat {
     | FMPAConstructor(name, args) =>

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -17,7 +17,7 @@ type model = AppTypes.model
 
 @ppx.deriving(show) type rec data = FT.AutoComplete.data
 
-type props = {functions: Functions.t, allowShortCircuiting: bool}
+type props = {functions: Functions.t}
 
 @ppx.deriving(show) type rec tokenInfo = FluidTypes.TokenInfo.t
 
@@ -455,11 +455,7 @@ let generateExprs = (m: model, props: props, tl: toplevel, ti) => {
       }
     )
 
-  let shortCircuiting = if props.allowShortCircuiting {
-    list{FACKeyword(KAnd), FACKeyword(KOr)}
-  } else {
-    list{}
-  }
+  let shortCircuiting = list{FACKeyword(KAnd), FACKeyword(KOr)}
 
   let keywords = if !isInQuery {
     List.map(~f=x => FACKeyword(x), list{KLet, KIf, KLambda, KMatch, KPipe})
@@ -661,7 +657,6 @@ let regenerate = (m: model, a: t, (tlid, ti): query): t =>
   | Some(tl) =>
     let props = {
       functions: m.functions,
-      allowShortCircuiting: m.settings.contributingSettings.inProgressFeatures.allowShortCircuitingBinops,
     }
     let queryString = toQueryString(ti)
     let fieldList = findFields(m, tl, ti)

--- a/client/src/fluid/FluidAutocomplete.resi
+++ b/client/src/fluid/FluidAutocomplete.resi
@@ -8,7 +8,7 @@ let focusItem: int => AppTypes.cmd
 
 @ppx.deriving(show) type rec query = (TLID.t, FluidTypes.TokenInfo.t)
 
-type props = {functions: Functions.t, allowShortCircuiting: bool}
+type props = {functions: Functions.t}
 
 let asName: item => string
 

--- a/client/src/fluid/FluidExpression.res
+++ b/client/src/fluid/FluidExpression.res
@@ -778,7 +778,7 @@ let toHumanReadable = (expr: t, showID: bool): string => {
     | EFnCall(_, name, list{}, _) => `(fn${id} "${FQFnName.toString(name)}")`
     | EFnCall(_, name, exprs, _) => `(fn${id} "${FQFnName.toString(name)}"\n${newlineList(exprs)})`
     | EInfix(_, BinOp(op), lhs, rhs) =>
-      `(binop${id} "${PT.Expr.BinaryOperation.toString(op)}"\n${r(lhs)}\n${r(rhs)})`
+      `(binop${PT.Expr.BinaryOperation.toString(op)}${id} ${r(lhs)} ${r(rhs)})`
     | EInfix(_, InfixFnCall(name, _), lhs, rhs) =>
       `(infixFn${id} "${PT.InfixStdlibFnName.toString(name)}"\n${r(lhs)}\n${r(rhs)})`
     | EVariable(_, name) => `(${name}${id})`

--- a/client/src/fluid/ShortCircuitingBinOpDeprecation.res
+++ b/client/src/fluid/ShortCircuitingBinOpDeprecation.res
@@ -1,0 +1,33 @@
+open Prelude
+module TL = Toplevel
+module E = ProgramTypes.Expr
+module MP = FluidMatchPattern
+
+let refactor = (_: AppTypes.model, tl: toplevel, id: id): AppTypes.modification => {
+  let replaceBinOp = ((ast: FluidAST.t, expr: E.t)): option<AppTypes.modification> => {
+    let newExpr = switch expr {
+    | E.EInfix(_, InfixFnCall({module_: None, function: "&&"}, _), lhs, rhs) =>
+      Some(E.EInfix(gid(), BinOp(E.BinaryOperation.BinOpAnd), lhs, rhs))
+    | E.EInfix(_, InfixFnCall({module_: None, function: "||"}, _), lhs, rhs) =>
+      Some(E.EInfix(gid(), BinOp(E.BinaryOperation.BinOpOr), lhs, rhs))
+    | _ => None
+    }
+
+    newExpr |> Option.map(~f=newExpr =>
+      FluidAST.replace(~replacement=newExpr, FluidExpression.toID(expr), ast) |> TL.setASTMod(tl)
+    )
+  }
+
+  TL.getAST(tl)
+  |> Option.thenAlso(~f=ast => FluidAST.findExpr(id, ast))
+  |> Option.andThen(~f=replaceBinOp)
+  |> Option.unwrap(~default=AppTypes.Modification.NoChange)
+}
+
+let shouldShow = (e: E.t): bool => {
+  switch e {
+  | EInfix(_, InfixFnCall({module_: None, function: "&&"}, _), _, _)
+  | EInfix(_, InfixFnCall({module_: None, function: "||"}, _), _, _) => true
+  | _ => false
+  }
+}

--- a/client/test/FluidTestData.res
+++ b/client/test/FluidTestData.res
@@ -988,10 +988,7 @@ let defaultTestModel: AppTypes.Model.t = {
     ...AppTypes.Model.default.settings,
     contributingSettings: {
       ...AppTypes.Model.default.settings.contributingSettings,
-      inProgressFeatures: {
-        ...AppTypes.Model.default.settings.contributingSettings.inProgressFeatures,
-        allowShortCircuitingBinops: true,
-      },
+      inProgressFeatures: AppTypes.Model.default.settings.contributingSettings.inProgressFeatures,
     },
   },
 }

--- a/client/test/TestFluidAutocomplete.res
+++ b/client/test/TestFluidAutocomplete.res
@@ -210,7 +210,7 @@ let setQuery = (q: string, a: AC.t): AC.t => {
   let fullQ = defaultFullQuery(a, q)
   let props = defaultTestProps
   AC.refilter(
-    {functions: props.functions, allowShortCircuiting: true},
+    {functions: props.functions},
     fullQ,
     a,
     List.map(~f=({item, _}) => item, a.completions),


### PR DESCRIPTION
Changelog:

```
Editor
- default to short-circuiting `||`/`&&`
- deprecate old `||`/`&&` functions
- add `convert-to-short-circuiting` command to migrate from old `||`\`&&` functions
```

Removes the old settings, defaults to the new expressions, deprecates old expressions, and updates docs/deprecation settings. Also adds a command to convert automatically.

Deprecated old version
![Screenshot 2023-01-02 at 6 22 30 PM](https://user-images.githubusercontent.com/181762/210284676-7a4e6ddc-832f-41c6-8441-2a38a7a9cd8a.png)

Doc for new version
![Screenshot 2023-01-02 at 6 22 40 PM](https://user-images.githubusercontent.com/181762/210284677-4a9aa50d-2fe6-47f5-9464-d1fa62714bb2.png)

I'm not super happy with the docstring or the name `convert-to-short-circuiting`. Advice appreciated.