### PR TITLE
Add List.groupAdjacentBy_v0 and List.groupBy_v0

### DIFF
--- a/backend/testfiles/execution/list.tests
+++ b/backend/testfiles/execution/list.tests
@@ -240,21 +240,10 @@ List.zip_v0 [] [] = Just []
 List.zip_v0 [Test.typeError_v0 "msg"] [Just ""] = Test.typeError "msg"
 
 
-List.groupAdjacentBy_v0 [1, 2, 2, 3, 2, 2, 2, 1, 1, 1] (fun a b -> a == b) = [[1], [2, 2], [3], [2, 2, 2], [1, 1, 1]]
-List.groupAdjacentBy_v0 [1, 2, 3, 2, 3, 2] (fun x y -> x < y) = [[1, 2, 3], [2, 3], [2]]
-List.groupAdjacentBy_v0 [] (fun x y -> x == y) = []
-List.groupAdjacentBy_v0 [1] (fun x y -> x == y) = [[1]]
-List.groupAdjacentBy_v0 ["a"] (fun x y -> x == y) = [["a"]]
-List.groupAdjacentBy_v0 [5, 4, 3, 3, 2, 1] (fun x y -> x > y) = [[5, 4, 3], [3, 2, 1]]
-List.groupAdjacentBy_v0 [1, 1, 1, 1, 1] (fun a b -> a == b) = [[1, 1, 1, 1, 1]]
-List.groupAdjacentBy_v0 [1, 2, 3, 4, 5] (fun x y -> 1) = Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `1`"
-
-
-List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2) = [(1, [1, 3, 5]), (0, [2, 4])]
-List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2) = [(1, [1, 3, 5]), (0, [2, 4])]
-List.groupBy_v0 ["apple", "banana", "avocado", "grape", "apricot"] (fun s -> String.first_v0 s 1) = [("a", ["apple", "avocado", "apricot"]), ("b", ["banana"]), ("g", ["grape"])]
-List.groupBy_v0 ['a', 'b', 'c', 'a', 'b'] (fun c -> c) = [('a', ['a', 'a']), ('b', ['b', 'b']), ('c', ['c'])]
-List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2 == 0) = [(false, [1, 3, 5]), (true, [2, 4])]
-List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> ((Int.mod_v0 x 2), "test")) = [((1, "test"), [1, 3, 5]), ((0, "test"), [2, 4])]
-List.groupBy_v0 [] (fun x -> x) = []
-
+List.groupByWithKey_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2) = [(1, [1, 3, 5]), (0, [2, 4])]
+List.groupByWithKey_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2) = [(1, [1, 3, 5]), (0, [2, 4])]
+List.groupByWithKey_v0 ["apple", "banana", "avocado", "grape", "apricot"] (fun s -> String.first_v0 s 1) = [("a", ["apple", "avocado", "apricot"]), ("b", ["banana"]), ("g", ["grape"])]
+List.groupByWithKey_v0 ['a', 'b', 'c', 'a', 'b'] (fun c -> c) = [('a', ['a', 'a']), ('b', ['b', 'b']), ('c', ['c'])]
+List.groupByWithKey_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2 == 0) = [(false, [1, 3, 5]), (true, [2, 4])]
+List.groupByWithKey_v0 [1, 2, 3, 4, 5] (fun x -> ((Int.mod_v0 x 2), "test")) = [((1, "test"), [1, 3, 5]), ((0, "test"), [2, 4])]
+List.groupByWithKey_v0 [] (fun x -> x) = []

--- a/backend/testfiles/execution/list.tests
+++ b/backend/testfiles/execution/list.tests
@@ -238,3 +238,23 @@ List.zip_v0 [10;20;30] [1;2;3] = Just [ (10, 1); (20, 2); (30, 3) ]
 List.zip_v0 [10;20] [1;2;3] = Nothing
 List.zip_v0 [] [] = Just []
 List.zip_v0 [Test.typeError_v0 "msg"] [Just ""] = Test.typeError "msg"
