### PR TITLE
Add function signature and convert viewIntrospect to Tailwind

### DIFF
--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -267,7 +267,7 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
     avatars,
     Html.div(
       list{
-        Attrs.classList(list{("use-wrapper", true), ("fade", hasFF)}),
+        Attrs.classList(list{(%twc("bg-transparent ml-6 flex flex-col items-stretch"), true), (%twc("opacity-30"), hasFF)}),
         // Block opening the omnibox here by preventing canvas pan start
         EventListeners.nothingMouseEvent("mousedown"),
       },

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -168,16 +168,41 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
 
         switch fnAndRail {
         | Some(fn, sendToRail) =>
-           let types = fn.parameters |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
-            |> List.map(~f=DType.type2str) |> List.join(~sep=", ")
-            let returnType = fn.returnType
-            Some(viewDoc(
-            Belt.List.concatMany([
-            FluidAutocomplete.documentationForFunctionHeader(fn),
-            list{Html.div(list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))},list{Html.span(list{},list{Html.text((`(${types})`)) ,Html.span(list{Attrs.class(%twc("mx-1"))},list{Icons.fontAwesome("arrow-right")})}), Html.span(list{Attrs.class(%twc("text-green"))},list{Html.text(DType.type2str(returnType))})})},
-            FluidAutocomplete.documentationForFunction(fn, Some(sendToRail)),
-            ])
-            ))
+          let types =
+            fn.parameters
+            |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
+            |> List.map(~f=DType.type2str)
+            |> List.join(~sep=", ")
+          let returnType = fn.returnType
+          Some(
+            viewDoc(
+              Belt.List.concatMany([
+                FluidAutocomplete.documentationForFunctionHeader(fn),
+                list{
+                  Html.div(
+                    list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))},
+                    list{
+                      Html.span(
+                        list{},
+                        list{
+                          Html.text(`(${types})`),
+                          Html.span(
+                            list{Attrs.class(%twc("mx-1"))},
+                            list{Icons.fontAwesome("arrow-right")},
+                          ),
+                        },
+                      ),
+                      Html.span(
+                        list{Attrs.class(%twc("text-green"))},
+                        list{Html.text(DType.type2str(returnType))},
+                      ),
+                    },
+                  ),
+                },
+                FluidAutocomplete.documentationForFunction(fn, Some(sendToRail)),
+              ]),
+            ),
+          )
         | None => None
         }
       }
@@ -197,30 +222,47 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
           )
 
         switch paramAndFnDesc {
-        | Some(Some(param), f, index) =>{
-          let header = param.name ++ ": " ++ DType.type2str(param.typ)
-          let parameters = f.parameters |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
-            |> List.map(~f=DType.type2str) |>List.map(~f=Html.text)
-          let signature = parameters-> List.updateAt(~index=index, ~f=(x) => Html.span(list{Attrs.class(%twc("text-white1"))}, list{x}) ) -> List.intersperse(~sep=Html.text(", "))
-          Some(
-            viewDoc(
-              Belt.List.concatMany([
-                FluidAutocomplete.documentationForFunctionHeader(f),
-                list{
-                  Html.div(list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))}, list{
-                    Html.span(list{}, list{Html.text("(")}),
-                    Html.span(list{},signature),
-                    Html.span(list{}, list{Html.text(")")}),
-                    Html.span(list{Attrs.class(%twc("mx-1"))},list{Icons.fontAwesome("arrow-right")}),
-                    Html.span(list{Attrs.class(%twc("text-green"))}, list{Html.text(DType.type2str(f.returnType))}),
-                  })
-                },
-
-                FluidAutocomplete.documentationForFunction(f, None),
-                list{p(header), p(param.description)},
-              ]),
-            ),
-          )}
+        | Some(Some(param), f, index) => {
+            let header = param.name ++ ": " ++ DType.type2str(param.typ)
+            let parameters =
+              f.parameters
+              |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
+              |> List.map(~f=DType.type2str)
+              |> List.map(~f=Html.text)
+            let signature =
+              parameters
+              ->List.updateAt(~index, ~f=x =>
+                Html.span(list{Attrs.class(%twc("text-white1"))}, list{x})
+              )
+              ->List.intersperse(~sep=Html.text(", "))
+            Some(
+              viewDoc(
+                Belt.List.concatMany([
+                  FluidAutocomplete.documentationForFunctionHeader(f),
+                  list{
+                    Html.div(
+                      list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))},
+                      list{
+                        Html.span(list{}, list{Html.text("(")}),
+                        Html.span(list{}, signature),
+                        Html.span(list{}, list{Html.text(")")}),
+                        Html.span(
+                          list{Attrs.class(%twc("mx-1"))},
+                          list{Icons.fontAwesome("arrow-right")},
+                        ),
+                        Html.span(
+                          list{Attrs.class(%twc("text-green"))},
+                          list{Html.text(DType.type2str(f.returnType))},
+                        ),
+                      },
+                    ),
+                  },
+                  FluidAutocomplete.documentationForFunction(f, None),
+                  list{p(header), p(param.description)},
+                ]),
+              ),
+            )
+          }
         | _ => None
         }
       }
@@ -288,7 +330,10 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
     avatars,
     Html.div(
       list{
-        Attrs.classList(list{(%twc("bg-transparent ml-6 flex flex-col items-stretch"), true), (%twc("opacity-30"), hasFF)}),
+        Attrs.classList(list{
+          (%twc("bg-transparent ml-6 flex flex-col items-stretch"), true),
+          (%twc("opacity-30"), hasFF),
+        }),
         // Block opening the omnibox here by preventing canvas pan start
         EventListeners.nothingMouseEvent("mousedown"),
       },

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -183,13 +183,9 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
                     list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))},
                     list{
                       Html.span(
-                        list{},
+                        list{tw(%twc("font-code"))},
                         list{
-                          Html.text(`(${types})`),
-                          Html.span(
-                            list{Attrs.class(%twc("mx-1"))},
-                            list{Icons.fontAwesome("arrow-right")},
-                          ),
+                          Html.text(`(${types}) -> `),
                         },
                       ),
                       Html.span(
@@ -241,15 +237,11 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
                   FluidAutocomplete.documentationForFunctionHeader(f),
                   list{
                     Html.div(
-                      list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))},
+                      list{tw(%twc("lowercase text-xxs text-grey2 mb-2 font-code"))},
                       list{
                         Html.span(list{}, list{Html.text("(")}),
                         Html.span(list{}, signature),
-                        Html.span(list{}, list{Html.text(")")}),
-                        Html.span(
-                          list{Attrs.class(%twc("mx-1"))},
-                          list{Icons.fontAwesome("arrow-right")},
-                        ),
+                        Html.span(list{tw(%twc("font-code"))}, list{Html.text(") -> ")}),
                         Html.span(
                           list{Attrs.class(%twc("text-green"))},
                           list{Html.text(DType.type2str(f.returnType))},

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -183,23 +183,34 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
             |> Functions.findByStr(name)
             |> Option.map(~f=(f: Function.t) => {
               let param = f.parameters |> List.getAt(~index)
-              (param, f)
+              (param, f, index)
             })
           )
 
         switch paramAndFnDesc {
-        | Some(Some(param), f) =>
+        | Some(Some(param), f, index) =>{
           let header = param.name ++ ": " ++ DType.type2str(param.typ)
-
+          let parameters = f.parameters |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
+            |> List.map(~f=DType.type2str) |>List.map(~f=Html.text)
+          let signature = parameters-> List.updateAt(~index=index, ~f=(x) => Html.span(list{Attrs.class(%twc("text-white1"))}, list{x}) ) -> List.intersperse(~sep=Html.text(", "))
           Some(
             viewDoc(
-              Belt.List.concat(
+              Belt.List.concatMany([
+                list{
+                  Html.div(list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))}, list{
+                    Html.span(list{}, list{Html.text("(")}),
+                    Html.span(list{},signature),
+                    Html.span(list{}, list{Html.text(")")}),
+                    Html.span(list{Attrs.class(%twc("mx-1"))},list{Icons.fontAwesome("arrow-right")}),
+                    Html.span(list{Attrs.class(%twc("text-green"))}, list{Html.text(DType.type2str(f.returnType))}),
+                  })
+                },
+
                 FluidAutocomplete.documentationForFunction(f, None),
                 list{p(header), p(param.description)},
-              ),
+              ]),
             ),
-          )
-
+          )}
         | _ => None
         }
       }

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -173,6 +173,7 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
             let returnType = fn.returnType
             Some(viewDoc(
             Belt.List.concatMany([
+            FluidAutocomplete.documentationForFunctionHeader(fn),
             list{Html.div(list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))},list{Html.span(list{},list{Html.text((`(${types})`)) ,Html.span(list{Attrs.class(%twc("mx-1"))},list{Icons.fontAwesome("arrow-right")})}), Html.span(list{Attrs.class(%twc("text-green"))},list{Html.text(DType.type2str(returnType))})})},
             FluidAutocomplete.documentationForFunction(fn, Some(sendToRail)),
             ])
