### PR TITLE
Add DRecords everywhere

### DIFF
--- a/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_function.json
+++ b/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_function.json
@@ -1380,6 +1380,58 @@
                 "DDB",
                 "Visitors"
               ],
+              "dict": [
+                "DDict",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict with error": [
+                "DDict",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "dict3": [
+                "DDict",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "dict4": [
+                "DDict",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict5": [
+                "DDict",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
               "e \u002B 0": [
                 "DFloat",
                 2.718281828459045
@@ -4207,70 +4259,6 @@
               "null": [
                 "DUnit"
               ],
-              "obj": [
-                "DDict",
-                {
-                  "foo": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj with error": [
-                "DDict",
-                {
-                  "v": [
-                    "DError",
-                    [
-                      "SourceNone"
-                    ],
-                    "some error string"
-                  ]
-                }
-              ],
-              "obj2": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DUnit"
-                  ]
-                }
-              ],
-              "obj3": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DStr",
-                    "x"
-                  ]
-                }
-              ],
-              "obj4": [
-                "DDict",
-                {
-                  "foo\\\\bar": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj5": [
-                "DDict",
-                {
-                  "$type": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
               "option": [
                 "DOption",
                 null
@@ -4296,6 +4284,15 @@
               "pi \u002B 1": [
                 "DFloat",
                 4.141592653589793
+              ],
+              "record": [
+                "DRecord",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
               ],
               "result": [
                 "DResult",
@@ -4648,6 +4645,58 @@
                 "DDB",
                 "Visitors"
               ],
+              "dict": [
+                "DDict",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict with error": [
+                "DDict",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "dict3": [
+                "DDict",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "dict4": [
+                "DDict",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict5": [
+                "DDict",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
               "e \u002B 0": [
                 "DFloat",
                 2.718281828459045
@@ -7475,70 +7524,6 @@
               "null": [
                 "DUnit"
               ],
-              "obj": [
-                "DDict",
-                {
-                  "foo": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj with error": [
-                "DDict",
-                {
-                  "v": [
-                    "DError",
-                    [
-                      "SourceNone"
-                    ],
-                    "some error string"
-                  ]
-                }
-              ],
-              "obj2": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DUnit"
-                  ]
-                }
-              ],
-              "obj3": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DStr",
-                    "x"
-                  ]
-                }
-              ],
-              "obj4": [
-                "DDict",
-                {
-                  "foo\\\\bar": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj5": [
-                "DDict",
-                {
-                  "$type": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
               "option": [
                 "DOption",
                 null
@@ -7564,6 +7549,15 @@
               "pi \u002B 1": [
                 "DFloat",
                 4.141592653589793
+              ],
+              "record": [
+                "DRecord",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
               ],
               "result": [
                 "DResult",

--- a/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_function.json
+++ b/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_function.json
@@ -4294,6 +4294,61 @@
                   ]
                 }
               ],
+              "record with error": [
+                "DRecord",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "record2": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DUnit"
+                  ]
+                }
+              ],
+              "record3": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "record4": [
+                "DRecord",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "record5": [
+                "DRecord",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
               "result": [
                 "DResult",
                 [
@@ -7554,6 +7609,61 @@
                 "DRecord",
                 {
                   "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "record with error": [
+                "DRecord",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "record2": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DUnit"
+                  ]
+                }
+              ],
+              "record3": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "record4": [
+                "DRecord",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "record5": [
+                "DRecord",
+                {
+                  "$type": [
                     "DInt",
                     5
                   ]

--- a/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_handler.json
+++ b/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_handler.json
@@ -3823,6 +3823,61 @@
                   ]
                 }
               ],
+              "record with error": [
+                "DRecord",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "record2": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DUnit"
+                  ]
+                }
+              ],
+              "record3": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "record4": [
+                "DRecord",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "record5": [
+                "DRecord",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
               "result": [
                 "DResult",
                 [
@@ -7083,6 +7138,61 @@
                 "DRecord",
                 {
                   "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "record with error": [
+                "DRecord",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "record2": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DUnit"
+                  ]
+                }
+              ],
+              "record3": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "record4": [
+                "DRecord",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "record5": [
+                "DRecord",
+                {
+                  "$type": [
                     "DInt",
                     5
                   ]

--- a/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_handler.json
+++ b/backend/serialization/vanilla_ClientTypes-Analysis-PerformAnalysisParams_handler.json
@@ -909,6 +909,58 @@
                 "DDB",
                 "Visitors"
               ],
+              "dict": [
+                "DDict",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict with error": [
+                "DDict",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "dict3": [
+                "DDict",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "dict4": [
+                "DDict",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict5": [
+                "DDict",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
               "e \u002B 0": [
                 "DFloat",
                 2.718281828459045
@@ -3736,70 +3788,6 @@
               "null": [
                 "DUnit"
               ],
-              "obj": [
-                "DDict",
-                {
-                  "foo": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj with error": [
-                "DDict",
-                {
-                  "v": [
-                    "DError",
-                    [
-                      "SourceNone"
-                    ],
-                    "some error string"
-                  ]
-                }
-              ],
-              "obj2": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DUnit"
-                  ]
-                }
-              ],
-              "obj3": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DStr",
-                    "x"
-                  ]
-                }
-              ],
-              "obj4": [
-                "DDict",
-                {
-                  "foo\\\\bar": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj5": [
-                "DDict",
-                {
-                  "$type": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
               "option": [
                 "DOption",
                 null
@@ -3825,6 +3813,15 @@
               "pi \u002B 1": [
                 "DFloat",
                 4.141592653589793
+              ],
+              "record": [
+                "DRecord",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
               ],
               "result": [
                 "DResult",
@@ -4177,6 +4174,58 @@
                 "DDB",
                 "Visitors"
               ],
+              "dict": [
+                "DDict",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict with error": [
+                "DDict",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "dict3": [
+                "DDict",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "dict4": [
+                "DDict",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict5": [
+                "DDict",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
               "e \u002B 0": [
                 "DFloat",
                 2.718281828459045
@@ -7004,70 +7053,6 @@
               "null": [
                 "DUnit"
               ],
-              "obj": [
-                "DDict",
-                {
-                  "foo": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj with error": [
-                "DDict",
-                {
-                  "v": [
-                    "DError",
-                    [
-                      "SourceNone"
-                    ],
-                    "some error string"
-                  ]
-                }
-              ],
-              "obj2": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DUnit"
-                  ]
-                }
-              ],
-              "obj3": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DStr",
-                    "x"
-                  ]
-                }
-              ],
-              "obj4": [
-                "DDict",
-                {
-                  "foo\\\\bar": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj5": [
-                "DDict",
-                {
-                  "$type": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
               "option": [
                 "DOption",
                 null
@@ -7093,6 +7078,15 @@
               "pi \u002B 1": [
                 "DFloat",
                 4.141592653589793
+              ],
+              "record": [
+                "DRecord",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
               ],
               "result": [
                 "DResult",

--- a/backend/serialization/vanilla_ClientTypes-Runtime-Dval-T_complete.json
+++ b/backend/serialization/vanilla_ClientTypes-Runtime-Dval-T_complete.json
@@ -192,6 +192,58 @@
       "DDB",
       "Visitors"
     ],
+    "dict": [
+      "DDict",
+      {
+        "foo": [
+          "DInt",
+          5
+        ]
+      }
+    ],
+    "dict with error": [
+      "DDict",
+      {
+        "v": [
+          "DError",
+          [
+            "SourceNone"
+          ],
+          "some error string"
+        ]
+      }
+    ],
+    "dict3": [
+      "DDict",
+      {
+        "type": [
+          "DStr",
+          "weird"
+        ],
+        "value": [
+          "DStr",
+          "x"
+        ]
+      }
+    ],
+    "dict4": [
+      "DDict",
+      {
+        "foo\\\\bar": [
+          "DInt",
+          5
+        ]
+      }
+    ],
+    "dict5": [
+      "DDict",
+      {
+        "$type": [
+          "DInt",
+          5
+        ]
+      }
+    ],
     "e \u002B 0": [
       "DFloat",
       2.718281828459045
@@ -3019,70 +3071,6 @@
     "null": [
       "DUnit"
     ],
-    "obj": [
-      "DDict",
-      {
-        "foo": [
-          "DInt",
-          5
-        ]
-      }
-    ],
-    "obj with error": [
-      "DDict",
-      {
-        "v": [
-          "DError",
-          [
-            "SourceNone"
-          ],
-          "some error string"
-        ]
-      }
-    ],
-    "obj2": [
-      "DDict",
-      {
-        "type": [
-          "DStr",
-          "weird"
-        ],
-        "value": [
-          "DUnit"
-        ]
-      }
-    ],
-    "obj3": [
-      "DDict",
-      {
-        "type": [
-          "DStr",
-          "weird"
-        ],
-        "value": [
-          "DStr",
-          "x"
-        ]
-      }
-    ],
-    "obj4": [
-      "DDict",
-      {
-        "foo\\\\bar": [
-          "DInt",
-          5
-        ]
-      }
-    ],
-    "obj5": [
-      "DDict",
-      {
-        "$type": [
-          "DInt",
-          5
-        ]
-      }
-    ],
     "option": [
       "DOption",
       null
@@ -3108,6 +3096,15 @@
     "pi \u002B 1": [
       "DFloat",
       4.141592653589793
+    ],
+    "record": [
+      "DRecord",
+      {
+        "foo": [
+          "DInt",
+          5
+        ]
+      }
     ],
     "result": [
       "DResult",

--- a/backend/serialization/vanilla_ClientTypes-Runtime-Dval-T_complete.json
+++ b/backend/serialization/vanilla_ClientTypes-Runtime-Dval-T_complete.json
@@ -3106,6 +3106,61 @@
         ]
       }
     ],
+    "record with error": [
+      "DRecord",
+      {
+        "v": [
+          "DError",
+          [
+            "SourceNone"
+          ],
+          "some error string"
+        ]
+      }
+    ],
+    "record2": [
+      "DRecord",
+      {
+        "type": [
+          "DStr",
+          "weird"
+        ],
+        "value": [
+          "DUnit"
+        ]
+      }
+    ],
+    "record3": [
+      "DRecord",
+      {
+        "type": [
+          "DStr",
+          "weird"
+        ],
+        "value": [
+          "DStr",
+          "x"
+        ]
+      }
+    ],
+    "record4": [
+      "DRecord",
+      {
+        "foo\\\\bar": [
+          "DInt",
+          5
+        ]
+      }
+    ],
+    "record5": [
+      "DRecord",
+      {
+        "$type": [
+          "DInt",
+          5
+        ]
+      }
+    ],
     "result": [
       "DResult",
       [

--- a/backend/serialization/vanilla_LibBackend-TraceCloudStorage-CloudStorageFormat_simple.json
+++ b/backend/serialization/vanilla_LibBackend-TraceCloudStorage-CloudStorageFormat_simple.json
@@ -64,6 +64,58 @@
             "DDB",
             "Visitors"
           ],
+          "dict": [
+            "DDict",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict with error": [
+            "DDict",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "dict3": [
+            "DDict",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "dict4": [
+            "DDict",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict5": [
+            "DDict",
+            {
+              "$type": [
+                "DInt",
+                5
+              ]
+            }
+          ],
           "e \u002B 0": [
             "DFloat",
             2.718281828459045
@@ -2891,70 +2943,6 @@
           "null": [
             "DUnit"
           ],
-          "obj": [
-            "DDict",
-            {
-              "foo": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj with error": [
-            "DDict",
-            {
-              "v": [
-                "DError",
-                [
-                  "SourceNone"
-                ],
-                "some error string"
-              ]
-            }
-          ],
-          "obj2": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DUnit"
-              ]
-            }
-          ],
-          "obj3": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DStr",
-                "x"
-              ]
-            }
-          ],
-          "obj4": [
-            "DDict",
-            {
-              "foo\\\\bar": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj5": [
-            "DDict",
-            {
-              "$type": [
-                "DInt",
-                5
-              ]
-            }
-          ],
           "option": [
             "DOption",
             null
@@ -2980,6 +2968,15 @@
           "pi \u002B 1": [
             "DFloat",
             4.141592653589793
+          ],
+          "record": [
+            "DRecord",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
           ],
           "result": [
             "DResult",
@@ -3197,6 +3194,58 @@
               "db": [
                 "DDB",
                 "Visitors"
+              ],
+              "dict": [
+                "DDict",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict with error": [
+                "DDict",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "dict3": [
+                "DDict",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "dict4": [
+                "DDict",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "dict5": [
+                "DDict",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
               ],
               "e \u002B 0": [
                 "DFloat",
@@ -6025,70 +6074,6 @@
               "null": [
                 "DUnit"
               ],
-              "obj": [
-                "DDict",
-                {
-                  "foo": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj with error": [
-                "DDict",
-                {
-                  "v": [
-                    "DError",
-                    [
-                      "SourceNone"
-                    ],
-                    "some error string"
-                  ]
-                }
-              ],
-              "obj2": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DUnit"
-                  ]
-                }
-              ],
-              "obj3": [
-                "DDict",
-                {
-                  "type": [
-                    "DStr",
-                    "weird"
-                  ],
-                  "value": [
-                    "DStr",
-                    "x"
-                  ]
-                }
-              ],
-              "obj4": [
-                "DDict",
-                {
-                  "foo\\\\bar": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
-              "obj5": [
-                "DDict",
-                {
-                  "$type": [
-                    "DInt",
-                    5
-                  ]
-                }
-              ],
               "option": [
                 "DOption",
                 null
@@ -6114,6 +6099,15 @@
               "pi \u002B 1": [
                 "DFloat",
                 4.141592653589793
+              ],
+              "record": [
+                "DRecord",
+                {
+                  "foo": [
+                    "DInt",
+                    5
+                  ]
+                }
               ],
               "result": [
                 "DResult",
@@ -6273,7 +6267,7 @@
       7,
       "testFn",
       2,
-      "QFIzAL5SZ34",
+      "wPWDmMyVA1A",
       [
         "DDict",
         {
@@ -6334,6 +6328,58 @@
           "db": [
             "DDB",
             "Visitors"
+          ],
+          "dict": [
+            "DDict",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict with error": [
+            "DDict",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "dict3": [
+            "DDict",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "dict4": [
+            "DDict",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict5": [
+            "DDict",
+            {
+              "$type": [
+                "DInt",
+                5
+              ]
+            }
           ],
           "e \u002B 0": [
             "DFloat",
@@ -9162,70 +9208,6 @@
           "null": [
             "DUnit"
           ],
-          "obj": [
-            "DDict",
-            {
-              "foo": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj with error": [
-            "DDict",
-            {
-              "v": [
-                "DError",
-                [
-                  "SourceNone"
-                ],
-                "some error string"
-              ]
-            }
-          ],
-          "obj2": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DUnit"
-              ]
-            }
-          ],
-          "obj3": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DStr",
-                "x"
-              ]
-            }
-          ],
-          "obj4": [
-            "DDict",
-            {
-              "foo\\\\bar": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj5": [
-            "DDict",
-            {
-              "$type": [
-                "DInt",
-                5
-              ]
-            }
-          ],
           "option": [
             "DOption",
             null
@@ -9251,6 +9233,15 @@
           "pi \u002B 1": [
             "DFloat",
             4.141592653589793
+          ],
+          "record": [
+            "DRecord",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
           ],
           "result": [
             "DResult",

--- a/backend/serialization/vanilla_LibBackend-TraceCloudStorage-CloudStorageFormat_simple.json
+++ b/backend/serialization/vanilla_LibBackend-TraceCloudStorage-CloudStorageFormat_simple.json
@@ -2978,6 +2978,61 @@
               ]
             }
           ],
+          "record with error": [
+            "DRecord",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "record2": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DUnit"
+              ]
+            }
+          ],
+          "record3": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "record4": [
+            "DRecord",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "record5": [
+            "DRecord",
+            {
+              "$type": [
+                "DInt",
+                5
+              ]
+            }
+          ],
           "result": [
             "DResult",
             [
@@ -6109,6 +6164,61 @@
                   ]
                 }
               ],
+              "record with error": [
+                "DRecord",
+                {
+                  "v": [
+                    "DError",
+                    [
+                      "SourceNone"
+                    ],
+                    "some error string"
+                  ]
+                }
+              ],
+              "record2": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DUnit"
+                  ]
+                }
+              ],
+              "record3": [
+                "DRecord",
+                {
+                  "type": [
+                    "DStr",
+                    "weird"
+                  ],
+                  "value": [
+                    "DStr",
+                    "x"
+                  ]
+                }
+              ],
+              "record4": [
+                "DRecord",
+                {
+                  "foo\\\\bar": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
+              "record5": [
+                "DRecord",
+                {
+                  "$type": [
+                    "DInt",
+                    5
+                  ]
+                }
+              ],
               "result": [
                 "DResult",
                 [
@@ -6267,7 +6377,7 @@
       7,
       "testFn",
       2,
-      "wPWDmMyVA1A",
+      "BfkHA4rbrsI",
       [
         "DDict",
         {
@@ -9238,6 +9348,61 @@
             "DRecord",
             {
               "foo": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "record with error": [
+            "DRecord",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "record2": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DUnit"
+              ]
+            }
+          ],
+          "record3": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "record4": [
+            "DRecord",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "record5": [
+            "DRecord",
+            {
+              "$type": [
                 "DInt",
                 5
               ]

--- a/backend/serialization/vanilla_LibExecution-AnalysisTypes-TraceData_testTraceData.json
+++ b/backend/serialization/vanilla_LibExecution-AnalysisTypes-TraceData_testTraceData.json
@@ -196,6 +196,58 @@
             "DDB",
             "Visitors"
           ],
+          "dict": [
+            "DDict",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict with error": [
+            "DDict",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "dict3": [
+            "DDict",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "dict4": [
+            "DDict",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict5": [
+            "DDict",
+            {
+              "$type": [
+                "DInt",
+                5
+              ]
+            }
+          ],
           "e \u002B 0": [
             "DFloat",
             2.718281828459045
@@ -3023,70 +3075,6 @@
           "null": [
             "DUnit"
           ],
-          "obj": [
-            "DDict",
-            {
-              "foo": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj with error": [
-            "DDict",
-            {
-              "v": [
-                "DError",
-                [
-                  "SourceNone"
-                ],
-                "some error string"
-              ]
-            }
-          ],
-          "obj2": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DUnit"
-              ]
-            }
-          ],
-          "obj3": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DStr",
-                "x"
-              ]
-            }
-          ],
-          "obj4": [
-            "DDict",
-            {
-              "foo\\\\bar": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj5": [
-            "DDict",
-            {
-              "$type": [
-                "DInt",
-                5
-              ]
-            }
-          ],
           "option": [
             "DOption",
             null
@@ -3112,6 +3100,15 @@
           "pi \u002B 1": [
             "DFloat",
             4.141592653589793
+          ],
+          "record": [
+            "DRecord",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
           ],
           "result": [
             "DResult",
@@ -3464,6 +3461,58 @@
             "DDB",
             "Visitors"
           ],
+          "dict": [
+            "DDict",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict with error": [
+            "DDict",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "dict3": [
+            "DDict",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "dict4": [
+            "DDict",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "dict5": [
+            "DDict",
+            {
+              "$type": [
+                "DInt",
+                5
+              ]
+            }
+          ],
           "e \u002B 0": [
             "DFloat",
             2.718281828459045
@@ -6291,70 +6340,6 @@
           "null": [
             "DUnit"
           ],
-          "obj": [
-            "DDict",
-            {
-              "foo": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj with error": [
-            "DDict",
-            {
-              "v": [
-                "DError",
-                [
-                  "SourceNone"
-                ],
-                "some error string"
-              ]
-            }
-          ],
-          "obj2": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DUnit"
-              ]
-            }
-          ],
-          "obj3": [
-            "DDict",
-            {
-              "type": [
-                "DStr",
-                "weird"
-              ],
-              "value": [
-                "DStr",
-                "x"
-              ]
-            }
-          ],
-          "obj4": [
-            "DDict",
-            {
-              "foo\\\\bar": [
-                "DInt",
-                5
-              ]
-            }
-          ],
-          "obj5": [
-            "DDict",
-            {
-              "$type": [
-                "DInt",
-                5
-              ]
-            }
-          ],
           "option": [
             "DOption",
             null
@@ -6380,6 +6365,15 @@
           "pi \u002B 1": [
             "DFloat",
             4.141592653589793
+          ],
+          "record": [
+            "DRecord",
+            {
+              "foo": [
+                "DInt",
+                5
+              ]
+            }
           ],
           "result": [
             "DResult",

--- a/backend/serialization/vanilla_LibExecution-AnalysisTypes-TraceData_testTraceData.json
+++ b/backend/serialization/vanilla_LibExecution-AnalysisTypes-TraceData_testTraceData.json
@@ -3110,6 +3110,61 @@
               ]
             }
           ],
+          "record with error": [
+            "DRecord",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "record2": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DUnit"
+              ]
+            }
+          ],
+          "record3": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "record4": [
+            "DRecord",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "record5": [
+            "DRecord",
+            {
+              "$type": [
+                "DInt",
+                5
+              ]
+            }
+          ],
           "result": [
             "DResult",
             [
@@ -6370,6 +6425,61 @@
             "DRecord",
             {
               "foo": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "record with error": [
+            "DRecord",
+            {
+              "v": [
+                "DError",
+                [
+                  "SourceNone"
+                ],
+                "some error string"
+              ]
+            }
+          ],
+          "record2": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DUnit"
+              ]
+            }
+          ],
+          "record3": [
+            "DRecord",
+            {
+              "type": [
+                "DStr",
+                "weird"
+              ],
+              "value": [
+                "DStr",
+                "x"
+              ]
+            }
+          ],
+          "record4": [
+            "DRecord",
+            {
+              "foo\\\\bar": [
+                "DInt",
+                5
+              ]
+            }
+          ],
+          "record5": [
+            "DRecord",
+            {
+              "$type": [
                 "DInt",
                 5
               ]

--- a/backend/serialization/vanilla_LibExecution-DvalReprInternalRoundtrippable-FormatV0-Dval_complete.json
+++ b/backend/serialization/vanilla_LibExecution-DvalReprInternalRoundtrippable-FormatV0-Dval_complete.json
@@ -2973,6 +2973,61 @@
         ]
       }
     ],
+    "record with error": [
+      "DRecord",
+      {
+        "v": [
+          "DError",
+          [
+            "SourceNone"
+          ],
+          "some error string"
+        ]
+      }
+    ],
+    "record2": [
+      "DRecord",
+      {
+        "type": [
+          "DStr",
+          "weird"
+        ],
+        "value": [
+          "DUnit"
+        ]
+      }
+    ],
+    "record3": [
+      "DRecord",
+      {
+        "type": [
+          "DStr",
+          "weird"
+        ],
+        "value": [
+          "DStr",
+          "x"
+        ]
+      }
+    ],
+    "record4": [
+      "DRecord",
+      {
+        "foo\\\\bar": [
+          "DInt",
+          5
+        ]
+      }
+    ],
+    "record5": [
+      "DRecord",
+      {
+        "$type": [
+          "DInt",
+          5
+        ]
+      }
+    ],
     "result": [
       "DResult",
       [

--- a/backend/serialization/vanilla_LibExecution-DvalReprInternalRoundtrippable-FormatV0-Dval_complete.json
+++ b/backend/serialization/vanilla_LibExecution-DvalReprInternalRoundtrippable-FormatV0-Dval_complete.json
@@ -59,6 +59,58 @@
       "DDB",
       "Visitors"
     ],
+    "dict": [
+      "DDict",
+      {
+        "foo": [
+          "DInt",
+          5
+        ]
+      }
+    ],
+    "dict with error": [
+      "DDict",
+      {
+        "v": [
+          "DError",
+          [
+            "SourceNone"
+          ],
+          "some error string"
+        ]
+      }
+    ],
+    "dict3": [
+      "DDict",
+      {
+        "type": [
+          "DStr",
+          "weird"
+        ],
+        "value": [
+          "DStr",
+          "x"
+        ]
+      }
+    ],
+    "dict4": [
+      "DDict",
+      {
+        "foo\\\\bar": [
+          "DInt",
+          5
+        ]
+      }
+    ],
+    "dict5": [
+      "DDict",
+      {
+        "$type": [
+          "DInt",
+          5
+        ]
+      }
+    ],
     "e \u002B 0": [
       "DFloat",
       2.718281828459045
@@ -2886,70 +2938,6 @@
     "null": [
       "DUnit"
     ],
-    "obj": [
-      "DDict",
-      {
-        "foo": [
-          "DInt",
-          5
-        ]
-      }
-    ],
-    "obj with error": [
-      "DDict",
-      {
-        "v": [
-          "DError",
-          [
-            "SourceNone"
-          ],
-          "some error string"
-        ]
-      }
-    ],
-    "obj2": [
-      "DDict",
-      {
-        "type": [
-          "DStr",
-          "weird"
-        ],
-        "value": [
-          "DUnit"
-        ]
-      }
-    ],
-    "obj3": [
-      "DDict",
-      {
-        "type": [
-          "DStr",
-          "weird"
-        ],
-        "value": [
-          "DStr",
-          "x"
-        ]
-      }
-    ],
-    "obj4": [
-      "DDict",
-      {
-        "foo\\\\bar": [
-          "DInt",
-          5
-        ]
-      }
-    ],
-    "obj5": [
-      "DDict",
-      {
-        "$type": [
-          "DInt",
-          5
-        ]
-      }
-    ],
     "option": [
       "DOption",
       null
@@ -2975,6 +2963,15 @@
     "pi \u002B 1": [
       "DFloat",
       4.141592653589793
+    ],
+    "record": [
+      "DRecord",
+      {
+        "foo": [
+          "DInt",
+          5
+        ]
+      }
     ],
     "result": [
       "DResult",

--- a/backend/serialization/vanilla_Microsoft-FSharp-Core-FSharpResult-2-System-Tuple-4-System-Guid-System-Collections-Generic-Dictionary-2-System-UInt64-ClientTypes-Analysis-ExecutionResult-System-Int32-NodaTime-Instant-System-String-_simple.json
+++ b/backend/serialization/vanilla_Microsoft-FSharp-Core-FSharpResult-2-System-Tuple-4-System-Guid-System-Collections-Generic-Dictionary-2-System-UInt64-ClientTypes-Analysis-ExecutionResult-System-Int32-NodaTime-Instant-System-String-_simple.json
@@ -199,6 +199,58 @@
               "DDB",
               "Visitors"
             ],
+            "dict": [
+              "DDict",
+              {
+                "foo": [
+                  "DInt",
+                  5
+                ]
+              }
+            ],
+            "dict with error": [
+              "DDict",
+              {
+                "v": [
+                  "DError",
+                  [
+                    "SourceNone"
+                  ],
+                  "some error string"
+                ]
+              }
+            ],
+            "dict3": [
+              "DDict",
+              {
+                "type": [
+                  "DStr",
+                  "weird"
+                ],
+                "value": [
+                  "DStr",
+                  "x"
+                ]
+              }
+            ],
+            "dict4": [
+              "DDict",
+              {
+                "foo\\\\bar": [
+                  "DInt",
+                  5
+                ]
+              }
+            ],
+            "dict5": [
+              "DDict",
+              {
+                "$type": [
+                  "DInt",
+                  5
+                ]
+              }
+            ],
             "e \u002B 0": [
               "DFloat",
               2.718281828459045
@@ -3026,70 +3078,6 @@
             "null": [
               "DUnit"
             ],
-            "obj": [
-              "DDict",
-              {
-                "foo": [
-                  "DInt",
-                  5
-                ]
-              }
-            ],
-            "obj with error": [
-              "DDict",
-              {
-                "v": [
-                  "DError",
-                  [
-                    "SourceNone"
-                  ],
-                  "some error string"
-                ]
-              }
-            ],
-            "obj2": [
-              "DDict",
-              {
-                "type": [
-                  "DStr",
-                  "weird"
-                ],
-                "value": [
-                  "DUnit"
-                ]
-              }
-            ],
-            "obj3": [
-              "DDict",
-              {
-                "type": [
-                  "DStr",
-                  "weird"
-                ],
-                "value": [
-                  "DStr",
-                  "x"
-                ]
-              }
-            ],
-            "obj4": [
-              "DDict",
-              {
-                "foo\\\\bar": [
-                  "DInt",
-                  5
-                ]
-              }
-            ],
-            "obj5": [
-              "DDict",
-              {
-                "$type": [
-                  "DInt",
-                  5
-                ]
-              }
-            ],
             "option": [
               "DOption",
               null
@@ -3115,6 +3103,15 @@
             "pi \u002B 1": [
               "DFloat",
               4.141592653589793
+            ],
+            "record": [
+              "DRecord",
+              {
+                "foo": [
+                  "DInt",
+                  5
+                ]
+              }
             ],
             "result": [
               "DResult",

--- a/backend/serialization/vanilla_Microsoft-FSharp-Core-FSharpResult-2-System-Tuple-4-System-Guid-System-Collections-Generic-Dictionary-2-System-UInt64-ClientTypes-Analysis-ExecutionResult-System-Int32-NodaTime-Instant-System-String-_simple.json
+++ b/backend/serialization/vanilla_Microsoft-FSharp-Core-FSharpResult-2-System-Tuple-4-System-Guid-System-Collections-Generic-Dictionary-2-System-UInt64-ClientTypes-Analysis-ExecutionResult-System-Int32-NodaTime-Instant-System-String-_simple.json
@@ -3113,6 +3113,61 @@
                 ]
               }
             ],
+            "record with error": [
+              "DRecord",
+              {
+                "v": [
+                  "DError",
+                  [
+                    "SourceNone"
+                  ],
+                  "some error string"
+                ]
+              }
+            ],
+            "record2": [
+              "DRecord",
+              {
+                "type": [
+                  "DStr",
+                  "weird"
+                ],
+                "value": [
+                  "DUnit"
+                ]
+              }
+            ],
+            "record3": [
+              "DRecord",
+              {
+                "type": [
+                  "DStr",
+                  "weird"
+                ],
+                "value": [
+                  "DStr",
+                  "x"
+                ]
+              }
+            ],
+            "record4": [
+              "DRecord",
+              {
+                "foo\\\\bar": [
+                  "DInt",
+                  5
+                ]
+              }
+            ],
+            "record5": [
+              "DRecord",
+              {
+                "$type": [
+                  "DInt",
+                  5
+                ]
+              }
+            ],
             "result": [
               "DResult",
               [

--- a/backend/src/ClientTypes/ClientRuntimeTypes.fs
+++ b/backend/src/ClientTypes/ClientRuntimeTypes.fs
@@ -144,6 +144,7 @@ module Dval =
     | DTuple of T * T * List<T>
     | DFnVal of FnValImpl // See docs/dblock-serialization.md
     | DDict of Map<string, T>
+    | DRecord of Map<string, T> // CLEANUP add type name
     | DError of DvalSource * string
     | DIncomplete of DvalSource
     | DHttpResponse of int64 * List<string * string> * T

--- a/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
+++ b/backend/src/ClientTypes2ExecutionTypes/RuntimeTypes.fs
@@ -358,6 +358,7 @@ module Dval =
     | Dval.DTuple (first, second, theRest) ->
       RT.DTuple(r first, r second, List.map r theRest)
     | Dval.DDict o -> RT.DDict(Map.map r o)
+    | Dval.DRecord o -> RT.DRecord(Map.map r o)
     | Dval.DOption None -> RT.DOption None
     | Dval.DOption (Some dv) -> RT.DOption(Some(r dv))
     | Dval.DResult (Ok dv) -> RT.DResult(Ok(r dv))
@@ -400,6 +401,7 @@ module Dval =
     | RT.DTuple (first, second, theRest) ->
       Dval.DTuple(r first, r second, List.map r theRest)
     | RT.DDict o -> Dval.DDict(Map.map r o)
+    | RT.DRecord o -> Dval.DRecord(Map.map r o)
     | RT.DOption None -> Dval.DOption None
     | RT.DOption (Some dv) -> Dval.DOption(Some(r dv))
     | RT.DResult (Ok dv) -> Dval.DResult(Ok(r dv))

--- a/backend/src/LibExecution/DvalReprDeveloper.fs
+++ b/backend/src/LibExecution/DvalReprDeveloper.fs
@@ -113,6 +113,17 @@ let toRepr (dv : Dval) : string =
       let l = [ first; second ] @ theRest
       let elems = String.concat ", " (List.map (toRepr_ indent) l)
       $"({inl}{elems}{nl})"
+    | DRecord o ->
+      if Map.isEmpty o then
+        "{}"
+      else
+        let strs =
+          o
+          |> Map.toList
+          |> List.map (fun (key, value) -> ($"{key}: {toRepr_ indent value}"))
+
+        let elems = String.concat $",{inl}" strs
+        "{" + $"{inl}{elems}{nl}" + "}"
     | DDict o ->
       if Map.isEmpty o then
         "{}"

--- a/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
+++ b/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
@@ -76,6 +76,7 @@ module FormatV0 =
     | DTuple of Dval * Dval * List<Dval>
     | DLambda // See docs/dblock-serialization.md
     | DDict of DvalMap
+    | DRecord of DvalMap
     | DError of DvalSource * string
     | DIncomplete of DvalSource
     | DHttpResponse of int64 * List<string * string> * Dval
@@ -116,6 +117,7 @@ module FormatV0 =
     | DTuple (first, second, theRest) ->
       RT.DTuple(toRT first, toRT second, List.map toRT theRest)
     | DDict o -> RT.DDict(Map.map toRT o)
+    | DRecord o -> RT.DRecord(Map.map toRT o)
     | DOption None -> RT.DOption None
     | DOption (Some dv) -> RT.DOption(Some(toRT dv))
     | DResult (Ok dv) -> RT.DResult(Ok(toRT dv))
@@ -152,6 +154,7 @@ module FormatV0 =
     | RT.DTuple (first, second, theRest) ->
       DTuple(fromRT first, fromRT second, List.map fromRT theRest)
     | RT.DDict o -> DDict(Map.map fromRT o)
+    | RT.DRecord o -> DRecord(Map.map fromRT o)
     | RT.DOption None -> DOption None
     | RT.DOption (Some dv) -> DOption(Some(fromRT dv))
     | RT.DResult (Ok dv) -> DResult(Ok(fromRT dv))
@@ -200,6 +203,7 @@ module Test =
       List.all isRoundtrippableDval fields
     | RT.DList dvals -> List.all isRoundtrippableDval dvals
     | RT.DDict map -> map |> Map.values |> List.all isRoundtrippableDval
+    | RT.DRecord map -> map |> Map.values |> List.all isRoundtrippableDval
     | RT.DUuid _ -> true
     | RT.DTuple (v1, v2, rest) -> List.all isRoundtrippableDval (v1 :: v2 :: rest)
     | RT.DOption (Some v)

--- a/backend/src/LibExecutionStdLib/LibList.fs
+++ b/backend/src/LibExecutionStdLib/LibList.fs
@@ -44,6 +44,7 @@ module DvalComparator =
     | DBytes b1, DBytes b2 -> compare b1 b2
     | DHttpResponse _, DHttpResponse _ -> 0 // this is being deleted soon
     | DDict o1, DDict o2 -> compareMaps (Map.toList o1) (Map.toList o2)
+    | DRecord o1, DRecord o2 -> compareMaps (Map.toList o1) (Map.toList o2)
     | DOption o1, DOption o2 ->
       match o1, o2 with
       | None, None -> 0
@@ -82,6 +83,7 @@ module DvalComparator =
     | DBytes _, _
     | DHttpResponse _, _
     | DDict _, _
+    | DRecord _, _
     | DOption _, _
     | DResult _, _
     | DConstructor _, _ ->

--- a/backend/src/LibExecutionStdLib/LibNoModule.fs
+++ b/backend/src/LibExecutionStdLib/LibNoModule.fs
@@ -32,6 +32,12 @@ let rec equals (a : Dval) (b : Dval) : bool =
          (fun k v ->
            Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false)
          a
+  | DRecord a, DRecord b ->
+    Map.count a = Map.count b
+    && Map.forall
+         (fun k v ->
+           Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false)
+         a
   | DFnVal a, DFnVal b ->
     match a, b with
     | Lambda a, Lambda b -> equalsLambdaImpl a b
@@ -66,6 +72,7 @@ let rec equals (a : Dval) (b : Dval) : bool =
   | DList _, _
   | DTuple _, _
   | DDict _, _
+  | DRecord _, _
   | DFnVal _, _
   | DDateTime _, _
   | DPassword _, _


### PR DESCRIPTION
This adds DRecords everywhere. By design, it doesn't do anything with them - in the few cases where we tried to enable them we got errors as almost everything (we're talking DBs here) use DDicts. They can be converted later, for now our goal is simply to get DRecords into the codebase so that the later PR will be manageable.