### PR TITLE
spike - tuple let patterns

### DIFF
--- a/backend/src/ClientTypes/ClientProgramTypes.fs
+++ b/backend/src/ClientTypes/ClientProgramTypes.fs
@@ -47,7 +47,11 @@ type MatchPattern =
 
 type LetPattern =
   | LPVariable of id * name : string
-  | LPTuple of id * first : string * second : string * theRest : List<string>
+  | LPTuple of
+    id *
+    first : LetPattern *
+    second : LetPattern *
+    theRest : List<LetPattern>
 
 type SendToRail =
   | Rail

--- a/backend/src/ClientTypes/ClientProgramTypes.fs
+++ b/backend/src/ClientTypes/ClientProgramTypes.fs
@@ -45,6 +45,9 @@ type MatchPattern =
   | MPBlank of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
 
+type LetPattern =
+  | LPVariable of id * name : string
+  | LPTuple of id * first : string * second : string * theRest : List<string>
 
 type SendToRail =
   | Rail
@@ -67,6 +70,7 @@ type Expr =
   | ENull of id
   | EBlank of id
   | ELet of id * string * Expr * Expr
+  | ELetWithPattern of id * LetPattern * Expr * Expr
   | EIf of id * Expr * Expr * Expr
   | EInfix of id * Infix * Expr * Expr
   | ELambda of id * List<id * string> * Expr

--- a/backend/src/ClientTypes/ClientRuntimeTypes.fs
+++ b/backend/src/ClientTypes/ClientRuntimeTypes.fs
@@ -65,6 +65,11 @@ type MatchPattern =
   | MPBlank of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
 
+
+type LetPattern =
+  | LPVariable of id * name : string
+  | LPTuple of id * first : string * second : string * theRest : List<string>
+
 module Expr =
   type T =
     | EInteger of id * int64
@@ -75,6 +80,7 @@ module Expr =
     | ENull of id
     | EBlank of id
     | ELet of id * string * T * T
+    | ELetWithPattern of id * LetPattern * T * T
     | EIf of id * T * T * T
     | ELambda of id * List<id * string> * T
     | EFieldAccess of id * T * string

--- a/backend/src/ClientTypes/ClientRuntimeTypes.fs
+++ b/backend/src/ClientTypes/ClientRuntimeTypes.fs
@@ -68,7 +68,7 @@ type MatchPattern =
 
 type LetPattern =
   | LPVariable of id * name : string
-  | LPTuple of id * first : string * second : string * theRest : List<string>
+  | LPTuple of id * first : LetPattern * second : LetPattern * theRest : List<LetPattern>
 
 module Expr =
   type T =

--- a/backend/src/ClientTypes2ExecutionTypes/ProgramTypes.fs
+++ b/backend/src/ClientTypes2ExecutionTypes/ProgramTypes.fs
@@ -101,17 +101,17 @@ module MatchPattern =
       CTPT.MPTuple(id, toCT first, toCT second, List.map toCT theRest)
 
 module LetPattern =
-  let fromCT (p : CTPT.LetPattern) : PT.LetPattern =
+  let rec fromCT (p : CTPT.LetPattern) : PT.LetPattern =
     match p with
     | CTPT.LPVariable (id, str) -> PT.LPVariable(id, str)
     | CTPT.LPTuple (id, first, second, theRest) ->
-      PT.LPTuple(id, first, second, theRest)
+      PT.LPTuple(id, fromCT first, fromCT second, List.map fromCT theRest)
 
-  let toCT (p : PT.LetPattern) : CTPT.LetPattern =
+  let rec toCT (p : PT.LetPattern) : CTPT.LetPattern =
     match p with
     | PT.LPVariable (id, str) -> CTPT.LPVariable(id, str)
     | PT.LPTuple (id, first, second, theRest) ->
-      CTPT.LPTuple(id, first, second, theRest)
+      CTPT.LPTuple(id, toCT first, toCT second, List.map toCT theRest)
 
 module SendToRail =
   let fromCT (str : CTPT.SendToRail) : PT.SendToRail =

--- a/backend/src/ClientTypes2ExecutionTypes/ProgramTypes.fs
+++ b/backend/src/ClientTypes2ExecutionTypes/ProgramTypes.fs
@@ -100,6 +100,18 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       CTPT.MPTuple(id, toCT first, toCT second, List.map toCT theRest)
 
+module LetPattern =
+  let fromCT (p : CTPT.LetPattern) : PT.LetPattern =
+    match p with
+    | CTPT.LPVariable (id, str) -> PT.LPVariable(id, str)
+    | CTPT.LPTuple (id, first, second, theRest) ->
+      PT.LPTuple(id, first, second, theRest)
+
+  let toCT (p : PT.LetPattern) : CTPT.LetPattern =
+    match p with
+    | PT.LPVariable (id, str) -> CTPT.LPVariable(id, str)
+    | PT.LPTuple (id, first, second, theRest) ->
+      CTPT.LPTuple(id, first, second, theRest)
 
 module SendToRail =
   let fromCT (str : CTPT.SendToRail) : PT.SendToRail =
@@ -151,6 +163,8 @@ module Expr =
     | CTPT.Expr.EBlank (id) -> PT.EBlank(id)
     | CTPT.Expr.ELet (id, name, expr, body) ->
       PT.ELet(id, name, fromCT expr, fromCT body)
+    | CTPT.Expr.ELetWithPattern (id, pat, expr, body) ->
+      PT.ELetWithPattern(id, LetPattern.fromCT pat, fromCT expr, fromCT body)
     | CTPT.Expr.EIf (id, cond, ifExpr, thenExpr) ->
       PT.EIf(id, fromCT cond, fromCT ifExpr, fromCT thenExpr)
     | CTPT.EInfix (id, infix, first, second) ->
@@ -201,6 +215,8 @@ module Expr =
     | PT.EBlank (id) -> CTPT.Expr.EBlank(id)
     | PT.ELet (id, name, expr, body) ->
       CTPT.Expr.ELet(id, name, toCT expr, toCT body)
