### PR TITLE
Allow LocalExec to run other scripts; add WIP sync-data script

### DIFF
--- a/backend/src/LocalExec/Libs/CLI.fs
+++ b/backend/src/LocalExec/Libs/CLI.fs
@@ -1,0 +1,143 @@
+/// StdLib functions for building the CLI
+/// (as opposed to functions needed by CLI programs, which are in StdLibCLI)
+module LocalExec.Libs.CLI
+
+open System.Threading.Tasks
+
+open Prelude
+open LibExecution.RuntimeTypes
+open LibExecution.StdLib.Shortcuts
+
+module PT = LibExecution.ProgramTypes
+module RT = LibExecution.RuntimeTypes
+module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
+module Exe = LibExecution.Execution
+
+let (builtInFns, builtInTypes) =
+  LibExecution.StdLib.combine
+    [ StdLibExecution.StdLib.contents
+      StdLibCLI.StdLib.contents
+      StdLibDarkInternal.StdLib.contents ]
+    []
+    []
+
+let libraries : RT.Libraries =
+  { builtInTypes = builtInTypes |> Tablecloth.Map.fromListBy (fun typ -> typ.name)
+    builtInFns = builtInFns |> Tablecloth.Map.fromListBy (fun fn -> fn.name)
+    packageFns = Map.empty
+    packageTypes = Map.empty }
+
+
+let execute
+  (parentState : RT.ExecutionState)
+  (mod' : Parser.CanvasV2.CanvasModule)
+  (symtable : Map<string, RT.Dval>)
+  : Task<RT.Dval> =
+
+  task {
+    let config : Config =
+      { allowLocalHttpAccess = true; httpclientTimeoutInMs = 30000 }
+    let program : Program =
+      { canvasID = System.Guid.NewGuid()
+        internalFnsAllowed = true
+        fns =
+          mod'.fns
+          |> List.map (fun fn -> PT2RT.UserFunction.toRT fn)
+          |> Tablecloth.Map.fromListBy (fun fn -> fn.name)
+        types =
+          mod'.types
+          |> List.map (fun typ -> PT2RT.UserType.toRT typ)
+          |> Tablecloth.Map.fromListBy (fun typ -> typ.name)
+        dbs = Map.empty
+        secrets = [] }
+
+    let tracing = Exe.noTracing RT.Real
+    let notify = parentState.notify
+    let sendException = parentState.reportException
+    let state =
+      Exe.createState libraries tracing sendException notify 7UL program config
+
+    if mod'.exprs.Length = 1 then
+      return! Exe.executeExpr state symtable (PT2RT.Expr.toRT mod'.exprs[0])
+    else if mod'.exprs.Length = 0 then
+      return DError(SourceNone, "No expressions to execute")
+    else // mod'.exprs.Length > 1
+      return DError(SourceNone, "Multiple expressions to execute")
+  }
+
+let types : List<BuiltInType> =
+  [ { name = typ [ "LocalExec" ] "ExecutionError" 0
+      description = "Result of Execution"
+      typeParams = []
+      definition =
+        CustomType.Record(
+          { name = "msg"; typ = TString; description = "The error message" },
+          [ { name = "metadata"
+              typ = TDict TString
+              description = "List of metadata as strings" } ]
+        )
+      deprecated = NotDeprecated } ]
+
+
+let fns : List<BuiltInFn> =
+  [ { name = fn [ "LocalExec" ] "parseAndExecuteScript" 0
+      typeParams = []
+      parameters =
+        [ Param.make "filename" TString ""
+          Param.make "code" TString ""
+          Param.make "symtable" (TList TString) "" ]
+      returnType =
+        TResult(
+          TInt,
+          TCustomType(FQName.BuiltIn(typ [ "CLI" ] "ExecutionError" 0), [])
+        )
+      description = "Parses and executes arbitrary Dark code"
+      fn =
+        function
+        | state, [], [ DString filename; DString code; args ] ->
+          uply {
+            let err (msg : string) (metadata : List<string * string>) =
+              let metadata = metadata |> List.map (fun (k, v) -> k, DString v) |> Map
+              let fields = [ "msg", DString msg; "metadata", DDict metadata ]
+              DResult(
+                Error(
+                  DRecord(
+                    FQName.BuiltIn(typ [ "CLI" ] "ExecutionError" 0),
+                    Map fields
+                  )
+                )
+              )
+
+            let exnError (e : exn) : Dval =
+              let msg = Exception.getMessages e |> String.concat "\n"
+              let metadata =
+                Exception.toMetadata e |> List.map (fun (k, v) -> k, string v)
+              err msg metadata
+
+            let parsedScript =
+              try
+                Parser.CanvasV2.parse filename code |> Ok
+              with e ->
+                Error(exnError e)
+
+            try
+              match parsedScript with
+              | Ok mod' ->
+                let symtable = [ ("args", args) ] |> Map.ofList
+
+                match! execute state mod' symtable with
+                | DInt i -> return DResult(Ok(DInt i))
+                | DError(_, e) -> return err e []
+                | result ->
+                  let asString = LibExecution.DvalReprDeveloper.toRepr result
+                  return err $"Expected an integer" [ "actualValue", asString ]
+              | Error e -> return e
+            with e ->
+              return exnError e
+          }
+        | _ -> incorrectArgs ()
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated } ]
+
+let contents = (fns, types)

--- a/backend/src/LocalExec/Libs/Packages.fs
+++ b/backend/src/LocalExec/Libs/Packages.fs
@@ -33,6 +33,8 @@ let types : List<BuiltInType> =
               description = "The version of the function" } ]
         )
       deprecated = NotDeprecated }
