### PR TITLE
Update Dark ProgramTypes given internal changes and misc work on the editor

### DIFF
--- a/backend/experiments/LibExperimentalExecution/LibExperimentalExecution.fsproj
+++ b/backend/experiments/LibExperimentalExecution/LibExperimentalExecution.fsproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="../../src/LibBackend/LibBackend.fsproj" />
     <ProjectReference Include="../../src/StdLibCloudExecution/StdLibCloudExecution.fsproj" />
     <ProjectReference Include="../StdLibExperimental/StdLibExperimental.fsproj" />
+    <ProjectReference Include="../../src/StdLibDarkInternal/StdLibDarkInternal.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/backend/experiments/LibExperimentalExecution/RealExperimentalExecution.fs
+++ b/backend/experiments/LibExperimentalExecution/RealExperimentalExecution.fs
@@ -28,44 +28,41 @@ let (builtInFns, builtInTypes) =
     []
 
 
-let packageFns : Lazy<Task<Map<RT.FnName.Package, RT.PackageFn.T>>> =
-  lazy
-    (task {
-      let! packages = PackageManager.allFunctions ()
+let packageFns () : Task<Map<RT.FnName.Package, RT.PackageFn.T>> =
+  (task {
+    let! packages = PackageManager.allFunctions ()
 
-      return
-        packages
-        |> List.map (fun (f : PT.PackageFn.T) ->
-          (f.name |> PT2RT.FnName.Package.toRT, PT2RT.PackageFn.toRT f))
-        |> Map.ofList
-    })
+    return
+      packages
+      |> List.map (fun (f : PT.PackageFn.T) ->
+        (f.name |> PT2RT.FnName.Package.toRT, PT2RT.PackageFn.toRT f))
+      |> Map.ofList
+  })
 
-let packageTypes : Lazy<Task<Map<RT.TypeName.Package, RT.PackageType.T>>> =
-  lazy
-    (task {
-      let! packages = PackageManager.allTypes ()
+let packageTypes () : Task<Map<RT.TypeName.Package, RT.PackageType.T>> =
+  (task {
+    let! packages = PackageManager.allTypes ()
 
-      return
-        packages
-        |> List.map (fun (t : PT.PackageType.T) ->
-          (t.name |> PT2RT.TypeName.Package.toRT, PT2RT.PackageType.toRT t))
-        |> Map.ofList
-    })
+    return
+      packages
+      |> List.map (fun (t : PT.PackageType.T) ->
+        (t.name |> PT2RT.TypeName.Package.toRT, PT2RT.PackageType.toRT t))
+      |> Map.ofList
+  })
 
-let libraries : Lazy<Task<RT.Libraries>> =
-  lazy
-    (task {
-      let! packageFns = Lazy.force packageFns
-      let! packageTypes = Lazy.force packageTypes
-      // TODO: this keeps a cached version so we're not loading them all the time.
-      // Of course, this won't be up to date if we add more functions. This should be
-      // some sort of LRU cache.
-      return
-        { builtInTypes = builtInTypes |> Map.fromListBy (fun typ -> typ.name)
-          builtInFns = builtInFns |> Map.fromListBy (fun fn -> fn.name)
-          packageFns = packageFns
-          packageTypes = packageTypes }
-    })
+let libraries () : Task<RT.Libraries> =
+  (task {
+    let! packageFns = packageFns ()
+    let! packageTypes = packageTypes ()
+    // TODO: this keeps a cached version so we're not loading them all the time.
+    // Of course, this won't be up to date if we add more functions. This should be
+    // some sort of LRU cache.
+    return
+      { builtInTypes = builtInTypes |> Map.fromListBy (fun typ -> typ.name)
+        builtInFns = builtInFns |> Map.fromListBy (fun fn -> fn.name)
+        packageFns = packageFns
+        packageTypes = packageTypes }
+  })
 
 let createState
   (traceID : AT.TraceID.T)
