### PR TITLE
Autocomplete dropdown

### DIFF
--- a/client/src/fluid/FluidAutocomplete.res
+++ b/client/src/fluid/FluidAutocomplete.res
@@ -845,13 +845,26 @@ let documentationForFunction = (
     }
   }
 
-  let name = Html.span(
-    list{tw(%twc("text-grey3 text-xs text-ellipsis w-max overflow-hidden whitespace-nowrap"))},
-    list{Html.text(f.name |> FQFnName.toString)},
-  )
+  let name = if String.startsWith(~prefix="dark/", f.name |> FQFnName.toString){
+    let pkgName = Js.String.splitByRe(%re("/\/(?=[^\/]*$)/"), f.name |> FQFnName.toString)
+    Html.span(
+      list{tw(%twc("text-grey4 text-xs text-ellipsis w-max overflow-hidden whitespace-nowrap"))},
+      list{
+        Html.div(
+          list{tw(%twc("mb-1 text-grey2 text-xxs"))},
+          list{Icons.fontAwesome(~style=%twc("mr-1.5 text-[#BA8A61]"), "box-open"),
+          Html.text(pkgName[0] |> Option.unwrap(~default="")),}
+          ),
+        Html.text(pkgName[1] |> Option.unwrap(~default="")),
+        })
+    }else{
+      Html.span(
+      list{tw(%twc("text-grey3 text-xs text-ellipsis w-max overflow-hidden whitespace-nowrap"))},
+      list{Html.text(f.name |> FQFnName.toString)},)
+    }
 
   let documentationHeader = Html.div(
-    list{tw(%twc("flex justify-between items-center mb-2"))},
+    list{tw(%twc("flex justify-between mb-2 mt-1"))},
     list{name, Html.div(list{}, deprecationHeader)},
   )
 

--- a/client/src/fluid/FluidAutocompleteView.res
+++ b/client/src/fluid/FluidAutocompleteView.res
@@ -15,29 +15,47 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
   let html = {
     let returnTypeHtml = {
       let returnTypeClass = switch validity {
-      | FACItemInvalidReturnType(_) => %twc("text-red1")
+      | FACItemInvalidReturnType(_) => %twc("text-red1 group-[.highlight]:text-[#f3c8c6]")
       | _ => ""
       }
 
-      list{Html.span(list{Attrs.class(returnTypeClass)}, list{Html.text(rt)})}
+      list{Html.span(list{tw(returnTypeClass)}, list{Html.text(rt)})}
     }
 
     let argsHtml = switch args {
     | list{} => list{}
     | list{arg0, ...rest} =>
       let arg0Class = switch validity {
-      | FACItemInvalidPipedArg(_) => %twc("text-red1")
+      | FACItemInvalidPipedArg(_) => %twc("text-red1 group-[.highlight]:text-[#f3c8c6]")
       | _ => ""
       }
 
       let args = list{
-        Html.span(list{Attrs.class(arg0Class)}, list{Html.text(arg0)}),
+        Html.span(list{tw(arg0Class)}, list{Html.text(arg0)}),
         ...List.map(~f=Html.text, rest),
       }
 
       args
       |> List.intersperse(~sep=Html.text(", "))
-      |> (args => Belt.List.concatMany([list{Html.text("(")}, list{Html.span(list{Attrs.class(%twc("inline-block align-top overflow-hidden max-w-[25ch] text-ellipsis whitespace-nowrap"))},args)}, list{Html.text(") -> ")}]))
+      |> (
+        args =>
+          Belt.List.concatMany([
+            list{Html.text("(")},
+            list{
+              Html.span(
+                list{
+                  tw(
+                    %twc(
+                      "inline-block align-top overflow-hidden max-w-[25ch] text-ellipsis whitespace-nowrap"
+                    ),
+                  ),
+                },
+                args,
+              ),
+            },
+            list{Html.text(") -> ")},
+          ])
+      )
     }
 
     Belt.List.concat(argsHtml, returnTypeHtml)
@@ -54,11 +72,10 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
       %twc("text-grey3")
     }
     let highlighted = index == i