+    | PT.ELetWithPattern (id, pat, expr, body) ->
+      CTPT.Expr.ELetWithPattern(id, LetPattern.toCT pat, toCT expr, toCT body)
     | PT.EIf (id, cond, ifExpr, thenExpr) ->
       CTPT.Expr.EIf(id, toCT cond, toCT ifExpr, toCT thenExpr)
     | PT.EInfix (id, PT.InfixFnCall (name, str), first, second) ->

--- a/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
+++ b/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
@@ -142,15 +142,15 @@ module MatchPattern =
       MPTuple(id, r first, r second, List.map r theRest)
 
 module LetPattern =
-  let fromCT (p : LetPattern) : RT.LetPattern =
+  let rec fromCT (p : LetPattern) : RT.LetPattern =
     match p with
     | LPVariable (id, str) -> RT.LPVariable(id, str)
-    | LPTuple (id, first, second, theRest) -> RT.LPTuple(id, first, second, theRest)
+    | LPTuple (id, first, second, theRest) -> RT.LPTuple(id, fromCT first, fromCT second, List.map fromCT theRest)
 
-  let toCT (p : RT.LetPattern) : LetPattern =
+  let rec toCT (p : RT.LetPattern) : LetPattern =
     match p with
     | RT.LPVariable (id, str) -> LPVariable(id, str)
-    | RT.LPTuple (id, first, second, theRest) -> LPTuple(id, first, second, theRest)
+    | RT.LPTuple (id, first, second, theRest) -> LPTuple(id, toCT first, toCT second, List.map toCT theRest)
 
 module Expr =
   let pipeToRT (pipe : Expr.IsInPipe) : RT.IsInPipe =

--- a/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
+++ b/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
@@ -145,14 +145,12 @@ module LetPattern =
   let fromCT (p : LetPattern) : RT.LetPattern =
     match p with
     | LPVariable (id, str) -> RT.LPVariable(id, str)
-    | LPTuple (id, first, second, theRest) ->
-      RT.LPTuple(id, first, second, theRest)
+    | LPTuple (id, first, second, theRest) -> RT.LPTuple(id, first, second, theRest)
 
   let toCT (p : RT.LetPattern) : LetPattern =
     match p with
     | RT.LPVariable (id, str) -> LPVariable(id, str)
-    | RT.LPTuple (id, first, second, theRest) ->
-      LPTuple(id, first, second, theRest)
+    | RT.LPTuple (id, first, second, theRest) -> LPTuple(id, first, second, theRest)
 
 module Expr =
   let pipeToRT (pipe : Expr.IsInPipe) : RT.IsInPipe =
@@ -191,7 +189,8 @@ module Expr =
     | Expr.EFieldAccess (id, obj, fieldname) -> RT.EFieldAccess(id, r obj, fieldname)
     | Expr.ELambda (id, vars, body) -> RT.ELambda(id, vars, r body)
     | Expr.ELet (id, lhs, rhs, body) -> RT.ELet(id, lhs, r rhs, r body)
-    | Expr.ELetWithPattern (id, pat, rhs, body) -> RT.ELetWithPattern(id, LetPattern.fromCT pat, r rhs, r body)
+    | Expr.ELetWithPattern (id, pat, rhs, body) ->
+      RT.ELetWithPattern(id, LetPattern.fromCT pat, r rhs, r body)
     | Expr.EIf (id, cond, thenExpr, elseExpr) ->
       RT.EIf(id, r cond, r thenExpr, r elseExpr)
     | Expr.EApply (id, expr, exprs, pipe, ster) ->
@@ -231,7 +230,8 @@ module Expr =
     | RT.EFieldAccess (id, obj, fieldname) -> Expr.EFieldAccess(id, r obj, fieldname)
     | RT.ELambda (id, vars, body) -> Expr.ELambda(id, vars, r body)
     | RT.ELet (id, lhs, rhs, body) -> Expr.ELet(id, lhs, r rhs, r body)
-    | RT.ELetWithPattern (id, pat, rhs, body) -> Expr.ELetWithPattern(id, LetPattern.toCT pat, r rhs, r body)
+    | RT.ELetWithPattern (id, pat, rhs, body) ->
+      Expr.ELetWithPattern(id, LetPattern.toCT pat, r rhs, r body)
     | RT.EIf (id, cond, thenExpr, elseExpr) ->
       Expr.EIf(id, r cond, r thenExpr, r elseExpr)
     | RT.EApply (id, expr, exprs, pipe, ster) ->

--- a/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
+++ b/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
@@ -141,6 +141,19 @@ module MatchPattern =
     | RT.MPTuple (id, first, second, theRest) ->
       MPTuple(id, r first, r second, List.map r theRest)
 
+module LetPattern =
+  let fromCT (p : LetPattern) : RT.LetPattern =
+    match p with
+    | LPVariable (id, str) -> RT.LPVariable(id, str)
+    | LPTuple (id, first, second, theRest) ->
+      RT.LPTuple(id, first, second, theRest)
+
+  let toCT (p : RT.LetPattern) : LetPattern =
+    match p with
+    | RT.LPVariable (id, str) -> LPVariable(id, str)
+    | RT.LPTuple (id, first, second, theRest) ->
+      LPTuple(id, first, second, theRest)
+
 module Expr =
   let pipeToRT (pipe : Expr.IsInPipe) : RT.IsInPipe =
     match pipe with
@@ -178,6 +191,7 @@ module Expr =
     | Expr.EFieldAccess (id, obj, fieldname) -> RT.EFieldAccess(id, r obj, fieldname)
     | Expr.ELambda (id, vars, body) -> RT.ELambda(id, vars, r body)
     | Expr.ELet (id, lhs, rhs, body) -> RT.ELet(id, lhs, r rhs, r body)
+    | Expr.ELetWithPattern (id, pat, rhs, body) -> RT.ELetWithPattern(id, LetPattern.fromCT pat, r rhs, r body)
     | Expr.EIf (id, cond, thenExpr, elseExpr) ->
       RT.EIf(id, r cond, r thenExpr, r elseExpr)
     | Expr.EApply (id, expr, exprs, pipe, ster) ->
@@ -217,6 +231,7 @@ module Expr =
     | RT.EFieldAccess (id, obj, fieldname) -> Expr.EFieldAccess(id, r obj, fieldname)
     | RT.ELambda (id, vars, body) -> Expr.ELambda(id, vars, r body)
     | RT.ELet (id, lhs, rhs, body) -> Expr.ELet(id, lhs, r rhs, r body)
