### PR TITLE
Move deploy lock to a darklang canvas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,6 @@ commands:
   ##########################
   deploy-lock-remove-on-fail:
     steps:
-      # Can only be used from in-container executors as it needs gcloud
-      - auth-with-gcp-on-fail
       - run:
           name: Remove deploy lock
           when: on_fail
@@ -184,25 +182,12 @@ commands:
           command: |
             ./scripts/production/gcp-authorize-kubectl
 
-
   auth-gcr:
     steps:
       - run:
           name: Auth with GCR
           command: |
             gcloud auth configure-docker
-
-  auth-with-gcp-on-fail:
-    steps:
-      - run:
-          name: Auth with GCP (on fail)
-          when: on_fail
-          command: |
-            # Don't run a second time (no need, but also token becomes invalid after an hour)
-            if [[ "${CIRCLE_BRANCH}" = "main" || ! -f CIRCLE_OIDC_TOKEN_FILE ]]; then
-              echo $CIRCLE_OIDC_TOKEN > CIRCLE_OIDC_TOKEN_FILE
-              gcloud auth login --brief --cred-file .circleci/gcp-workload-identity-config.json
-            fi
 
 ##########################
 # Actual workflow
@@ -449,7 +434,6 @@ jobs:
     executor: in-container
     steps:
       - darkcheckout
-      - auth-with-gcp: { background: false }
       - run: scripts/deployment/deploy-lock-one-add
       - slack-notify-job-failure
       - deploy-lock-remove-on-fail
@@ -549,8 +533,6 @@ workflows:
             - predeployment-checks
 
       - deploy-lock:
-          context:
-            - gcp context
           filters:
             branches:
               only: main

--- a/scripts/deployment/_deploy-lock-request
+++ b/scripts/deployment/_deploy-lock-request
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 . ./scripts/devcontainer/_assert-in-container "$0" "$@"
 
-# Add a lock identifier for the commit and the timestamp.
+# Make requests to deploy lock server
 
 set -euo pipefail
 
+set -x
+
 if [ ! -v DEPLOY_LOCK_TOKEN ] ;
 then
-  echo "No deploy lock token, get it from https://darklang.com/a/ops-circleci"
+  echo "No deploy lock token, get it from https://darklang.com/a/ops-circleci" >&2
   exit 1
 fi
 
 REQUEST_PATH=$1
 METHOD=$2
-shift 2
 
-curl -s "https://ops-circleci.builtwithdark.com/deploy-lock${REQUEST_PATH}" \
+curl -f -s "https://ops-circleci.builtwithdark.com/deploy-lock${REQUEST_PATH}" \
   -X "${METHOD}" \
   -H 'Content-type: application/json' \
-  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
-  "$@"
+  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}"

--- a/scripts/deployment/_deploy-lock-request
+++ b/scripts/deployment/_deploy-lock-request
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+. ./scripts/devcontainer/_assert-in-container "$0" "$@"
+
+# Add a lock identifier for the commit and the timestamp.
+
+set -euo pipefail
+
+if [ ! -v DEPLOY_LOCK_TOKEN ] ;
+then
+  echo "No deploy lock token, get it from https://darklang.com/a/ops-circleci"
+  exit 1
+fi
+
+REQUEST_PATH=$1
+METHOD=$2
+shift 2
+
+curl -s "https://ops-circleci.builtwithdark.com/deploy-lock${REQUEST_PATH}" \
+  -X "${METHOD}" \
+  -H 'Content-type: application/json' \
+  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
+  "$@"

--- a/scripts/deployment/deploy-lock-all-clear
+++ b/scripts/deployment/deploy-lock-all-clear
@@ -5,8 +5,4 @@
 
 set -euo pipefail
 
-curl -s https://ops-circleci.builtwithdark.com/deploy-lock \
-  -X DELETE \
-  -H 'Content-type: application/json' \
-  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
-  | jq -r .
+./scripts/deployment/_deploy-lock-request / DELETE | jq -r .

--- a/scripts/deployment/deploy-lock-all-clear
+++ b/scripts/deployment/deploy-lock-all-clear
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
-DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
-
-gcloud storage rm "${DEPLOY_LOCK_BUCKET}/*"
+curl -s https://ops-circleci.builtwithdark.com/deploy-lock \
+  -X DELETE \
+  -H 'Content-type: application/json' \
+  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
+  | jq -r .

--- a/scripts/deployment/deploy-lock-all-list
+++ b/scripts/deployment/deploy-lock-all-list
@@ -5,6 +5,7 @@
 
 set -euo pipefail
 
-DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
-
-gcloud storage ls ${DEPLOY_LOCK_BUCKET}/ | sed 's!.*/!!'
+curl -s https://ops-circleci.builtwithdark.com/deploy-lock \
+  -H 'Content-type: application/json' \
+  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
+  | jq -r .[]

--- a/scripts/deployment/deploy-lock-all-list
+++ b/scripts/deployment/deploy-lock-all-list
@@ -5,7 +5,4 @@
 
 set -euo pipefail
 