+
+
+List.groupAdjacentBy_v0 [1, 2, 2, 3, 2, 2, 2, 1, 1, 1] (fun a b -> a == b) = [[1], [2, 2], [3], [2, 2, 2], [1, 1, 1]]
+List.groupAdjacentBy_v0 [1, 2, 3, 2, 3, 2] (fun x y -> x < y) = [[1, 2, 3], [2, 3], [2]]
+List.groupAdjacentBy_v0 [] (fun x y -> x == y) = []
+List.groupAdjacentBy_v0 [1] (fun x y -> x == y) = [[1]]
+List.groupAdjacentBy_v0 ["a"] (fun x y -> x == y) = [["a"]]
+List.groupAdjacentBy_v0 [5, 4, 3, 3, 2, 1] (fun x y -> x > y) = [[5, 4, 3], [3, 2, 1]]
+List.groupAdjacentBy_v0 [1, 1, 1, 1, 1] (fun a b -> a == b) = [[1, 1, 1, 1, 1]]
+List.groupAdjacentBy_v0 [1, 2, 3, 4, 5] (fun x y -> 1) = Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `1`"
+
+
+List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2) = [(1, [1, 3, 5]), (0, [2, 4])]
+List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2) = [(1, [1, 3, 5]), (0, [2, 4])]
+List.groupBy_v0 ["apple", "banana", "avocado", "grape", "apricot"] (fun s -> String.first_v0 s 1) = [("a", ["apple", "avocado", "apricot"]), ("b", ["banana"]), ("g", ["grape"])]
+List.groupBy_v0 ['a', 'b', 'c', 'a', 'b'] (fun c -> c) = [('a', ['a', 'a']), ('b', ['b', 'b']), ('c', ['c'])]
+List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> Int.mod_v0 x 2 == 0) = [(false, [1, 3, 5]), (true, [2, 4])]
+List.groupBy_v0 [1, 2, 3, 4, 5] (fun x -> ((Int.mod_v0 x 2), "test")) = [((1, "test"), [1, 3, 5]), ((0, "test"), [2, 4])]
+List.groupBy_v0 [] (fun x -> x) = []
+


### PR DESCRIPTION
Related issue: https://github.com/darklang/dark/issues/2552

Adds:
* groupAdjacentBy :  List a -> (a -> a -> Bool) -> List (List a))
* groupBy : List a -> (a -> b) -> List (Tuple (b, (List a)))

The definition of `groupBy` with a key function is more straightforward, the only edge-cases were the ordering of tuples inside the list (based on the first appearence of a key), and the ordering of elements in each tuple.

The definition for `groupAdjacentBy` is not as clear. Initially I went with the definition that's used in [Haskell](https://hackage.haskell.org/package/base-4.7.0.1/docs/src/Data-List.html)
```hs
-- | The 'groupBy' function is the non-overloaded version of 'group'.
groupBy                 :: (a -> a -> Bool) -> [a] -> [[a]]
groupBy _  []           =  []
groupBy eq (x:xs)       =  (x:ys) : groupBy eq zs
                           where (ys,zs) = span (eq x) xs
```

but this has strange behavior when the predicate is not a function that decides equality. For example:
```
List.groupAdjacentBy_v0 [1, 2, 3, 2, 3, 2] (fun x y -> x < y) 
```

Using the definition in Haskell, the response would be `[[1,2,3,2,3,2]]` since all the elements are compared to the first element in the group (1).
Another implementation would be actually checking each adjacent elements, in that case the result would be `[[1, 2, 3], [2, 3], [2]]`

The `(<)` predicate can be considered as not being valid, but I think it's important to have a good definition for such edge-cases.

**The current implementation uses the `[[1, 2, 3], [2, 3], [2]]` approach.**

Questions:
* We pass the list first and then the predicate. Haskell does the opposite. We don't yet have currying (I assume), but I was wondering if there's a decision regarding this order of arguments.
