### PR TITLE
Convert parts of canvas to tailwind

### DIFF
--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -511,7 +511,14 @@ let viewBackToCanvas = (currentPage: AppTypes.Page.t, showTooltip: bool): Html.h
       )
 
     Html.div(
-      list{Attrs.id("back-to-canvas"), tw(%twc("fixed bottom-2 right-16 w-36 cursor-pointer text-center text-cyan font-text text-base"))},
+      list{
+        Attrs.id("back-to-canvas"),
+        tw(
+          %twc(
+            "fixed bottom-2 right-16 w-36 cursor-pointer text-center text-cyan font-text text-base"
+          ),
+        ),
+      },
       list{
         tooltip,
         Html.div(
@@ -735,14 +742,18 @@ let view = (m: model): Html.html<msg> => {
   let viewDocs = list{
     Html.a(
       list{
-        tw(%twc("font-text cursor-pointer flex flex-col items-center justify-center absolute bottom-0 right-0 no-underline text-inherit pt-0 pr-2.5 pb-2.5 pl-0 hover:text-yellow1 active:outline-none focus:outline-none")),
+        tw(
+          %twc(
+            "font-text cursor-pointer flex flex-col items-center justify-center absolute bottom-0 right-0 no-underline text-inherit pt-0 pr-2.5 pb-2.5 pl-0 hover:text-yellow1 active:outline-none focus:outline-none"
+          ),
+        ),
         Attrs.href(docsURL),
         Attrs.target("_blank"),
         // Block opening the omnibox here by preventing canvas pan start
         EventListeners.nothingMouseEvent("mousedown"),
         EventListeners.eventNoPropagation(~key="doc", "click", _ => Msg.UpdateHeapio(OpenDocs)),
       },
-      list{fontAwesome(~style=%twc("text-2xl"),"book"), Html.text("Docs")},
+      list{fontAwesome(~style=%twc("text-2xl"), "book"), Html.text("Docs")},
     ),
   }
 

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -16,6 +16,8 @@ module Msg = AppTypes.Msg
 type model = AppTypes.model
 type msg = AppTypes.msg
 
+let tw = Attrs.class
+
 let appID = "app"
 
 let fontAwesome = Icons.fontAwesome
@@ -492,7 +494,7 @@ let viewBackToCanvas = (currentPage: AppTypes.Page.t, showTooltip: bool): Html.h
   | FocusedFn(_) =>
     let helpIcon = Html.div(
       list{
-        Attrs.class("help-icon"),
+        tw(%twc("text-4xl text-cyan")),
         EventListeners.eventNoPropagation(~key="ept", "mouseenter", _ => Msg.ToolTipMsg(
           OpenFnTooltip(true),
         )),
@@ -509,12 +511,12 @@ let viewBackToCanvas = (currentPage: AppTypes.Page.t, showTooltip: bool): Html.h
       )
 
     Html.div(
-      list{Attrs.id("back-to-canvas"), Attrs.class("back-to-canvas")},
+      list{Attrs.id("back-to-canvas"), tw(%twc("fixed bottom-2 right-16 w-36 cursor-pointer text-center text-cyan font-text text-base"))},
       list{
         tooltip,
         Html.div(
           list{
-            Attrs.class("back-to-canvas-content"),
+            tw(%twc("flex items-center justify-between")),
             Vdom.prop("alt", "architecture preview"),
             EventListeners.eventNoPropagation(~key="return-to-arch", "click", _ =>
               Msg.GoToArchitecturalView
@@ -522,7 +524,7 @@ let viewBackToCanvas = (currentPage: AppTypes.Page.t, showTooltip: bool): Html.h
           },
           list{
             helpIcon,
-            Html.a(list{Attrs.class("content")}, list{Vdom.text("Return to main canvas")}),
+            Html.a(list{tw(%twc("w-24 font-text"))}, list{Vdom.text("Return to main canvas")}),
           },
         ),
       },

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -735,14 +735,14 @@ let view = (m: model): Html.html<msg> => {
   let viewDocs = list{
     Html.a(
       list{
-        Attrs.class("doc-container"),
+        tw(%twc("font-text cursor-pointer flex flex-col items-center justify-center absolute bottom-0 right-0 no-underline text-inherit pt-0 pr-2.5 pb-2.5 pl-0 hover:text-yellow1 active:outline-none focus:outline-none")),
         Attrs.href(docsURL),
         Attrs.target("_blank"),
         // Block opening the omnibox here by preventing canvas pan start
         EventListeners.nothingMouseEvent("mousedown"),
         EventListeners.eventNoPropagation(~key="doc", "click", _ => Msg.UpdateHeapio(OpenDocs)),
       },
-      list{fontAwesome("book"), Html.text("Docs")},
+      list{fontAwesome(~style=%twc("text-2xl"),"book"), Html.text("Docs")},
     ),
   }
 

--- a/client/src/components/Tutorial.res
+++ b/client/src/components/Tutorial.res
@@ -13,9 +13,8 @@ type tutorialStep = AppTypes.Tutorial.Step.t
 type tooltipState = AppTypes.Tooltip.t
 type tooltipMsg = AppTypes.Tooltip.msg
 
-let tw= Attrs.class
+let tw = Attrs.class
 let tw2 = (c1, c2) => Attrs.class(`${c1} ${c2}`)
-
 
 type rec toolTipDirection =
   | Left
@@ -323,7 +322,9 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
     }
   }
 
-let buttonsStyle= %twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-none text-black2 w-full text-center disabled:text-cyan1 disabled:cursor-default")
+let buttonsStyle = %twc(
+  "outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-none text-black2 w-full text-center disabled:text-cyan1 disabled:cursor-default"
+)
 let viewNavigationBtns = (tlid: option<TLID.t>, step: tutorialStep, uniqueStr: string): Html.html<
   msg,
 > => {
@@ -387,11 +388,18 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | None => t.title
     }
 
-    let viewDesc = Html.h1(list{tw(%twc("text-lg font-text text-black2 m-0 text-center"))}, list{Html.text(t.title)})
+    let viewDesc = Html.h1(
+      list{tw(%twc("text-lg font-text text-black2 m-0 text-center"))},
+      list{Html.text(t.title)},
+    )
     let viewDetail = switch t.details {
     | Some(txtList) =>
       let txtview = List.map(
-        ~f=txt => Html.p(list{tw(%twc("text-base font-text text-black2 text-center"))}, list{Html.text(txt)}),
+        ~f=txt =>
+          Html.p(
+            list{tw(%twc("text-base font-text text-black2 text-center"))},
+            list{Html.text(txt)},
+          ),
         txtList,
       )
 
@@ -404,7 +412,11 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | Some(text, action) =>
       Html.button(
         list{
-          tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-0 w-max text-cyan1 bg-white3 transition-[background-color] rounded hover:text-white3 hover:bg-[#8eeade]")),
+          tw(
+            %twc(
+              "outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-0 w-max text-cyan1 bg-white3 transition-[background-color] rounded hover:text-white3 hover:bg-[#8eeade]"
+            ),
+          ),
           EventListeners.eventNoPropagation(~key="close-settings" ++ text, "click", _ => action),
         },
         list{Html.p(list{tw(%twc("m-0"))}, list{Html.text(text)})},
@@ -457,13 +469,25 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
       list{
         Html.div(
           ~unique=uniqueStr,
-          list{tw2(%twc("absolute text-sm flex w-max max-w-[15.625rem] bg-tooltip rounded-md mt-1.5 z-[5000] shadow-[0_2px_4px_1px_rgba(24,24,24,0.7)]"), directionToClass)},
+          list{
+            tw2(
+              %twc(
+                "absolute text-sm flex w-max max-w-[15.625rem] bg-tooltip rounded-md mt-1.5 z-[5000] shadow-[0_2px_4px_1px_rgba(24,24,24,0.7)]"
+              ),
+              directionToClass,
+            ),
+          },
           list{
             Html.div(
               list{tw(%twc("flex flex-col items-center p-2"))},
               list{viewStepCount, viewDesc, viewDetail, viewBtn, viewNextPrevBtns, closeBtn},
             ),
-            Html.div(list{tw2(%twc("bg-tooltip block w-2.5 h-2.5 z-0 absolute rotate-45") , t.tipAlignment)}, list{}),
+            Html.div(
+              list{
+                tw2(%twc("bg-tooltip block w-2.5 h-2.5 z-0 absolute rotate-45"), t.tipAlignment),
+              },
+              list{},
+            ),
           },
         ),
       },

--- a/client/src/components/Tutorial.res
+++ b/client/src/components/Tutorial.res
@@ -323,6 +323,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
     }
   }
 
+let buttonsStyle= %twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-none text-black2 w-full text-center disabled:text-cyan1 disabled:cursor-default")
 let viewNavigationBtns = (tlid: option<TLID.t>, step: tutorialStep, uniqueStr: string): Html.html<
   msg,
 > => {
@@ -340,7 +341,7 @@ let viewNavigationBtns = (tlid: option<TLID.t>, step: tutorialStep, uniqueStr: s
 
     Html.button(
       list{
-        tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-none text-black2 w-full text-center disabled:text-[#3cbfad] disabled:cursor-default")),
+        tw(buttonsStyle),
         EventListeners.nothingMouseEvent("mousedown"),
         EventListeners.nothingMouseEvent("mouseup"),
         clickEvent,
@@ -364,7 +365,7 @@ let viewNavigationBtns = (tlid: option<TLID.t>, step: tutorialStep, uniqueStr: s
 
     Html.button(
       list{
-        tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-none text-black2 w-full text-center disabled:text-[#3cbfad] disabled:cursor-default")),
+        tw(buttonsStyle),
         EventListeners.nothingMouseEvent("mousedown"),
         EventListeners.nothingMouseEvent("mouseup"),
         clickEvent,
@@ -403,7 +404,7 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | Some(text, action) =>
       Html.button(
         list{
-          tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 w-max border-0 font-text text-cyan bg-white3 rounded hover:text-white3 hover:bg-[#8eeade] ")),
+          tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-0 w-max text-cyan1 bg-white3 transition-[background-color] rounded hover:text-white3 hover:bg-[#8eeade]")),
           EventListeners.eventNoPropagation(~key="close-settings" ++ text, "click", _ => action),
         },
         list{Html.p(list{tw(%twc("m-0"))}, list{Html.text(text)})},
@@ -415,7 +416,7 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | Tutorial(_) | Crud =>
       Html.button(
         list{
-          tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 border-none text-black2 font-text text-center w-full ")),
+          tw(buttonsStyle),
           EventListeners.nothingMouseEvent("mousedown"),
           EventListeners.nothingMouseEvent("mouseup"),
           EventListeners.eventNoPropagation(
@@ -456,13 +457,13 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
       list{
         Html.div(
           ~unique=uniqueStr,
-          list{tw2(%twc("absolute text-sm flex w-max max-w-[250px] bg-cyan rounded-md z-[5000] shadow-[0_2px_4px_1px_rgba(24,24,24,0.7)] mt-1.5"), directionToClass)},
+          list{tw2(%twc("absolute text-sm flex w-max max-w-[15.625rem] bg-tooltip rounded-md mt-1.5 z-[5000] shadow-[0_2px_4px_1px_rgba(24,24,24,0.7)]"), directionToClass)},
           list{
             Html.div(
               list{tw(%twc("flex flex-col items-center p-2"))},
               list{viewStepCount, viewDesc, viewDetail, viewBtn, viewNextPrevBtns, closeBtn},
             ),
-            Html.div(list{tw2(%twc("bg-cyan block w-2.5 h-2.5 z-0 absolute rotate-45") , t.tipAlignment)}, list{}),
+            Html.div(list{tw2(%twc("bg-tooltip block w-2.5 h-2.5 z-0 absolute rotate-45") , t.tipAlignment)}, list{}),
           },
         ),
       },

--- a/client/src/components/Tutorial.res
+++ b/client/src/components/Tutorial.res
@@ -13,6 +13,10 @@ type tutorialStep = AppTypes.Tutorial.Step.t
 type tooltipState = AppTypes.Tooltip.t
 type tooltipMsg = AppTypes.Tooltip.msg
 
+let tw= Attrs.class
+let tw2 = (c1, c2) => Attrs.class(`${c1} ${c2}`)
+
+
 type rec toolTipDirection =
   | Left
   | Right
@@ -191,7 +195,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/create-http-handler")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | Worker => {
@@ -202,7 +206,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/process-background-jobs-worker")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | Cron => {
@@ -213,7 +217,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/create-daily-job-cron-handler")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | Repl => {
@@ -224,7 +228,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/create-tool-repl")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | Datastore => {
@@ -235,7 +239,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/save-data-to-datastore")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | Function => {
@@ -246,7 +250,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/extract-function")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | FourOhFour => {
@@ -259,7 +263,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/discussion/trace-driven-development")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | Deleted => {
@@ -267,7 +271,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
       details: None,
       action: None,
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | PackageManager => {
@@ -277,7 +281,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
       }),
       action: None,
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | StaticAssets => {
@@ -288,7 +292,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
         ToolTipMsg(OpenLink("https://docs.darklang.com/how-to/static-assets")),
       ),
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   | FnParam => {
@@ -296,7 +300,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
       details: None,
       action: None,
       align: Left,
-      tipAlignment: "",
+      tipAlignment: %twc("-right-1 top-6"),
       tooltipStyle: Default,
     }
   | FnBackToCanvas => {
@@ -304,7 +308,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
       details: None,
       action: None,
       align: Top,
-      tipAlignment: "",
+      tipAlignment: %twc("-bottom-1"),
       tooltipStyle: Default,
     }
   | Secrets => {
@@ -314,7 +318,7 @@ let generateContent = (t: AppTypes.Tooltip.source): tooltipContent =>
       }),
       action: None,
       align: Bottom,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("left-11 -top-1"),
       tooltipStyle: Default,
     }
   }
@@ -336,7 +340,7 @@ let viewNavigationBtns = (tlid: option<TLID.t>, step: tutorialStep, uniqueStr: s
 
     Html.button(
       list{
-        Attrs.class("page-btn"),
+        tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-none text-black2 w-full text-center disabled:text-[#3cbfad] disabled:cursor-default")),
         EventListeners.nothingMouseEvent("mousedown"),
         EventListeners.nothingMouseEvent("mouseup"),
         clickEvent,
@@ -360,7 +364,7 @@ let viewNavigationBtns = (tlid: option<TLID.t>, step: tutorialStep, uniqueStr: s
 
     Html.button(
       list{
-        Attrs.class("page-btn"),
+        tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 font-text border-none text-black2 w-full text-center disabled:text-[#3cbfad] disabled:cursor-default")),
         EventListeners.nothingMouseEvent("mousedown"),
         EventListeners.nothingMouseEvent("mouseup"),
         clickEvent,
@@ -370,7 +374,7 @@ let viewNavigationBtns = (tlid: option<TLID.t>, step: tutorialStep, uniqueStr: s
     )
   }
 
-  Html.div(list{Attrs.class("btn-container")}, list{prevBtn, nextBtn})
+  Html.div(list{tw(%twc("flex w-full justify-evenly"))}, list{prevBtn, nextBtn})
 }
 
 let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent): Html.html<
@@ -382,11 +386,11 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | None => t.title
     }
 
-    let viewDesc = Html.h1(list{Attrs.class("description")}, list{Html.text(t.title)})
+    let viewDesc = Html.h1(list{tw(%twc("text-lg font-text text-black2 m-0 text-center"))}, list{Html.text(t.title)})
     let viewDetail = switch t.details {
     | Some(txtList) =>
       let txtview = List.map(
-        ~f=txt => Html.p(list{Attrs.class("details")}, list{Html.text(txt)}),
+        ~f=txt => Html.p(list{tw(%twc("text-base font-text text-black2 text-center"))}, list{Html.text(txt)}),
         txtList,
       )
 
@@ -399,10 +403,10 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | Some(text, action) =>
       Html.button(
         list{
-          Attrs.class("action-button"),
+          tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 w-max border-0 font-text text-cyan bg-white3 rounded hover:text-white3 hover:bg-[#8eeade] ")),
           EventListeners.eventNoPropagation(~key="close-settings" ++ text, "click", _ => action),
         },
-        list{Html.p(list{}, list{Html.text(text)})},
+        list{Html.p(list{tw(%twc("m-0"))}, list{Html.text(text)})},
       )
     | None => Vdom.noNode
     }
@@ -411,7 +415,7 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | Tutorial(_) | Crud =>
       Html.button(
         list{
-          Attrs.class("page-btn"),
+          tw(%twc("outline-0 p-1 font-medium bg-transparent mt-2.5 border-none text-black2 font-text text-center w-full ")),
           EventListeners.nothingMouseEvent("mousedown"),
           EventListeners.nothingMouseEvent("mouseup"),
           EventListeners.eventNoPropagation(
@@ -429,7 +433,7 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     | Tutorial(step) =>
       let (current, total) = currentStepFraction(step)
       Html.p(
-        list{Attrs.class("step-title")},
+        list{tw(%twc("font-text text-black2 text-center"))},
         list{Html.text(`${Int.toString(current)}/${Int.toString(total)}`)},
       )
     | Crud | Default => Vdom.noNode
@@ -441,24 +445,24 @@ let viewToolTip = (~shouldShow: bool, ~tlid: option<TLID.t>, t: tooltipContent):
     }
 
     let directionToClass = switch t.align {
-    | Top => "above"
-    | Bottom => "below"
-    | Left => "left-of"
-    | Right => "right-of"
+    | Top => %twc("items-center flex-col-reverse bottom-3.5 right-1")
+    | Bottom => %twc("items-center flex-col top-3.5")
+    | Left => %twc("right-12 -top-16")
+    | Right => %twc("left-5 top-0")
     }
 
     Html.div(
-      list{Attrs.class("tooltipWrapper")},
+      list{tw(%twc("relative"))},
       list{
         Html.div(
           ~unique=uniqueStr,
-          list{Attrs.class("tooltips " ++ directionToClass)},
+          list{tw2(%twc("absolute text-sm flex w-max max-w-[250px] bg-cyan rounded-md z-[5000] shadow-[0_2px_4px_1px_rgba(24,24,24,0.7)] mt-1.5"), directionToClass)},
           list{
             Html.div(
-              list{Attrs.class("content")},
+              list{tw(%twc("flex flex-col items-center p-2"))},
               list{viewStepCount, viewDesc, viewDetail, viewBtn, viewNextPrevBtns, closeBtn},
             ),
-            Html.div(list{Attrs.class("tip " ++ t.tipAlignment)}, list{}),
+            Html.div(list{tw2(%twc("bg-cyan block w-2.5 h-2.5 z-0 absolute rotate-45") , t.tipAlignment)}, list{}),
           },
         ),
       },

--- a/client/src/components/UserTutorial.res
+++ b/client/src/components/UserTutorial.res
@@ -17,7 +17,7 @@ let generateCRUDContent: Tutorial.tooltipContent = {
     ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/first-dark-application")),
   ),
   align: Left,
-  tipAlignment: %twc("left-11 -right-1 top-6"),
+  tipAlignment: %twc("-right-1 top-6"),
   tooltipStyle: Crud,
 }
 

--- a/client/src/components/UserTutorial.res
+++ b/client/src/components/UserTutorial.res
@@ -17,7 +17,7 @@ let generateCRUDContent: Tutorial.tooltipContent = {
     ToolTipMsg(OpenLink("https://docs.darklang.com/tutorials/first-dark-application")),
   ),
   align: Left,
-  tipAlignment: "align-left",
+  tipAlignment: %twc("left-11 -right-1 top-6"),
   tooltipStyle: Crud,
 }
 
@@ -32,7 +32,7 @@ let generateTutorialContent = (tutorialStep: step, username: string): Tutorial.t
       }),
       action: None,
       align: Left,
-      tipAlignment: "align-left",
+      tipAlignment: %twc("-right-1 top-6"),
       tooltipStyle: Tutorial(tutorialStep),
     }
   | VerbChange => {
@@ -40,7 +40,7 @@ let generateTutorialContent = (tutorialStep: step, username: string): Tutorial.t
       details: None,
       action: None,
       align: Right,
-      tipAlignment: "align-top",
+      tipAlignment: %twc("top-3.5 -left-1 bottom-6"),
       tooltipStyle: Tutorial(tutorialStep),
     }
   | ReturnValue => {
@@ -48,7 +48,7 @@ let generateTutorialContent = (tutorialStep: step, username: string): Tutorial.t
       details: None,
       action: None,
       align: Right,
-      tipAlignment: "align-top",
+      tipAlignment: %twc("top-3.5 -left-1 bottom-6"),
       tooltipStyle: Tutorial(tutorialStep),
     }
   | OpenTab => {
@@ -56,7 +56,7 @@ let generateTutorialContent = (tutorialStep: step, username: string): Tutorial.t
       details: None,
       action: None,
       align: Right,
-      tipAlignment: "align-top",
+      tipAlignment: %twc("top-3.5 -left-1 bottom-6"),
       tooltipStyle: Tutorial(tutorialStep),
     }
   | GettingStarted => {
@@ -67,7 +67,7 @@ let generateTutorialContent = (tutorialStep: step, username: string): Tutorial.t
         ToolTipMsg(OpenLink("https://darklang.com/a/" ++ (username ++ "-crud"))),
       ),
       align: Right,
-      tipAlignment: "align-top",
+      tipAlignment: %twc("top-3.5 -left-1 bottom-6"),
       tooltipStyle: Tutorial(tutorialStep),
     }
   }

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -878,8 +878,10 @@ let documentationForFunction = (
     },
   )
 
-let onErrorRail = if ViewErrorRailDoc.hintForFunction(f, sendToRail) != Html.noNode{
-  Html.div(list{tw(%twc("flex items-center font-text ml-2"))},list{
+  let onErrorRail = if ViewErrorRailDoc.hintForFunction(f, sendToRail) != Html.noNode {
+    Html.div(
+      list{tw(%twc("flex items-center font-text ml-2"))},
+      list{
         Html.span(list{tw(%twc("text-grey6 font-medium mr-px"))}, list{Html.text("(")}),
         Tooltip.tooltip(
           ~style=%twc("-left-5 top-0 bg-black3"),
@@ -889,10 +891,11 @@ let onErrorRail = if ViewErrorRailDoc.hintForFunction(f, sendToRail) != Html.noN
           list{Html.text("On Error Rail")},
         ),
         Html.span(list{tw(%twc("text-grey6 font-medium ml-px"))}, list{Html.text(")")}),
-      })
-} else{
-  Html.noNode
-}
+      },
+    )
+  } else {
+    Html.noNode
+  }
 
   let row = Html.div(list{tw(%twc("flex items-center mt-2"))}, list{return, onErrorRail})
 
@@ -903,13 +906,25 @@ let onErrorRail = if ViewErrorRailDoc.hintForFunction(f, sendToRail) != Html.noN
     | ReplacedBy(name) => list{
         Html.span(
           list{tw(sharedStyle)},
-          list{Html.text("replaced by "), Html.span(list{tw(%twc("font-code text-purple1"))},list{Html.text(FQFnName.StdlibFnName.toString(name))})},
+          list{
+            Html.text("replaced by "),
+            Html.span(
+              list{tw(%twc("font-code text-purple1"))},
+              list{Html.text(FQFnName.StdlibFnName.toString(name))},
+            ),
+          },
         ),
       }
     | RenamedTo(name) => list{
         Html.span(
           list{tw(sharedStyle)},
-          list{Html.text("renamed to "),  Html.span(list{tw(%twc("font-code text-purple1"))}, list{Html.text(FQFnName.StdlibFnName.toString(name))})},
+          list{
+            Html.text("renamed to "),
+            Html.span(
+              list{tw(%twc("font-code text-purple1"))},
+              list{Html.text(FQFnName.StdlibFnName.toString(name))},
+            ),
+          },
         ),
       }
     | DeprecatedBecause(reason) => list{Html.span(list{tw(sharedStyle)}, list{Html.text(reason)})}

--- a/client/styles/_canvas.scss
+++ b/client/styles/_canvas.scss
@@ -246,34 +246,6 @@ body #app * {
   text-align: center;
 }
 
-.doc-container {
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  bottom: 0px;
-  right: 0px;
-  text-decoration: none;
-  color: inherit;
-  padding: 0px 10px 10px 0px;
-
-  &:hover {
-    color: lighten($yellow, 10%);
-  }
-
-  &:active,
-  &:focus {
-    outline: none;
-  }
-
-  .fa-book {
-    font-size: 24px;
-    margin-bottom: 5px;
-  }
-}
-
 .my-account {
   position: fixed;
   top: 5px;

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -65,7 +65,7 @@ $queue-color: $cyan;
 $repl-color: $pink;
 $user-functions: saturate($cyan, 10%);
 $db-color: #a1887f;
-$tooltip-color: lighten(saturate($cyan,20%),10%);
+$tooltip-color: lighten(saturate($cyan, 20%), 10%);
 :root {
   --httpGetColor: #{$http-get};
   --httpPostColor: #{$http-post};

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -65,6 +65,7 @@ $queue-color: $cyan;
 $repl-color: $pink;
 $user-functions: saturate($cyan, 10%);
 $db-color: #a1887f;
+$tooltip-color: lighten(saturate($cyan,20%),10%);
 :root {
   --httpGetColor: #{$http-get};
   --httpPostColor: #{$http-post};
@@ -78,6 +79,7 @@ $db-color: #a1887f;
   --replColor: #{$repl-color};
   --userFunctionsColor: #{$user-functions};
   --dbColor: #{$db-color};
+  --tooltipColor: #{$tooltip-color};
 }
 :root {
   --sidebarBgColor: #{darken($canvas-background, 10%)};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,7 +56,7 @@ module.exports = {
       "default-toplevel": "var(--defaultToplevelColor)",
       "user-functions": "var(--userFunctionsColor)",
       db: "var(--dbColor)",
-      tooltip: "var(--tooltipColor)"
+      tooltip: "var(--tooltipColor)",
     },
     extend: {
       borderWidth: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
     colors: {
       transparent: "transparent",
       current: "currentColor",
+      inherit: "inherit",
       black1: "#181818",
       black2: "#282828",
       black3: "#383838",
@@ -28,6 +29,7 @@ module.exports = {
       red: "#ab4642",
       orange: "#dc9656",
       yellow: "#f7ca88",
+      yellow1: "#fadfb8", //lighten($yellow, 10%)
       green: "#a1b56c",
       cyan: "#86c1b9",
       cyan1: "#3cbfad", //darken($tooltip-color, 25%)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,7 @@ module.exports = {
       yellow: "#f7ca88",
       green: "#a1b56c",
       cyan: "#86c1b9",
+      cyan1: "#3cbfad", //darken($tooltip-color, 25%)
       blue: "#7cafc2",
       purple: "#b18bba",
       purple1: "#c7abcd", // lighten($purple, 10%)
@@ -53,6 +54,7 @@ module.exports = {
       "default-toplevel": "var(--defaultToplevelColor)",
       "user-functions": "var(--userFunctionsColor)",
       db: "var(--dbColor)",
+      tooltip: "var(--tooltipColor)"
     },
     extend: {
       borderWidth: {


### PR DESCRIPTION
Changelog:

```
Internal improvements
-  Convert the tutorial toolotips to Tailwind.
```

**Questions:**

1. I came across this note while converting the tutorial tooltip to tailwind:
 `" NOTE: This will change in the future to pretty tool tips, this is just an inbetween state"`
 If you have a general idea of the things you want to be changed please let me know. For now it is just converted to tailwind.

2. The tooltips for the sidebar elements are converted to Tailwind but they are not used currently. Re-adding them was mentioned as a followup to this PR #4511. Should I re-add them? (I am not sure how they would look like with the current popups we have)
 
### Before ->After
![Frame 11 (4)](https://user-images.githubusercontent.com/87861924/212113927-2c4d14c8-47c9-4140-8444-27f075497c76.png)

![Frame 13](https://user-images.githubusercontent.com/87861924/212113270-ea0e9fde-6591-4895-b4d1-a9272d59c94e.png)

<img width="605" alt="Frame 12 (5)" src="https://user-images.githubusercontent.com/87861924/212112907-eea65ed8-26b5-41f0-9e10-13bc9f7dc29a.png">

![Frame 17 (3)](https://user-images.githubusercontent.com/87861924/212326625-a6d81f52-3438-40b8-983f-e30eb7057a78.png)


![Frame 15](https://user-images.githubusercontent.com/87861924/212116134-468ff979-b97b-4c17-80eb-1bc674b97428.png)
