### PR TITLE
Fix Int.random to correct work on range 0 1

### DIFF
--- a/backend/src/LibExecutionStdLib/LibInt.fs
+++ b/backend/src/LibExecutionStdLib/LibInt.fs
@@ -286,7 +286,11 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DInt a; DInt b ] ->
           let lower, upper = if a > b then (b, a) else (a, b)
-          lower + randomSeeded().NextInt64(upper - lower) |> DInt |> Ply
+          // The next line is a fix to correct work when an upper bound equal '1'.
+          // It is need because System.Random.NexInt64(Int64) _always_ returns 0 for 1
+          // line from the official doc: "The _exclusive_ upper bound of the random number to be generated"
+          let correction: int64  = if upper = 1 then 2 else 0
+          lower + randomSeeded().NextInt64(upper - lower + correction) |> DInt |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/LibExecutionStdLib/LibInt.fs
+++ b/backend/src/LibExecutionStdLib/LibInt.fs
@@ -289,7 +289,7 @@ let fns : List<BuiltInFn> =
           // The next line is a fix to correct work when an upper bound equal '1'.
           // It is need because System.Random.NexInt64(Int64) _always_ returns 0 for 1
           // line from the official doc: "The _exclusive_ upper bound of the random number to be generated"
-          let correction: int64  = if upper = 1 then 2 else 0
+          let correction : int64 = if upper = 1 then 2 else 0
           lower + randomSeeded().NextInt64(upper - lower + correction) |> DInt |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/testfiles/execution/int.tests
+++ b/backend/testfiles/execution/int.tests
@@ -165,6 +165,29 @@ Int.divide_v0 1 0 = Test.typeError_v0 "Division by zero"
 (List.range_v0 1 5) |> List.map_v0 (fun x -> Int.random_v1  2  1) |> List.map_v0 (fun x -> (x >=  1) && (x <=  2)) = [true; true; true; true; true]
 (List.range_v0 1 5) |> List.map_v0 (fun x -> Int.random_v1 20 10) |> List.map_v0 (fun x -> (x >= 10) && (x <= 20)) = [true; true; true; true; true]
 
+// uncomment tests below to check the edge case Int.random_v1 0 1
+// at least one test have to be passed
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+// Int.random_v1 0 1 = 1
+
 Int.sum_v0 [1;2] = 3
 Int.sum_v0 [1.0;2] = Test.typeError_v0 "Expected the argument `a` to be a list of ints, but it was `[\n  1.0, 2\n]`"
 

--- a/scripts/formatting/pre-commit-hook.sh
+++ b/scripts/formatting/pre-commit-hook.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # To install:
-# - cp scripts/pre-commit-hook.sh .git/hooks/pre-commit
+# - cp scripts/formatting/pre-commit-hook.sh .git/hooks/pre-commit
 # - chmod +x .git/hooks/pre-commit
 
 # Works on all filetype, silently ignoring unsupported files


### PR DESCRIPTION
Changelog:

```
Area of change
- Int.random_v1 
```

## What is the problem/goal being addressed?
For a case, `Int.random_v1 0 1` always returns 0  

## What is the solution to this problem?
Increasing an upper bound on 1 for this case. 

## How are you sure this works/how was this tested?
Run several times the bunch of 10 tests `Int.random_v1 0 1 = 1` and check that at least one test get value 1. In fact, 30-60% of tests were passed. 

## Has this information been included in the comments?
yes 