+    | RT.ELetWithPattern (id, pat, rhs, body) -> Expr.ELetWithPattern(id, LetPattern.toCT pat, r rhs, r body)
     | RT.EIf (id, cond, thenExpr, elseExpr) ->
       Expr.EIf(id, r cond, r thenExpr, r elseExpr)
     | RT.EApply (id, expr, exprs, pipe, ster) ->

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -408,6 +408,12 @@ let partiallyEvaluate
               let! rhs = r rhs
               let! next = r next
               return ELet(id, name, rhs, next)
+            | ELetWithPattern (id, pat, rhs, next) ->
+              // todo: do I need to do anything with the pattern?
+              // (check matchPatterns)
+              let! rhs = r rhs
+              let! next = r next
+              return ELetWithPattern(id, pat, rhs, next)
             | EApply (id, name, exprs, inPipe, ster) ->
               let! exprs = Ply.List.mapSequentially r exprs
               return EApply(id, name, exprs, inPipe, ster)

--- a/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -90,7 +90,8 @@ module Expr =
       ST.EInfix(id, ST.BinOp(BinaryOperation.toST (op)), toST arg1, toST arg2)
     | PT.ELambda (id, vars, body) -> ST.ELambda(id, vars, toST body)
     | PT.ELet (id, lhs, rhs, body) -> ST.ELet(id, lhs, toST rhs, toST body)
-    | PT.ELetWithPattern(id, pat, rhs, body) -> ST.ELetWithPattern(id, LetPattern.toST pat, toST rhs, toST body)
+    | PT.ELetWithPattern (id, pat, rhs, body) ->
+      ST.ELetWithPattern(id, LetPattern.toST pat, toST rhs, toST body)
     | PT.EIf (id, cond, thenExpr, elseExpr) ->
       ST.EIf(id, toST cond, toST thenExpr, toST elseExpr)
     | PT.EPartial (id, str, expr) -> ST.EPartial(id, str, toST expr)

--- a/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -58,11 +58,11 @@ module MatchPattern =
       ST.MPTuple(id, toST first, toST second, List.map toST theRest)
 
 module LetPattern =
-  let toST (p : PT.LetPattern) : ST.LetPattern =
+  let rec toST (p : PT.LetPattern) : ST.LetPattern =
     match p with
     | PT.LPVariable (id, str) -> ST.LPVariable(id, str)
     | PT.LPTuple (id, first, second, theRest) ->
-      ST.LPTuple(id, first, second, theRest)
+      ST.LPTuple(id, toST first, toST second, List.map toST theRest)
 
 
 module Expr =

--- a/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -57,6 +57,12 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       ST.MPTuple(id, toST first, toST second, List.map toST theRest)
 
+module LetPattern =
+  let toST (p : PT.LetPattern) : ST.LetPattern =
+    match p with
+    | PT.LPVariable (id, str) -> ST.LPVariable(id, str)
+    | PT.LPTuple (id, first, second, theRest) ->
+      ST.LPTuple(id, first, second, theRest)
 
 
 module Expr =
@@ -84,6 +90,7 @@ module Expr =
       ST.EInfix(id, ST.BinOp(BinaryOperation.toST (op)), toST arg1, toST arg2)
     | PT.ELambda (id, vars, body) -> ST.ELambda(id, vars, toST body)
     | PT.ELet (id, lhs, rhs, body) -> ST.ELet(id, lhs, toST rhs, toST body)
+    | PT.ELetWithPattern(id, pat, rhs, body) -> ST.ELetWithPattern(id, LetPattern.toST pat, toST rhs, toST body)
     | PT.EIf (id, cond, thenExpr, elseExpr) ->
       ST.EIf(id, toST cond, toST thenExpr, toST elseExpr)
     | PT.EPartial (id, str, expr) -> ST.EPartial(id, str, toST expr)

--- a/backend/src/LibBinarySerialization/SerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypes.fs
@@ -112,6 +112,11 @@ type MatchPattern =
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
 
 [<MessagePack.MessagePackObject>]
+type LetPattern =
+  | LPVariable of id * name : string
+  | LPTuple of id * first : string * second : string * theRest : List<string>
+
+[<MessagePack.MessagePackObject>]
 type SendToRail =
   | Rail
   | NoRail
@@ -135,6 +140,8 @@ type Expr =
   | EFloat of id * Sign * string * string
   | ENull of id
   | EBlank of id
+  // todo: rename to LetWithoutPattern *and* rename the other LetWithPattern to just Let
+  // todo: deprecate in favor of the new Let
   | ELet of id * string * Expr * Expr
   | EIf of id * Expr * Expr * Expr
   | EDeprecatedBinOp of id * FQFnName.T * Expr * Expr * SendToRail
@@ -154,6 +161,7 @@ type Expr =
   | EFeatureFlag of id * string * Expr * Expr * Expr
   | ETuple of id * Expr * Expr * List<Expr>
   | EInfix of id * Infix * Expr * Expr
+  | ELetWithPattern of id * LetPattern * Expr * Expr
 
 [<MessagePack.MessagePackObject>]
 type DType =

--- a/backend/src/LibBinarySerialization/SerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypes.fs
@@ -114,7 +114,11 @@ type MatchPattern =
 [<MessagePack.MessagePackObject>]
 type LetPattern =
   | LPVariable of id * name : string
-  | LPTuple of id * first : string * second : string * theRest : List<string>
+  | LPTuple of
+    id *
+    first : LetPattern *
+    second : LetPattern *
+    theRest : List<LetPattern>
 
 [<MessagePack.MessagePackObject>]
 type SendToRail =

--- a/backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
@@ -81,6 +81,12 @@ module MatchPattern =
     | ST.MPTuple (id, first, second, theRest) ->
       PT.MPTuple(id, toPT first, toPT second, List.map toPT theRest)
 
+module LetPattern =
+  let toPT (p : ST.LetPattern) : PT.LetPattern =
+    match p with
+    | ST.LPVariable (id, str) -> PT.LPVariable(id, str)
+    | ST.LPTuple (id, first, second, theRest) ->
+      PT.LPTuple(id, first, second, theRest)
 
 
 module Expr =
