### PR TITLE
Update Int::random; add List::unique

### DIFF
--- a/backend/src/LibExecutionStdLib/LibInt.fs
+++ b/backend/src/LibExecutionStdLib/LibInt.fs
@@ -290,7 +290,7 @@ let fns : List<BuiltInFn> =
           // .NET's "nextInt64" is exclusive,
           // but we'd rather an inclusive version of this function
           let correction : int64 = 1
-          
+
           lower + randomSeeded().NextInt64(upper - lower + correction) |> DInt |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/LibExecutionStdLib/LibInt.fs
+++ b/backend/src/LibExecutionStdLib/LibInt.fs
@@ -286,10 +286,11 @@ let fns : List<BuiltInFn> =
         (function
         | _, [ DInt a; DInt b ] ->
           let lower, upper = if a > b then (b, a) else (a, b)
-          // The next line is a fix to correct work when an upper bound equal '1'.
-          // It is need because System.Random.NexInt64(Int64) _always_ returns 0 for 1
-          // line from the official doc: "The _exclusive_ upper bound of the random number to be generated"
-          let correction : int64 = if upper = 1 then 2 else 0
+
+          // .NET's "nextInt64" is exclusive,
+          // but we'd rather an inclusive version of this function
+          let correction : int64 = 1
+          
           lower + randomSeeded().NextInt64(upper - lower + correction) |> DInt |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/LibExecutionStdLib/LibList.fs
+++ b/backend/src/LibExecutionStdLib/LibList.fs
@@ -481,8 +481,7 @@ let fns : List<BuiltInFn> =
 
     // TODO: type check to ensure `varA` is "comparable"
     { name = fn "List" "unique" 0
-      parameters =
-        [ Param.make "list" (TList varA) ""  ]
+      parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TList varA
       description =
         "Returns the passed list, with only unique values.
@@ -490,10 +489,7 @@ let fns : List<BuiltInFn> =
          order will not be maintained."
       fn =
         (function
-        | _, [ DList l ] ->
-          uply {
-            return List.distinct l |> List.sort |> DList
-          }
+        | _, [ DList l ] -> List.distinct l |> List.sort |> DList |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/LibExecutionStdLib/LibList.fs
+++ b/backend/src/LibExecutionStdLib/LibList.fs
@@ -445,6 +445,7 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    // TODO: type check to ensure `varB` is "comparable"
     { name = fn "List" "uniqueBy" 0
       parameters =
         [ Param.make "list" (TList varA) ""
@@ -471,6 +472,27 @@ let fns : List<BuiltInFn> =
             let distinct = List.distinctBy snd projected
 
             return distinct |> List.sortBy fst |> List.map fst |> DList
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    // TODO: type check to ensure `varA` is "comparable"
+    { name = fn "List" "unique" 0
+      parameters =
+        [ Param.make "list" (TList varA) ""  ]
+      returnType = TList varA
+      description =
+        "Returns the passed list, with only unique values.
+         Only one of each value will be returned, but the
+         order will not be maintained."
+      fn =
+        (function
+        | _, [ DList l ] ->
+          uply {
+            return List.distinct l |> List.sort |> DList
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented

--- a/backend/testfiles/execution/int.tests
+++ b/backend/testfiles/execution/int.tests
@@ -165,28 +165,11 @@ Int.divide_v0 1 0 = Test.typeError_v0 "Division by zero"
 (List.range_v0 1 5) |> List.map_v0 (fun x -> Int.random_v1  2  1) |> List.map_v0 (fun x -> (x >=  1) && (x <=  2)) = [true; true; true; true; true]
 (List.range_v0 1 5) |> List.map_v0 (fun x -> Int.random_v1 20 10) |> List.map_v0 (fun x -> (x >= 10) && (x <= 20)) = [true; true; true; true; true]
 
-// uncomment tests below to check the edge case Int.random_v1 0 1
-// at least one test have to be passed
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
-// Int.random_v1 0 1 = 1
+((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 1) |> List.member_v0 0) = true
+((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 1) |> List.member_v0 1) = true
+((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 2) |> List.member_v0 0) = true
+((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 2) |> List.member_v0 1) = true
+((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 2) |> List.member_v0 2) = true
 
 Int.sum_v0 [1;2] = 3
 Int.sum_v0 [1.0;2] = Test.typeError_v0 "Expected the argument `a` to be a list of ints, but it was `[\n  1.0, 2\n]`"

--- a/backend/testfiles/execution/int.tests
+++ b/backend/testfiles/execution/int.tests
@@ -165,11 +165,8 @@ Int.divide_v0 1 0 = Test.typeError_v0 "Division by zero"
 (List.range_v0 1 5) |> List.map_v0 (fun x -> Int.random_v1  2  1) |> List.map_v0 (fun x -> (x >=  1) && (x <=  2)) = [true; true; true; true; true]
 (List.range_v0 1 5) |> List.map_v0 (fun x -> Int.random_v1 20 10) |> List.map_v0 (fun x -> (x >= 10) && (x <= 20)) = [true; true; true; true; true]
 
-((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 1) |> List.member_v0 0) = true
-((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 1) |> List.member_v0 1) = true
-((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 2) |> List.member_v0 0) = true
-((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 2) |> List.member_v0 1) = true
-((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 2) |> List.member_v0 2) = true
+((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 1) |> List.unique_v0) = [0; 1]
+((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random_v1 0 2) |> List.unique_v0) = [0; 1; 2]
 
 Int.sum_v0 [1;2] = 3
 Int.sum_v0 [1.0;2] = Test.typeError_v0 "Expected the argument `a` to be a list of ints, but it was `[\n  1.0, 2\n]`"

--- a/backend/testfiles/execution/list.tests
+++ b/backend/testfiles/execution/list.tests
@@ -192,6 +192,11 @@ List.uniqueBy_v0 [1;1;1;1] (fun x -> x) = [ 1 ]
 List.uniqueBy_v0 [7;42;7;2;10] (fun x -> x) = [ 2; 7; 10; 42 ]
 List.uniqueBy_v0 [] (fun x -> x) = []
 
+List.unique_v0 [1;2;3;4] = [ 1; 2; 3; 4 ]
+List.unique_v0 [1;1;1;1] = [ 1 ]
+List.unique_v0 [7;42;7;2;10] = [ 2; 7; 10; 42 ]
+List.unique_v0 [] = []
+
 List.unzip_v0 [(1,10);10;(3,30)] = Test.typeError_v0 "Expected the argument `pairs` to be a tuple with exactly two values, but it was `10`. It is of type Int instead of `Tuple`"
 List.unzip_v0 [(1,10);(2,20);(3,30,40)] = Test.typeError_v0 "Expected the argument `pairs` to be a tuple with exactly two values, but it was `(\n  3, 30, 40\n)`. It has length 3 but should have length 2"
 List.unzip_v0 [(1,10);(2,20);(3,30)] = [ [ 1; 2; 3 ]; [ 10; 20; 30 ] ]


### PR DESCRIPTION
Changelog:

```
Standard library
- update Int::random to be inclusive in more scenarios
- add List::unique_v0 - like List::uniqueBy_v0, but without a fn required as input
```


Just as I'd expect `Int::random 0 1` to return 0 or 1, I'd expect `Int::random 0 2` to expect any of {0, 1, 2}. Do you agree, @pbiggar? If so, I think we can update the impl to reflect this.