### PR TITLE
List destructuring

### DIFF
--- a/backend/src/LibAnalysis/ClientProgramTypes.fs
+++ b/backend/src/LibAnalysis/ClientProgramTypes.fs
@@ -278,6 +278,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
+  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
 
 module MatchPattern =
   let rec fromCT (pat : MatchPattern) : PT.MatchPattern =
@@ -294,6 +295,8 @@ module MatchPattern =
     | MPTuple (id, first, second, theRest) ->
       PT.MPTuple(id, fromCT first, fromCT second, List.map fromCT theRest)
     | MPList (id, pats) -> PT.MPList(id, List.map fromCT pats)
+    | MPListCons (id, heads, tail) ->
+      PT.MPListCons(id, List.map fromCT heads, fromCT tail)
 
   let rec toCT (pat : PT.MatchPattern) : MatchPattern =
     match pat with
@@ -309,7 +312,8 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       MPTuple(id, toCT first, toCT second, List.map toCT theRest)
     | PT.MPList (id, pats) -> MPList(id, List.map toCT pats)
-
+    | PT.MPListCons (id, heads, tail) ->
+      MPListCons(id, List.map toCT heads, toCT tail)
 
 type BinaryOperation =
   | BinOpAnd

--- a/backend/src/LibAnalysis/ClientProgramTypes.fs
+++ b/backend/src/LibAnalysis/ClientProgramTypes.fs
@@ -278,7 +278,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
-  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
+  | MPListCons of id * head : MatchPattern * tail : MatchPattern
 
 module MatchPattern =
   let rec fromCT (pat : MatchPattern) : PT.MatchPattern =
@@ -295,8 +295,7 @@ module MatchPattern =
     | MPTuple (id, first, second, theRest) ->
       PT.MPTuple(id, fromCT first, fromCT second, List.map fromCT theRest)
     | MPList (id, pats) -> PT.MPList(id, List.map fromCT pats)
-    | MPListCons (id, heads, tail) ->
-      PT.MPListCons(id, List.map fromCT heads, fromCT tail)
+    | MPListCons (id, head, tail) -> PT.MPListCons(id, fromCT head, fromCT tail)
 
   let rec toCT (pat : PT.MatchPattern) : MatchPattern =
     match pat with
@@ -312,8 +311,7 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       MPTuple(id, toCT first, toCT second, List.map toCT theRest)
     | PT.MPList (id, pats) -> MPList(id, List.map toCT pats)
-    | PT.MPListCons (id, heads, tail) ->
-      MPListCons(id, List.map toCT heads, toCT tail)
+    | PT.MPListCons (id, head, tail) -> MPListCons(id, toCT head, toCT tail)
 
 type BinaryOperation =
   | BinOpAnd

--- a/backend/src/LibAnalysis/ClientRuntimeTypes.fs
+++ b/backend/src/LibAnalysis/ClientRuntimeTypes.fs
@@ -233,7 +233,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
-  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
+  | MPListCons of id * head : MatchPattern * tail : MatchPattern
 
 module MatchPattern =
   let rec fromCT (p : MatchPattern) : RT.MatchPattern =
@@ -251,7 +251,7 @@ module MatchPattern =
     | MPTuple (id, first, second, theRest) ->
       RT.MPTuple(id, r first, r second, List.map r theRest)
     | MPList (id, pats) -> RT.MPList(id, List.map r pats)
-    | MPListCons (id, heads, tail) -> RT.MPListCons(id, List.map r heads, r tail)
+    | MPListCons (id, head, tail) -> RT.MPListCons(id, r head, r tail)
 
   let rec toCT (p : RT.MatchPattern) : MatchPattern =
     let r = toCT
@@ -268,7 +268,7 @@ module MatchPattern =
     | RT.MPTuple (id, first, second, theRest) ->
       MPTuple(id, r first, r second, List.map r theRest)
     | RT.MPList (id, pats) -> MPList(id, List.map r pats)
-    | RT.MPListCons (id, heads, tail) -> MPListCons(id, List.map r heads, r tail)
+    | RT.MPListCons (id, head, tail) -> MPListCons(id, r head, r tail)
 
 module CustomType =
   // TYPESCLEANUP support type parameters

