### PR TITLE
Paul/packages3

### DIFF
--- a/backend/experiments/LibExperimentalExecution/RealExperimentalExecution.fs
+++ b/backend/experiments/LibExperimentalExecution/RealExperimentalExecution.fs
@@ -27,7 +27,7 @@ let (stdlibFns, stdlibTypes) =
     []
 
 
-let packageFns : Lazy<Task<Map<RT.FQFnName.T, RT.Package.Fn>>> =
+let packageFns : Lazy<Task<Map<RT.FQFnName.PackageFnName, RT.Package.Fn>>> =
   lazy
     (task {
       let! packages = PackageManager.allFunctions ()
@@ -35,8 +35,7 @@ let packageFns : Lazy<Task<Map<RT.FQFnName.T, RT.Package.Fn>>> =
       return
         packages
         |> List.map (fun (f : PT.Package.Fn) ->
-          (f.name |> PT2RT.FQFnName.PackageFnName.toRT |> RT.FQFnName.Package,
-           PT2RT.Package.toRT f))
+          (f.name |> PT2RT.FQFnName.PackageFnName.toRT, PT2RT.Package.toRT f))
         |> Map.ofList
     })
 
@@ -48,10 +47,8 @@ let libraries : Lazy<Task<RT.Libraries>> =
       // Of course, this won't be up to date if we add more functions. This should be
       // some sort of LRU cache.
       return
-        { stdlibTypes =
-            stdlibTypes |> Map.fromListBy (fun typ -> RT.FQTypeName.Stdlib typ.name)
-          stdlibFns =
-            stdlibFns |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
+        { stdlibTypes = stdlibTypes |> Map.fromListBy (fun typ -> typ.name)
+          stdlibFns = stdlibFns |> Map.fromListBy (fun fn -> fn.name)
           packageFns = packageFns }
     })
 

--- a/backend/experiments/cli/Main.fs
+++ b/backend/experiments/cli/Main.fs
@@ -46,9 +46,8 @@ let (stdlibFns, stdlibTypes) =
 
 
 let libraries : RT.Libraries =