@@ -124,6 +130,7 @@ module Expr =
       Exception.raiseInternal "package serialized as a binop" [ "name", name ]
     | ST.ELambda (id, vars, body) -> PT.ELambda(id, vars, toPT body)
     | ST.ELet (id, lhs, rhs, body) -> PT.ELet(id, lhs, toPT rhs, toPT body)
+    | ST.ELetWithPattern(id, pat, rhs, body) -> PT.ELetWithPattern(id, LetPattern.toPT pat, toPT rhs, toPT body)
     | ST.EIf (id, cond, thenExpr, elseExpr) ->
       PT.EIf(id, toPT cond, toPT thenExpr, toPT elseExpr)
     | ST.EPartial (id, str, expr) -> PT.EPartial(id, str, toPT expr)

--- a/backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
@@ -130,7 +130,8 @@ module Expr =
       Exception.raiseInternal "package serialized as a binop" [ "name", name ]
     | ST.ELambda (id, vars, body) -> PT.ELambda(id, vars, toPT body)
     | ST.ELet (id, lhs, rhs, body) -> PT.ELet(id, lhs, toPT rhs, toPT body)
-    | ST.ELetWithPattern(id, pat, rhs, body) -> PT.ELetWithPattern(id, LetPattern.toPT pat, toPT rhs, toPT body)
+    | ST.ELetWithPattern (id, pat, rhs, body) ->
+      PT.ELetWithPattern(id, LetPattern.toPT pat, toPT rhs, toPT body)
     | ST.EIf (id, cond, thenExpr, elseExpr) ->
       PT.EIf(id, toPT cond, toPT thenExpr, toPT elseExpr)
     | ST.EPartial (id, str, expr) -> PT.EPartial(id, str, toPT expr)

--- a/backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypesToProgramTypes.fs
@@ -82,11 +82,11 @@ module MatchPattern =
       PT.MPTuple(id, toPT first, toPT second, List.map toPT theRest)
 
 module LetPattern =
-  let toPT (p : ST.LetPattern) : PT.LetPattern =
+  let rec toPT (p : ST.LetPattern) : PT.LetPattern =
     match p with
     | ST.LPVariable (id, str) -> PT.LPVariable(id, str)
     | ST.LPTuple (id, first, second, theRest) ->
-      PT.LPTuple(id, first, second, theRest)
+      PT.LPTuple(id, toPT first, toPT second, List.map toPT theRest)
 
 
 module Expr =

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -51,7 +51,11 @@ type MatchPattern =
 
 type LetPattern =
   | LPVariable of id * name : string
-  | LPTuple of id * first : string * second : string * theRest : List<string>
+  | LPTuple of
+    id *
+    first : LetPattern *
+    second : LetPattern *
+    theRest : List<LetPattern>
 
 /// Whether a function's result is unwrapped automatically (and, in the case of
 /// Error/Nothing, sent to the error rail). NoRail functions are not unwrapped.

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -49,6 +49,10 @@ type MatchPattern =
   | MPBlank of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
 
+type LetPattern =
+  | LPVariable of id * name : string
+  | LPTuple of id * first : string * second : string * theRest : List<string>
+
 /// Whether a function's result is unwrapped automatically (and, in the case of
 /// Error/Nothing, sent to the error rail). NoRail functions are not unwrapped.
 type SendToRail =
@@ -78,6 +82,7 @@ type Expr =
   | ENull of id
   | EBlank of id
   | ELet of id * string * Expr * Expr
+  | ELetWithPattern of id * LetPattern * Expr * Expr
   | EIf of id * Expr * Expr * Expr
   | EInfix of id * Infix * Expr * Expr
   // the id in the varname list is the analysis id, used to get a livevalue

--- a/backend/src/LibExecution/ProgramTypesAst.fs
+++ b/backend/src/LibExecution/ProgramTypesAst.fs
@@ -7,6 +7,7 @@ open Prelude
 open ProgramTypes
 
 // Traverse is really only meant to be used by preTraversal and postTraversal
+// TODO: should this also traverse MatchPatterns and LetPatterns (within `EMatch` and `ELetWithPattern`)?)
 let traverse (f : Expr -> Expr) (expr : Expr) : Expr =
   match expr with
   | EInteger _
@@ -19,6 +20,7 @@ let traverse (f : Expr -> Expr) (expr : Expr) : Expr =
   | EPipeTarget _
   | EFloat _ -> expr
   | ELet (id, name, rhs, next) -> ELet(id, name, f rhs, f next)
+  | ELetWithPattern (id, pat, rhs, next) -> ELetWithPattern(id, pat, f rhs, f next)
   | EIf (id, cond, ifexpr, elseexpr) -> EIf(id, f cond, f ifexpr, f elseexpr)
   | EFieldAccess (id, expr, fieldname) -> EFieldAccess(id, f expr, fieldname)
   | EInfix (id, op, left, right) -> EInfix(id, op, f left, f right)

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -54,11 +54,11 @@ module MatchPattern =
 
 
 module LetPattern =
-  let toRT (p : PT.LetPattern) : RT.LetPattern =
+  let rec toRT (p : PT.LetPattern) : RT.LetPattern =
     match p with
     | PT.LPVariable (id, str) -> RT.LPVariable(id, str)
     | PT.LPTuple (id, first, second, theRest) ->
-      RT.LPTuple(id, first, second, theRest)
+      RT.LPTuple(id, toRT first, toRT second, List.map toRT theRest)
 
 
 

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -53,6 +53,14 @@ module MatchPattern =
       RT.MPTuple(id, toRT first, toRT second, List.map toRT theRest)
 
 
+module LetPattern =
+  let toRT (p : PT.LetPattern) : RT.LetPattern =
+    match p with
+    | PT.LPVariable (id, str) -> RT.LPVariable(id, str)
+    | PT.LPTuple (id, first, second, theRest) ->
+      RT.LPTuple(id, first, second, theRest)
+
+
 
 module Expr =
   let rec toRT (e : PT.Expr) : RT.Expr =
@@ -92,6 +100,7 @@ module Expr =
       RT.EOr(id, toRT expr1, toRT expr2)
     | PT.ELambda (id, vars, body) -> RT.ELambda(id, vars, toRT body)
     | PT.ELet (id, lhs, rhs, body) -> RT.ELet(id, lhs, toRT rhs, toRT body)
