### PR TITLE
Address NotYetImplementedTODO

### DIFF
--- a/backend/src/BackendOnlyStdLib/LibCrypto.fs
+++ b/backend/src/BackendOnlyStdLib/LibCrypto.fs
@@ -34,7 +34,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DBytes data ] -> MD5.HashData(ReadOnlySpan data) |> DBytes |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = ImpurePreviewable
       deprecated = NotDeprecated }
 
@@ -50,7 +50,7 @@ let fns : List<BuiltInFn> =
           let hmac = new HMACSHA256(key)
           data |> hmac.ComputeHash |> DBytes |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = ImpurePreviewable
       deprecated = NotDeprecated }
 
@@ -66,6 +66,6 @@ let fns : List<BuiltInFn> =
           let hmac = new HMACSHA1(key)
           data |> hmac.ComputeHash |> DBytes |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = ImpurePreviewable
       deprecated = NotDeprecated } ]

--- a/backend/src/BackendOnlyStdLib/LibJwt.fs
+++ b/backend/src/BackendOnlyStdLib/LibJwt.fs
@@ -400,7 +400,7 @@ let fns : List<BuiltInFn> =
         | _, [ DStr key; payload ] ->
           signAndEncode key Map.empty payload |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = ImpurePreviewable
       deprecated = ReplacedBy(fn "JWT" "signAndEncode" 1) }
 
@@ -417,7 +417,7 @@ let fns : List<BuiltInFn> =
         | _, [ DStr key; DObj headers; payload ] ->
           signAndEncode key headers payload |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "JWT" "signAndEncodeWithHeaders" 1) }
 
@@ -434,7 +434,7 @@ let fns : List<BuiltInFn> =
           with
           | e -> Ply(DResult(Error(DStr e.Message)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = ImpurePreviewable
       deprecated = NotDeprecated }
 
@@ -454,7 +454,7 @@ let fns : List<BuiltInFn> =
           with
           | e -> Ply(DResult(Error(DStr e.Message)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated }
 
@@ -487,7 +487,7 @@ let fns : List<BuiltInFn> =
             |> Ply
           | None -> Ply(DOption None)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Impure
       deprecated = ReplacedBy(fn "JWT" "verifyAndExtract" 1) }
 
@@ -518,6 +518,6 @@ let fns : List<BuiltInFn> =
             |> Ply
           | Error msg -> Ply(DResult(Error(DStr msg)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated } ]

--- a/backend/src/BackendOnlyStdLib/LibX509.fs
+++ b/backend/src/BackendOnlyStdLib/LibX509.fs
@@ -54,6 +54,6 @@ let fns : List<BuiltInFn> =
             // certificate if it fails (either data is bullshit or it's not an RSA cert).
             Ply(DResult(Error(DStr "No certificates")))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated } ]

--- a/backend/src/ClientTypes2BackendTypes/UI.fs
+++ b/backend/src/ClientTypes2BackendTypes/UI.fs
@@ -36,7 +36,7 @@ module Functions =
   module SqlSpec =
     let toCT (s : RT.SqlSpec) : CTUI.Functions.SqlSpec =
       match s with
-      | RT.NotYetImplementedTODO -> CTUI.Functions.Unknown
+      | RT.NotYetImplemented -> CTUI.Functions.Unknown
       | RT.NotQueryable -> CTUI.Functions.NotQueryable
       | RT.QueryFunction -> CTUI.Functions.QueryFunction
       | RT.SqlUnaryOp str -> CTUI.Functions.SqlUnaryOp str

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -803,7 +803,7 @@ type Deprecation =
 /// used within a Postgres query.
 type SqlSpec =
   /// Can be implemented, but we haven't yet
-  | NotYetImplementedTODO
+  | NotYetImplemented
 
   /// This is not a function which can be queried
   | NotQueryable
@@ -834,7 +834,7 @@ type SqlSpec =
 
   member this.isQueryable() : bool =
     match this with
-    | NotYetImplementedTODO
+    | NotYetImplemented
     | NotQueryable
     | QueryFunction -> false
     | SqlUnaryOp _

--- a/backend/src/LibExecutionStdLib/LibBool.fs
+++ b/backend/src/LibExecutionStdLib/LibBool.fs
@@ -98,7 +98,7 @@ let fns : List<BuiltInFn> =
             | _ -> DBool false
           )
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated =
         DeprecatedBecause

--- a/backend/src/LibExecutionStdLib/LibBool.fs
+++ b/backend/src/LibExecutionStdLib/LibBool.fs
@@ -62,7 +62,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DBool a; DBool b ] -> Ply(DBool(a <> b))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -80,7 +80,7 @@ let fns : List<BuiltInFn> =
             | _ -> DBool false
           )
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 