-    let classHighlighted =
-      switch (highlighted, validity) {
-      | (true, FACItemValid) => %twc("bg-highlight-color text-white2")
-      | (true, _) => %twc("bg-highlight-color text-[#11262e]")
-      | (false, _) => ""
+    let classHighlighted = switch (highlighted, validity) {
+    | (true, FACItemValid) => %twc("bg-highlight-color text-white2")
+    | (true, _) => %twc("group bg-highlight-color text-[#11262e]")
+    | (false, _) => ""
     }
 
     let name = FluidAutocomplete.asName(item)
@@ -75,9 +92,10 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
       ~unique=name,
       list{
         Attrs.classList(list{
-          (%twc("list-none py-0 px-2 h-4"),true),
+          (%twc("list-none py-0 px-2 h-4"), true),
           ("autocomplete-item", true),
           (classHighlighted, highlighted),
+          ("highlight",true),
           (class', true),
         }),
         EventListeners.nothingMouseEvent("mouseup"),
@@ -93,5 +111,15 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
       list{Html.text(fnDisplayName), versionView, types},
     )
   })
-  Html.div(list{Attrs.id("fluid-dropdown"), tw(%twc("cursor-pointer bg-black3 text-white3 z-[1000] absolute -left-2 min-w-max w-full max-h-[6.25rem] overflow-y-scroll p-0 border border-solid border-black1 border-t-0 shadow-[1px_1px_1px_black] rounded-b-sm"))}, list{Html.ul(list{tw(%twc("m-0 text-white2 pr-1"))}, autocompleteList)})
+  Html.div(
+    list{
+      Attrs.id("fluid-dropdown"),
+      tw(
+        %twc(
+          "cursor-pointer bg-black3 text-white3 z-[1000] absolute -left-2 min-w-max w-full max-h-[6.25rem] overflow-y-scroll p-0 border border-solid border-black1 border-t-0 shadow-[1px_1px_1px_black] rounded-b-sm"
+        ),
+      ),
+    },
+    list{Html.ul(list{tw(%twc("m-0 text-white2 pr-1"))}, autocompleteList)},
+  )
 }

--- a/client/src/fluid/FluidAutocompleteView.res
+++ b/client/src/fluid/FluidAutocompleteView.res
@@ -15,7 +15,6 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
   let html = {
     let returnTypeHtml = {
       let returnTypeClass = switch validity {
-      //invalid-culprit
       | FACItemInvalidReturnType(_) => %twc("text-red1")
       | _ => ""
       }
@@ -27,7 +26,6 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
     | list{} => list{}
     | list{arg0, ...rest} =>
       let arg0Class = switch validity {
-      //invalid-culprit
       | FACItemInvalidPipedArg(_) => %twc("text-red1")
       | _ => ""
       }
@@ -44,8 +42,7 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
 
     Belt.List.concat(argsHtml, returnTypeHtml)
   }
-//types
-  Html.span(list{tw(%twc("float-right ml-8 lowercase text-[13.33px] font-code h-4 text-white3"))}, html)
+  Html.span(list{tw(%twc("float-right ml-8 lowercase text-[13.33px] font-code h-4"))}, html)
 }
 
 let view = (ac: state): Html.html<AppTypes.msg> => {
@@ -54,15 +51,20 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
     let class' = if validity == FACItemValid {
       "valid"
     } else {
-      // invalid
       %twc("text-grey3")
     }
     let highlighted = index == i
+    let classHighlighted =
+      switch (highlighted, validity) {
+      | (true, FACItemValid) => %twc("bg-highlight-color text-white2")
+      | (true, _) => %twc("bg-highlight-color text-[#11262e]")
+      | (false, _) => ""
+    }
+
     let name = FluidAutocomplete.asName(item)
     let fnDisplayName = FluidUtil.fnDisplayName(name)
     let versionDisplayName = FluidUtil.versionDisplayName(name)
     let versionView = if String.length(versionDisplayName) > 0 {
-      //version
       Html.span(list{tw(%twc("text-grey2 align-bottom"))}, list{Html.text(versionDisplayName)})
     } else {
       Vdom.noNode
@@ -73,11 +75,9 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
       ~unique=name,
       list{
         Attrs.classList(list{
-          //li
           (%twc("list-none py-0 px-2 h-4"),true),
           ("autocomplete-item", true),
-          //fluid-selected
-          (%twc("bg-highlight-color text-white3"), highlighted),
+          (classHighlighted, highlighted),
           (class', true),
         }),
         EventListeners.nothingMouseEvent("mouseup"),
@@ -93,6 +93,5 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
       list{Html.text(fnDisplayName), versionView, types},
     )
   })
