### PR TITLE
Clip the arguments after a certain number of characters -autocomplete

### DIFF
--- a/client/src/fluid/FluidAutocompleteView.res
+++ b/client/src/fluid/FluidAutocompleteView.res
@@ -35,7 +35,7 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
 
       args
       |> List.intersperse(~sep=Html.text(", "))
-      |> (args => Belt.List.concatMany([list{Html.text("(")}, args, list{Html.text(") -> ")}]))
+      |> (args => Belt.List.concatMany([list{Html.text("(")}, list{Html.span(list{Attrs.class(%twc("inline-block align-top overflow-hidden max-w-[25ch] text-ellipsis whitespace-nowrap"))},args)}, list{Html.text(") -> ")}]))
     }
 
     Belt.List.concat(argsHtml, returnTypeHtml)


### PR DESCRIPTION
Changelog:

```
Internal improvements
- Reduce the amount of space within the autocomplete dropdown box.
```

This reduces the autocomplete width by clipping the arguments of the function signature after a certain number of characters.

<img width="1920" alt="Frame 22" src="https://user-images.githubusercontent.com/87861924/212720321-e75baf50-03a8-4ee3-9505-9b15dcaf3cb7.png">

**Followup:**
- [ ] Add the full signature to the documentation box