--- a/backend/src/LibExecutionStdLib/LibBytes.fs
+++ b/backend/src/LibExecutionStdLib/LibBytes.fs
@@ -46,7 +46,7 @@ let fns : List<BuiltInFn> =
             |> DResult
             |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Bytes" "base64Decode" 1) }
 
@@ -87,7 +87,7 @@ let fns : List<BuiltInFn> =
             with
             | e -> Ply(DResult(Error(DStr("Not a valid base64 string"))))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -107,7 +107,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -135,7 +135,7 @@ let fns : List<BuiltInFn> =
 
           buf |> string |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -148,6 +148,6 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DBytes bytes ] -> bytes |> Array.length |> Dval.int |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibChar.fs
+++ b/backend/src/LibExecutionStdLib/LibChar.fs
@@ -65,7 +65,7 @@ let fns : List<BuiltInFn> =
         function
         | state, [ c ] -> Errors.removedFunction state "Char::toUppercase"
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated =
         DeprecatedBecause("used an old Character type that no longer exists") }
@@ -80,7 +80,7 @@ let fns : List<BuiltInFn> =
         function
         | _, [ DChar c ] -> Ply(DChar(c.ToUpper()))
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -94,7 +94,7 @@ let fns : List<BuiltInFn> =
         function
         | _, [ DChar c ] -> Ply(DChar(c.ToLower()))
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -110,7 +110,7 @@ let fns : List<BuiltInFn> =
           // chars that are not letters would be incorrectly reported as uppercase
           Ply(DBool(c.ToLower() = c && c.ToUpper() <> c))
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -126,7 +126,7 @@ let fns : List<BuiltInFn> =
           // chars that are not letters would be incorrectly reported as uppercase
           Ply(DBool(c.ToUpper() = c && c.ToLower() <> c))
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -140,7 +140,7 @@ let fns : List<BuiltInFn> =
         | _, [ DChar c ] ->
           (if c.Length = 1 then System.Char.IsDigit(c[0]) else false) |> DBool |> Ply
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -159,7 +159,7 @@ let fns : List<BuiltInFn> =
           |> DBool
           |> Ply
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -173,6 +173,6 @@ let fns : List<BuiltInFn> =
         | _, [ DChar c ] ->
           (if c.Length = 1 then System.Char.IsAscii c[0] else false) |> DBool |> Ply
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibCrypto.fs
+++ b/backend/src/LibExecutionStdLib/LibCrypto.fs
@@ -34,7 +34,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DBytes data ] -> SHA256.HashData(ReadOnlySpan data) |> DBytes |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -47,6 +47,6 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DBytes data ] -> SHA384.HashData(ReadOnlySpan data) |> DBytes |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibDate.fs
+++ b/backend/src/LibExecutionStdLib/LibDate.fs
@@ -601,6 +601,6 @@ let fns : List<BuiltInFn> =
           let diff = (DDateTime.toInstant endDate) - (DDateTime.toInstant startDate)
           diff.TotalSeconds |> System.Math.Round |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibDict.fs
+++ b/backend/src/LibExecutionStdLib/LibDict.fs
@@ -30,7 +30,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr k; v ] -> Ply(DObj(Map.ofList [ (k, v) ]))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -43,7 +43,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj o ] -> Ply(DInt(int64 (Map.count o)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -63,7 +63,7 @@ let fns : List<BuiltInFn> =
           |> fun l -> DList l
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -77,7 +77,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj o ] -> o |> Map.values |> Seq.toList |> (fun l -> DList l |> Ply)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -95,7 +95,7 @@ let fns : List<BuiltInFn> =
           |> DList
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -129,7 +129,7 @@ let fns : List<BuiltInFn> =
           let result = List.fold Map.empty f l
           Ply(DObj result)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -169,7 +169,7 @@ let fns : List<BuiltInFn> =
           | Some map -> Ply(DOption(Some(DObj(map))))
           | None -> Ply(DOption None)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -186,7 +186,7 @@ let fns : List<BuiltInFn> =
            | Some d -> Ply(d)
            | None -> Ply(DNull))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "get" 1) }
 
@@ -200,7 +200,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj o; DStr s ] -> Ply(DOption(Map.tryFind s o))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "get" 2) }
 
@@ -215,7 +215,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj o; DStr s ] -> Map.tryFind s o |> Dval.option |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -230,7 +230,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj o; DStr s ] -> Ply(DBool(Map.containsKey s o))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -257,7 +257,7 @@ let fns : List<BuiltInFn> =
             return DObj result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "map" 0) }
 
@@ -294,7 +294,7 @@ let fns : List<BuiltInFn> =
             return DObj result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -342,7 +342,7 @@ let fns : List<BuiltInFn> =
               return DObj result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Dict" "filter" 1) }
 