+    | PT.ELetWithPattern (id, pattern, rhs, body) -> RT.ELetWithPattern(id, LetPattern.toRT pattern, toRT rhs, toRT body)
     | PT.EIf (id, cond, thenExpr, elseExpr) ->
       RT.EIf(id, toRT cond, toRT thenExpr, toRT elseExpr)
     | PT.EPartial (_, _, oldExpr)

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -100,7 +100,8 @@ module Expr =
       RT.EOr(id, toRT expr1, toRT expr2)
     | PT.ELambda (id, vars, body) -> RT.ELambda(id, vars, toRT body)
     | PT.ELet (id, lhs, rhs, body) -> RT.ELet(id, lhs, toRT rhs, toRT body)
-    | PT.ELetWithPattern (id, pattern, rhs, body) -> RT.ELetWithPattern(id, LetPattern.toRT pattern, toRT rhs, toRT body)
+    | PT.ELetWithPattern (id, pattern, rhs, body) ->
+      RT.ELetWithPattern(id, LetPattern.toRT pattern, toRT rhs, toRT body)
     | PT.EIf (id, cond, thenExpr, elseExpr) ->
       RT.EIf(id, toRT cond, toRT thenExpr, toRT elseExpr)
     | PT.EPartial (_, _, oldExpr)

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -458,7 +458,9 @@ module MatchPattern =
     | MPVariable (id, _)
     | MPBlank id
     | MPTuple (id, _, _, _)
-    | MPConstructor (id, _, _) -> id/// Functions for working with Dark match patterns
+    | MPConstructor (id, _, _) -> id
+
+/// Functions for working with Dark match patterns
 
 module LetPattern =
   let toID (pat : LetPattern) : id =

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -151,6 +151,21 @@ type Expr =
   /// </code>
   | ELet of id * string * Expr * Expr
 
+  /// <summary>
+  /// Composed of binding pattern, the bound expression,
+  /// and the expression that follows, where the bound value is available
+  /// </summary>
+  ///
+  /// <code>
+  /// let str = expr1
+  /// expr2
+  /// </code>
+  /// <code>
+  /// let (a, b) = expr1
+  /// expr2
+  /// </code>
+  | ELetWithPattern of id * LetPattern * Expr * Expr
+
   /// Composed of condition, expr if true, and expr if false
   | EIf of id * Expr * Expr * Expr
 
@@ -209,6 +224,10 @@ and MatchPattern =
   | MPNull of id
   | MPBlank of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
+
+and LetPattern =
+  | LPVariable of id * name : string
+  | LPTuple of id * first : string * second : string * theRest : List<string>
 
 type DvalMap = Map<string, Dval>
 
@@ -413,6 +432,7 @@ module Expr =
     | ELambda (id, _, _)
     | EBlank id
     | ELet (id, _, _, _)
+    | ELetWithPattern (id, _, _, _)
     | EIf (id, _, _, _)
     | EApply (id, _, _, _, _)
     | EList (id, _)
@@ -438,7 +458,13 @@ module MatchPattern =
     | MPVariable (id, _)
     | MPBlank id
     | MPTuple (id, _, _, _)
-    | MPConstructor (id, _, _) -> id
+    | MPConstructor (id, _, _) -> id/// Functions for working with Dark match patterns
+
+module LetPattern =
+  let toID (pat : LetPattern) : id =
+    match pat with
+    | LPVariable (id, _)
+    | LPTuple (id, _, _, _) -> id
 
 /// Functions for working with Dark runtime values
 module Dval =

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -227,7 +227,11 @@ and MatchPattern =
 
 and LetPattern =
   | LPVariable of id * name : string
-  | LPTuple of id * first : string * second : string * theRest : List<string>
+  | LPTuple of
+    id *
+    first : LetPattern *
+    second : LetPattern *
+    theRest : List<LetPattern>
 
 type DvalMap = Map<string, Dval>
 

--- a/backend/src/LibExecution/RuntimeTypesAst.fs
+++ b/backend/src/LibExecution/RuntimeTypesAst.fs
@@ -8,6 +8,7 @@ open Prelude
 open VendoredTablecloth
 open RuntimeTypes
 
+// TODO: should this also traverse MatchPatterns (in `EMatch`) and LetPatterns (in `ELetWithPattern`)?
 let rec preTraversal (f : Expr -> Expr) (expr : Expr) : Expr =
   let r = preTraversal f
   let expr = f expr
@@ -23,6 +24,7 @@ let rec preTraversal (f : Expr -> Expr) (expr : Expr) : Expr =
   | EFQFnValue _
   | EFloat _ -> expr
   | ELet (id, name, rhs, next) -> ELet(id, name, r rhs, r next)
+  | ELetWithPattern (id, pat, rhs, next) -> ELetWithPattern(id, pat, r rhs, r next)
   | EIf (id, cond, ifexpr, elseexpr) -> EIf(id, r cond, r ifexpr, r elseexpr)
   | EFieldAccess (id, expr, fieldname) -> EFieldAccess(id, r expr, fieldname)
   | EApply (id, name, exprs, inPipe, ster) ->
@@ -41,6 +43,8 @@ let rec preTraversal (f : Expr -> Expr) (expr : Expr) : Expr =
   | EAnd (id, left, right) -> EAnd(id, r left, r right)
   | EOr (id, left, right) -> EOr(id, r left, r right)
 
+
+// TODO: should this also traverse MatchPatterns (in `EMatch`) and LetPatterns (in `ELetWithPattern`)?
 let rec postTraversal (f : Expr -> Expr) (expr : Expr) : Expr =
   let r = postTraversal f
 
@@ -56,6 +60,7 @@ let rec postTraversal (f : Expr -> Expr) (expr : Expr) : Expr =
     | ENull _
     | EFloat _ -> expr
     | ELet (id, name, rhs, next) -> ELet(id, name, r rhs, r next)