--- a/backend/src/LibAnalysis/ClientRuntimeTypes.fs
+++ b/backend/src/LibAnalysis/ClientRuntimeTypes.fs
@@ -233,6 +233,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
+  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
 
 module MatchPattern =
   let rec fromCT (p : MatchPattern) : RT.MatchPattern =
@@ -250,6 +251,7 @@ module MatchPattern =
     | MPTuple (id, first, second, theRest) ->
       RT.MPTuple(id, r first, r second, List.map r theRest)
     | MPList (id, pats) -> RT.MPList(id, List.map r pats)
+    | MPListCons (id, heads, tail) -> RT.MPListCons(id, List.map r heads, r tail)
 
   let rec toCT (p : RT.MatchPattern) : MatchPattern =
     let r = toCT
@@ -266,6 +268,7 @@ module MatchPattern =
     | RT.MPTuple (id, first, second, theRest) ->
       MPTuple(id, r first, r second, List.map r theRest)
     | RT.MPList (id, pats) -> MPList(id, List.map r pats)
+    | RT.MPListCons (id, heads, tail) -> MPListCons(id, List.map r heads, r tail)
 
 module CustomType =
   // TYPESCLEANUP support type parameters

--- a/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -221,8 +221,7 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       ST.MPTuple(id, toST first, toST second, List.map toST theRest)
     | PT.MPList (id, pats) -> ST.MPList(id, List.map toST pats)
-    | PT.MPListCons (id, heads, tail) ->
-      ST.MPListCons(id, List.map toST heads, toST tail)
+    | PT.MPListCons (id, head, tail) -> ST.MPListCons(id, toST head, toST tail)
 
 
   let rec toPT (p : ST.MatchPattern) : PT.MatchPattern =
@@ -239,8 +238,7 @@ module MatchPattern =
     | ST.MPTuple (id, first, second, theRest) ->
       PT.MPTuple(id, toPT first, toPT second, List.map toPT theRest)
     | ST.MPList (id, pats) -> PT.MPList(id, List.map toPT pats)
-    | ST.MPListCons (id, heads, tail) ->
-      PT.MPListCons(id, List.map toPT heads, toPT tail)
+    | ST.MPListCons (id, head, tail) -> PT.MPListCons(id, toPT head, toPT tail)
 
 
 module Expr =

--- a/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -221,6 +221,9 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       ST.MPTuple(id, toST first, toST second, List.map toST theRest)
     | PT.MPList (id, pats) -> ST.MPList(id, List.map toST pats)
+    | PT.MPListCons (id, heads, tail) ->
+      ST.MPListCons(id, List.map toST heads, toST tail)
+
 
   let rec toPT (p : ST.MatchPattern) : PT.MatchPattern =
     match p with
@@ -236,6 +239,8 @@ module MatchPattern =
     | ST.MPTuple (id, first, second, theRest) ->
       PT.MPTuple(id, toPT first, toPT second, List.map toPT theRest)
     | ST.MPList (id, pats) -> PT.MPList(id, List.map toPT pats)
+    | ST.MPListCons (id, heads, tail) ->
+      PT.MPListCons(id, List.map toPT heads, toPT tail)
 
 
 module Expr =

--- a/backend/src/LibBinarySerialization/SerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypes.fs
@@ -195,6 +195,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
+  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
 
 [<MessagePack.MessagePackObject>]
 type BinaryOperation =

--- a/backend/src/LibBinarySerialization/SerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypes.fs
@@ -195,7 +195,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
-  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
+  | MPListCons of id * head : MatchPattern * tail : MatchPattern
 
 [<MessagePack.MessagePackObject>]
 type BinaryOperation =

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -7,7 +7,6 @@ open FSharp.Control.Tasks.Affine.Unsafe
 
 open Prelude
 open RuntimeTypes
-open Prelude
 
 /// Gathers any global data (Secrets, DBs, etc.)
 /// that may be needed to evaluate an expression
@@ -413,32 +412,23 @@ let rec eval' (state : ExecutionState) (st : Symtable) (e : Expr) : DvalTask =
               false, [], traceIncompleteWithArgs id allPatterns
           | _ -> false, [], traceIncompleteWithArgs id allPatterns
 
-        | MPListCons (id, headPats, tailPat) ->
+        | MPListCons (id, headPat, tailPat) ->
           match dv with
