### PR TITLE
Rename DateTime.add to DateTime.addSeconds and fix ResponseChat textarea

### DIFF
--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -789,7 +789,7 @@ module Package =
 // </remarks>
 type Previewable =
   // The same inputs will always yield the same outputs,
-  // so we don't need to save results. e.g. `DateTime.add`
+  // so we don't need to save results. e.g. `DateTime.addSeconds`
   | Pure
 
   // Output may vary with the same inputs, though we can safely preview.

--- a/backend/src/StdLibExecution/Libs/DateTime.fs
+++ b/backend/src/StdLibExecution/Libs/DateTime.fs
@@ -136,7 +136,7 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "DateTime" "add" 0
+    { name = fn "DateTime" "addSeconds" 0
       typeParams = []
       parameters = [ Param.make "d" TDateTime ""; Param.make "seconds" TInt "" ]
       returnType = TDateTime

--- a/backend/testfiles/execution/date.tests
+++ b/backend/testfiles/execution/date.tests
@@ -207,11 +207,11 @@ module Convertsion =
   // DateTime.today_v0 |> DateTime.toString_v0 = "2020-10-17T00:00:00Z" // todo, how can we test this
 
 module AddingSeconds =
-  DateTime.add_v0 (d "2020-11-26T04:37:46Z") 0 = (d "2020-11-26T04:37:46Z")
-  DateTime.add_v0 (d "2020-11-26T04:37:46Z") 1 = (d "2020-11-26T04:37:47Z")
-  DateTime.add_v0 (d "2020-11-26T04:37:46Z") 10 = (d "2020-11-26T04:37:56Z")
-  DateTime.add_v0 (d "2020-11-26T04:37:46Z") 1000000 = (d "2020-12-07T18:24:26Z")
-  DateTime.add_v0 (d "2020-11-26T04:37:46Z") -10 = (d "2020-11-26T04:37:36Z")
+  DateTime.addSeconds_v0 (d "2020-11-26T04:37:46Z") 0 = (d "2020-11-26T04:37:46Z")
+  DateTime.addSeconds_v0 (d "2020-11-26T04:37:46Z") 1 = (d "2020-11-26T04:37:47Z")
+  DateTime.addSeconds_v0 (d "2020-11-26T04:37:46Z") 10 = (d "2020-11-26T04:37:56Z")
+  DateTime.addSeconds_v0 (d "2020-11-26T04:37:46Z") 1000000 = (d "2020-12-07T18:24:26Z")
+  DateTime.addSeconds_v0 (d "2020-11-26T04:37:46Z") -10 = (d "2020-11-26T04:37:36Z")
 
 module SubtractingSeconds =
   DateTime.subtractSeconds_v0 (d "2020-11-26T04:37:46Z") 0 = (d "2020-11-26T04:37:46Z")

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -455,7 +455,7 @@ module CompiledFunctions =
   (friends (fun p -> DateTime.greaterThanOrEqualTo p.dob (d "2000-01-01T01:02:03Z"))) = ["GrumpyCat"]
   (friends (fun p -> DateTime.greaterThanOrEqualTo p.dob (rossDOB ()))) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
   (friends (fun p -> DateTime.greaterThan p.dob (rossDOB ()))) = [" Chandler "; "GrumpyCat"; "Rachel" ]
-  (friends (fun p -> DateTime.lessThanOrEqualTo p.dob (DateTime.add_v0 (DateTime.now_v0) 1 ))) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross"]
+  (friends (fun p -> DateTime.lessThanOrEqualTo p.dob (DateTime.addSeconds_v0 (DateTime.now_v0) 1 ))) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross"]
   (friends (fun p -> DateTime.lessThanOrEqualTo p.dob (DateTime.subtractSeconds_v0 (DateTime.now_v0) 1 ))) = [" Chandler "; "GrumpyCat"; "Rachel"; "Ross"]
   (friends (fun p -> DateTime.atStartOfDay_v0 p.dob == (d "1969-08-19T00:00:00Z"))) = [" Chandler "]
   (friends (fun p -> DateTime.hour_v2 p.dob == 10)) = [" Chandler "]

--- a/canvases/dark-editor-vue/src/components/Prompt.vue
+++ b/canvases/dark-editor-vue/src/components/Prompt.vue
@@ -114,16 +114,17 @@ const submitPrompt = async () => {
       return
     }
 
-    // test ui without using tokens
-    // const data = '(let a = 1 \n a)'
-    // responses.value.push(data)
-
     prompt.value = ''
     const data = await response.json()
     responses.value.push(data.choices[0].text)
   } catch (error) {
     console.error('Error sending prompt to server:', error)
   }
+
+  // test ui without using tokens
+  // const data = '(let a = 1 \n a)'
+  // responses.value.push(data)
+
   isLoading.value = false
   //reset prompt textarea size
   autosize.destroy(content.value)

--- a/canvases/dark-editor-vue/src/components/ResponseChat.vue
+++ b/canvases/dark-editor-vue/src/components/ResponseChat.vue
@@ -92,7 +92,6 @@
 
 <script setup lang="ts">
 import { ref, defineProps, defineEmits, onMounted } from 'vue'
-import AutoSizeTextarea from './AutoSizeTextarea.vue'
 import '../global.d.ts'
 import * as CodeMirror from 'codemirror'
 import 'codemirror/lib/codemirror.css'
@@ -146,7 +145,7 @@ const props = defineProps({
 })
 
 const executeCode = async (index: number) => {
-  let code: string = content.value // Use the content ref instead of the DOM element
+  let code: string = content.value
 
   try {
     const response = await fetch('/get-program-json', {

--- a/canvases/dark-editor-vue/src/components/ResponseChat.vue
+++ b/canvases/dark-editor-vue/src/components/ResponseChat.vue
@@ -121,6 +121,7 @@ onMounted(() => {
       mode: 'javascript',
       theme: 'yonce',
       viewportMargin: Infinity,
+      value: props.response,
     })
     updateEditorSize(editor)
 
@@ -145,13 +146,11 @@ const props = defineProps({
 })
 
 const executeCode = async (index: number) => {
-  let code: string = (
-    document.querySelectorAll('.responseTextarea')[index] as HTMLInputElement
-  ).value
+  let code: string = content.value // Use the content ref instead of the DOM element
 
   try {
-    const response = await fetch("/get-program-json", {
-      method: "POST",
+    const response = await fetch('/get-program-json', {
+      method: 'POST',
       body: code,
     })
 
@@ -159,10 +158,10 @@ const executeCode = async (index: number) => {
       throw new Error('Error in parsing the expr and serializing it as JSON')
     }
 
-    const userProgramJson = await response.text();
-    const userProgramResult = await window.darklang.evalUserProgram(userProgramJson);
+    const userProgramJson = await response.text()
+    const userProgramResult = await window.darklang.evalUserProgram(userProgramJson)
 
-    console.log(userProgramResult); // TODO: something better than console.log
+    console.log(userProgramResult) // TODO: something better than console.log
   } catch (error) {
     console.error('Error:', error)
   }


### PR DESCRIPTION
Changelog:

```
Language 
-  Rename DateTime.add to DateTime.addSeconds
```

This PR:
- Fixes what broke after Codemirror PR merge
Fix: use the updated textarea value in executeCode function.
- Renames DateTime.add to DateTime.addSeconds