### PR TITLE
Float clamp and Int power return Result

### DIFF
--- a/backend/testfiles/execution/float.tests
+++ b/backend/testfiles/execution/float.tests
@@ -52,20 +52,20 @@ Float.negate_v0 5.6 = -5.6
 Float.negate_v0 0.0 = -0.0
 Float.negate_v0 -0.0 = 0.0
 
-Float.clamp_v0 Test.infinity_v0 -1.0 0.5 = 0.5
-Float.clamp_v0 Test.negativeInfinity_v0 -1.0 0.5 = -1.0
-Float.clamp_v0 Test.nan_v0 -1.0 1.0 = Test.nan_v0
-Float.clamp_v0 0.5 Test.infinity_v0 1.0 = 1.0
-Float.clamp_v0 0.5 Test.negativeInfinity_v0 1.0 = 0.5
-Float.clamp_v0 0.5 Test.nan_v0 1.0 = Test.typeError_v0 "clamp requires arguments to be valid numbers"
-Float.clamp_v0 -1.0 0.5 Test.infinity_v0 = 0.5
-Float.clamp_v0 -1.0 0.5 Test.negativeInfinity_v0 = -1.0
-Float.clamp_v0 0.5 1.0 Test.nan_v0 = Test.typeError_v0 "clamp requires arguments to be valid numbers"
-Float.clamp_v0 -2.0 -5.0 5.0 = -2.0
-Float.clamp_v0 -3.0 -2.0 1.0 = -2.0
-Float.clamp_v0 -5.0 1.0 1.0 = 1.0
-Float.clamp_v0 1.0 2.0 1.0 = 1.0
-Float.clamp_v0 3.0 0.0 2.0 = 2.0
+Float.clamp_v0 Test.infinity_v0 -1.0 0.5 = Ok 0.5
+Float.clamp_v0 Test.negativeInfinity_v0 -1.0 0.5 = Ok -1.0
+Float.clamp_v0 Test.nan_v0 -1.0 1.0 = Ok Test.nan_v0
+Float.clamp_v0 0.5 Test.infinity_v0 1.0 = Ok  1.0
+Float.clamp_v0 0.5 Test.negativeInfinity_v0 1.0 = Ok  0.5
+Float.clamp_v0 0.5 Test.nan_v0 1.0 = Error "clamp requires arguments to be valid numbers"
+Float.clamp_v0 -1.0 0.5 Test.infinity_v0 = Ok 0.5
+Float.clamp_v0 -1.0 0.5 Test.negativeInfinity_v0 = Ok -1.0
+Float.clamp_v0 0.5 1.0 Test.nan_v0 = Error "clamp requires arguments to be valid numbers"
+Float.clamp_v0 -2.0 -5.0 5.0 = Ok -2.0
+Float.clamp_v0 -3.0 -2.0 1.0 = Ok -2.0
+Float.clamp_v0 -5.0 1.0 1.0 = Ok 1.0
+Float.clamp_v0 1.0 2.0 1.0 = Ok 1.0
+Float.clamp_v0 3.0 0.0 2.0 = Ok 2.0
 
 Float.divide_v0 9.0 2.0 = 4.5
 

--- a/backend/testfiles/execution/int.tests
+++ b/backend/testfiles/execution/int.tests
@@ -59,19 +59,20 @@ List.map_v0 (List.range_v0 (-5) 5) (fun v -> Int.mod_v0 v 4) = [3;0;1;2;3;0;1;2;
 5 % (-5) = Test.typeError_v0 "Expected the argument `b` to be positive, but it was `-5`"
 List.map_v0 (List.range_v0 -5 5) (fun v -> v % 4) = [ 3; 0; 1; 2; 3; 0; 1; 2; 3; 0; 1 ]
 
-Int.power_v0 8 5 = 32768
-Int.power_v0 0 1 = 0
-Int.power_v0 1 0 = 1
-Int.power_v0 1000 0 = 1
-Int.power_v0 -8 5 = -32768
-Int.power_v0 200 20 = Test.typeError_v0 "Error raising to exponent"
-Int.power_v0 200 7 = 12800000000000000L
-Int.power_v0 1 2147483649I = 1
-Int.power_v0 -1 2147483649I = -1
+Int.power_v0 8 5 = Ok 32768
+Int.power_v0 0 1 = Ok 0
+Int.power_v0 1 0 = Ok 1
+Int.power_v0 1000 0 = Ok 1
+Int.power_v0 -8 5 = Ok -32768
+Int.power_v0 200 20 = Error "Error raising to exponent"
+Int.power_v0 200 7 = Ok 12800000000000000L
+Int.power_v0 1 2147483649I = Ok 1
+Int.power_v0 -1 2147483649I = Ok -1
+Int.power_v0 2 -3 = Error "Expected the argument `exponent` to be positive, but it was `-3`"
 
-5 ^ 2 = 25
--8 ^ 5 = -32768
-50 ^ 2 = 2500
+5 ^ 2 = Ok 25
+-8 ^ 5 = Ok -32768
+50 ^ 2 = Ok 2500
 
 Int.greaterThan_v0 20 1 = true
 20 > 1 = true


### PR DESCRIPTION
```
- Float clamp and Int power 
```

## What is the problem/goal being addressed?
Functions using DError (sometimes called err) or Exception.raiseCode should return a Result instead

## What is the solution to this problem?
Refactoring to change return type to Result 

## How are you sure this works/how was this tested?
Modified tests were passed.
