### PR TITLE
Add Fun::identity fn

### DIFF
--- a/backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
+++ b/backend/src/LibExecutionStdLib/LibExecutionStdLib.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="LibDate.fs" />
     <Compile Include="LibDict.fs" />
     <Compile Include="LibFloat.fs" />
+    <Compile Include="LibFun.fs" />
     <Compile Include="LibHttp.fs" />
     <Compile Include="LibHttpClient.fs" />
     <Compile Include="LibInt.fs" />

--- a/backend/src/LibExecutionStdLib/LibFun.fs
+++ b/backend/src/LibExecutionStdLib/LibFun.fs
@@ -1,0 +1,47 @@
+module LibExecutionStdLib.LibFun
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+
+open LibExecution.RuntimeTypes
+open Prelude
+
+module Errors = LibExecution.Errors
+
+let fn = FQFnName.stdlibFnName
+
+let err (str : string) = Ply(Dval.errStr str)
+
+let incorrectArgs = Errors.incorrectArgs
+
+let fns : List<BuiltInFn> =
+  [ { name = fn "Fun" "identity" 0
+      parameters = [ Param.make "val" (TVariable "a") "" ]
+      returnType = TVariable "a"
+      description = "Returns the input <param a>, without doing anything."
+      fn =
+        (function
+        | _, [ v ] -> Ply v
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "Fun" "identityB" 0
+      parameters = [ ]
+      returnType = TFn ([TVariable "a"], TVariable "a")
+      description = "Returns a function that returns its input, without doing anything"
+      fn =
+        (function
+        | _, [ ] ->
+          { parameters = [id 9999, "a"]
+            symtable = Map.empty
+            body = EVariable(id 9182, "a") }
+          |> Lambda
+          |> DFnVal
+          |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated } ]

--- a/backend/src/LibExecutionStdLib/StdLib.fs
+++ b/backend/src/LibExecutionStdLib/StdLib.fs
@@ -19,6 +19,7 @@ let prefixFns : List<BuiltInFn> =
     LibDate.fns
     LibDict.fns
     LibFloat.fns
+    LibFun.fns
     LibHttp.fns
     LibHttpClient.fns
     LibHttpClientAuth.fns

--- a/backend/testfiles/execution/fun.tests
+++ b/backend/testfiles/execution/fun.tests
@@ -1,0 +1,4 @@
+Fun.identity 1 = 1
+Fun.identity "test" = "test"
+Fun.identity (Just "test") = Just "test"
+Fun.identity (fun a -> a + 1) = (fun a -> a + 1)

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -129,6 +129,9 @@ List.push_v0 [] (fun x -> -4.611686018e+18) = [(fun x -> -4.611686018e+18)]
  let x = 6 in
  [1; 2; 3; 4] |> List.map_v0 y) = [ 6; 7; 8; 9 ]
 
+[test.pipe identity function]
+([1; 2; 3] |> List.map_v0 Fun.identity) = [1; 2; 3]
+
 [test.lambda2]
 (String.join_v0
   (List.map_v0


### PR DESCRIPTION
Changelog:

```
Area of change
- details
```

It's broken currently - the interpreter doesn't allow you to pass a stdlib fn as the RHS of a pipe (has to be lambda or use fn, it seems). See the test in language.tests

The identityB fn would probably work (I haven't tested) but seems unideal.

I'm going to leave this for a few days while I do other work - @ anyone: feel free to pick up this PR in the meantime.