-curl -s https://ops-circleci.builtwithdark.com/deploy-lock \
-  -H 'Content-type: application/json' \
-  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
-  | jq -r .[]
+./scripts/deployment/_deploy-lock-request / GET | jq -r .[]

--- a/scripts/deployment/deploy-lock-one-add
+++ b/scripts/deployment/deploy-lock-one-add
@@ -9,15 +9,6 @@ LOCKNAME=$(./scripts/deployment/deploy-lock-one-get-name)
 
 echo "Adding lock file with name ${LOCKNAME}"
 
-if [ ! -v DEPLOY_LOCK_TOKEN ] ;
-then
-  echo "No deploy lock token, get it from https://darklang.com/a/ops-circleci"
-  exit 1
-fi
-
-curl -s https://ops-circleci.builtwithdark.com/deploy-lock \
-  -X POST \
-  -H 'Content-type: application/json' \
-  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
+./scripts/deployment/_deploy-lock-request / POST \
   -d "{ \"lockName\": \"${LOCKNAME}\" }" \
   | jq -r .

--- a/scripts/deployment/deploy-lock-one-add
+++ b/scripts/deployment/deploy-lock-one-add
@@ -4,11 +4,10 @@
 # Add a lock identifier for the commit and the timestamp.
 
 set -euo pipefail
+set -x
 
 LOCKNAME=$(./scripts/deployment/deploy-lock-one-get-name)
 
 echo "Adding lock file with name ${LOCKNAME}"
 
-./scripts/deployment/_deploy-lock-request / POST \
-  -d "{ \"lockName\": \"${LOCKNAME}\" }" \
-  | jq -r .
+./scripts/deployment/_deploy-lock-request "/${LOCKNAME}" POST | jq -r .

--- a/scripts/deployment/deploy-lock-one-add
+++ b/scripts/deployment/deploy-lock-one-add
@@ -5,12 +5,19 @@
 
 set -euo pipefail
 
-DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
+LOCKNAME=$(./scripts/deployment/deploy-lock-one-get-name)
 
-LOCKFILE_NAME=$(./scripts/deployment/deploy-lock-one-get-name)
-touch "$LOCKFILE_NAME"
+echo "Adding lock file with name ${LOCKNAME}"
 
-echo "Adding lock file with id ${LOCKFILE_NAME}"
+if [ ! -v DEPLOY_LOCK_TOKEN ] ;
+then
+  echo "No deploy lock token, get it from https://darklang.com/a/ops-circleci"
+  exit 1
+fi
 
-gcloud storage cp "${LOCKFILE_NAME}" "${DEPLOY_LOCK_BUCKET}"
-rm "$LOCKFILE_NAME"
+curl -s https://ops-circleci.builtwithdark.com/deploy-lock \
+  -X POST \
+  -H 'Content-type: application/json' \
+  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
+  -d "{ \"lockName\": \"${LOCKNAME}\" }" \
+  | jq -r .

--- a/scripts/deployment/deploy-lock-one-remove
+++ b/scripts/deployment/deploy-lock-one-remove
@@ -7,8 +7,4 @@ set -euo pipefail
 
 LOCKNAME=$(./scripts/deployment/deploy-lock-one-get-name)
 
-curl -s "https://ops-circleci.builtwithdark.com/deploy-lock/${LOCKNAME}" \
-  -X DELETE \
-  -H 'Content-type: application/json' \
-  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
-  | jq  -r .
+./scripts/deployment/_deploy-lock-request "/${LOCKNAME}" DELETE | jq -r .

--- a/scripts/deployment/deploy-lock-one-remove
+++ b/scripts/deployment/deploy-lock-one-remove
@@ -5,7 +5,10 @@
 
 set -euo pipefail
 
-DEPLOY_LOCK_BUCKET="gs://darklang-deploy-lock"
-LOCKFILE_NAME=$(./scripts/deployment/deploy-lock-one-get-name)
+LOCKNAME=$(./scripts/deployment/deploy-lock-one-get-name)
 
-gcloud storage rm "${DEPLOY_LOCK_BUCKET}/${LOCKFILE_NAME}"
+curl -s "https://ops-circleci.builtwithdark.com/deploy-lock/${LOCKNAME}" \
+  -X DELETE \
+  -H 'Content-type: application/json' \
+  -H "Authorization: Bearer ${DEPLOY_LOCK_TOKEN}" \
+  | jq  -r .


### PR DESCRIPTION
Changelog:

```
Internal
- Move deployment lock to a darklang canvas
```

The deploy lock uses a storage bucket, which requires cloud permissions to be put almost everywhere during a deploy.

This reimplements the deploy lock as a simple dark DB, in https://darklang.com/a/ops-circleci, and rewrites the deploy lock scripts to use it.

There is a secret in that canvas already. For deploying locally, which we almost never do, we could stop using the deploy lock perhaps, or have a key locally. I'm leaving that decision to a later day, when we have more experience with how the goes.

- [ ] Followup: restrict gcp deployment permissions to only the darklang-static-assets bucket