-//ul
-  Html.div(list{Attrs.id("fluid-dropdown"), tw(%twc("cursor-pointer bg-black3 text-grey3 z-[1000] absolute -left-2 min-w-max w-full overflow-y-scroll p-0 max-h-[100px] border-[1px] border-solid border-black1 border-t-0 shadow-[1px_1px_1px_black] rounded-b-sm"))}, list{Html.ul(list{tw(%twc("m-0 text-white2 pr-1"))}, autocompleteList)})
+  Html.div(list{Attrs.id("fluid-dropdown"), tw(%twc("cursor-pointer bg-black3 text-white3 z-[1000] absolute -left-2 min-w-max w-full max-h-[6.25rem] overflow-y-scroll p-0 border border-solid border-black1 border-t-0 shadow-[1px_1px_1px_black] rounded-b-sm"))}, list{Html.ul(list{tw(%twc("m-0 text-white2 pr-1"))}, autocompleteList)})
 }

--- a/client/src/fluid/FluidAutocompleteView.res
+++ b/client/src/fluid/FluidAutocompleteView.res
@@ -79,10 +79,11 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
     }
 
     let name = FluidAutocomplete.asName(item)
+    |> Js.String.replaceByRe(%re("/^.+\//gm"), "")
     let fnDisplayName = FluidUtil.fnDisplayName(name)
     let versionDisplayName = FluidUtil.versionDisplayName(name)
     let versionView = if String.length(versionDisplayName) > 0 {
-      Html.span(list{tw(%twc("text-grey2 align-bottom"))}, list{Html.text(versionDisplayName)})
+      Html.span(list{Attrs.classes(["version", %twc("text-grey2 align-bottom")])}, list{Html.text(versionDisplayName)})
     } else {
       Vdom.noNode
     }

--- a/client/src/fluid/FluidAutocompleteView.res
+++ b/client/src/fluid/FluidAutocompleteView.res
@@ -8,12 +8,15 @@ module Msg = AppTypes.Msg
 type data = FluidTypes.AutoComplete.data
 type state = FluidTypes.AutoComplete.t
 
+let tw = Attrs.class
+
 let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg> => {
   let (args, rt) = FluidAutocomplete.asTypeStrings(item)
   let html = {
     let returnTypeHtml = {
       let returnTypeClass = switch validity {
-      | FACItemInvalidReturnType(_) => "invalid-culprit"
+      //invalid-culprit
+      | FACItemInvalidReturnType(_) => %twc("text-red1")
       | _ => ""
       }
 
@@ -24,7 +27,8 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
     | list{} => list{}
     | list{arg0, ...rest} =>
       let arg0Class = switch validity {
-      | FACItemInvalidPipedArg(_) => "invalid-culprit"
+      //invalid-culprit
+      | FACItemInvalidPipedArg(_) => %twc("text-red1")
       | _ => ""
       }
 
@@ -40,8 +44,8 @@ let viewAutocompleteItemTypes = ({item, validity}: data): Html.html<AppTypes.msg
 
     Belt.List.concat(argsHtml, returnTypeHtml)
   }
-
-  Html.span(list{Attrs.class("types")}, html)
+//types
+  Html.span(list{tw(%twc("float-right ml-8 lowercase text-[13.33px] font-code h-4 text-white3"))}, html)
 }
 
 let view = (ac: state): Html.html<AppTypes.msg> => {
@@ -50,14 +54,16 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
     let class' = if validity == FACItemValid {
       "valid"
     } else {
-      "invalid"
+      // invalid
+      %twc("text-grey3")
     }
     let highlighted = index == i
     let name = FluidAutocomplete.asName(item)
     let fnDisplayName = FluidUtil.fnDisplayName(name)
     let versionDisplayName = FluidUtil.versionDisplayName(name)
     let versionView = if String.length(versionDisplayName) > 0 {
-      Html.span(list{Attrs.class("version")}, list{Html.text(versionDisplayName)})
+      //version
+      Html.span(list{tw(%twc("text-grey2 align-bottom"))}, list{Html.text(versionDisplayName)})
     } else {
       Vdom.noNode
     }
@@ -67,8 +73,11 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
       ~unique=name,
       list{
         Attrs.classList(list{
+          //li
+          (%twc("list-none py-0 px-2 h-4"),true),
           ("autocomplete-item", true),
-          ("fluid-selected", highlighted),
+          //fluid-selected
+          (%twc("bg-highlight-color text-white3"), highlighted),
           (class', true),
         }),
         EventListeners.nothingMouseEvent("mouseup"),
@@ -84,6 +93,6 @@ let view = (ac: state): Html.html<AppTypes.msg> => {
       list{Html.text(fnDisplayName), versionView, types},
     )
   })
-
-  Html.div(list{Attrs.id("fluid-dropdown")}, list{Html.ul(list{}, autocompleteList)})
+//ul
+  Html.div(list{Attrs.id("fluid-dropdown"), tw(%twc("cursor-pointer bg-black3 text-grey3 z-[1000] absolute -left-2 min-w-max w-full overflow-y-scroll p-0 max-h-[100px] border-[1px] border-solid border-black1 border-t-0 shadow-[1px_1px_1px_black] rounded-b-sm"))}, list{Html.ul(list{tw(%twc("m-0 text-white2 pr-1"))}, autocompleteList)})
 }

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -100,7 +100,6 @@ $lock-color: lighten($red, 10%);
 $link-color: $white1;
 $link-hover-color: $yellow;
 