@@ -75,7 +72,7 @@ let createState
   (tracing : RT.Tracing)
   : Task<RT.ExecutionState> =
   task {
-    let! libraries = Lazy.force libraries
+    let! libraries = libraries ()
 
     let extraMetadata (state : RT.ExecutionState) : Metadata =
       [ "tlid", tlid
@@ -169,6 +166,6 @@ let reexecuteFunction
 /// Ensure library is ready to be called. Throws if it cannot initialize.
 let init () : Task<unit> =
   task {
-    let! (_ : RT.Libraries) = Lazy.force libraries
+    let! (_ : RT.Libraries) = libraries ()
     return ()
   }

--- a/backend/experiments/LibExperimentalExecution/RealExperimentalExecution.fs
+++ b/backend/experiments/LibExperimentalExecution/RealExperimentalExecution.fs
@@ -22,7 +22,8 @@ let (builtInFns, builtInTypes) =
   LibExecution.StdLib.combine
     [ StdLibExecution.StdLib.contents
       StdLibCloudExecution.StdLib.contents
-      StdLibExperimental.StdLib.contents ]
+      StdLibExperimental.StdLib.contents
+      StdLibDarkInternal.StdLib.contents ]
     []
     []
 

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -2,6 +2,7 @@
 module LibExecution.ProgramTypes
 
 open Prelude
+
 /// Used to name where type/function/etc lives, eg a BuiltIn module, a User module,
 /// or a Package module.
 module FQName =

--- a/backend/src/LibRealExecution/RealExecution.fs
+++ b/backend/src/LibRealExecution/RealExecution.fs
@@ -26,48 +26,45 @@ let contents : LibExecution.StdLib.Contents =
     []
     []
 
-let packageFns : Lazy<Task<Map<RT.FnName.Package, RT.PackageFn.T>>> =
-  lazy
-    (task {
-      let! packages = PackageManager.allFunctions ()
+let packageFns : Task<Map<RT.FnName.Package, RT.PackageFn.T>> =
+  (task {
+    let! packages = PackageManager.allFunctions ()
 
-      return
-        packages
-        |> List.map (fun (f : PT.PackageFn.T) ->
-          (f.name |> PT2RT.FnName.Package.toRT, PT2RT.PackageFn.toRT f))
-        |> Map.ofList
-    })
+    return
+      packages
+      |> List.map (fun (f : PT.PackageFn.T) ->
+        (f.name |> PT2RT.FnName.Package.toRT, PT2RT.PackageFn.toRT f))
+      |> Map.ofList
+  })
 
-let packageTypes : Lazy<Task<Map<RT.TypeName.Package, RT.PackageType.T>>> =
-  lazy
-    (task {
-      let! packages = PackageManager.allTypes ()
+let packageTypes : Task<Map<RT.TypeName.Package, RT.PackageType.T>> =
+  (task {
+    let! packages = PackageManager.allTypes ()
 
-      return
-        packages
-        |> List.map (fun (t : PT.PackageType.T) ->
-          (t.name |> PT2RT.TypeName.Package.toRT, PT2RT.PackageType.toRT t))
-        |> Map.ofList
-    })
+    return
+      packages
+      |> List.map (fun (t : PT.PackageType.T) ->
+        (t.name |> PT2RT.TypeName.Package.toRT, PT2RT.PackageType.toRT t))
+      |> Map.ofList
+  })
 
-let libraries : Lazy<Task<RT.Libraries>> =
-  lazy
-    (task {
-      let! packageFns = Lazy.force packageFns
-      let! packageTypes = Lazy.force packageTypes
+let libraries : Task<RT.Libraries> =
+  (task {
+    let! packageFns = packageFns
+    let! packageTypes = packageTypes
 
-      let fns = contents |> Tuple2.first |> Map.fromListBy (fun fn -> fn.name)
-      let types = contents |> Tuple2.second |> Map.fromListBy (fun typ -> typ.name)
+    let fns = contents |> Tuple2.first |> Map.fromListBy (fun fn -> fn.name)
+    let types = contents |> Tuple2.second |> Map.fromListBy (fun typ -> typ.name)
 
-      // TODO: this keeps a cached version so we're not loading them all the time.
-      // Of course, this won't be up to date if we add more functions. This should be
-      // some sort of LRU cache.
-      return
-        { builtInTypes = types
-          builtInFns = fns
-          packageFns = packageFns
-          packageTypes = packageTypes }
-    })
+    // TODO: this keeps a cached version so we're not loading them all the time.
+    // Of course, this won't be up to date if we add more functions. This should be
+    // some sort of LRU cache.
+    return
+      { builtInTypes = types
+        builtInFns = fns
+        packageFns = packageFns
+        packageTypes = packageTypes }
+  })
 
 let createState
   (traceID : AT.TraceID.T)
@@ -77,7 +74,7 @@ let createState
   (tracing : RT.Tracing)
   : Task<RT.ExecutionState> =
   task {
-    let! libraries = Lazy.force libraries
+    let! libraries = libraries
 
     let extraMetadata (state : RT.ExecutionState) : Metadata =
       [ "tlid", tlid
@@ -172,6 +169,6 @@ let reexecuteFunction
 /// Ensure library is ready to be called. Throws if it cannot initialize.
 let init () : Task<unit> =
   task {
-    let! (_ : RT.Libraries) = Lazy.force libraries
+    let! (_ : RT.Libraries) = libraries
     return ()
   }

--- a/backend/src/LocalExec/Libs/Packages.fs
+++ b/backend/src/LocalExec/Libs/Packages.fs
@@ -65,6 +65,7 @@ let fns : List<BuiltInFn> =
             do!
               Sql.query "DELETE FROM package_functions_v0"
               |> Sql.executeStatementAsync
+            do! Sql.query "DELETE FROM package_types_v0" |> Sql.executeStatementAsync
             return DUnit
           }
         | _ -> incorrectArgs ()

--- a/backend/src/StdLibDarkInternal/Helpers/ProgramTypesToDarkTypes.fs
+++ b/backend/src/StdLibDarkInternal/Helpers/ProgramTypesToDarkTypes.fs
@@ -517,7 +517,7 @@ module UserFunction =
 
   let toDT (userFn : PT.UserFunction.T) : Dval =
     DRecord(
-      ptTyp [] "UserFunction" 0,
+      ptTyp [ "UserFunction" ] "T" 0,
       Map
         [ "tlid", DInt(int64 userFn.tlid)
           "name", FnName.UserProgram.toDT userFn.name

--- a/backend/src/StdLibDarkInternal/Libs/Canvases.fs
+++ b/backend/src/StdLibDarkInternal/Libs/Canvases.fs
@@ -171,6 +171,7 @@ let fns : List<BuiltInFn> =
               |> List.map PT2DT.UserType.toDT
               |> DList
 
+            let fns =
             // let dbs =
             //   Map.values canvas.dbs
             //   |> Seq.toList

--- a/backend/src/StdLibDarkInternal/Libs/Canvases.fs
+++ b/backend/src/StdLibDarkInternal/Libs/Canvases.fs
@@ -172,6 +172,11 @@ let fns : List<BuiltInFn> =
               |> DList
 
             let fns =
+              canvas.userFunctions
+              |> Map.values
+              |> Seq.toList
+              |> List.map PT2DT.UserFunction.toDT
+              |> DList
             // let dbs =
             //   Map.values canvas.dbs
             //   |> Seq.toList

--- a/backend/src/StdLibDarkInternal/Libs/Canvases.fs
+++ b/backend/src/StdLibDarkInternal/Libs/Canvases.fs
@@ -204,7 +204,10 @@ let fns : List<BuiltInFn> =
             //   |> DList
 
             return
-              DRecord(FQName.BuiltIn(typ "Program" 0), Map [ "types", types ])
+              DRecord(
+                FQName.BuiltIn(typ "Program" 0),
+                Map [ "types", types; "fns", fns ]
+              )
               |> Ok
               |> DResult
           }

--- a/backend/src/StdLibDarkInternal/StdLibDarkInternal.fsproj
+++ b/backend/src/StdLibDarkInternal/StdLibDarkInternal.fsproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="../Prelude/Prelude.fsproj" />
     <ProjectReference Include="../LibExecution/LibExecution.fsproj" />
     <ProjectReference Include="../LibBackend/LibBackend.fsproj" />
+    <ProjectReference Include="../Parser/Parser.fsproj" />
     <ProjectReference Include="../ClientTypes2BackendTypes/ClientTypes2BackendTypes.fsproj" />
   </ItemGroup>
   <ItemGroup>

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -124,7 +124,7 @@ let libraries : Lazy<Task<RT.Libraries>> =
       let (fns, types) =
         LibExecution.StdLib.combine
           [ LibTest.contents
-            LibRealExecution.RealExecution.contents
+            LibRealExecution.RealExecution.builtins
             StdLibCli.StdLib.contents ]
           []
           []

--- a/canvases/dark-editor-vue/src/App.vue
+++ b/canvases/dark-editor-vue/src/App.vue
@@ -3,7 +3,8 @@ import { ref } from 'vue'
 
 import { fromSerializedDarkModel, type Model } from './types'
 import Header from './components/Header.vue'
-import ConversationView from './views/ConversationView.vue'
+// import ConversationView from './views/ConversationView.vue'
+import MainView from './views/MainView.vue'
 
 let init: Model = {
   isLoading: false,
@@ -12,6 +13,7 @@ let init: Model = {
   codeSnippets: [],
   tasks: [],
   actions: [],
+  functions: [],
 }
 
 // Set initial state; listen for state updates from Dark
@@ -51,6 +53,7 @@ document.head.appendChild(darklangJSScript)
 <template>
   <div class="h-screen overflow-hidden">
     <Header />
-    <ConversationView v-bind:state="state" />
+    <!-- <ConversationView v-bind:state="state" /> -->
+    <MainView v-bind:state="state" />
   </div>
 </template>

--- a/canvases/dark-editor-vue/src/App.vue
+++ b/canvases/dark-editor-vue/src/App.vue
@@ -14,6 +14,7 @@ let init: Model = {
   tasks: [],
   actions: [],
   functions: [],
+  types: [],
 }
 
 // Set initial state; listen for state updates from Dark

--- a/canvases/dark-editor-vue/src/components/Conversation.vue
+++ b/canvases/dark-editor-vue/src/components/Conversation.vue
@@ -48,6 +48,7 @@ const isPromptVisible = ref(false)
           :codeSnippets="state.codeSnippets"
           :tasks="state.tasks"
           :actions="state.actions"
+          :functions="state.functions"
         />
       </div>
     </div>

--- a/canvases/dark-editor-vue/src/components/Function.vue
+++ b/canvases/dark-editor-vue/src/components/Function.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { ref, defineProps, defineEmits, onMounted } from 'vue'
+import * as CodeMirror from 'codemirror'
+import 'codemirror/lib/codemirror.css'
+import 'codemirror/theme/yonce.css'
+import 'codemirror/mode/javascript/javascript.js'
+
+const props = defineProps({
+  modelValue: String,
+})
+
+const emits = defineEmits(['update:modelValue'])
+
+let textarea = ref(null) as any
+let editor = null as any
+
+function updateEditorSize(editor: CodeMirror.Editor) {
+  const lineHeight = editor.defaultTextHeight()
+  const lineCount = editor.lineCount()
+  const newHeight = lineCount * lineHeight + 5
+
+  editor.setSize(null, newHeight)
+}
+
+onMounted(() => {
+  editor = CodeMirror.fromTextArea(textarea.value, {
+    lineNumbers: true,
+    theme: 'yonce',
+    mode: 'javascript',
+    viewportMargin: Infinity,
+  })
+
+  editor.setValue(props.modelValue)
+  updateEditorSize(editor)
+
+  editor.on('changes', () => {
+    const value = editor.getValue()
+    emits('update:modelValue', value)
+    updateEditorSize(editor)
+  })
+})
+</script>
+
+<template>
+  <div class="rounded">
+    <textarea
+      ref="textarea"
+      class="text-white bg-transparent w-full outline-none h-auto"
+      placeholder="Enter function here"
+    ></textarea>
+  </div>
+</template>

--- a/canvases/dark-editor-vue/src/components/Function.vue
+++ b/canvases/dark-editor-vue/src/components/Function.vue
@@ -6,10 +6,10 @@ import 'codemirror/theme/yonce.css'
 import 'codemirror/mode/javascript/javascript.js'
 
 const props = defineProps({
-  modelValue: String,
+  content: String,
 })
 
-const emits = defineEmits(['update:modelValue'])
+const emits = defineEmits(['update:content'])
 
 let textarea = ref(null) as any
 let editor = null as any
@@ -30,12 +30,12 @@ onMounted(() => {
     viewportMargin: Infinity,
   })
 
-  editor.setValue(props.modelValue)
+  editor.setValue(props.content)
   updateEditorSize(editor)
 
   editor.on('changes', () => {
     const value = editor.getValue()
-    emits('update:modelValue', value)
+    emits('update:content', value)
     updateEditorSize(editor)
   })
 })

--- a/canvases/dark-editor-vue/src/components/Repl.vue
+++ b/canvases/dark-editor-vue/src/components/Repl.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import type { CodeSnippet } from '@/types'
+import * as CodeMirror from 'codemirror'
+import 'codemirror/lib/codemirror.css'
+import 'codemirror/theme/yonce.css'
+import 'codemirror/mode/javascript/javascript.js'
+
+const props = defineProps<{
+  code: CodeSnippet
+}>()
+
+const textareaRef = ref(null) as any
+const codeSnippet = ref('')
+const content = ref<string>('')
+
+function updateEditorSize(editor: CodeMirror.Editor) {
+  const lineHeight = editor.defaultTextHeight()
+  const lineCount = editor.lineCount()
+  const newHeight = lineCount * lineHeight + 5
+  editor.setSize(null, newHeight)
+}
+
+onMounted(() => {
+  //@ts-ignore
+  const editor = CodeMirror.fromTextArea(textareaRef.value, {
+    lineNumbers: true,
+    theme: 'yonce',
+    mode: 'javascript',
+    viewportMargin: Infinity,
+    value: codeSnippet.value,
+  })
+
+  updateEditorSize(editor)
+
+  editor.on('change', () => {
+    content.value = editor.getValue()
+    codeSnippet.value = content.value
+    updateEditorSize(editor)
+  })
+})
+
+async function runCode() {
+  try {
+    const textareaContent = textareaRef.value.value
+    const evt = { CodeEval: [textareaContent] }
+    const result = await window.darklang.handleEvent(evt)
+    console.log('result', result)
+  } catch (error) {
+    console.error(error)
+  }
+}
+</script>
+
+<template>
+  <div class="bg-[#1C1C1C]">
+    <textarea
+      v-model="codeSnippet"
+      ref="textareaRef"
+      class="text-white bg-transparent w-full outline-none h-auto"
+      placeholder="Enter function here"
+    ></textarea>
+  </div>
+  <button @click="runCode" class="bg-[#323232] text-white px-2 py-1 mt-2 rounded">
+    Run
+  </button>
+  <div
+    v-if="props.code.eval"
+    class="text-xs p-2 bg-[#323232] rounded text-white mt-4"
+  >
+    {{ props.code.eval }}
+  </div>
+</template>

--- a/canvases/dark-editor-vue/src/types.ts
+++ b/canvases/dark-editor-vue/src/types.ts
@@ -40,6 +40,7 @@ export interface Model {
   tasks: Task[]
   actions: Action[]
   functions: string[]
+  types: string[]
 }
 
 // -- parse the internal model based on however Dark stuff is serialized --
@@ -130,5 +131,6 @@ export function fromSerializedDarkModel(serializedDarkModel: string): Model {
     tasks: tasks,
     actions: actions,
     functions: source.functions,
+    types: source.types,
   }
 }

--- a/canvases/dark-editor-vue/src/types.ts
+++ b/canvases/dark-editor-vue/src/types.ts
@@ -39,6 +39,7 @@ export interface Model {
   codeSnippets: CodeSnippet[]
   tasks: Task[]
   actions: Action[]
+  functions: string[]
 }
 
 // -- parse the internal model based on however Dark stuff is serialized --
@@ -128,5 +129,6 @@ export function fromSerializedDarkModel(serializedDarkModel: string): Model {
     codeSnippets: codeSnippets,
     tasks: tasks,
     actions: actions,
+    functions: source.functions,
   }
 }

