### PR TITLE
Fix bugs and expand storage of Dvals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:83c7543
+      - image: darklang/dark-base:81c7d9e
 
 commands:
   show-large-files-and-directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 
 FROM ubuntu:22.04 as dark-base
 
-ENV FORCE_BUILD 3
+ENV FORCE_BUILD 8
 
 # Creates variables to allow builds to work on both amd64 and arm64
 ARG TARGETARCH
@@ -66,7 +66,6 @@ RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key ad
 RUN curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN curl -sSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 
-# We want postgres 9.6, but it is not in later ubuntus
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list
 
 RUN echo "deb https://deb.nodesource.com/node_14.x jammy main" > /etc/apt/sources.list.d/nodesource.list
@@ -103,9 +102,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
       brotli \
       sudo \
       locales \
-      postgresql-9.6 \
-      postgresql-client-9.6 \
-      postgresql-contrib-9.6 \
+      postgresql-14 \
+      postgresql-client-14 \
+      postgresql-contrib-14 \
       git-restore-mtime \
       nodejs \
       google-cloud-sdk \
@@ -182,8 +181,8 @@ RUN /etc/init.d/postgresql start && \
 
 # Adjust PostgreSQL configuration so that remote connections to the
 # database are possible.
-RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.6/main/pg_hba.conf
-RUN echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
+RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/14/main/pg_hba.conf
+RUN echo "listen_addresses='*'" >> /etc/postgresql/14/main/postgresql.conf
 
 USER dark
 # Add VOLUMEs to allow backup of config, logs and databases

--- a/backend/src/BackendOnlyStdLib/LibDB.fs
+++ b/backend/src/BackendOnlyStdLib/LibDB.fs
@@ -336,48 +336,6 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    // previously called DB::keys
-    { name = fn "DB" "schemaFields" 1
-      parameters = [ tableParam ]
-      returnType = TList varA
-      description = "Fetch all the fieldNames in <param table>"
-      fn =
-        (function
-        | state, [ DDB dbname ] ->
-          let db = state.program.dbs[dbname]
-
-          db.cols
-          |> List.filter (fun (k, _v) -> k <> "")
-          |> List.map (fun (k, _v) -> DStr k)
-          |> DList
-          |> Ply
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "DB" "schema" 1
-      parameters = [ tableParam ]
-      returnType = ocamlTObj
-      description =
-        "Returns a <type Dict> representing {{ { fieldName: fieldType } }} in <param table>"
-      fn =
-        (function
-        | state, [ DDB dbname ] ->
-          let db = state.program.dbs[dbname]
-
-          db.cols
-          |> List.filter (fun (k, _v) -> k <> "")
-          |> List.map (fun (k, v) -> (k, (v.toOldString () |> DStr)))
-          |> Dval.obj
-          |> Ply
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
     { name = fn "DB" "generateKey" 0
       parameters = []
       returnType = TStr

--- a/backend/src/BackendOnlyStdLib/LibDB.fs
+++ b/backend/src/BackendOnlyStdLib/LibDB.fs
@@ -98,7 +98,7 @@ let fns : List<BuiltInFn> =
             let! items = UserDB.getMany state db skeys
 
             if List.length items = List.length skeys then
-              return items |> List.map snd |> DList |> Some |> DOption
+              return items |> DList |> Some |> DOption
             else
               return DOption None
           }
@@ -127,7 +127,7 @@ let fns : List<BuiltInFn> =
                 keys
 
             let! result = UserDB.getMany state db skeys
-            return result |> List.map snd |> DList
+            return result |> DList
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/LibBackend/Db.fs
+++ b/backend/src/LibBackend/Db.fs
@@ -107,6 +107,12 @@ module Sql =
     idsParam.Value <- ids |> List.map int64 |> List.toArray
     Sql.parameter idsParam
 
+  let array (npgsqlType) (vs : 'a []) : SqlValue =
+    let typ = NpgsqlTypes.NpgsqlDbType.Array ||| npgsqlType
+    let param = NpgsqlParameter("vals", typ)
+    param.Value <- vs
+    Sql.parameter param
+
   let traceID (traceID : LibExecution.AnalysisTypes.TraceID.T) : SqlValue =
     let typ = NpgsqlTypes.NpgsqlDbType.Uuid
     let idParam =

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -89,6 +89,7 @@ let typecheckDval (name : string) (dval : Dval) (expectedType : DType) : unit =
 let escapeFieldname (str : string) : string =
   // Allow underscore, numbers, letters, only
   // TODO: should allow hyphen?
+  // CLEANUP: error on bad field name
   System.Text.RegularExpressions.Regex.Replace(str, "[^a-zA-Z0-9_]", "")
 
 

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -50,16 +50,15 @@ let dvalToSql (dval : Dval) : SqlValue =
   | DError _
   | DIncomplete _ -> Errors.foundFakeDval dval
   | DObj _
-  | DList _
+  | DList _ // CLEANUP allow
   | DHttpResponse _
   | DFnVal _
-  | DChar _
+  | DChar _ // CLEANUP allow
   | DDB _
   | DPassword _
-  | DOption _
-  | DResult _
-  | DBytes _
-  | DUnit
+  | DOption _ // CLEANUP allow
+  | DResult _ // CLEANUP allow
+  | DBytes _ // CLEANUP allow
   | DUserEnum _ // TODO: revisit
   | DTuple _ ->
     error2 "This value is not yet supported" (DvalReprDeveloper.toRepr dval)
@@ -69,6 +68,7 @@ let dvalToSql (dval : Dval) : SqlValue =
   | DBool b -> Sql.bool b
   | DStr s -> Sql.string s
   | DUuid id -> Sql.uuid id
+  | DUnit -> Sql.dbnull
 
 
 let typecheck (name : string) (actualType : DType) (expectedType : DType) : unit =

--- a/backend/src/LibBackend/UserDB.fs
+++ b/backend/src/LibBackend/UserDB.fs
@@ -201,16 +201,15 @@ and getOption
   }
 
 
-// CLEANUP: this is identical to getManyWithKeys, remove the key
 and getMany
   (state : RT.ExecutionState)
   (db : RT.DB.T)
   (keys : string list)
-  : Task<List<string * RT.Dval>> =
+  : Task<List<RT.Dval>> =
   task {
     let! results =
       Sql.query
-        "SELECT key, data
+        "SELECT data
         FROM user_data
         WHERE table_tlid = @tlid
           AND account_id = @accountID
@@ -224,8 +223,8 @@ and getMany
                           "userVersion", Sql.int db.version
                           "darkVersion", Sql.int currentDarkVersion
                           "keys", Sql.stringArray (Array.ofList keys) ]
-      |> Sql.executeAsync (fun read -> (read.string "key", read.string "data"))
-    return results |> List.map (fun (key, data) -> (key, toObj db data))
+      |> Sql.executeAsync (fun read -> read.string "data")
+    return results |> List.map (fun (data) -> (toObj db data))
   }
 
 

--- a/backend/src/LibBackend/UserDB.fs
+++ b/backend/src/LibBackend/UserDB.fs
@@ -56,15 +56,16 @@ let rec queryExactFields
                           "canvasID", Sql.uuid state.program.canvasID
                           "fields",
                           Sql.jsonb (
-                            DvalReprInternalQueryable.toJsonStringV0 fieldTypes queryObj
+                            DvalReprInternalQueryable.toJsonStringV0
+                              fieldTypes
+                              queryObj
                           ) ]
       |> Sql.executeAsync (fun read -> (read.string "key", read.string "data"))
     return results |> List.map (fun (key, data) -> (key, toObj db data))
   }
 
-and schemaToTypes (db : RT.DB.T) : List<string*RT.DType> =
-    db.cols
-    |> List.map (fun (name, typ) -> (name, typ))
+and schemaToTypes (db : RT.DB.T) : List<string * RT.DType> =
+  db.cols |> List.map (fun (name, typ) -> (name, typ))
 
 // Handle the DB hacks while converting this into a DVal
 and toObj (db : RT.DB.T) (obj : string) : RT.Dval =
@@ -165,7 +166,9 @@ and set
                       "darkVersion", Sql.int currentDarkVersion
                       "key", Sql.string key
                       "data",
-                      Sql.jsonb (DvalReprInternalQueryable.toJsonStringV0 fieldTypes merged) ]
+                      Sql.jsonb (
+                        DvalReprInternalQueryable.toJsonStringV0 fieldTypes merged
+                      ) ]
   |> Sql.executeStatementAsync
   |> Task.map (fun () -> id)
 

--- a/backend/src/LibExecution/DvalReprDeveloper.fs
+++ b/backend/src/LibExecution/DvalReprDeveloper.fs
@@ -6,9 +6,6 @@ open Tablecloth
 
 open RuntimeTypes
 
-// CLEANUP: make these clearer/better messages for developers.
-// They don't need to be backwards-compatible.
-
 let rec typeName (t : DType) : string =
   match t with
   | TInt -> "Int"
@@ -16,13 +13,15 @@ let rec typeName (t : DType) : string =
   | TBool -> "Bool"
   | TUnit -> "Unit"
   | TChar -> "Character"
-  | TStr -> "Str" // CLEANUP change to String
-  | TList _ -> "List"
-  | TTuple _ -> "Tuple"
-  | TDict _ -> "Dict"
+  | TStr -> "String"
+  | TList nested -> $"List<{typeName nested}>"
+  | TTuple (n1, n2, rest) ->
+    let nested = (n1 :: n2 :: rest) |> List.map typeName |> String.concat ", "
+    $"({nested})"
+  | TDict nested -> $"Dict<{typeName nested}>"
   | TRecord _ -> "Dict"
   | TFn _ -> "Block"
-  | TVariable _varname -> "Any"
+  | TVariable varname -> $"'{varname}"
   | TIncomplete -> "Incomplete"
   | TError -> "Error"
   | THttpResponse _ -> "Response"
@@ -30,9 +29,9 @@ let rec typeName (t : DType) : string =
   | TDateTime -> "DateTime"
   | TPassword -> "Password"
   | TUuid -> "UUID"
-  | TOption _ -> "Option"
-  | TResult _ -> "Result"
-  | TUserType t -> t.type_
+  | TOption nested -> $"Option<{typeName nested}>"
+  | TResult (ok, err) -> $"Result<{typeName ok}, {typeName err}>"
+  | TUserType t -> $"{t.type_}_v{t.version}"
   | TBytes -> "Bytes"
 
 let dvalTypeName (dv : Dval) : string = dv |> Dval.toType |> typeName

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -195,7 +195,7 @@ let parseJsonV0 (typ : DType) (str : string) : Dval =
         Exception.raiseInternal "Invalid fields" []
     | _ ->
       Exception.raiseInternal