+    | ELetWithPattern (id, pat, rhs, next) -> ELetWithPattern(id, pat, r rhs, r next)
     | EApply (id, name, exprs, inPipe, ster) ->
       EApply(id, name, List.map r exprs, inPipe, ster)
     | EIf (id, cond, ifexpr, elseexpr) -> EIf(id, r cond, r ifexpr, r elseexpr)

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -10,9 +10,11 @@
 (let x = 5 in let x = 6 in x) = 6
 
 [tests.let with pattern]
+(let (a, b) = (1, 2) in 2) = 2
+(let (a, b) = (1, 2) in b) = 2
+(let (a, b) = (1, 2) in (b, a)) = (2, 1)
+(let (d, d) = (2, 1) in d) = 1
 (let (_, _) = (1, 2) in 2) = 2
-//(let (a, b) = (1, 2) in b) = 2
-//(let (d, d) = (2, 1) in d) = 1
 
 
 [tests.list]

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -9,6 +9,11 @@
 (let x = 5 in x) = 5
 (let x = 5 in let x = 6 in x) = 6
 
+[tests.let with pattern]
+(let (_, _) = (1, 2) in 2) = 2
+//(let (a, b) = (1, 2) in b) = 2
+//(let (d, d) = (2, 1) in d) = 1
+
 
 [tests.list]
 [] = []

--- a/backend/tests/FuzzTests/ExecutionRegression.FuzzTests.fs
+++ b/backend/tests/FuzzTests/ExecutionRegression.FuzzTests.fs
@@ -98,6 +98,7 @@ let rec patternFromExpr (expr : RT.Expr) : Gen<RT.MatchPattern> =
 
   // TODO: we could populate a Symtable to use with EVariable and EFieldAccess
   // usages in the RHS expr
+  | RT.ELetWithPattern _
   | RT.ELet _ ->
     Gen.frequency [ (1, G.RuntimeTypes.MatchPattern.genVar)
                     (1, G.RuntimeTypes.matchPattern) ]

--- a/backend/tests/FuzzTests/Generators.fs
+++ b/backend/tests/FuzzTests/Generators.fs
@@ -199,7 +199,13 @@ module RuntimeTypes =
     // more often than others
     let rec gen' s : Gen<RT.MatchPattern> =
       let finitePatterns =
-        [ MP.genInt; MP.genBool; MP.genBlank; MP.genNull; MP.genChar; MP.genStr; MP.genVar ]
+        [ MP.genInt
+          MP.genBool
+          MP.genBlank
+          MP.genNull
+          MP.genChar
+          MP.genStr
+          MP.genVar ]
 
       let allPatterns = MP.constructor (s, gen') :: finitePatterns
 

--- a/backend/tests/TestUtils/FSharpToExpr.fs
+++ b/backend/tests/TestUtils/FSharpToExpr.fs
@@ -297,13 +297,14 @@ let rec convertToExpr' (ast : SynExpr) : PT.Expr =
 
   // When we add patterns on the left hand side of lets, the pattern below
   // could be expanded to use convertPat
+  // TODO: this doesn't allow nesting (i.e. `let (a, (b, c)) = (1, (2, 3))`. Should it?)
   | SynExpr.LetOrUse (_,
                       _,
                       [ SynBinding (_, _, _, _, _, _, _, pat, _, rhs, _, _, _) ],
                       body,
                       _,
                       _) ->
-    let letErr () =
+    let letErr pat =
       Exception.raiseInternal
         "Unsupported let or use expr pat type"
         [ "ast", ast; "pat", pat ]
@@ -311,12 +312,29 @@ let rec convertToExpr' (ast : SynExpr) : PT.Expr =
     // TODO this is used as an ineloquent type check
     let nameFromPat (pat : SynPat) : string =
       match pat with
+      | SynPat.Wild (_) -> "_"
       | SynPat.Named (name, _, _, _) -> name.idText
-      | _ -> letErr ()
+      | _ -> letErr pat
 
     let rec handlePat (pat : SynPat) =
       match pat with
-      | SynPat.Named (name, _, _, _) -> PT.ELet(id, name.idText, c rhs, c body)
+      | SynPat.Paren (subPat, _) -> handlePat subPat
+
+      | SynPat.Wild (_) ->
+        // TODO: migrate to this
+        //PT.ELetWithPattern(id, PT.LetPattern.LPVariable(gid (), "_"), c rhs, c body)
+        PT.ELet(id, "_", c rhs, c body)
+
+      | SynPat.Named (name, _, _, _) ->
+        // TODO: migrate to this
+        //PT.ELetWithPattern(
+        //  id,
+        //  PT.LetPattern.LPVariable(gid (), name.idText),
+        //  c rhs,
+        //  c body
+        //)
+        PT.ELet(id, name.idText, c rhs, c body)
+
       | SynPat.Tuple (_, (first :: second :: theRest), _) ->
         let letPattern =
           PT.LetPattern.LPTuple(
@@ -326,8 +344,8 @@ let rec convertToExpr' (ast : SynExpr) : PT.Expr =
             List.map nameFromPat theRest
           )
         PT.ELetWithPattern(id, letPattern, c rhs, c body)
-      | SynPat.Wild (_) -> PT.ELet(id, "_", c rhs, c body)
-      | _ -> letErr()
+
+      | _ -> letErr pat
 
     handlePat pat
 

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -568,8 +568,7 @@ module Expect =
     let check path (a : 'a) (e : 'a) =
       if a <> e then errorFn path (string actual) (string expected)
 
-    if checkIDs then
-      check path (LetPattern.toID actual) (LetPattern.toID expected)
+    if checkIDs then check path (LetPattern.toID actual) (LetPattern.toID expected)
 
     match actual, expected with
     | LPVariable (_, name), LPVariable (_, name') -> check path name name'

--- a/client/src/fluid/AST.res
+++ b/client/src/fluid/AST.res
@@ -45,7 +45,9 @@ let rec uses = (var: string, expr: E.t): list<E.t> => {
       } else {
         list{}
       }
-    | ELet(_, _, rhs, body) => List.flatten(list{u(rhs), u(body)})
+    | ELet(_, _, rhs, body)
+    | ELetWithPattern(_, _, rhs, body) =>
+      List.flatten(list{u(rhs), u(body)})
     | EIf(_, cond, ifbody, elsebody) => List.flatten(list{u(cond), u(ifbody), u(elsebody)})
     | EFnCall(_, _, exprs, _) => exprs |> List.map(~f=u) |> List.flatten
     | EInfix(_, _, lhs, rhs) => Belt.List.concat(u(lhs), u(rhs))
@@ -233,6 +235,11 @@ let rec sym_exec = (~trace: (E.t, sym_set) => unit, st: sym_set, expr: E.t): uni
       }
 
       sexe(bound, body)
+    | ELetWithPattern(_id, _pat, rhs, _body) =>
+      // TODO: learn what this fn does
+      // TODO: expand; do whatever I should
+      sexe(st, rhs)
+
     | EFnCall(_, _, exprs, _) => List.forEach(~f=sexe(st), exprs)
     | EInfix(_, _, lhs, rhs) => List.forEach(~f=sexe(st), list{lhs, rhs})
     | EIf(_, cond, ifbody, elsebody)

--- a/client/src/fluid/CaretTarget.res
+++ b/client/src/fluid/CaretTarget.res
@@ -147,7 +147,7 @@ let rec forEndOfExpr': fluidExpr => t = expr =>
     }
   | ENull(id) => {astRef: ARNull(id), offset: String.length("null")}
   | EBlank(id) => {astRef: ARBlank(id), offset: 0}