@@ -398,7 +398,7 @@ let fns : List<BuiltInFn> =
             | Error dv -> return dv
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -463,7 +463,7 @@ let fns : List<BuiltInFn> =
             | Some v -> return v
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -489,7 +489,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj dict ] -> Ply(DBool(Map.isEmpty dict))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -504,7 +504,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj l; DObj r ] -> Ply(DObj(Map.mergeFavoringRight l r))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -519,7 +519,7 @@ let fns : List<BuiltInFn> =
         | _, [ DObj o ] ->
           DObj o |> DvalReprLegacyExternal.toPrettyMachineJsonStringV1 |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -536,7 +536,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj o; DStr k; v ] -> Ply(DObj(Map.add k v o))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -550,6 +550,6 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DObj o; DStr k ] -> Ply(DObj(Map.remove k o))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibFloat.fs
+++ b/backend/src/LibExecutionStdLib/LibFloat.fs
@@ -19,7 +19,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> a |> Math.Ceiling |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -32,7 +32,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> a |> Math.Ceiling |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -50,7 +50,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> a |> Math.Floor |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -69,7 +69,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> a |> Math.Floor |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -82,7 +82,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> a |> Math.Round |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -96,7 +96,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> a |> Math.Truncate |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -110,7 +110,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> DFloat(Math.Abs a) |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -123,7 +123,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> DFloat(a * -1.0) |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -136,7 +136,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(Math.Sqrt a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -279,7 +279,7 @@ let fns : List<BuiltInFn> =
           let sum = List.fold (fun acc elem -> acc + elem) 0.0 floats
           Ply(DFloat sum)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -293,7 +293,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(Math.Min(a, b)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -307,7 +307,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a; DFloat b ] -> Ply(DFloat(Math.Max(a, b)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -335,7 +335,7 @@ let fns : List<BuiltInFn> =
             let min, max = if a < b then (a, b) else (b, a)
             Ply(DFloat(Math.Clamp(v, min, max)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -349,7 +349,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> a |> Math.Truncate |> int64 |> DInt |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -370,6 +370,6 @@ let fns : List<BuiltInFn> =
              |> DResult
              |> Ply)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibHttp.fs
+++ b/backend/src/LibExecutionStdLib/LibHttp.fs
@@ -30,7 +30,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ dv; DInt code ] -> Ply(DHttpResponse(Response(code, [], dv)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -58,7 +58,7 @@ let fns : List<BuiltInFn> =
 
           Ply(DHttpResponse(Response(code, pairs, dv)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -73,7 +73,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ dv ] -> Ply(DHttpResponse(Response(200L, [], dv)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -90,7 +90,7 @@ let fns : List<BuiltInFn> =
         | _, [ dv; DInt code ] ->
           Ply(DHttpResponse(Response(code, [ ("Content-Type", "text/html") ], dv)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -107,7 +107,7 @@ let fns : List<BuiltInFn> =
         | _, [ dv; DInt code ] ->
           Ply(DHttpResponse(Response(code, [ ("Content-Type", "text/plain") ], dv)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -128,7 +128,7 @@ let fns : List<BuiltInFn> =
             )
           )
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -143,7 +143,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr url ] -> Ply(DHttpResponse(Redirect url))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -158,7 +158,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr _ as msg ] -> Ply(DHttpResponse(Response(400L, [], msg)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -173,7 +173,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DHttpResponse(Response(404L, [], DNull)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -188,7 +188,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DHttpResponse(Response(401L, [], DNull)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -203,7 +203,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DHttpResponse(Response(403L, [], DNull)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -251,7 +251,7 @@ let fns : List<BuiltInFn> =
           |> DObj
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "setCookie" 1) }
 
@@ -306,7 +306,7 @@ let fns : List<BuiltInFn> =
           |> DObj
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "Http" "setCookie" 2) }
 
@@ -406,6 +406,6 @@ let fns : List<BuiltInFn> =
           |> Ply
 
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibHttpClient.fs
+++ b/backend/src/LibExecutionStdLib/LibHttpClient.fs
@@ -36,7 +36,7 @@ let fns : List<BuiltInFn> =
             )
           )
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -56,7 +56,7 @@ let fns : List<BuiltInFn> =
             )
           )
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -72,7 +72,7 @@ let fns : List<BuiltInFn> =
         | _, [] ->
           Ply(DObj(Map.ofList [ "Content-Type", DStr "text/plain; charset=utf-8" ]))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -88,7 +88,7 @@ let fns : List<BuiltInFn> =
         | _, [] ->
           Ply(DObj(Map.ofList [ "Content-Type", DStr "text/html; charset=utf-8" ]))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -104,7 +104,7 @@ let fns : List<BuiltInFn> =
           let authString = "Bearer " + token
           Ply(DObj(Map.ofList [ "Authorization", DStr authString ]))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "HttpClient" "bearerToken" 1) }
 
@@ -120,6 +120,6 @@ let fns : List<BuiltInFn> =
           let authString = "Bearer " + token
           Ply(DObj(Map.ofList [ "Authorization", DStr authString ]))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibHttpClientAuth.fs
+++ b/backend/src/LibExecutionStdLib/LibHttpClientAuth.fs
@@ -49,7 +49,7 @@ let fns : List<BuiltInFn> =
           Ply(DObj(Map [ "Authorization", (DStr(encodeBasicAuthBroken u p)) ]))
         | args -> incorrectArgs ())
       previewable = Pure
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       deprecated = ReplacedBy(fn "HttpClient" "basicAuth" 1) }
 
 
@@ -64,5 +64,5 @@ let fns : List<BuiltInFn> =
           Ply(DObj(Map [ "Authorization", (DStr(encodeBasicAuth u p)) ]))
         | args -> incorrectArgs ())
       previewable = Pure
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibInt.fs
+++ b/backend/src/LibExecutionStdLib/LibInt.fs
@@ -75,7 +75,7 @@ let fns : List<BuiltInFn> =
     //          else // In case there's another failure mode, rollbar
     //            Exception.raiseInternal "Unexpected failiure mode" [] e)
     //     | _ -> incorrectArgs ())