-        "Value in Datastore does not match Datastoreected type"
+        "Value in Datastore does not match Datastore expected type"
         [ "type", typ; "value", j ]
 
   str |> parseJson |> convert typ

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -86,7 +86,7 @@ let rec private toJsonV0 (w : Utf8JsonWriter) (typ : DType) (dv : Dval) : unit =
       let result = if result.Contains "." then result else $"{result}.0"
       w.WriteRawValue result
   | TBool, DBool b -> w.WriteBooleanValue b
-  | TUnit, DUnit -> w.WriteNullValue()
+  | TUnit, DUnit -> w.WriteNumberValue(0)
   | TStr, DStr s -> w.WriteStringValue s
   | TList ltype, DList l -> w.writeArray (fun () -> List.iter (writeDval ltype) l)
   | TDict objType, DObj o ->
@@ -174,7 +174,7 @@ let parseJsonV0 (typ : DType) (str : string) : Dval =
       |> NodaTime.Instant.ofIsoString
       |> DarkDateTime.fromInstant
       |> DDateTime
-    | TUnit, JsonValueKind.Null -> DUnit
+    | TUnit, JsonValueKind.Number -> DUnit
     | TList nested, JsonValueKind.Array ->
       j.EnumerateArray() |> Seq.map (convert nested) |> Seq.toList |> DList
     // | TTuple (t1, t2, rest), JsonValueKind.Array ->

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -68,111 +68,137 @@ type Utf8JsonWriter with
 // Password
 // UUID
 
-let rec private toJsonV0 (w : Utf8JsonWriter) (dv : Dval) : unit =
+let rec private toJsonV0 (w : Utf8JsonWriter) (typ : DType) (dv : Dval) : unit =
   let writeDval = toJsonV0 w
 
-  let wrapStringValue (typ : string) (str : string) =
-    w.writeObject (fun () ->
-      w.WritePropertyName "type"
-      w.WriteStringValue(typ)
-      w.WritePropertyName "value"
-      w.WriteStringValue(str))
-
-  match dv with
+  match typ, dv with
   // basic types
-  | DInt i -> w.WriteNumberValue i
-  | DFloat f ->
-    // TODO: These can't be parsed as System.Text.Json doesn't allow it. I went ahead
-    // with implementing this anyway as when we use types during serialization, we'll
-    // be able to use `"Infinity"` (a string) and we'll know from the type that we
-    // want a float not a string here. So I've disabled the infinity/NaN tests until
-    // we have this in place.
+  | TInt, DInt i -> w.WriteNumberValue i // CLEANUP if the number is outside the range, store as a string?
+  | TFloat, DFloat f ->
     if System.Double.IsNaN f then
-      w.WriteRawValue "NaN"
+      w.WriteStringValue "NaN"
     else if System.Double.IsNegativeInfinity f then
-      w.WriteRawValue "-Infinity"
+      w.WriteStringValue "-Infinity"
     else if System.Double.IsPositiveInfinity f then
-      w.WriteRawValue "Infinity"
+      w.WriteStringValue "Infinity"
     else
       let result = sprintf "%.12g" f
       let result = if result.Contains "." then result else $"{result}.0"
       w.WriteRawValue result
-  | DBool b -> w.WriteBooleanValue b
-  | DUnit -> w.WriteNullValue()
-  | DStr s -> w.WriteStringValue s
-  | DList l -> w.writeArray (fun () -> List.iter writeDval l)
-  | DObj o ->
+  | TBool, DBool b -> w.WriteBooleanValue b
+  | TUnit, DUnit -> w.WriteNullValue()
+  | TStr, DStr s -> w.WriteStringValue s
+  | TList ltype, DList l -> w.writeArray (fun () -> List.iter (writeDval ltype) l)
+  | TDict objType, DObj o ->
     w.writeObject (fun () ->
       Map.iter
         (fun k v ->
           w.WritePropertyName k
-          writeDval v)
+          writeDval objType v)
         o)
-  | DChar c -> wrapStringValue "character" c
-  | DDateTime date -> wrapStringValue "date" (DarkDateTime.toIsoString date)
-  | DPassword (Password hashed) ->
-    hashed |> Base64.defaultEncodeToString |> wrapStringValue "password"
-  | DUuid uuid -> wrapStringValue "uuid" (string uuid)
-
+  | TRecord fields, DObj dvalMap ->
+    let schema = Map.ofList fields
+    w.writeObject (fun () ->
+      dvalMap
+      |> Map.toList
+      |> List.iter (fun (k, dval) ->
+        w.WritePropertyName k
+        writeDval (Map.find k schema) dval))
+  | TChar, DChar c -> w.WriteStringValue c
+  | TDateTime, DDateTime date -> w.WriteStringValue(DarkDateTime.toIsoString date)
+  | TPassword, DPassword (Password hashed) ->
+    hashed |> Base64.defaultEncodeToString |> w.WriteStringValue
+  | TUuid, DUuid uuid -> w.WriteStringValue(string uuid)
   // Not supported
-  | DTuple _
-  | DFnVal _
-  | DError _
-  | DIncomplete _
-  | DHttpResponse _
-  | DUserEnum _
-  | DDB _
-  | DOption _
-  | DResult _
-  | DBytes _ -> Exception.raiseInternal "Not supported in queryable" []
+  | TTuple (t1, t2, trest), DTuple (d1, d2, rest) ->
+    w.writeArray (fun () ->
+      List.iter2 writeDval (t1 :: t2 :: trest) (d1 :: d2 :: rest))
+  | TBytes, DBytes bytes ->
+    bytes |> Base64.defaultEncodeToString |> w.WriteStringValue
+  | TOption _, DOption None -> w.writeObject (fun () -> w.WriteNull "Nothing")
+  | TOption oType, DOption (Some dv) ->
+    w.writeObject (fun () ->
+      w.WritePropertyName "Just"
+      writeDval oType dv)
+  | TResult (okType, _), DResult (Ok dv) ->
+    w.writeObject (fun () ->
+      w.WritePropertyName "Ok"
+      writeDval okType dv)
+  | TResult (_, errType), DResult (Error dv) ->
+    w.writeObject (fun () ->
+      w.WritePropertyName "Error"
+      writeDval errType dv)
+  | THttpResponse _, DHttpResponse _
+  | TFn _, DFnVal _
+  | TError _, DError _
+  | TIncomplete, DIncomplete _
+  | TDB _, DDB _ -> Exception.raiseInternal "Not supported in queryable" []
+  | _ ->
+    Exception.raiseInternal
+      "Value to be stored does not match Datastore type"
+      [ "value", dv; "type", typ ]
 
 
 
-let toJsonStringV0 (dvalMap : DvalMap) : string =
+let toJsonStringV0 (fieldTypes : List<string * DType>) (dvalMap : DvalMap) : string =
+  let fieldTypes = Map fieldTypes
   writeJson (fun w ->
     w.writeObject (fun () ->
       dvalMap
       |> Map.toList
       |> List.iter (fun (k, dval) ->
         w.WritePropertyName k
-        toJsonV0 w dval)))
+        toJsonV0 w (Map.find k fieldTypes) dval)))
 
 
-let parseJsonV0 (str : string) : Dval =
-  let rec convert (j : JsonElement) : Dval =
-    match j.ValueKind with
-    | JsonValueKind.Number ->
-      let mutable i : int64 = 0L
-      if j.TryGetInt64(&i) then DInt i else DFloat(j.GetDouble())
-    | JsonValueKind.True -> DBool true
-    | JsonValueKind.False -> DBool false
-    | JsonValueKind.String -> DStr(j.GetString())
-    | JsonValueKind.Null -> DUnit
-    | JsonValueKind.Array ->
-      j.EnumerateArray() |> Seq.map convert |> Seq.toList |> DList
-    | JsonValueKind.Object ->
-      let fields =
-        j.EnumerateObject()
-        |> Seq.map (fun jp -> (jp.Name, convert jp.Value))
-        |> Seq.toList
-        |> List.sortBy (fun (k, _) -> k)
-      // These are the only types that are allowed in the queryable
-      // representation. We may allow more in the future, but the real thing to
-      // do is to use the DB's type and version to encode/decode them correctly
-      match fields with
-      | [ ("type", DStr "character"); ("value", DStr v) ] -> DChar v
-      | [ ("type", DStr "date"); ("value", DStr v) ] ->
-        DDateTime(NodaTime.Instant.ofIsoString v |> DarkDateTime.fromInstant)
-      | [ ("type", DStr "password"); ("value", DStr v) ] ->
-        v |> Base64.decodeFromString |> Password |> DPassword
-      | [ ("type", DStr "uuid"); ("value", DStr v) ] -> DUuid(System.Guid v)
-      | _ -> fields |> Map.ofList |> DObj
+let parseJsonV0 (typ : DType) (str : string) : Dval =
+  let rec convert (typ : DType) (j : JsonElement) : Dval =
+    match typ, j.ValueKind with
+    | TInt, JsonValueKind.Number -> j.GetInt64() |> DInt
+    | TFloat, JsonValueKind.Number -> j.GetDouble() |> DFloat
+    | TFloat, JsonValueKind.String ->
+      match j.GetString() with
+      | "NaN" -> DFloat System.Double.NaN
+      | "Infinity" -> DFloat System.Double.PositiveInfinity
+      | "-Infinity" -> DFloat System.Double.NegativeInfinity
+      | v -> Exception.raiseInternal "Invalid float" [ "value", v ]
+    | TBool, JsonValueKind.True -> DBool true
+    | TBool, JsonValueKind.False -> DBool false
+    | TStr, JsonValueKind.String -> DStr(j.GetString())
+    | TChar, JsonValueKind.String -> DChar(j.GetString())
+    | TUuid, JsonValueKind.String -> DUuid(System.Guid(j.GetString()))
+    | TPassword, JsonValueKind.String ->
+      j.GetString() |> Base64.decodeFromString |> Password |> DPassword
+    | TDateTime, JsonValueKind.String ->
+      j.GetString()
+      |> NodaTime.Instant.ofIsoString
+      |> DarkDateTime.fromInstant
+      |> DDateTime
+    | TUnit, JsonValueKind.Null -> DUnit
+    | TList nested, JsonValueKind.Array ->
+      j.EnumerateArray() |> Seq.map (convert nested) |> Seq.toList |> DList
+    // | TTuple (t1, t2, rest), JsonValueKind.Array ->
+    //   j.EnumerateArray() |> Seq.map (convert nested) |> Seq.toList |> DList
+    | TRecord typFields, JsonValueKind.Object ->
+      // Use maps to cooalesce duplicate keys and ensure the obj matches the type
+      let typFields = Map typFields
+      let objFields =
+        j.EnumerateObject() |> Seq.map (fun jp -> (jp.Name, jp.Value)) |> Map
+      if Map.count objFields = Map.count typFields then
+        objFields
+        |> Map.mapWithIndex (fun k v ->
+          match Map.tryFind k typFields with
+          | Some t -> convert t v
+          | None -> Exception.raiseInternal "Missing field" [ "field", k ])
+        |> DObj
+      else
+        Exception.raiseInternal "Invalid fields" []
     | _ ->
       Exception.raiseInternal