--- a/canvases/dark-editor-vue/src/views/MainView.vue
+++ b/canvases/dark-editor-vue/src/views/MainView.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { ref, defineProps } from 'vue'
+import type { Model } from '../types'
+
+const props = defineProps<{
+  state: Model
+}>()
+
+let showTextArea = ref(false)
+let currentFunction = ref('')
+function displayTextarea() {
+  showTextArea.value = !showTextArea.value
+}
+function ShowFunction(functionItem: string) {
+  showTextArea.value = true
+  currentFunction.value = functionItem
+}
+</script>
+
+<template>
+  <main>
+    <div class="h-screen flex">
+      <div class="min-h-screen bg-[#151515] text-white w-1/5">
+        <h1 class="p-2 mt-2 font-semibold">Types and functions</h1>
+        <div class="p-2 m-2 rounded bg-[#3a3a3a]">
+          <h2 class="font-semibold">Types</h2>
+          <ul class="text-[#9ea4ac] text-sm">
+            <li>type-one</li>
+            <li>type-two</li>
+            <li>type-three</li>
+          </ul>
+        </div>
+        <div class="p-2 m-2 rounded bg-[#3a3a3a]">
+          <h2 class="font-semibold">Functions</h2>
+          <ul>
+            <li
+              class="text-[#9ea4ac] text-sm cursor-pointer"
+              v-for="(functionItem, index) in state.functions"
+              :key="index"
+              @click="ShowFunction(functionItem)"
+            >
+              {{ functionItem }}
+            </li>
+          </ul>
+        </div>
+        <div class="p-2 m-2 rounded bg-[#3a3a3a]">
+          <h2 class="font-semibold">Handlers</h2>
+          <ul class="text-[#9ea4ac] text-sm"></ul>
+        </div>
+      </div>
+
+      <div v-if="showTextArea" class="p-2 m-2 rounded bg-[#3a3a3a] w-2/5 h-fit">
+        <h2 class="font-semibold">Function</h2>
+        <textarea
+          v-model="currentFunction"
+          class="text-white bg-transparent w-full outline-none h-auto"
+          placeholder="Enter function here"
+        ></textarea>
+      </div>
+
+      <div class="w-2/5">
+        <h1>REPL</h1>
+      </div>
+    </div>
+  </main>
+</template>

--- a/canvases/dark-editor-vue/src/views/MainView.vue
+++ b/canvases/dark-editor-vue/src/views/MainView.vue
@@ -68,7 +68,7 @@ function getTypes(typeItem: string) {
           :key="index"
         >
           <p class="text-[#eeeeee] text-sm">function-name-v</p>
-          <Function :modelValue="currentFunction" />
+          <Function :content="currentFunction" />
         </div>
 
         <div
@@ -77,12 +77,17 @@ function getTypes(typeItem: string) {
           :key="index"
         >
           <p class="text-[#eeeeee] text-sm">type-name</p>
-          <Function :modelValue="currentType" />
+          <Function :content="currentType" />
         </div>
       </div>
 
-      <div>
-        <Repl :snippet="state.codeSnippets[0]" />
+      <div class="w-1/2">
+        <div
+          v-if="state.codeSnippets.length > 0"
+          class="p-2 m-2 rounded bg-[#3a3a3a]"
+        >
+          <Repl :code="state.codeSnippets[0]" />
+        </div>
       </div>
     </div>
   </main>

--- a/canvases/dark-editor-vue/src/views/MainView.vue
+++ b/canvases/dark-editor-vue/src/views/MainView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, defineProps } from 'vue'
 import type { Model } from '../types'
+import Function from '@/components/Function.vue'
 
 const props = defineProps<{
   state: Model
@@ -49,22 +50,15 @@ function ShowFunction(functionItem: string) {
         </div>
       </div>
 
-      <div class="w-2/5 flex flex-col h-fit">
+      <div class="flex flex-col h-full overflow-y-scroll pb-28">
         <div
           class="p-2 m-2 rounded bg-[#3a3a3a]"
           v-for="(currentFunction, index) in currentFunctions"
           :key="index"
         >
-          <h2 class="font-semibold">Function</h2>
-          <textarea
-            v-model="currentFunctions[index]"
-            class="text-white bg-transparent w-full outline-none h-auto"
-            placeholder="Enter function here"
-          ></textarea>
+          <p class="text-[#eeeeee] text-sm">function-name-v</p>
+          <Function v-model="currentFunctions[index]" />
         </div>
-      </div>
-      <div class="w-2/5">
-        <h1>REPL</h1>
       </div>
     </div>
   </main>

--- a/canvases/dark-editor-vue/src/views/MainView.vue
+++ b/canvases/dark-editor-vue/src/views/MainView.vue
@@ -2,18 +2,24 @@
 import { ref, defineProps } from 'vue'
 import type { Model } from '../types'
 import Function from '@/components/Function.vue'
+import Repl from '@/components/Repl.vue'
 
 const props = defineProps<{
   state: Model
 }>()
 
-let currentFunctions = ref([] as string[])
-let clickedFunctions = new Set<string>()
+let functionsList = ref(new Set<string>())
+let typesList = ref(new Set<string>())
 
-function ShowFunction(functionItem: string) {
-  if (!clickedFunctions.has(functionItem)) {
-    clickedFunctions.add(functionItem)
-    currentFunctions.value.push(functionItem)
+function getFunctions(functionItem: string) {
+  if (!functionsList.value.has(functionItem)) {
+    functionsList.value.add(functionItem)
+  }
+}
+
+function getTypes(typeItem: string) {
+  if (!typesList.value.has(typeItem)) {
+    typesList.value.add(typeItem)
   }
 }
 </script>
@@ -26,9 +32,14 @@ function ShowFunction(functionItem: string) {
         <div class="p-2 m-2 rounded bg-[#3a3a3a]">
           <h2 class="font-semibold">Types</h2>
           <ul class="text-[#9ea4ac] text-sm">
-            <li>type-one</li>
-            <li>type-two</li>
-            <li>type-three</li>
+            <li
+              class="text-[#9ea4ac] text-sm cursor-pointer"
+              v-for="(typeItem, index) in state.types"
+              :key="index"
+              @click="getTypes(typeItem)"
+            >
+              {{ typeItem }}
+            </li>
           </ul>
         </div>
         <div class="p-2 m-2 rounded bg-[#3a3a3a]">
@@ -38,7 +49,7 @@ function ShowFunction(functionItem: string) {
               class="text-[#9ea4ac] text-sm cursor-pointer"
               v-for="(functionItem, index) in state.functions"
               :key="index"
-              @click="ShowFunction(functionItem)"
+              @click="getFunctions(functionItem)"
             >
               {{ functionItem }}
             </li>
@@ -53,12 +64,25 @@ function ShowFunction(functionItem: string) {
       <div class="flex flex-col h-full overflow-y-scroll pb-28">
         <div
           class="p-2 m-2 rounded bg-[#3a3a3a]"
-          v-for="(currentFunction, index) in currentFunctions"
+          v-for="(currentFunction, index) in functionsList"
           :key="index"
         >
           <p class="text-[#eeeeee] text-sm">function-name-v</p>
-          <Function v-model="currentFunctions[index]" />
+          <Function :modelValue="currentFunction" />
         </div>
+
+        <div
+          class="p-2 m-2 rounded bg-[#3a3a3a]"
+          v-for="(currentType, index) in typesList"
+          :key="index"
+        >
+          <p class="text-[#eeeeee] text-sm">type-name</p>
+          <Function :modelValue="currentType" />
+        </div>
+      </div>
+
+      <div>
+        <Repl :snippet="state.codeSnippets[0]" />
       </div>
     </div>
   </main>

--- a/canvases/dark-editor-vue/src/views/MainView.vue
+++ b/canvases/dark-editor-vue/src/views/MainView.vue
@@ -6,14 +6,14 @@ const props = defineProps<{
   state: Model
 }>()
 
-let showTextArea = ref(false)
-let currentFunction = ref('')
-function displayTextarea() {
-  showTextArea.value = !showTextArea.value
-}
+let currentFunctions = ref([] as string[])
+let clickedFunctions = new Set<string>()
+
 function ShowFunction(functionItem: string) {
-  showTextArea.value = true
-  currentFunction.value = functionItem
+  if (!clickedFunctions.has(functionItem)) {
+    clickedFunctions.add(functionItem)
+    currentFunctions.value.push(functionItem)
+  }
 }
 </script>
 
@@ -49,15 +49,20 @@ function ShowFunction(functionItem: string) {
         </div>
       </div>
 
-      <div v-if="showTextArea" class="p-2 m-2 rounded bg-[#3a3a3a] w-2/5 h-fit">
-        <h2 class="font-semibold">Function</h2>
-        <textarea
-          v-model="currentFunction"
-          class="text-white bg-transparent w-full outline-none h-auto"
-          placeholder="Enter function here"
-        ></textarea>
+      <div class="w-2/5 flex flex-col h-fit">
+        <div
+          class="p-2 m-2 rounded bg-[#3a3a3a]"
+          v-for="(currentFunction, index) in currentFunctions"
+          :key="index"
+        >
+          <h2 class="font-semibold">Function</h2>
+          <textarea
+            v-model="currentFunctions[index]"
+            class="text-white bg-transparent w-full outline-none h-auto"
+            placeholder="Enter function here"
+          ></textarea>
+        </div>
       </div>
-
       <div class="w-2/5">
         <h1>REPL</h1>
       </div>

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -139,7 +139,8 @@ type Model =
     chatHistory: List<ChatHistoryItem>
     codeSnippets: List<CodeSnippet>
     tasks: List<Task>
-    actions: List<Action> }
+    actions: List<Action>
+    functions: List<String> }
 
 
 // Update
@@ -180,6 +181,7 @@ let update (model: Model) (msg: Msg) : Model =
           codeSnippets = model.codeSnippets
           tasks = model.tasks
           actions = model.actions
+          functions = model.functions
 
           // CLEANUP: update this syntax to { model with systemPrompt = systemPrompt } when we can
           systemPrompt = response.body |> String.fromBytes }
@@ -197,7 +199,8 @@ let update (model: Model) (msg: Msg) : Model =
               [ ChatHistoryItem.UserPrompt (rUnwrap (String.random 5)) userPrompt ]
           codeSnippets = model.codeSnippets
           tasks = model.tasks
-          actions = model.actions }
+          actions = model.actions
+          functions = model.functions }
 
     updateStateInJS newModel
 
@@ -271,7 +274,8 @@ let update (model: Model) (msg: Msg) : Model =
           chatHistory = List.append model.chatHistory newChatItemsItems
           codeSnippets = List.append model.codeSnippets newCodeSnippets
           tasks = List.append model.tasks newtasks
-          actions = model.actions }
+          actions = model.actions
+          functions = model.functions }
 
     | Error err, _ -> log "error getting tasks " ++ err
     | _, Error err -> log "error getting response " ++ err
@@ -311,7 +315,8 @@ let update (model: Model) (msg: Msg) : Model =
               chatHistory = model.chatHistory
               codeSnippets = updatedCodeSnippets
               tasks = model.tasks
-              actions = model.actions }
+              actions = model.actions
+              functions = model.functions }
 
         | Error err -> sendError model codeSnippet err
 
