### PR TITLE
Misc improvements to dark-editor

### DIFF
--- a/backend/src/StdLibExecution/Libs/Json.fs
+++ b/backend/src/StdLibExecution/Libs/Json.fs
@@ -474,6 +474,10 @@ let fns : List<BuiltInFn> =
         (function
         | state, [ typeArg ], [ arg ] ->
 
+          // TODO: somehow collect list of TVariable -> TypeReference
+          // "'b = Int",
+          // so we can Json.serialize<'b>, if 'b is in the surrounding context
+
           try
             let types = ExecutionState.availableTypes state
             let response = writeJson (fun w -> serialize types w typeArg arg)

--- a/canvases/dark-editor-vue/src/App.vue
+++ b/canvases/dark-editor-vue/src/App.vue
@@ -41,6 +41,8 @@ darklangJSScript.addEventListener('load', async () => {
   // TODO: we don't need to expose this onace the logic in ResponseChat.vue is
   // ported to Dark.
   window.darklang = darklang
+
+  window.darklang.handleEvent({ LoadSystemPrompt: [] })
 })
 
 document.head.appendChild(darklangJSScript)

--- a/canvases/dark-editor-vue/src/global.d.ts
+++ b/canvases/dark-editor-vue/src/global.d.ts
@@ -1,5 +1,20 @@
+// This file is to inform Vue of properties on globals that it doesn't know about.
+
 interface Window {
-  Darklang: any;
-  darklang: any;
-  stateUpdated: any;
+  /**
+   * Exposed by `editor-bootstrap.js
+   *
+   * avails an `init` function to load the Darklang WASM runtime.
+   * */
+  Darklang: any
+
+  /**
+   * The interface with the Darkland WASM runtime.
+   *
+   * includes functions like `handleEvent`.
+   */
+  darklang: any
+
+  /** Function exposed to Darklang runtime to recieve updated state from Dark code. */
+  stateUpdated: any
 }

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -4,10 +4,24 @@ let log (s: String) : Unit =
   let _ = WASM.Editor.callJSFunction "console.log" [ s ]
   ()
 
+let logErr (s: String) : Unit =
+  let _ = WASM.Editor.callJSFunction "console.error" [ s ]
+  ()
+
 let rUnwrap (result: Result<'a, 'b>) : 'a =
   match result with
   | Ok s -> s
-  | Error e -> log e // TODO: this won't work if non-string
+  | Error e ->
+    // TODO: handle non-string errors with Json.serialize<'b>, or using RuntimeTypes somehow
+    // match Json.serialize<'b> e with
+    // | Ok serializedError ->
+    //   logErr (
+    //     "Couldn't unwrap Result - instead of an OK, got this Error: "
+    //     ++ serializedError
+    //   )
+    // | Error err -> logErr ("couldn't serialize error to log: " ++ err)
+
+    logErr ("Couldn't unwrap Result - instead of an OK, got this Error: " ++ e)
 
 
 // todo: throw this stuff into an OpenAI module?
@@ -130,6 +144,7 @@ type Model =
 
 // Update
 type Msg =
+  | LoadSystemPrompt
   | UserGavePrompt of prompt: String
   | UserRequestedCodeEval of id: String * codeSnippet: String
 
@@ -149,6 +164,28 @@ let sendError (model: Model) (codeSnippet: String) (err: String) : Model =
 
 let update (model: Model) (msg: Msg) : Model =
   match msg with
+  | LoadSystemPrompt ->
+    let systemPrompt =
+      WASM.HttpClient.request
+        "get"
+        "http://dark-editor.dlio.localhost:11003/system-prompt"
+        []
+        Bytes.empty
+
+    match systemPrompt with
+    | Ok response ->
+      Model
+        { isLoading = model.isLoading
+          chatHistory = model.chatHistory
+          codeSnippets = model.codeSnippets
+          tasks = model.tasks
+          actions = model.actions
+
+          // CLEANUP: update this syntax to { model with systemPrompt = systemPrompt } when we can
+          systemPrompt = response.body |> String.fromBytes }
+    | Error err -> logErr "Couldn't load system prompt"
+
+
   | UserGavePrompt userPrompt ->
     let newModel =
       Model
@@ -164,7 +201,7 @@ let update (model: Model) (msg: Msg) : Model =
 
     updateStateInJS newModel
 
-    let getTasks =
+    let getTasksPrompt =
       (WASM.HttpClient.request
         "get"
         "http://dark-editor.dlio.localhost:11003/task-creation-prompt"
@@ -179,7 +216,7 @@ let update (model: Model) (msg: Msg) : Model =
     // we have to deal with http calls and such in-line, like here
     let fullPrompt = model.systemPrompt ++ userPrompt
 
-    match openAIcompletion getTasks, openAIcompletion fullPrompt with
+    match openAIcompletion getTasksPrompt, openAIcompletion fullPrompt with
     | Ok apiResponseTasks, Ok apiResponse ->
       let taskIndex = String.indexOf_v0 apiResponseTasks "Tasks:"
 
@@ -242,7 +279,6 @@ let update (model: Model) (msg: Msg) : Model =
       log "error getting tasks and response " ++ err1 ++ " " ++ err2
 
 
-
   | UserRequestedCodeEval id codeSnippet ->
     // split this into 2 groups - the one we're updating, and the rest
     let (snippetToUpdate, otherSnippets) =
@@ -302,6 +338,8 @@ let updateStateInJS (newState: Model) : Result<Unit, String> =
 ///
 /// Listen for events from the JS host, and update the state accordingly.
 let handleEvent (evt: String) : Result<String, String> =
+  log ("handling event" ++ evt)
+
   match Json.parse<Msg> evt with
   | Ok msg ->
     match WASM.Editor.getState<Model> () with
@@ -323,20 +361,8 @@ let handleEvent (evt: String) : Result<String, String> =
 
 
 // Init
-// (things to run on startup, before accepting any events
-//  the initial state is set to the result of the final expr)
-let systemPrompt =
-  WASM.HttpClient.request
-    "get"
-    "http://dark-editor.dlio.localhost:11003/system-prompt"
-    []
-    Bytes.empty
-
-1 + 2 // useless -- just to prove we can
-
-let initState =
-  match systemPrompt with
-  | Ok response ->
+let init () : Model =
+  let initState =
     let demoSnippet =
       CodeSnippet
         { id = (String.random 5) |> rUnwrap
@@ -362,24 +388,15 @@ let initState =
 
     Model
       { isLoading = false
-        systemPrompt = String.fromBytes response.body
+        systemPrompt = "Loading..."
         chatHistory = chatHistory
         codeSnippets = [ demoSnippet ]
         tasks = []
         actions = demoAction }
 
-  | Error err ->
-    Model
-      { systemPrompt = String.fromBytes "nope"
-        chatHistory = [] }
+  updateStateInJS initState
 
-updateStateInJS initState
-
-initState
-
-
-
-
+  initState
 
 
 

--- a/canvases/dark-editor/main.dark
+++ b/canvases/dark-editor/main.dark
@@ -18,12 +18,8 @@ let _handler _req =
   let body =
     match file with
     | Ok f -> f
-    | Error _ -> Bytes.empty
 
-  PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
-    (body)
-    [ ("Content-Type", "text/html") ]
-    200
+  PACKAGE.Darklang.Stdlib.Http.responseWithHtml (String.fromBytes body) 200
 
 [<HttpHandler("GET", "/assets/:path")>]
 let _handler _req =
@@ -80,16 +76,8 @@ let _handler _req =
   | Ok program ->
     let types = Option.withDefault (Dict.get program "types") "[]"
     let fns = Option.withDefault (Dict.get program "fns") "[]"
-    let exprs = Option.withDefault (Dict.get program "exprs") "[]"
 
-    let json =
-      "{ \"types\": "
-      ++ types
-      ++ ", \"fns\": "
-      ++ fns
-      ++ ", \"exprs\": "
-      ++ exprs
-      ++ "}"
+    let json = "{ \"types\": " ++ types ++ ", \"fns\": " ++ fns ++ "}"
 
     PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
       (String.toBytes json)

--- a/packages/darklang/stdlib/http.dark
+++ b/packages/darklang/stdlib/http.dark
@@ -48,7 +48,7 @@ module Darklang =
         : PACKAGE.Darklang.Stdlib.Http.Response =
         PACKAGE.Darklang.Stdlib.Http.Response
           { statusCode = statusCode
-            headers = [ "Content-Type", "text/html; charset=utf-8" ]
+            headers = [ ("Content-Type", "text/html; charset=utf-8") ]
             body = body |> String.toBytes }
 
 
@@ -61,7 +61,7 @@ module Darklang =
         : PACKAGE.Darklang.Stdlib.Http.Response =
         PACKAGE.Darklang.Stdlib.Http.Response
           { statusCode = statusCode
-            headers = [ "Content-Type", "text/plain; charset=utf-8" ]
+            headers = [ ("Content-Type", "text/plain; charset=utf-8") ]
             body = String.toBytes text }
 
       /// Returns a <type Response> that can be returned from an HTTP handler to
@@ -73,7 +73,7 @@ module Darklang =
         : PACKAGE.Darklang.Stdlib.Http.Response =
         PACKAGE.Darklang.Stdlib.Http.Response
           { statusCode = statusCode
-            headers = [ "Content-Type", "application/json" ]
+            headers = [ ("Content-Type", "application/json") ]
             body = String.toBytes json }
 
       /// Returns a <type Response> that can be returned from an HTTP handler to
@@ -81,7 +81,7 @@ module Darklang =
       let redirectTo (url: String) : PACKAGE.Darklang.Stdlib.Http.Response =
         PACKAGE.Darklang.Stdlib.Http.Response
           { statusCode = 302
-            headers = [ "Location", url ]
+            headers = [ ("Location", url) ]
             body = Bytes.empty }
 
       /// Returns a <type Response> that can be returned from an HTTP handler to
@@ -149,13 +149,13 @@ module Darklang =
             $"{DateTime.dayOfWeek e}, {DateTime.day e} {DateTime.month e} {DateTime.year e} {DateTime.hour e}:{DateTime.minute e}:{DateTime.second} GMT"
 
           let cookie =
-            [ "Expires", expires
-              "Max-Age", cookie.maxAge |> Int.toString
-              "Domain", cookie.domain
-              "Path", cookie.path
-              "Secure", cookie.secure |> Bool.toString
-              "HttpOnly", cookie.httpOnly |> Bool.toString
-              "SameSite", cookie.sameSite ]
+            [ ("Expires", expires)
+              ("Max-Age", cookie.maxAge |> Int.toString)
+              ("Domain", cookie.domain)
+              ("Path", cookie.path)
+              ("Secure", cookie.secure |> Bool.toString)
+              ("HttpOnly", cookie.httpOnly |> Bool.toString)
+              ("SameSite", cookie.sameSite) ]
             |> List.filterMap (fun (k, v) -> if v == "" then Nothing else Just(k, v))
             |> List.map (fun (k, v) -> k ++ "=" ++ v)
             |> String.join "; "

--- a/scripts/prep-experiment1
+++ b/scripts/prep-experiment1
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-./scripts/run-canvas-hack load-from-disk dark-serve-static
-
-./scripts/run-canvas-hack load-from-disk dark-editor
+./scripts/run-canvas-hack load-from-disk dark-serve-static \
+  & ./scripts/run-canvas-hack load-from-disk dark-editor \
+  & npm run build --prefix canvases/dark-editor-vue


### PR DESCRIPTION
No changelog

- extracts init logic to a separate fn
- slightly improved error-handling
- fix some issues caused by our parser apparently parsing `[1, 2]` as `[1,2]` rather than `[(1, 2)]`)