-
 /* Typograhy */
 $code-font-size: 13.3333px;
 $string-color: lighten($purple, 10%);

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -66,6 +66,7 @@ $repl-color: $pink;
 $user-functions: saturate($cyan, 10%);
 $db-color: #a1887f;
 $tooltip-color: lighten(saturate($cyan, 20%), 10%);
+$highlight-color: saturate(darken($blue, 20%), 10%);
 :root {
   --httpGetColor: #{$http-get};
   --httpPostColor: #{$http-post};
@@ -80,6 +81,7 @@ $tooltip-color: lighten(saturate($cyan, 20%), 10%);
   --userFunctionsColor: #{$user-functions};
   --dbColor: #{$db-color};
   --tooltipColor: #{$tooltip-color};
+  --highlightColor: #{$highlight-color};
 }
 :root {
   --sidebarBgColor: #{darken($canvas-background, 10%)};
@@ -98,7 +100,6 @@ $lock-color: lighten($red, 10%);
 $link-color: $white1;
 $link-hover-color: $yellow;
 
-$highlight-color: saturate(darken($blue, 20%), 10%);
 
 /* Typograhy */
 $code-font-size: 13.3333px;

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -934,7 +934,7 @@ test.describe.parallel("Integration Tests", async () => {
     await expectExactText(
       page,
       ".autocomplete-item.bg-highlight-color.valid",
-      "test_admin/stdlib/Test::one_v1Any",
+      "Test::one_v1Any",
     );
     await page.keyboard.press("Enter");
 

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -232,18 +232,18 @@ test.describe.parallel("Integration Tests", async () => {
     await page.type("#active-editor", "re");
     let start = Date.now();
     await page.type("#active-editor", "q");
-    await expectContainsText(page, Locators.fluidACHighlightedValue, "request");
+    await expectContainsText(page, ".autocomplete-item.bg-highlight-color", "request");
     // There's a race condition here, sometimes the client doesn't manage to load the
     // trace for quite some time, and the autocomplete box ends up in a weird
     // condition
     await awaitAnalysis(page, start, token);
     await expectExactText(
       page,
-      Locators.fluidACHighlightedValue,
+      ".autocomplete-item.bg-highlight-color",
       "requestDict",
     );
     await page.type("#active-editor", ".bo");
-    await expectExactText(page, Locators.fluidACHighlightedValue, "bodyfield");
+    await expectExactText(page, ".autocomplete-item.bg-highlight-color", "bodyfield");
     await page.keyboard.press("Enter");
   });
 
@@ -264,7 +264,7 @@ test.describe.parallel("Integration Tests", async () => {
 
     await expectContainsText(
       page,
-      Locators.fluidACHighlightedValue,
+      ".autocomplete-item.bg-highlight-color",
       "Int::add",
     );
     await page.keyboard.press("Enter");
@@ -277,7 +277,7 @@ test.describe.parallel("Integration Tests", async () => {
     await page.keyboard.press("ArrowDown");
     await expectContainsText(
       page,
-      Locators.fluidACHighlightedValue,
+      ".autocomplete-item.bg-highlight-color",
       "Http::badRequest",
     );
     await page.keyboard.press("Enter");
@@ -492,7 +492,7 @@ test.describe.parallel("Integration Tests", async () => {
     await createRepl(page);
 
     await page.type("#active-editor", "DB::del");
-    let selector = ".autocomplete-item.fluid-selected .version";
+    let selector = ".autocomplete-item.bg-highlight-color .version";
     await expectExactText(page, selector, "v1");
   });
 
@@ -925,7 +925,7 @@ test.describe.parallel("Integration Tests", async () => {
     await awaitAnalysis(page, before, token);
     await expectExactText(
       page,
-      ".autocomplete-item.fluid-selected.valid",
+      ".autocomplete-item.bg-highlight-color.valid",
       "test_admin/stdlib/Test::one_v1Any",
     );
     await page.keyboard.press("Enter");

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -232,7 +232,11 @@ test.describe.parallel("Integration Tests", async () => {
     await page.type("#active-editor", "re");
     let start = Date.now();
     await page.type("#active-editor", "q");
-    await expectContainsText(page, ".autocomplete-item.bg-highlight-color", "request");
+    await expectContainsText(
+      page,
+      ".autocomplete-item.bg-highlight-color",
+      "request",
+    );
     // There's a race condition here, sometimes the client doesn't manage to load the
     // trace for quite some time, and the autocomplete box ends up in a weird
     // condition
@@ -243,7 +247,11 @@ test.describe.parallel("Integration Tests", async () => {
       "requestDict",
     );
     await page.type("#active-editor", ".bo");
-    await expectExactText(page, ".autocomplete-item.bg-highlight-color", "bodyfield");
+    await expectExactText(
+      page,
+      ".autocomplete-item.bg-highlight-color",
+      "bodyfield",
+    );
     await page.keyboard.press("Enter");
   });
 

--- a/integration-tests/tests.ts
+++ b/integration-tests/tests.ts
@@ -934,7 +934,7 @@ test.describe.parallel("Integration Tests", async () => {
     await expectExactText(
       page,
       ".autocomplete-item.bg-highlight-color.valid",
-      "Test::one_v1Any",
+      "Test::onev1Any",
     );
     await page.keyboard.press("Enter");
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,7 @@ module.exports = {
       white3: "#f8f8f8",
 
       red: "#ab4642",
+      red1: "#e5736e", //lighten(saturate($red, 25%)
       orange: "#dc9656",
       yellow: "#f7ca88",
       yellow1: "#fadfb8", //lighten($yellow, 10%)
@@ -57,6 +58,7 @@ module.exports = {
       "user-functions": "var(--userFunctionsColor)",
       db: "var(--dbColor)",
       tooltip: "var(--tooltipColor)",
+      "highlight-color": "var(--highlightColor)",
     },
     extend: {
       borderWidth: {


### PR DESCRIPTION
Changelog:

```
Internal improvements
- Convert the autocomplete dropdown to Tailwind CSS.
- Remove the package name from the autocomplete.
```

### Before
![ocean-Dark-Google-Chrome-2023-01 (2)](https://user-images.githubusercontent.com/87861924/214261197-3d5fca11-6a77-46a9-8550-7608e459da1a.gif)


### After
![ocean-Dark-Google-Chrome-2023-01 (1)](https://user-images.githubusercontent.com/87861924/214260741-edb85d6f-6d27-4961-af63-c3ac66b2b846.gif)

### Before->After
**Valid item**
<img width="1943" alt="valid" src="https://user-images.githubusercontent.com/87861924/214264097-f06f2f46-e008-429a-be71-193720bca871.png">

**Invalid return type**
<img width="2237" alt="invalid return" src="https://user-images.githubusercontent.com/87861924/214264217-deda413a-acbd-4631-afbd-097de26783dc.png">

**Invalid piped argument**
<img width="1474" alt="invalid piped arg" src="https://user-images.githubusercontent.com/87861924/214264378-400d4213-577c-4b9d-97b1-ab749373f138.png">

**package functions :** 
Nothing I've tried looked good. In order to draw the user's attention to the function more than the package I've used slightly different color and font size but I'm not sure if this is enough.
![image](https://user-images.githubusercontent.com/87861924/214841816-e053fe93-0f21-482c-8835-466bd70935dc.png)
![image](https://user-images.githubusercontent.com/87861924/214841999-7b9b08e7-798b-42fa-8251-f84c3136684a.png)

**Questions:**
- For the package functions I'm using a regex to test if the function names begin with 'dark/' and to separate the package name from the function name. Is there a better way to acheive this? 
- Should we create all these variations of colors? I couldn't find a way to do it in tailwind. At the moment, I am using the hex value for some of them or a close match from the colors that we already have.
lighten(white2, 10%)
darken(white, 5%)
lighten($grey2, 15%)
lighten(saturate($red, 25%), 20%)
lighten(saturate($red, 20%), 40%)
...