@@ -384,13 +389,31 @@ let init () : Model =
             BotResponseItem.CodeSnippet demoSnippet.id
             BotResponseItem.Actions demoAction ] ]
 
+    let getFnList =
+      let response =
+        WASM.HttpClient.request
+          "GET"
+          "http://dark-editor.dlio.localhost:11003/all-functions"
+          []
+          Bytes.empty
+
+      match response with
+      | Ok response ->
+        log "got response"
+        response.body |> String.fromBytes |> String.split "\n\n"
+
+      | Error err -> "Error getting response: " ++ err
+
+
+
     Model
       { isLoading = false
         systemPrompt = "Loading..."
         chatHistory = chatHistory
         codeSnippets = [ demoSnippet ]
         tasks = []
-        actions = demoAction }
+        actions = demoAction
+        functions = getFnList }
 
   updateStateInJS initState
 

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -149,6 +149,7 @@ type Msg =
   | LoadSystemPrompt
   | UserGavePrompt of prompt: String
   | UserRequestedCodeEval of id: String * codeSnippet: String
+  | CodeEval of code: String
 
 
 let sendError (model: Model) (codeSnippet: String) (err: String) : Model =
@@ -326,6 +327,37 @@ let update (model: Model) (msg: Msg) : Model =
         | Error err -> sendError model codeSnippet err
 
       | Error err -> sendError model codeSnippet err
+
+  | CodeEval code ->
+    let parsedAndSerialized = parseAndSerializeProgram code
+
+    match parsedAndSerialized with
+    | Ok parsedAndSerialized ->
+      let evalPgm = (WASM.Editor.evalUserProgram parsedAndSerialized)
+
+      match evalPgm with
+      | Ok evalPgm ->
+        evalPgm
+
+        let codeSnippet =
+          CodeSnippet
+            { id = "evaluated-program"
+              code = code
+              eval = Just evalPgm }
+
+        Model
+          { isLoading = false
+            systemPrompt = model.systemPrompt
+            chatHistory = model.chatHistory
+            codeSnippets = [ codeSnippet ]
+            tasks = model.tasks
+            actions = model.actions
+            functions = model.functions
+            types = model.types }
+
+      | Error err -> log "couldn't eval program"
+
+    | Error err -> log "couldn't parse and serialize program"
 
 
 /// Single point of communicating to JS host

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -140,7 +140,8 @@ type Model =
     codeSnippets: List<CodeSnippet>
     tasks: List<Task>
     actions: List<Action>
-    functions: List<String> }
+    functions: List<String>
+    types: List<String> }
 
 
 // Update
@@ -182,6 +183,7 @@ let update (model: Model) (msg: Msg) : Model =
           tasks = model.tasks
           actions = model.actions
           functions = model.functions
+          types = model.types
 
           // CLEANUP: update this syntax to { model with systemPrompt = systemPrompt } when we can
           systemPrompt = response.body |> String.fromBytes }
@@ -200,7 +202,8 @@ let update (model: Model) (msg: Msg) : Model =
           codeSnippets = model.codeSnippets
           tasks = model.tasks
           actions = model.actions
-          functions = model.functions }
+          functions = model.functions
+          types = model.types }
 
     updateStateInJS newModel
 
@@ -275,7 +278,8 @@ let update (model: Model) (msg: Msg) : Model =
           codeSnippets = List.append model.codeSnippets newCodeSnippets
           tasks = List.append model.tasks newtasks
           actions = model.actions
-          functions = model.functions }
+          functions = model.functions
+          types = model.types }
 
     | Error err, _ -> log "error getting tasks " ++ err
     | _, Error err -> log "error getting response " ++ err
@@ -316,7 +320,8 @@ let update (model: Model) (msg: Msg) : Model =
               codeSnippets = updatedCodeSnippets
               tasks = model.tasks
               actions = model.actions
-              functions = model.functions }
+              functions = model.functions
+              types = model.types }
 
         | Error err -> sendError model codeSnippet err
 
@@ -393,7 +398,23 @@ let init () : Model =
       let response =
         WASM.HttpClient.request
           "GET"
-          "http://dark-editor.dlio.localhost:11003/all-functions"
+          "http://dark-editor.dlio.localhost:11003/all-canvas-functions"
+          []
+          Bytes.empty
+
+      match response with
+      | Ok response ->
+        log "got response"
+        response.body |> String.fromBytes |> String.split "\n\n"
+
+      | Error err -> "Error getting response: " ++ err
+
+
+    let getTypeList =
+      let response =
+        WASM.HttpClient.request
+          "GET"
+          "http://dark-editor.dlio.localhost:11003/all-canvas-types"
           []
           Bytes.empty
 
@@ -413,7 +434,8 @@ let init () : Model =
         codeSnippets = [ demoSnippet ]
         tasks = []
         actions = demoAction
-        functions = getFnList }
+        functions = getFnList
+        types = getTypeList }
 
   updateStateInJS initState
 

--- a/canvases/dark-editor/main.dark
+++ b/canvases/dark-editor/main.dark
@@ -159,3 +159,26 @@ let _handler _req =
   let result = prettyPackages
 
   PACKAGE.Darklang.Stdlib.Http.response (String.toBytes result) 200
+
+// to delete once PACKAGE.Darklang.PrettyPrinter.packages packages errors are resolved
+[<HttpHandler("GET", "/all-functions")>]
+let _handler _req =
+  let functions =
+    """
+    let rUnwrap (result: Result<'a, 'b>) : 'a =
+      match result with
+      | Ok s -> s
+      | Error e ->
+        log e // TODO: this won't work if non-string
+        alert "Expected OK, got Error - see log"
+
+    let log (s: String) : Unit =
+      let _ = WASM.Editor.callJSFunction "console.log" [ s ]
+      ()
+
+    let logErr (s: String) : Unit =
+      let _ = WASM.Editor.callJSFunction "console.error" [ s ]
+      ()
+    """
+
+  PACKAGE.Darklang.Stdlib.Http.response (String.toBytes functions) 200

--- a/canvases/dark-editor/main.dark
+++ b/canvases/dark-editor/main.dark
@@ -121,14 +121,41 @@ let _handler _req =
 // TODO, move this to a `/scripts/deployment/data-backup.dark`
 // to be called like `.../data-backup export --test`
 
-[<HttpHandler("GET", "/this-canvas-id")>]
+[<HttpHandler("GET", "/export-this-canvas")>]
 let _handler _req =
   let canvasId = DarkInternal.Canvas.darkEditorCanvasID ()
 
-  PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
-    (canvasId |> Uuid.toString |> String.toBytes)
-    [ ("Content-Type", "text/plain") ]
-    200
+  let take =
+    match PACKAGE.Darklang.Stdlib.Http.Request.queryParam request "take" with
+    | Nothing -> 100
+    | Just take -> take |> Int.parse |> rUnwrap
+
+  let drop =
+    match PACKAGE.Darklang.Stdlib.Http.Request.queryParam request "drop" with
+    | Nothing -> 0
+    | Just drop -> drop |> Int.parse |> rUnwrap
+
+  match DarkInternal.Canvas.fullProgram canvasId with
+  | Ok program ->
+    let prettyTypes =
+      program.types
+      |> List.drop drop
+      |> List.take take
+      |> List.map (fun t -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.userType t)
+      |> String.join "\n\n"
+
+    let prettyFns =
+      program.fns
+      |> List.map (fun fn ->
+        PACKAGE.Darklang.PrettyPrinter.ProgramTypes.userFunction fn)
+      |> String.join "\n\n"
+
+    let response = prettyTypes ++ "\n------------------\n" ++ prettyFns
+
+    PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
+      (response |> String.toBytes)
+      [ ("Content-Type", "text/plain") ]
+      200
 
 
 // dark-exportable is `c622b6ab-f117-4c9b-826d-51ea2d175b18`

--- a/canvases/dark-editor/main.dark
+++ b/canvases/dark-editor/main.dark
@@ -157,6 +157,68 @@ let _handler _req =
       [ ("Content-Type", "text/plain") ]
       200
 