-          | DList vals ->
-            if List.length vals >= List.length headPats then
-              let (headVals, tailVals) = List.splitAt (List.length headPats) vals
-              let (headPassResults, headVarResults, headTraceResults) =
-                List.zip headVals headPats
-                |> List.map (fun (dv, pat) -> checkPattern dv pat)
-                |> List.unzip3
-              let allHeadPass = headPassResults |> List.forall identity
-              let allHeadVars = headVarResults |> List.collect identity
-              let allHeadTraces = headTraceResults |> List.collect identity
-              if allHeadPass then
-                let (tailPass, tailVars, tailTraces) =
-                  checkPattern (DList tailVals) tailPat
-                if tailPass then
-                  let combinedVars = allHeadVars @ tailVars
-                  let combinedTraces = allHeadTraces @ tailTraces
-                  true, combinedVars, (id, dv) :: combinedTraces
-                else
-                  false, [], traceIncompleteWithArgs id (headPats @ [ tailPat ])
+          | DList vals when List.length vals >= 1 ->
+            let (headVal, tailVals) = (List.head vals, List.tail vals)
+            let (headPass, headVars, headTraces) = checkPattern headVal headPat
+            if headPass then
+              let (tailPass, tailVars, tailTraces) =
+                checkPattern (DList tailVals) tailPat
+              if tailPass then
+                let combinedVars = headVars @ tailVars
+                let combinedTraces = headTraces @ tailTraces
+                true, combinedVars, (id, dv) :: combinedTraces
               else
-                false, [], traceIncompleteWithArgs id (headPats @ [ tailPat ])
+                false, [], traceIncompleteWithArgs id [ headPat; tailPat ]
             else
-              false, [], traceIncompleteWithArgs id (headPats @ [ tailPat ])
-          | _ -> false, [], traceIncompleteWithArgs id (headPats @ [ tailPat ])
+              false, [], traceIncompleteWithArgs id [ headPat; tailPat ]
+          | _ -> false, [], traceIncompleteWithArgs id [ headPat; tailPat ]
         | MPList (id, pats) ->
           match dv with
           | DList vals ->

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -180,6 +180,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
+  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
 
 type BinaryOperation =
   | BinOpAnd

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -180,7 +180,7 @@ type MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
-  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
+  | MPListCons of id * head : MatchPattern * tail : MatchPattern
 
 type BinaryOperation =
   | BinOpAnd

--- a/backend/src/LibExecution/ProgramTypesAst.fs
+++ b/backend/src/LibExecution/ProgramTypesAst.fs
@@ -77,6 +77,7 @@ let rec preTraversal
     | MPList (id, pats) -> MPList(id, List.map f pats)
     | MPTuple (id, p1, p2, pats) -> MPTuple(id, f p1, f p2, List.map f pats)
     | MPEnum (id, name, pats) -> MPEnum(id, name, List.map f pats)
+    | MPListCons (id, heads, tail) -> MPListCons(id, List.map f heads, f tail)
 
   let rec preTraversalTypeRef (typeRef : TypeReference) : TypeReference =
     let f = preTraversalTypeRef
@@ -195,7 +196,8 @@ let rec matchPatternPreTraversal
   | MPTuple (patternID, first, second, theRest) ->
     MPTuple(patternID, r first, r second, List.map r theRest)
   | MPList (patternID, pats) -> MPList(patternID, List.map r pats)
-
+  | MPListCons (patternID, heads, tail) ->
+    MPListCons(patternID, List.map r heads, r tail)
 
 let rec matchPatternPostTraversal
   (f : MatchPattern -> MatchPattern)
@@ -216,4 +218,6 @@ let rec matchPatternPostTraversal
     | MPTuple (patternID, first, second, theRest) ->
       MPTuple(patternID, r first, r second, List.map r theRest)
     | MPList (patternID, pats) -> MPList(patternID, List.map r pats)
+    | MPListCons (patternID, heads, tail) ->
+      MPListCons(patternID, List.map r heads, r tail)
   f result