-    //   sqlSpec = NotYetImplementedTODO
+    //   sqlSpec = NotYetImplemented
     //   previewable = Pure
     //   deprecated = NotDeprecated }
 
@@ -108,7 +108,7 @@ let fns : List<BuiltInFn> =
                  [ "v", v; "d", d ]
                  e)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -428,6 +428,6 @@ let fns : List<BuiltInFn> =
              |> DResult
              |> Ply)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibJson.fs
+++ b/backend/src/LibExecutionStdLib/LibJson.fs
@@ -39,7 +39,7 @@ let fns : List<BuiltInFn> =
             | _ -> return DNull
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "JSON" "read" 1) }
 
@@ -61,7 +61,7 @@ let fns : List<BuiltInFn> =
           | Ok dv -> Ply dv
           | Error msg -> Ply(DError(SourceNone, msg))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "JSON" "parse" 1) }
 
@@ -85,6 +85,6 @@ let fns : List<BuiltInFn> =
           |> DResult
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibList.fs
+++ b/backend/src/LibExecutionStdLib/LibList.fs
@@ -136,7 +136,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ v ] -> Ply(DList [ v ])
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -150,7 +150,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> List.tryHead l |> Option.defaultValue DNull |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "head" 1) }
 
@@ -163,7 +163,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> Ply(DOption(List.tryHead l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "head" 2) }
 
@@ -178,7 +178,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> l |> List.tryHead |> Dval.option |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -197,7 +197,7 @@ let fns : List<BuiltInFn> =
         | _, [ DList l ] ->
           (if List.isEmpty l then None else Some(DList l.Tail)) |> DOption |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -210,7 +210,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DList [])
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -224,7 +224,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l; i ] -> Ply(DList(i :: l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -237,7 +237,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l; i ] -> Ply(DList(l @ [ i ]))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -251,7 +251,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> (if List.isEmpty l then DNull else List.last l) |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "last" 1) }
 
@@ -266,7 +266,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> Ply(DOption(List.tryLast l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "last" 2) }
 
@@ -281,7 +281,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> l |> List.tryLast |> Dval.option |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -294,7 +294,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> Ply(DList(List.rev l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -323,7 +323,7 @@ let fns : List<BuiltInFn> =
             return Option.defaultValue DNull result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "findFirst" 1) }
 
@@ -352,7 +352,7 @@ let fns : List<BuiltInFn> =
             return DOption result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "findFirst" 2) }
 
