### PR TITLE
wip: Make HttpClient.request work with BytesArrayContent body in WASM

### DIFF
--- a/backend/src/Wasm/DarkEditor.fs
+++ b/backend/src/Wasm/DarkEditor.fs
@@ -86,3 +86,28 @@ let HandleEvent (serializedEvent : string) : Task<string> =
 
     return LibExecution.DvalReprDeveloper.toRepr result
   }
+
+
+let generateRandomBytes (length: int) =
+  let random = new Random()
+  let buffer = Array.zeroCreate<byte> length
+  random.NextBytes(buffer)
+  buffer
+
+
+[<JSInvokable>]
+let Test () : Task<unit> =
+  task {
+    let! response =
+      Wasm.Libs.HttpClient.HttpClient.request
+        { url  = "http://dark-repl.dlio.localhost:11003/handle-bytes"
+          method  = HttpMethod.Post
+          headers  = []
+          body  = generateRandomBytes 10 }
+
+    match response with
+    | Ok response ->
+      WasmHelpers.callJSFunction "console.log" [ "got response"; System.Text.Encoding.UTF8.GetString response.body]
+    | Error err ->
+      WasmHelpers.callJSFunction "console.log" [ "got error" ]
+  }

--- a/backend/src/Wasm/Libs/HttpClient.fs
+++ b/backend/src/Wasm/Libs/HttpClient.fs
@@ -81,6 +81,7 @@ module HttpClient =
             new HttpRequestMessage(
               httpRequest.method,
               reqUri,
+              Content = new ByteArrayContent(httpRequest.body),
 
               // Support both Http 2.0 and 3.0
               // https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpversionpolicy?view=net-7.0
@@ -88,14 +89,6 @@ module HttpClient =
               Version = System.Net.HttpVersion.Version30,
               VersionPolicy = System.Net.Http.HttpVersionPolicy.RequestVersionOrLower
             )
-
-          let strBody = System.Text.Encoding.UTF8.GetString httpRequest.body
-
-          // CLEANUP: BodyContent, used by the 'regular' HttpClient,
-          // doesn't seem to work in the Wasm runtime,
-          // so we'll have to figure out some other way of supporting
-          // non-text bodies in that environment
-          if strBody <> "" then req.Content <- new StringContent(strBody)
 
           // headers
           httpRequest.headers

--- a/backend/static/editor-bootstrap.js
+++ b/backend/static/editor-bootstrap.js
@@ -32,7 +32,9 @@ const Darklang = {
 
     await invoke("InitializeDarkRuntime");
 
-    await invoke("LoadClient", sourceURL, parseUrl);
+    await invoke("Test");
+
+    //await invoke("LoadClient", sourceURL, parseUrl);
 
     // return object to expose as 'darklang'
     return {

--- a/canvases/dark-repl/main.dark
+++ b/canvases/dark-repl/main.dark
@@ -2,6 +2,10 @@
 let _handler _req =
   Http.redirectTo "/assets/index.html"
 
+[<HttpHandler("POST", "/handle-bytes")>]
+let _handler _req =
+  Http.response (request.body |> Bytes.length |> Int.toString |> String.toBytes) 200
+
 [<HttpHandler("GET", "/assets/:path")>]
 let _handler _req =
   let body =

--- a/canvases/dark-serve-static/main.dark
+++ b/canvases/dark-serve-static/main.dark
@@ -1,3 +1,8 @@
+
+[<HttpHandler("POST", "/handle-bytes")>]
+let _handler _req =
+  Http.response (request.body |> Bytes.length |> Int.toString |> String.toBytes) 200
+
 [<HttpHandler("GET", "/:path")>]
 let _handler _req =
   let body =


### PR DESCRIPTION
Changelog:

```
Area of change
- details
```

Our `HttpClient.request` function fails when:
- run in the WebAssembly runtime
- in a `uply { }`
- if we set the `Content` of the HttpRequest to a BytesArrayContent

It does _not_ fail if we run it outside of a `uply{}`.

I tried updating `HttpClient.fs` itself to make the call synchronous - didn't work.

Not sure what to try here next - there are a few layers of uply _above_ the actual fn impl - will try .net's HttpClient at a few levels of that stack, and see where it fails, maybe.