+
+
     { name = typ [ "LocalExec"; "Packages" ] "Type" 0
       description = "The name of a package type"
       typeParams = []
@@ -48,8 +50,6 @@ let types : List<BuiltInType> =
             { name = "version"; typ = TInt; description = "The version of the type" } ]
         )
       deprecated = NotDeprecated } ]
-
-
 
 
 let fns : List<BuiltInFn> =
@@ -181,4 +181,6 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated } ]
+
+
 let contents : LibExecution.StdLib.Contents = (fns, types)

--- a/backend/src/LocalExec/LocalExec.fsproj
+++ b/backend/src/LocalExec/LocalExec.fsproj
@@ -22,10 +22,12 @@
     <ProjectReference Include="../Parser/Parser.fsproj" />
     <ProjectReference Include="../StdLibExecution/StdLibExecution.fsproj" />
     <ProjectReference Include="../StdLibCLI/StdLibCLI.fsproj" />
+    <ProjectReference Include="../StdLibDarkInternal/StdLibDarkInternal.fsproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Libs/Packages.fs" />
+    <Compile Include="Libs/CLI.fs" />
     <Compile Include="StdLib.fs" />
     <Compile Include="LocalExec.fs" />
   </ItemGroup>

--- a/backend/src/LocalExec/StdLib.fs
+++ b/backend/src/LocalExec/StdLib.fs
@@ -15,4 +15,4 @@ let typeRenames : StdLib.TypeRenames =
   []
 
 let contents : StdLib.Contents =
-  StdLib.combine [ Libs.Packages.contents ] fnRenames typeRenames
+  StdLib.combine [ Libs.Packages.contents; Libs.CLI.contents ] fnRenames typeRenames

--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -4,12 +4,14 @@ let listDirectoryRecursive (dir: String) : List<String> =
   let nested = dirs |> List.map (fun d -> listDirectoryRecursive d) |> List.flatten
   dirs |> List.append files |> List.append nested
 
-let listPackageFiles (dir: String) : List<String> =
+
+// Packages
+let listPackageFilesOnDisk (dir: String) : List<String> =
   dir
   |> listDirectoryRecursive
   |> List.filter (fun x -> x |> String.endsWith ".dark")
 
-let loadFile (filename: String) : Unit =
+let loadPackageFile (filename: String) : Unit =
   filename
   |> File.read
   |> unwrap
@@ -17,10 +19,37 @@ let loadFile (filename: String) : Unit =
   |> LocalExec.Packages.parseAndSave filename
   |> unwrap
 
-type CliOptions =
+let printPackageFunction (p: LocalExec.Packages.Function) : Unit =
+  let modules = p.modules |> String.join "."
+
+  print
+    $"Package Function {p.owner}.{modules}.{p.name}_v{Int.toString_v0 p.version}"
+
+let printPackageType (p: LocalExec.Packages.Type) : Unit =
+  let modules = p.modules |> String.join "."
+  print $"Package Type {p.owner}.{modules}.{p.name}_v{Int.toString_v0 p.version}"
+
+let printAllPackages () : Unit =
+  let functions = LocalExec.Packages.listFunctions ()
+  functions |> List.iter (fun p -> printPackageFunction p)
+
+  let types = LocalExec.Packages.listTypes ()
+  types |> List.iter (fun p -> printPackageType p)
+
+
+// Running scripts
+let runScript (path: String) (args: List<String>) : Int =
+  let script = (File.read path) |> unwrap |> String.fromBytes
+  let result = (LocalExec.parseAndExecuteScript path script args) |> unwrap
+  result
+
+
+// parse args and execute
+type CLIOptions =
   | Help
   | LoadPackages
   | ListPackages