+[<HttpHandler("GET", "/all-canvas-functions")>]
+let _handler _req =
+  let canvasId = DarkInternal.Canvas.darkEditorCanvasID ()
+
+  let take =
+    match PACKAGE.Darklang.Stdlib.Http.Request.queryParam request "take" with
+    | Nothing -> 100
+    | Just take -> take |> Int.parse |> rUnwrap
+
+  let drop =
+    match PACKAGE.Darklang.Stdlib.Http.Request.queryParam request "drop" with
+    | Nothing -> 0
+    | Just drop -> drop |> Int.parse |> rUnwrap
+
+  match DarkInternal.Canvas.fullProgram canvasId with
+  | Ok program ->
+
+    let prettyFns =
+      program.fns
+      |> List.map (fun fn ->
+        PACKAGE.Darklang.PrettyPrinter.ProgramTypes.userFunction fn)
+      |> String.join "\n\n"
+
+    let response = prettyFns
+
+    PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
+      (response |> String.toBytes)
+      [ ("Content-Type", "text/plain") ]
+      200
+
+
+[<HttpHandler("GET", "/all-canvas-types")>]
+let _handler _req =
+  let canvasId = DarkInternal.Canvas.darkEditorCanvasID ()
+
+  let take =
+    match PACKAGE.Darklang.Stdlib.Http.Request.queryParam request "take" with
+    | Nothing -> 100
+    | Just take -> take |> Int.parse |> rUnwrap
+
+  let drop =
+    match PACKAGE.Darklang.Stdlib.Http.Request.queryParam request "drop" with
+    | Nothing -> 0
+    | Just drop -> drop |> Int.parse |> rUnwrap
+
+
+  match DarkInternal.Canvas.fullProgram canvasId with
+  | Ok program ->
+    let prettyTypes =
+      program.types
+      |> List.drop drop
+      |> List.take take
+      |> List.map (fun t -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.userType t)
+      |> String.join "\n\n"
+
+    let response = prettyTypes
+
+    PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
+      (response |> String.toBytes)
+      [ ("Content-Type", "text/plain") ]
+      200
+
 
 // dark-exportable is `c622b6ab-f117-4c9b-826d-51ea2d175b18`
 [<HttpHandler("GET", "/export-canvas/:canvasId")>]
@@ -186,26 +248,3 @@ let _handler _req =
   let result = prettyPackages
 
   PACKAGE.Darklang.Stdlib.Http.response (String.toBytes result) 200
-
-// to delete once PACKAGE.Darklang.PrettyPrinter.packages packages errors are resolved
-[<HttpHandler("GET", "/all-functions")>]
-let _handler _req =
-  let functions =
-    """
-    let rUnwrap (result: Result<'a, 'b>) : 'a =
-      match result with
-      | Ok s -> s
-      | Error e ->
-        log e // TODO: this won't work if non-string
-        alert "Expected OK, got Error - see log"
-
-    let log (s: String) : Unit =
-      let _ = WASM.Editor.callJSFunction "console.log" [ s ]
-      ()
-
-    let logErr (s: String) : Unit =
-      let _ = WASM.Editor.callJSFunction "console.error" [ s ]
-      ()
-    """
-
-  PACKAGE.Darklang.Stdlib.Http.response (String.toBytes functions) 200

--- a/packages/darklang/prettyPrinter/packages.dark
+++ b/packages/darklang/prettyPrinter/packages.dark
@@ -7,12 +7,12 @@ module Darklang =
     module Packages =
       type ModulelessPackageTypeName =
         { owner: String
-          typ: String
+          name: 'name
           version: Int }
 
       type ModulelessPackageFnName =
         { owner: String
-          function_: String
+          name: 'name
           version: Int }
 
       type ModulelessPackageType =
@@ -34,7 +34,7 @@ module Darklang =
             name =
               PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageTypeName
                 { owner = p.name.owner
-                  typ = p.name.typ
+                  name = p.name.name
                   version = p.name.version }
             typeParams = p.typeParams
             definition = p.definition
@@ -62,7 +62,7 @@ module Darklang =
             name =
               PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageFnName
                 { owner = p.name.owner
-                  function_ = p.name.function_
+                  name = p.name.name
                   version = p.name.version }
             body = p.body
             typeParams = p.typeParams
@@ -86,7 +86,7 @@ module Darklang =
           [ PACKAGE.Darklang.PrettyPrinter.Packages.Module
               { name =
                   (t.name
-                   |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.fullForReference)
+                   |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.fullForReference)
                   ++ "has no modules"
                 types = []
                 fns = []
@@ -162,7 +162,7 @@ module Darklang =
           [ PACKAGE.Darklang.PrettyPrinter.Packages.Module
               { name =
                   (f.name
-                   |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.fullForReference)
+                   |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.fullForReference)
                   ++ "has no modules"
                 types = []
                 fns = []
@@ -260,7 +260,7 @@ module Darklang =
                     PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package
                       { owner = t.name.owner
                         modules = []
-                        typ = t.name.typ
+                        name = t.name.name
                         version = t.name.version }
                   typeParams = t.typeParams
                   definition = t.definition
@@ -285,7 +285,7 @@ module Darklang =
                     PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package
                       { owner = t.name.owner
                         modules = []
-                        function_ = t.name.function_
+                        name = t.name.name
                         version = t.name.version }
                   body = t.body
                   typeParams = t.typeParams
@@ -344,12 +344,8 @@ module Darklang =
         PACKAGE.Darklang.PrettyPrinter.Packages.toModules
           withOwnerStuffRepresentedAsRootLevelModule
 
-      "what about here 7"
 
-// CLEANUP make ordering 'better' in some way
-
-// modules
-// |> List.map (fun m -> PACKAGE.Darklang.PrettyPrinter.packageModule m)
-// |> String.join "\n\n"
-
-//"we got here"
+      // CLEANUP make ordering 'better' in some way
+      modules
+      |> List.map (fun m -> PACKAGE.Darklang.PrettyPrinter.packageModule m)
+      |> String.join "\n\n"

--- a/packages/darklang/prettyPrinter/packages.dark
+++ b/packages/darklang/prettyPrinter/packages.dark
@@ -320,8 +320,6 @@ module Darklang =
 
         $"module {m.name} =\n{bodyPart}"
 
-
-
     let packages (p: PACKAGE.Darklang.Stdlib.Packages) : String =
       let withOwnerStuffRepresentedAsRootLevelModule =
         PACKAGE.Darklang.Stdlib.Packages
@@ -346,8 +344,12 @@ module Darklang =
         PACKAGE.Darklang.PrettyPrinter.Packages.toModules
           withOwnerStuffRepresentedAsRootLevelModule
 
-      // CLEANUP make ordering 'better' in some way
+      "what about here 7"
 
-      modules
-      |> List.map (fun m -> PACKAGE.Darklang.PrettyPrinter.packageModule m)
-      |> String.join "\n\n"
+// CLEANUP make ordering 'better' in some way
+
+// modules
+// |> List.map (fun m -> PACKAGE.Darklang.PrettyPrinter.packageModule m)
+// |> String.join "\n\n"
+
+//"we got here"

--- a/packages/darklang/prettyPrinter/packages.dark
+++ b/packages/darklang/prettyPrinter/packages.dark
@@ -5,76 +5,11 @@
 module Darklang =
   module PrettyPrinter =
     module Packages =
-      type ModulelessPackageTypeName =
-        { owner: String
-          name: 'name
-          version: Int }
-
-      type ModulelessPackageFnName =
-        { owner: String
-          name: 'name
-          version: Int }
-
-      type ModulelessPackageType =
-        { tlid: PACKAGE.Darklang.Stdlib.TLID
-          id: Uuid
-          name: PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageTypeName
-          typeParams: List<String>
-          definition: PACKAGE.Darklang.Stdlib.ProgramTypes.CustomType.T
-          description: String
-          deprecated:
-            PACKAGE.Darklang.Stdlib.ProgramTypes.Deprecation<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T> }
-
-      let packageTypeWithoutModules
-        (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T)
-        : PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageType =
-        PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageType
-          { tlid = p.tlid
-            id = p.id
-            name =
-              PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageTypeName
-                { owner = p.name.owner
-                  name = p.name.name
-                  version = p.name.version }
-            typeParams = p.typeParams
-            definition = p.definition
-            description = p.description
-            deprecated = p.deprecated }
-
-      type ModulelessPackageFn =
-        { tlid: PACKAGE.Darklang.Stdlib.TLID
-          id: Uuid
-          name: PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageFnName
-          body: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
-          typeParams: List<String>
-          parameters: List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.Parameter>
-          returnType: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
-          description: String
-          deprecated:
-            PACKAGE.Darklang.Stdlib.ProgramTypes.Deprecation<PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T> }
-
-      let packageFnWithoutModules
-        (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T)
-        : PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageFn =
-        PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageFn
-          { tlid = p.tlid
-            id = p.id
-            name =
-              PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageFnName
-                { owner = p.name.owner
-                  name = p.name.name
-                  version = p.name.version }
-            body = p.body
-            typeParams = p.typeParams
-            parameters = p.parameters
-            returnType = p.returnType
-            description = p.description
-            deprecated = p.deprecated }
 
       type Module =
         { name: String
-          types: List<PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageType>
-          fns: List<PACKAGE.Darklang.PrettyPrinter.Packages.ModulelessPackageFn>
+          types: List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T>
+          fns: List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T>
           submodules: List<PACKAGE.Darklang.PrettyPrinter.Packages.Module> }
 
       let withType
@@ -103,8 +38,8 @@ module Darklang =
               PACKAGE.Darklang.PrettyPrinter.Packages.Module
                 { name = firstModuleNamePart
                   types =
-                    [ PACKAGE.Darklang.PrettyPrinter.Packages.packageTypeWithoutModules
-                        t ]
+                    [ { t with
+                          name = { t.name with modules = [] } } ]
                   fns = []
                   submodules = [] }
 
@@ -133,8 +68,8 @@ module Darklang =
                   types =
                     List.append
                       foundModule.types
-                      [ PACKAGE.Darklang.PrettyPrinter.Packages.packageTypeWithoutModules
-                          t ] }
+                      [ { t with
+                            name = { t.name with modules = [] } } ] }
 
             List.append otherModules [ updatedModule ]
 
