### PR TITLE
OpenTelemetry sampling

### DIFF
--- a/backend/src/LibService/LaunchDarkly.fs
+++ b/backend/src/LibService/LaunchDarkly.fs
@@ -196,6 +196,41 @@ module Internal =
     stringSetTestDefault name testDefault
     fun canvasID -> stringVar name $"canvas-{canvasID}" default_
 
+  // -------------
+  // per-service values
+  // -------------
+  let serviceBool
+    (name : string)
+    (default_ : bool)
+    (testDefault : bool)
+    : string -> bool =
+    boolSetTestDefault name testDefault
+    fun serviceName -> boolVar name $"service-{serviceName}" default_
+
+  let serviceInt
+    (name : string)
+    (default_ : int)
+    (testDefault : int)
+    : string -> int =
+    intSetTestDefault name testDefault
+    fun serviceName -> intVar name $"service-{serviceName}" default_
+
+  let serviceFloat
+    (name : string)
+    (default_ : float)
+    (testDefault : float)
+    : string -> float =
+    floatSetTestDefault name testDefault
+    fun serviceName -> floatVar name $"service-{serviceName}" default_
+
+  let serviceString
+    (name : string)
+    (default_ : string)
+    (testDefault : string)
+    : string -> string =
+    stringSetTestDefault name testDefault
+    fun serviceName -> stringVar name $"service-{serviceName}" default_
+
 
 
 let flush () : unit = Internal.client.Force().Dispose()
@@ -215,6 +250,12 @@ let traceSamplingRule =
 // --------------
 let knownBroken = Internal.canvasBool "canvas-known-broken" false false
 
+
+// --------------
+// Service Flags - may be different for each service
+// --------------
+// Whether to record traces
+let traceSamplePercentage = Internal.serviceInt "trace-sample-percentage" 100 100
 
 // --------------
 // System flags - this allows us to change the run-time values of system

--- a/backend/src/LibService/LaunchDarkly.fs
+++ b/backend/src/LibService/LaunchDarkly.fs
@@ -255,7 +255,8 @@ let knownBroken = Internal.canvasBool "canvas-known-broken" false false
 // Service Flags - may be different for each service
 // --------------
 // Whether to record traces
-let traceSamplePercentage = Internal.serviceInt "trace-sample-percentage" 100 100
+let telemetrySamplePercentage =
+  Internal.serviceFloat "telemetry-sample-percentage" 100.0 100.0
 
 // --------------
 // System flags - this allows us to change the run-time values of system

--- a/backend/src/LibService/LibService.fsproj
+++ b/backend/src/LibService/LibService.fsproj
@@ -12,9 +12,9 @@
     <None Include="paket.references" />
     <Compile Include="ConfigDsl.fs" />
     <Compile Include="Config.fs" />
+    <Compile Include="LaunchDarkly.fs" />
     <Compile Include="Telemetry.fs" />
     <Compile Include="Logging.fs" />
-    <Compile Include="LaunchDarkly.fs" />
     <Compile Include="Rollbar.fs" />
     <Compile Include="FireAndForget.fs" />
     <Compile Include="DBConnection.fs" />

--- a/backend/src/LibService/Telemetry.fs
+++ b/backend/src/LibService/Telemetry.fs
@@ -308,7 +308,7 @@ let configureAspNetCore
 /// A sampler is used to reduce the number of events, to not overwhelm the results.
 /// In our case, we want to control costs too - we only have 1.5B honeycomb events
 /// per month, and it's easy to use them very quickly in a loop
-type DarkSampler() =
+type HttpSampler() =
   inherit OpenTelemetry.Trace.Sampler()
 
   let keep = SamplingResult(SamplingDecision.RecordAndSample)
@@ -346,7 +346,7 @@ type DarkSampler() =
     // This turned out to be useless for the initial need (trimming short DB queries)
     keep
 
-let sampler = DarkSampler()
+let sampler = HttpSampler()
 
 type TraceDBQueries =
   | TraceDBQueries
@@ -398,6 +398,7 @@ module Console =
     let tp =
       Sdk.CreateTracerProviderBuilder()
       |> addTelemetry serviceName traceDBQueries
+      |> fun tp -> tp.SetSampler(AlwaysOnSampler())
       |> fun tp -> tp.Build()
     tracerProvider <- tp
 


### PR DESCRIPTION
Changelog:

```
Infrastructure
- enable sampling of OpenTelemetry data
```

We are spending too much on opentelemetry, and that is about to double due to our provider increasing costs. This is the start of addressing that, by allowing whole-trace sampling. I'd love to sample only errors, but that doesn't exist in dotnet OpenTelemetry.

The plan is in https://github.com/darklang/classic-dark/issues/16, merging this is step 1.