### PR TITLE
Fix access to Wasm.HttpClient functions from dark-editor and dark-repl

### DIFF
--- a/backend/src/Wasm/Libs/Editor.fs
+++ b/backend/src/Wasm/Libs/Editor.fs
@@ -124,7 +124,10 @@ let fns : List<BuiltInFn> =
             let source = Json.Vanilla.deserialize<UserProgramSource> sourceJson
 
             let stdLib =
-              LibExecution.StdLib.combine [ StdLibExecution.StdLib.contents ] [] []
+              LibExecution.StdLib.combine
+                [ StdLibExecution.StdLib.contents; Wasm.Libs.HttpClient.contents ]
+                []
+                []
 
             let! result =
               let expr = exprsCollapsedIntoOne source.exprs

--- a/backend/src/Wasm/Wasm.fsproj
+++ b/backend/src/Wasm/Wasm.fsproj
@@ -30,8 +30,8 @@
   <ItemGroup>
     <Compile Include="WasmHelpers.fs" />
     <Compile Include="EvalHelpers.fs" />
-    <Compile Include="Libs/Editor.fs" />
     <Compile Include="Libs/HttpClient.fs" />
+    <Compile Include="Libs/Editor.fs" />
     <Compile Include="StdLib.fs" />
     <Compile Include="Init.fs" />
     <Compile Include="DarkEditor.fs" />


### PR DESCRIPTION

No changelog