+  | RunScript of path: String * args: List<String>
 
 let usage () : String =
   "Usage: LocalExec [options]
@@ -29,53 +58,57 @@ let usage () : String =
       -h, --help     Show this help message and exit
       load-packages  Load packages from packages
       list-packages  List packages
+      run-script     Parse and run .dark script
   "
 
-let printPackageFunction (p: LocalExec.Packages.Function) : Unit =
-  let modules = p.modules |> String.join "."
-  print $"Package Function {p.owner}.{modules}.{p.name}_v{Int.toString_v0 p.version}"
-
-let printPackageType (p: LocalExec.Packages.Type) : Unit =
-  let modules = p.modules |> String.join "."
-  print $"Package Type {p.owner}.{modules}.{p.name}_v{Int.toString_v0 p.version}"
-
-let printPackages () : Unit =
-  let functions = LocalExec.Packages.listFunctions ()
-  functions |> List.iter (fun p -> printPackageFunction p)
-  let types = LocalExec.Packages.listTypes ()
-  types |> List.iter (fun p -> printPackageType p)
-
-
-let parseArgs (args: List<String>) : Result<CliOptions, String> =
+let parseArgs (args: List<String>) : Result<CLIOptions, String> =
   match args with
-  | [] -> Ok CliOptions.Help
-  | [ "-h" ] -> Ok CliOptions.Help
-  | [ "--help" ] -> Ok CliOptions.Help
-  | [ "load-packages" ] -> Ok CliOptions.LoadPackages
-  | [ "list-packages" ] -> Ok CliOptions.ListPackages
+  | [] -> Ok CLIOptions.Help
+  | [ "-h" ] -> Ok CLIOptions.Help
+  | [ "--help" ] -> Ok CLIOptions.Help
+
+  | [ "list-packages" ] -> Ok CLIOptions.ListPackages
+  | [ "load-packages" ] -> Ok CLIOptions.LoadPackages
+
+  | [ "run-script" ] -> Error "Missing path to script after `run-script`"
+  | "run-script" :: path :: args -> Ok(CLIOptions.RunScript (path, args))
+
   | _ -> Error "Invalid arguments"
+
 
 let main (args: List<String>) : Int =
   match parseArgs args with
   | Ok Help ->
     print (usage ())
     0
+
+  | Ok ListPackages ->
+    printAllPackages ()
+    0
+
   | Ok LoadPackages ->
     LocalExec.Packages.clear ()
-    let files = listPackageFiles "/home/dark/app/packages"
+    let files = listPackageFilesOnDisk "/home/dark/app/packages"
 
-    do
+    do // can we get rid of this do?
       List.iter files (fun f ->
         print $"Loading {f}"
-        loadFile f)
+        loadPackageFile f)
 
     print "Done loading packages"
-    printPackages ()
+    printAllPackages ()
     0
-  | Ok ListPackages ->
-    printPackages ()
-    0
+
+  | Ok(RunScript(path, args)) ->
+    print $"Running script with LocalExec: {path}"
+    runScript path args
+
+  | Ok _ ->
+    print "Parsed args but not implemented yet"
+    1
+
   | Error msg ->
+    print (usage ())
     print ("Error: " ++ msg)
     1
 

