### PR TITLE
Handling errors 

### DIFF
--- a/backend/src/Wasm/Libs/Editor.fs
+++ b/backend/src/Wasm/Libs/Editor.fs
@@ -138,11 +138,14 @@ let fns : List<BuiltInFn> =
                 let inputVars = Map.empty
                 LibExecution.Execution.executeExpr state inputVars expr
 
-              return
-                LibExecution.DvalReprDeveloper.toRepr result
-                |> DString
-                |> Ok
-                |> DResult
+              match result with
+              | DError (_source, err) -> return DResult(Error(DString err))
+              | result ->
+                return
+                  LibExecution.DvalReprDeveloper.toRepr result
+                  |> DString
+                  |> Ok
+                  |> DResult
             with
             | e ->
               let error = Exception.getMessages e |> String.concat " "

--- a/backend/src/Wasm/Libs/Editor.fs
+++ b/backend/src/Wasm/Libs/Editor.fs
@@ -40,8 +40,7 @@ let fns : List<BuiltInFn> =
               let state = editor.CurrentState
               // TODO: assert that the type matches the given typeParam
               return DResult(Ok state)
-            with
-            | e ->
+            with e ->
               return
                 $"Error getting state: {e.Message}" |> DString |> Error |> DResult
           }
@@ -139,15 +138,14 @@ let fns : List<BuiltInFn> =
                 LibExecution.Execution.executeExpr state inputVars expr
 
               match result with
-              | DError (_source, err) -> return DResult(Error(DString err))
+              | DError(_source, err) -> return DResult(Error(DString err))
               | result ->
                 return
                   LibExecution.DvalReprDeveloper.toRepr result
                   |> DString
                   |> Ok
                   |> DResult
-            with
-            | e ->
+            with e ->
               let error = Exception.getMessages e |> String.concat " "
               return DResult(Error(DString($"Error parsing code: {error}")))
           }