@@ -179,8 +114,8 @@ module Darklang =
                 { name = firstModuleNamePart
                   types = []
                   fns =
-                    [ PACKAGE.Darklang.PrettyPrinter.Packages.packageFnWithoutModules
-                        f ]
+                    [ { f with
+                          name = { f.name with modules = [] } } ]
                   submodules = [] }
 
             List.append otherModules [ newModule ]
@@ -208,8 +143,8 @@ module Darklang =
                   fns =
                     List.append
                       foundModule.fns
-                      [ PACKAGE.Darklang.PrettyPrinter.Packages.packageFnWithoutModules
-                          f ] }
+                      [ { f with
+                            name = { f.name with modules = [] } } ] }
 
             List.append otherModules [ updatedModule ]
 
@@ -252,22 +187,7 @@ module Darklang =
         | types ->
           m.types
           |> List.map (fun t ->
-            let withEmptyModules =
-              PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T
-                { tlid = t.tlid
-                  id = t.id
-                  name =
-                    PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package
-                      { owner = t.name.owner
-                        modules = []
-                        name = t.name.name
-                        version = t.name.version }
-                  typeParams = t.typeParams
-                  definition = t.definition
-                  description = t.description
-                  deprecated = t.deprecated }
-
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.packageType withEmptyModules)
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.packageType t)
           |> String.join "\n\n"
           |> Just
 
@@ -276,25 +196,8 @@ module Darklang =
         | [] -> Nothing
         | fns ->
           m.fns
-          |> List.map (fun t ->
-            let withEmptyModules =
-              PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T
-                { tlid = t.tlid
-                  id = t.id
-                  name =
-                    PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package
-                      { owner = t.name.owner
-                        modules = []
-                        name = t.name.name
-                        version = t.name.version }
-                  body = t.body
-                  typeParams = t.typeParams
-                  parameters = t.parameters
-                  returnType = t.returnType
-                  description = t.description
-                  deprecated = t.deprecated }
-
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.packageFn withEmptyModules)
+          |> List.map (fun f ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.packageFn f)
           |> String.join "\n\n"
           |> Just
 

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -968,7 +968,7 @@ module Darklang =
         let bodyPart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr p.body
 
-        $"let {namePart}{typeParamPart} {paramPart} : {retPart} =\n{bodyPart}"
+        $"let {namePart}{typeParamPart} {paramPart} : {retPart} =\n{PACKAGE.Darklang.PrettyPrinter.indent bodyPart}"
 
 
       let packageType

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -5,45 +5,141 @@
 module Darklang =
   module PrettyPrinter =
     module ProgramTypes =
-      module TypeName =
+      module FQName =
         module BuiltIn =
           let atDefinition
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.BuiltIn)
+            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn)
             : String =
             "why are you trying to print a stdlib type name _definition_?"
 
           let fullForReference
-            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.BuiltIn)
+            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn)
             : String =
             let modulesPart =
               match t.modules with
               | [] -> ""
               | modules -> modules |> String.join "." |> (fun parts -> $"{parts}.")
 
+            let namePart = t.name
+
             let versionPart =
               if t.version == 0 then "" else $"_v{Int.toString t.version}"
 
-            $"{modulesPart}{t.typ}{versionPart}"
+            $"{modulesPart}{namePart}{versionPart}"
+
+
+        module UserProgram =
+          let atDefinition
+            // TODO: take in just typ and version - modules should have already been dealt with
+            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram)
+            : String =
+            match u.modules with
+            | [] ->
+              let versionPart =
+                if u.version == 0 then "" else $"_v{Int.toString u.version}"
+
+              $"{u.name}{versionPart}"
+            | _ -> "(UserTypeName.atDefinition unexpected nonempty u.modules)"
+
+          let fullForReference
+            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram)
+            : String =
+            let versionPart =
+              if u.version == 0 then "" else $"_v{Int.toString u.version}"
+
+            //TODO: name should be a string
+            $"{u.name}{versionPart}"
+
 
         module Package =
           let atDefinition
             // TODO: take in just owner, typ, and version - modules should have already been dealt with
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package)
+            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package)
             : String =
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
-            $"{p.typ}{versionPart}"
+            $"{p.name}{versionPart}"
 
           let fullForReference
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package)
+            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package)
             : String =
             let modulesPart = String.join p.modules "."
 
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
-            $"PACKAGE.{p.owner}.{modulesPart}.{p.typ}{versionPart}"
+            //TODO name should be a string
+            $"PACKAGE.{p.owner}.{modulesPart}.{p.name}{versionPart}"
+
+
+        let atDefinition
+          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T)
+          : String =
+          match t with
+          | BuiltIn b ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.BuiltIn.atDefinition
+              b
+          | UserProgram u -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.UserProgram.atDefinition
+              u
+          | Package p -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.atDefinition
+              p
+
+        let fullForReference
+          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T) : String =
+          match t with
+          | BuiltIn b ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.BuiltIn.fullForReference
+              b
+          | UserProgram u -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.UserProgram.fullForReference
+              u
+          | Package p -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.fullForReference
+              p
+
+
+      module TypeName =
+        module Name =
+          let atDefinition
+            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name)
+            : String =
+            "why are you trying to print a stdlib type name _definition_?"
+
+          let fullForReference
+            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name)
+            : String =
+            let modulesPart =
+              match t.modules with
+              | [] -> ""
+              | modules -> modules |> String.join "." |> (fun parts -> $"{parts}.")
+
+            //TODO this should be a string
+            let namePart = t.name
+
+            let versionPart =
+              if t.version == 0 then "" else $"_v{Int.toString t.version}"
+
+            $"{modulesPart}{namePart}{versionPart}"
+
+        module BuiltIn =
+          let atDefinition
+            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.BuiltIn)
+            : String =
+              "why are you trying to print a stdlib type name _definition_?"
+
+          let fullForReference (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.BuiltIn)
+            : String =
+            let modulesPart =
+              match t.modules with
+              | [] -> ""
+              | modules -> modules |> String.join "." |> (fun parts -> $"{parts}.")
+
+            //TODO this should be a string
+            let namePart = t.name
+
+            let versionPart =
+              if t.version == 0 then "" else $"_v{Int.toString t.version}"
+
+            $"{modulesPart}{namePart}{versionPart}"
 
         module UserProgram =
           let atDefinition
@@ -55,7 +151,9 @@ module Darklang =
               let versionPart =
                 if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
-              $"{u.typ}{versionPart}"
+              match u.name with
+              | TypeName name ->
+                $"{name}{versionPart}"
             | _ -> "(UserTypeName.atDefinition unexpected nonempty u.modules)"
 
           let fullForReference
@@ -64,43 +162,64 @@ module Darklang =
             let versionPart =
               if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
-            $"{u.typ}{versionPart}"
+            $"{u.name}{versionPart}"
 
-        let fullForReference
-          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
-          : String =
-          match t with
-          | User u ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.fullForReference
-              u
-          | Package p ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.fullForReference
-              p
-          | Stdlib s ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.fullForReference
-              s
+
+        module Package =
+          let atDefinition
+            // TODO: take in just owner, typ, and version - modules should have already been dealt with
+            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package)
+            : String =
+            let versionPart =
+              if p.version == 0 then "" else $"_v{Int.toString p.version}"
+
+            $"{p.name}{versionPart}"
+
+          let fullForReference
+            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package)
+            : String =
+            let modulesPart = String.join p.modules "."
+
+            let versionPart =
+              if p.version == 0 then "" else $"_v{Int.toString p.version}"
+
+            $"PACKAGE.{p.owner}.{modulesPart}.{p.name}{versionPart}"
+
 
         let atDefinition
           (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
           : String =
           match t with
-          | User u ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
+          | BuiltIn b ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.atDefinition
+              b
+          | UserProgram u -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
               u
-          | Package p ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.atDefinition
+          | Package p -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.atDefinition
               p
           | Stdlib s ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.atDefinition
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.fullForReference
               s
+
+        let fullForReference
+          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
+          : String =
+          match t with
+          | BuiltIn b ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.fullForReference
+              b
+          | UserProgram u -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.fullForReference
+              u
+          | Package p -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.fullForReference
+              p
 
 
       module FnName =
         module BuiltIn =
           let atDefinition
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.BuiltIn)
-            : String =
-            "why are you trying to print a stdlib type name _definition_?"
+              (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.BuiltIn)
+              : String =
+              "why are you trying to print a stdlib type name _definition_?"
 
           let fullForReference
             (f: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.BuiltIn)
@@ -113,29 +232,11 @@ module Darklang =
             let versionPart =
               if f.version == 0 then "" else $"_v{Int.toString f.version}"
 
-            $"{modulesPart}{f.function_}{versionPart}"
+            match f.name with
+            | FnName name ->
+              $"{modulesPart}{name}{versionPart}"
 
-        module PackageFnName =
-          let atDefinition
-            // TODO: take in just owner, typ, and version - modules should have already been dealt with
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Package)
-            : String =
-            let versionPart =
-              if p.version == 0 then "" else $"_v{Int.toString p.version}"
-
-            $"{p.function_}{versionPart}"
-
-          let fullForReference
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Package)
-            : String =
-            let modulesPart = String.join p.modules "."
-
-            let versionPart =
-              if p.version == 0 then "" else $"_v{Int.toString p.version}"
-
-            $"PACKAGE.{p.owner}.{modulesPart}.{p.function_}{versionPart}"
-
-        module UserFnName =
+        module UserProgram =
           let atDefinition
             // TODO: take in just typ and version - modules should have already been dealt with
             (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.UserProgram)
@@ -145,7 +246,9 @@ module Darklang =
               let versionPart =
                 if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
-              $"{u.function_}{versionPart}"
+              match u.name with
+              | FnName name ->
+                $"{name}{versionPart}"
             | _ -> "(UserFnName.atDefinition unexpected nonempty u.modules)"
 
           let fullForReference
@@ -153,35 +256,61 @@ module Darklang =
             : String =
             let versionPart =
               if u.version == 0 then "" else $"_v{Int.toString u.version}"
+            match u.name with
+            | FnName name ->
+              $"{name}{versionPart}"
 