--- a/backend/src/LibExecution/ProgramTypesAst.fs
+++ b/backend/src/LibExecution/ProgramTypesAst.fs
@@ -77,7 +77,7 @@ let rec preTraversal
     | MPList (id, pats) -> MPList(id, List.map f pats)
     | MPTuple (id, p1, p2, pats) -> MPTuple(id, f p1, f p2, List.map f pats)
     | MPEnum (id, name, pats) -> MPEnum(id, name, List.map f pats)
-    | MPListCons (id, heads, tail) -> MPListCons(id, List.map f heads, f tail)
+    | MPListCons (id, head, tail) -> MPListCons(id, f head, f tail)
 
   let rec preTraversalTypeRef (typeRef : TypeReference) : TypeReference =
     let f = preTraversalTypeRef
@@ -196,8 +196,7 @@ let rec matchPatternPreTraversal
   | MPTuple (patternID, first, second, theRest) ->
     MPTuple(patternID, r first, r second, List.map r theRest)
   | MPList (patternID, pats) -> MPList(patternID, List.map r pats)
-  | MPListCons (patternID, heads, tail) ->
-    MPListCons(patternID, List.map r heads, r tail)
+  | MPListCons (patternID, head, tail) -> MPListCons(patternID, r head, r tail)
 
 let rec matchPatternPostTraversal
   (f : MatchPattern -> MatchPattern)
@@ -218,6 +217,5 @@ let rec matchPatternPostTraversal
     | MPTuple (patternID, first, second, theRest) ->
       MPTuple(patternID, r first, r second, List.map r theRest)
     | MPList (patternID, pats) -> MPList(patternID, List.map r pats)
-    | MPListCons (patternID, heads, tail) ->
-      MPListCons(patternID, List.map r heads, r tail)
+    | MPListCons (patternID, head, tail) -> MPListCons(patternID, r head, r tail)
   f result

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -121,8 +121,8 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       RT.MPTuple(id, toRT first, toRT second, List.map toRT theRest)
     | PT.MPList (id, pats) -> RT.MPList(id, List.map toRT pats)
-
-
+    | PT.MPListCons (id, heads, tail) ->
+      RT.MPListCons(id, List.map toRT heads, toRT tail)
 
 module Expr =
   let rec toRT (e : PT.Expr) : RT.Expr =

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -121,8 +121,7 @@ module MatchPattern =
     | PT.MPTuple (id, first, second, theRest) ->
       RT.MPTuple(id, toRT first, toRT second, List.map toRT theRest)
     | PT.MPList (id, pats) -> RT.MPList(id, List.map toRT pats)
-    | PT.MPListCons (id, heads, tail) ->
-      RT.MPListCons(id, List.map toRT heads, toRT tail)
+    | PT.MPListCons (id, head, tail) -> RT.MPListCons(id, toRT head, toRT tail)
 
 module Expr =
   let rec toRT (e : PT.Expr) : RT.Expr =

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -336,7 +336,7 @@ and MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
-  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
+  | MPListCons of id * head : MatchPattern * tail : MatchPattern
 
 type DvalMap = Map<string, Dval>
 

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -336,6 +336,7 @@ and MatchPattern =
   | MPUnit of id
   | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
   | MPList of id * List<MatchPattern>
+  | MPListCons of id * heads : List<MatchPattern> * tail : MatchPattern
 
 type DvalMap = Map<string, Dval>
 
@@ -525,6 +526,7 @@ module MatchPattern =
     | MPVariable (id, _)
     | MPTuple (id, _, _, _)
     | MPEnum (id, _, _)
+    | MPListCons (id, _, _)
     | MPList (id, _) -> id
 
 // Functions for working with Dark runtime values

--- a/backend/src/Parser/ProgramTypes.fs
+++ b/backend/src/Parser/ProgramTypes.fs
@@ -226,15 +226,6 @@ module MatchPattern =
       | SynPat.Tuple (_, args, _) -> List.map r args
       | e -> [ r e ]
 
-    let rec convertListConsPattern
-      (pat : SynPat)
-      : List<PT.MatchPattern> * PT.MatchPattern =
-      match pat with
-      | SynPat.ListCons (head, tail, _, _) ->
-        let headPats, tailPat = convertListConsPattern tail
-        (r head :: headPats, tailPat)
-      | _ -> ([], r pat)
-
     match pat with
     | SynPat.Named (SynIdent (name, _), _, _, _) -> PT.MPVariable(id, name.idText)
     | SynPat.Wild _ -> PT.MPVariable(gid (), "_") // wildcard, not blank
