### PR TITLE
HttpClient.request returns a Result in all cases

### DIFF
--- a/backend/src/BackendOnlyStdLib/LibHttpClient.fs
+++ b/backend/src/BackendOnlyStdLib/LibHttpClient.fs
@@ -293,7 +293,7 @@ let fns : List<BuiltInFn> =
 
               | Error (HttpClient.BadUrl details) ->
                 // TODO: include a DvalSource rather than SourceNone
-                return DError(SourceNone, $"Bad URL: {details}")
+                return DResult(Error(DStr $"Bad URL: {details}"))
 
               | Error (HttpClient.Timeout) ->
                 return DResult(Error(DStr $"Request timed out"))
@@ -306,11 +306,11 @@ let fns : List<BuiltInFn> =
             }
 
           | Error reqHeadersErr, _ ->
-            uply { return DError(SourceNone, reqHeadersErr) }
+            uply { return DResult(Error(DStr reqHeadersErr)) }
 
           | _, None ->
             let error = "Expected valid HTTP method (e.g. 'get' or 'POST')"
-            uply { return DError(SourceNone, error) }
+            uply { return DResult(Error(DStr error)) }
 
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BackendOnlyStdLib/LibHttpClient.fs
+++ b/backend/src/BackendOnlyStdLib/LibHttpClient.fs
@@ -306,7 +306,7 @@ let fns : List<BuiltInFn> =
             }
 
           | Error reqHeadersErr, _ ->
-            uply { return DResult(Error(DStr reqHeadersErr)) }
+            uply { return DError(SourceNone, reqHeadersErr) }
 
           | _, None ->
             let error = "Expected valid HTTP method (e.g. 'get' or 'POST')"

--- a/backend/testfiles/execution/httpclient.tests
+++ b/backend/testfiles/execution/httpclient.tests
@@ -26,7 +26,7 @@ HttpClient.basicAuth_v1 "" ":" = { Authorization = "Basic Ojo=" }
 
 // type errors for bad `headers` are OK
 HttpClient.request "get" "https://darklang.com" [1] Bytes.empty = Test.typeError_v0 "Expected request headers to be a List of (string * string), but got: 1"
-HttpClient.request "get" "https://darklang.com" [("", "")] Bytes.empty = Test.typeError_v0 "Empty request header key provided"
+HttpClient.request "get" "https://darklang.com" [("", "")] Bytes.empty = Error "Empty request header key provided"
 
 // type errors for bad `method` are OK
 HttpClient.request "" "https://darklang.com" [] Bytes.empty = Error "Expected valid HTTP method (e.g. 'get' or 'POST')"

--- a/backend/testfiles/execution/httpclient.tests
+++ b/backend/testfiles/execution/httpclient.tests
@@ -25,22 +25,22 @@ HttpClient.basicAuth_v1 "" ":" = { Authorization = "Basic Ojo=" }
 // Tests that try to make requests to the internet
 
 // type errors for bad `headers` are OK
-HttpClient.request "get" "https://darklang.com" [1] Bytes.empty = Test.typeError_v0 "Expected request headers to be a List of (string * string), but got: 1"
-HttpClient.request "get" "https://darklang.com" [("", "")] Bytes.empty = Test.typeError_v0 "Empty request header key provided"
+HttpClient.request "get" "https://darklang.com" [1] Bytes.empty = Error "Expected request headers to be a List of (string * string), but got: 1"
+HttpClient.request "get" "https://darklang.com" [("", "")] Bytes.empty = Error "Empty request header key provided"
 
 // type errors for bad `method` are OK
-HttpClient.request "" "https://darklang.com" [] Bytes.empty = Test.typeError_v0 "Expected valid HTTP method (e.g. 'get' or 'POST')"
-HttpClient.request " get " "https://darklang.com" [] Bytes.empty = Test.typeError_v0 "Expected valid HTTP method (e.g. 'get' or 'POST')"
-HttpClient.request "🇵🇷" "https://darklang.com" [] Bytes.empty = Test.typeError_v0 "Expected valid HTTP method (e.g. 'get' or 'POST')"
+HttpClient.request "" "https://darklang.com" [] Bytes.empty = Error "Expected valid HTTP method (e.g. 'get' or 'POST')"
+HttpClient.request " get " "https://darklang.com" [] Bytes.empty = Error "Expected valid HTTP method (e.g. 'get' or 'POST')"
+HttpClient.request "🇵🇷" "https://darklang.com" [] Bytes.empty = Error "Expected valid HTTP method (e.g. 'get' or 'POST')"
 
 // unsupported protocols
-HttpClient.request "get" "ftp://darklang.com" [] Bytes.empty = Test.typeError_v0 "Bad URL: Unsupported Protocol"
-HttpClient.request "put" "file:///etc/passwd" [] Bytes.empty = Test.typeError_v0 "Bad URL: Unsupported Protocol"
-HttpClient.request "put" "/just-a-path" [] Bytes.empty = Test.typeError_v0 "Bad URL: Unsupported Protocol"
+HttpClient.request "get" "ftp://darklang.com" [] Bytes.empty = Error "Bad URL: Unsupported Protocol"
+HttpClient.request "put" "file:///etc/passwd" [] Bytes.empty = Error"Bad URL: Unsupported Protocol"
+HttpClient.request "put" "/just-a-path" [] Bytes.empty = Error "Bad URL: Unsupported Protocol"
 
 // totally bogus URLs
-HttpClient.request "get" "" [] Bytes.empty = Test.typeError_v0 "Bad URL: Invalid URI"
-HttpClient.request "post" "{ ] nonsense ^#( :" [] Bytes.empty = Test.typeError_v0 "Bad URL: Invalid URI"
+HttpClient.request "get" "" [] Bytes.empty = Error "Bad URL: Invalid URI"
+HttpClient.request "post" "{ ] nonsense ^#( :" [] Bytes.empty = Error "Bad URL: Invalid URI"
 
 // basic requests work
 ((HttpClient.request "get" "https://example.com" [] Bytes.empty) |> Result.map_v1 (fun response -> response.statusCode)) = Ok 200

--- a/backend/testfiles/execution/httpclient.tests
+++ b/backend/testfiles/execution/httpclient.tests
@@ -25,8 +25,8 @@ HttpClient.basicAuth_v1 "" ":" = { Authorization = "Basic Ojo=" }
 // Tests that try to make requests to the internet
 
 // type errors for bad `headers` are OK
-HttpClient.request "get" "https://darklang.com" [1] Bytes.empty = Error "Expected request headers to be a List of (string * string), but got: 1"
-HttpClient.request "get" "https://darklang.com" [("", "")] Bytes.empty = Error "Empty request header key provided"
+HttpClient.request "get" "https://darklang.com" [1] Bytes.empty = Test.typeError_v0 "Expected request headers to be a List of (string * string), but got: 1"
+HttpClient.request "get" "https://darklang.com" [("", "")] Bytes.empty = Test.typeError_v0 "Empty request header key provided"
 
 // type errors for bad `method` are OK
 HttpClient.request "" "https://darklang.com" [] Bytes.empty = Error "Expected valid HTTP method (e.g. 'get' or 'POST')"


### PR DESCRIPTION
```
- HttpClient.request
```
## What is the problem/goal being addressed?
Functions using DError (sometimes called err) or Exception.raiseCode should return a Result instead

## What is the solution to this problem?
Refactoring to change return type to Result

## How are you sure this works/how was this tested?
Modified tests were passed.