-  | ELet(_, _, _, bodyExpr) => forEndOfExpr'(bodyExpr)
+  | ELet(_, _, _, bodyExpr) | ELetWithPattern(_, _, _, bodyExpr) => forEndOfExpr'(bodyExpr)
   | EIf(_, _, _, elseExpr) => forEndOfExpr'(elseExpr)
   | EInfix(_, _, _, rhsExpr) => forEndOfExpr'(rhsExpr)
   | ELambda(_, _, bodyExpr) => forEndOfExpr'(bodyExpr)
@@ -252,6 +252,8 @@ let rec forStartOfExpr': fluidExpr => t = expr =>
   | ENull(id) => {astRef: ARNull(id), offset: 0}
   | EBlank(id) => {astRef: ARBlank(id), offset: 0}
   | ELet(id, _, _, _) => {astRef: ARLet(id, LPKeyword), offset: 0}
+  // TODO consider using a new construct for ARLet - I don't think this will turn out well as-is.
+  | ELetWithPattern(id, _, _, _) => {astRef: ARLet(id, LPKeyword), offset: 0}
   | EIf(id, _, _, _) => {astRef: ARIf(id, IPIfKeyword), offset: 0}
   | EMatch(id, _, _) => {astRef: ARMatch(id, MPKeyword), offset: 0}
   | EInfix(_, _, lhsExpr, _) => forStartOfExpr'(lhsExpr)