-  { stdlibTypes =
-      stdlibTypes |> Map.fromListBy (fun typ -> RT.FQTypeName.Stdlib typ.name)
-    stdlibFns = stdlibFns |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
+  { stdlibTypes = stdlibTypes |> Map.fromListBy (fun typ -> typ.name)
+    stdlibFns = stdlibFns |> Map.fromListBy (fun fn -> fn.name)
     packageFns = Map.empty }
 
 

--- a/backend/src/LibAnalysis/Analysis.fs
+++ b/backend/src/LibAnalysis/Analysis.fs
@@ -56,14 +56,11 @@ module Eval =
       let (stdlibFns, stdlibTypes) =
         LibExecution.StdLib.combine [ StdLibExecution.StdLib.contents ] [] []
 
-      let packageFns =
-        request.packageFns |> Map.fromListBy (fun fn -> RT.FQFnName.Package fn.name)
+      let packageFns = request.packageFns |> Map.fromListBy (fun fn -> fn.name)
 
       let libraries : RT.Libraries =
-        { stdlibTypes =
-            stdlibTypes |> Map.fromListBy (fun typ -> RT.FQTypeName.Stdlib typ.name)
-          stdlibFns =
-            stdlibFns |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
+        { stdlibTypes = stdlibTypes |> Map.fromListBy (fun typ -> typ.name)
+          stdlibFns = stdlibFns |> Map.fromListBy (fun fn -> fn.name)
           packageFns = packageFns }
       let results, traceDvalFn = Exe.traceDvals ()
       let functionResults = request.traceData.functionResults

--- a/backend/src/LibAnalysis/ClientRuntimeTypes.fs
+++ b/backend/src/LibAnalysis/ClientRuntimeTypes.fs
@@ -748,6 +748,7 @@ module Package =
 
   type Fn =
     { name : FQFnName.PackageFnName
+      tlid : tlid
       body : Expr.T
       typeParams : List<string>
       parameters : List<Parameter>
@@ -756,6 +757,7 @@ module Package =
   module Fn =
     let fromCT (fn : Fn) : RT.Package.Fn =
       { name = FQFnName.PackageFnName.fromCT fn.name
+        tlid = fn.tlid
         body = Expr.fromCT fn.body
         typeParams = fn.typeParams
         parameters = List.map Parameter.fromCT fn.parameters
@@ -763,6 +765,7 @@ module Package =
 
     let toCT (fn : RT.Package.Fn) : Fn =
       { name = FQFnName.PackageFnName.toCT fn.name
+        tlid = fn.tlid
         body = Expr.toCT fn.body
         typeParams = fn.typeParams
         parameters = List.map Parameter.toCT fn.parameters

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -146,7 +146,7 @@ let typecheckDval
   (dval : Dval)
   (expectedType : TypeReference)
   =
-  match TypeChecker.unify types expectedType dval with
+  match TypeChecker.unify [name] types expectedType dval with
   | Ok () -> ()
   | Error err -> error $"Incorrect type in {name}: {err}"
 

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -146,7 +146,7 @@ let typecheckDval
   (dval : Dval)
   (expectedType : TypeReference)
   =
-  match TypeChecker.unify [name] types expectedType dval with
+  match TypeChecker.unify [ name ] types expectedType dval with
   | Ok () -> ()
   | Error err -> error $"Incorrect type in {name}: {err}"
 
@@ -252,7 +252,7 @@ let (|Fn|_|) (mName : string) (fName : string) (v : int) (expr : Expr) =
 /// Returns the sql snippet for this expression, the variables that need to be
 /// bound to it, and the actual type of the expression.
 let rec lambdaToSql
-  (fns : Map<FQFnName.T, BuiltInFn>)
+  (fns : Map<FQFnName.StdlibFnName, BuiltInFn>)
   (types : Map<FQTypeName.T, CustomType.T>)
   (symtable : DvalMap)
   (paramName : string)
@@ -265,11 +265,12 @@ let rec lambdaToSql
 
   let (sql, vars, actualType) =
     match expr with
-    | EApply (_, FnName name, [], args) ->
+    | EApply (_, FnName (FQFnName.Stdlib name as fqName), [], args) ->
+      let nameStr = FQFnName.toString fqName
       match Map.get name fns with
       | Some fn ->
         // check the abstract type here. We will check the concrete type later
-        typecheck (FQFnName.toString name) fn.returnType expectedType
+        typecheck nameStr fn.returnType expectedType
 
         let actualTypes, argSqls, sqlVars =
           let paramCount = List.length fn.parameters
@@ -302,7 +303,7 @@ let rec lambdaToSql
               fn.parameters
           else
             error
-              $"{FQFnName.StdlibFnName.toString fn.name} has {paramCount} functions but we have {argCount} arguments"
+              $"{nameStr} has {paramCount} functions but we have {argCount} arguments"
 
         // Check the unified return type (basic on the actual arguments) against the
         // expected type
@@ -318,7 +319,7 @@ let rec lambdaToSql
             | None -> error "Could not find return type"
           | typ -> typ
 
-        typecheck (FQFnName.toString name) returnType expectedType
+        typecheck nameStr returnType expectedType
 
 
         match fn, argSqls with
@@ -337,11 +338,10 @@ let rec lambdaToSql
           $"({fnName} ({argSql}))", sqlVars, returnType
         | { sqlSpec = SqlCallback2 fn }, [ arg1; arg2 ] ->
           $"({fn arg1 arg2})", sqlVars, returnType
-        | _, _ ->
-          error $"This function ({FQFnName.toString name}) is not yet implemented"
+        | _, _ -> error $"This function ({nameStr}) is not yet implemented"
       | None ->
         error
-          $"Only builtin functions can be used in queries right now; {FQFnName.toString name} is not a builtin function"
+          $"Only builtin functions can be used in queries right now; {nameStr} is not a builtin function"
 
     | EAnd (_, left, right) ->
       let leftSql, leftVars, leftActual = lts TBool left

--- a/backend/src/LibBackend/UserDB.fs
+++ b/backend/src/LibBackend/UserDB.fs
@@ -57,7 +57,7 @@ let rec set
 
   let availableTypes = RT.ExecutionState.availableTypes state
 
-  match LibExecution.TypeChecker.unify [ key ] availableTypes db.typ dv with
+  match LibExecution.TypeChecker.unify [ db.name ] availableTypes db.typ dv with
   | Error err ->
     let msg = LibExecution.TypeChecker.Error.toString err
     Exception.raiseCode msg

--- a/backend/src/LibBackend/UserDB.fs
+++ b/backend/src/LibBackend/UserDB.fs
@@ -57,7 +57,7 @@ let rec set
 
   let availableTypes = RT.ExecutionState.availableTypes state
 
-  match LibExecution.TypeChecker.unify availableTypes db.typ dv with
+  match LibExecution.TypeChecker.unify [ key ] availableTypes db.typ dv with
   | Error err ->
     let msg = LibExecution.TypeChecker.Error.toString err
     Exception.raiseCode msg

--- a/backend/src/LibExecution/Errors.fs
+++ b/backend/src/LibExecution/Errors.fs
@@ -90,15 +90,16 @@ let incorrectArgsMsg (name : FQFnName.T) (p : Param) (actual : Dval) : string =
       ->
       let altfn = { std with modules = [ "Float" ] }
 
-      $" Try using {FQFnName.StdlibFnName.toString altfn}, or use Float.truncate to truncate Floats to Ints."
+      $". Try using {FQFnName.StdlibFnName.toString altfn}, or use Float.truncate to truncate Floats to Ints."
     | TInt, DString _, FQFnName.Stdlib std when
       (std.modules = [ "Int" ] && std.function_ = "add")
       || (std.modules = [] && std.function_ = "+")
       ->
-      " Use ++ to concatenate"
+      ". Use ++ to concatenate"
     | _ -> ""
   $"{FQFnName.toString name} was expected to be called with a `{expectedTypeRepr}`"
-  + $" in {p.name}, but was actually called with {actualRepr}.{conversionMsg}"
+  + $" in {p.name}, but was actually called with {actualRepr}"
+  + conversionMsg
 
 let incorrectArgsToDError (source : DvalSource) (fn : Fn) (argList : List<Dval>) =
   let paramLength = List.length fn.parameters

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -692,12 +692,12 @@ and callFn
 
     let fn =
       match desc with
-      | FQFnName.Stdlib _std ->
+      | FQFnName.Stdlib std ->
         // CLEANUP: do this when the libraries are loaded
-        state.libraries.stdlibFns.TryFind desc |> Option.map builtInFnToFn
+        state.libraries.stdlibFns.TryFind std |> Option.map builtInFnToFn
       | FQFnName.User u -> state.program.userFns.TryFind u |> Option.map userFnToFn
-      | FQFnName.Package _pkg ->
-        state.libraries.packageFns.TryFind desc |> Option.map packageFnToFn
+      | FQFnName.Package pkg ->
+        state.libraries.packageFns.TryFind pkg |> Option.map packageFnToFn
 
     let! result =
       uply {

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -817,6 +817,7 @@ and execFn
                     match e with
                     | Errors.IncorrectArgs ->
                       Errors.incorrectArgsToDError sourceID fn arglist
+                    | Errors.FakeDvalFound dv -> dv
                     | (:? CodeException
                     | :? GrandUserException) as e ->
                       // There errors are created by us, within the libraries, so they are

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -767,10 +767,8 @@ and execFn
         match TypeChecker.checkFunctionReturnType [ name ] userTypes fn result with
         | Ok () -> result
         | Error err ->
-          DError(
-            sourceID,
-            $"Type error(s) in return type: {TypeChecker.Error.toString err}"
-          )
+          let msg = $"Type error in return type: {TypeChecker.Error.toString err}"
+          DError(sourceID, msg)
 
     if state.tracing.realOrPreview = Preview
        && not state.onExecutionPath

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -337,6 +337,15 @@ module Expr =
     | EEnum (id, _, _, _)
     | EMatch (id, _, _) -> id
 
+module PipeExpr =
+  let toID (expr : PipeExpr) : id =
+    match expr with
+    | EPipeVariable (id, _)
+    | EPipeLambda (id, _, _)
+    | EPipeInfix (id, _, _)
+    | EPipeFnCall (id, _, _, _)
+    | EPipeEnum (id, _, _, _) -> id
+
 // Used to mark whether a function/type has been deprecated, and if so,
 // details about possible replacements/alternatives, and reasoning
 type Deprecation<'name> =

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -312,6 +312,31 @@ and PipeExpr =
     typeName : FQTypeName.T *
     caseName : string *
     fields : List<Expr>
+
+module Expr =
+  let toID (expr : Expr) : id =
+    match expr with
+    | EInt (id, _)
+    | EBool (id, _)
+    | EString (id, _)
+    | EChar (id, _)
+    | EFloat (id, _, _, _)
+    | EUnit id
+    | ELet (id, _, _, _)
+    | EIf (id, _, _, _)
+    | EInfix (id, _, _, _)
+    | ELambda (id, _, _)
+    | EFieldAccess (id, _, _)
+    | EVariable (id, _)
+    | EFnCall (id, _, _, _)
+    | EList (id, _)
+    | EDict (id, _)
+    | ETuple (id, _, _, _)
+    | EPipe (id, _, _, _)
+    | ERecord (id, _, _)
+    | EEnum (id, _, _, _)
+    | EMatch (id, _, _) -> id
+
 // Used to mark whether a function/type has been deprecated, and if so,
 // details about possible replacements/alternatives, and reasoning
 type Deprecation<'name> =

--- a/backend/src/LibExecution/ProgramTypesAst.fs
+++ b/backend/src/LibExecution/ProgramTypesAst.fs
@@ -22,12 +22,20 @@ let traverse (f : Expr -> Expr) (expr : Expr) : Expr =
   match expr with
   | EInt _
   | EBool _
-  | EString _
   | EChar _
   | EUnit _
   | EVariable _
   | EFloat _ -> expr
   | ELet (id, pat, rhs, next) -> ELet(id, pat, f rhs, f next)
+  | EString (id, strs) ->
+    EString(
+      id,
+      strs
+      |> List.map (fun s ->
+        match s with
+        | StringText t -> StringText t
+        | StringInterpolation e -> StringInterpolation(f e))
+    )
   | EIf (id, cond, ifexpr, elseexpr) -> EIf(id, f cond, f ifexpr, f elseexpr)
   | EFieldAccess (id, expr, fieldname) -> EFieldAccess(id, f expr, fieldname)
   | EInfix (id, op, left, right) -> EInfix(id, op, f left, f right)
@@ -130,11 +138,19 @@ let rec preTraversal
   match exprFn expr with
   | EInt _
   | EBool _
-  | EString _
   | EChar _
   | EUnit _
   | EVariable _
   | EFloat _ -> expr
+  | EString (id, strs) ->
+    EString(
+      id,
+      strs
+      |> List.map (fun s ->
+        match s with
+        | StringText t -> StringText t
+        | StringInterpolation e -> StringInterpolation(f e))
+    )
   | ELet (id, pat, rhs, next) -> ELet(id, preTraversalLetPattern pat, f rhs, f next)
   | EIf (id, cond, ifexpr, elseexpr) -> EIf(id, f cond, f ifexpr, f elseexpr)
   | EFieldAccess (id, expr, fieldname) -> EFieldAccess(id, f expr, fieldname)

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -327,6 +327,7 @@ module Package =
 
   let toRT (f : PT.Package.Fn) : RT.Package.Fn =
     { name = FQFnName.PackageFnName.toRT f.name
+      tlid = f.tlid
       body = Expr.toRT f.body
       typeParams = f.typeParams
       parameters = List.map Parameter.toRT f.parameters

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -774,6 +774,7 @@ module Package =
 
   type Fn =
     { name : FQFnName.PackageFnName
+      tlid : tlid
       typeParams : List<string>
       parameters : List<Parameter>
       returnType : TypeReference
@@ -912,7 +913,7 @@ and BuiltInFnSig =
 and FnImpl =
   | StdLib of BuiltInFnSig
   | UserFunction of tlid * Expr
-  | PackageFunction of Expr
+  | PackageFunction of tlid * Expr
 
 
 // CLEANUP consider renaming to `ExecutionType`, `EvaluationMode`, etc.
@@ -1063,4 +1064,4 @@ let packageFnToFn (fn : Package.Fn) : Fn =
     returnType = fn.returnType
     previewable = Impure
     sqlSpec = NotQueryable
-    fn = PackageFunction fn.body }
+    fn = PackageFunction(fn.tlid, fn.body) }

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -177,10 +177,8 @@ module FQFnName =
       true
     | _ -> false
 
-  let isInternalFn (fqfnName : T) : bool =
-    match fqfnName with
-    | Stdlib std -> List.tryHead std.modules = Some "DarkInternal"
-    | _ -> false
+  let isInternalFn (name : StdlibFnName) : bool =
+    List.tryHead name.modules = Some "DarkInternal"
 
 
 module DarkDateTime =
@@ -962,11 +960,11 @@ and TestContext =
 
 // Non-user-specific functionality needed to run code
 and Libraries =
-  { stdlibTypes : Map<FQTypeName.T, BuiltInType>
-    stdlibFns : Map<FQFnName.T, BuiltInFn>
+  { stdlibTypes : Map<FQTypeName.StdlibTypeName, BuiltInType>
+    stdlibFns : Map<FQFnName.StdlibFnName, BuiltInFn>
 
     // TODO: package types
-    packageFns : Map<FQFnName.T, Package.Fn> }
+    packageFns : Map<FQFnName.PackageFnName, Package.Fn> }
 
 and ExceptionReporter = ExecutionState -> Metadata -> exn -> unit
 
@@ -1014,7 +1012,8 @@ module ExecutionState =
     let stdlibTypes =
       state.libraries.stdlibTypes
       |> Map.toList
-      |> List.map (fun (name, stdlibType) -> name, stdlibType.definition)
+      |> List.map (fun (name, stdlibType) ->
+        FQTypeName.Stdlib name, stdlibType.definition)
 
     let userTypes =
       state.program.userTypes

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -307,4 +307,4 @@ let checkFunctionReturnType
   (result : Dval)
   : Result<unit, Error.T> =
 
-  unify ("return" :: path) availableTypes fn.returnType result
+  unify ("result" :: path) availableTypes fn.returnType result

--- a/backend/src/LibRealExecution/RealExecution.fs
+++ b/backend/src/LibRealExecution/RealExecution.fs
@@ -34,8 +34,7 @@ let packageFns : Lazy<Task<Map<RT.FQFnName.PackageFnName, RT.Package.Fn>>> =
       return
         packages
         |> List.map (fun (f : PT.Package.Fn) ->
-          (f.name |> PT2RT.FQFnName.PackageFnName.toRT,
-           PT2RT.Package.toRT f))
+          (f.name |> PT2RT.FQFnName.PackageFnName.toRT, PT2RT.Package.toRT f))
         |> Map.ofList
     })
 
@@ -43,14 +42,8 @@ let libraries : Lazy<Task<RT.Libraries>> =
   lazy
     (task {
       let! packageFns = Lazy.force packageFns
-      let fns =
-        contents
-        |> Tuple2.first
-        |> Map.fromListBy (fun fn -> fn.name)
-      let types =
-        contents
-        |> Tuple2.second
-        |> Map.fromListBy (fun typ -> typ.name)
+      let fns = contents |> Tuple2.first |> Map.fromListBy (fun fn -> fn.name)
+      let types = contents |> Tuple2.second |> Map.fromListBy (fun typ -> typ.name)
 
       // TODO: this keeps a cached version so we're not loading them all the time.
       // Of course, this won't be up to date if we add more functions. This should be

--- a/backend/src/LibRealExecution/RealExecution.fs
+++ b/backend/src/LibRealExecution/RealExecution.fs
@@ -26,7 +26,7 @@ let contents : LibExecution.StdLib.Contents =
     []
     []
 
-let packageFns : Lazy<Task<Map<RT.FQFnName.T, RT.Package.Fn>>> =
+let packageFns : Lazy<Task<Map<RT.FQFnName.PackageFnName, RT.Package.Fn>>> =
   lazy
     (task {
       let! packages = PackageManager.allFunctions ()
@@ -34,7 +34,7 @@ let packageFns : Lazy<Task<Map<RT.FQFnName.T, RT.Package.Fn>>> =
       return
         packages
         |> List.map (fun (f : PT.Package.Fn) ->
-          (f.name |> PT2RT.FQFnName.PackageFnName.toRT |> RT.FQFnName.Package,
+          (f.name |> PT2RT.FQFnName.PackageFnName.toRT,
            PT2RT.Package.toRT f))
         |> Map.ofList
     })
@@ -46,11 +46,11 @@ let libraries : Lazy<Task<RT.Libraries>> =
       let fns =
         contents
         |> Tuple2.first
-        |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
+        |> Map.fromListBy (fun fn -> fn.name)
       let types =
         contents
         |> Tuple2.second
-        |> Map.fromListBy (fun typ -> RT.FQTypeName.Stdlib typ.name)
+        |> Map.fromListBy (fun typ -> typ.name)
 
       // TODO: this keeps a cached version so we're not loading them all the time.
       // Of course, this won't be up to date if we add more functions. This should be

--- a/backend/src/LocalExec/Libs/Packages.fs
+++ b/backend/src/LocalExec/Libs/Packages.fs
@@ -24,7 +24,7 @@ let types : List<BuiltInType> =
             description = "The modules in the package" },
           [ { name = "name"; typ = TString; description = "The name of the package" }
             { name = "version"
-              typ = TString
+              typ = TInt
               description = "The version of the package" } ]
         )
       deprecated = NotDeprecated } ]
@@ -76,7 +76,13 @@ let fns : List<BuiltInFn> =
     { name = fn' [ "LocalExec"; "Packages" ] "list" 0
       typeParams = []
       parameters = [ Param.make "unit" TUnit "" ]
-      returnType = TList(TString)
+      returnType =
+        TList(
+          TCustomType(
+            FQTypeName.Stdlib(typ' [ "LocalExec"; "Packages" ] "Package" 0),
+            []
+          )
+        )
       description = "List all packages"
       fn =
         function
@@ -86,7 +92,6 @@ let fns : List<BuiltInFn> =
               Sql.query "SELECT fnname, modules, version FROM package_functions_v0"
               |> Sql.executeAsync (fun read ->
                 (read.string "fnname", read.string "modules", read.int "version"))
-            debuG "packages" packages
             return
               (DList(
                 packages

--- a/backend/src/LocalExec/Libs/Packages.fs
+++ b/backend/src/LocalExec/Libs/Packages.fs
@@ -19,10 +19,13 @@ let types : List<BuiltInType> =
       typeParams = []
       definition =
         CustomType.Record(
-          { name = "modules"
-            typ = TList TString
-            description = "The modules in the package" },
-          [ { name = "name"; typ = TString; description = "The name of the package" }
+          { name = "owner"
+            typ = TString
+            description = "The username of the owner of the package" },
+          [ { name = "modules"
+              typ = TList TString
+              description = "The modules in the package" }
+            { name = "name"; typ = TString; description = "The name of the package" }
             { name = "version"
               typ = TInt
               description = "The version of the package" } ]
@@ -89,19 +92,24 @@ let fns : List<BuiltInFn> =
         | _, _, [ DUnit ] ->
           uply {
             let! packages =
-              Sql.query "SELECT fnname, modules, version FROM package_functions_v0"
+              Sql.query
+                "SELECT owner, modules, fnname, version FROM package_functions_v0"
               |> Sql.executeAsync (fun read ->
-                (read.string "fnname", read.string "modules", read.int "version"))
+                (read.string "owner",
+                 read.string "fnname",
+                 read.string "modules",
+                 read.int "version"))
             return
               (DList(
                 packages
-                |> List.map (fun (fnname, modules, version) ->
+                |> List.map (fun (owner, fnname, modules, version) ->
                   DRecord(
                     FQTypeName.Stdlib(typ' [ "LocalExec"; "Packages" ] "Package" 0),
                     Map(
-                      [ ("name", DString fnname)
+                      [ ("owner", DString owner)
                         ("modules",
                          modules |> String.split "." |> List.map DString |> DList)
+                        ("name", DString fnname)
                         ("version", DInt version) ]
                     )
                   ))

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -21,9 +21,8 @@ let (stdlibFns, stdlibTypes) =
 
 
 let libraries : RT.Libraries =
-  { stdlibTypes =
-      stdlibTypes |> Map.fromListBy (fun typ -> RT.FQTypeName.Stdlib typ.name)
-    stdlibFns = stdlibFns |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
+  { stdlibTypes = stdlibTypes |> Map.fromListBy (fun typ -> typ.name)
+    stdlibFns = stdlibFns |> Map.fromListBy (fun fn -> fn.name)
     packageFns = Map.empty }
 
 let defaultTLID = 7UL

--- a/backend/src/LocalExec/main.dark
+++ b/backend/src/LocalExec/main.dark
@@ -32,8 +32,8 @@ let usage () : String =
   "
 
 let printPackage (p : LocalExec.Packages.Package) : Unit =
-  let modules = p.modules |> List.map (fun m -> m |> String.join ".")
-  print $"Package {modules} {p.name} {Int.toString p.version}"
+  let modules = p.modules |> String.join "."
+  print $"Package {p.owner}.{modules}.{p.name}_v{Int.toString_v0 p.version}"
 
 let parseArgs (args : List<String>) : Result<CliOptions, String> =
   match args with

--- a/backend/src/LocalExec/main.dark
+++ b/backend/src/LocalExec/main.dark
@@ -31,6 +31,10 @@ let usage () : String =
       list-packages  List packages
   "
 
+let printPackage (p : LocalExec.Packages.Package) : Unit =
+  let modules = p.modules |> List.map (fun m -> m |> String.join ".")
+  print $"Package {modules} {p.name} {Int.toString p.version}"
+
 let parseArgs (args : List<String>) : Result<CliOptions, String> =
   match args with
   | [] -> Ok CliOptions.Help
@@ -40,7 +44,6 @@ let parseArgs (args : List<String>) : Result<CliOptions, String> =
   | ["list-packages"]  -> Ok CliOptions.ListPackages
   | _ -> Error "Invalid arguments"
 
-
 let main (args : List<String>) : Int =
   match parseArgs args with
   | Ok Help ->
@@ -49,11 +52,15 @@ let main (args : List<String>) : Int =
   | Ok LoadPackages ->
     LocalExec.Packages.clear()
     let files = listPackageFiles "/home/dark/app/packages"
-    do List.iter files (fun f -> loadFile f)
+    do List.iter files (fun f ->
+      print $"Loading {f}"
+      loadFile f)
+    print "Done loading packages"
     0
   | Ok ListPackages ->
     let packages = LocalExec.Packages.list()
-    packages |> List.iter (fun p -> print p)
+    packages |> List.iter (fun p -> printPackage p)
+    print "Done listing packages"
     0
   | Error msg ->
     print ("Error: " ++ msg)

--- a/backend/src/Parser/ProgramTypes.fs
+++ b/backend/src/Parser/ProgramTypes.fs
@@ -378,9 +378,11 @@ module Expr =
     | SynExpr.InterpolatedString (parts, _, _) ->
       let parts =
         parts
-        |> List.map (function
-          | SynInterpolatedStringPart.String (s, _) -> PT.StringText s
-          | SynInterpolatedStringPart.FillExpr (e, _) -> PT.StringInterpolation(c e))
+        |> List.filterMap (function
+          | SynInterpolatedStringPart.String ("", _) -> None
+          | SynInterpolatedStringPart.String (s, _) -> Some(PT.StringText s)
+          | SynInterpolatedStringPart.FillExpr (e, _) ->
+            Some(PT.StringInterpolation(c e)))
       PT.EString(id, parts)
 
 

--- a/backend/src/StdLibDarkInternal/Libs/Documentation.fs
+++ b/backend/src/StdLibDarkInternal/Libs/Documentation.fs
@@ -70,7 +70,7 @@ let fns : List<BuiltInFn> =
                     paramTypeName
                     [ ("name", DString p.name)
                       ("type", DString(typeNameToStr p.typ)) ])
-              [ ("name", DString(FQFnName.toString key))
+              [ ("name", DString(FQFnName.StdlibFnName.toString key))
                 ("documentation", DString data.description)
                 ("parameters", DList parameters)
                 ("returnType", DString returnType) ]

--- a/backend/src/StdLibExecution/Libs/List.fs
+++ b/backend/src/StdLibExecution/Libs/List.fs
@@ -1506,6 +1506,7 @@ let fns : List<BuiltInFn> =
                 uply {
                   match! Interpreter.applyFnVal state b [ e ] with
                   | DUnit -> return ()
+                  | DError _ as dv -> return Errors.foundFakeDval dv
                   | v ->
                     Exception.raiseCode (Errors.expectedLambdaValue "fn" "unit" v)
                 })

--- a/backend/src/Wasm/DarkEditor.fs
+++ b/backend/src/Wasm/DarkEditor.fs
@@ -27,11 +27,9 @@ let getStateForEval
         []
         []
 
-    { stdlibTypes =
-        stdlibTypes |> List.map (fun typ -> FQTypeName.Stdlib typ.name, typ) |> Map
+    { stdlibTypes = stdlibTypes |> List.map (fun typ -> typ.name, typ) |> Map
 
-      stdlibFns =
-        stdlibFns |> List.map (fun fn -> FQFnName.Stdlib fn.name, fn) |> Map
+      stdlibFns = stdlibFns |> List.map (fun fn -> fn.name, fn) |> Map
 
       packageFns = packageFns }
 

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -185,7 +185,7 @@ module Roundtrip =
 module ValueMissingColumnGivesGoodError =
   // TYPESCLEANUP: can we test a missing column against the DB anymore?
   // (DB.set_v1 (XY { x = "x"; y = "v" }) "i" XDB) = Test.typeError_v0 "Found but did not expect: [y]"
-  (DB.set_v1 (XY { x = "x"; y = "v" }) "i" XDB) = Test.typeError_v0 "Expected a value of type `X_v0` but got a `XY_v0`"
+  (DB.set_v1 (XY { x = "x"; y = "v" }) "i" XDB) = Test.typeError_v0 "Expected a value of type `X_v0` but got a `XY_v0` in XDB"
 
 
 module SetDoesUpsert =

--- a/backend/testfiles/execution/http.tests
+++ b/backend/testfiles/execution/http.tests
@@ -19,7 +19,7 @@
 
 
 Http.badRequest_v0 "Your request resulted in an error" = Http.response_v0 "Your request resulted in an error" 400
-Http.badRequest_v0 1 = Test.typeError_v0 "Http.badRequest was expected to be called with a `String` in error, but was actually called with 1."
+Http.badRequest_v0 1 = Test.typeError_v0 "Http.badRequest was expected to be called with a `String` in error, but was actually called with 1"
 Http.notFound_v0 = Http.response_v0 () 404
 
 Http.unauthorized_v0 = Http.response_v0 () 401

--- a/backend/testfiles/execution/json.tests
+++ b/backend/testfiles/execution/json.tests
@@ -30,7 +30,7 @@ Json.serialize<Bool> 1 = Error "Can't currently serialize this type/value combin
 Json.serialize<Bool> "False" = Error "Can't currently serialize this type/value combination"
 Json.serialize<Bool> "tRUE" = Error "Can't currently serialize this type/value combination"
 
-Json.parse<Bool> 1 = Test.typeError "Json.parse was expected to be called with a `String` in json, but was actually called with 1."
+Json.parse<Bool> 1 = Test.typeError "Json.parse was expected to be called with a `String` in json, but was actually called with 1"
 Json.parse<Bool> "tru" = Error "not JSON"
 Json.parse<Bool> "null" = Error "Can't currently parse this type/value combination"
 Json.parse<Bool> "" = Error "not JSON"

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -64,7 +64,7 @@ module Records =
   Cols2 { col1 = 2 } = Test.typeError "Missing key `col2` in Cols2_v0"
   Cols2 { col1 = 2; other = 3 } = Test.typeError "Unexpected field `other` in Cols2_v0"
   Cols2 { col1 = 2; col2 = 3; col3 = 4 } = Test.typeError "Unexpected field `col3` in Cols2_v0"
-  Cols1 { col1 = "" } = Test.typeError "Expected a value of type `Int` but got a `String`"
+  Cols1 { col1 = "" } = Test.typeError "Expected a value of type `Int` but got a `String` in col1"
 
   // Invalid type
   MyNonExistantType { col1 = 2 } = Test.typeError "There is no type named `MyNonExistantType_v0`"
@@ -107,7 +107,7 @@ module Enums =
       // (match MyEnum.C "test" with | C -> v) = Test.typeError "TODO"
       // (match MyEnum.C "test" with | D -> "ok" | C _ -> v) = Test.typeError "TODO"
       // (match MyEnum.C "test" with | 5 -> "ok" | C _ -> v) = Test.typeError "TODO"
-      (MyEnum.C 5) = Test.typeError "Expected a value of type `String` but got a `Int`"
+      (MyEnum.C 5) = Test.typeError "Expected a value of type `String` but got a `Int` in C"
 
 
   module Simple =
@@ -137,8 +137,8 @@ module Enums =
     (EnumOfMixedCases.W == (EnumOfMixedCases.Y 1)) = false
     (EnumOfMixedCases.Y 1 == EnumOfMixedCases.Y 1) = true
 
-    EnumOfMixedCases.X 1 = Test.typeError "Expected a value of type `String` but got a `Int`"
-    EnumOfMixedCases.Y "test" = Test.typeError "Expected a value of type `Int` but got a `String`"
+    EnumOfMixedCases.X 1 = Test.typeError "Expected a value of type `String` but got a `Int` in X"
+    EnumOfMixedCases.Y "test" = Test.typeError "Expected a value of type `Int` but got a `String` in Y"
     EnumOfMixedCases.Z 1 = Test.typeError "Case `Z` expected 2 fields but got 1"
 
     (let values = [EnumOfMixedCases.W;
@@ -318,7 +318,7 @@ module Lambdas =
   (let y = (fun msg -> Test.typeError msg) in List.map_v0 [] y) = []
   // (let y = (fun a b -> a + b) in y 2 3) = 5 // TODO: allow
   (let y = (fun a b -> a * b) in List.fold_v0 [1; 2; 3; 4] 1 y) = 24
-  (List.fold_v0 [4] 1 5) = Test.typeError_v0 "List.fold was expected to be called with a `Function` in fn, but was actually called with 5."
+  (List.fold_v0 [4] 1 5) = Test.typeError_v0 "List.fold was expected to be called with a `Function` in fn, but was actually called with 5"
   (List.fold_v0 [4] 1 (Test.typeError "test")) = Test.typeError "test"
 
   (let x = 5 in
@@ -657,7 +657,7 @@ module Match =
 
 module Error =
   List.map_v0 [1;2;3;4;5] (fun x y -> x) = Test.typeError_v0 "Expected 2 arguments, got 1"
-  Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 "Option.map2 was expected to be called with a `Option<'b>` in option2, but was actually called with \"not an option\"."
+  Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 "Option.map2 was expected to be called with a `Option<'b>` in option2, but was actually called with \"not an option\""
 
 module ErrorPropagation =
   type EPRec = { i: Int; m: Int; j: Int; n: Int }
@@ -807,7 +807,7 @@ module FunctionCalls =
 
 module InvalidFnCalls =
   functionWhichDoesntExist 6 = Test.typeError "Function functionWhichDoesntExist is not found"
-  stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected a value of type `String` but got a `Int`"
+  stringFn 5 = Test.typeError "Type error in function parameters: Expected a value of type `String` but got a `Int` in stringFn->key"
   stringFn "str1" "str2" = Test.typeError "stringFn has 0 type parameters and 1 parameters, but here was called with 0 type arguments and 2 arguments."
 
   fnWithTypeArgAndOneParam 1 = Test.typeError "fnWithTypeArgAndOneParam has 1 type parameters and 1 parameters, but here was called with 0 type arguments and 1 arguments."
@@ -877,7 +877,7 @@ module Packages =
   Test.Test.returnsResultError () = Error false
 
   module Invalid =
-    Test.Test.stringFn 5 = Test.typeError "Type error(s) in function parameters: Expected a value of type `String` but got a `Int`"
+    Test.Test.stringFn 5 = Test.typeError "Type error in function parameters: Expected a value of type `String` but got a `Int` in test.Test.stringFn->key"
     Test.Test.stringFn "str1" "str2" = Test.typeError "test.Test.stringFn_v0 has 0 type parameters and 1 parameters, but here was called with 0 type arguments and 2 arguments."
     Test.Test.derrorFn "test" = Test.typeError "test"
 

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -251,6 +251,9 @@ module InterpolatedString =
   (let one = 1 in  $"test {one}") = Test.typeError_v0 "Expected string, got 1"
   (let name = "John" in let age = "30" in $"Name: {name}, Age: {age} years old.") = "Name: John, Age: 30 years old."
   (let two = 2 in "test 1" == $"test {one}") = Test.typeError_v0 "There is no variable named: one"
+  (let one = 1 in $"test {Int.toString one}") = "test 1"
+
+
 
 module FnCall =
   5 + 3 = 8

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -125,8 +125,7 @@ let libraries : Lazy<RT.Libraries> =
         []
         []
 
-     { stdlibTypes =
-         types |> Map.fromListBy (fun typ -> typ.name)
+     { stdlibTypes = types |> Map.fromListBy (fun typ -> typ.name)
        stdlibFns = fns |> Map.fromListBy (fun fn -> fn.name)
        packageFns = Map.empty })
 

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -126,8 +126,8 @@ let libraries : Lazy<RT.Libraries> =
         []
 
      { stdlibTypes =
-         types |> Map.fromListBy (fun typ -> RT.FQTypeName.Stdlib typ.name)
-       stdlibFns = fns |> Map.fromListBy (fun fn -> RT.FQFnName.Stdlib fn.name)
+         types |> Map.fromListBy (fun typ -> typ.name)
+       stdlibFns = fns |> Map.fromListBy (fun fn -> fn.name)
        packageFns = Map.empty })
 
 let executionStateFor

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -110,7 +110,7 @@ let t
         packageFns
         |> List.map (fun v ->
           let fn = PT2RT.Package.toRT v
-          ((RT.FQFnName.Package fn.name), fn))
+          (fn.name, fn))
         |> Map
 
       let! (state : RT.ExecutionState) =

--- a/backend/tests/Tests/TypeChecker.Tests.fs
+++ b/backend/tests/Tests/TypeChecker.Tests.fs
@@ -39,7 +39,7 @@ let testBasicTypecheckWorks : Test =
 
     let typeArgs = [] // CLEANUP consider adding this as a param
 
-    TypeChecker.checkFunctionCall Map.empty fn typeArgs args
+    TypeChecker.checkFunctionCall [] Map.empty fn typeArgs args
 
   testMany
     "basic type checking"
@@ -50,8 +50,10 @@ let testBasicTypecheckWorks : Test =
      [ (intAdd, [ ("a", RT.DInt 5L); ("b", RT.DInt 4L) ]), Ok()
        ((intAdd, [ ("a", RT.DInt 5L); ("b", RT.DBool true) ]),
         Error(
-          (TypeChecker.Error.TypeUnificationFailure
-            { expectedType = RT.TInt; actualValue = RT.DBool true })
+          TypeChecker.Error.TypeUnificationFailure(
+            { expectedType = RT.TInt; actualValue = RT.DBool true },
+            []
+          )
         )) ])
 
 let testArguments : Test =

--- a/backend/tests/Tests/TypeChecker.Tests.fs
+++ b/backend/tests/Tests/TypeChecker.Tests.fs
@@ -52,7 +52,7 @@ let testBasicTypecheckWorks : Test =
         Error(
           TypeChecker.Error.TypeUnificationFailure(
             { expectedType = RT.TInt; actualValue = RT.DBool true },
-            []
+            [ "b" ]
           )
         )) ])
 
@@ -81,7 +81,7 @@ let testArguments : Test =
     [ (("myBadFn", RT.TString, S.eInt 7),
        RT.DError(
          RT.SourceNone,
-         "Type error(s) in return type: Expected a value of type `String` but got a `Int`"
+         "Type error in return type: Expected a value of type `String` but got a `Int` in myBadFn->result"
        ))
       (("myGoodFn", RT.TString, S.eStr "test"), RT.DString "test")
       (("myAnyFn", RT.TVariable "a", S.eInt 5), RT.DInt 5L) ]

--- a/backend/tests/Tests/TypeChecker.Tests.fs
+++ b/backend/tests/Tests/TypeChecker.Tests.fs
@@ -25,7 +25,7 @@ module S = TestUtils.RTShortcuts
 
 let testBasicTypecheckWorks : Test =
   let t
-    ((fn, args) : RT.FQFnName.T * List<string * RT.Dval>)
+    ((fn, args) : RT.FQFnName.StdlibFnName * List<string * RT.Dval>)
     : Result<unit, TypeChecker.Error.T> =
     let args = Map.ofList args
 
@@ -44,8 +44,8 @@ let testBasicTypecheckWorks : Test =
   testMany
     "basic type checking"
     t
-    (let intAdd =
-      RT.FQFnName.Stdlib { modules = [ "Int" ]; function_ = "add"; version = 0 }
+    (let intAdd : RT.FQFnName.StdlibFnName =
+      { modules = [ "Int" ]; function_ = "add"; version = 0 }
 
      [ (intAdd, [ ("a", RT.DInt 5L); ("b", RT.DInt 4L) ]), Ok()
        ((intAdd, [ ("a", RT.DInt 5L); ("b", RT.DBool true) ]),

--- a/scripts/run-backend-server
+++ b/scripts/run-backend-server
@@ -42,6 +42,7 @@ if [[ "$PUBLISHED" == "true" ]]; then
   CRONCHECKER_BINPATH="backend/Build/out/CronChecker/Release/net7.0/linux-x64/publish"
   QUEUEWORKER_BINPATH="backend/Build/out/QueueWorker/Release/net7.0/linux-x64/publish"
   PRODEXEC_BINPATH="backend/Build/out/ProdExec/Release/net7.0/linux-x64/publish"
+  LOCALEXEC_BINPATH="backend/Build/out/LocalExec/Release/net7.0/linux-x64/publish"
 
   BWDDANGERSERVER_BINPATH="backend/Build/out/BwdDangerServer/Release/net7.0/linux-x64/publish"
 else
@@ -49,6 +50,7 @@ else
   CRONCHECKER_BINPATH="backend/Build/out/CronChecker/Debug/net7.0"
   QUEUEWORKER_BINPATH="backend/Build/out/QueueWorker/Debug/net7.0"
   PRODEXEC_BINPATH="backend/Build/out/ProdExec/Debug/net7.0"
+  LOCALEXEC_BINPATH="backend/Build/out/LocalExec/Debug/net7.0"
 
   BWDDANGERSERVER_BINPATH="backend/Build/out/BwdDangerServer/Debug/net7.0"
 fi
@@ -59,6 +61,7 @@ BWDSERVER_EXE="${BWDSERVER_BINPATH}/BwdServer"
 CRONCHECKER_EXE="${CRONCHECKER_BINPATH}/CronChecker"
 QUEUEWORKER_EXE="${QUEUEWORKER_BINPATH}/QueueWorker"
 PRODEXEC_EXE="${PRODEXEC_BINPATH}/ProdExec"
+LOCALEXEC_EXE="${LOCALEXEC_BINPATH}/LocalExec"
 
 BWDDANGERSERVER_EXE="${BWDDANGERSERVER_BINPATH}/BwdDangerServer"
 
@@ -79,7 +82,12 @@ echo "Waiting for postgres"
 echo "Waiting for compiled servers"
 for ((i=1;i<=1000;i++));
 do
-  if [[ ! -f "${BWDSERVER_EXE}" || ! -f "${CRONCHECKER_EXE}" || ! -f "${QUEUEWORKER_EXE}" || ! -f "${PRODEXEC_EXE}" || ! -f "${BWDDANGERSERVER_EXE}" ]]; then
+  if [[ ! -f "${BWDSERVER_EXE}" \
+     || ! -f "${CRONCHECKER_EXE}" \
+     || ! -f "${QUEUEWORKER_EXE}" \
+     || ! -f "${PRODEXEC_EXE}" \
+     || ! -f "${LOCALEXEC_EXE}" \
+     || ! -f "${BWDDANGERSERVER_EXE}" ]]; then
     sleep 0.01
   fi
 done
@@ -87,6 +95,8 @@ echo "Done waiting for compiled servers"
 
 echo "Running migrations"
 "${PRODEXEC_EXE}" migrations run > "$LOGS/migrations.log" 2>&1
+echo "Loading packages"
+"${LOCALEXEC_EXE}" load-packages > "$LOGS/packages.log" 2>&1 &
 echo "Running bwdserver"
 "${BWDSERVER_EXE}" > "$LOGS/bwdserver.log" 2>&1 &
 echo "Running cronchecker"


### PR DESCRIPTION
Changelog:

```
Language:
- add support for packages
```

- Packages are now added locally at each compile (when the local DB is cleared)
- Type checker includes more information about the path of the error (eg a key in a record, or a parameter name)
- Get the correct names for packages
- Print the AST of the expression referred to by a DError
- Refactor function calling
`AST.preTraversal` should look in `EString.StringInterpolation`
