### PR TITLE
Reenable circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ commands:
       - run: scripts/deployment/shipit release prepare --arg CHANGE_CAUSE="test" --manifest=gcr-image-ids.json
 
   ##########################
-  # misc
+  # Google Cloud
   ##########################
   auth-with-gcp:
     parameters: { background: { type: boolean } }
@@ -176,8 +176,7 @@ commands:
           name: Auth with GCP
           background: << parameters.background >>
           command: |
-            echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > gcloud-service-key.json
-            gcloud auth activate-service-account --key-file gcloud-service-key.json
+            gcloud auth login --brief --cred-file .circleci/gcp-workflow-identity-config.json
             gcloud auth configure-docker
             ./scripts/production/gcp-authorize-kubectl
 
@@ -188,8 +187,7 @@ commands:
           when: on_fail
           command: |
             if [[ "${CIRCLE_BRANCH}" = "main" ]]; then
-              echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > gcloud-service-key.json
-              gcloud auth activate-service-account --key-file gcloud-service-key.json
+              gcloud auth login --brief --cred-file .circleci/gcp-workflow-idenity-config.json
               gcloud auth configure-docker
               ./scripts/production/gcp-authorize-kubectl
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ commands:
           name: Auth with GCP
           background: << parameters.background >>
           command: |
+            echo $CIRCLE_OIDC_TOKEN >> CIRCLE_OIDC_TOKEN_FILE
             gcloud auth login --brief --cred-file .circleci/gcp-workflow-identity-config.json
             gcloud auth configure-docker
             ./scripts/production/gcp-authorize-kubectl
@@ -187,6 +188,7 @@ commands:
           when: on_fail
           command: |
             if [[ "${CIRCLE_BRANCH}" = "main" ]]; then
+              echo $CIRCLE_OIDC_TOKEN >> CIRCLE_OIDC_TOKEN_FILE
               gcloud auth login --brief --cred-file .circleci/gcp-workflow-idenity-config.json
               gcloud auth configure-docker
               ./scripts/production/gcp-authorize-kubectl
@@ -544,3 +546,5 @@ workflows:
             - static-checks
             - predeployment-checks
             - validate-honeycomb-config
+
+# VS Code Extension Version: 1.5.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ commands:
 
   ##########################
   # Google Cloud
+  # https://circleci.com/docs/openid-connect-tokens/#setting-up-gcp
   ##########################
   auth-with-gcp:
     parameters: { background: { type: boolean } }
@@ -462,12 +463,13 @@ jobs:
       - slack-notify-build
 
 workflows:
-  version: 2
   build-and-deploy:
     jobs:
       # initial builds & tests
       - static-checks
       - predeployment-checks:
+          context:
+            - gcp context
           filters:
             branches:
               ignore: /^(pull\/).*$/
@@ -495,6 +497,8 @@ workflows:
 
       # pre-deploy, in parallel with integration-tests
       - push-assets-to-gcp:
+          context:
+            - gcp context
           filters:
             branches:
               only: main
@@ -505,6 +509,8 @@ workflows:
 
       # pre-deploy, in parallel with integration-tests
       - push-containers-to-gcp:
+          context:
+            - gcp context
           filters:
             branches:
               only: main
@@ -516,6 +522,8 @@ workflows:
 
       # actual deploy
       - deploy:
+          context:
+            - gcp context
           filters:
             branches:
               only: main
@@ -529,6 +537,8 @@ workflows:
             - predeployment-checks
 
       - deploy-lock:
+          context:
+            - gcp context
           filters:
             branches:
               only: main
@@ -546,5 +556,3 @@ workflows:
             - static-checks
             - predeployment-checks
             - validate-honeycomb-config
-
-# VS Code Extension Version: 1.5.1

--- a/.circleci/gcp-workflow-identity-config.json
+++ b/.circleci/gcp-workflow-identity-config.json
@@ -1,0 +1,13 @@
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/118633020131/locations/global/workloadIdentityPools/circleci/providers/circleci",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/circleci-deployer@balmy-ground-195100.iam.gserviceaccount.com:generateAccessToken",
+  "credential_source": {
+    "file": "CIRCLE_OIDC_TOKEN_FILE",
+    "format": {
+      "type": "text"
+    }
+  }
+}


### PR DESCRIPTION
No changelog

This re-enables CircleCI, using OIDC.

This only provides a working token to GCP under specific situations, and for the length of the build only. Right now it's limited to only members of the Github group for engineers (and only needed for deploys).