### PR TITLE
Handle Dicts/Records in JSON stdlib fns

### DIFF
--- a/backend/testfiles/execution/json.tests
+++ b/backend/testfiles/execution/json.tests
@@ -296,7 +296,16 @@ Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = Ok (Enh("printer br
 
 
 // #### Records
-// TODO
+type Person = { Name: string; Age: int }
+
+Json.serialize<Person> { Name = "Bob"; Age = 42 } = Ok """{"Age":42,"Name":"Bob"}"""
+Json.parse<Person> """{ "Name": "Bob", "Age": 42 }""" = Ok { Name = "Bob"; Age = 42 }
+
+(let personMaybe = Json.parse<Person> """{ "Name": "Bob", "Age": 42 }"""
+ match personMaybe with
+ | Ok person -> person.Age
+ | Error _ -> 0) = 42
+
 
 
 // ### Package

--- a/backend/testfiles/execution/json.tests
+++ b/backend/testfiles/execution/json.tests
@@ -297,9 +297,12 @@ Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = Ok (Enh("printer br
 
 // #### Records
 type Person = { Name: string; Age: int }
+type People = { GroupName: string; People: List<Person> }
 
 Json.serialize<Person> { Name = "Bob"; Age = 42 } = Ok """{"Age":42,"Name":"Bob"}"""
 Json.parse<Person> """{ "Name": "Bob", "Age": 42 }""" = Ok { Name = "Bob"; Age = 42 }
+Json.serialize<People> { GroupName = "Two Georges"; People = [{ Name = "George A"; Age = 27 }; { Name = "George B"; Age = 42 }] } = Ok """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}"""
+Json.parse<People> """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}""" = Ok { GroupName = "Two Georges"; People = [{ Name = "George A"; Age = 27 }; { Name = "George B"; Age = 42 }] }
 
 (let personMaybe = Json.parse<Person> """{ "Name": "Bob", "Age": 42 }"""
  match personMaybe with


### PR DESCRIPTION
```
Language and Standard Library
- Add minimal support for records+dictionaries to Json::parse<'a> and ::serialize<'a>
```

This was blocking Ocean, so we hacked together to get out a working solution. Does this seem reasonable for now, @pbiggar?

My hesitation is that we're returning a DDict in the parser when we want to return a DRecord.
This was done as the Parser currently interprets (afaik) all 'objects' as DDicts - so, returning a DRecord as we'd _like_ to do would result in difficult testing (until we support labeling a record like `Person { Name = ... }`)