--- a/scripts/deployment/sync-packages-and-canvases.dark
+++ b/scripts/deployment/sync-packages-and-canvases.dark
@@ -1,0 +1,158 @@
+//#!/usr/bin/env darklang-internal
+
+// We do not currently have a database in production that we can safely rely on
+// between deploys. This script is a temporary solution to backup packages and
+// canvases before a deploy, and restore them after a deploy.
+//
+// A companion canvas exists in `dark-classic`, at `dark-ai-backup`, which contains:
+// - a simple data store of `Exports`
+//   roughly: `{ canvases: List<String>; packages: String; timestamp: Date }`
+// - an endpoint to export to (`POST /save-export`)
+// - an endpoint to import from (`GET /latest-export`)
+
+let unwrap (result: Result<String, 'a>) : String =
+  match result with
+  | Ok value -> value
+  | Error error ->
+    // TODO: ensure this actually fails
+    // (it should because of the type signature conflicting with the return type)
+    ()
+
+type CanvasExport = { name: String; content: String }
+
+type DataExport =
+  {
+    /// One big pretty-printed collection of all the nested package modules
+    packages: String
+
+    canvases: List<CanvasExport>
+  }
+
+type ImportResults =
+  {
+    /// List of top-level modules imported
+    packagesImported: List<String>
+
+    canvasesImported: List<String>
+  }
+
+let gatherDataToExport () : Result<DataExport, String> =
+  let packages = DarkInternal.Packages.all ()
+  let canvases = [] // TODO: something like DarkInternal.Canvases.all ()
+
+  let prettyPackages = PACKAGE.Darklang.PrettyPrinter.packages packages
+
+  let prettyCanvases =
+    canvases
+    |> List.map (fun canvas ->
+      CanvasExport
+        { name = canvas.name
+          content = PACKAGE.Darklang.PrettyPrinter.canvas canvas })
+
+  (DataExport
+    { packages = prettyPackages
+      canvases = prettyCanvases })
+  |> Ok
+
+let export (unit: Unit) : Result<Unit, String> =
+  print "gathering data to export"
+  let data = (gatherDataToExport ()) |> unwrap
+
+  print "serializing data to export"
+  let json = (Json.serialize<DataExport> data) |> unwrap
+
+  print "exporting data to `dark-ai-backup`"
+
+  let response =
+    (HttpClient.request
+      "POST"
+      "http://dark-ai-backup.builtwithdark.com/save-export"
+      [ ("Content-Type", "application/json") ]
+      (String.toBytes json))
+    |> unwrap
+
+  // TODO: ensure 200 OK
+
+  print "done export"
+
+  Ok()
+
+let import () : Result<ImportResults, String> =
+  print "fetching latest export from `dark-ai-backup`"
+
+  let response =
+    (HttpClient.request
+      "GET"
+      "http://dark-ai-backup.builtwithdark.com/latest-export"
+      [ ("Accept", "application/json") ]
+      Bytes.empty)
+    |> unwrap
+
+  print "deserializing response from `dark-ai-backup`"
+  let deserialized = (Json.parse<DataExport> response) |> unwrap
+
+  print "parsing and importing packages"
+
+  let packageImportResults =
+    DarkInternal.Packages.parseAndImport deserialized.Packages
+
+    List.fold packageImportResults (Ok []) (fun acc result ->
+      match acc with
+      | Error error -> Error error
+      | Ok acc ->
+        let result = DarkInternal.Packages.parseAndImport package
+
+        match result with
+        | Ok _ -> Ok(List.append acc [ package.name ])
+        | Error error -> Error error)
+
+
+  print "parsing and importing canvases"
+  // List of results -- hopefully List of OKs
+  let canvasImportResults =
+    List.fold canvasImportResults (Ok []) (fun acc result ->
+      match acc with
+      | Error error -> Error error
+      | Ok acc ->
+        let result = DarkInternal.Canvas.parseAndImport canvas
+
+        match result with
+        | Ok _ -> Ok(List.append acc [ canvas.name ])
+        | Error error -> Error error)
+
+  print "handling results"
+
+  match (packageImportResults, canvasImportResults) with
+  | (Ok packages, Ok canvases) ->
+    (ImportResults
+      { packagesImported = packages
+        canvasesImported = canvases })
+    |> Ok
+  | (Error error, _) -> Error error
+  | (_, Error error) -> Error error
+
+
+let main (args: List<String>) : Int =
+  print "running `sync-packages-and-canvases.dark`"
+
+  match args with
+  | [ "export" ] ->
+    match export () with
+    | Ok _ -> 0
+    | Error error ->
+      print error
+      1
+
+  | [ "import" ] ->
+    match import () with
+    | Ok _ -> 0
+    | Error error ->
+      print error
+      1
+  | _ ->
+    print
+      "Usage: ./scripts/run-cli-internal ./scripts/deployment/sync-packages-and-canvases.dark [export|import]"
+
+    1
+
+main args


### PR DESCRIPTION
Changelog:

```
LocalExec
- enable ability to add another script

Infra
- add incomplete script to sync packages and canvases during deploys
```

This is final useful bit extracted out of #4949.