### PR TITLE
Enable WASM eval of full user program (types, fns, exprs) rather than just expr

### DIFF
--- a/backend/src/Parser/CanvasV2.fs
+++ b/backend/src/Parser/CanvasV2.fs
@@ -60,6 +60,8 @@ let parseLetBinding (m : CanvasModule) (letBinding : SynBinding) : CanvasModule 
 
     match attrs with
     | [] ->
+      // TODO: if the fn has no params, it's just a let expr
+      // (probably need a refactor here)
       let newFn = ProgramTypes.UserFunction.fromSynBinding letBinding
       { m with fns = newFn :: m.fns }
 

--- a/backend/src/Wasm/Libs/HttpClient.fs
+++ b/backend/src/Wasm/Libs/HttpClient.fs
@@ -187,7 +187,7 @@ let types : List<BuiltInType> =
       deprecated = NotDeprecated } ]
 
 let fns : List<BuiltInFn> =
-  [ { name = fn' [ "WASM"; "HttpClient" ] "requestFromWasm" 0
+  [ { name = fn' [ "WASM"; "HttpClient" ] "request" 0
       typeParams = []
       parameters =
         [ Param.make "method" TString ""

--- a/backend/static/editor-bootstrap.js
+++ b/backend/static/editor-bootstrap.js
@@ -28,23 +28,26 @@ const Darklang = {
 
     // return object to expose as 'darklang'
     return {
-      editor: {
-        loadClient: async function (url) {
-          return await invoke("LoadClient", url);
-        },
-        handleEvent: async function (event) {
-          return await invoke("HandleEvent", JSON.stringify(event));
-        },
-        // just for debugging purposes
-        exportClient: async function () {
-          return invoke("ExportClient");
-        },
+      /** Load a client Dark code from a URL */
+      loadClient: async function (url) {
+        return await invoke("LoadClient", url);
       },
 
-      // just for dark-repl
-      evalExpr: async function (serializedExpr) {
-        return await invoke("EvalExpr", serializedExpr);
+      /** Handle an event that the JS client has captured
+       * and is forwarding to the WASM runtime */
+      handleEvent: async function (event) {
+        return await invoke("HandleEvent", JSON.stringify(event));
       },
+
+      /** Evaluate a serialized user program,
+       * returning the result of the expr defined last
+       *
+       * Note: Pretty soon, this should be remove-able in favor
+       * of the Darklang WASM runtime directly evaluating based on the state it maintains.
+       * */
+      evalUserProgram: async function (serializedProgram) {
+        return await invoke("EvalUserProgram", serializedProgram);
+      }
     };
   },
 };

--- a/canvases/dark-editor-vue/src/components/ResponseChat.vue
+++ b/canvases/dark-editor-vue/src/components/ResponseChat.vue
@@ -105,7 +105,7 @@ const executeCode = async(index: number) => {
   let code: string = (document.querySelectorAll('.responseTextarea')[index] as HTMLInputElement).value;
 
   try {
-    const response = await fetch("/get-expr-json", {
+    const response = await fetch("/get-program-json", {
       method: "POST",
       body: code,
     });
@@ -116,9 +116,9 @@ const executeCode = async(index: number) => {
       );
     }
 
-    const exprJson = await response.text();
-    
-    const result = await window.darklang.evalExpr(exprJson);
+    const userProgramJson = await response.text();
+
+    const result = await window.darklang.evalUserProgram(userProgramJson);
 
     console.log(result); // TODO: something better than console.log
   } catch (error) {

--- a/canvases/dark-editor-vue/src/views/MainView.vue
+++ b/canvases/dark-editor-vue/src/views/MainView.vue
@@ -33,7 +33,7 @@ const systemPromptValue = ref('')
 const darklangJSScript: HTMLScriptElement = document.createElement('script')
 darklangJSScript.setAttribute(
   "src",
-  "http://dark-serve-static.dlio.localhost:11003/darklang-wasm.js",
+  "http://dark-serve-static.dlio.localhost:11003/editor-bootstrap.js",
 );
 darklangJSScript.setAttribute("defer", "");
 darklangJSScript.addEventListener("load", async () => {

--- a/canvases/dark-editor/main.dark
+++ b/canvases/dark-editor/main.dark
@@ -12,14 +12,28 @@ let _handler _req =
     (Dict.fromListOverwritingDuplicates [ ("Content-Type", "text/html") ])
     200
 
-[<HttpHandler("POST", "/get-expr-json")>]
-let _handler _req =
-  let requestCode = String.fromBytes request.body
-  let exprJson = Experiments.parseAndSerializeExpr requestCode
 
-  match exprJson with
-  | Ok exprJson -> Http.response (String.toBytes exprJson) 200
-  | Err err -> Http.response (String.toBytes err) 400
+[<HttpHandler("POST", "/get-program-json")>]
+let _handler _req =
+  let sourceInBytes = request.body
+  let program =
+    Experiments.parseAndSerializeProgram (String.fromBytes sourceInBytes)
+
+  match program with
+  | Ok program ->
+    let types = Option.withDefault (Dict.get_v2 program "types") "[]"
+    let fns = Option.withDefault (Dict.get_v2 program "fns") "[]"
+    let exprs = Option.withDefault (Dict.get_v2 program "exprs") "[]"
+
+    let json = "{ \"types\": " ++ types ++ ", \"fns\": " ++ fns ++ ", \"exprs\": " ++ exprs ++ "}"
+
+    Http.responseWithHeaders
+      (String.toBytes json)
+      (Dict.fromListOverwritingDuplicates [ ("content-type","application-json")])
+      200
+
+  | Error err -> Http.response (String.toBytes ("Couldn't parse the program \n" ++ err)) 400
+
 
 [<HttpHandler("GET", "/assets/index.css")>]
 let _handler _req =

--- a/canvases/dark-js-wasm-io/main.dark
+++ b/canvases/dark-js-wasm-io/main.dark
@@ -66,11 +66,11 @@ let _handler _req =
     </section>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
-  <script src="http://dark-serve-static.dlio.localhost:11003/darklang-wasm.js"></script>
+  <script src="http://dark-serve-static.dlio.localhost:11003/editor-bootstrap.js"></script>
   <script>
     (async () => {
       const darklang = await Darklang.init();
-      await darklang.editor.loadClient("http://dark-js-wasm-io.dlio.localhost:11003/client.dark");
+      await darklang.loadClient("http://dark-js-wasm-io.dlio.localhost:11003/client.dark");
 
       // TODO: use
       const app = new Vue({
@@ -84,7 +84,7 @@ let _handler _req =
 
           // something happened in the UI - tell the WASM'd Dark program!
           async eventHappened(event) {
-            const response = await darklang.editor.handleEvent(event);
+            const response = await darklang.handleEvent(event);
             console.log("response", response)
           },
         },

--- a/canvases/dark-repl/README.md
+++ b/canvases/dark-repl/README.md
@@ -1,21 +1,19 @@
-# dark-wasm-demo
+# dark-repl
 
-## What it does
 - take user input
-- use an experimental StdLib function `parseAndSerializeExpr` to parse the Expr as text,
-  and serialize it as JSON such that it can be passed to a function defined in Wasm.fsproj.
+- use an experimental StdLib function `parseAndSerializeProgram` to parse the code as text,
+  and serialize it as JSON such that it can be passed to a function defined in `Wasm.fsproj`.
   (the F# parser which we have been (ab)using does not work out-of-the-box in WASM)
-- load WASM'd F# code via the `dark-serve-static` canvas
+- load WASM'd Dark runtime via the `dark-serve-static` canvas
   note: this canvas _must_ be seeded along with this one, as it serves the assets.
-- call the WASM'd F# code, passing in the serialized Expr
-- have the WASM'd F#/Dark code evaluate the expression
-- expect the WASM'd F# code to pass back the results of the evaluation
+- evaluate the user code via the WASM Darklang runtime,
+  which returns the result of the last-provided expr
 - display the results
 
 Note: as we use experimental functions, this canvas must be run on the experimental BwdServer, at :11003.
 
 ## Demo:
 - `./scripts/run-canvas-hack load-from-disk dark-serve-static`
-- `./scripts/run-canvas-hack load-from-disk dark-wasm-demo`
-- go to http://dark-wasm-demo.dlio.localhost:11003
+- `./scripts/run-canvas-hack load-from-disk dark-repl`
+- go to http://dark-repl.dlio.localhost:11003
 - hit "submit"

--- a/canvases/dark-repl/main.dark
+++ b/canvases/dark-repl/main.dark
@@ -1,11 +1,23 @@
-[<HttpHandler("POST", "/get-expr-json")>]
+[<HttpHandler("POST", "/get-program-json")>]
 let _handler _req =
-  let requestCode = String.fromBytes request.body
-  let exprJson = Experiments.parseAndSerializeExpr requestCode
+  let sourceInBytes = request.body
+  let program =
+    Experiments.parseAndSerializeProgram (String.fromBytes sourceInBytes)
 
-  match exprJson with
-  | Ok exprJson -> Http.response (String.toBytes exprJson) 200
-  | Err err -> Http.response (String.toBytes err) 400
+  match program with
+  | Ok program ->
+    let types = Option.withDefault (Dict.get_v2 program "types") "[]"
+    let fns = Option.withDefault (Dict.get_v2 program "fns") "[]"
+    let exprs = Option.withDefault (Dict.get_v2 program "exprs") "[]"
+
+    let json = "{ \"types\": " ++ types ++ ", \"fns\": " ++ fns ++ ", \"exprs\": " ++ exprs ++ "}"
+
+    Http.responseWithHeaders
+      (String.toBytes json)
+      (Dict.fromListOverwritingDuplicates [ ("content-type","application-json")])
+      200
+
+  | Error _err -> Http.response (String.toBytes "Couldn't parse the program") 400
 
 
 [<HttpHandler("GET", "/")>]
@@ -17,7 +29,7 @@ let _handler _req =
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dark WASM demo</title>
+    <title>Dark REPL</title>
     <style>
       * { font-family: Courier New, sans-serif; font-size: 26px; background-color: black; color: white }
       body, html { height: 100%; margin: 0 }
@@ -30,14 +42,17 @@ let _handler _req =
   <body>
     <div class="container">
       <div>
-        <textarea id="input-textarea" class="textarea">1 + 2</textarea>
+        <textarea id="input-textarea" class="textarea">type Person = {Name: String}
+
+(Person { Name = "Joe" })
+  |> fun p -> String.toLowercase_v1 p.Name</textarea>
       </div>
       <div>
         <textarea id="output-textarea" class="textarea" disabled></textarea>
       </div>
     </div>
 
-    <script src="http://dark-serve-static.dlio.localhost:11003/darklang-wasm.js"></script>
+    <script src="http://dark-serve-static.dlio.localhost:11003/editor-bootstrap.js"></script>
     <script>
       function setOutput (message) {
         document.getElementById("output-textarea").value = message;
@@ -49,11 +64,10 @@ let _handler _req =
         async function doEval() {
           try {
             const code = document.getElementById("input-textarea").value;
-            const codeInParens = "(\n" + code + "\n)";
 
-            const response = await fetch("/get-expr-json", {
+            const response = await fetch("/get-program-json", {
               method: "POST",
-              body: codeInParens,
+              body: code,
             });
 
             if (!response.ok) {
@@ -61,8 +75,9 @@ let _handler _req =
               throw new Error("Error in parsing the expr and serializing it as JSON" + errorText);
             }
 
-            const exprJson = await response.json();
-            const result = await darklang.evalExpr(JSON.stringify(exprJson));
+            const programJson = await response.json();
+            console.log("programJson", programJson)
+            const result = await darklang.evalUserProgram(JSON.stringify(programJson));
             setOutput(result);
           } catch (error) {
             //setOutput("Error" + error);


### PR DESCRIPTION
Changelog:

```
WASM Runtime
- enable WASM eval of full user program (types, fns, exprs) rather than just expr

canvases/dark-editor
- eval full user program rather than just expr

canvases/dark-repl
- eval full user program rather than just expr
```