@@ -265,9 +256,8 @@ module MatchPattern =
       PT.MPEnum(id, enumName.idText, args)
     | SynPat.Tuple (_isStruct, (first :: second :: theRest), _range) ->
       PT.MPTuple(id, r first, r second, List.map r theRest)
-    | SynPat.ListCons (rhsPat, lhsPat, _, _) ->
-      let headPats, tailPat = convertListConsPattern lhsPat
-      PT.MPListCons(id, r rhsPat :: headPats, tailPat)
+    | SynPat.ListCons (headPat, tailPat, _, _) ->
+      PT.MPListCons(id, r headPat, r tailPat)
     | SynPat.ArrayOrList (_, pats, _) -> PT.MPList(id, List.map r pats)
     | _ -> Exception.raiseInternal "unhandled pattern" [ "pattern", pat ]
 

--- a/backend/src/StdLibExecution/Libs/NoModule.fs
+++ b/backend/src/StdLibExecution/Libs/NoModule.fs
@@ -239,6 +239,10 @@ and equalsMatchPattern (pattern1 : MatchPattern) (pattern2 : MatchPattern) : boo
     && List.forall2 equalsMatchPattern elems1 elems2
   | MPList (_, elems1), MPList (_, elems2) ->
     elems1.Length = elems2.Length && List.forall2 equalsMatchPattern elems1 elems2
+  | MPListCons (_, heads, tail), MPListCons (_, heads', tail') ->
+    equalsMatchPattern tail tail'
+    && heads.Length = heads'.Length
+    && List.forall2 equalsMatchPattern heads heads'
   // exhaustiveness check
   | MPVariable _, _
   | MPEnum _, _
@@ -249,6 +253,7 @@ and equalsMatchPattern (pattern1 : MatchPattern) (pattern2 : MatchPattern) : boo
   | MPFloat _, _
   | MPUnit _, _
   | MPTuple _, _
+  | MPListCons _, _
   | MPList _, _ -> false
 
 

--- a/backend/src/StdLibExecution/Libs/NoModule.fs
+++ b/backend/src/StdLibExecution/Libs/NoModule.fs
@@ -239,10 +239,8 @@ and equalsMatchPattern (pattern1 : MatchPattern) (pattern2 : MatchPattern) : boo
     && List.forall2 equalsMatchPattern elems1 elems2
   | MPList (_, elems1), MPList (_, elems2) ->
     elems1.Length = elems2.Length && List.forall2 equalsMatchPattern elems1 elems2
-  | MPListCons (_, heads, tail), MPListCons (_, heads', tail') ->
-    equalsMatchPattern tail tail'
-    && heads.Length = heads'.Length
-    && List.forall2 equalsMatchPattern heads heads'
+  | MPListCons (_, head, tail), MPListCons (_, head', tail') ->
+    equalsMatchPattern head head' && equalsMatchPattern tail tail'
   // exhaustiveness check
   | MPVariable _, _
   | MPEnum _, _

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -40,6 +40,70 @@ module Lists =
   [ 5; Test.typeError_v0 "test"; 0 ] = Test.typeError_v0 "test"
   [ 5; Test.typeError_v0 "1"; Test.typeError_v0 "2" ] = Test.typeError_v0 "1"
 