--- a/canvases/dark-editor-vue/src/App.vue
+++ b/canvases/dark-editor-vue/src/App.vue
@@ -8,6 +8,7 @@ import TasksAndActionsView from './views/TasksAndActionsView.vue'
 import CodeAndContextView from './views/CodeAndContextView.vue'
 
 let init: Model = {
+  isLoading: false,
   systemPrompt: '<system prompt here>!',
   chatHistory: [],
   codeSnippets: [],

--- a/canvases/dark-editor-vue/src/App.vue
+++ b/canvases/dark-editor-vue/src/App.vue
@@ -61,7 +61,7 @@ document.head.appendChild(darklangJSScript)
       <div class="w-2/5 overflow-auto pb-24">
         <ConversationView v-bind:state="state" />
       </div>
-      <div class="w-2/5 overflow-auto pb-24">
+      <div class="w-2/5 overflow-auto pb-32">
         <CodeAndContextView
           v-bind:state="state"
           :codeSnippets="state.codeSnippets"

--- a/canvases/dark-editor-vue/src/components/CodeSnippet.vue
+++ b/canvases/dark-editor-vue/src/components/CodeSnippet.vue
@@ -58,7 +58,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex p-4 m-2 mt-6 bg-[#1C1C1C] rounded-2xl overflow-hidden relative">
+  <div class="flex p-4 m-2 bg-[#1C1C1C] rounded-2xl overflow-hidden relative">
     <div class="flex flex-col items-center mt-4 px-1">
       <button class="mb-3" @click="runCode">
         <fa icon="play" class="w-4 h-4 text-[#8f53ff]" />

--- a/canvases/dark-editor-vue/src/components/Conversation.vue
+++ b/canvases/dark-editor-vue/src/components/Conversation.vue
@@ -43,6 +43,7 @@ const isPromptVisible = ref(false)
         <ConversationStep
           v-for="chatItem in state.chatHistory"
           :key="chatItem.id"
+          :isLoading="state.isLoading"
           :chatItem="chatItem"
           :codeSnippets="state.codeSnippets"
           :tasks="state.tasks"
@@ -52,6 +53,6 @@ const isPromptVisible = ref(false)
     </div>
 
     <!-- User Prompt Input at the bottom -->
-    <Prompt />
+    <Prompt :state="state" />
   </div>
 </template>

--- a/canvases/dark-editor-vue/src/components/ConversationStep.vue
+++ b/canvases/dark-editor-vue/src/components/ConversationStep.vue
@@ -25,16 +25,19 @@ let props = defineProps<{
       </p>
     </div>
 
-    <div class="p-3 flex-grow" v-if="chatItem.typ === 'Bot'">
+    <div class="pl-3 flex-grow" v-if="chatItem.typ === 'Bot'">
       <div v-for="(item, index) in chatItem.items">
-        <p v-if="item.typ === 'Text'">
-          {{ item.text }}
-        </p>
+        <pre class="whitespace-pre-wrap break-w text-sm" v-if="item.typ === 'Text'"
+          >{{ item.text }} </pre
+        >
       </div>
     </div>
 
-    <p class="p-3 flex-grow" v-else-if="chatItem.typ === 'User'">
-      {{ chatItem.prompt }}
-    </p>
+    <div
+      class="pl-3 flex items-center flex-grow"
+      v-else-if="chatItem.typ === 'User'"
+    >
+      <pre class="whitespace-pre-wrap break-w text-sm">{{ chatItem.prompt }}</pre>
+    </div>
   </div>
 </template>

--- a/canvases/dark-editor-vue/src/components/ConversationStep.vue
+++ b/canvases/dark-editor-vue/src/components/ConversationStep.vue
@@ -10,6 +10,7 @@ let props = defineProps<{
 
 <template>
   <div
+    v-if="chatItem.typ === 'Bot' ? chatItem.items.length > 0 : chatItem.prompt"
     class="flex p-3 mb-2 ml-2 rounded text-white"
     :class="{ 'bg-[#222222] rounded-xl overflow-scroll': chatItem.typ === 'Bot' }"
   >

--- a/canvases/dark-editor-vue/src/components/Prompt.vue
+++ b/canvases/dark-editor-vue/src/components/Prompt.vue
@@ -11,10 +11,8 @@ async function submit() {
   try {
     isLoading.value = true
     console.log('emitting prompt to submit')
-    const evt = { DisplayPrompt: [userInput.value] }
+    const evt = { UserGavePrompt: [userInput.value] }
     const result = await window.darklang.handleEvent(evt)
-    const evt2 = { UserGavePrompt: [userInput.value] }
-    const result2 = await window.darklang.handleEvent(evt2)
     console.log('result', result)
     userInput.value = ''
     isLoading.value = false

--- a/canvases/dark-editor-vue/src/components/Prompt.vue
+++ b/canvases/dark-editor-vue/src/components/Prompt.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import type { text } from '@fortawesome/fontawesome-svg-core'
 import { ref, onMounted } from 'vue'
 import autosize from 'autosize'
+import type { Model } from '../types'
+
+let props = defineProps<{ state: Model }>()
 
 const userInput = ref('Write a function that divides two numbers')
 const content = ref()
@@ -9,13 +11,11 @@ const isLoading = ref(false)
 
 async function submit() {
   try {
-    isLoading.value = true
     console.log('emitting prompt to submit')
     const evt = { UserGavePrompt: [userInput.value] }
     const result = await window.darklang.handleEvent(evt)
     console.log('result', result)
     userInput.value = ''
-    isLoading.value = false
     autosize.destroy(content.value)
     autosize(content.value)
     let contentTextarea = document.getElementById('content') as HTMLTextAreaElement
@@ -45,11 +45,11 @@ onMounted(() => autosize(content.value))
     ></textarea>
     <button
       @click="submit"
-      :class="{ 'opacity-50 cursor-not-allowed': isLoading }"
-      :disabled="isLoading"
+      :class="{ 'opacity-50 cursor-not-allowed': props.state.isLoading }"
+      :disabled="props.state.isLoading"
       class="absolute bottom-2 right-2 py-1 px-2 mx-2 rounded-md text-white bg-[#C56AE4] hover:bg-[#9f56b8]"
     >
-      <span v-if="!isLoading">send</span>
+      <span v-if="!props.state.isLoading">send</span>
       <span v-else class="flex">
         <fa icon="fa-spinner" class="animate-spin w-6 p-1" />
       </span>

--- a/canvases/dark-editor-vue/src/components/Prompt.vue
+++ b/canvases/dark-editor-vue/src/components/Prompt.vue
@@ -11,8 +11,10 @@ async function submit() {
   try {
     isLoading.value = true
     console.log('emitting prompt to submit')
-    const evt = { UserGavePrompt: [userInput.value] }
+    const evt = { DisplayPrompt: [userInput.value] }
     const result = await window.darklang.handleEvent(evt)
+    const evt2 = { UserGavePrompt: [userInput.value] }
+    const result2 = await window.darklang.handleEvent(evt2)
     console.log('result', result)
     userInput.value = ''
     isLoading.value = false

--- a/canvases/dark-editor-vue/src/types.ts
+++ b/canvases/dark-editor-vue/src/types.ts
@@ -33,6 +33,7 @@ export type ChatHistoryItem =
   | { typ: 'Bot'; id: string; items: BotResponseItem[] }
 
 export interface Model {
+  isLoading: boolean
   systemPrompt: string
   chatHistory: ChatHistoryItem[]
   codeSnippets: CodeSnippet[]
@@ -121,6 +122,7 @@ export function fromSerializedDarkModel(serializedDarkModel: string): Model {
   })
 
   return {
+    isLoading: source.isLoading,
     systemPrompt: source.systemPrompt,
     chatHistory: chatHistory,
     codeSnippets: codeSnippets,

--- a/canvases/dark-editor-vue/src/views/CodeAndContextView.vue
+++ b/canvases/dark-editor-vue/src/views/CodeAndContextView.vue
@@ -16,9 +16,11 @@ function snippetForId(id: string): CodeSnippet {
 
 <template>
   <div class="min-h-screen bg-[#151515] text-white">
-    <h1>Context & Code</h1>
-    <h2>Context</h2>
-    <h2>Code</h2>
+    <h1 class="p-2 mt-2 font-semibold">Context And Code</h1>
+    <div class="p-2 m-2">
+      <h2 class="font-semibold">Context</h2>
+    </div>
+    <h2 class="p-2 m-2 font-semibold">Code</h2>
     <div v-for="(item, index) in codeSnippets" :key="index">
       <CodeSnippetComponent :key="item.id" :snippet="snippetForId(item.id)" />
     </div>

--- a/canvases/dark-editor-vue/src/views/TasksAndActionsView.vue
+++ b/canvases/dark-editor-vue/src/views/TasksAndActionsView.vue
@@ -10,19 +10,22 @@ const props = defineProps<{
 
 <template>
   <div class="min-h-screen bg-[#151515] text-white">
-    <h1>Tasks & Actions</h1>
-    <h2>Tasks</h2>
-    <ul>
-      <li v-for="(task, index) in tasks" :key="index">
-        {{ task.description }}
-      </li>
-    </ul>
-
-    <h2>Actions</h2>
-    <ul>
-      <li v-for="(action, index) in actions" :key="index">
-        {{ action.description }}
-      </li>
-    </ul>
+    <h1 class="p-2 mt-2 font-semibold">Tasks And Actions</h1>
+    <div class="p-2 m-2 rounded bg-[#3a3a3a]">
+      <h2 class="font-semibold">Tasks</h2>
+      <ul class="text-[#9ea4ac] text-sm">
+        <li v-for="(task, index) in tasks" :key="index">
+          {{ task.description }}
+        </li>
+      </ul>
+    </div>
+    <div class="p-2 m-2 rounded bg-[#3a3a3a]">
+      <h2 class="font-semibold">Actions</h2>
+      <ul class="text-[#9ea4ac] text-sm">
+        <li v-for="(action, index) in actions" :key="index">
+          {{ action.description }}
+        </li>
+      </ul>
+    </div>
   </div>
 </template>

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -122,16 +122,26 @@ type Model =
 // Update
 type Msg =
   | UserGavePrompt of prompt: String
+  | DisplayPrompt of prompt: String
   | UserRequestedCodeEval of id: String * codeSnippet: String
 
 
 let sendError (model: Model) (codeSnippet: String) (err: String) : Model =
   let errMsg = "Update the code snippet to fix " ++ "\n" ++ err ++ "\n" ++ "```" ++ "\n" ++ codeSnippet ++ "\n" ++ "```"
-  update model (Msg.UserGavePrompt errMsg)
+  let newModel = update model (Msg.DisplayPrompt errMsg)
+  update newModel (Msg.UserGavePrompt errMsg)
 
 
 let update (model: Model) (msg: Msg) : Model =
   match msg with
+  | DisplayPrompt prompt ->
+    Model
+      { systemPrompt = model.systemPrompt
+        chatHistory = List.append model.chatHistory [ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) prompt]
+        codeSnippets = model.codeSnippets
+        tasks = model.tasks
+        actions = model.actions }
+
   | UserGavePrompt userPrompt ->
     // I guess, until we have cmds or something,
     // we have to deal with http calls and such in-line, like here
@@ -175,7 +185,7 @@ let update (model: Model) (msg: Msg) : Model =
           )
 
       let newChatItemsItems = [
-        ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) userPrompt
+        ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) ""
         ChatHistoryItem.BotResponse (rUnwrap(String.random 5)) botResponseParts
       ]
 

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -66,7 +66,7 @@ let openAIcompletion (prompt: String): Result<String, String> =
   | Error e -> Error ("Couldn't serialize request" ++ e)
 
 
-let parseAndSerializeProgram (userProgram: String): String =
+let parseAndSerializeProgram (userProgram: String): Result<String, String> =
   let response =
     WASM.HttpClient.request
       "POST"
@@ -74,9 +74,11 @@ let parseAndSerializeProgram (userProgram: String): String =
       []
       (String.toBytes userProgram)
 
-  response |> rUnwrap |> (fun r -> r.body) |> String.fromBytes
-
-
+  let statusCode = response |> rUnwrap |> (fun r -> r.statusCode)
+  match statusCode with
+  | 200 -> Ok (response |> rUnwrap |> (fun r -> r.body) |> String.fromBytes)
+  | 400 -> Error (response |> rUnwrap |> (fun r -> r.body) |> String.fromBytes)
+  | _ -> Error ("Unexpected response code: " ++ Int.toString statusCode)
 
 
 // TODO: in the prompt, include something like
@@ -191,7 +193,10 @@ let update (model: Model) (msg: Msg) : Model =
     | Nothing -> log "couldn't find snippet"
     | Just snippetToUpdate ->
       let parsedAndSerialized = parseAndSerializeProgram codeSnippet
-      let evalResult = (WASM.Editor.evalUserProgram parsedAndSerialized) |> rUnwrap
+      let evalResult =
+        match parsedAndSerialized with
+        | Error err ->  err
+        | Ok parsedAndSerialized -> (WASM.Editor.evalUserProgram parsedAndSerialized) |> rUnwrap
 
       let updatedCodeSnippets =
         List.append

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -126,7 +126,7 @@ type Msg =
 
 
 let sendError (model: Model) (codeSnippet: String) (err: String) : Model =
-  let errMsg = "update the code snippet to fix " ++ "\n" ++ err ++ "\n" ++ "```" ++ codeSnippet ++"```"
+  let errMsg = "Update the code snippet to fix " ++ "\n" ++ err ++ "\n" ++ "```" ++ "\n" ++ codeSnippet ++ "\n" ++ "```"
   update model (Msg.UserGavePrompt errMsg)
 
 
@@ -218,7 +218,7 @@ let update (model: Model) (msg: Msg) : Model =
               actions = model.actions }
 
         | Error err ->
-        sendError model codeSnippet err
+          sendError model codeSnippet err
 
       | Error err ->
         sendError model codeSnippet err
@@ -281,29 +281,29 @@ let initState =
 
     let demoTask = [
       Task { id = (String.random 5) |> rUnwrap
-             description = "Task: first task in progress"
+             description = "First task in progress"
              status = Status.InProgress};
 
       Task { id = (String.random 5) |> rUnwrap
-             description = "Task: second task to do"
+             description = "Second task to do"
              status = Status.Todo};
 
       Task { id = (String.random 5) |> rUnwrap
-             description = "Task: first task task done"
+             description = "Third task task done"
              status = Status.InProgress}
     ]
 
     let demoAction = [
       Action { id = (String.random 5) |> rUnwrap
-               description = "Action: first action"
+               description = "First action"
                status = Status.InProgress};
 
       Action { id = (String.random 5) |> rUnwrap
-               description = "Action: second action"
+               description = "Second action"
                status = Status.Todo};
 
       Action { id = (String.random 5) |> rUnwrap
-               description = "Action: third action"
+               description = "Third action"
                status = Status.InProgress}
     ]
 
@@ -317,9 +317,7 @@ let initState =
         [
           BotResponseItem.Text "OK - here's some code:"
           BotResponseItem.CodeSnippet demoSnippet.id
-          BotResponseItem.Text "And here are some tasks:"
           BotResponseItem.Tasks demoTask
-          BotResponseItem.Text "And here are some actions:"
           BotResponseItem.Actions demoAction
         ]
     ]

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -122,27 +122,26 @@ type Model =
 // Update
 type Msg =
   | UserGavePrompt of prompt: String
-  | DisplayPrompt of prompt: String
   | UserRequestedCodeEval of id: String * codeSnippet: String
 
 
 let sendError (model: Model) (codeSnippet: String) (err: String) : Model =
-  let errMsg = "Update the code snippet to fix " ++ "\n" ++ err ++ "\n" ++ "```" ++ "\n" ++ codeSnippet ++ "\n" ++ "```"
-  let newModel = update model (Msg.DisplayPrompt errMsg)
-  update newModel (Msg.UserGavePrompt errMsg)
+  let errMsg = "update the code snippet to fix " ++ "\n" ++ err ++ "\n" ++ "```" ++ codeSnippet ++"```"
+  update model (Msg.UserGavePrompt errMsg)
 
 
 let update (model: Model) (msg: Msg) : Model =
   match msg with
-  | DisplayPrompt prompt ->
-    Model
-      { systemPrompt = model.systemPrompt
-        chatHistory = List.append model.chatHistory [ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) prompt]
-        codeSnippets = model.codeSnippets
-        tasks = model.tasks
-        actions = model.actions }
-
   | UserGavePrompt userPrompt ->
+    let newModel =
+      Model
+        { systemPrompt = model.systemPrompt
+          chatHistory = List.append model.chatHistory [ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) userPrompt]
+          codeSnippets = model.codeSnippets
+          tasks = model.tasks
+          actions = model.actions }
+    updateStateInJS  newModel
+
     // I guess, until we have cmds or something,
     // we have to deal with http calls and such in-line, like here
     let fullPrompt = model.systemPrompt ++ userPrompt
@@ -185,7 +184,7 @@ let update (model: Model) (msg: Msg) : Model =
           )
 
       let newChatItemsItems = [
-        ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) ""
+        ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) userPrompt
         ChatHistoryItem.BotResponse (rUnwrap(String.random 5)) botResponseParts
       ]
 

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -111,7 +111,8 @@ type CodeSnippet =
   { id: String; code: String; eval: Option<String> }
 
 type Model =
-  { systemPrompt: String
+  { isLoading: Bool
+    systemPrompt: String
     chatHistory: List<ChatHistoryItem>
     codeSnippets: List<CodeSnippet>
     tasks : List<Task>
@@ -135,7 +136,8 @@ let update (model: Model) (msg: Msg) : Model =
   | UserGavePrompt userPrompt ->
     let newModel =
       Model
-        { systemPrompt = model.systemPrompt
+        { isLoading = true
+          systemPrompt = model.systemPrompt
           chatHistory = List.append model.chatHistory [ChatHistoryItem.UserPrompt (rUnwrap(String.random 5)) userPrompt]
           codeSnippets = model.codeSnippets
           tasks = model.tasks
@@ -189,7 +191,8 @@ let update (model: Model) (msg: Msg) : Model =
       ]
 
       Model
-        { systemPrompt = model.systemPrompt
+        { isLoading = false
+          systemPrompt = model.systemPrompt
           chatHistory = List.append model.chatHistory newChatItemsItems
           codeSnippets = List.append model.codeSnippets newCodeSnippets
           tasks = List.append model.tasks newtasks
@@ -220,7 +223,8 @@ let update (model: Model) (msg: Msg) : Model =
                 otherSnippets
 
           Model
-            { systemPrompt = model.systemPrompt
+            { isLoading = false
+              systemPrompt = model.systemPrompt
               chatHistory = model.chatHistory
               codeSnippets = updatedCodeSnippets
               tasks = model.tasks
@@ -332,7 +336,8 @@ let initState =
     ]
 
     Model
-      { systemPrompt = String.fromBytes response.body
+      { isLoading = false
+        systemPrompt = String.fromBytes response.body
         chatHistory = chatHistory
         codeSnippets = [demoSnippet]
         tasks = demoTask

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -198,10 +198,13 @@ let update (model: Model) (msg: Msg) : Model =
     | Nothing -> log "couldn't find snippet"
     | Just snippetToUpdate ->
       let parsedAndSerialized = parseAndSerializeProgram codeSnippet
-      let evalResult =
-        match parsedAndSerialized with
-        | Ok parsedAndSerialized ->
-          let evalPgm = (WASM.Editor.evalUserProgram parsedAndSerialized) |> rUnwrap
+      match parsedAndSerialized with
+      | Ok parsedAndSerialized ->
+        let evalPgm = (WASM.Editor.evalUserProgram parsedAndSerialized)
+
+        match evalPgm with
+        | Ok evalPgm ->
+          evalPgm
           let updatedCodeSnippets =
             List.append
                 [CodeSnippet { id = snippetToUpdate.id; code = codeSnippet; eval = Just evalPgm}]
@@ -215,9 +218,11 @@ let update (model: Model) (msg: Msg) : Model =
               actions = model.actions }
 
         | Error err ->
-          sendError model codeSnippet err
+        sendError model codeSnippet err
 
-      evalResult
+      | Error err ->
+        sendError model codeSnippet err
+
 
 /// Single point of communicating to JS host
 ///

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -125,6 +125,11 @@ type Msg =
   | UserRequestedCodeEval of id: String * codeSnippet: String
 
 
+let sendError (model: Model) (codeSnippet: String) (err: String) : Model =
+  let errMsg = "update the code snippet to fix " ++ "\n" ++ err ++ "\n" ++ "```" ++ codeSnippet ++"```"
+  update model (Msg.UserGavePrompt errMsg)
+
+
 let update (model: Model) (msg: Msg) : Model =
   match msg with
   | UserGavePrompt userPrompt ->
@@ -195,20 +200,24 @@ let update (model: Model) (msg: Msg) : Model =
       let parsedAndSerialized = parseAndSerializeProgram codeSnippet
       let evalResult =
         match parsedAndSerialized with
-        | Error err ->  err
-        | Ok parsedAndSerialized -> (WASM.Editor.evalUserProgram parsedAndSerialized) |> rUnwrap
+        | Ok parsedAndSerialized ->
+          let evalPgm = (WASM.Editor.evalUserProgram parsedAndSerialized) |> rUnwrap
+          let updatedCodeSnippets =
+            List.append
+                [CodeSnippet { id = snippetToUpdate.id; code = codeSnippet; eval = Just evalPgm}]
+                otherSnippets
 
-      let updatedCodeSnippets =
-        List.append
-          [CodeSnippet { id = snippetToUpdate.id; code = codeSnippet; eval = Just evalResult }]
-          otherSnippets
+          Model
+            { systemPrompt = model.systemPrompt
+              chatHistory = model.chatHistory
+              codeSnippets = updatedCodeSnippets
+              tasks = model.tasks
+              actions = model.actions }
 
-      Model
-        { systemPrompt = model.systemPrompt
-          chatHistory = model.chatHistory
-          codeSnippets = updatedCodeSnippets
-          tasks = model.tasks
-          actions = model.actions }
+        | Error err ->
+          sendError model codeSnippet err
+
+      evalResult
 
 /// Single point of communicating to JS host
 ///

--- a/canvases/dark-editor/system-prompt.txt
+++ b/canvases/dark-editor/system-prompt.txt
@@ -126,13 +126,14 @@ Below all types and function defined, include at least one expression to be eval
 Within the code snippets, do not add code comments.
 All code snippets should be wrapped in ``` tags.
 
-Here's an example of a prompt/response combination:
+Here's an example of a response to the following prompt:
 
 User: build a small program that models a list of People,
 a function that returns the age of a Person, then hardcode a list of people
 and return the age of each person
 
-You:
+Response:
+
 Ok, no problem.
 ```
 type Person = {


### PR DESCRIPTION
Changelog:

```
canvases/dark-editor
- Start handling errors.
```

This PR includes:
- Updating the parseAndSerializeProgram fn to use Result type for better error handling.
- Starting to handle errors ( send syntax errors and parsing errors as prompts and get the updated code snippet).
- Minor styling changes.
- Fixing the loading spinner.
- Displaying the user prompt immediately after sending it.

Current state:

https://github.com/darklang/dark/assets/87861924/29fa190f-9657-4df5-aa70-a8e304a0d9fd










