### PR TITLE
Tidy CanvasHack

### DIFF
--- a/backend/experiments/CanvasHack/CanvasHack.fsproj
+++ b/backend/experiments/CanvasHack/CanvasHack.fsproj
@@ -17,9 +17,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/LibExecution/LibExecution.fsproj" />
-    <ProjectReference Include="../../src/Parser/Parser.fsproj" />
-    <ProjectReference Include="../../src/StdLibExecution/StdLibExecution.fsproj" />
     <ProjectReference Include="../../src/LibBackend/LibBackend.fsproj" />
+    <ProjectReference Include="../../src/Parser/Parser.fsproj" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
No changelog

FYI: I got annoyed at having to type the full of `./scripts/run-canvas-hack load-from-disk dark-editor`.
This allows you to just type `./scripts/run-canvas-hack dark-editor`