+module ListCons =
+  // base
+  (match [1; 2; 3] with | 1::2::[3] -> 42) = 42
+  (match [1; 2; 3] with | 1::2::[3] -> 42 | [] -> 4 | _ -> 2) = 42
+  (match [1; 2; 3] with | [] -> 4 | 1::2::[3] -> 42 | _ -> 2) = 42
+  (match [1; 2; 3] with |  _ -> 2 | 1::2::[3] -> 42 |[] -> 4) = 2
+  (match [1; 2; 3] with | head::rest -> head + (rest |> List.head |> Test.unwrap)) = 3
+
+  // head tail
+  let headTail (list: List<Int>) : (Int * List<Int>)  =
+    match list with
+    | head :: tail -> (head, tail)
+    | [] -> (0,[])
+
+  (headTail []) = (0, [])
+  (headTail [1]) = (1, [])
+  (headTail [1; 2]) = (1, [2])
+  (headTail [1; 2; 3]) = (1, [2; 3])
+  (match ["dd";"aa";"fff";"gg"] with
+    | head::tail -> (head,tail)) = ("dd", ["aa";"fff";"gg"])
+
+  // heads tail
+  let sequence (list : List<Int>) : Int =
+    match list with
+    | a :: b :: c :: rest -> a + b + c
+    | a :: b :: rest -> a + b - 1
+    |[] -> 0
+    | _ -> -1
+
+  (sequence []) = 0
+  (sequence [1]) = -1
+  (sequence [1; 2]) = 2
+  (sequence [1; 2; 3]) = 6
+  (sequence [1; 2; 3; 0]) = 6
+
+  // nested
+  let complexSum (list : List<List<Int>>) : Int =
+    match list with
+    | (a1 :: a2 :: ar) :: (b1 :: b2 :: br) :: (c1 :: cr) :: rest -> a1 + a2 + b1 + b2 + c1
+    | (a :: ar)::(b :: brest) :: rest -> a + b
+    | _ -> 0
+
+  (complexSum []) = 0
+  (complexSum [[1;2];[3;4]]) = 4
+  (complexSum [[1;2;3];[3;4;5];[4;5;6]]) = 14
+
+  // wildcard
+  (match [1;2;3;4] with
+   | 1::a::[4;3] -> a+1
+   | _ ::a:: _ -> a+2
+   | 1::a::rest -> a+3) = 4
+
+  // misc
+  (match [1;2;3;4] with
+  | 2::a::[3;4] -> a+1
+  | 1::a::[4;3] -> a+2
+  | 1::a::[3;4] -> a+3
+  | 1::a::rest -> a+4) = 5
+
+  (match [1;2;3;4] with
+   | 2::a::rest -> a-1
+   | 1::a::rest -> a*2) = 4
+
+
 module Tuple =
   (1,2) = (1,2)
   (1,2,3) = (1,2,3)
@@ -431,61 +495,7 @@ module Pipes =
 
 
 module Match =
-  // List destructuring
   // TODO - check for incomplete pattern matches
