### PR TITLE
Deleting Record.set and replacing usage to new record update syntax

### DIFF
--- a/backend/src/StdLibExecution/Libs/Dict.fs
+++ b/backend/src/StdLibExecution/Libs/Dict.fs
@@ -396,27 +396,6 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    // TYPESCLEANUP - just a quick hack since we don't have record setting syntax
-    { name = fn "Record" "set" 0
-      typeParams = []
-      parameters =
-        [ Param.make "record" (TVariable "a") ""
-          Param.make "key" TString ""
-          Param.make "val" varA "" ]
-      returnType = (TVariable "a")
-      description =
-        "Returns a copy of <param record> with the <param key> set to <param val>"
-      fn =
-        (function
-        | _, _, [ DRecord(typeName, o); DString k; v ] ->
-          Ply(DRecord(typeName, Map.add k v o))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplemented
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-
     { name = fn "Dict" "set" 0
       typeParams = []
       parameters =

--- a/backend/testfiles/execution/httpclient.tests
+++ b/backend/testfiles/execution/httpclient.tests
@@ -148,7 +148,7 @@ module BadSSL =
 // Basic request works including headers
 (let response = (HttpClient.request "get" "https://httpbin.org/status/200" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter(fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/_request-content-type-empty.test
+++ b/backend/testfiles/httpclient/v0/_request-content-type-empty.test
@@ -15,7 +15,7 @@ Hello back
 (let reqHeaders = [("Content-Type", "")]
  let response = (HttpClient.request "get" "http://URL" reqHeaders Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     {
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/_response-cookie.test
+++ b/backend/testfiles/httpclient/v0/_response-cookie.test
@@ -18,7 +18,7 @@ Hello back
 // jar", as presumably all other tests will fail if it does.
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/_response-redirect-304.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-304.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 304
       headers =

--- a/backend/testfiles/httpclient/v0/_response-redirect-destination.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-destination.test
@@ -16,7 +16,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/_response-redirect-to-same-place-absolute.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-to-same-place-absolute.test
@@ -12,7 +12,7 @@ Location: http://URL
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
   HttpClient.Response
     { statusCode = 302
       headers =

--- a/backend/testfiles/httpclient/v0/_uri-with-auth-both.test
+++ b/backend/testfiles/httpclient/v0/_uri-with-auth-both.test
@@ -16,7 +16,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://user:password@URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/_uri-with-path-fragment.test
+++ b/backend/testfiles/httpclient/v0/_uri-with-path-fragment.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://URL?q=5#row=5-👨‍👩‍👧‍👦" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/basic-delete.test
+++ b/backend/testfiles/httpclient/v0/basic-delete.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "delete" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-get.test
+++ b/backend/testfiles/httpclient/v0/basic-get.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-head-returns-body.test
+++ b/backend/testfiles/httpclient/v0/basic-head-returns-body.test
@@ -17,7 +17,7 @@ Here's a body!
 // clients successfully ignore it.
 (let response = (HttpClient.request "head" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-head.test
+++ b/backend/testfiles/httpclient/v0/basic-head.test
@@ -13,7 +13,7 @@ Content-Length: 568
 [test]
 (let response = (HttpClient.request "head" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-options.test
+++ b/backend/testfiles/httpclient/v0/basic-options.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "options" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-patch.test
+++ b/backend/testfiles/httpclient/v0/basic-patch.test
@@ -16,7 +16,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "patch" "http://URL" [("Content-Type", "application/json; charset=utf-8")] ("5" |> String.toBytes)) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-post.test
+++ b/backend/testfiles/httpclient/v0/basic-post.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "post" "http://URL" [] ("-1" |> String.toBytes)) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-put.test
+++ b/backend/testfiles/httpclient/v0/basic-put.test
@@ -17,7 +17,7 @@ Hello back
 (let reqHeaders = [("content-type", "application/json; charset=utf-8")]
  let response = (HttpClient.request "put" "http://URL" reqHeaders ("string" |> String.toBytes)) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/request-content-type-unknown-charset.test
+++ b/backend/testfiles/httpclient/v0/request-content-type-unknown-charset.test
@@ -17,7 +17,7 @@ Hello back
 (let reqHeaders = [("Content-Type", "application/json; charset=invalid")]
  let response = (HttpClient.request "get" "http://URL" reqHeaders Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/request-content-type-unknown-ct.test
+++ b/backend/testfiles/httpclient/v0/request-content-type-unknown-ct.test
@@ -17,7 +17,7 @@ Hello back
 (let reqHeaders = [("Content-Type", "x/notAValidContentType")]
  let response = (HttpClient.request "get" "http://URL" reqHeaders Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/request-form-simple.test
+++ b/backend/testfiles/httpclient/v0/request-form-simple.test
@@ -15,7 +15,7 @@ Content-Length: 0
 (let reqHeaders = [("Content-type", "application/x-www-form-urlencoded")]
  let response = (HttpClient.request "get" "http://URL" reqHeaders Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/request-query-param-float.test
+++ b/backend/testfiles/httpclient/v0/request-query-param-float.test
@@ -14,7 +14,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://URL?f=5.7&n=-0.0&l=1231325345345345.34534534634634634" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/request-query-param-int.test
+++ b/backend/testfiles/httpclient/v0/request-query-param-int.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://URL?i=5&n=-1" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/response-header-duplicate.test
+++ b/backend/testfiles/httpclient/v0/response-header-duplicate.test
@@ -16,7 +16,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-300.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-300.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 300
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-301.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-301.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 301
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-302.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-302.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 302
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-303.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-303.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 303
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-305.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-305.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 305
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-306.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-306.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 306
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-307.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-307.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 307
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-308.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-308.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 308
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-to-file.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-to-file.test
@@ -12,7 +12,7 @@ Location: file:////etc/passwd
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
   HttpClient.Response
     { statusCode = 301
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-charset.test
@@ -21,7 +21,7 @@ Content-Length: LENGTH
  let reqBody = { var1 = 2; var2 = [] }
  let response = (HttpClient.request "post" "http://URL" reqBody {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-Record.set_v0 response "headers" respHeaders) =
+{response with headers = respHeaders}) =
    HttpClient.Response
     { body = ""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-no-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-no-charset.test
@@ -18,7 +18,7 @@ var1=2&var2=[]
 (let reqHeaders = { "Content-type" = "application/x-www-form-urlencoded" }
  let response = (HttpClient.request "post" "http://URL" {x=6; y=false; z = "str"} {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-Record.set_v0 response "headers" respHeaders) =
+{response with headers = respHeaders}) =
    HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-get.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-get.test
@@ -17,7 +17,7 @@ Content-Length: LENGTH
 (let reqHeaders = { "Content-length" = "6"; }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post-bad.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post-bad.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let reqHeaders = { "Content-length" = "6" }
  let response = (HttpClient.request "post" "http://URL" "morethansix" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let reqHeaders = { "Content-length" = "6" }
  let response = (HttpClient.request "post" "http://URL" "morethansix" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-default.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-default.test
@@ -17,7 +17,7 @@ Content-Length: LENGTH
 (let reqHeaders = { "Accept" = "*"; "Accept-Encoding" = "invalid" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-header-string.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-string.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let reqHeaders = { "some_header" = "string" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-multipart-form-with-body-and-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/request-multipart-form-with-body-and-charset.test
@@ -17,7 +17,7 @@ Content-Length: LENGTH
 (let reqHeaders = { "Content-type" = "multipart/form-data" }
  let response = (HttpClient.request "post" "http://URL" [] {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-Record.set_v0 response "headers" respHeaders) =
+{response with headers = respHeaders}) =
   HttpClient.Response
     { body = ""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-list.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-list.test
@@ -17,7 +17,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://URL" { l = [1;2;"a string"; [6]] } HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
   HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-null.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-null.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://URL" { x = null } HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-basic.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-basic.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = { value = "some-string" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-key.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = { "😭👨‍👩‍👧‍👦" = "emoji" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-value.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let query = { emoji = "😭👨‍👩‍👧‍👦" }
  let response = (HttpClient.request "get" "http://URL" query {}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-key.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = Dict.set {} "" "empty"
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-value.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = { empty = "" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-values.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-values.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let query = { empty = ""; notEmpty = "some value" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-key.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = { "[]()`~*&^%$#@!:"<>?,./;'-=_+" = "control" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-value.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = { punctuation = "[]()`~*&^%$#@!:\"<>?,./;'-=_+" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-key.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = { "with spaces" = "x" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-value.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let query = { x = "with spaces" }
  let response = (HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-body-invalid-string.test
+++ b/backend/testfiles/httpclient/v0/todo/response-body-invalid-string.test
@@ -16,7 +16,7 @@ RANDOM_BYTES
 // RANDOM_BYTES filled in by the test suite
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "utf-8 decoding error"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-body-unicode.test
+++ b/backend/testfiles/httpclient/v0/todo/response-body-unicode.test
@@ -15,7 +15,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = """👱👱🏻👱🏼👱🏽👱🏾👱🏿", "👨‍❤️‍💋‍👨", "﷽﷽﷽"""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-content-encoding-brotli.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-encoding-brotli.test
@@ -17,7 +17,7 @@ Content-Encoding: br
 [test]
 (let response = (HttpClient.request "get" "http://URL/" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-content-encoding-deflate.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-encoding-deflate.test
@@ -17,7 +17,7 @@ Content-Encoding: deflate
 [test]
 (let response = (HttpClient.request "get" "http://URL/" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-content-encoding-gzipped.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-encoding-gzipped.test
@@ -17,7 +17,7 @@ Content-Encoding: gzip
 [test]
 (let response = (HttpClient.request "get" "http://URL/" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-content-type-invalid.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-type-invalid.test
@@ -17,7 +17,7 @@ Content-Length: LENGTH
 (let reqHeaders = {}
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-form-encoded.test
+++ b/backend/testfiles/httpclient/v0/todo/response-form-encoded.test
@@ -18,7 +18,7 @@ var1=2&var2=[]
 (let reqHeaders = { "Content-type" = "application/x-www-form-urlencoded" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-Record.set_v0 response "headers" respHeaders) =
+{response with headers = respHeaders}) =
    HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-form-with-body-and-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/response-form-with-body-and-charset.test
@@ -18,7 +18,7 @@ var1=2&var2=[]
 (let reqHeaders = { "Content-type" = "application/x-www-form-urlencoded" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-Record.set_v0 response "headers" respHeaders) =
+{response with headers = respHeaders}) =
    HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-form-with-body-no-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/response-form-with-body-no-charset.test
@@ -19,7 +19,7 @@ var1=2&var2=[]
 // string comes out.
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-header-empty.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-empty.test
@@ -17,7 +17,7 @@ Some-Header:
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-header-int.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-int.test
@@ -17,7 +17,7 @@ Some-Header: 5
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-header-lowercase.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-lowercase.test
@@ -19,7 +19,7 @@ OneVVord: MixedCase
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-header-object.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-object.test
@@ -17,7 +17,7 @@ Some-Header: {}
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-header-string.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-string.test
@@ -17,7 +17,7 @@ Some-Header: string
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset-dest.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset-dest.test
@@ -18,7 +18,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset.test
@@ -16,7 +16,7 @@ Date: xxx, xx xxx xxxx xx:xx:xx xxx
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-delete.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-delete.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-destination
  | Ok _ -> "fail"
  | Error response ->
     let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-    Record.set_v0 response "headers" respHeaders) =
+    {response with headers = respHeaders}) =
   HttpClient.Response
     { body = ""
       statusCode = 302

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-no-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/x-www-form-urlencoded"}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-with-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "get" "http://URL" {} {"Content-Type" = "application/x-www-form-urlencoded"}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-no-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/json"}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-with-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "get" "http://URL" {} {"Content-Type" = "application/json"}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-no-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "post" "http://URL" "" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-with-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-no-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "post" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8")}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-with-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "get" "http://URL" {} {("content-type", "text/plain; charset=utf-8")}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-no-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "text/askdjnkajsfunr"}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-with-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "get" "http://URL" {} {"Content-Type" = "text/askdjnkajsfunr"}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-no-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "put" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8")}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-with-body.test
@@ -19,7 +19,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (HttpClient.request "put" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8")}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-auth-header.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-auth-header.test
@@ -20,7 +20,7 @@ Redirect destination reached with auth
 (let reqHeaders = { Authorization = "Basic: bWU6b3BlbnNlc2FtZQ==" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached with auth"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-cookies.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-cookies.test
@@ -20,7 +20,7 @@ Redirect destination reached with cookies
 (let reqHeaders = { Cookie = "yummy_cookie=choco; tasty_cookie=strawberry" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached with cookies"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-query-params.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-query-params.test
@@ -17,7 +17,7 @@ Redirect destination reached with params
 [test]
 (let response = (HttpClient.request "get" "http://URL" { value = "x" } {}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached with params"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-no-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-form-urlencoded-content-type-no-b
 [test]
 (let response = (HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/x-www-form-urlencoded" }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-with-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-form-urlencoded-content-type-with
 [test]
 (let response = (HttpClient.request "post" "http://URL" "body" {} {"Content-Type" = "application/x-www-form-urlencoded" }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-no-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-json-content-type-no-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/json" }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-with-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-json-content-type-with-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "body" {} {"Content-Type" = "application/json" }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-no-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-no-content-type-no-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-with-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-no-content-type-with-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "body" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-no-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-plain-content-type-no-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8") }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-with-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-plain-content-type-with-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "body" {} {("content-type", "text/plain; charset=utf-8") }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-no-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-weird-content-type-no-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "text/askdjnkajsfunr" }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-with-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-post-with-weird-content-type-with-body
 [test]
 (let response = (HttpClient.request "post" "http://URL" "body" {} {"Content-Type" = "text/askdjnkajsfunr" }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-no-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-put-with-content-type-no-body
 [test]
 (let response = (HttpClient.request "put" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8") }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-with-body.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-put-with-content-type-with-body
 [test]
 (let response = (HttpClient.request "put" "http://URL" "body" {} {("content-type", "text/plain; charset=utf-8") }) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-absolute.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-absolute.test
@@ -15,7 +15,7 @@ Location: https://httpbin.org/status/200
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> Dict.remove_v0 "date"
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
       { body = ""
         statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-200.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-200.test
@@ -14,7 +14,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (HttpClient.request "get" "http://URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-404.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-404.test
@@ -16,7 +16,7 @@ Location: /v0/invalid-url
  | Ok -> "fail"
  | Error response ->
     let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-    Record.set_v0 response "headers" respHeaders) =
+    {response with headers = respHeaders}) =
   HttpClient.Response
     { body = "intentionally not found"
       statusCode = 404

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-same-place-relative.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-same-place-relative.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-to-same-place-relative
  | Ok -> "fail"
  | Error response ->
     let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
-    Record.set_v0 response "headers" respHeaders) =
+    {response with headers = respHeaders}) =
   HttpClient.Response
     { body = ""
       statusCode = 302

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-with-auth-header.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-with-auth-header.test
@@ -17,7 +17,7 @@ Location: /v0/response-redirect-dest-with-auth-header
 (let reqHeaders = { Authorization = "Basic: bWU6b3BlbnNlc2FtZQ==" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached with auth"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-with-cookies.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-with-cookies.test
@@ -17,7 +17,7 @@ Location: /v0/response-redirect-dest-with-cookies
 (let reqHeaders = { Cookie = "yummy_cookie=choco; tasty_cookie=strawberry" }
  let response = (HttpClient.request "get" "http://URL" {} reqHeaders) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached with cookies"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-with-query-params.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-with-query-params.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-dest-with-query-params?value=x
 [test]
 (let response = (HttpClient.request "get" "http://URL" { value = "x" } {}) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "Redirect destination reached with params"
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-password.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-password.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://:pa👨‍👩‍👧‍👦ss@URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-username.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-username.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://us👨‍👩‍👧‍👦er@URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-password.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-password.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://:password@URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username-with-colon.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username-with-colon.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://user:@URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 [test]
 (let response = (HttpClient.request "get" "http://user@URL" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-plus-header.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-plus-header.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let headers = Dict { Authorization = "Basic: bWU6b3BlbnNlc2FtZQ==" }
  let response = (HttpClient.request "get" "http://user:password@URL" {} headers) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200

--- a/backend/testfiles/httpclient/v0/uri-with-path-basic.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-basic.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://URL/some/2path/hyphen-ated/under_scored" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers = [

--- a/backend/testfiles/httpclient/v0/uri-with-path-dots.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-dots.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://URL/some/../2path/hyphen-ated/under_scored/" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/uri-with-path-slash.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-slash.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (HttpClient.request "get" "http://URL/" [] Bytes.empty) |> Test.unwrap
  let respHeaders = response.headers |> List.filter (fun h -> Tuple2.first h != "date")
- Record.set_v0 response "headers" respHeaders) =
+ {response with headers = respHeaders}) =
    HttpClient.Response
     { statusCode = 200
       headers =


### PR DESCRIPTION
1. Delete `Record.set` method  
2. Replase usage from Records.set to {.. with } e.g.: 
```fsharp
// was
Record.set_v0 response "headers" respHeaders
// became
{response with headers = respHeaders}
```