@@ -204,6 +205,7 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
           Some(
             viewDoc(
               Belt.List.concatMany([
+                FluidAutocomplete.documentationForFunctionHeader(f),
                 list{
                   Html.div(list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))}, list{
                     Html.span(list{}, list{Html.text("(")}),

--- a/client/src/canvas/View.res
+++ b/client/src/canvas/View.res
@@ -168,7 +168,15 @@ let viewTL_ = (m: model, tl: toplevel): Html.html<msg> => {
 
         switch fnAndRail {
         | Some(fn, sendToRail) =>
-          Some(viewDoc(FluidAutocomplete.documentationForFunction(fn, Some(sendToRail))))
+           let types = fn.parameters |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
+            |> List.map(~f=DType.type2str) |> List.join(~sep=", ")
+            let returnType = fn.returnType
+            Some(viewDoc(
+            Belt.List.concatMany([
+            list{Html.div(list{Attrs.class(%twc("lowercase text-xxs text-grey2 mb-2"))},list{Html.span(list{},list{Html.text((`(${types})`)) ,Html.span(list{Attrs.class(%twc("mx-1"))},list{Icons.fontAwesome("arrow-right")})}), Html.span(list{Attrs.class(%twc("text-green"))},list{Html.text(DType.type2str(returnType))})})},
+            FluidAutocomplete.documentationForFunction(fn, Some(sendToRail)),
+            ])
+            ))
         | None => None
         }
       }

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -808,9 +808,7 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
   }
 }
 
-let documentationForFunctionHeader = (
-    f: Function.t,
-): list<Tea.Html.html<'msg>> => {
+let documentationForFunctionHeader = (f: Function.t): list<Tea.Html.html<'msg>> => {
   let deprecationHeader = if f.deprecation != NotDeprecated {
     list{
       Html.span(
@@ -840,7 +838,10 @@ let documentationForFunctionHeader = (
     }
   } else {
     list{
-      Html.span(list{tw(%twc("font-text text-grey2 text-xs whitespace-nowrap"))}, list{Html.text("Not deprecated ")}),
+      Html.span(
+        list{tw(%twc("font-text text-grey2 text-xs whitespace-nowrap"))},
+        list{Html.text("Not deprecated ")},
+      ),
     }
   }
 
@@ -860,7 +861,6 @@ let documentationForFunction = (
   f: Function.t,
   sendToRail: option<ProgramTypes.Expr.SendToRail.t>,
 ): list<Tea.Html.html<'msg>> => {
-
   let desc = if String.length(f.description) != 0 {
     PrettyDocs.convert(f.description)
   } else {
@@ -968,7 +968,7 @@ let rec documentationForItem = ({item, validity}: data): option<list<Vdom.t<'a>>
   | FACFunction(f) =>
     let docsHeader = documentationForFunctionHeader(f)
     let docs = documentationForFunction(f, None)
-    Some(Belt.List.concatMany([docsHeader,docs, list{typeDoc}]))
+    Some(Belt.List.concatMany([docsHeader, docs, list{typeDoc}]))
   | FACConstructorName("Just", _) => simpleDoc("An Option containing a value")
   | FACConstructorName("Nothing", _) => simpleDoc("An Option representing Nothing")
   | FACConstructorName("Ok", _) => simpleDoc("A successful Result containing a value")

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -851,14 +851,21 @@ let documentationForFunction = (
   )
 
   let documentationHeader = Html.div(
-    list{tw(%twc("flex justify-between items-center mb-2"))},
+    list{tw(%twc("flex justify-between items-center mb-0.5"))},
     list{name, Html.div(list{}, deprecationHeader)},
   )
+
+  let signature = {
+    let types = f.parameters |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
+    |> List.map(~f=DType.type2str) |> List.join(~sep=", ")
+    let returnType = f.returnType
+    Html.div(list{tw(%twc("lowercase text-xxs text-grey2 mb-2"))},list{Html.span(list{},list{Html.text(`(${types})`) ,Html.span(list{tw(%twc("mx-1"))},list{Icons.fontAwesome("arrow-right")})}), Html.span(list{tw(%twc("text-green"))},list{Html.text(DType.type2str(returnType))})})
+  }
 
   let desc = if String.length(f.description) != 0 {
     PrettyDocs.convert(f.description)
   } else {
-    list{Html.i(list{}, list{Html.text("no description provided")})}
+    list{Html.text("")}
   }
 
   let return = Html.div(
@@ -951,7 +958,7 @@ let documentationForFunction = (
     }
   }
 
-  Belt.List.concatMany([list{documentationHeader}, desc, list{row}, deprecationFooter])
+  Belt.List.concatMany([list{documentationHeader}, list{signature}, desc, list{row}, deprecationFooter])
 }
 
 let rec documentationForItem = ({item, validity}: data): option<list<Vdom.t<'a>>> => {

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -851,16 +851,9 @@ let documentationForFunction = (
   )
 
   let documentationHeader = Html.div(
-    list{tw(%twc("flex justify-between items-center mb-0.5"))},
+    list{tw(%twc("flex justify-between items-center mb-2"))},
     list{name, Html.div(list{}, deprecationHeader)},
   )
-
-  let signature = {
-    let types = f.parameters |> List.map(~f=(x: RuntimeTypes.BuiltInFn.Param.t) => x.typ)
-    |> List.map(~f=DType.type2str) |> List.join(~sep=", ")
-    let returnType = f.returnType
-    Html.div(list{tw(%twc("lowercase text-xxs text-grey2 mb-2"))},list{Html.span(list{},list{Html.text(`(${types})`) ,Html.span(list{tw(%twc("mx-1"))},list{Icons.fontAwesome("arrow-right")})}), Html.span(list{tw(%twc("text-green"))},list{Html.text(DType.type2str(returnType))})})
-  }
 
   let desc = if String.length(f.description) != 0 {
     PrettyDocs.convert(f.description)
@@ -958,7 +951,7 @@ let documentationForFunction = (
     }
   }
 
-  Belt.List.concatMany([list{documentationHeader}, list{signature}, desc, list{row}, deprecationFooter])
+  Belt.List.concatMany([list{documentationHeader}, desc, list{row}, deprecationFooter])
 }
 
 let rec documentationForItem = ({item, validity}: data): option<list<Vdom.t<'a>>> => {

--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -808,9 +808,8 @@ let typeErrorDoc = ({item, validity}: data): Vdom.t<AppTypes.msg> => {
   }
 }
 
-let documentationForFunction = (
-  f: Function.t,
-  sendToRail: option<ProgramTypes.Expr.SendToRail.t>,
+let documentationForFunctionHeader = (
+    f: Function.t,
 ): list<Tea.Html.html<'msg>> => {
   let deprecationHeader = if f.deprecation != NotDeprecated {
     list{
@@ -851,9 +850,16 @@ let documentationForFunction = (
   )
 
   let documentationHeader = Html.div(
-    list{tw(%twc("flex justify-between items-center mb-2"))},
+    list{tw(%twc("flex justify-between items-center mb-0.5"))},
     list{name, Html.div(list{}, deprecationHeader)},
   )
+  list{documentationHeader}
+}
+
+let documentationForFunction = (
+  f: Function.t,
+  sendToRail: option<ProgramTypes.Expr.SendToRail.t>,
+): list<Tea.Html.html<'msg>> => {
 
   let desc = if String.length(f.description) != 0 {
     PrettyDocs.convert(f.description)
@@ -951,7 +957,7 @@ let documentationForFunction = (
     }
   }
 
-  Belt.List.concatMany([list{documentationHeader}, desc, list{row}, deprecationFooter])
+  Belt.List.concatMany([desc, list{row}, deprecationFooter])
 }
 
 let rec documentationForItem = ({item, validity}: data): option<list<Vdom.t<'a>>> => {
@@ -960,8 +966,9 @@ let rec documentationForItem = ({item, validity}: data): option<list<Vdom.t<'a>>
   let simpleDoc = (text: string) => Some(list{p(text), typeDoc})
   switch item {
   | FACFunction(f) =>
+    let docsHeader = documentationForFunctionHeader(f)
     let docs = documentationForFunction(f, None)
-    Some(List.append(docs, list{typeDoc}))
+    Some(Belt.List.concatMany([docsHeader,docs, list{typeDoc}]))
   | FACConstructorName("Just", _) => simpleDoc("An Option containing a value")
   | FACConstructorName("Nothing", _) => simpleDoc("An Option representing Nothing")
   | FACConstructorName("Ok", _) => simpleDoc("A successful Result containing a value")

--- a/client/src/fluid/FluidAutocomplete.resi
+++ b/client/src/fluid/FluidAutocomplete.resi
@@ -43,6 +43,11 @@ let documentationForFunction: (
   option<ProgramTypes.Expr.SendToRail.t>,
 ) => list<Tea.Html.html<AppTypes.msg>>
 
+let documentationForFunctionHeader: (
+  Function.t,
+) => list<Tea.Html.html<AppTypes.msg>>
+
+
 let documentationForItem: data => option<list<Vdom.t<AppTypes.msg>>>
 
 let isOpened: t => bool

--- a/client/src/fluid/FluidAutocomplete.resi
+++ b/client/src/fluid/FluidAutocomplete.resi
@@ -43,10 +43,7 @@ let documentationForFunction: (
   option<ProgramTypes.Expr.SendToRail.t>,
 ) => list<Tea.Html.html<AppTypes.msg>>
 
-let documentationForFunctionHeader: (
-  Function.t,
-) => list<Tea.Html.html<AppTypes.msg>>
-
+let documentationForFunctionHeader: Function.t => list<Tea.Html.html<AppTypes.msg>>
 
 let documentationForItem: data => option<list<Vdom.t<AppTypes.msg>>>
 

--- a/client/src/fluid/FluidAutocompleteView.res
+++ b/client/src/fluid/FluidAutocompleteView.res
@@ -35,7 +35,25 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
 
       args
       |> List.intersperse(~sep=Html.text(", "))
-      |> (args => Belt.List.concatMany([list{Html.text("(")}, list{Html.span(list{Attrs.class(%twc("inline-block align-top overflow-hidden max-w-[25ch] text-ellipsis whitespace-nowrap"))},args)}, list{Html.text(") -> ")}]))
+      |> (
+        args =>
+          Belt.List.concatMany([
+            list{Html.text("(")},
+            list{
+              Html.span(
+                list{
+                  Attrs.class(
+                    %twc(
+                      "inline-block align-top overflow-hidden max-w-[25ch] text-ellipsis whitespace-nowrap"
+                    ),
+                  ),
+                },
+                args,
+              ),
+            },
+            list{Html.text(") -> ")},
+          ])
+      )
     }
 
     Belt.List.concat(argsHtml, returnTypeHtml)

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -18,12 +18,12 @@ let fieldStyle = %twc("block text-xs text-grey7")
 let typeStyle = %twc("inline-block ml-2 before:content-[':'] before:mr-2")
 let nameStyle = %twc("inline-block")
 let refBlockStyle = %twc(
-  "block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 before:absolute before:text-2xl before:top-[calc(50%-15px)] hover:cursor-pointer hover:text-[#3a839e] hover:bg-black1 before:font-icons before:font-black before:text-2xl before:text-black3 before:hover:text-black1"
+  "block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 hover:cursor-pointer hover:text-[#3a839e] hover:bg-black1 before:absolute before:top-[calc(50%-15px)] before:font-icons before:font-black before:text-2xl before:text-black3 before:hover:text-black1"
 )
 let specStyle = %twc("inline-block ml-8 pt-0 pb-0.5 px-2 w-max first:ml-0")
 let arrowDirection = (direction: string) =>
   if direction == "refers-to" {
-    %twc("before:content-arrowRight before:-left-6")
+    %twc("before:content-arrowRight before:-left-6 before:text-black2")
   } else {
     %twc("before:content-arrowLeft before:-left-5")
   }

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -249,7 +249,7 @@ let typeView = (
   direction: string,
 ): Html.html<msg> => {
   let header = list{
-    Icons.darkIcon(~style=%twc("text-blue"),"type"),
+    Icons.darkIcon(~style=%twc("text-blue"),"types"),
     Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
 

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -21,8 +21,12 @@ let refBlockStyle = %twc(
   "block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 before:absolute before:text-2xl before:top-[calc(50%-15px)] hover:cursor-pointer hover:text-[#3a839e] hover:bg-black1 before:font-icons before:font-black before:text-2xl before:text-black3 before:hover:text-black1"
 )
 let specStyle = %twc("inline-block ml-8 pt-0 pb-0.5 px-2 w-max first:ml-0")
-let arrowRefersTo = %twc("before:content-arrowRight before:-left-6")
-let arrowUsedIn = %twc("before:content-arrowLeft before:-left-5")
+let arrowDirection = (direction: string) =>
+  if direction == "refers-to" {
+    %twc("before:content-arrowRight before:-left-6")
+  } else {
+    %twc("before:content-arrowLeft before:-left-5")
+  }
 
 let dbColsView = (cols: list<PT.DB.Col.t>): Html.html<msg> => {
   let colView = (col: PT.DB.Col.t) =>
@@ -131,7 +135,7 @@ let dbView = (
         Attrs.classes([
           "introspect-db",
           refBlockStyle,
-          {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+          arrowDirection(direction),
           direction,
         ]),
         EventListeners.eventNoPropagation(
@@ -174,7 +178,7 @@ let handlerView = (
         refBlockStyle,
         "ref-block",
         "introspect-handler",
-        {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+        arrowDirection(direction),
         %twc("flex flex-row justify-start"),
         direction,
       ]),
@@ -211,7 +215,7 @@ let fnView = (
       list{
         Attrs.classes([
           refBlockStyle,
-          {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+          arrowDirection(direction),
           direction,
         ]),
         EventListeners.eventNoPropagation(
@@ -248,7 +252,7 @@ let packageFnView = (
     list{
       Attrs.classes([
         refBlockStyle,
-        {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+        arrowDirection(direction),
         "ref-block ",
         "introspect-pkg-fn",
         direction,
@@ -286,7 +290,7 @@ let typeView = (
       list{
         Attrs.classes([
           refBlockStyle,
-          {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+          arrowDirection(direction),
           "typ ",
           direction,
         ]),

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -13,15 +13,23 @@ type msg = AppTypes.msg
 let tw = Attrs.class
 let tw2 = (c1, c2) => Attrs.class(`${c1} ${c2}`)
 
+let fieldsStyle = %twc("block w-max text-grey8 ml-[1.375rem]")
+let fieldStyle = %twc("block text-xs text-grey7")
+let typeStyle = %twc("inline-block ml-2 before:content-[':'] before:mr-2")
+let nameStyle = %twc("inline-block")
+// add before:top-[calc(50%-12px)] to refBlockStyle if you figure out how to add an icon to before:content
+let refBlockStyle = %twc("block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 first:mb-2 before:absolute before:text-2xl hover:cursor-pointer hover:text-[#3a839e] hover:bg-black2")
+let specStyle = %twc("inline-block ml-8 pt-0 pb-0.5 px-2 w-max first:ml-0")
+
 let dbColsView = (cols: list<PT.DB.Col.t>): Html.html<msg> => {
   let colView = (col: PT.DB.Col.t) =>
     switch col {
     | {name: Some(name), typ: Some(typ), _} =>
       let html = Html.div(
-        list{Attrs.class("field")},
+        list{tw(fieldStyle)},
         list{
-          Html.div(list{Attrs.class("name")}, list{Html.text(name)}),
-          Html.div(list{Attrs.class("type")}, list{Html.text(DType.type2str(typ))}),
+          Html.div(list{tw(nameStyle)}, list{Html.text(name)}),
+          Html.div(list{tw(typeStyle)}, list{Html.text(DType.type2str(typ))}),
         },
       )
 
@@ -29,13 +37,13 @@ let dbColsView = (cols: list<PT.DB.Col.t>): Html.html<msg> => {
     | _ => None
     }
 
-  Html.div(list{Attrs.class("fields")}, List.filterMap(~f=colView, cols))
+  Html.div(list{tw(fieldsStyle)}, List.filterMap(~f=colView, cols))
 }
 
 let fnParamsView = (params: list<PT.UserFunction.Parameter.t>): Html.html<msg> => {
   let paramView = (p: PT.UserFunction.Parameter.t) => {
     let name = Html.span(
-      list{Attrs.classList(list{(%twc("inline-block"), true), (%twc("text-red italic"), p.name == "")})},
+      list{Attrs.classList(list{(nameStyle, true), (%twc("text-red italic"), p.name == "")})},
       list{
         Html.text(
           if p.name == "" {
@@ -48,7 +56,7 @@ let fnParamsView = (params: list<PT.UserFunction.Parameter.t>): Html.html<msg> =
     )
 
     let ptype = Html.span(
-      list{Attrs.classList(list{(%twc("inline-block ml-2 before:content-[':'] before:mr-2"), true), (%twc("text-red italic"), p.typ == None)})},
+      list{Attrs.classList(list{(typeStyle, true), (%twc("text-red italic"), p.typ == None)})},
       list{
         Html.text(
           switch p.typ {
@@ -59,24 +67,24 @@ let fnParamsView = (params: list<PT.UserFunction.Parameter.t>): Html.html<msg> =
       },
     )
 
-    Html.div(list{tw(%twc("block text-xs text-grey7"))}, list{name, ptype})
+    Html.div(list{tw(fieldStyle)}, list{name, ptype})
   }
 
-  Html.div(list{tw(%twc("block w-max text-grey8 ml-[22px]"))}, List.map(~f=paramView, params))
+  Html.div(list{tw(fieldsStyle)}, List.map(~f=paramView, params))
 }
 
 let packageFnParamsView = (params: list<PT.Package.Parameter.t>): Html.html<msg> => {
   let paramView = (p: PT.Package.Parameter.t) => {
-    let name = Html.span(list{Attrs.classList(list{("name", true)})}, list{Html.text(p.name)})
+    let name = Html.span(list{Attrs.classList(list{(nameStyle, true)})}, list{Html.text(p.name)})
     let ptype = Html.span(
-      list{Attrs.classList(list{("type", true)})},
+      list{Attrs.classList(list{(typeStyle, true)})},
       list{Html.text(DType.type2str(p.typ))},
     )
 
-    Html.div(list{Attrs.class("field")}, list{name, ptype})
+    Html.div(list{tw(fieldStyle)}, list{name, ptype})
   }
 
-  Html.div(list{Attrs.class("fields")}, List.map(~f=paramView, params))
+  Html.div(list{tw(fieldsStyle)}, List.map(~f=paramView, params))
 }
 
 let fnReturnTypeView = (returnType: option<DType.t>): Html.html<msg> =>
@@ -85,7 +93,7 @@ let fnReturnTypeView = (returnType: option<DType.t>): Html.html<msg> =>
     let typeStr = DType.type2str(v)
     Html.div(
       list{},
-      list{Html.text("Returns "), Html.span(list{tw(%twc("inline-block ml-2"))}, list{Html.text(typeStr)})},
+      list{Html.text("Returns "), Html.span(list{tw(typeStyle)}, list{Html.text(typeStr)})},
     )
   | None => Vdom.noNode
   }
@@ -111,10 +119,12 @@ let dbView = (
   cols: list<PT.DB.Col.t>,
   direction: string,
 ): Html.html<msg> =>
+Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
+  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.class("ref-block db " ++ direction),
+        Attrs.classes([refBlockStyle, direction]),
         EventListeners.eventNoPropagation(
           ~key="ref-db-link" ++ TLID.toString(tlid),
           "click",
@@ -125,15 +135,16 @@ let dbView = (
     ),
     list{
       Html.div(
-        list{Attrs.class("dbheader")},
+        list{tw(%twc("flex items-center w-full"))},
         list{
-          Icons.fontAwesome("database"),
-          Html.span(list{Attrs.class("dbname")}, list{Html.text(name)}),
+          Icons.fontAwesome(~style=%twc("text-blue"), "database"),
+          Html.span(list{tw(%twc("pl-2"))}, list{Html.text(name)}),
         },
       ),
       dbColsView(cols),
     },
   )
+})
 
 let handlerView = (
   originTLID: TLID.t,
@@ -145,14 +156,15 @@ let handlerView = (
   module Spec = PT.Handler.Spec
   let modifier_ = switch Spec.modifier(spec) {
   | Some(F(_, "_")) | Some(F(_, "")) | Some(Blank(_)) | None => Vdom.noNode
-  | Some(F(_, m)) => Html.div(list{Attrs.class("spec")}, list{Html.text(m)})
+  | Some(F(_, m)) => Html.div(list{tw(specStyle)}, list{Html.text(m)})
   }
   let space = Spec.space(spec)->B.toString
   let name = Spec.name(spec)->B.toString
-
+Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
+  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("left-long")}),
   Html.div(
     list{
-      Attrs.class("ref-block handler " ++ direction),
+      Attrs.classes([refBlockStyle, %twc("flex flex-row justify-start"), direction]),
       EventListeners.eventNoPropagation(
         ~key="ref-handler-link" ++ TLID.toString(tlid),
         "click",
@@ -161,11 +173,11 @@ let handlerView = (
       ...hoveringRefProps(originTLID, originIDs, ~key="ref-handler-hover"),
     },
     list{
-      Html.div(list{Attrs.class("spec space")}, list{Html.text(space)}),
-      Html.div(list{Attrs.class("spec")}, list{Html.text(name)}),
+      Html.div(list{tw2(specStyle, %twc("text-blue"))}, list{Html.text(space)}),
+      Html.div(list{tw(specStyle)}, list{Html.text(name)}),
       modifier_,
     },
-  )
+  )})
 }
 
 let fnView = (
@@ -178,15 +190,15 @@ let fnView = (
   direction: string,
 ): Html.html<msg> => {
   let header = list{
-    Icons.darkIcon("fn"),
+    Icons.darkIcon(~style=%twc("text-blue"),"fn"),
     Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
-  Html.div(list{tw(%twc("flex items-center justify-center -ml-6"))},list{
+  Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
   Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     Belt.List.concat(
       list{
-        tw2(%twc("block box-content relative min-w-[120px] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.3333px] first:mt-0 first:mb-2 before:absolute before:text-2xl hover:cursor-pointer hover:text-[#3a839e] hover:bg-black2"), direction),
+        tw2(refBlockStyle, direction),
         EventListeners.eventNoPropagation(
           ~key="ref-fn-link" ++ TLID.toString(tlid),
           "click",
@@ -196,7 +208,7 @@ let fnView = (
       hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     ),
     list{
-      Html.div(list{tw(%twc("flex w-full items-center text-blue"))},header),
+      Html.div(list{tw(%twc("flex w-full items-center"))},header),
       fnParamsView(params),
       fnReturnTypeView(returnType),
     },
@@ -215,13 +227,14 @@ let packageFnView = (
 ): Html.html<msg> => {
   // Spec is here: https://www.notion.so/darklang/PM-Function-References-793d95469dfd40d5b01c2271cb8f4a0f
   let header = list{
-    Icons.fontAwesome("box-open"),
-    Html.span(list{Attrs.class("fnname")}, list{Html.text(name)}),
+    Icons.fontAwesome(~style=%twc("text-grey7"), "box-open"),
+    Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
-
+Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
+  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     list{
-      Attrs.class("ref-block pkg-fn " ++ direction),
+      Attrs.classes([refBlockStyle, direction]),
       EventListeners.eventNoPropagation(
         ~key="ref-fn-link" ++ TLID.toString(tlid),
         "click",
@@ -230,11 +243,11 @@ let packageFnView = (
       ...hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     },
     list{
-      Html.div(list{Attrs.class("fnheader fnheader-pkg")}, header),
+      Html.div(list{tw(%twc("flex w-full items-center"))}, header),
       packageFnParamsView(params),
       fnReturnTypeView(B.toOption(returnType)),
     },
-  )
+  )})
 }
 
 let typeView = (
@@ -246,14 +259,14 @@ let typeView = (
   direction: string,
 ): Html.html<msg> => {
   let header = list{
-    Icons.darkIcon("type"),
-    Html.span(list{Attrs.class("typename")}, list{Html.text(name)}),
+    Icons.darkIcon(~style=%twc("text-blue"),"type"),
+    Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
 
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.class("ref-block typ " ++ direction),
+        Attrs.classes([refBlockStyle, "typ ", direction]),
         EventListeners.eventNoPropagation(
           ~key="ref-typ-link" ++ TLID.toString(tlid),
           "click",
@@ -262,7 +275,7 @@ let typeView = (
       },
       hoveringRefProps(originTLID, originIDs, ~key="ref-typ-hover"),
     ),
-    list{Html.div(list{Attrs.class("typeheader")}, header)},
+    list{Html.div(list{tw(%twc("flex w-full items-center"))}, header)},
   )
 }
 

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -14,7 +14,7 @@ let tw = Attrs.class
 let tw2 = (c1, c2) => Attrs.class(`${c1} ${c2}`)
 
 let fieldsStyle = %twc("block w-max text-grey8 ml-[1.375rem]")
-let fieldStyle = %twc("block text-xs text-grey7")
+let fieldStyle = %twc("block text-xs text-grey6")
 let typeStyle = %twc("inline-block ml-2 before:content-[':'] before:mr-2")
 let nameStyle = %twc("inline-block")
 let refBlockStyle = %twc(

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -124,6 +124,7 @@ Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
   Html.div(
     Belt.List.concat(
       list{
+        Attrs.id("db"),
         Attrs.classes([refBlockStyle, direction]),
         EventListeners.eventNoPropagation(
           ~key="ref-db-link" ++ TLID.toString(tlid),
@@ -160,11 +161,12 @@ let handlerView = (
   }
   let space = Spec.space(spec)->B.toString
   let name = Spec.name(spec)->B.toString
-Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
-  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("left-long")}),
+Html.div(list{tw(%twc("group flex items-center -ml-6"))},list{
+  Html.span(list{tw(%twc("text-black3 text-2xl group-hover:text-black2"))}, list{Icons.fontAwesome("left-long")}),
   Html.div(
     list{
-      Attrs.classes([refBlockStyle, %twc("flex flex-row justify-start"), direction]),
+      Attrs.id("handler"),
+      Attrs.classes([refBlockStyle,"ref-block", %twc("flex flex-row justify-start"), direction]),
       EventListeners.eventNoPropagation(
         ~key="ref-handler-link" ++ TLID.toString(tlid),
         "click",
@@ -234,7 +236,8 @@ Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
   Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     list{
-      Attrs.classes([refBlockStyle, direction]),
+      Attrs.id("pkg-fn"),
+      Attrs.classes([refBlockStyle,"ref-block ", direction]),
       EventListeners.eventNoPropagation(
         ~key="ref-fn-link" ++ TLID.toString(tlid),
         "click",
@@ -243,7 +246,7 @@ Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
       ...hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     },
     list{
-      Html.div(list{tw(%twc("flex w-full items-center"))}, header),
+      Html.div(list{Attrs.id("fnheader"),tw(%twc("flex w-full items-center"))}, header),
       packageFnParamsView(params),
       fnReturnTypeView(B.toOption(returnType)),
     },

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -10,6 +10,9 @@ module B = BlankOr
 module Msg = AppTypes.Msg
 type msg = AppTypes.msg
 
+let tw = Attrs.class
+let tw2 = (c1, c2) => Attrs.class(`${c1} ${c2}`)
+
 let dbColsView = (cols: list<PT.DB.Col.t>): Html.html<msg> => {
   let colView = (col: PT.DB.Col.t) =>
     switch col {
@@ -32,7 +35,7 @@ let dbColsView = (cols: list<PT.DB.Col.t>): Html.html<msg> => {
 let fnParamsView = (params: list<PT.UserFunction.Parameter.t>): Html.html<msg> => {
   let paramView = (p: PT.UserFunction.Parameter.t) => {
     let name = Html.span(
-      list{Attrs.classList(list{("name", true), ("has-blanks", p.name == "")})},
+      list{Attrs.classList(list{(%twc("inline-block"), true), (%twc("text-red italic"), p.name == "")})},
       list{
         Html.text(
           if p.name == "" {
@@ -45,7 +48,7 @@ let fnParamsView = (params: list<PT.UserFunction.Parameter.t>): Html.html<msg> =
     )
 
     let ptype = Html.span(
-      list{Attrs.classList(list{("type", true), ("has-blanks", p.typ == None)})},
+      list{Attrs.classList(list{(%twc("inline-block ml-2 before:content-[':'] before:mr-2"), true), (%twc("text-red italic"), p.typ == None)})},
       list{
         Html.text(
           switch p.typ {
@@ -56,10 +59,10 @@ let fnParamsView = (params: list<PT.UserFunction.Parameter.t>): Html.html<msg> =
       },
     )
 
-    Html.div(list{Attrs.class("field")}, list{name, ptype})
+    Html.div(list{tw(%twc("block text-xs text-grey7"))}, list{name, ptype})
   }
 
-  Html.div(list{Attrs.class("fields")}, List.map(~f=paramView, params))
+  Html.div(list{tw(%twc("block w-max text-grey8 ml-[22px]"))}, List.map(~f=paramView, params))
 }
 
 let packageFnParamsView = (params: list<PT.Package.Parameter.t>): Html.html<msg> => {
@@ -82,7 +85,7 @@ let fnReturnTypeView = (returnType: option<DType.t>): Html.html<msg> =>
     let typeStr = DType.type2str(v)
     Html.div(
       list{},
-      list{Html.text("Returns "), Html.span(list{Attrs.class("type")}, list{Html.text(typeStr)})},
+      list{Html.text("Returns "), Html.span(list{tw(%twc("inline-block ml-2"))}, list{Html.text(typeStr)})},
     )
   | None => Vdom.noNode
   }
@@ -176,13 +179,14 @@ let fnView = (
 ): Html.html<msg> => {
   let header = list{
     Icons.darkIcon("fn"),
-    Html.span(list{Attrs.class("fnname")}, list{Html.text(name)}),
+    Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
-
+  Html.div(list{tw(%twc("flex items-center justify-center -ml-6"))},list{
+  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.class("ref-block fn " ++ direction),
+        tw2(%twc("block box-content relative min-w-[120px] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.3333px] first:mt-0 first:mb-2 before:absolute before:text-2xl hover:cursor-pointer hover:text-[#3a839e] hover:bg-black2"), direction),
         EventListeners.eventNoPropagation(
           ~key="ref-fn-link" ++ TLID.toString(tlid),
           "click",
@@ -192,11 +196,12 @@ let fnView = (
       hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     ),
     list{
-      Html.div(list{Attrs.class("fnheader fnheader-user")}, header),
+      Html.div(list{tw(%twc("flex w-full items-center text-blue"))},header),
       fnParamsView(params),
       fnReturnTypeView(returnType),
     },
   )
+  })
 }
 
 let packageFnView = (

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -17,9 +17,10 @@ let fieldsStyle = %twc("block w-max text-grey8 ml-[1.375rem]")
 let fieldStyle = %twc("block text-xs text-grey7")
 let typeStyle = %twc("inline-block ml-2 before:content-[':'] before:mr-2")
 let nameStyle = %twc("inline-block")
-// add before:top-[calc(50%-12px)] to refBlockStyle if you figure out how to add an icon to before:content
-let refBlockStyle = %twc("block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 first:mb-2 before:absolute before:text-2xl hover:cursor-pointer hover:text-[#3a839e] hover:bg-black2")
+let refBlockStyle = %twc("block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 before:absolute before:text-2xl before:top-[calc(50%-15px)] hover:cursor-pointer hover:text-[#3a839e] hover:bg-black1 before:font-icons before:font-black before:text-2xl before:text-black3 before:hover:text-black1")
 let specStyle = %twc("inline-block ml-8 pt-0 pb-0.5 px-2 w-max first:ml-0")
+let arrowRefersTo = %twc("before:content-arrowRight before:-left-6")
+let arrowUsedIn = %twc("before:content-arrowLeft before:-left-5")
 
 let dbColsView = (cols: list<PT.DB.Col.t>): Html.html<msg> => {
   let colView = (col: PT.DB.Col.t) =>
@@ -119,13 +120,11 @@ let dbView = (
   cols: list<PT.DB.Col.t>,
   direction: string,
 ): Html.html<msg> =>
-Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
-  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     Belt.List.concat(
       list{
         Attrs.id("db"),
-        Attrs.classes([refBlockStyle, direction]),
+        Attrs.classes([refBlockStyle, {direction=="refers-to"? arrowRefersTo : arrowUsedIn}, direction]),
         EventListeners.eventNoPropagation(
           ~key="ref-db-link" ++ TLID.toString(tlid),
           "click",
@@ -145,7 +144,6 @@ Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
       dbColsView(cols),
     },
   )
-})
 
 let handlerView = (
   originTLID: TLID.t,
@@ -161,12 +159,10 @@ let handlerView = (
   }
   let space = Spec.space(spec)->B.toString
   let name = Spec.name(spec)->B.toString
-Html.div(list{tw(%twc("group flex items-center -ml-6"))},list{
-  Html.span(list{tw(%twc("text-black3 text-2xl group-hover:text-black2"))}, list{Icons.fontAwesome("left-long")}),
   Html.div(
     list{
       Attrs.id("handler"),
-      Attrs.classes([refBlockStyle,"ref-block", %twc("flex flex-row justify-start"), direction]),
+      Attrs.classes([refBlockStyle,"ref-block", {direction=="refers-to"? arrowRefersTo : arrowUsedIn}, %twc("flex flex-row justify-start"), direction]),
       EventListeners.eventNoPropagation(
         ~key="ref-handler-link" ++ TLID.toString(tlid),
         "click",
@@ -178,9 +174,7 @@ Html.div(list{tw(%twc("group flex items-center -ml-6"))},list{
       Html.div(list{tw2(specStyle, %twc("text-blue"))}, list{Html.text(space)}),
       Html.div(list{tw(specStyle)}, list{Html.text(name)}),
       modifier_,
-    },
-  )})
-}
+    },)}
 
 let fnView = (
   originTLID: TLID.t,
@@ -195,12 +189,10 @@ let fnView = (
     Icons.darkIcon(~style=%twc("text-blue"),"fn"),
     Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
-  Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
-  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     Belt.List.concat(
       list{
-        tw2(refBlockStyle, direction),
+        Attrs.classes([refBlockStyle,{direction=="refers-to"? arrowRefersTo : arrowUsedIn}, direction]),
         EventListeners.eventNoPropagation(
           ~key="ref-fn-link" ++ TLID.toString(tlid),
           "click",
@@ -214,9 +206,7 @@ let fnView = (
       fnParamsView(params),
       fnReturnTypeView(returnType),
     },
-  )
-  })
-}
+  )}
 
 let packageFnView = (
   originTLID: TLID.t,
@@ -232,12 +222,10 @@ let packageFnView = (
     Icons.fontAwesome(~style=%twc("text-grey7"), "box-open"),
     Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
-Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
-  Html.span(list{tw(%twc("text-black2 text-2xl"))}, list{Icons.fontAwesome("right-long")}),
   Html.div(
     list{
       Attrs.id("pkg-fn"),
-      Attrs.classes([refBlockStyle,"ref-block ", direction]),
+      Attrs.classes([refBlockStyle,{direction=="refers-to"? arrowRefersTo : arrowUsedIn},"ref-block ", direction]),
       EventListeners.eventNoPropagation(
         ~key="ref-fn-link" ++ TLID.toString(tlid),
         "click",
@@ -250,8 +238,7 @@ Html.div(list{tw(%twc("flex items-center -ml-6"))},list{
       packageFnParamsView(params),
       fnReturnTypeView(B.toOption(returnType)),
     },
-  )})
-}
+  )}
 
 let typeView = (
   originTLID: TLID.t,
@@ -269,7 +256,7 @@ let typeView = (
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.classes([refBlockStyle, "typ ", direction]),
+        Attrs.classes([refBlockStyle,{direction=="refers-to"? arrowRefersTo : arrowUsedIn}, "typ ", direction]),
         EventListeners.eventNoPropagation(
           ~key="ref-typ-link" ++ TLID.toString(tlid),
           "click",

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -17,7 +17,9 @@ let fieldsStyle = %twc("block w-max text-grey8 ml-[1.375rem]")
 let fieldStyle = %twc("block text-xs text-grey7")
 let typeStyle = %twc("inline-block ml-2 before:content-[':'] before:mr-2")
 let nameStyle = %twc("inline-block")
-let refBlockStyle = %twc("block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 before:absolute before:text-2xl before:top-[calc(50%-15px)] hover:cursor-pointer hover:text-[#3a839e] hover:bg-black1 before:font-icons before:font-black before:text-2xl before:text-black3 before:hover:text-black1")
+let refBlockStyle = %twc(
+  "block box-content relative min-w-[7.5rem] my-2 mx-0 p-2 bg-black3 text-grey8 text-[13.333px] first:mt-0 before:absolute before:text-2xl before:top-[calc(50%-15px)] hover:cursor-pointer hover:text-[#3a839e] hover:bg-black1 before:font-icons before:font-black before:text-2xl before:text-black3 before:hover:text-black1"
+)
 let specStyle = %twc("inline-block ml-8 pt-0 pb-0.5 px-2 w-max first:ml-0")
 let arrowRefersTo = %twc("before:content-arrowRight before:-left-6")
 let arrowUsedIn = %twc("before:content-arrowLeft before:-left-5")
@@ -94,7 +96,10 @@ let fnReturnTypeView = (returnType: option<DType.t>): Html.html<msg> =>
     let typeStr = DType.type2str(v)
     Html.div(
       list{},
-      list{Html.text("Returns "), Html.span(list{tw(typeStyle)}, list{Html.text(typeStr)})},
+      list{
+        Html.text("Returns"),
+        Html.span(list{tw(%twc("inline-block ml-2"))}, list{Html.text(typeStr)}),
+      },
     )
   | None => Vdom.noNode
   }
@@ -124,7 +129,11 @@ let dbView = (
     Belt.List.concat(
       list{
         Attrs.id("db"),
-        Attrs.classes([refBlockStyle, {direction=="refers-to"? arrowRefersTo : arrowUsedIn}, direction]),
+        Attrs.classes([
+          refBlockStyle,
+          {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+          direction,
+        ]),
         EventListeners.eventNoPropagation(
           ~key="ref-db-link" ++ TLID.toString(tlid),
           "click",
@@ -162,7 +171,13 @@ let handlerView = (
   Html.div(
     list{
       Attrs.id("handler"),
-      Attrs.classes([refBlockStyle,"ref-block", {direction=="refers-to"? arrowRefersTo : arrowUsedIn}, %twc("flex flex-row justify-start"), direction]),
+      Attrs.classes([
+        refBlockStyle,
+        "ref-block",
+        {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+        %twc("flex flex-row justify-start"),
+        direction,
+      ]),
       EventListeners.eventNoPropagation(
         ~key="ref-handler-link" ++ TLID.toString(tlid),
         "click",
@@ -174,7 +189,9 @@ let handlerView = (
       Html.div(list{tw2(specStyle, %twc("text-blue"))}, list{Html.text(space)}),
       Html.div(list{tw(specStyle)}, list{Html.text(name)}),
       modifier_,
-    },)}
+    },
+  )
+}
 
 let fnView = (
   originTLID: TLID.t,
@@ -186,13 +203,17 @@ let fnView = (
   direction: string,
 ): Html.html<msg> => {
   let header = list{
-    Icons.darkIcon(~style=%twc("text-blue"),"fn"),
+    Icons.darkIcon(~style=%twc("text-blue"), "fn"),
     Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.classes([refBlockStyle,{direction=="refers-to"? arrowRefersTo : arrowUsedIn}, direction]),
+        Attrs.classes([
+          refBlockStyle,
+          {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+          direction,
+        ]),
         EventListeners.eventNoPropagation(
           ~key="ref-fn-link" ++ TLID.toString(tlid),
           "click",
@@ -202,11 +223,12 @@ let fnView = (
       hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     ),
     list{
-      Html.div(list{tw(%twc("flex w-full items-center"))},header),
+      Html.div(list{tw(%twc("flex w-full items-center"))}, header),
       fnParamsView(params),
       fnReturnTypeView(returnType),
     },
-  )}
+  )
+}
 
 let packageFnView = (
   originTLID: TLID.t,
@@ -225,7 +247,12 @@ let packageFnView = (
   Html.div(
     list{
       Attrs.id("pkg-fn"),
-      Attrs.classes([refBlockStyle,{direction=="refers-to"? arrowRefersTo : arrowUsedIn},"ref-block ", direction]),
+      Attrs.classes([
+        refBlockStyle,
+        {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+        "ref-block ",
+        direction,
+      ]),
       EventListeners.eventNoPropagation(
         ~key="ref-fn-link" ++ TLID.toString(tlid),
         "click",
@@ -234,11 +261,12 @@ let packageFnView = (
       ...hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     },
     list{
-      Html.div(list{Attrs.id("fnheader"),tw(%twc("flex w-full items-center"))}, header),
+      Html.div(list{Attrs.id("fnheader"), tw(%twc("flex w-full items-center"))}, header),
       packageFnParamsView(params),
       fnReturnTypeView(B.toOption(returnType)),
     },
-  )}
+  )
+}
 
 let typeView = (
   originTLID: TLID.t,
@@ -249,14 +277,19 @@ let typeView = (
   direction: string,
 ): Html.html<msg> => {
   let header = list{
-    Icons.darkIcon(~style=%twc("text-blue"),"types"),
+    Icons.darkIcon(~style=%twc("text-blue"), "types"),
     Html.span(list{tw(%twc("inline-block pl-2"))}, list{Html.text(name)}),
   }
 
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.classes([refBlockStyle,{direction=="refers-to"? arrowRefersTo : arrowUsedIn}, "typ ", direction]),
+        Attrs.classes([
+          refBlockStyle,
+          {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
+          "typ ",
+          direction,
+        ]),
         EventListeners.eventNoPropagation(
           ~key="ref-typ-link" ++ TLID.toString(tlid),
           "click",

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -128,8 +128,8 @@ let dbView = (
   Html.div(
     Belt.List.concat(
       list{
-        Attrs.id("db"),
         Attrs.classes([
+          "db",
           refBlockStyle,
           {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
           direction,
@@ -170,10 +170,10 @@ let handlerView = (
   let name = Spec.name(spec)->B.toString
   Html.div(
     list{
-      Attrs.id("handler"),
       Attrs.classes([
         refBlockStyle,
         "ref-block",
+        "handler",
         {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
         %twc("flex flex-row justify-start"),
         direction,
@@ -246,11 +246,11 @@ let packageFnView = (
   }
   Html.div(
     list{
-      Attrs.id("pkg-fn"),
       Attrs.classes([
         refBlockStyle,
         {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
         "ref-block ",
+        "pkg-fn",
         direction,
       ]),
       EventListeners.eventNoPropagation(
@@ -261,7 +261,7 @@ let packageFnView = (
       ...hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     },
     list{
-      Html.div(list{Attrs.id("fnheader"), tw(%twc("flex w-full items-center"))}, header),
+      Html.div(list{tw2("fnheader",%twc("flex w-full items-center"))}, header),
       packageFnParamsView(params),
       fnReturnTypeView(B.toOption(returnType)),
     },

--- a/client/src/toplevels/ViewIntrospect.res
+++ b/client/src/toplevels/ViewIntrospect.res
@@ -129,7 +129,7 @@ let dbView = (
     Belt.List.concat(
       list{
         Attrs.classes([
-          "db",
+          "introspect-db",
           refBlockStyle,
           {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
           direction,
@@ -173,7 +173,7 @@ let handlerView = (
       Attrs.classes([
         refBlockStyle,
         "ref-block",
-        "handler",
+        "introspect-handler",
         {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
         %twc("flex flex-row justify-start"),
         direction,
@@ -250,7 +250,7 @@ let packageFnView = (
         refBlockStyle,
         {direction == "refers-to" ? arrowRefersTo : arrowUsedIn},
         "ref-block ",
-        "pkg-fn",
+        "introspect-pkg-fn",
         direction,
       ]),
       EventListeners.eventNoPropagation(
@@ -261,7 +261,7 @@ let packageFnView = (
       ...hoveringRefProps(originTLID, originIDs, ~key="ref-fn-hover"),
     },
     list{
-      Html.div(list{tw2("fnheader",%twc("flex w-full items-center"))}, header),
+      Html.div(list{tw2("introspect-fnheader", %twc("flex w-full items-center"))}, header),
       packageFnParamsView(params),
       fnReturnTypeView(B.toOption(returnType)),
     },

--- a/client/src/ui/Icons.res
+++ b/client/src/ui/Icons.res
@@ -7,5 +7,5 @@ let fontAwesome = (~style="", name: string): Html.html<'msg> =>
 let fontAwesomeBrands = (~style="", name: string): Html.html<'msg> =>
   Html.i(list{Attrs.class(`fab fa-${name} font-brands ${style}`)}, list{})
 
-let darkIcon = (name: string): Html.html<'msg> =>
-  Html.i(list{Attrs.class("di di-" ++ name)}, list{})
+let darkIcon = (~style="", name: string): Html.html<'msg> =>
+  Html.i(list{Attrs.class(`di di-${name} ${style}`)}, list{})

--- a/client/test/TestPrettyDocs.res
+++ b/client/test/TestPrettyDocs.res
@@ -64,10 +64,7 @@ let run = () => {
     test("converts normal string", () => expect(convert("Bye")) |> toEqual(list{txt("Bye")}))
     test("converts code blocks", () =>
       expect(convert("{{Ok <var value>}}")) |> toEqual(list{
-        tag(
-          "bg-grey1 py-0 px-1.5",
-          list{txt("Ok "), tag("text-purple1", list{txt("value")})},
-        ),
+        tag("bg-grey1 py-0 px-1.5", list{txt("Ok "), tag("text-purple1", list{txt("value")})}),
       })
     )
     test("converts link tag", () =>
@@ -87,10 +84,7 @@ let run = () => {
         txt(".\n It will got to "),
         link("error rail", "https://docs.darklang.com/tutorials/handle-error-errorrail"),
         txt(", if it is "),
-        tag(
-          "bg-grey1 py-0 px-1.5",
-          list{txt("Error "), tag("text-purple1", list{txt("message")})},
-        ),
+        tag("bg-grey1 py-0 px-1.5", list{txt("Error "), tag("text-purple1", list{txt("message")})}),
       })
     )
     ()

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -509,7 +509,7 @@ test.describe.parallel("Integration Tests", async () => {
 
     await page.waitForSelector(Locators.dbLockLocator, { timeout: 8000 });
 
-    await page.click("#db"); // this click is required due to caching
+    await page.click(".db"); // this click is required due to caching
     await expect(page.locator(".delete-col")).not.toBeVisible();
   });
 
@@ -1141,8 +1141,8 @@ test.describe.parallel("Integration Tests", async () => {
   // and then back to our Handler.
   test("package_function_references_work", async ({ page }, testInfo) => {
     const repl = ".toplevel.tl-92595864";
-    const refersTo = ".ref-block.refers-to#pkg-fn";
-    const usedIn = ".ref-block.used-in#handler";
+    const refersTo = ".ref-block.refers-to.pkg-fn";
+    const usedIn = ".ref-block.used-in.handler";
 
     // Start at this specific repl handler
     await gotoHash(page, testInfo, "handler=92595864");
@@ -1152,7 +1152,7 @@ test.describe.parallel("Integration Tests", async () => {
     await page.waitForSelector(refersTo);
     await expectExactText(
       page,
-      ".ref-block.refers-to #fnheader",
+      ".ref-block.refers-to .fnheader",
       "test_admin/stdlib/Test::one_v1",
     );
 

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -509,7 +509,7 @@ test.describe.parallel("Integration Tests", async () => {
 
     await page.waitForSelector(Locators.dbLockLocator, { timeout: 8000 });
 
-    await page.click(".db"); // this click is required due to caching
+    await page.click(".introspect-db"); // this click is required due to caching
     await expect(page.locator(".delete-col")).not.toBeVisible();
   });
 
@@ -1141,8 +1141,8 @@ test.describe.parallel("Integration Tests", async () => {
   // and then back to our Handler.
   test("package_function_references_work", async ({ page }, testInfo) => {
     const repl = ".toplevel.tl-92595864";
-    const refersTo = ".ref-block.refers-to.pkg-fn";
-    const usedIn = ".ref-block.used-in.handler";
+    const refersTo = ".ref-block.refers-to.introspect-pkg-fn";
+    const usedIn = ".ref-block.used-in.introspect-handler";
 
     // Start at this specific repl handler
     await gotoHash(page, testInfo, "handler=92595864");
@@ -1152,7 +1152,7 @@ test.describe.parallel("Integration Tests", async () => {
     await page.waitForSelector(refersTo);
     await expectExactText(
       page,
-      ".ref-block.refers-to .fnheader",
+      ".ref-block.refers-to .introspect-fnheader",
       "test_admin/stdlib/Test::one_v1",
     );
 

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -509,7 +509,7 @@ test.describe.parallel("Integration Tests", async () => {
 
     await page.waitForSelector(Locators.dbLockLocator, { timeout: 8000 });
 
-    await page.click(".db"); // this click is required due to caching
+    await page.click("#db"); // this click is required due to caching
     await expect(page.locator(".delete-col")).not.toBeVisible();
   });
 
@@ -1141,8 +1141,8 @@ test.describe.parallel("Integration Tests", async () => {
   // and then back to our Handler.
   test("package_function_references_work", async ({ page }, testInfo) => {
     const repl = ".toplevel.tl-92595864";
-    const refersTo = ".ref-block.refers-to.pkg-fn";
-    const usedIn = ".ref-block.used-in.handler";
+    const refersTo = ".ref-block.refers-to#pkg-fn";
+    const usedIn = ".ref-block.used-in#handler";
 
     // Start at this specific repl handler
     await gotoHash(page, testInfo, "handler=92595864");
@@ -1152,7 +1152,7 @@ test.describe.parallel("Integration Tests", async () => {
     await page.waitForSelector(refersTo);
     await expectExactText(
       page,
-      ".ref-block.refers-to .fnheader",
+      ".ref-block.refers-to #fnheader",
       "test_admin/stdlib/Test::one_v1",
     );
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -59,6 +59,10 @@ module.exports = {
       tooltip: "var(--tooltipColor)",
     },
     extend: {
+      content: {
+        arrowRight: '"\\f30b"',
+        arrowLeft: '"\\f30a"',
+      },
       borderWidth: {
         3: "3px",
       },
@@ -92,6 +96,7 @@ module.exports = {
       code: ['"Fira Code"', "mono"],
       text: ['"Source Sans Pro"', "sans-serif"],
       brands: ['"Font Awesome 6 Brands"', "sans-serif"],
+      icons: ['"Font Awesome 5 Free"', "sans-serif"],
     },
   },
   corePlugins: {


### PR DESCRIPTION
Changelog:

```
Internal improvements
- Convert ViewIntrospect to Tailwind CSS.
- Add the function signature to the documentation box.
```

### Function signature

![dark-Dark-Google-Chrome-2023-01 (4)](https://user-images.githubusercontent.com/87861924/213680474-bdb313b8-0c4f-4103-824f-d38ad5373920.gif)

### Convert ViewIntrospect to tailwind
before->after
<img width="2030" alt="Frame 23 (4)" src="https://user-images.githubusercontent.com/87861924/213888431-8270737e-e4cc-44f1-99e4-9017ea5ecf53.png">

typeView
![image](https://user-images.githubusercontent.com/87861924/213527282-1cfede0b-b6eb-4aa1-980a-61de2a12865d.png)


**Questions:** 
- `_introspect.scss` file is not used anymore. Should I delete it?
- Should we remove the return type from the docbox now that we have a signature?