### PR TITLE
New documentation box design PR -followup

### DIFF
--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -903,13 +903,13 @@ let onErrorRail = if ViewErrorRailDoc.hintForFunction(f, sendToRail) != Html.noN
     | ReplacedBy(name) => list{
         Html.span(
           list{tw(sharedStyle)},
-          list{Html.text("replaced by "), Html.span(list{tw(%twc("font-text text-purple1"))},list{Html.text(FQFnName.StdlibFnName.toString(name))})},
+          list{Html.text("replaced by "), Html.span(list{tw(%twc("font-code text-purple1"))},list{Html.text(FQFnName.StdlibFnName.toString(name))})},
         ),
       }
     | RenamedTo(name) => list{
         Html.span(
           list{tw(sharedStyle)},
-          list{Html.text("renamed to "),  Html.span(list{tw(%twc("font-text text-purple1"))}, list{Html.text(FQFnName.StdlibFnName.toString(name))})},
+          list{Html.text("renamed to "),  Html.span(list{tw(%twc("font-code text-purple1"))}, list{Html.text(FQFnName.StdlibFnName.toString(name))})},
         ),
       }
     | DeprecatedBecause(reason) => list{Html.span(list{tw(sharedStyle)}, list{Html.text(reason)})}

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -739,7 +739,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
           list{
             expected,
             Html.span(
-              list{tw(%twc("bg-teal/25 rounded text-teal px-1 py-px"))},
+              list{tw(%twc("bg-grey1/50 rounded text-green px-1 py-px"))},
               list{Html.text(acFirstArgType->Belt.Option.getWithDefault("no argument"))},
             ),
           },
@@ -749,7 +749,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
           list{
             actual,
             Html.span(
-              list{tw(%twc("bg-orange1/25 rounded text-orange1 px-1 py-px"))},
+              list{tw(%twc("bg-grey1/50 rounded text-orange px-1 py-px"))},
               list{Html.text(DType.type2str(typ))},
             ),
           },
@@ -776,7 +776,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
           list{
             expected,
             Html.span(
-              list{tw(%twc("bg-teal/25 rounded text-teal px-1 py-px"))},
+              list{tw(%twc("bg-grey1/50 rounded text-green px-1 py-px"))},
               list{Html.span(list{}, list{Html.text(DType.type2str(returnType))})},
             ),
           },
@@ -786,7 +786,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
           list{
             actual,
             Html.span(
-              list{tw(%twc("bg-orange1/25 rounded text-orange1 px-1 py-px"))},
+              list{tw(%twc("bg-grey1/50 rounded text-orange px-1 py-px"))},
               list{Html.text(acReturnType)},
             ),
           },
@@ -903,13 +903,13 @@ let onErrorRail = if ViewErrorRailDoc.hintForFunction(f, sendToRail) != Html.noN
     | ReplacedBy(name) => list{
         Html.span(
           list{tw(sharedStyle)},
-          list{Html.text("replaced by " ++ FQFnName.StdlibFnName.toString(name))},
+          list{Html.text("replaced by "), Html.span(list{tw(%twc("font-text text-purple1"))},list{Html.text(FQFnName.StdlibFnName.toString(name))})},
         ),
       }
     | RenamedTo(name) => list{
         Html.span(
           list{tw(sharedStyle)},
-          list{Html.text("renamed to " ++ FQFnName.StdlibFnName.toString(name))},
+          list{Html.text("renamed to "),  Html.span(list{tw(%twc("font-text text-purple1"))}, list{Html.text(FQFnName.StdlibFnName.toString(name))})},
         ),
       }
     | DeprecatedBecause(reason) => list{Html.span(list{tw(sharedStyle)}, list{Html.text(reason)})}

--- a/client/src/ui/PrettyDocs.res
+++ b/client/src/ui/PrettyDocs.res
@@ -16,7 +16,7 @@ let nestedTag = Regex.regex(`<\\\w+[^>]*<`)
 
 let nestedCodeBlock = Regex.regex(`{{[^}]+{{`)
 
-let \"type" = %twc("text-green")
+let typ = %twc("text-green")
 let param = %twc("text-purple1")
 let fn = %twc("text-purple1")
 let var = %twc("text-purple1")
@@ -73,7 +73,7 @@ let rec convert_ = (s: string): parseResult => {
     switch Regex.captures(~re=Regex.regex(~flags="s", tagEx), input) {
     | list{_, before, tagType, tagData, after} if List.member(~value=tagType, validTags) =>
       let tagNode = switch tagType {
-      | "type" => tag(\"type", list{txt(tagData)})
+      | "type" => tag(typ, list{txt(tagData)})
       | "param" => tag(param, list{txt(tagData)})
       | "fn" => tag(fn, list{txt(tagData)})
       | "var" => tag(var, list{txt(tagData)})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,12 +27,10 @@ module.exports = {
 
       red: "#ab4642",
       orange: "#dc9656",
-      orange1: "#a67254",
       yellow: "#f7ca88",
       green: "#a1b56c",
       cyan: "#86c1b9",
       blue: "#7cafc2",
-      teal: "#71c7b2",
       purple: "#b18bba",
       purple1: "#c7abcd", // lighten($purple, 10%)
       pink: "#d5839d",


### PR DESCRIPTION
No changelog

Followup to the New documentation box design PR #4664 

### Changes:
- Styled the deprecated function name with our usual function color and changed the font to font-code.
- Used `typ` instead of `\"type"`.
- Removed the added colors.
- Used colors from our color palette, and used different colors  for the foreground and background.

**Function name:**
![image](https://user-images.githubusercontent.com/87861924/212178137-8c46900c-32fc-4506-9f96-940442583a01.png)

**Type error:**
![image](https://user-images.githubusercontent.com/87861924/212178024-3a63d705-70fa-40e2-8bdb-437d804c451d.png)

Still experimenting with color options for the foreground and background in the types. I would appreciate your input on whether a colored or grey background would be more suitable.