@@ -382,7 +382,7 @@ let fns : List<BuiltInFn> =
             return Dval.option result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -395,7 +395,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l; i ] -> Ply(DBool(List.contains i l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -415,7 +415,7 @@ let fns : List<BuiltInFn> =
           else
             List.replicate (int times) v |> DList |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -447,7 +447,7 @@ let fns : List<BuiltInFn> =
         | _, [ DInt start; DInt stop ] ->
           [ start..stop ] |> List.map DInt |> DList |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -487,7 +487,7 @@ let fns : List<BuiltInFn> =
             return! List.fold f (Ply init) l
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -508,7 +508,7 @@ let fns : List<BuiltInFn> =
 
           List.fold f [] l |> DList |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -531,7 +531,7 @@ let fns : List<BuiltInFn> =
 
           Ply(DList(join l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -557,7 +557,7 @@ let fns : List<BuiltInFn> =
 
           Ply(DList(f l1 l2))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -591,7 +591,7 @@ let fns : List<BuiltInFn> =
             return distinct |> List.sortBy fst |> List.map fst |> DList
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -604,7 +604,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList l ] -> Ply(DBool(List.isEmpty l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -623,7 +623,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DList list ] -> list |> List.sort |> DList |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -660,7 +660,7 @@ let fns : List<BuiltInFn> =
             return withKeys |> List.sortBy fst |> List.map snd |> DList
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -707,7 +707,7 @@ let fns : List<BuiltInFn> =
             | e -> return DResult(Error(DStr e.Message))
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -724,7 +724,7 @@ let fns : List<BuiltInFn> =
         | _, [ DList l1; DList l2 ] ->
           Ply(DList(List.append l1 l2)) (* no checking for fake cf required *)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -764,7 +764,7 @@ let fns : List<BuiltInFn> =
               return DList(result)
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "filter" 1) }
 
@@ -814,7 +814,7 @@ let fns : List<BuiltInFn> =
               return DBool(result.Length = l.Length)
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -865,7 +865,7 @@ let fns : List<BuiltInFn> =
             | Some v -> return v
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "filter" 2) }
 
@@ -916,7 +916,7 @@ let fns : List<BuiltInFn> =
             | Some v -> return v
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -975,7 +975,7 @@ let fns : List<BuiltInFn> =
             | Some v -> return v
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -991,7 +991,7 @@ let fns : List<BuiltInFn> =
           elif c > int64 (List.length l) then Ply(DList [])
           else Ply(DList(List.skip (int c) l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1042,7 +1042,7 @@ let fns : List<BuiltInFn> =
             | Some v -> return v
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1058,7 +1058,7 @@ let fns : List<BuiltInFn> =
           elif c >= int64 (List.length l) then Ply(DList l)
           else Ply(DList(List.take (int c) l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1111,7 +1111,7 @@ let fns : List<BuiltInFn> =
             | Some v -> return v
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1137,7 +1137,7 @@ let fns : List<BuiltInFn> =
             return DList result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "map" 0) }
 
@@ -1165,7 +1165,7 @@ let fns : List<BuiltInFn> =
             return Dval.list result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1201,7 +1201,7 @@ let fns : List<BuiltInFn> =
             return Dval.list result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1242,7 +1242,7 @@ let fns : List<BuiltInFn> =
             return Dval.list result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1289,7 +1289,7 @@ let fns : List<BuiltInFn> =
               return DOption(Some(Dval.list result))
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1325,7 +1325,7 @@ let fns : List<BuiltInFn> =
           |> Dval.list
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1360,7 +1360,7 @@ let fns : List<BuiltInFn> =
             |> DOption
             |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1404,7 +1404,7 @@ let fns : List<BuiltInFn> =
           match result with
           | (l, l2) -> Ply(DList [ DList l; DList l2 ])
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       // CLEANUP deprecate and replace with tuples
       deprecated = NotDeprecated }
@@ -1424,7 +1424,7 @@ let fns : List<BuiltInFn> =
           else
             Ply(DOption(List.tryItem (int index) l))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "List" "getAt" 1) }
 
@@ -1440,7 +1440,7 @@ let fns : List<BuiltInFn> =
         | _, [ DList l; DInt index ] ->
           (List.tryItem (int index) l) |> Dval.option |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1463,7 +1463,7 @@ let fns : List<BuiltInFn> =
           let index = RNG.GetInt32(l.Length)
           (List.tryItem index l) |> Dval.option |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Impure
       deprecated = NotDeprecated }
 
@@ -1515,6 +1515,6 @@ let fns : List<BuiltInFn> =
             | Error fakeDval -> return fakeDval
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibMath.fs
+++ b/backend/src/LibExecutionStdLib/LibMath.fs
@@ -26,7 +26,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DFloat System.Math.PI)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -41,7 +41,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DFloat System.Math.Tau)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -58,7 +58,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat degrees ] -> Ply(DFloat(degrees * System.Math.PI / 180.0))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -75,7 +75,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat turns ] -> Ply(DFloat(System.Math.Tau * turns))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -93,7 +93,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat rads ] -> Ply(DFloat rads)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -111,7 +111,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Cos a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -128,7 +128,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Sin a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -146,7 +146,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Tan a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -172,7 +172,7 @@ let fns : List<BuiltInFn> =
           else
             Ply(DOption(Some(DFloat res)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -198,7 +198,7 @@ let fns : List<BuiltInFn> =
           else
             Ply(DOption(Some(DFloat res)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -216,7 +216,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Atan a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -236,7 +236,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat y; DFloat x ] -> Ply(DFloat(System.Math.Atan2(y, x)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -249,7 +249,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Cosh a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -262,7 +262,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Sinh a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -275,6 +275,6 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DFloat a ] -> Ply(DFloat(System.Math.Sinh a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -177,7 +177,7 @@ let fns : List<BuiltInFn> =
 
           sb |> string |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -190,6 +190,6 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr s ] -> s |> Uri.EscapeDataString |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -28,7 +28,7 @@ let fns : List<BuiltInFn> =
         | _, [ a ] ->
           a |> DvalReprLegacyExternal.toEnduserReadableTextV0 |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -44,7 +44,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ a ] -> Ply(DStr(DvalReprDeveloper.toRepr a))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = DeprecatedBecause "Not intended for external use" }
 
@@ -105,7 +105,7 @@ let fns : List<BuiltInFn> =
             )
           )
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = DeprecatedBecause "It is just a demo function" }
 
