### PR TITLE
Fix documentation box overflow issue

### DIFF
--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -846,7 +846,7 @@ let documentationForFunction = (
   }
 
   let name = Html.span(
-    list{tw(%twc("text-grey3 text-xs"))},
+    list{tw(%twc("text-grey3 text-xs text-ellipsis max-w-[35ch] overflow-hidden whitespace-nowrap"))},
     list{Html.text(f.name |> FQFnName.toString)},
   )
 

--- a/client/src/ui/PrettyDocs.res
+++ b/client/src/ui/PrettyDocs.res
@@ -22,7 +22,7 @@ let fn = %twc("text-purple1")
 let var = %twc("text-purple1")
 let err = %twc("text-red pb-3.5")
 let cmd = %twc("text-pink whitespace-nowrap")
-let code = %twc("bg-grey1 whitespace-nowrap py-0 px-1.5")
+let code = %twc("bg-grey1 py-0 px-1.5")
 let default = %twc("text-white1")
 
 let validTags = list{"param", "fn", "var", "type", "err", "cmd"}

--- a/client/test/TestPrettyDocs.res
+++ b/client/test/TestPrettyDocs.res
@@ -40,7 +40,7 @@ let run = () => {
     test("convert_ parses nested tags correctly", () =>
       expect(convert("{{<param d1> > <param d2>}}")) |> toEqual(list{
         tag(
-          "bg-grey1 whitespace-nowrap py-0 px-1.5",
+          "bg-grey1 py-0 px-1.5",
           list{
             tag("text-purple1", list{txt("d1")}),
             txt(" > "),
@@ -65,7 +65,7 @@ let run = () => {
     test("converts code blocks", () =>
       expect(convert("{{Ok <var value>}}")) |> toEqual(list{
         tag(
-          "bg-grey1 whitespace-nowrap py-0 px-1.5",
+          "bg-grey1 py-0 px-1.5",
           list{txt("Ok "), tag("text-purple1", list{txt("value")})},
         ),
       })
@@ -88,7 +88,7 @@ let run = () => {
         link("error rail", "https://docs.darklang.com/tutorials/handle-error-errorrail"),
         txt(", if it is "),
         tag(
-          "bg-grey1 whitespace-nowrap py-0 px-1.5",
+          "bg-grey1 py-0 px-1.5",
           list{txt("Error "), tag("text-purple1", list{txt("message")})},
         ),
       })


### PR DESCRIPTION
No changelog
 
This fixes some broken things I've noticed in the documentation box.

### Before: 

List::sortBy function 
![image](https://user-images.githubusercontent.com/87861924/212567564-3c9dd244-61d0-4c5d-a6d1-1da42c82f4c6.png)
 
and 

Functions with long names
![image](https://user-images.githubusercontent.com/87861924/212567610-9cbd1f40-8f12-421c-b75a-735f301b011c.png)

### After:

![image](https://user-images.githubusercontent.com/87861924/212567641-e27e5770-bf6b-464b-99cf-787cdded53ba.png)

![image](https://user-images.githubusercontent.com/87861924/212567679-597ad28c-2c75-47eb-ae78-f3cec4764497.png)
