### PR TITLE
Split WASM stdlib into HttpClient and Editor

### DIFF
--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -45,6 +45,7 @@ module FQTypeName =
   let modNamePat = @"^[A-Z][a-z0-9A-Z_]*$"
   let typeNamePat = @"^[A-Z][a-z0-9A-Z_]*$"
 
+
   let stdlibTypeName
     (modul : string)
     (typ : string)

--- a/backend/src/Wasm/DarkEditor.fs
+++ b/backend/src/Wasm/DarkEditor.fs
@@ -25,7 +25,7 @@ type DarkEditor() =
     let libraries : Libraries =
       let stdlibFns, stdlibTypes =
         LibExecution.StdLib.combine
-          [ StdLibExecution.StdLib.contents; LibWASM.contents ]
+          [ StdLibExecution.StdLib.contents; Libs.Editor.contents ]
           []
           []
 
@@ -84,7 +84,7 @@ type DarkEditor() =
                })
              (getState source.types source.fns, DUnit)
 
-      LibWASM.editor <-
+      Libs.Editor.editor <-
         { Types = source.types; Functions = source.fns; CurrentState = initialState }
 
       return Json.Vanilla.serialize initialState
@@ -94,7 +94,7 @@ type DarkEditor() =
   [<JSInvokable>]
   static member HandleEvent(serializedEvent : string) : Ply<string> =
     uply {
-      let state = getState LibWASM.editor.Types LibWASM.editor.Functions
+      let state = getState Libs.Editor.editor.Types Libs.Editor.editor.Functions
 
       let! result =
         LibExecution.Interpreter.callFn
@@ -110,7 +110,7 @@ type DarkEditor() =
 
   // just for debugging
   [<JSInvokable>]
-  static member ExportClient() : string = Json.Vanilla.serialize LibWASM.editor
+  static member ExportClient() : string = Json.Vanilla.serialize Libs.Editor.editor
 
 
   // just for dark-repl

--- a/backend/src/Wasm/Init.fs
+++ b/backend/src/Wasm/Init.fs
@@ -10,6 +10,6 @@ type Init =
   static member InitializeDarkRuntime() : unit =
     Environment.SetEnvironmentVariable("TZ", "UTC")
     LibAnalysis.Analysis.initSerializers ()
-    Json.Vanilla.allow<Wasm.LibWASM.Editor>
+    Json.Vanilla.allow<Wasm.Libs.Editor.Editor>
       "to 'Export' the editor - just for debugging"
     System.Console.WriteLine("Dark runtime initialized")

--- a/backend/src/Wasm/Libs/Editor.fs
+++ b/backend/src/Wasm/Libs/Editor.fs
@@ -1,0 +1,106 @@
+/// StdLib for handling JS-WASM interactions via WASM'd Darklang code
+module Wasm.Libs.Editor
+
+open System
+
+open Prelude
+open Tablecloth
+
+open LibExecution.RuntimeTypes
+open LibExecution.StdLib.Shortcuts
+
+let types : List<BuiltInType> = []
+
+
+type Editor =
+  { Types : List<UserType.T>
+    Functions : List<UserFunction.T>
+    CurrentState : Dval }
+
+// this is client.dark, loaded and live, along with some current state
+let mutable editor : Editor = { Types = []; Functions = []; CurrentState = DUnit }
+
+
+// TODO: throw these fns in the "WASM.Editor" module once parsing works
+let fns : List<BuiltInFn> =
+  [ { name = fn' [ "WASM" ] "getState" 0
+      typeParams = [ "state" ]
+      parameters = []
+      returnType = TResult(TVariable "a", TString)
+      description = "TODO"
+      fn =
+        (function
+        | _, [ _typeParam ], [] ->
+          uply {
+            let state = editor.CurrentState
+            // TODO: assert that the type matches the given typeParam
+            return DResult(Ok state)
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
+    { name = fn' [ "WASM" ] "setState" 0
+      typeParams = [ "a" ]
+      parameters = [ Param.make "state" (TVariable "a") "" ]
+      returnType = TResult(TUnit, TString)
+      description = "TODO"
+      fn =
+        (function
+        | _, [ _typeParam ], [ v ] ->
+          uply {
+            // TODO: verify that the type matches the given typeParam
+            editor <- { editor with CurrentState = v }
+            return DResult(Ok DUnit)
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
+    { name = fn' [ "WASM" ] "callJSFunction" 0
+      typeParams = []
+      parameters =
+        [ Param.make "functionName" TString ""
+          Param.make "args" (TList TString) "" ]
+      returnType = TResult(TUnit, TString)
+      description = "Calls a globally-accessible JS function with the given args"
+      fn =
+        (function
+        | _, _, [ DString functionName; DList args ] ->
+          let args =
+            args
+            |> List.fold (Ok []) (fun agg item ->
+              match agg, item with
+              | (Error err, _) -> Error err
+              | (Ok l, DString arg) -> Ok(arg :: l)
+              | (_, notAString) ->
+                // this should be a DError, not a "normal" error
+                $"Expected args to be a `List<String>`, but got: {LibExecution.DvalReprDeveloper.toRepr notAString}"
+                |> Error)
+            |> Result.map (fun pairs -> List.rev pairs)
+
+          match args with
+          | Ok args ->
+            uply {
+              try
+                do Wasm.WasmHelpers.callJSFunction functionName args
+                return DResult(Ok DUnit)
+              with
+              | e ->
+                return
+                  $"Error calling {functionName} with provided args: {e.Message}"
+                  |> DString
+                  |> Error
+                  |> DResult
+            }
+          | Error err -> Ply(DResult(Error(DString err)))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated } ]
+
+let contents = (fns, types)

--- a/backend/src/Wasm/Libs/HttpClient.fs
+++ b/backend/src/Wasm/Libs/HttpClient.fs
@@ -1,28 +1,19 @@
 /// StdLib for handling JS-WASM interactions via WASM'd Darklang code
-module Wasm.LibWASM
+module Wasm.Libs.HttpClient
 
 open System
-
-open Prelude
-open Tablecloth
-
-open LibExecution.RuntimeTypes
-
-open LibExecution.StdLib.Shortcuts
-
-module RT = LibExecution.RuntimeTypes
-module CAT = LibAnalysis.ClientAnalysisTypes
-module Exe = LibExecution.Execution
-
 open System.IO
 open System.Net.Http
 
 open System.Threading.Tasks
 open FSharp.Control.Tasks
 
+open Prelude
+
 open LibExecution
 open VendoredTablecloth
-
+open LibExecution.RuntimeTypes
+open LibExecution.StdLib.Shortcuts
 
 module HttpClient =
   type Method = HttpMethod
@@ -183,6 +174,7 @@ type HeaderError =
   | TypeMismatch of string
 
 let types : List<BuiltInType> =
+  // TODO: put this into the WASM submodule
   [ { name = typ "HttpClient" "Response" 0
       typeParams = []
       definition =
@@ -194,101 +186,8 @@ let types : List<BuiltInType> =
       description = "The response from a HTTP request"
       deprecated = NotDeprecated } ]
 
-let debug args = WasmHelpers.callJSFunction "console.log" args
-
-
-type Editor =
-  { Types : List<UserType.T>
-    Functions : List<UserFunction.T>
-    CurrentState : Dval }
-
-// this is editor.dark, loaded and live, along with some current state
-let mutable editor : Editor = { Types = []; Functions = []; CurrentState = DUnit }
-
-
 let fns : List<BuiltInFn> =
-  [ { name = fn "WASM" "getState" 0
-      typeParams = [ "state" ]
-      parameters = []
-      returnType = TResult(TVariable "a", TString)
-      description = "TODO"
-      fn =
-        (function
-        | _, [ _typeParam ], [] ->
-          uply {
-            let state = editor.CurrentState
-            // TODO: assert that the type matches the given typeParam
-            return DResult(Ok state)
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "WASM" "setState" 0
-      typeParams = [ "a" ]
-      parameters = [ Param.make "state" (TVariable "a") "" ]
-      returnType = TResult(TUnit, TString)
-      description = "TODO"
-      fn =
-        (function
-        | _, [ _typeParam ], [ v ] ->
-          uply {
-            // TODO: verify that the type matches the given typeParam
-            editor <- { editor with CurrentState = v }
-            return DResult(Ok DUnit)
-          }
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "WASM" "callJSFunction" 0
-      typeParams = []
-      parameters =
-        [ Param.make "functionName" TString ""
-          Param.make "args" (TList TString) "" ]
-      returnType = TResult(TUnit, TString)
-      description = "Calls a globally-accessible JS function with the given args"
-      fn =
-        (function
-        | _, _, [ DString functionName; DList args ] ->
-          let args =
-            args
-            |> List.fold (Ok []) (fun agg item ->
-              match agg, item with
-              | (Error err, _) -> Error err
-              | (Ok l, DString arg) -> Ok(arg :: l)
-              | (_, notAString) ->
-                // this should be a DError, not a "normal" error
-                $"Expected args to be a `List<String>`, but got: {LibExecution.DvalReprDeveloper.toRepr notAString}"
-                |> Error)
-            |> Result.map (fun pairs -> List.rev pairs)
-
-          match args with
-          | Ok args ->
-            uply {
-              try
-                do WasmHelpers.callJSFunction functionName args
-                return DResult(Ok DUnit)
-              with
-              | e ->
-                return
-                  $"Error calling {functionName} with provided args: {e.Message}"
-                  |> DString
-                  |> Error
-                  |> DResult
-            }
-          | Error err -> Ply(DResult(Error(DString err)))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
-    { name = fn' [ "WASM"; "HttpClient" ] "requestFromWasm" 0
+  [ { name = fn' [ "WASM"; "HttpClient" ] "requestFromWasm" 0
       typeParams = []
       parameters =
         [ Param.make "method" TString ""

--- a/backend/src/Wasm/StdLib.fs
+++ b/backend/src/Wasm/StdLib.fs
@@ -1,0 +1,23 @@
+module Wasm.StdLib
+
+open Prelude
+open LibExecution.RuntimeTypes
+
+module StdLib = LibExecution.StdLib
+
+
+let fnRenames : StdLib.FnRenames =
+  // old names, new names
+  // eg: fn "Http" "respond" 0, fn "Http" "response" 0
+  []
+
+let typeRenames : StdLib.TypeRenames =
+  // old names, new names
+  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
+  []
+
+let contents =
+  StdLib.combine
+    [ Libs.Editor.contents; Libs.HttpClient.contents ]
+    fnRenames
+    typeRenames

--- a/backend/src/Wasm/Wasm.fsproj
+++ b/backend/src/Wasm/Wasm.fsproj
@@ -29,7 +29,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="WasmHelpers.fs" />
-    <Compile Include="Libs/WASM.fs" />
+    <Compile Include="Libs/Editor.fs" />
+    <Compile Include="Libs/HttpClient.fs" />
+    <Compile Include="StdLib.fs" />
     <Compile Include="Init.fs" />
     <Compile Include="DarkEditor.fs" />
     <Compile Include="Program.fs" />


### PR DESCRIPTION
Changelog:

```
WebAssembly Runtime
- split stdlib into 2 files and (partially) 'modules'
```