@@ -118,7 +118,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DError (_, err) ] -> Ply(DStr err)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated =
         DeprecatedBecause "It is no longer allowed to use errors as arguments" }

--- a/backend/src/LibExecutionStdLib/LibObject.fs
+++ b/backend/src/LibExecutionStdLib/LibObject.fs
@@ -164,6 +164,6 @@ let fns : List<BuiltInFn> =
         | _, [ DObj o ] ->
           DObj o |> PrettyResponseJsonV0.toPrettyResponseJsonV0 |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = ReplacedBy(fn "Object" "toJSON" 1) } ]

--- a/backend/src/LibExecutionStdLib/LibOption.fs
+++ b/backend/src/LibExecutionStdLib/LibOption.fs
@@ -45,7 +45,7 @@ let fns : List<BuiltInFn> =
             | None _ -> return (DOption None)
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Option" "map" 1) }
 
@@ -71,7 +71,7 @@ let fns : List<BuiltInFn> =
             | None -> return DOption None
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -102,7 +102,7 @@ let fns : List<BuiltInFn> =
               return Dval.optionJust result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -136,7 +136,7 @@ let fns : List<BuiltInFn> =
             | None -> return DOption None
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -154,6 +154,6 @@ let fns : List<BuiltInFn> =
            | Some dv -> Ply dv
            | None -> Ply default')
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibResult.fs
+++ b/backend/src/LibExecutionStdLib/LibResult.fs
@@ -46,7 +46,7 @@ let fns : List<BuiltInFn> =
             | Error _ -> return DResult r
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "map" 1) }
 
@@ -74,7 +74,7 @@ let fns : List<BuiltInFn> =
             | Error _ -> return DResult r
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -101,7 +101,7 @@ let fns : List<BuiltInFn> =
               return DResult(Error result)
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "mapError" 1) }
 
@@ -129,7 +129,7 @@ let fns : List<BuiltInFn> =
               return Dval.resultError result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -149,7 +149,7 @@ let fns : List<BuiltInFn> =
           | Ok dv -> Ply dv
           | Error _ -> Ply default'
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -169,7 +169,7 @@ let fns : List<BuiltInFn> =
           | Some dv -> Ply(DResult(Ok dv))
           | None -> Ply(DResult(Error(DStr error)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "fromOption" 1) }
 
@@ -190,7 +190,7 @@ let fns : List<BuiltInFn> =
           | Some dv -> Ply(Dval.resultOk dv)
           | None -> Ply(DResult(Error(DStr error)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "fromOption" 2) }
 
@@ -208,7 +208,7 @@ let fns : List<BuiltInFn> =
           | Some dv -> Ply(Dval.resultOk dv)
           | None -> Ply(DResult(Error(error)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -224,7 +224,7 @@ let fns : List<BuiltInFn> =
           | Ok dv -> Ply(DOption(Some dv))
           | Error _ -> Ply(DOption None)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "toOption" 1) }
 
@@ -240,7 +240,7 @@ let fns : List<BuiltInFn> =
           | Ok dv -> Ply(Dval.optionJust dv)
           | Error _ -> Ply(DOption None)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -271,7 +271,7 @@ let fns : List<BuiltInFn> =
               return Dval.resultOk result
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -305,7 +305,7 @@ let fns : List<BuiltInFn> =
             | Error msg -> return DResult(Error msg)
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Result" "andThen" 1) }
 
@@ -340,6 +340,6 @@ let fns : List<BuiltInFn> =
             | Error msg -> return DResult(Error msg)
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibString.fs
+++ b/backend/src/LibExecutionStdLib/LibString.fs
@@ -33,7 +33,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr s ] -> Ply(DBool(s = ""))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -113,7 +113,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DStr "\n")
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -202,7 +202,7 @@ let fns : List<BuiltInFn> =
            with
            | e -> err (Errors.argumentWasnt "numeric" "s" (DStr s)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toInt" 1) }
 
@@ -234,7 +234,7 @@ let fns : List<BuiltInFn> =
             |> DResult
             |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Int" "parse" 0) }
 
@@ -254,7 +254,7 @@ let fns : List<BuiltInFn> =
                Errors.argumentWasnt "a string representation of an IEEE float" "s" dv
              ))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toFloat" 1) }
 
