### PR TITLE
Fix fn-name clip in the doc-box

### DIFF
--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -841,12 +841,12 @@ let documentationForFunction = (
     }
   } else {
     list{
-      Html.span(list{tw(%twc("font-text text-grey2 text-xs"))}, list{Html.text("Not deprecated ")}),
+      Html.span(list{tw(%twc("font-text text-grey2 text-xs whitespace-nowrap"))}, list{Html.text("Not deprecated ")}),
     }
   }
 
   let name = Html.span(
-    list{tw(%twc("text-grey3 text-xs text-ellipsis max-w-[35ch] overflow-hidden whitespace-nowrap"))},
+    list{tw(%twc("text-grey3 text-xs text-ellipsis w-max overflow-hidden whitespace-nowrap"))},
     list{Html.text(f.name |> FQFnName.toString)},
   )
 


### PR DESCRIPTION
Changelog:

No changelog

**Problem**
When a function is selected, the width of the documentation box expands but the function name stays clipped.
![image](https://user-images.githubusercontent.com/87861924/212995937-3f57ecba-d6a1-49fd-b381-5141d3790de5.png)
![image](https://user-images.githubusercontent.com/87861924/212996688-305d2aa1-be6b-4940-98a0-95a29e174bc9.png)

**Fixed**
![image](https://user-images.githubusercontent.com/87861924/212995805-b3ac6adf-8e55-4f77-82a4-b3b04c04e6b7.png)
![image](https://user-images.githubusercontent.com/87861924/212996589-e4930c26-7873-467f-a231-0f0d125c2aa7.png)