-        "Invalid type in internalQueryableV1 json"
-        [ "json", j ]
+        "Value in Datastore does not match Datastoreected type"
+        [ "type", typ; "value", j ]
 
-  str |> parseJson |> convert
+  str |> parseJson |> convert typ
 
 
 
@@ -185,8 +211,9 @@ module Test =
     | DBool _
     | DDateTime _
     | DPassword _
+    | DChar _
+    | DFloat _
     | DUuid _ -> true
-    | DFloat f -> System.Double.IsFinite f // See comment above
     | DList dvals -> List.all isQueryableDval dvals
     | DObj map -> map |> Map.values |> List.all isQueryableDval
     | DUserEnum (_typeName, _caseName, fields) ->
@@ -195,7 +222,6 @@ module Test =
 
     // TODO support
     | DTuple _
-    | DChar _
     | DBytes _
     | DHttpResponse _
     | DOption _

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -319,36 +319,6 @@ and DType =
     | TFn _ -> true
     | _ -> false
 
-  // This string was created in the very old days, and is barely used anymore
-  member this.toOldString() : string =
-    // Used in DB::schema_v0, to save type in honeycomb after queue execution
-    // TODO CLEANUP After merge, inline into DB::schema and use better types for honeycomb
-    match this with
-    | TInt -> "Int"
-    | TFloat -> "Float"
-    | TBool -> "Bool"
-    | TUnit -> "Nothing"
-    | TChar -> "Character"
-    | TStr -> "Str"
-    | TList _ -> "List"
-    | TTuple _ -> "Tuple"
-    | TFn _ -> "Block"
-    | TRecord _ -> "Dict"
-    | TVariable _ -> "Any"
-    | TIncomplete -> "Incomplete"
-    | TError -> "Error"
-    | THttpResponse _ -> "Response"
-    | TDB _ -> "Datastore"
-    | TDateTime -> "DateTime"
-    | TDict _ -> "Dict"
-    | TPassword -> "Password"
-    | TUuid -> "UUID"
-    | TOption _ -> "Option"
-    | TResult _ -> "Result"
-    | TUserType t -> t.type_
-    | TBytes -> "Bytes"
-
-
 /// Record the source of an incomplete or error. Would be useful to add more
 /// information later, such as the iteration count that led to this, or
 /// something like a stack trace

--- a/backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -11,8 +11,6 @@ let fn = FQFnName.stdlibFnName
 let incorrectArgs = LibExecution.Errors.incorrectArgs
 
 let varA = TVariable "a"
-let varB = TVariable "b"
-
 
 
 let fns : List<BuiltInFn> =