-            $"{u.function_}{versionPart}"
+        module Package =
+          let atDefinition
+            // TODO: take in just owner, typ, and version - modules should have already been dealt with
+            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Package)
+            : String =
+            let versionPart =
+              if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
-        let fullForReference
-          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T)
-          : String =
-          match t with
-          | User u ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.UserProgram.fullForReference
-              u
-          | Package p ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.fullForReference
-              p
-          | Stdlib s ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.BuiltIn.fullForReference
-              s
+            match p.name with
+            | FnName name ->
+              $"{name}{versionPart}"
+
+
+          let fullForReference
+            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Package)
+            : String =
+            let modulesPart = String.join p.modules "."
+
+            let versionPart =
+              if p.version == 0 then "" else $"_v{Int.toString p.version}"
+
+            match p.name with
+            | FnName name ->
+              $"PACKAGE.{p.owner}.{modulesPart}.{name}{versionPart}"
+
 
         let atDefinition
           (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T)
           : String =
           match t with
-          | User u ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.UserProgram.atDefinition
+          | BuiltIn b ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.BuiltIn.atDefinition
+              b
+          | UserProgram u -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.UserProgram.atDefinition
+              u
+          | Package p -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.Package.atDefinition
+              p
+
+        let fullForReference
+          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T)
+          : String =
+          match t with
+          | BuiltIn b ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.BuiltIn.fullForReference
+              b
+          | UserProgram u ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.UserProgram.fullForReference
               u
           | Package p ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.atDefinition p
-          | Stdlib s ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.BuiltIn.atDefinition s
-
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.Package.fullForReference
+              p
 
       let typeReference
         (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference)
@@ -757,7 +886,7 @@ module Darklang =
         (userType: PACKAGE.Darklang.Stdlib.ProgramTypes.UserType)
         : String =
         let namePart =
-          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.userTypeName
+          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
             userType.name
 
         let typeParamPart =
@@ -791,7 +920,8 @@ module Darklang =
         // TODO: do something with description and deprecated
         // TODO: shouldn't there be modules here somewhere?
         let namePart =
-          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.userFnName u.name
+          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.UserProgram.atDefinition
+            u.name
 
         let typeParamsPart = String.join u.typeParams " "
 
@@ -799,7 +929,7 @@ module Darklang =
           String.join (
             List.map u.parameters (fun p ->
               PACKAGE.Darklang.PrettyPrinter.ProgramTypes.UserFunction.parameter p)
-          )
+          ) " "
 
         let retPart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference u.returnType
@@ -831,8 +961,7 @@ module Darklang =
       let packageFn (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T) : String =
         // TODO: handle `deprecated`, `description`
         let namePart =
-          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.atDefinition
-            p.name
+          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.userFnName p.name
 
         let typeParamPart =
           match p.typeParams with

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -20,12 +20,10 @@ module Darklang =
               | [] -> ""
               | modules -> modules |> String.join "." |> (fun parts -> $"{parts}.")
 
-            let namePart = t.name
-
             let versionPart =
               if t.version == 0 then "" else $"_v{Int.toString t.version}"
-
-            $"{modulesPart}{namePart}{versionPart}"
+            // TODO: name should be a string
+            $"{modulesPart}{t.name}{versionPart}"
 
 
         module UserProgram =
@@ -38,6 +36,7 @@ module Darklang =
               let versionPart =
                 if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
+              //TODO: name should be a string
               $"{u.name}{versionPart}"
             | _ -> "(UserTypeName.atDefinition unexpected nonempty u.modules)"
 
@@ -59,6 +58,7 @@ module Darklang =
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
+            //TODO: name should be a string
             $"{p.name}{versionPart}"
 
           let fullForReference
@@ -98,28 +98,6 @@ module Darklang =
 
 
       module TypeName =
-        module Name =
-          let atDefinition
-            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name)
-            : String =
-            "why are you trying to print a stdlib type name _definition_?"
-
-          let fullForReference
-            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name)
-            : String =
-            let modulesPart =
-              match t.modules with
-              | [] -> ""
-              | modules -> modules |> String.join "." |> (fun parts -> $"{parts}.")
-
-            //TODO this should be a string
-            let namePart = t.name
-
-            let versionPart =
-              if t.version == 0 then "" else $"_v{Int.toString t.version}"
-
-            $"{modulesPart}{namePart}{versionPart}"
-
         module BuiltIn =
           let atDefinition
             (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.BuiltIn)
@@ -133,13 +111,12 @@ module Darklang =
               | [] -> ""
               | modules -> modules |> String.join "." |> (fun parts -> $"{parts}.")
 
-            //TODO this should be a string
-            let namePart = t.name
-
             let versionPart =
               if t.version == 0 then "" else $"_v{Int.toString t.version}"
 
-            $"{modulesPart}{namePart}{versionPart}"
+            match t.name with
+            | TypeName name ->
+              $"{modulesPart}{name}{versionPart}"
 
         module UserProgram =
           let atDefinition
@@ -152,8 +129,7 @@ module Darklang =
                 if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
               match u.name with
-              | TypeName name ->
-                $"{name}{versionPart}"
+              | TypeName name -> $"{name}{versionPart}"
             | _ -> "(UserTypeName.atDefinition unexpected nonempty u.modules)"
 
           let fullForReference
@@ -162,7 +138,8 @@ module Darklang =
             let versionPart =
               if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
-            $"{u.name}{versionPart}"
+            match u.name with
+            | TypeName name -> $"{name}{versionPart}"
 
 
         module Package =
@@ -173,7 +150,8 @@ module Darklang =
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
-            $"{p.name}{versionPart}"
+            match p.name with
+            | TypeName name -> $"{name}{versionPart}"
 
           let fullForReference
             (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package)
@@ -183,7 +161,8 @@ module Darklang =
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
-            $"PACKAGE.{p.owner}.{modulesPart}.{p.name}{versionPart}"
+            match p.name with
+            | TypeName name -> $"PACKAGE.{p.owner}.{modulesPart}.{name}{versionPart}"
 
 
         let atDefinition
@@ -193,13 +172,12 @@ module Darklang =
           | BuiltIn b ->
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.atDefinition
               b
-          | UserProgram u -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
+          | UserProgram u ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
               u
-          | Package p -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.atDefinition
+          | Package p ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.atDefinition
               p