@@ -347,7 +347,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr s ] -> s |> String.lengthInEgcs |> Dval.int |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO // there isn't a unicode version of length
+      sqlSpec = NotYetImplemented // there isn't a unicode version of length
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -377,7 +377,7 @@ let fns : List<BuiltInFn> =
             )
           )
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "append" 1) }
 
@@ -393,7 +393,7 @@ let fns : List<BuiltInFn> =
         // TODO add fuzzer to ensure all strings are normalized no matter what we do to them.
         | _, [ DStr s1; DStr s2 ] -> (s1 + s2) |> String.normalize |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -408,7 +408,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr s1; DStr s2 ] -> Ply(DStr(s2 + s1))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -436,7 +436,7 @@ let fns : List<BuiltInFn> =
           |> Ply
 
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "slugify" 1) }
 
@@ -463,7 +463,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "slugify" 2) }
 
@@ -493,7 +493,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -542,7 +542,7 @@ let fns : List<BuiltInFn> =
             |> DList
             |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "split" 1) }
 
@@ -585,7 +585,7 @@ let fns : List<BuiltInFn> =
             |> DList
             |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -608,7 +608,7 @@ let fns : List<BuiltInFn> =
           // CLEANUP: The OCaml doesn't normalize after concat, so we don't either
           Ply(DStr((String.concat sep strs)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -621,7 +621,7 @@ let fns : List<BuiltInFn> =
         function
         | state, [ l ] -> Errors.removedFunction state "String::fromList"
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "fromList" 1) }
 
@@ -643,7 +643,7 @@ let fns : List<BuiltInFn> =
           )
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -656,7 +656,7 @@ let fns : List<BuiltInFn> =
         function
         | state, [ c ] -> Errors.removedFunction state "String::fromChar"
         | _ -> incorrectArgs ()
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "fromChar" 1) }
 
@@ -669,7 +669,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DChar c ] -> Ply(DStr(c))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -690,7 +690,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -734,7 +734,7 @@ let fns : List<BuiltInFn> =
             with
             | e -> err "Not a valid base64 string"
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       // CLEANUP: this shouldnt return a string and should be deprecated
       deprecated = NotDeprecated }
@@ -759,7 +759,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -783,7 +783,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Crypto" "sha384" 0) }
 
@@ -807,7 +807,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "Crypto" "sha256" 0) }
 
@@ -838,7 +838,7 @@ let fns : List<BuiltInFn> =
 
             randomString (int l) |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Impure
       deprecated = ReplacedBy(fn "String" "random" 1) }
 
@@ -869,7 +869,7 @@ let fns : List<BuiltInFn> =
 
             randomString (int l) |> DStr |> Ok |> DResult |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Impure
       deprecated = ReplacedBy(fn "String" "random" 1) }
 
@@ -905,7 +905,7 @@ let fns : List<BuiltInFn> =
 
             randomString (int l) |> DStr |> Ok |> DResult |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Impure
       deprecated = NotDeprecated }
 
@@ -937,7 +937,7 @@ let fns : List<BuiltInFn> =
 
           Ply(DStr(htmlEscape s))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       // CLEANUP mark as Pure
       previewable = Impure
       deprecated = NotDeprecated }
@@ -959,7 +959,7 @@ let fns : List<BuiltInFn> =
             )
 
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "toUUID" 1) }
 
@@ -973,7 +973,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr needle; DStr haystack ] -> DBool(haystack.Contains needle) |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = ReplacedBy(fn "String" "isSubstring" 1) }
 