@@ -32,7 +30,7 @@ let fns : List<BuiltInFn> =
 
 
     { name = fn "" "notEquals" 0
-      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      parameters = [ Param.make "a" varA ""; Param.make "b" varA "" ]
       returnType = TBool
       description = "Returns true if the two value are not equal"
       fn =

--- a/backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -20,32 +20,33 @@ let rec equals (a : Dval) (b : Dval) : bool =
   | DUnit, DUnit -> true
   | DStr a, DStr b -> a = b
   | DChar a, DChar b -> a = b
-  | DList a, DList b ->
-    a.Length = b.Length
-    && List.forall2 equals a b
+  | DList a, DList b -> a.Length = b.Length && List.forall2 equals a b
   | DTuple (a1, a2, a3), DTuple (b1, b2, b3) ->
     if a3.Length <> b3.Length then // special case - this is a type error
       Exception.raiseCode "tuples must be the same length"
     else
       equals a1 b1 && equals a2 b2 && List.forall2 equals a3 b3
   | DObj a, DObj b ->
-      Map.count a = Map.count b
-      && Map.forall (fun k v -> Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false) a
+    Map.count a = Map.count b
+    && Map.forall
+         (fun k v ->
+           Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false)
+         a
   | DFnVal a, DFnVal b ->
-      match a, b with
-      | Lambda a, Lambda b -> equalsLambdaImpl a b
-      | FnName a, FnName b -> a = b
-      | Lambda _, FnName _
-      | FnName _, Lambda _ -> false
+    match a, b with
+    | Lambda a, Lambda b -> equalsLambdaImpl a b
+    | FnName a, FnName b -> a = b
+    | Lambda _, FnName _
+    | FnName _, Lambda _ -> false
   | DDateTime a, DDateTime b -> a = b
   | DPassword _, DPassword _ -> false
   | DUuid a, DUuid b -> a = b
   | DOption a, DOption b ->
-      match a, b with
-      | Some a, Some b -> equals a b
-      | None, None -> true
-      | Some _, None
-      | None, Some _ -> false
+    match a, b with
+    | Some a, Some b -> equals a b
+    | None, None -> true
+    | Some _, None
+    | None, Some _ -> false
   | DResult a, DResult b ->
     match a, b with
     | Ok a, Ok b
@@ -82,44 +83,84 @@ let rec equals (a : Dval) (b : Dval) : bool =
   | DIncomplete _, _ -> Exception.raiseCode "Both values must be the same type"
 
 and equalsLambdaImpl (impl1 : LambdaImpl) (impl2 : LambdaImpl) : bool =
-    impl1.parameters.Length = impl2.parameters.Length
-    && List.forall2 (fun (_, str1) (_, str2) -> str1 = str2) impl1.parameters impl2.parameters
-    && equalsSymtable impl1.symtable impl2.symtable
-    && equalsExpr impl1.body impl2.body
+  impl1.parameters.Length = impl2.parameters.Length
+  && List.forall2
+       (fun (_, str1) (_, str2) -> str1 = str2)
+       impl1.parameters
+       impl2.parameters
+  && equalsSymtable impl1.symtable impl2.symtable
+  && equalsExpr impl1.body impl2.body
 
 and equalsSymtable (a : Symtable) (b : Symtable) : bool =
-    Map.count a = Map.count b
-    && Map.forall (fun k v -> Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false) a
+  Map.count a = Map.count b
+  && Map.forall
+       (fun k v ->
+         Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false)
+       a
 
 and equalsExpr (expr1 : Expr) (expr2 : Expr) : bool =
   match expr1, expr2 with
   | EInteger (_, int1), EInteger (_, int2) -> int1 = int2
   | EBool (_, bool1), EBool (_, bool2) -> bool1 = bool2
-  | EString (_, segments1), EString (_, segments2) -> equalsStringSegments segments1 segments2
+  | EString (_, segments1), EString (_, segments2) ->
+    equalsStringSegments segments1 segments2
   | ECharacter (_, char1), ECharacter (_, char2) -> char1 = char2
   | EFloat (_, float1), EFloat (_, float2) -> float1 = float2
   | EUnit _, EUnit _ -> true
-  | ELet (_, pattern1, expr1, body1), ELet (_, pattern2, expr2, body2) -> equalsLetPattern pattern1 pattern2 && equalsExpr expr1 expr2 && equalsExpr body1 body2
-  | EIf (_, cond1, then1, else1), EIf (_, cond2, then2, else2) -> equalsExpr cond1 cond2 && equalsExpr then1 then2 && equalsExpr else1 else2
+  | ELet (_, pattern1, expr1, body1), ELet (_, pattern2, expr2, body2) ->
+    equalsLetPattern pattern1 pattern2
+    && equalsExpr expr1 expr2
+    && equalsExpr body1 body2
+  | EIf (_, cond1, then1, else1), EIf (_, cond2, then2, else2) ->
+    equalsExpr cond1 cond2 && equalsExpr then1 then2 && equalsExpr else1 else2
   | ELambda (_, parameters1, body1), ELambda (_, parameters2, body2) ->
-    parameters1.Length = parameters2.Length && List.forall2 (fun (_, str1) (_, str2) -> str1 = str2) parameters1 parameters2 && equalsExpr body1 body2
-  | EFieldAccess (_, target1, fieldName1), EFieldAccess (_, target2, fieldName2) -> equalsExpr target1 target2 && fieldName1 = fieldName2
+    parameters1.Length = parameters2.Length
+    && List.forall2 (fun (_, str1) (_, str2) -> str1 = str2) parameters1 parameters2
+    && equalsExpr body1 body2
+  | EFieldAccess (_, target1, fieldName1), EFieldAccess (_, target2, fieldName2) ->
+    equalsExpr target1 target2 && fieldName1 = fieldName2
   | EVariable (_, name1), EVariable (_, name2) -> name1 = name2
-  | EApply (_, fn1, args1, isInPipe1), EApply (_, fn2, args2, isInPipe2) -> equalsExpr fn1 fn2 && List.forall2 equalsExpr args1 args2 && equalsIsInPipe isInPipe1 isInPipe2
+  | EApply (_, fn1, args1, isInPipe1), EApply (_, fn2, args2, isInPipe2) ->
+    equalsExpr fn1 fn2
+    && List.forall2 equalsExpr args1 args2
+    && equalsIsInPipe isInPipe1 isInPipe2
   | EFQFnValue (_, fqfn1), EFQFnValue (_, fqfn2) -> fqfn1 = fqfn2
   | EList (_, elems1), EList (_, elems2) ->
     elems1.Length = elems2.Length && List.forall2 equalsExpr elems1 elems2
   | ETuple (_, elem1_1, elem2_1, elems1), ETuple (_, elem1_2, elem2_2, elems2) ->
-      equalsExpr elem1_1 elem1_2 && equalsExpr elem2_1 elem2_2 && elems1.Length = elems2.Length && List.forall2 equalsExpr elems1 elems2
+    equalsExpr elem1_1 elem1_2
+    && equalsExpr elem2_1 elem2_2
+    && elems1.Length = elems2.Length
+    && List.forall2 equalsExpr elems1 elems2
   | ERecord (_, fields1), ERecord (_, fields2) ->
-    fields1.Length = fields2.Length && List.forall2 (fun (name1, expr1) (name2, expr2) -> name1 = name2 && equalsExpr expr1 expr2) fields1 fields2
-  | EConstructor (_, tag1, args1), EConstructor (_, tag2, args2) -> tag1 = tag2 && args1.Length = args2.Length && List.forall2 equalsExpr args1 args2
+    fields1.Length = fields2.Length
+    && List.forall2
+         (fun (name1, expr1) (name2, expr2) ->
+           name1 = name2 && equalsExpr expr1 expr2)
+         fields1
+         fields2
+  | EConstructor (_, tag1, args1), EConstructor (_, tag2, args2) ->
+    tag1 = tag2
+    && args1.Length = args2.Length
+    && List.forall2 equalsExpr args1 args2
   | EMatch (_, target1, cases1), EMatch (_, target2, cases2) ->
-    equalsExpr target1 target2 && cases1.Length = cases2.Length && List.forall2 (fun (p1, e1) (p2, e2) -> equalsMatchPattern p1 p2 && equalsExpr e1 e2) cases1 cases2
-  | EFeatureFlag (_, flag1, on1, off1), EFeatureFlag (_, flag2, on2, off2) -> equalsExpr flag1 flag2 && equalsExpr on1 on2 && equalsExpr off1 off2
-  | EAnd (_, lhs1, rhs1), EAnd (_, lhs2, rhs2) -> equalsExpr lhs1 lhs2 && equalsExpr rhs1 rhs2
-  | EOr (_, lhs1, rhs1), EOr (_, lhs2, rhs2) -> equalsExpr lhs1 lhs2 && equalsExpr rhs1 rhs2
-  | EUserEnum (_, name1, case1, args1), EUserEnum (_, name2, case2, args2) -> name1 = name2 && case1 = case2 && args1.Length = args2.Length && List.forall2 equalsExpr args1 args2
+    equalsExpr target1 target2
+    && cases1.Length = cases2.Length
+    && List.forall2
+         (fun (p1, e1) (p2, e2) -> equalsMatchPattern p1 p2 && equalsExpr e1 e2)
+         cases1
+         cases2
+  | EFeatureFlag (_, flag1, on1, off1), EFeatureFlag (_, flag2, on2, off2) ->
+    equalsExpr flag1 flag2 && equalsExpr on1 on2 && equalsExpr off1 off2
+  | EAnd (_, lhs1, rhs1), EAnd (_, lhs2, rhs2) ->
+    equalsExpr lhs1 lhs2 && equalsExpr rhs1 rhs2
+  | EOr (_, lhs1, rhs1), EOr (_, lhs2, rhs2) ->
+    equalsExpr lhs1 lhs2 && equalsExpr rhs1 rhs2
+  | EUserEnum (_, name1, case1, args1), EUserEnum (_, name2, case2, args2) ->
+    name1 = name2
+    && case1 = case2
+    && args1.Length = args2.Length
+    && List.forall2 equalsExpr args1 args2
   // exhaustiveness check
   | EInteger _, _
   | EBool _, _
@@ -149,11 +190,17 @@ and equalsLetPattern (pattern1 : LetPattern) (pattern2 : LetPattern) : bool =
   match pattern1, pattern2 with
   | LPVariable (_, name1), LPVariable (_, name2) -> name1 = name2
 
-and equalsStringSegments (segments1 : List<StringSegment>) (segments2 : List<StringSegment>) : bool =
+and equalsStringSegments
+  (segments1 : List<StringSegment>)
+  (segments2 : List<StringSegment>)
+  : bool =
   segments1.Length = segments2.Length
   && List.forall2 equalsStringSegment segments1 segments2
 
-and equalsStringSegment (segment1 : StringSegment) (segment2 : StringSegment) : bool =
+and equalsStringSegment
+  (segment1 : StringSegment)
+  (segment2 : StringSegment)
+  : bool =
   match segment1, segment2 with
   | StringText text1, StringText text2 -> text1 = text2
   | StringInterpolation expr1, StringInterpolation expr2 -> equalsExpr expr1 expr2
@@ -172,7 +219,10 @@ and equalsIsInPipe (pipe1 : IsInPipe) (pipe2 : IsInPipe) : bool =
 and equalsMatchPattern (pattern1 : MatchPattern) (pattern2 : MatchPattern) : bool =
   match pattern1, pattern2 with
   | MPVariable (_, name1), MPVariable (_, name2) -> name1 = name2
-  | MPConstructor (_, tag1, args1), MPConstructor (_, tag2, args2) -> tag1 = tag2 && args1.Length = args2.Length && List.forall2 equalsMatchPattern args1 args2
+  | MPConstructor (_, tag1, args1), MPConstructor (_, tag2, args2) ->
+    tag1 = tag2
+    && args1.Length = args2.Length
+    && List.forall2 equalsMatchPattern args1 args2
   | MPInteger (_, int1), MPInteger (_, int2) -> int1 = int2
   | MPBool (_, bool1), MPBool (_, bool2) -> bool1 = bool2
   | MPCharacter (_, char1), MPCharacter (_, char2) -> char1 = char2
@@ -180,7 +230,10 @@ and equalsMatchPattern (pattern1 : MatchPattern) (pattern2 : MatchPattern) : boo
   | MPFloat (_, float1), MPFloat (_, float2) -> float1 = float2
   | MPUnit _, MPUnit _ -> true
   | MPTuple (_, elem1_1, elem2_1, elems1), MPTuple (_, elem1_2, elem2_2, elems2) ->
-   equalsMatchPattern elem1_1 elem1_2 && equalsMatchPattern elem2_1 elem2_2 && elems1.Length = elems2.Length && List.forall2 equalsMatchPattern elems1 elems2
+    equalsMatchPattern elem1_1 elem1_2
+    && equalsMatchPattern elem2_1 elem2_2
+    && elems1.Length = elems2.Length
+    && List.forall2 equalsMatchPattern elems1 elems2
   // exhaustiveness check
   | MPVariable _, _
   | MPConstructor _, _
@@ -200,8 +253,7 @@ let fns : List<BuiltInFn> =
       description = "Returns true if the two value are equal"
       fn =
         (function
-        | _, [ a; b ] ->
-          equals a b |> DBool |> Ply
+        | _, [ a; b ] -> equals a b |> DBool |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "="
       previewable = Pure

--- a/backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -56,6 +56,8 @@ let rec equals (a : Dval) (b : Dval) : bool =
   | DDB a, DDB b -> a = b
   | DHttpResponse (code1, headers1, body1), DHttpResponse (code2, headers2, body2) ->
     code1 = code2 && headers1 = headers2 && equals body1 body2
+  | DUserEnum (a1, a2, a3), DUserEnum (b1, b2, b3) ->
+    a1 = b1 && a2 = b2 && a3.Length = b3.Length && List.forall2 equals a3 b3
   // exhaustivenss check
   | DInt _, _
   | DFloat _, _
@@ -75,6 +77,7 @@ let rec equals (a : Dval) (b : Dval) : bool =
   | DBytes _, _
   | DDB _, _
   | DHttpResponse _, _
+  | DUserEnum _, _
   | DError _, _
   | DIncomplete _, _ -> Exception.raiseCode "Both values must be the same type"
 
@@ -116,6 +119,7 @@ and equalsExpr (expr1 : Expr) (expr2 : Expr) : bool =
   | EFeatureFlag (_, flag1, on1, off1), EFeatureFlag (_, flag2, on2, off2) -> equalsExpr flag1 flag2 && equalsExpr on1 on2 && equalsExpr off1 off2
   | EAnd (_, lhs1, rhs1), EAnd (_, lhs2, rhs2) -> equalsExpr lhs1 lhs2 && equalsExpr rhs1 rhs2
   | EOr (_, lhs1, rhs1), EOr (_, lhs2, rhs2) -> equalsExpr lhs1 lhs2 && equalsExpr rhs1 rhs2
+  | EUserEnum (_, name1, case1, args1), EUserEnum (_, name2, case2, args2) -> name1 = name2 && case1 = case2 && args1.Length = args2.Length && List.forall2 equalsExpr args1 args2
   // exhaustiveness check
   | EInteger _, _
   | EBool _, _
@@ -137,7 +141,8 @@ and equalsExpr (expr1 : Expr) (expr2 : Expr) : bool =
   | EMatch _, _
   | EFeatureFlag _, _
   | EAnd _, _
-  | EOr _, _ -> false
+  | EOr _, _
+  | EUserEnum _, _ -> false
 
 
 and equalsLetPattern (pattern1 : LetPattern) (pattern2 : LetPattern) : bool =

--- a/backend/src/Parser/Parser.fs
+++ b/backend/src/Parser/Parser.fs
@@ -501,6 +501,7 @@ let parseTestFile (filename : string) : Module =
       | "float" -> PT.TFloat
       | "DateTime" -> PT.TDateTime
       | "UUID" -> PT.TUuid
+      | "unit" -> PT.TUnit
       | "Password" -> PT.TPassword
       | _ ->
         Exception.raiseInternal

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -135,9 +135,10 @@ module Roundtrip =
     fetch (fun p -> p.``false`` == false) = Just (sample ())
     fetch (fun p -> p.``false`` != false) = Just (otherSample ())
 
-    // fetch (fun p -> p.list == [1;2;3]) = Just (sample ())
-    // fetch (fun p -> p.list != [1;2;3]) = Just (otherSample ())
-    // fetch (fun p -> p.list == []) = Nothing
+    // A bug in postgresql jsonb support prevents this from working
+    fetch (fun p -> p.list == [1;2;3]) = Just (sample ())
+    fetch (fun p -> p.list != [1;2;3]) = Just (otherSample ())
+    fetch (fun p -> p.list == []) = Nothing
 
     fetch (fun p -> p.char == 'c') = Just (sample ())
     fetch (fun p -> p.char != 'c') = Just (otherSample ())
@@ -415,12 +416,6 @@ module FindAll =
 
   // sql injection
   friendsError (fun p -> "; select * from users;" == p.name ) = []
-
-  // CLEANUP we should catch this. See note about SqlBinOp in SqlCompiler.fs
-  // invalid type comparison
-  (let _ = Test.setExpectedExceptionCount 1 in
-   friendsError (fun p -> p.height == "string")) =
-     Test.sqlError "An error occurred while querying the Datastore"
 
 module CompiledFunctions =
   (friends (fun p -> Float.lessThan_v0 90.0 p.income)) = [ "Ross" ]

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -407,7 +407,7 @@ module FindAll =
 
   // lambda doesnt return a bool
   friendsError (fun p -> "x") =
-    Test.sqlError "Incorrect type in string \"x\", expected Bool, but got a Str"
+    Test.sqlError "Incorrect type in string \"x\", expected Bool, but got a String"
 
   // bad variable name
   friendsError (fun p -> let x = 32 in true && p.height > y) =

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -80,11 +80,14 @@ module Roundtrip =
     let fetch (fn : 'a -> bool) =
       let z = DB.set_v1 (sample ()) "sample" DB in
       let z = DB.set_v1 (otherSample ()) "other" DB in
-      DB.queryOne_v4 DB fn
+      DB.query_v4 DB fn
 
     // invalid type comparisons errors
-    fetch (fun p -> 5 == "str") = Nothing
-    fetch (fun p -> 5 != "str") = Nothing
+    // these work, but the DError has a random string in it that we can't match
+    // fetch (fun p -> 5 == "str") =
+    //   Test.sqlError "Incorrect type in variable, expected Bool, but got a Error"
+    // fetch (fun p -> 5 != "str") =
+    //   Test.sqlError "Incorrect type in variable, expected Bool, but got a Error"
 
     fetch (fun p -> p.int == "str") =
       Test.sqlError "Incorrect type in b, expected Int, but got a String"
@@ -96,64 +99,70 @@ module Roundtrip =
     fetch (fun p -> "str" == p.int) =
       Test.sqlError "Incorrect type in b, expected String, but got a Int"
 
-    fetch (fun p -> p.iNsEnSiTiVe == "iNsEnSiTiVe") = Just (sample ())
-    fetch (fun p -> p.iNsEnSiTiVe != "iNsEnSiTiVe") = Just (otherSample ())
-    fetch (fun p -> p.iNsEnSiTiVe == "nothing") = Nothing
+    fetch (fun p -> p.iNsEnSiTiVe == "iNsEnSiTiVe") = [sample ()]
+    fetch (fun p -> p.iNsEnSiTiVe != "iNsEnSiTiVe") = [otherSample ()]
+    fetch (fun p -> p.iNsEnSiTiVe == "nothing") = []
 
-    fetch (fun p -> p.``ALLCAPS`` == 1) = Just (sample ())
-    fetch (fun p -> p.``ALLCAPS`` != 1) = Just (otherSample ())
-    fetch (fun p -> p.``ALLCAPS`` == 1000) = Nothing
+    fetch (fun p -> p.``ALLCAPS`` == 1) = [sample ()]
+    fetch (fun p -> p.``ALLCAPS`` != 1) = [otherSample ()]
+    fetch (fun p -> p.``ALLCAPS`` == 1000) = []
 
-    fetch (fun p -> p.int == 2) = Just (sample ())
-    fetch (fun p -> p.int != 2) = Just (otherSample ())
-    fetch (fun p -> p.int == 200) = Nothing
+    fetch (fun p -> p.int == 2) = [sample ()]
+    fetch (fun p -> p.int != 2) = [otherSample ()]
+    fetch (fun p -> p.int == 200) = []
 
-    fetch (fun p -> p.float == 3.0) = Just (sample ())
-    fetch (fun p -> p.float != 3.0) = Just (otherSample ())
-    fetch (fun p -> p.float == 30.0) = Nothing
+    fetch (fun p -> p.float == 3.0) = [sample ()]
+    fetch (fun p -> p.float != 3.0) = [otherSample ()]
+    fetch (fun p -> p.float == 30.0) = []
 
-    fetch (fun p -> p.negZero == -0.0) = Just (sample ())
-    fetch (fun p -> p.negZero != -0.0) = Just (otherSample ())
-    fetch (fun p -> p.negZero == 19000.0) = Nothing
+    fetch (fun p -> p.negZero == -0.0) = [sample ()]
+    fetch (fun p -> p.negZero != -0.0) = [otherSample ()]
+    fetch (fun p -> p.negZero == 19000.0) = []
 
     // CLEANUP: nan shouldn't be equal
-    fetch (fun p -> p.nan == Test.nan) = Just (sample ())
-    fetch (fun p -> p.nan != Test.nan) = Just (otherSample ())
-    fetch (fun p -> p.nan == 14.0) = Nothing
+    fetch (fun p -> p.nan == Test.nan) = [sample ()]
+    fetch (fun p -> p.nan != Test.nan) = [otherSample ()]
+    fetch (fun p -> p.nan == 14.0) = []
 
-    fetch (fun p -> p.infinity == Test.infinity) = Just (sample ())
-    fetch (fun p -> p.infinity != Test.infinity) = Just (otherSample ())
-    fetch (fun p -> p.infinity == 1.0) = Nothing
+    fetch (fun p -> p.infinity == Test.infinity) = [sample ()]
+    fetch (fun p -> p.infinity != Test.infinity) = [otherSample ()]
+    fetch (fun p -> p.infinity == 1.0) = []
 
-    fetch (fun p -> p.negInfinity == Test.negativeInfinity) = Just (sample ())
-    fetch (fun p -> p.negInfinity != Test.negativeInfinity) = Just (otherSample ())
-    fetch (fun p -> p.negInfinity == 1.0) = Nothing
+    fetch (fun p -> p.negInfinity == Test.negativeInfinity) = [sample ()]
+    fetch (fun p -> p.negInfinity != Test.negativeInfinity) = [otherSample ()]
+    fetch (fun p -> p.negInfinity == 1.0) = []
 
-    fetch (fun p -> p.``true`` == true) = Just (sample ())
-    fetch (fun p -> p.``true`` != true) = Just (otherSample ())
+    fetch (fun p -> p.``true`` == true) = [sample ()]
+    fetch (fun p -> p.``true`` != true) = [otherSample ()]
 
-    fetch (fun p -> p.``false`` == false) = Just (sample ())
-    fetch (fun p -> p.``false`` != false) = Just (otherSample ())
+    fetch (fun p -> p.``false`` == false) = [sample ()]
+    fetch (fun p -> p.``false`` != false) = [otherSample ()]
 
     // A bug in postgresql jsonb support prevents this from working
-    fetch (fun p -> p.list == [1;2;3]) = Just (sample ())
-    fetch (fun p -> p.list != [1;2;3]) = Just (otherSample ())
-    fetch (fun p -> p.list == []) = Nothing
+    fetch (fun p -> p.list == [1;2;3]) = [sample ()]
+    fetch (fun p -> p.list != [1;2;3]) = [otherSample ()]
+    fetch (fun p -> p.list == []) = []
 
-    fetch (fun p -> p.char == 'c') = Just (sample ())
-    fetch (fun p -> p.char != 'c') = Just (otherSample ())
-    fetch (fun p -> p.char == 'x') = Nothing
+    fetch (fun p -> p.char == 'c') = [sample ()]
+    fetch (fun p -> p.char != 'c') = [otherSample ()]
+    fetch (fun p -> p.char == 'x') = []
 
-    fetch (fun p -> p.emojiChar == ((Test.toChar "👍") |> Test.unwrap)) = Just (sample ())
-    fetch (fun p -> p.emojiChar != ((Test.toChar "👍") |> Test.unwrap)) = Just (otherSample ())
-    fetch (fun p -> p.emojiChar == 'x') = Nothing
+    fetch (fun p -> p.emojiChar == ((Test.toChar "👍") |> Test.unwrap)) = [sample ()]
+    fetch (fun p -> p.emojiChar != ((Test.toChar "👍") |> Test.unwrap)) = [otherSample ()]
+    fetch (fun p -> p.emojiChar == 'x') = []
 
-    fetch (fun p -> p.uuid == ((Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap)) = Just (sample ())
-    fetch (fun p -> p.uuid != ((Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap)) = Just (otherSample ())
-    fetch (fun p -> p.uuid == ((Uuid.parse "11111111-1111-1111-1111-000000000000") |> Test.unwrap)) = Nothing
+    fetch (fun p -> p.uuid == ((Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap)) = [sample ()]
+    fetch (fun p -> p.uuid != ((Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap)) = [otherSample ()]
+    fetch (fun p -> p.uuid == ((Uuid.parse "11111111-1111-1111-1111-000000000000") |> Test.unwrap)) = []
 
-// CLEANUP test equality of two different types
-// CLEANUP finish testing these types
+    fetch (fun p -> p.datetime == ((DateTime.parse_v2 "2020-01-01T00:00:00Z") |> Test.unwrap)) = [sample ()]
+    fetch (fun p -> p.datetime != ((DateTime.parse_v2 "2020-01-01T00:00:00Z") |> Test.unwrap)) = [otherSample ()]
+    fetch (fun p -> p.datetime == ((DateTime.parse_v2 "2019-12-31T23:59:59Z") |> Test.unwrap)) = []
+
+    (fetch (fun p -> p.unit == ())) |> List.sortBy (fun v -> v.int) = [sample (), otherSample ()]
+    fetch (fun p -> p.unit != ()) = []
+
+
 // CLEANUP test ``ALL CAPS``
 // CLEANUP test partial evaluation of lists and tuples
 
@@ -247,7 +256,9 @@ module GetMany =
 
   (let one = DB.set_v1 { x = "hello" } "one" X in
    let two = DB.set_v1 { x = "goodbye" } "two" X in
-   DB.getMany_v3 ["one"; "two"] X) = Just [ { x = "hello"}; { x = "goodbye"}]
+   (DB.getMany_v3 ["one"; "two"] X)
+   |> Test.unwrap
+   |> List.sortBy (fun v -> v.x)) = [ { x = "goodbye"}; { x = "hello"}]
 
 
 module QueryWithKey =

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -1,31 +1,52 @@
 [<DB>] type X = { x : string }
 [<DB>] type Z = { x : char }
-[<DB>] type Lists = { strs : List<string>; ints : List<int> }
 [<DB>] type XY = { x : string; y: string }
 [<DB>] type SortedX = { x : string; sortBy: int }
-[<DB>] type Timestamp = { ts : DateTime }
 [<DB>] type Uuid = { uu : UUID }
 
-module RoundtripUnit =
-  // CLEANUP () should have been removed and shouldn't work here
-  (let _ = DB.set_v1 { x = () } "hello" X in
-   DB.get_v2 "hello" X) = Just { x = () }
+module Roundtrip =
+  [<DB>] type DB = {
+    iNsEnSiTiVe : string
+    ``ALL CAPS`` : int
+    int : int
+    float : float
+    negZero : float
+    nan : float
+    infinity : float
+    negInfinity : float
+    ``true`` : bool
+    ``false`` : bool
+    char : char
+    emojiChar : char
+    uuid : UUID
+    list : List<int>
+    datetime : DateTime
+    // pw : Password
+  }
 
-module RoundtripCaseInsensitive =
-  [<DB>] type Insensitive = { cOlUmNnAmE : string }
-  (let _ = DB.set_v1 { cOlUmNnAmE = "some value" } "hello" Insensitive in
-   DB.get_v2 "hello" Insensitive) = Just { cOlUmNnAmE = "some value" }
+  let sample () = {
+    iNsEnSiTiVe = "iNsEnSiTiVe"
+    ``ALL CAPS`` = 1
+    int = 2
+    float = 3.0
+    negZero = -0.0
+    nan = Test.nan
+    infinity = Test.infinity
+    negInfinity = Test.negativeInfinity
+    ``true`` = true
+    ``false`` = false
+    list = [1;2;3]
+    char = 'c'
+    emojiChar = (Test.toChar "👍") |> Test.unwrap
+    uuid = (Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap
+    datetime = (DateTime.parse_v2 "2020-01-01T00:00:00Z") |> Test.unwrap
+    // pw = Password.hash_v0 "password"
+  }
 
-module RoundtripPassword =
-  [<DB>] type Passwords = { password : Password }
-  (let pw = Password.hash_v0 "password" in
-   let x = DB.set_v1 { password = pw } "test" Passwords in
-   let y = (DB.queryOneWithExactFields_v0 { password = pw } Passwords) |> Test.unwrap in
-   Password.check_v0 y.password "password") = true
-
-module RoundtripLists =
-  (let _ = DB.set_v1 { strs = ["str1"; "str2"]; ints = [-1,6,0]} "lists" Lists in
-  DB.get_v2 "lists" Lists) = Just { strs = ["str1"; "str2"]; ints = [-1,6,0]}
+  // TODO: Add roundtrip for records, unit, tuple, option, result, bytes
+  (let v = sample ()
+   let z = DB.set_v1 v "all" DB in
+   (z, DB.get_v2 "all" DB)) = (sample (), Just (sample ()))
 
 
 module ValueMissingColumnGivesGoodError =
@@ -219,7 +240,7 @@ let prepFriends () =
    // Note spaces around Chandler, that's to test trim functions
    let _ = addFriend "chandler" " Chandler " 72 true "1969-08-19T10:13:42Z" 83.0 in
    let _ = addFriend "cat" "GrumpyCat" 10 false "2012-04-04T00:00:00Z"  0.0 in
-   DB.set_v1 { height = (); name = (); human = (); dob = (); income = () } "()" Person)
+   ())
 
 let d (datestr:string) =
   (DateTime.parse_v2 datestr) |> Test.unwrap
@@ -239,7 +260,7 @@ let friends (lambda: ('a -> bool)) =
 
 // Test standard language features
 module FindAll =
-  (friends (fun p -> true)) = [(); " Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
+  (friends (fun p -> true)) = [ " Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
 
   // with condition
   (friends (fun p -> p.height > 3)) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
@@ -247,14 +268,8 @@ module FindAll =
   // boolean queries
   (friends (fun p -> p.human)) = [" Chandler "; "Rachel"; "Ross" ]
 
-  (friends (fun p -> p.name == () )) = [()]
-
-  // () inequality works CLEANUP
-  (friends (fun p -> p.name != () )) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
-
-  // CLEANUP weird behaviour here - shouldn't the () object be returned here.
-  // () is not '()' (string)
-  (friends (fun p -> p.name != "()" )) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
+  // () inequality works
+  (friends (fun p -> p.name != "" )) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
 
   // &&
   (friends (fun p -> p.human && p.height > 66 )) = [" Chandler "; "Ross" ]

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -21,7 +21,6 @@ module Roundtrip =
     uuid : UUID
     list : List<int>
     datetime : DateTime
-    // pw : Password
   }
 
   let sample () = {
@@ -40,7 +39,7 @@ module Roundtrip =
     emojiChar = (Test.toChar "👍") |> Test.unwrap
     uuid = (Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap
     datetime = (DateTime.parse_v2 "2020-01-01T00:00:00Z") |> Test.unwrap
-    // pw = Password.hash_v0 "password"
+    // dont test password because hashing it twice will get different values
   }
 
   // TODO: Add roundtrip for records, unit, tuple, option, result, bytes
@@ -49,9 +48,15 @@ module Roundtrip =
    (z, DB.get_v2 "all" DB)) = (sample (), Just (sample ()))
 
 
+  [<DB>] type Passwords = { password : Password }
+  (let pw = Password.hash_v0 "password" in
+   let x = DB.set_v1 { password = pw } "test" Passwords in
+   let y = (DB.queryOneWithExactFields_v0 { password = pw } Passwords) |> Test.unwrap in
+   Password.check_v0 y.password "password") = true
+
+
 module ValueMissingColumnGivesGoodError =
   (DB.set_v1 { x = "x"; col = "v" } "i" X) = Test.typeError_v0 "Found but did not expect: [col]"
-
 
 
 module SetDoesUpsert =
@@ -250,7 +255,8 @@ let friends (lambda: ('a -> bool)) =
   |> List.map_v0 (fun p -> p.name)
   |> List.sort_v0
 
-// Test standard language features
+
+  // Test standard language features
 module FindAll =
   (friends (fun p -> true)) = [ " Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
 

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -307,12 +307,6 @@ module FindAll =
    friendsError (fun p -> p.height == "string")) =
      Test.sqlError "An error occurred while querying the Datastore"
 
-  // do we look up dates correctly when the function type is not a date
-  (let _ = Test.setExpectedExceptionCount 1 in
-   friendsError (fun p -> p.dob != DateTime.now_v0)) =
-     Test.sqlError "An error occurred while querying the Datastore"
-
-
 module CompiledFunctions =
   (friends (fun p -> Float.lessThan_v0 90.0 p.income)) = [ "Ross" ]
   (friends (fun p -> Float.lessThanOrEqualTo_v0 p.income 82.10)) = ["GrumpyCat"; "Rachel"]
@@ -414,7 +408,7 @@ module QueryCount =
    DB.queryCount_v0 Person (fun p -> p.height > 3)) = 4
 
 module Dates =
-
+  [<DB>] type Timestamp = { ts : DateTime }
   let beforeDate () =
     d "1900-01-01T00:00:00Z"
 

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -7,7 +7,7 @@
 module Roundtrip =
   [<DB>] type DB = {
     iNsEnSiTiVe : string
-    ``ALL CAPS`` : int
+    ``ALLCAPS`` : int
     int : int
     float : float
     negZero : float
@@ -21,11 +21,12 @@ module Roundtrip =
     uuid : UUID
     list : List<int>
     datetime : DateTime
+    unit : unit
   }
 
   let sample () = {
     iNsEnSiTiVe = "iNsEnSiTiVe"
-    ``ALL CAPS`` = 1
+    ``ALLCAPS`` = 1
     int = 2
     float = 3.0
     negZero = -0.0
@@ -39,6 +40,27 @@ module Roundtrip =
     emojiChar = (Test.toChar "👍") |> Test.unwrap
     uuid = (Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap
     datetime = (DateTime.parse_v2 "2020-01-01T00:00:00Z") |> Test.unwrap
+    unit = ()
+    // dont test password because hashing it twice will get different values
+  }
+
+  let otherSample () = {
+    iNsEnSiTiVe = "normal"
+    ``ALLCAPS`` = 2
+    int = 3
+    float = 4.0
+    negZero = -1.0
+    nan = 0.0
+    infinity = 5.4
+    negInfinity = -385.33
+    ``true`` = false
+    ``false`` = true
+    list = [1;3;45]
+    char = 'd'
+    emojiChar = 'e'
+    uuid = (Uuid.parse "55555555-5555-5555-5555-555555555555") |> Test.unwrap
+    datetime = (DateTime.parse_v2 "2011-11-11T11:11:11Z") |> Test.unwrap
+    unit = ()
     // dont test password because hashing it twice will get different values
   }
 
@@ -53,6 +75,47 @@ module Roundtrip =
    let x = DB.set_v1 { password = pw } "test" Passwords in
    let y = (DB.queryOneWithExactFields_v0 { password = pw } Passwords) |> Test.unwrap in
    Password.check_v0 y.password "password") = true
+
+  module QueryEquality =
+    let fetch (fn : 'a -> bool) =
+      let z = DB.set_v1 (sample ()) "sample" DB in
+      let z = DB.set_v1 (otherSample ()) "other" DB in
+      DB.queryOne_v4 DB fn
+
+    fetch (fun p -> p.iNsEnSiTiVe == "iNsEnSiTiVe") = Just (sample ())
+    fetch (fun p -> p.iNsEnSiTiVe != "iNsEnSiTiVe") = Just (otherSample ())
+    fetch (fun p -> p.iNsEnSiTiVe == "nothing") = Nothing
+
+    fetch (fun p -> p.``ALLCAPS`` == 1) = Just (sample ())
+    fetch (fun p -> p.``ALLCAPS`` != 1) = Just (otherSample ())
+    fetch (fun p -> p.``ALLCAPS`` == 1000) = Nothing
+
+    fetch (fun p -> p.int == 2) = Just (sample ())
+    fetch (fun p -> p.int != 2) = Just (otherSample ())
+    fetch (fun p -> p.int == 200) = Nothing
+
+    fetch (fun p -> p.float == 3.0) = Just (sample ())
+    fetch (fun p -> p.float != 3.0) = Just (otherSample ())
+    fetch (fun p -> p.float == 30.0) = Nothing
+
+    fetch (fun p -> p.negZero == -0.0) = Just (sample ())
+    fetch (fun p -> p.negZero != -0.0) = Just (otherSample ())
+    fetch (fun p -> p.negZero == 19000.0) = Nothing
+
+    // CLEANUP: nan shouldn't be equal
+    fetch (fun p -> p.nan == Test.nan) = Just (sample ())
+    fetch (fun p -> p.nan != Test.nan) = Just (otherSample ())
+    fetch (fun p -> p.nan == 14.0) = Nothing
+
+    fetch (fun p -> p.infinity == Test.infinity) = Just (sample ())
+    fetch (fun p -> p.infinity != Test.infinity) = Just (otherSample ())
+    fetch (fun p -> p.infinity == 1.0) = Nothing
+
+    fetch (fun p -> p.negInfinity == Test.negativeInfinity) = Just (sample ())
+    fetch (fun p -> p.negInfinity != Test.negativeInfinity) = Just (otherSample ())
+    fetch (fun p -> p.negInfinity == 1.0) = Nothing
+
+
 
 
 module ValueMissingColumnGivesGoodError =
@@ -260,13 +323,20 @@ let friends (lambda: ('a -> bool)) =
 module FindAll =
   (friends (fun p -> true)) = [ " Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
 
+  // equality
+  (friends (fun p -> p.name == "Ross")) = [ "Ross" ]
+  (friends (fun p -> p.height == 73)) = [ "Ross" ]
+  (friends (fun p -> p.human == false)) = [ "GrumpyCat" ]
+  (friends (fun p -> p.income == 100.0)) = [ "Ross" ]
+  (friends (fun p -> p.dob == (rossDOB ()))) = [ "Ross" ]
+
   // with condition
   (friends (fun p -> p.height > 3)) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
 
   // boolean queries
   (friends (fun p -> p.human)) = [" Chandler "; "Rachel"; "Ross" ]
 
-  // () inequality works
+  // string inequality works
   (friends (fun p -> p.name != "" )) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
 
   // &&
@@ -413,30 +483,5 @@ module QueryCount =
   (let _ = prepFriends () in
    DB.queryCount_v0 Person (fun p -> p.height > 3)) = 4
 
-module Dates =
-  [<DB>] type Timestamp = { ts : DateTime }
-  let beforeDate () =
-    d "1900-01-01T00:00:00Z"
-
-  let middleDate () =
-    d "2000-01-01T00:00:00Z"
-
-  let afterDate () =
-    d "2100-01-01T00:00:00Z"
-
-  let prepDates () =
-    (let _ = DB.set_v1 { ts = beforeDate () } "before" Timestamp in
-    let _ = DB.set_v1 { ts = middleDate () } "middle" Timestamp in
-    DB.set_v1 { ts = afterDate () } "after"  Timestamp)
-
-  // DateTime.lessThan
-  (let _ = prepDates () in
-  DB.queryOne_v4 Timestamp (fun value -> DateTime.lessThan_v0 (middleDate ()) value.ts)) =
-    Just ({ ts = afterDate () })
-
-  // DateTime.greaterThan
-  (let _ = prepDates () in
-  DB.queryOne_v4 Timestamp (fun value -> DateTime.greaterThan_v0 (middleDate ()) value.ts)) =
-    Just { ts = beforeDate () }
 
 (DB.generateKey_v0 |> String.length_v1) = 36

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -82,6 +82,20 @@ module Roundtrip =
       let z = DB.set_v1 (otherSample ()) "other" DB in
       DB.queryOne_v4 DB fn
 
+    // invalid type comparisons errors
+    fetch (fun p -> 5 == "str") = Nothing
+    fetch (fun p -> 5 != "str") = Nothing
+
+    fetch (fun p -> p.int == "str") =
+      Test.sqlError "Incorrect type in b, expected Int, but got a String"
+    fetch (fun p -> p.int != "str") =
+      Test.sqlError "Incorrect type in b, expected Int, but got a String"
+
+    fetch (fun p -> "str" == p.int) =
+      Test.sqlError "Incorrect type in b, expected String, but got a Int"
+    fetch (fun p -> "str" == p.int) =
+      Test.sqlError "Incorrect type in b, expected String, but got a Int"
+
     fetch (fun p -> p.iNsEnSiTiVe == "iNsEnSiTiVe") = Just (sample ())
     fetch (fun p -> p.iNsEnSiTiVe != "iNsEnSiTiVe") = Just (otherSample ())
     fetch (fun p -> p.iNsEnSiTiVe == "nothing") = Nothing
@@ -115,7 +129,32 @@ module Roundtrip =
     fetch (fun p -> p.negInfinity != Test.negativeInfinity) = Just (otherSample ())
     fetch (fun p -> p.negInfinity == 1.0) = Nothing
 
+    fetch (fun p -> p.``true`` == true) = Just (sample ())
+    fetch (fun p -> p.``true`` != true) = Just (otherSample ())
 
+    fetch (fun p -> p.``false`` == false) = Just (sample ())
+    fetch (fun p -> p.``false`` != false) = Just (otherSample ())
+
+    // fetch (fun p -> p.list == [1;2;3]) = Just (sample ())
+    // fetch (fun p -> p.list != [1;2;3]) = Just (otherSample ())
+    // fetch (fun p -> p.list == []) = Nothing
+
+    fetch (fun p -> p.char == 'c') = Just (sample ())
+    fetch (fun p -> p.char != 'c') = Just (otherSample ())
+    fetch (fun p -> p.char == 'x') = Nothing
+
+    fetch (fun p -> p.emojiChar == ((Test.toChar "👍") |> Test.unwrap)) = Just (sample ())
+    fetch (fun p -> p.emojiChar != ((Test.toChar "👍") |> Test.unwrap)) = Just (otherSample ())
+    fetch (fun p -> p.emojiChar == 'x') = Nothing
+
+    fetch (fun p -> p.uuid == ((Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap)) = Just (sample ())
+    fetch (fun p -> p.uuid != ((Uuid.parse "00000050-0000-0000-0000-000000000000") |> Test.unwrap)) = Just (otherSample ())
+    fetch (fun p -> p.uuid == ((Uuid.parse "11111111-1111-1111-1111-000000000000") |> Test.unwrap)) = Nothing
+
+// CLEANUP test equality of two different types
+// CLEANUP finish testing these types
+// CLEANUP test ``ALL CAPS``
+// CLEANUP test partial evaluation of lists and tuples
 
 
 module ValueMissingColumnGivesGoodError =

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -54,14 +54,6 @@ module ValueMissingColumnGivesGoodError =
 
 
 
-module Schemas =
-  DB.schemaFields_v1 X = ["x"]
-  DB.schemaFields_v1 XY = ["x", "y"]
-  DB.schema_v1 X = { x = "Str" }
-  DB.schema_v1 SortedX = { x = "Str"; sortBy = "Int" }
-
-
-
 module SetDoesUpsert =
   (let old = DB.set_v1 { x = "hello" } "hello" X in
   let newval = DB.set_v1 { x = "goodbye" } "hello" X in

--- a/backend/testfiles/execution/dict.tests
+++ b/backend/testfiles/execution/dict.tests
@@ -2,7 +2,7 @@ Dict.empty_v0 = {}
 
 Dict.filterMap_v0 {} (fun (key, value) -> 0) = {}
 Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then Nothing else (Just (key ++ value))) = { c = "cz"; a = "ax"}
-Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then false else (Just (key ++ value))) = Test.typeError_v0 "Expected `fn` to return a Option, but it returned `false`"
+Dict.filterMap_v0 { a = "x"; b = "y"; c = "z" } (fun (key, value) -> if value == "y" then false else (Just (key ++ value))) = Test.typeError_v0 "Expected `fn` to return a Option<'b>, but it returned `false`"
 Dict.filter_v1 { key1 = "val1"; key2 = "val2" } (fun (k, v) -> k == "key1") = { key1 = "val1"}
 Dict.filter_v1 { key1 = 1; key2 = 3 }  (fun (k, v) -> v < 2) = { key1 = 1 }
 Dict.filter_v1 {} (fun (k, v) -> 0) = {}

--- a/backend/testfiles/execution/http.tests
+++ b/backend/testfiles/execution/http.tests
@@ -18,7 +18,7 @@ module Errors =
 
 
 Http.badRequest_v0 "Your request resulted in an error" = Http.response_v0 "Your request resulted in an error" 400
-Http.badRequest_v0 1 = Test.typeError_v0 "Http::badRequest was called with a Int (1), but `error` expected a Str."
+Http.badRequest_v0 1 = Test.typeError_v0 "Http::badRequest was called with a Int (1), but `error` expected a String."
 Http.notFound_v0 = Http.response_v0 () 404
 
 Http.unauthorized_v0 = Http.response_v0 () 401

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -381,7 +381,7 @@ module Constructors =
 
 module Error =
   List.map_v0 [1;2;3;4;5] (fun x y -> x) = Test.typeError_v0 "Expected 2 arguments, got 1"
-  Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 "Option::map2 was called with a Str (\"not an option\"), but `option2` expected a Option."
+  Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 "Option::map2 was called with a String (\"not an option\"), but `option2` expected a Option<'b>."
 
 module ErrorPropagation =
   List.head_v2 (Test.typeError_v0 "test") = Test.typeError_v0 "test"
@@ -520,7 +520,7 @@ module FunctionCalls =
 
 module InvalidFnCalls =
   functionWhichDoesntExist 6 = Test.incomplete // CLEANUP
-  stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
+  stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type String but found a Int"
   stringFn "str1" "str2" = Test.typeError "stringFn has 1 parameters, but here was called with 2 arguments."
 
   (let _ = Test.setExpectedExceptionCount 1 in
@@ -581,7 +581,7 @@ module Packages =
   Test.Test.Test.returnsResultError () = Error false
 
   module Invalid =
-    Test.Test.Test.stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type Str but found a Int"
+    Test.Test.Test.stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected to see a value of type String but found a Int"
     Test.Test.Test.stringFn "str1" "str2" = Test.typeError "test/test/Test::stringFn_v0 has 1 parameters, but here was called with 2 arguments."
     Test.Test.Test.derrorFn "test" = Test.typeError "test"
 

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -434,17 +434,17 @@ module Equality =
   (5.6 == 5.6) = true
   (-55555555555555555555555555555.5 == -55555555555555555555555555555.5) = true
   (5.6 != 5.7) = true
-  (5.7 != 6) = true
-  (5.7 != 5) = true
+  (5.7 != 6) = Test.typeError_v0 "Both values must be the same type"
+  (5.7 != 5) = Test.typeError_v0 "Both values must be the same type"
   (Test.typeError_v0 "test" != Test.typeError_v0 "different msg") = Test.typeError_v0 "test"
   (true == true) = true
   (false == false) = true
   (true != false) = true
   (() == ()) = true
-  (() != Nothing) = true
-  (() != false) = true
-  (() != 0) = true
-  (() != 0.0) = true
+  (() != Nothing) = Test.typeError_v0 "Both values must be the same type"
+  (() != false) = Test.typeError_v0 "Both values must be the same type"
+  (() != 0) = Test.typeError_v0 "Both values must be the same type"
+  (() != 0.0) = Test.typeError_v0 "Both values must be the same type"
   ([ 1; 2; 3 ] == [ 1; 2; 3 ]) = true
   ([ 1; 2; 3 ] != [ 3; 2; 1 ]) = true
   ({ x = 6; y = 7 } == { x = 6; y = 7 }) = true
@@ -466,12 +466,12 @@ module Equality =
   (Ok 0 == Ok 0) = true
   (Ok 0 != Error 0) = true
   ((String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼") == (String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼")) = true
-  //(fun x -> y) = (fun x -> y) // CLEANUP: they have different IDs so they're not equal
-  ((fun x -> let y = 1 in y) != (fun x -> let y = 1 in x)) = true
+  (fun x -> y) = (fun x -> y)
+  ((fun x -> let y = 1 in y) != (fun x -> let y = 2 in x)) = true
 
   [<DB>] type MyDB = { x : string; y: string }
   (MyDB == MyDB) = true
-  (MyDB != 5) = true
+  (MyDB != 5) = Test.typeError_v0 "Both values must be the same type"
 
 
 // ---------------------------

--- a/backend/testfiles/execution/list.tests
+++ b/backend/testfiles/execution/list.tests
@@ -41,7 +41,7 @@ List.filter_v2 [-20; 5; 9;] (fun x -> x > 20) = []
 List.filter_v2 [] (fun item -> "a") = []
 
 List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then Nothing else (Just (item * 2))) = [ 2; 6 ]
-List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then false else (Just (item * 2))) = Test.typeError_v0 "Expected `fn` to return a Option, but it returned `false`"
+List.filterMap_v0 [1;2;3] (fun item -> if item == 2 then false else (Just (item * 2))) = Test.typeError_v0 "Expected `fn` to return a Option<'b>, but it returned `false`"
 List.filterMap_v0 [] (fun item -> 0) = []
 
 List.findFirst_v2 [1;2;3] (fun x -> x > 5) = Nothing

--- a/backend/testfiles/execution/result.tests
+++ b/backend/testfiles/execution/result.tests
@@ -2,8 +2,8 @@ Result.andThen_v1 (Error "test") (fun x -> Error "test") = Error "test"
 Result.andThen_v1 (Error "test") (fun x -> Ok 5) = Error "test"
 Result.andThen_v1 (Ok 5) (fun x -> Error "test") = Error "test"
 Result.andThen_v1 (Ok 5) (fun x -> Ok (1 + x)) = Ok 6
-Result.andThen_v1 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expected `fn` to return a Result, but it returned `4`"
-Result.andThen_v1 (Ok 5) (fun x -> true) = Test.typeError_v0 "Expected `fn` to return a Result, but it returned `true`"
+Result.andThen_v1 (Ok 8) (fun x -> Int.divide x 2) = Test.typeError_v0 "Expected `fn` to return a Result<'ok, 'err>, but it returned `4`"
+Result.andThen_v1 (Ok 5) (fun x -> true) = Test.typeError_v0 "Expected `fn` to return a Result<'ok, 'err>, but it returned `true`"
 
 Result.fromOption_v2 (Just 6) "test" = Ok 6
 Result.fromOption_v2 Nothing "test" = Error "test"

--- a/backend/testfiles/execution/string.tests
+++ b/backend/testfiles/execution/string.tests
@@ -30,7 +30,7 @@ String.join_v0 ["🧟‍♀️🧟‍♂️", "🧟‍♀️🧑🏽‍🦰"] ""
 String.join_v0 ["👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️", "‍⚧️‍️🇵🇷"] "" = "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
 String.join_v0 ["🧟‍♀️🧟‍♂️‍", "🧟‍♀️🧑🏽‍🦰‍‍"] "" = "🧟‍♀️🧟‍♂️‍🧟‍♀️🧑🏽‍🦰‍‍"
 String.join_v0 ["🧑🏽‍🦰‍", "🧑🏼‍💻‍‍"] "" = "🧑🏽‍🦰‍🧑🏼‍💻‍‍"
-String.join_v0 ["a"; 0] "" = Test.typeError_v0 "Expected `l` to be a list of Strs, but the list contained `0`"
+String.join_v0 ["a"; 0] "" = Test.typeError_v0 "Expected `l` to be a list of Strings, but the list contained `0`"
 Bytes.length (String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼✋✋🏻✋🏿") = 62
 Bytes.length (String.toBytes_v0 "😄APPLE🍏") = 13
 Bytes.length (String.toBytes_v0 "Είναι προικισμένοι με λογική") = 53

--- a/backend/tests/FuzzTests/ExecutePureFunctions.FuzzTests.fs
+++ b/backend/tests/FuzzTests/ExecutePureFunctions.FuzzTests.fs
@@ -131,9 +131,7 @@ module Generators =
 
         | RT.TFn (paramTypes, returnType) ->
           let parameters =
-            List.mapi
-              (fun i (v : RT.DType) -> (id i, $"{v.toOldString().ToLower()}_{i}"))
-              paramTypes
+            List.mapi (fun i (v : RT.DType) -> (id i, string v)) paramTypes
 
           let! returnType =
             Gen.frequency [ (98, Gen.constant returnType)
@@ -261,9 +259,7 @@ module Generators =
                            Gen.map Error (genDval' errType s) ])
         | RT.TFn (paramTypes, returnType) ->
           let parameters =
-            List.mapi
-              (fun i (v : RT.DType) -> (id i, $"{v.toOldString ()}_{i}"))
-              paramTypes
+            List.mapi (fun i (v : RT.DType) -> (id i, string v)) paramTypes
 
           let! body = exprFromType returnType
 

--- a/backend/tests/FuzzTests/InternalJson.FuzzTests.fs
+++ b/backend/tests/FuzzTests/InternalJson.FuzzTests.fs
@@ -91,11 +91,13 @@ module Queryable =
       |> Arb.filter DvalReprInternalQueryable.Test.isQueryableDval
 
   let canV1Roundtrip (dv : RT.Dval) : bool =
-    let dvm = (Map.ofList [ "field", dv ])
+    let dvm = Map.ofList [ "field", dv ]
+    let fieldTypes = [ "field", RT.Dval.toType dv ]
+    let typ = RT.TRecord fieldTypes
 
     dvm
-    |> DvalReprInternalQueryable.toJsonStringV0
-    |> DvalReprInternalQueryable.parseJsonV0
+    |> DvalReprInternalQueryable.toJsonStringV0 fieldTypes
+    |> DvalReprInternalQueryable.parseJsonV0 typ
     |> Expect.dvalEquality (RT.DObj dvm)
 
   let tests config =

--- a/backend/tests/Tests/DvalRepr.Tests.fs
+++ b/backend/tests/Tests/DvalRepr.Tests.fs
@@ -192,6 +192,8 @@ module Password =
       let roundtrips name serialize deserialize =
         let bytes = UTF8.toBytes "encryptedbytes"
         let password = RT.DObj(Map.ofList [ "x", RT.DPassword(Password bytes) ])
+        let fieldTypes = [ "x", RT.TPassword ]
+        let typ = RT.TRecord fieldTypes
 
         let wrappedSerialize dval =
           dval
@@ -199,15 +201,15 @@ module Password =
             match dval with
             | RT.DObj dvalMap -> dvalMap
             | _ -> Exception.raiseInternal "dobj only here" [])
-          |> serialize
+          |> serialize fieldTypes
 
         Expect.equalDval
           password
           (password
            |> wrappedSerialize
-           |> deserialize
+           |> deserialize typ
            |> wrappedSerialize
-           |> deserialize)
+           |> deserialize typ)
           $"Passwords serialize in non-redaction function: {name}"
       // roundtrips
       roundtrips

--- a/backend/tests/Tests/TypeChecker.Tests.fs
+++ b/backend/tests/Tests/TypeChecker.Tests.fs
@@ -78,7 +78,7 @@ let testArguments : Test =
     [ (("myBadFn", RT.TStr, S.eInt 7),
        RT.DError(
          RT.SourceNone,
-         "Type error(s) in return type: Expected to see a value of type Str but found a Int"
+         "Type error(s) in return type: Expected to see a value of type String but found a Int"
        ))
       (("myGoodFn", RT.TStr, S.eStr "test"), RT.DStr "test")
       (("myAnyFn", RT.TVariable "a", S.eInt 5), RT.DInt 5L) ]

--- a/scripts/devcontainer/_start-background-services
+++ b/scripts/devcontainer/_start-background-services
@@ -14,7 +14,7 @@ for name in "${@}"; do
     # for some reason, uncommenting the equivalent line in the Dockerfile doesn't do the
     # job. don't have time right now to figure out why.
     LA="listen_addresses = '*'"
-    echo "$LA" | sudo tee -a /etc/postgresql/9.6/main/postgresql.conf
+    echo "$LA" | sudo tee -a /etc/postgresql/14/main/postgresql.conf
 
     # Fix weird permission problem, see from https://github.com/puntonim/docker-postgresql93/issues/2
     sudo chmod 766 /etc/ssl/private


### PR DESCRIPTION
This redoes a lot of how we store values, to remove inconsistencies, bugs, and weirdness. With those solved it modestly expands the types and tests handled.

DvalReprInternalQueryable is the json-based serialization that we use to store user values in the DB. It's converted to jsonb, and SqlCompiler then queries the stored results using Postgres' jsonb query functions. The SqlComiler thus obviously depends on the structure of the saved data, as created by DvalReprInternalQueryable.

The major problem with the format was that it didn't use the DB's schema to decide how to save data. Thus, when decoding the data, it guessed based on what it saw. If you had a record in the format `{ type: string, date: string }` then it would parse it as a date, not a record with two fields.

By including the type of the schema when parsing code, it allows us to remove all this sort of bugs that come from it. I also added the schema when saving code, to ensure we didn't accidentally save data in the wrong format.
This allowed us to save, without creating weird bugs:
- NaN, Infinity and -Infinity
- Tuples
- Options
- Results
- Unit
- Bytes
- Chars

Also fixed the weird storage/querying of DateTimes.

I replaced how DUnits were stored. They're now just the number 0, as opposed to null (which isn't a postgres type).

Also greatly expanded testing of equality and inequality in the DB. This ended up spilling out into the language - we now get type errors instead of `false` for values of different types, and also can accurately compare lambdas (including their code but ignoring their ids)

One thing this showed was what a mess typechecking is. I typechecked everywhere to get good error messages and to ensure I had the right types at the right times. Having real typechecking could have made this much better/simpler. It would also remove a lot of duplicated logic. The fact that actual types and type definitions both use DTypes is also a mess. Hoping to do better once we do some type system improvements.

In the SqlCompiler:
- added support for UUIDs
- added support for lists (some lists at leastt, this was hard)
- simplify support for DUnit
- track actual types in fn calls to define TVariables and check the other arguments (catches errors like `5 == "5"`)
- check return types as well
- account for TVariables when checking types
- massively expand testing around `==` and `!=`



Also:
- removed `DB.schema` and `DB.schemaFields`
- removed Dval.toOldString()
- fix a flaky test (ordering of getMany is undetermined)
- improved how we print type names (eg `Option<int>` instead of `Option`)
- print "String" instead of "Str" for TStr
- fix param types for `!=`
- upgrade container to postgres 14
- parse unit type

TODO: 
- [ ] DvalReprInternalQueryable support for more types
  - [ ] Option/Result
  - [ ] Tuples
  - [ ] Bytes
  - [ ] tests in roundtrip
- [ ] Test Float::greaterThan with NaN/Infinity/-Infinity
- [ ] Test a Result fn with two args, one with is Ok and the other Error
- [ ] same with Option