### PR TITLE
Fix parsing issue

### DIFF
--- a/backend/experiments/BwdDangerServer/Server.fs
+++ b/backend/experiments/BwdDangerServer/Server.fs
@@ -481,7 +481,8 @@ let initSerializers () =
   //Json.Vanilla.allow<CTPusher.Payload.UpdateWorkerStates> "Pusher"
 
   // other
-  Json.Vanilla.allow<RT.Expr> "Parsing with Experiments.parseAndSerializeProgram"
+  Json.Vanilla.allow<List<RT.Expr>>
+    "Parsing with Experiments.parseAndSerializeProgram"
   Json.Vanilla.allow<List<RT.UserType.T>>
     "Parsing with Experiments.parseAndSerializeProgram"
   Json.Vanilla.allow<List<RT.UserFunction.T>>

--- a/canvases/dark-editor/main.dark
+++ b/canvases/dark-editor/main.dark
@@ -17,7 +17,7 @@ let _handler _req =
 let _handler _req =
   let sourceInBytes = request.body
   let program =
-    Experiments.parseAndSerializeProgram (String.fromBytes sourceInBytes)
+    Experiments.parseAndSerializeProgram (String.fromBytes sourceInBytes) "user-code.dark"
 
   match program with
   | Ok program ->


### PR DESCRIPTION

No changelog

- Add `filename` parameter to `parseAndSerializeProgram` to resolve user program parsing issue