@@ -1049,7 +1049,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1079,7 +1079,7 @@ let fns : List<BuiltInFn> =
           |> DStr
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1131,7 +1131,7 @@ let fns : List<BuiltInFn> =
 
           Ply(DStr(lastN s n))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1180,7 +1180,7 @@ let fns : List<BuiltInFn> =
 
           Ply(DStr(dropLastN s n))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1223,7 +1223,7 @@ let fns : List<BuiltInFn> =
 
           Ply(DStr(dropFirstN s n))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1259,7 +1259,7 @@ let fns : List<BuiltInFn> =
 
             stringBuilder |> string |> String.normalize |> DStr |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1296,7 +1296,7 @@ let fns : List<BuiltInFn> =
             stringBuilder |> string |> String.normalize |> DStr |> Ply
 
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1361,7 +1361,7 @@ let fns : List<BuiltInFn> =
           let theBytes = System.Text.Encoding.UTF8.GetBytes str
           Ply(DBytes theBytes)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1375,7 +1375,7 @@ let fns : List<BuiltInFn> =
         | _, [ DStr subject; DStr prefix ] ->
           Ply(DBool(subject.StartsWith(prefix, System.StringComparison.Ordinal)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -1390,6 +1390,6 @@ let fns : List<BuiltInFn> =
         | _, [ DStr subject; DStr suffix ] ->
           Ply(DBool(subject.EndsWith(suffix, System.StringComparison.Ordinal)))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibTuple2.fs
+++ b/backend/src/LibExecutionStdLib/LibTuple2.fs
@@ -26,7 +26,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ first; second ] -> Ply(DTuple(first, second, []))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -40,7 +40,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DTuple (first, _second, []) ] -> Ply(first)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -54,7 +54,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DTuple (_first, second, []) ] -> Ply(second)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -68,7 +68,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DTuple (first, second, []) ] -> Ply(DTuple(second, first, []))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -92,7 +92,7 @@ let fns : List<BuiltInFn> =
             return DTuple(newFirst, second, [])
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -116,7 +116,7 @@ let fns : List<BuiltInFn> =
             return DTuple(first, newSecond, [])
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -151,6 +151,6 @@ let fns : List<BuiltInFn> =
             return DTuple(newFirst, newSecond, [])
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibTuple3.fs
+++ b/backend/src/LibExecutionStdLib/LibTuple3.fs
@@ -27,7 +27,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ first; second; third ] -> Ply(DTuple(first, second, [ third ]))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -44,7 +44,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DTuple (first, _second, [ _third ]) ] -> Ply(first)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -61,7 +61,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DTuple (_first, second, [ _third ]) ] -> Ply(second)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -78,7 +78,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DTuple (_first, _second, [ third ]) ] -> Ply(third)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -105,7 +105,7 @@ let fns : List<BuiltInFn> =
             return DTuple(newFirst, second, [ third ])
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -132,7 +132,7 @@ let fns : List<BuiltInFn> =
             return DTuple(first, newSecond, [ third ])
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -159,7 +159,7 @@ let fns : List<BuiltInFn> =
             return DTuple(first, second, [ newThird ])
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -216,6 +216,6 @@ let fns : List<BuiltInFn> =
             return DTuple(newFirst, newSecond, [ newThird ])
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/LibUuid.fs
+++ b/backend/src/LibExecutionStdLib/LibUuid.fs
@@ -27,7 +27,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DUuid(System.Guid.NewGuid()))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       // similarly to Date::now, it's not particularly fun for this to change
       // when live programming
       previewable = Impure
@@ -51,7 +51,7 @@ let fns : List<BuiltInFn> =
             |> DResult
             |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotYetImplemented
       previewable = Pure
       deprecated = NotDeprecated }
 

--- a/backend/tests/TestUtils/LibTest.fs
+++ b/backend/tests/TestUtils/LibTest.fs
@@ -29,7 +29,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ value ] -> Ply(DErrorRail(value))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -42,7 +42,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ DStr errorString ] -> Ply(DError(SourceNone, errorString))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -57,7 +57,7 @@ let fns : List<BuiltInFn> =
           let msg = LibBackend.SqlCompiler.errorTemplate + errorString
           Ply(DError(SourceNone, msg))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -70,7 +70,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DFloat(System.Double.NaN))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -83,7 +83,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DFloat(System.Double.PositiveInfinity))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -102,7 +102,7 @@ let fns : List<BuiltInFn> =
           else
             Ply(DOption None)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -115,7 +115,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [] -> Ply(DFloat(System.Double.NegativeInfinity))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -132,7 +132,7 @@ let fns : List<BuiltInFn> =
           state.test.sideEffectCount <- state.test.sideEffectCount + 1
           Ply(arg)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -145,7 +145,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [] -> Ply(Dval.int state.test.sideEffectCount)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -160,7 +160,7 @@ let fns : List<BuiltInFn> =
           print $"{msg}: {v}"
           Ply v
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -173,7 +173,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr msg ] -> Ply(DOption(Some(DError(SourceNone, msg))))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -186,7 +186,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr msg ] -> Ply(DResult(Ok(DError(SourceNone, msg))))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -199,7 +199,7 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DStr msg ] -> Ply(DResult(Ok(DError(SourceNone, msg))))
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -221,7 +221,7 @@ let fns : List<BuiltInFn> =
             return DNull
           }
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 
@@ -263,7 +263,7 @@ let fns : List<BuiltInFn> =
           |> DBytes
           |> Ply
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplementedTODO
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated }
 


### PR DESCRIPTION
Changelog:

```
Standard Library
- mark more functions as Not Queryable instead of Unknown
```

The remaining functions are queryable (but we're not doing them right now), so let's remove the TODO from the name.

No effect on the API/client.