### PR TITLE
Add parseAndSerializeExpr fn

### DIFF
--- a/backend/experiments/LibExperimentalStdLib/LibDarkEditor.fs
+++ b/backend/experiments/LibExperimentalStdLib/LibDarkEditor.fs
@@ -52,4 +52,22 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      deprecated = NotDeprecated }
+
+    { name = fn "DarkEditor" "parseAndSerializeExpr" 0
+      typeParams = []
+      parameters = [ Param.make "code" TString "" ]
+      returnType = TResult(TString, TString)
+      description = "Parses Dark code and serializes the result to JSON."
+      fn =
+        function
+        | _, _, [ DString code ] ->
+          uply {
+            let expr = Parser.RuntimeTypes.parseExprWithTypes Map.empty code
+            let serializedExpr = Json.Vanilla.serialize expr
+            return serializedExpr |> DString |> Ok |> DResult
+          }
+        | _ -> incorrectArgs ()
+      sqlSpec = NotQueryable
+      previewable = Impure
       deprecated = NotDeprecated } ]

--- a/backend/experiments/LibExperimentalStdLib/LibDarkEditor.fs
+++ b/backend/experiments/LibExperimentalStdLib/LibDarkEditor.fs
@@ -54,6 +54,7 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated }
 
+
     { name = fn "DarkEditor" "parseAndSerializeExpr" 0
       typeParams = []
       parameters = [ Param.make "code" TString "" ]

--- a/backend/experiments/LibExperimentalStdLib/LibDarkEditor.fs
+++ b/backend/experiments/LibExperimentalStdLib/LibDarkEditor.fs
@@ -63,7 +63,7 @@ let fns : List<BuiltInFn> =
         function
         | _, _, [ DString code ] ->
           uply {
-            let expr = Parser.RuntimeTypes.parseExprWithTypes Map.empty code
+            let expr = Parser.ProgramTypes.parseExprWithTypes Map.empty code
             let serializedExpr = Json.Vanilla.serialize expr
             return serializedExpr |> DString |> Ok |> DResult
           }


### PR DESCRIPTION
Changelog:

```
CanvasHack, experiment1
- `add Editor::parseAndSerializeExpr`
```
**Test:**
Result For `DarkEditor.parseAndSerializeExpr "1 + 2"` :
`Ok "["EInfix",701127178,["InfixFnCall",["ArithmeticPlus"]],["EInt",558621043,1],["EInt",148400566,2]]"`
