### PR TITLE
WIP Allow only callable values in pipe

### DIFF
--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -153,7 +153,7 @@ module Expr =
               match op with
               | PT.BinOpAnd -> RT.EAnd(id, prev, toRT expr2)
               | PT.BinOpOr -> RT.EOr(id, prev, toRT expr2)
-            | other -> RT.EApply(pipeID, toRT other, [ prev ], RT.InPipe pipeID)
+            | other -> RT.EApply(pipeID, toRT other, [ prev ], RT.NotInPipe)
           convert next)
 
         (expr2 :: rest)

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -196,6 +196,28 @@ module Pipes =
   |> x
   |> (+) 3)) = 10
 
+  // variable
+
+  (51
+  |> 57
+  |> 34.2
+  |> (+) 23) = Test.typeError_v0 "Expected a function value, got something else: 34.2"
+
+  ((4,3)
+  |> Tuple2.first
+  |> (+) 3) = 7
+
+  ((1,3)
+  |> Tuple2.first
+  |> (2,2)
+  |> (+) 3) = Test.typeError_v0 "Expected a function value, got something else: (\n  2, 2\n)"
+
+  ((1,3)
+  |> Tuple2.first
+  |> (2,2)
+  |> "wrong"
+  |> (+) 3) = Test.typeError_v0 @"Expected a function value, got something else: ""wrong"""
+
 
 module Match =
   (match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"


### PR DESCRIPTION
```
-  ProgramType to RuntimeType tranformation for EPipe 
```

## What is the problem/goal being addressed?
Allow only callable values in pipe: function, lambda, infix and/or etc.  

## What is the solution to this problem?
Mark wrong tokens as NotInPipe - super naive solution but it works now. 

## How are you sure this works/how was this tested?
Write tests 

There is the issue - a pipe execution break on last wrong value, e.g 

```F#
  (51
  |> 57
  |> 34.2
  |> (+) 23) = Test.typeError_v0 "Expected a function value, got something else: 34.2"
  // below the correct expected result but I don't know how breake pipe on the 1st wrong expression
  // |> (+) 23) = Test.typeError_v0 "Expected a function value, got something else: 57"
```