-
-  // head tail
-  let headTail (list: List<Int>) : (Int * List<Int>)  =
-    match list with
-    | head :: tail -> (head, tail)
-    | [] -> (0,[])
-
-  (headTail []) = (0, [])
-  (headTail [1]) = (1, [])
-  (headTail [1; 2]) = (1, [2])
-  (headTail [1; 2; 3]) = (1, [2; 3])
-  (match ["dd";"aa";"fff";"gg"] with
-    | head::tail -> (head,tail)) = ("dd", ["aa";"fff";"gg"])
-
-  // heads tail
-  let sequence (list : List<Int>) : Int =
-    match list with
-    | a :: b :: c :: d :: rest -> a + b + c + d
-    | a :: b :: rest -> a + b + List.length rest
-    | _ -> 0
-
-  (sequence []) = 0
-  (sequence [1]) = 0
-  (sequence [1; 2]) = 3
-  (sequence [1; 2; 3]) = 4
-  (sequence [1; 2; 3; 0]) = 6
-
-  // nested
-  let complexSum (list : List<List<Int>>) : Int =
-    match list with
-    | (a1 :: a2 :: ar) :: (b1 :: b2 :: br) :: (c1 :: cr) :: rest -> a1 + a2 + b1 + b2 + c1
-    | (a :: ar)::(b :: brest) :: rest -> a + b
-    | _ -> 0
-
-  (complexSum []) = 0
-  (complexSum [[1;2];[3;4]]) = 4
-  (complexSum [[1;2;3];[3;4;5];[4;5;6]]) = 14
-
-   // misc
-  (match [1;2;3;4] with
-  | 2::a::[3;4] -> a+1
-  | 1::a::[4;3] -> a+2
-  | 1::a::[3;4] -> a+3
-  | 1::a::rest -> a+4) = 5
-
-  (match [1;2;3;4] with
-   | 2::a::rest -> a-1
-   | 1::a::rest -> a*2) = 4
-
-  (match [1;2;3;4] with
-   | 1::a::[4;3] -> a+1
-   | _ ::a:: _ -> a+2
-   | 1::a::rest -> a+3) = 4
 
   (match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"
   (match "x" with | "y" -> "fail" | "x" -> "pass" | var -> "fail") = "pass"

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -431,30 +431,44 @@ module Pipes =
 
 
 module Match =
-  // list destruction
+  // List destruction
 
   // head tail
-  let headTail (list: List<'a>) : (Option<List<'a>> * List<'a>)  =
+  let headTail (list: List<Int>) : (Int * List<Int>)  =
     match list with
-    | head :: tail -> (Just head, tail)
-    | [] -> (Nothing, [])
+    | head :: tail -> (head, tail)
+    | [] -> (0,[])
 
-  (headTail []) = (Nothing, [])
-  (headTail [1]) = (Just 1, [])
-  (headTail [1; 2; 3]) = (Just 1, [2; 3])
-  (headTail ["ab";"cd";"efg"]) = (Just "ab", ["cd";"efg"])
-  
-  // elements
-  let sequence (list : List<Int>) : Option<Tuple<Int,Int,Int>> =
+  (headTail []) = (0, [])
+  (headTail [1]) = (1, [])
+  (headTail [1; 2]) = (1, [2])
+  (headTail [1; 2; 3]) = (1, [2; 3])
+  (match ["dd";"aa";"fff";"gg"] with
+    | head::tail -> (head,tail)) = ("dd", ["aa";"fff";"gg"])
+
+  // heads tail
+  let sequence (list : List<Int>) : Int =
     match list with
-    | a :: b :: c :: rest -> Just ((a, b, c))
-    | _ -> Nothing
+    | a :: b :: c :: d :: rest -> a + b + c + d
+    | a :: b :: rest -> a + b + List.length rest
+    | _ -> 0
 
-  (sequence []) = Nothing
-  (sequence [1]) = Nothing
-  (sequence [1; 2]) = Nothing
-  (sequence [1; 2; 3]) = Just (1, 2, 3)
-  (sequence [1; 2; 3; 4]) = Just (1, 2, 3)
+  (sequence []) = 0
+  (sequence [1]) = 0
+  (sequence [1; 2]) = 3
+  (sequence [1; 2; 3]) = 4
+  (sequence [1; 2; 3; 0]) = 6
+
+  // nested
+  let complexSum (list : List<List<Int>>) : Int =
+    match list with
+    | (a1 :: a2 :: ar) :: (b1 :: b2 :: br) :: (c1 :: cr) :: rest -> a1 + a2 + b1 + b2 + c1
+    | (a :: ar)::(b :: brest) :: rest -> a + b
+    | _ -> 0
+
+  (complexSum []) = 0
+  (complexSum [[1;2];[3;4]]) = 4
+  (complexSum [[1;2;3];[3;4;5];[4;5;6]]) = 14
 
   (match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"
   (match "x" with | "y" -> "fail" | "x" -> "pass" | var -> "fail") = "pass"

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -431,6 +431,31 @@ module Pipes =
 
 
 module Match =
+  // list destruction
+
+  // head tail
+  let headTail (list: List<'a>) : (Option<List<'a>> * List<'a>)  =
+    match list with
+    | head :: tail -> (Just head, tail)
+    | [] -> (Nothing, [])
+
+  (headTail []) = (Nothing, [])
+  (headTail [1]) = (Just 1, [])
+  (headTail [1; 2; 3]) = (Just 1, [2; 3])
+  (headTail ["ab";"cd";"efg"]) = (Just "ab", ["cd";"efg"])
+  
+  // elements
+  let sequence (list : List<Int>) : Option<Tuple<Int,Int,Int>> =
+    match list with
+    | a :: b :: c :: rest -> Just ((a, b, c))
+    | _ -> Nothing
+
+  (sequence []) = Nothing
+  (sequence [1]) = Nothing
+  (sequence [1; 2]) = Nothing
+  (sequence [1; 2; 3]) = Just (1, 2, 3)
+  (sequence [1; 2; 3; 4]) = Just (1, 2, 3)
+
   (match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"
   (match "x" with | "y" -> "fail" | "x" -> "pass" | var -> "fail") = "pass"
   (match true with | false -> "fail" | true -> "pass" | var -> "fail") = "pass"

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -431,7 +431,8 @@ module Pipes =
 
 
 module Match =
-  // List destruction
+  // List destructuring
+  // TODO - check for incomplete pattern matches
 
   // head tail
   let headTail (list: List<Int>) : (Int * List<Int>)  =
@@ -469,6 +470,22 @@ module Match =
   (complexSum []) = 0
   (complexSum [[1;2];[3;4]]) = 4
   (complexSum [[1;2;3];[3;4;5];[4;5;6]]) = 14
+
+   // misc
+  (match [1;2;3;4] with
+  | 2::a::[3;4] -> a+1
+  | 1::a::[4;3] -> a+2
+  | 1::a::[3;4] -> a+3
+  | 1::a::rest -> a+4) = 5
+
+  (match [1;2;3;4] with
+   | 2::a::rest -> a-1
+   | 1::a::rest -> a*2) = 4
+
+  (match [1;2;3;4] with
+   | 1::a::[4;3] -> a+1
+   | _ ::a:: _ -> a+2
+   | 1::a::rest -> a+3) = 4
 
   (match 6 with | 5 -> "fail" | 6 -> "pass" | var -> "fail") = "pass"
   (match "x" with | "y" -> "fail" | "x" -> "pass" | var -> "fail") = "pass"

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -458,8 +458,8 @@ module Expect =
     | MPTuple (_, first, second, theRest), MPTuple (_, first', second', theRest') ->
       eqList path (first :: second :: theRest) (first' :: second' :: theRest')
     | MPList (_, pats), MPList (_, pats') -> eqList path pats pats'
-    | MPListCons (_, heads, tail), MPListCons (_, heads', tail') ->
-      eqList path heads heads'
+    | MPListCons (_, head, tail), MPListCons (_, head', tail') ->
+      check path head head'
       check path tail tail'
     // exhaustiveness check
     | MPVariable _, _

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -458,6 +458,9 @@ module Expect =
     | MPTuple (_, first, second, theRest), MPTuple (_, first', second', theRest') ->
       eqList path (first :: second :: theRest) (first' :: second' :: theRest')
     | MPList (_, pats), MPList (_, pats') -> eqList path pats pats'
+    | MPListCons (_, heads, tail), MPListCons (_, heads', tail') ->
+      eqList path heads heads'
+      check path tail tail'
     // exhaustiveness check
     | MPVariable _, _
     | MPEnum _, _
@@ -468,6 +471,7 @@ module Expect =
     | MPChar _, _
     | MPUnit _, _
     | MPTuple _, _
+    | MPListCons _, _
     | MPList _, _ -> check path actual expected
 
 

--- a/backend/tests/Tests/Serialization.TestValues.fs
+++ b/backend/tests/Tests/Serialization.TestValues.fs
@@ -79,7 +79,16 @@ module RuntimeTypes =
         RT.MPString(128734857124UL, "1243sdfsadf"),
         [ RT.MPVariable(12748124UL, "var2") ]
       )
-      RT.MPFloat(12385781243UL, 79375.847583) ]
+      RT.MPFloat(12385781243UL, 79375.847583)
+      RT.MPListCons(
+        596996239UL,
+        RT.MPString(949735651UL, "val1"),
+        RT.MPListCons(
+          580612639UL,
+          RT.MPString(191110189UL, "val2"),
+          RT.MPList(448252771UL, [ RT.MPString(98945887UL, "val3") ])
+        )
+      ) ]
 
   let exprs : List<RT.Expr> =
     [ RT.EInt(124151234UL, 7)
@@ -197,6 +206,15 @@ module ProgramTypes =
         PT.MPInt(812831UL, 123),
         PT.MPBool(81871UL, true),
         [ PT.MPUnit(17123UL) ]
+      )
+      PT.MPListCons(
+        59696239UL,
+        PT.MPString(94973551UL, "val1"),
+        PT.MPListCons(
+          580612639UL,
+          PT.MPString(19111089UL, "val2"),
+          PT.MPList(44252771UL, [ PT.MPString(989487UL, "val3") ])
+        )
       ) ]
 
   let dtypes : List<PT.TypeReference> =


### PR DESCRIPTION
The list destructuring for `match with` expression. 
Usage cases:  
```fsharp
1. head :: tail 
2. a :: b :: c... :: n :: rest
3. (a::b::ab_rest)::(x::y::xy_rest)::rest 
```