### PR TITLE
Allow parsing user functions in pipes

### DIFF
--- a/backend/experiments/cli/LibCli.fs
+++ b/backend/experiments/cli/LibCli.fs
@@ -18,14 +18,14 @@ let varA = TVariable "a"
 
 
 let fns : List<BuiltInFn> =
-  [ { name = fn "IO" "print" 0 // CLEANUP make this not use IO prefix
+  [ { name = fn "" "print" 0
       typeParams = []
       parameters = [ Param.make "value" varA "The value to be printed." ]
       returnType = TUnit
       description = "Prints the given <param value> to the standard output."
       fn =
         (function
-        | state, _, [ value ] ->
+        | _, _, [ value ] ->
           let str = LibExecution.DvalReprDeveloper.toRepr value
           print str
           Ply(DUnit)
@@ -34,7 +34,7 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated }
 
-    { name = fn "IO" "readFile" 0
+    { name = fn "File" "read" 0
       typeParams = []
       parameters = [ Param.make "path" TString "" ]
       returnType = TResult(TBytes, TString)
@@ -42,7 +42,7 @@ let fns : List<BuiltInFn> =
         "Reads the contents of a file specified by <param path> asynchronously and returns its contents as Bytes wrapped in a Result"
       fn =
         (function
-        | state, _, [ DString path ] ->
+        | _, _, [ DString path ] ->
           uply {
             try
               let! contents = System.IO.File.ReadAllBytesAsync path

--- a/backend/experiments/cli/program.dark
+++ b/backend/experiments/cli/program.dark
@@ -14,7 +14,7 @@ let parseArguments (args: List<String>): Command =
 let executeCommand (command: Command) : unit =
   match command with
   | RunScript scriptPath ->
-    let script = IO.readFile scriptPath
+    let script = File.read scriptPath
     // Execute the script here
     ()
 
@@ -23,7 +23,7 @@ let executeCommand (command: Command) : unit =
 Options:
 -h, --help Show this help message and exit
 --prompt PROMPT Infer a script from the given prompt using OpenAI"
-    IO.print helpText
+    print helpText
 
   | Infer (prompt, scriptPath) ->
   // let script = System.IO.File.ReadAllText scriptPath
@@ -33,6 +33,6 @@ Options:
   ()
 
   | Invalid ->
-    IO.print "Invalid command. Use --help for more information."
+    print "Invalid command. Use --help for more information."
 
 args |> parseArguments |> executeCommand

--- a/backend/experiments/cli/program.dark
+++ b/backend/experiments/cli/program.dark
@@ -2,13 +2,14 @@ type Command =
   | RunScript of String
   | Help
   | Infer of String
+  | Invalid
 
 let parseArguments (args: List<String>): Command =
   match args with
   | ["--help"] -> Help
   | ["--prompt"; prompt; scriptPath] -> Infer (prompt, scriptPath)
   | [scriptPath] -> RunScript scriptPath
-  | _ -> failwith "Invalid arguments"
+  | _ -> Invalid
 
 let executeCommand (command: Command) : unit =
   match command with
@@ -22,7 +23,7 @@ let executeCommand (command: Command) : unit =
 Options:
 -h, --help Show this help message and exit
 --prompt PROMPT Infer a script from the given prompt using OpenAI"
-    print helpText
+    IO.print helpText
 
   | Infer (prompt, scriptPath) ->
   // let script = System.IO.File.ReadAllText scriptPath
@@ -30,5 +31,8 @@ Options:
   // let generatedScript = callOpenAI(prompt, script)
   // Execute the generated script here
   ()
+
+  | Invalid ->
+    IO.print "Invalid command. Use --help for more information."
 
 args |> parseArguments |> executeCommand

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -52,7 +52,13 @@ module FQFnName =
     | Package of PackageFnName
 
   let oneWordFunctions =
-    Set [ "equals"; "notEquals"; "equals_v0"; "notEquals_v0"; "emit_v1" ]
+    Set [ "equals"
+          "notEquals"
+          "equals_v0"
+          "notEquals_v0"
+          "emit_v1"
+          "print"
+          "print_v0" ]
 
   // CLEANUP Packages should just have a uuid
   let namePat = @"^[a-z][a-z0-9_]*$"

--- a/backend/src/Parser/ProgramTypes.fs
+++ b/backend/src/Parser/ProgramTypes.fs
@@ -605,6 +605,24 @@ module Expr =
     | expr ->
       Exception.raiseInternal "Unsupported expression" [ "ast", ast; "expr", expr ]
 
+  let convertVariablesToFnCalls
+    (functions : Set<PT.FQFnName.UserFnName>)
+    (e : PT.Expr)
+    : PT.Expr =
+    e
+    |> LibExecution.ProgramTypesAst.preTraversal (fun e ->
+      match e with
+      | PT.EVariable (id, name) ->
+        if Set.contains name functions then
+          PT.EFnCall(
+            id,
+            PT.FQFnName.User(PT.FQFnName.userFnName name),
+            [],
+            [ PT.Expr.EPipeTarget(gid ()) ]
+          )
+        else
+          e
+      | _ -> e)
 
 module UserFunction =
   let rec parseArgPat


### PR DESCRIPTION
When parsing, we didn't support user functions in some situations. The parser just thinks they're variables. It works fine in some cases like function application as F# put it in a structure where we know they're variables, but that doesn't work in pipes. This does a post-pass that handles it for pipes.

Also renames IO.print to `print` and `IO.readFile` to `File.read`