-          | Stdlib s ->
-            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.fullForReference
-              s
 
         let fullForReference
           (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
@@ -208,9 +186,11 @@ module Darklang =
           | BuiltIn b ->
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.BuiltIn.fullForReference
               b
-          | UserProgram u -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.fullForReference
+          | UserProgram u ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.fullForReference
               u
-          | Package p -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.fullForReference
+          | Package p ->
+            PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.fullForReference
               p
 
 
@@ -885,6 +865,7 @@ module Darklang =
       let userType
         (userType: PACKAGE.Darklang.Stdlib.ProgramTypes.UserType)
         : String =
+        //don't change userType.name here
         let namePart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
             userType.name
@@ -912,6 +893,7 @@ module Darklang =
           let typPart =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference p.typ
 
+          // Don't change p.name here it is already a string
           $"({p.name}: {typPart})"
 
       let userFunction
@@ -956,12 +938,14 @@ module Darklang =
           (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.Parameter)
           : String =
           // TODO: /// for description
+          //name is already a string
           $"({p.name}: {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference p.typ})"
 
       let packageFn (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T) : String =
         // TODO: handle `deprecated`, `description`
         let namePart =
-          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.userFnName p.name
+          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.Package.atDefinition
+            p.name
 
         let typeParamPart =
           match p.typeParams with
@@ -981,9 +965,10 @@ module Darklang =
         let retPart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference p.returnType
 
-        let bodyPart = PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr p.body
+        let bodyPart =
+          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr p.body
 
-        $"let {namePart}{typeParamPart} {paramPart} : {retPart} =\n{PACKAGE.Darklang.PrettyPrinter.indent bodyPart}"
+        $"let {namePart}{typeParamPart} {paramPart} : {retPart} =\n{bodyPart}"
 
 
       let packageType
@@ -991,7 +976,7 @@ module Darklang =
         : String =
         // TODO: take care of deprecated and description
         let namePart =
-          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.atDefinition
+          PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.Package.atDefinition
             p.name
 
         let typeParamPart =

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -796,11 +796,10 @@ module Darklang =
         let typeParamsPart = String.join u.typeParams " "
 
         let paramsPart =
-          String.join
-            (List.map
-              PACKAGE.Darklang.PrettyPrinter.ProgramTypes.UserFunction.parameter
-              u.parameters)
-            " "
+          String.join (
+            List.map u.parameters (fun p ->
+              PACKAGE.Darklang.PrettyPrinter.ProgramTypes.UserFunction.parameter p)
+          )
 
         let retPart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference u.returnType

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -865,7 +865,6 @@ module Darklang =
       let userType
         (userType: PACKAGE.Darklang.Stdlib.ProgramTypes.UserType)
         : String =
-        //don't change userType.name here
         let namePart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
             userType.name
@@ -893,7 +892,6 @@ module Darklang =
           let typPart =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference p.typ
 
-          // Don't change p.name here it is already a string
           $"({p.name}: {typPart})"
 
       let userFunction
@@ -938,7 +936,6 @@ module Darklang =
           (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.Parameter)
           : String =
           // TODO: /// for description
-          //name is already a string
           $"({p.name}: {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference p.typ})"
 
       let packageFn (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T) : String =

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -13,6 +13,7 @@ module Darklang =
             "why are you trying to print a stdlib type name _definition_?"
 
           let fullForReference
+            (nameToString: 'name -> String)
             (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn)
             : String =
             let modulesPart =
@@ -22,13 +23,14 @@ module Darklang =
 
             let versionPart =
               if t.version == 0 then "" else $"_v{Int.toString t.version}"
-            // TODO: name should be a string
-            $"{modulesPart}{t.name}{versionPart}"
+
+            $"{modulesPart}{nameToString t.name}{versionPart}"
 
 
         module UserProgram =
           let atDefinition
             // TODO: take in just typ and version - modules should have already been dealt with
+            (nameToString: 'name -> String)
             (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram)
             : String =
             match u.modules with
@@ -36,32 +38,32 @@ module Darklang =
               let versionPart =
                 if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
-              //TODO: name should be a string
-              $"{u.name}{versionPart}"
+              $"{nameToString u.name}{versionPart}"
             | _ -> "(UserTypeName.atDefinition unexpected nonempty u.modules)"
 
           let fullForReference
+            (nameToString: 'name -> String)
             (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram)
             : String =
             let versionPart =
               if u.version == 0 then "" else $"_v{Int.toString u.version}"
 
-            //TODO: name should be a string
-            $"{u.name}{versionPart}"
+            $"{nameToString u.name}{versionPart}"
 
 
         module Package =
           let atDefinition
             // TODO: take in just owner, typ, and version - modules should have already been dealt with
+            (nameToString: 'name -> String)
             (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package)
             : String =
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
-            //TODO: name should be a string
-            $"{p.name}{versionPart}"
+            $"{nameToString p.name}{versionPart}"
 
           let fullForReference
+            (nameToString: 'name -> String)
             (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package)
             : String =
             let modulesPart = String.join p.modules "."
@@ -69,8 +71,7 @@ module Darklang =
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
 
-            //TODO name should be a string
-            $"PACKAGE.{p.owner}.{modulesPart}.{p.name}{versionPart}"
+            $"PACKAGE.{p.owner}.{modulesPart}.{nameToString p.name}{versionPart}"
 
 
         let atDefinition

--- a/packages/darklang/stdlib/canvas.dark
+++ b/packages/darklang/stdlib/canvas.dark
@@ -1,6 +1,6 @@
 module Darklang =
-  module Stdlib =
-    type Canvas =
+  module Canvas =
+    type Program =
       { types: List<PACKAGE.Darklang.Stdlib.ProgramTypes.UserType.T>
         dbs: List<PACKAGE.Darklang.Stdlib.ProgramTypes.DB.T>
         fns: List<PACKAGE.Darklang.Stdlib.ProgramTypes.UserFunction.T>

--- a/packages/darklang/stdlib/programTypes.dark
+++ b/packages/darklang/stdlib/programTypes.dark
@@ -27,25 +27,68 @@ module Darklang =
 
         type T<'name> =
           | BuiltIn of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<'name>
-          | UserProgram of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<'name>
+          | UserProgram of
+            PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<'name>
           | Package of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<'name>
+
+        type NamePrinter<'name> = 'name -> String
+
+
+        let builtinToString (s: BuiltIn<'name>) (f: NamePrinter<'name>) : String =
+          let name = s.modules |> List.append [ f s.name ] |> String.join "."
+          if s.version == 0 then name else $"{name}_v{s.version}"
+
+        let userProgramToString
+          (s: UserProgram<'name>)
+          (f: NamePrinter<'name>)
+          : String =
+          let name = s.modules |> List.append [ f s.name ] |> String.join "."
+          if s.version == 0 then name else $"{name}_v{s.version}"
+
+        let packageToString (s: Package<'name>) (f: NamePrinter<'name>) : String =
+          let name =
+            [ "PACKAGE"; s.owner ] |> List.append [ f s.name ] |> String.join "."
+
+          if s.version == 0 then name else $"{name}_v{s.version}"
+
+        let toString (name: T<'name>) (f: NamePrinter<'name>) : String =
+          match name with
+          | BuiltIn b -> builtinToString b f
+          | UserProgram user -> userProgramToString user f
+          | Package pkg -> packageToString pkg f
 
 
       module TypeName =
         type Name = TypeName of String
         type T = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T<Name>
         type BuiltIn = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<Name>
-        type UserProgram = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<Name>
+
+        type UserProgram =
+          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<Name>
+
         type Package = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<Name>
 
+        let toString
+          (name: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
+          : String =
+          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.toString
+            name
+            (fun (TypeName n) -> n)
 
       module FnName =
         type Name = FnName of String
         type T = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T<Name>
         type BuiltIn = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<Name>
-        type UserProgram = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<Name>
+
+        type UserProgram =
+          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<Name>
+
         type Package = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<Name>
 
+        let toString (name: T) : String =
+          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.toString
+            name
+            (fun (FnName n) -> n)
 
       /// Darklang's available types (int, List<T>, user-defined types, etc.)
       type TypeReference =

--- a/packages/darklang/stdlib/programTypes.dark
+++ b/packages/darklang/stdlib/programTypes.dark
@@ -31,31 +31,6 @@ module Darklang =
             PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<'name>
           | Package of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<'name>
 
-        type NamePrinter<'name> = 'name -> String
-
-
-        let builtinToString (s: BuiltIn<'name>) (f: NamePrinter<'name>) : String =
-          let name = s.modules |> List.append [ f s.name ] |> String.join "."
-          if s.version == 0 then name else $"{name}_v{s.version}"
-
-        let userProgramToString
-          (s: UserProgram<'name>)
-          (f: NamePrinter<'name>)
-          : String =
-          let name = s.modules |> List.append [ f s.name ] |> String.join "."
-          if s.version == 0 then name else $"{name}_v{s.version}"
-
-        let packageToString (s: Package<'name>) (f: NamePrinter<'name>) : String =
-          let name =
-            [ "PACKAGE"; s.owner ] |> List.append [ f s.name ] |> String.join "."
-
-          if s.version == 0 then name else $"{name}_v{s.version}"
-
-        let toString (name: T<'name>) (f: NamePrinter<'name>) : String =
-          match name with
-          | BuiltIn b -> builtinToString b f
-          | UserProgram user -> userProgramToString user f
-          | Package pkg -> packageToString pkg f
 
 
       module TypeName =
@@ -68,13 +43,6 @@ module Darklang =
 
         type Package = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<Name>
 
-        let toString
-          (name: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
-          : String =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.toString
-            name
-            (fun (TypeName n) -> n)
-
       module FnName =
         type Name = FnName of String
         type T = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T<Name>
@@ -84,11 +52,6 @@ module Darklang =
           PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<Name>
 
         type Package = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<Name>
-
-        let toString (name: T) : String =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.toString
-            name
-            (fun (FnName n) -> n)
 
       /// Darklang's available types (int, List<T>, user-defined types, etc.)
       type TypeReference =

--- a/packages/darklang/stdlib/programTypes.dark
+++ b/packages/darklang/stdlib/programTypes.dark
@@ -1,71 +1,50 @@
 module Darklang =
   module Stdlib =
     module ProgramTypes =
+      /// Used to name where type/function/etc lives, eg a BuiltIn module, a User module,
+      /// or a Package module.
+      module FQName =
 
-      /// Used to reference a type defined by a User, Standard Library module, or Package
-      module FQTypeName =
-        /// A type written in F# and shipped in the executable.
-        /// Module required for all but a few cases.
-        type StdlibTypeName =
+        /// A name that is built into the runtime
+        type BuiltIn<'name> =
           { modules: List<String>
-            typ: String
+            name: 'name
             version: Int }
 
-        /// A type in the package manager
-        type PackageTypeName =
+        /// Part of the user's program (eg canvas or cli)
+        type UserProgram<'name> =
+          { modules: List<String>
+            name: 'name
+            version: Int }
+
+        /// The name of a thing in the package manager
+        // TODO: We plan to use UUIDs for this, but this is a placeholder
+        type Package<'name> =
           { owner: String
-            modules: List<String> // CLEANUP this is a nonemptylist internally
-            typ: String
-            version: Int }
-
-        /// A type written by a User in a Canvas
-        type UserTypeName =
-          {
-            /// The module in which the type is namespaced
             modules: List<String>
-
-            /// The name of the user-defined type
-            typ: String
-
-            /// The version (0 or greater) of the type
-            version: Int
-          }
-
-        type T =
-          | User of PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.UserProgram
-          | Stdlib of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn
-          | Package of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package
-
-
-      /// A Fully-Qualified Function Name
-      /// Includes package, module, and version information where relevant.
-      module FQFnName =
-        /// Standard Library Function Name
-        type StdlibFnName =
-          { modules: List<String>
-            function_: String
+            name: 'name
             version: Int }
 
-        /// A Function written by a User in a Canvas
-        type UserFnName =
-          { modules: List<String>
-            function_: String
-            version: Int }
+        type T<'name> =
+          | BuiltIn of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<'name>
+          | UserProgram of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<'name>
+          | Package of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<'name>
 
-        /// A Function in the Package Manager
-        type PackageFnName =
-          {
-            owner: String
-            /// CLEANUP: was NonEmptyList<String> in F#
-            modules: List<String>
-            function_: String
-            version: Int
-          }
 
-        type T =
-          | User of PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.UserProgram
-          | Stdlib of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn
-          | Package of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package
+      module TypeName =
+        type Name = TypeName of String
+        type T = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T<Name>
+        type BuiltIn = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<Name>
+        type UserProgram = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<Name>
+        type Package = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<Name>
+
+
+      module FnName =
+        type Name = FnName of String
+        type T = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T<Name>
+        type BuiltIn = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<Name>
+        type UserProgram = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<Name>
+        type Package = PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<Name>
 
 
       /// Darklang's available types (int, List<T>, user-defined types, etc.)
@@ -519,7 +498,7 @@ module Darklang =
         type T =
           { tlid: PACKAGE.Darklang.Stdlib.TLID
             id: Uuid
-            name: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package
+            name: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package
             typeParams: List<String>
             definition: PACKAGE.Darklang.Stdlib.ProgramTypes.CustomType.T
             description: String


### PR DESCRIPTION
No changelog

This PR:
- Updates Dark ProgramTypes given internal changes
- Fixes package-loading 
- Adds functions to the model in client.dark
- Starts creating a new view where functions, types, handlers, etc will live
- Starts adding a Repl

Current editor state:

https://github.com/darklang/dark/assets/87861924/de837a38-ae19-4665-b37f-f6bce9da6f1b



Follow-ups:
- [ ] Pretty print PipeExpr
- [ ] Editor: When presenting the function list, only show function names without displaying the body.