--- a/client/src/fluid/Fluid.res
+++ b/client/src/fluid/Fluid.res
@@ -1748,6 +1748,7 @@ let rec findAppropriateParentToWrap = (oldExpr: FluidExpression.t, ast: FluidAST
       recover("these cant be parents", ~debug=parent, None)
     // If the parent is some sort of "resetting", then we probably meant the child
     | ELet(_)
+    | ELetWithPattern(_)
     | EIf(_)
     | EMatch(_)
     | ERecord(_)
@@ -5378,7 +5379,8 @@ let reconstructExprFromRange = (astInfo: ASTInfo.t, (startPos, endPos): (int, in
         }
       | EBlank(_) => Some(EBlank(id))
       // empty let expr and subsets
-      | ELet(eID, _lhs, rhs, nextExpr) =>
+      | ELet(eID, _, rhs, nextExpr)
+      | ELetWithPattern(eID, _, rhs, nextExpr) =>
         let letKeywordSelected = findTokenValue(tokens, eID, "let-keyword") != None
         let newLhs = findTokenValue(tokens, eID, "let-var-name") |> Option.unwrap(~default="")
 

--- a/client/src/fluid/FluidLetPattern.res
+++ b/client/src/fluid/FluidLetPattern.res
@@ -1,0 +1,73 @@
+open Tc
+
+type t = ProgramTypes.LetPattern.t
+type id = ID.t
+
+let gid = Prelude.gid
+
+let toID = (p: t): id =>
+  switch p {
+  | LPVariable(id, _)
+  | LPTuple(id, _, _, _) => id
+  }
+
+let ids = (p: t): list<id> =>
+  list{toID(p)}
+
+let clone = (p: t): t =>
+  switch p {
+  | LPVariable(_, name) => LPVariable(gid(), name)
+  | LPTuple(_, first, second, theRest) =>
+    LPTuple(gid(), first, second, List.map(~f=p => p, theRest))
+  }
+
+let variableNames = (p: t): list<string> =>
+  switch p {
+  | LPVariable(_, name) => list{name}
+  | LPTuple(_, first, second, theRest) =>
+    list{first, second, ...theRest}
+  }
+
+let hasVariableNamed = (varName: string, p: t): bool =>
+  List.member(~value=varName, variableNames(p))
+
+let isBlank = (pat: t) =>
+  switch pat {
+  | _ => false
+  }
+
+let findLetPattern = (patID: id, within: t): option<t> =>
+  switch within {
+  | LPVariable(pid, _) =>
+    if patID == pid {
+      Some(within)
+    } else {
+      None
+    }
+  | LPTuple(pid, _first, _second, _theRest) =>
+    if patID == pid {
+      Some(within)
+    } else {
+      None
+    }
+  }
+
+let preTraversal = (~f: t => t, mp: t): t => {
+  let mp = f(mp)
+  switch mp {
+  | LPVariable(_) => mp
+  | LPTuple(patternID, first, second, theRest) =>
+    LPTuple(patternID, first, second, List.map(theRest, ~f=p => p))
+  }
+}
+
+let postTraversal = (~f: t => t, mp: t): t => {
+  let result = switch mp {
+  | LPVariable(_) => mp
+  | LPTuple(patternID, first, second, theRest) =>
+    LPTuple(patternID, first, second, List.map(theRest, ~f=p => p))
+  }
+
+  f(result)
+}
+

--- a/client/src/fluid/FluidLetPattern.resi
+++ b/client/src/fluid/FluidLetPattern.resi
@@ -1,0 +1,33 @@
+type t = ProgramTypes.LetPattern.t
+
+let toID: t => ID.t
+
+/* Returns the ids of all the patterns in this pattern. Includes this pattern's
+ * ID, does not include the matchID */
+let ids: t => list<ID.t>
+
+let clone: t => t
+
+let variableNames: t => list<string>
+
+let hasVariableNamed: (string, t) => bool
+
+@ocaml.doc(" [findLetPattern patID within] returns Some pattern
+  with ID.t = [patID] in the [within] tree, or None. ")
+let findLetPattern: (ID.t, t) => option<t>
+
+@ocaml.doc(" [isPatternBlank e] returns true iff [e] is an PBlank. ")
+let isBlank: t => bool
+
+@ocaml.doc(" [preTraversal f pattern] walks the entire pattern from top to bottom,
+  * calling f on each pattern. It returns a new patterm with every subpattern p
+  * replaced by [f p]. After calling [f], the result is then recursed into; if
+  * this isn't what you want call postTraversal. ")
+let preTraversal: (~f: t => t, t) => t
+
+@ocaml.doc(" [postTraversal f pattern] walks the entire pattern from bottom to top,
+  * calling f on each pattern. It returns a new pattern with every subpattern p
+  * replaced by [f p]. After calling [f], the result is NOT recursed into; if
+  * this isn't what you want call preTraversal. ")
+let postTraversal: (~f: t => t, t) => t
+

--- a/client/src/fluid/FluidPrinter.res
+++ b/client/src/fluid/FluidPrinter.res
@@ -126,6 +126,18 @@ let rec eToTestcase = (e: E.t): string => {
     spaced(list{"constructor", quoted(name), listed(List.map(exprs, ~f=r))})
   | EIf(_, cond, thenExpr, elseExpr) => spaced(list{"if'", r(cond), r(thenExpr), r(elseExpr)})
   | ELet(_, lhs, rhs, body) => spaced(list{"let'", quoted(lhs), r(rhs), r(body)})
+  | ELetWithPattern(_, pat, rhs, body) =>
+    let lpToTestcase = (mp: FluidLetPattern.t): string => {
+      let quoted = str => "\"" ++ (str ++ "\"")
+      let spaced = elems => String.join(~sep=" ", elems)
+      switch mp {
+      | LPVariable(_, name) => spaced(list{"lpVar", quoted(name)})
+      | LPTuple(_, first, second, theRest) =>
+        let exprs = list{first, second, ...theRest}
+        spaced(list{"lpTuple", "(" ++ (String.join(~sep=",", exprs) ++ ")")})
+      }
+    }
+    spaced(list{"let'", quoted(lpToTestcase(pat)), r(rhs), r(body)})
   | ELambda(_, names, body) =>
     let names = List.map(names, ~f=((_, name)) => quoted(name)) |> listed
 

--- a/client/src/fluid/FluidTokenizer.res
+++ b/client/src/fluid/FluidTokenizer.res
@@ -397,6 +397,22 @@ let rec exprToTokens = (~parentID=None, e: E.t, b: Builder.t): Builder.t => {
     |> addNested(~f=r(rhs))
     |> addNewlineIfNeeded(Some(E.toID(next), id, None))
     |> addNested(~f=r(next))
+  | ELetWithPattern(id, _pat, rhs, next) =>
+    let rhsID = switch rhs {
+    | ERightPartial(_, _, oldExpr)
+    | ELeftPartial(_, _, oldExpr)
+    | EPartial(_, _, oldExpr) =>
+      E.toID(oldExpr)
+    | _ => E.toID(rhs)
+    }
+    b
+    |> add(TLetKeyword(id, rhsID, parentID))
+    // TODO:
+    //|> add(TLetVarName(id, rhsID, pat, parentID))
+    |> add(TLetAssignment(id, rhsID, parentID))
+    |> addNested(~f=r(rhs))
+    |> addNewlineIfNeeded(Some(E.toID(next), id, None))
+    |> addNested(~f=r(next))
   | ECharacter(id, _) =>
     recover("tokenizing echaracter is not supported", b |> add(TBlank(id, id, parentID)))
   | EString(id, str) =>


### PR DESCRIPTION
Changelog:

```
Language and Standard Library: 
- add tuple let patterns

Editor:
- (hidden) add tuple let patterns
```
---

Progress:
- [x] most `backend` work for a basic model: 
 ```fsharp
type LetPattern =
  | LPVariable of id * name : string
  | LPTuple of id * first : string * second : string * theRest : List<string>

type Expr = 
  | ...
  | ELet of id * string * Expr * Expr
  | ELetWithPattern of id * LetPattern * Expr * Expr
 ```
  - [x] `SerializedTypes`, `ProgramTypes`, `RuntimeTypes`, `ClientTypes`, all the mappings
  - [x] interpreter implementation
  - [x] parsing `let (a, b) = (1, 2)` from `.test` files (`FsharpToExpr`)
  - [x] basic impl for future `FuzzTests`
- [x] basic modeling in `client` side of things
- [ ] (WIP) improving upon the `backend` model, making it recursive
  from
  ```fsharp
  type LetPattern =
    | LPVariable of id * name : string
    | LPTuple of id * first : string * second : string * theRest : List<string>
  ```
  to
  ```fsharp
  type LetPattern =
    | LPVariable of id * name : string
    | LPTuple of id * first : LetPattern * second : LetPattern * theRest : List<LetPattern>
  ```
  As far as a "spike" goes maybe it would have been best to focus on a basic Fluid impl. next, but the model feels solid and I suspect it'd be very annoying to re-do all of the fluid work if we update the model to be recursive after an initial implementation.
- [ ] update `LetPattern` model in `client` (to be recursive)
- [ ] Fluid work
  - [ ] lots of tests
- [ ] fill in and revise bits of `backend` work
  - [ ] review all nontrivial implementation
    most of the impl was copy/pasted from `MatchPattern` logic, so there are likely major simplifications to be made
  - [ ] figure out what to do - the `FSharpToExpr` now interprets all test files as the _new_ kind of let. this isn't merge-able until we test that `ELet("name", ...)` is 100% equivalent to `ELetWithPattern(... LPVariable("name", ...))`
  - [ ] `SqlCompiler`
  - [ ] review `FuzzTests` impl.
  - [ ] serialization tests
    - [ ] backend
    - [ ] client-side roundtrip