### PR TITLE
Add WrittenTypes

### DIFF
--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -58,7 +58,7 @@ let libraries : RT.Libraries =
 
 
 let execute
-  (mod' : Parser.CanvasV2.CanvasModule)
+  (mod' : Parser.CanvasV2.PTCanvasModule)
   (symtable : Map<string, RT.Dval>)
   : Task<RT.Dval> =
 

--- a/backend/src/Cli/Libs/Cli.fs
+++ b/backend/src/Cli/Libs/Cli.fs
@@ -31,7 +31,7 @@ let libraries : RT.Libraries =
 
 let execute
   (parentState : RT.ExecutionState)
-  (mod' : Parser.CanvasV2.CanvasModule)
+  (mod' : Parser.CanvasV2.PTCanvasModule)
   (symtable : Map<string, RT.Dval>)
   : Task<RT.Dval> =
 

--- a/backend/src/LocalExec/Libs/Cli.fs
+++ b/backend/src/LocalExec/Libs/Cli.fs
@@ -30,7 +30,7 @@ let libraries : RT.Libraries =
 
 let execute
   (parentState : RT.ExecutionState)
-  (mod' : Parser.CanvasV2.CanvasModule)
+  (mod' : Parser.CanvasV2.PTCanvasModule)
   (symtable : Map<string, RT.Dval>)
   : Task<RT.Dval> =
 

--- a/backend/src/LocalExec/Libs/Packages.fs
+++ b/backend/src/LocalExec/Libs/Packages.fs
@@ -91,9 +91,9 @@ let fns : List<BuiltInFn> =
         function
         | _, _, [ DString contents; DString path ] ->
           uply {
-            let packages = Parser.Package.parse path contents
-            do! LibBackend.PackageManager.savePackageFunctions packages.fns
-            do! LibBackend.PackageManager.savePackageTypes packages.types
+            let (fns, types) = Parser.Parser.parsePackage path contents
+            do! LibBackend.PackageManager.savePackageFunctions fns
+            do! LibBackend.PackageManager.savePackageTypes types
             return DUnit
           }
         | _ -> incorrectArgs ()

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -30,7 +30,7 @@ let defaultTLID = 7UL
 
 
 let execute
-  (mod' : Parser.CanvasV2.CanvasModule)
+  (mod' : Parser.CanvasV2.PTCanvasModule)
   (symtable : Map<string, RT.Dval>)
   : Task<RT.Dval> =
   task {
@@ -85,7 +85,7 @@ let execute
 let sourceOf
   (tlid : tlid)
   (id : id)
-  (modul : Parser.CanvasV2.CanvasModule)
+  (modul : Parser.CanvasV2.PTCanvasModule)
   : string =
   let ast =
     if tlid = defaultTLID then

--- a/backend/src/Parser/CanvasV2.fs
+++ b/backend/src/Parser/CanvasV2.fs
@@ -5,11 +5,23 @@ open FSharp.Compiler.Syntax
 open Prelude
 open Tablecloth
 
+module WT = WrittenTypes
+module WT2PT = WrittenTypesToProgramTypes
 module PT = LibExecution.ProgramTypes
 
 open Utils
 
-type CanvasModule =
+type WTCanvasModule =
+  { types : List<WT.UserType.T>
+    fns : List<WT.UserFunction.T>
+    dbs : List<WT.DB.T>
+    // TODO: consider breaking this down into httpHandlers, crons, workers, and repls
+    handlers : List<WT.Handler.Spec * WT.Expr>
+    exprs : List<WT.Expr> }
+
+let emptyWTModule = { types = []; fns = []; dbs = []; handlers = []; exprs = [] }
+
+type PTCanvasModule =
   { types : List<PT.UserType.T>
     fns : List<PT.UserFunction.T>
     dbs : List<PT.DB.T>
@@ -17,7 +29,6 @@ type CanvasModule =
     handlers : List<PT.Handler.Spec * PT.Expr>
     exprs : List<PT.Expr> }
 
-let emptyModule = { types = []; fns = []; dbs = []; handlers = []; exprs = [] }
 
 
 /// Extracts the parts we care about from an F# attribute
@@ -53,7 +64,7 @@ let (|SimpleAttribute|_|) (attr : SynAttribute) =
 
 /// Update a CanvasModule by parsing a single F# let binding
 /// Depending on the attribute present, this may add a user function, a handler, or a DB
-let parseLetBinding (m : CanvasModule) (letBinding : SynBinding) : CanvasModule =
+let parseLetBinding (m : WTCanvasModule) (letBinding : SynBinding) : WTCanvasModule =
   match letBinding with
   | SynBinding(_, _, _, _, attrs, _, _, pat, returnInfo, expr, _, _, _) ->
     let expr = ProgramTypes.Expr.fromSynExpr expr
@@ -69,11 +80,11 @@ let parseLetBinding (m : CanvasModule) (letBinding : SynBinding) : CanvasModule 
       match returnInfo with
       | None ->
         let newExpr =
-          PT.ELet(
+          WT.ELet(
             gid (),
             ProgramTypes.LetPattern.fromSynPat pat,
             expr,
-            PT.EUnit(gid ())
+            WT.EUnit(gid ())
           )
         { m with exprs = m.exprs @ [ newExpr ] }
       | Some _ ->
@@ -83,7 +94,7 @@ let parseLetBinding (m : CanvasModule) (letBinding : SynBinding) : CanvasModule 
     | [ attr ] ->
       match attr with
       | SimpleAttribute("HttpHandler", [ method; route ]) ->
-        let newHttpHanlder = PT.Handler.Spec.HTTP(route, method)
+        let newHttpHanlder = WT.Handler.Spec.HTTP(route, method)
         { m with handlers = (newHttpHanlder, expr) :: m.handlers }
 
       | SimpleAttribute("REPL", [ name ]) ->
@@ -120,7 +131,7 @@ let parseLetBinding (m : CanvasModule) (letBinding : SynBinding) : CanvasModule 
 
 
 module UserDB =
-  let fromSynTypeDefn (typeDef : SynTypeDefn) : PT.DB.T =
+  let fromSynTypeDefn (typeDef : SynTypeDefn) : WT.DB.T =
     match typeDef with
     | SynTypeDefn(SynComponentInfo(_, _params, _, [ id ], _, _, _, _),
                   SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev(_, typ, _),
@@ -136,7 +147,7 @@ module UserDB =
     | _ ->
       Exception.raiseInternal $"Unsupported db definition" [ "typeDef", typeDef ]
 
-let parseTypeDefn (m : CanvasModule) (typeDefn : SynTypeDefn) : CanvasModule =
+let parseTypeDefn (m : WTCanvasModule) (typeDefn : SynTypeDefn) : WTCanvasModule =
   match typeDefn with
   | SynTypeDefn(SynComponentInfo(attrs, _, _, _, _, _, _, _), _, _, _, _, _) ->
     let isDB =
@@ -168,9 +179,9 @@ let parseTypeDefn (m : CanvasModule) (typeDefn : SynTypeDefn) : CanvasModule =
 ///   or as DBs (i.e. with `[<DB>] DBName = Type`)
 /// - ? expressions are parsed as init commands (not currently supported)
 /// - anything else fails
-let parseDecls (decls : List<SynModuleDecl>) : CanvasModule =
+let parseDecls (decls : List<SynModuleDecl>) : WTCanvasModule =
   List.fold
-    emptyModule
+    emptyWTModule
     (fun m decl ->
       match decl with
       | SynModuleDecl.Let(_, bindings, _) ->
@@ -185,7 +196,17 @@ let parseDecls (decls : List<SynModuleDecl>) : CanvasModule =
       | _ -> Exception.raiseInternal $"Unsupported declaration" [ "decl", decl ])
     decls
 
-let postProcessModule (m : CanvasModule) : CanvasModule =
+let toPT (m : WTCanvasModule) : PTCanvasModule =
+  { types = m.types |> List.map WT2PT.UserType.toPT
+    fns = m.fns |> List.map WT2PT.UserFunction.toPT
+    dbs = m.dbs |> List.map WT2PT.DB.toPT
+    handlers =
+      m.handlers
+      |> List.map (fun (spec, expr) ->
+        (WT2PT.Handler.Spec.toPT spec, WT2PT.Expr.toPT expr))
+    exprs = m.exprs |> List.map WT2PT.Expr.toPT }
+
+let postProcessModule (m : PTCanvasModule) : PTCanvasModule =
   let userFnNames = m.fns |> List.map (fun f -> f.name) |> Set
   let userTypeNames = m.types |> List.map (fun t -> t.name) |> Set
   let fixExpr = NameResolution.Expr.resolveNames userFnNames userTypeNames
@@ -203,7 +224,7 @@ let postProcessModule (m : CanvasModule) : CanvasModule =
         { db with
             typ = NameResolution.TypeReference.resolveNames userTypeNames db.typ }) }
 
-let parse (filename : string) (source : string) : CanvasModule =
+let parse (filename : string) (source : string) : PTCanvasModule =
   let parsedAsFSharp = parseAsFSharpSourceFile filename source
 
   let decls =
@@ -222,8 +243,8 @@ let parse (filename : string) (source : string) : CanvasModule =
         $"wrong shape tree - ensure that input is a single expression, perhaps by wrapping the existing code in parens"
         [ "parsedAsFsharp", parsedAsFSharp ]
 
-  decls |> parseDecls |> postProcessModule
+  decls |> parseDecls |> toPT |> postProcessModule
 
 
-let parseFromFile (filename : string) : CanvasModule =
+let parseFromFile (filename : string) : PTCanvasModule =
   filename |> System.IO.File.ReadAllText |> parse filename

--- a/backend/src/Parser/FSharpToWrittenTypes.fs
+++ b/backend/src/Parser/FSharpToWrittenTypes.fs
@@ -1,4 +1,4 @@
-module internal Parser.ProgramTypes
+module internal Parser.FSharpToWrittenTypes
 
 open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis

--- a/backend/src/Parser/NameResolution.fs
+++ b/backend/src/Parser/NameResolution.fs
@@ -3,6 +3,7 @@ module internal Parser.NameResolution
 open Prelude
 open Tablecloth
 
+module FS2WT = FSharpToWrittenTypes
 module PT = LibExecution.ProgramTypes
 
 module TypeName =
@@ -118,7 +119,7 @@ module Expr =
           )
         // pipes with variables might be fn calls
         | PT.EPipeVariable(id, name) ->
-          match ProgramTypes.Expr.parseFn name with
+          match FS2WT.Expr.parseFn name with
           | Some(name, version) ->
             if
               Set.contains (PT.FnName.userProgram [] name version) userFunctions

--- a/backend/src/Parser/NameResolution.fs
+++ b/backend/src/Parser/NameResolution.fs
@@ -1,0 +1,245 @@
+module Parser.NameResolution
+
+open Prelude
+open Tablecloth
+
+module PT = LibExecution.ProgramTypes
+
+module TypeName =
+  let resolveNames
+    (userTypes : Set<PT.TypeName.UserProgram>)
+    (name : PT.TypeName.T)
+    : PT.TypeName.T =
+    match name with
+    | PT.FQName.Package _ -> name
+    | PT.FQName.UserProgram n ->
+      match n.modules with
+      | "PACKAGE" :: owner :: package :: rest ->
+        PT.FQName.Package
+          { owner = owner
+            modules = NonEmptyList.ofList (package :: rest)
+            name = n.name
+            version = n.version }
+      | _ ->
+        if Set.contains n userTypes then
+          PT.FQName.UserProgram n
+        else
+          PT.FQName.BuiltIn
+            { name = n.name; version = n.version; modules = n.modules }
+    | PT.FQName.BuiltIn n ->
+      let userName : PT.TypeName.UserProgram =
+        { modules = n.modules; name = n.name; version = n.version }
+      if Set.contains userName userTypes then
+        PT.FQName.UserProgram(userName)
+      else
+        PT.FQName.BuiltIn(n)
+
+module FnName =
+  let resolveNames
+    (userFns : Set<PT.FnName.UserProgram>)
+    (name : PT.FnName.T)
+    : PT.FnName.T =
+    match name with
+    | PT.FQName.Package _ -> name
+    | PT.FQName.UserProgram n ->
+      match n.modules with
+      | "PACKAGE" :: owner :: package :: rest ->
+        PT.FQName.Package
+          { owner = owner
+            modules = NonEmptyList.ofList (package :: rest)
+            name = n.name
+            version = n.version }
+      | _ ->
+        if Set.contains n userFns then
+          PT.FQName.UserProgram n
+        else
+          PT.FQName.BuiltIn
+            { name = n.name; version = n.version; modules = n.modules }
+    | PT.FQName.BuiltIn n ->
+      let userName : PT.FnName.UserProgram =
+        { modules = n.modules; name = n.name; version = n.version }
+      if Set.contains userName userFns then
+        PT.FQName.UserProgram(userName)
+      else
+        PT.FQName.BuiltIn(n)
+
+
+module TypeReference =
+
+  let rec resolveNames
+    (userTypes : Set<PT.TypeName.UserProgram>)
+    (typ : PT.TypeReference)
+    : PT.TypeReference =
+    let c = resolveNames userTypes
+    match typ with
+    | PT.TCustomType(tn, args) ->
+      PT.TCustomType(TypeName.resolveNames userTypes tn, List.map c args)
+    | PT.TFn(args, ret) -> PT.TFn(List.map c args, c ret)
+    | PT.TTuple(first, second, theRest) ->
+      PT.TTuple(c first, c second, List.map c theRest)
+    | PT.TList arg -> PT.TList(c arg)
+    | PT.TDict valArg -> PT.TDict(c valArg)
+    | PT.TVariable _ -> typ
+    | PT.TDB arg -> PT.TDB(c arg)
+    | PT.TBool
+    | PT.TBytes
+    | PT.TInt
+    | PT.TString
+    | PT.TChar
+    | PT.TFloat
+    | PT.TDateTime
+    | PT.TUuid
+    | PT.TUnit
+    | PT.TPassword -> typ
+
+
+module Expr =
+  // Second pass of parsing, fixing the thing it's impossible to get right on the
+  // first pass, such as whether function names are user or stdlib names. Parse the
+  // whole program once, and then run this on any expressions, passing in User types
+  // and functions. It converts user types that are not in the list to Stdlib types.
+  // TODO: we need some sort of unambiguous way to refer to user types
+  let resolveNames
+    (userFunctions : Set<PT.FnName.UserProgram>)
+    (userTypes : Set<PT.TypeName.UserProgram>)
+    (e : PT.Expr)
+    : PT.Expr =
+    let resolvePipeExprNames =
+      (fun e ->
+        match e with
+        | PT.EPipeFnCall(id, name, typeArgs, args) ->
+          PT.EPipeFnCall(id, name, typeArgs, args)
+        | PT.EPipeEnum(id, typeName, caseName, fields) ->
+          PT.EPipeEnum(
+            id,
+            TypeName.resolveNames userTypes typeName,
+            caseName,
+            fields
+          )
+        // pipes with variables might be fn calls
+        | PT.EPipeVariable(id, name) ->
+          match ProgramTypes.Expr.parseFn name with
+          | Some(name, version) ->
+            if
+              Set.contains (PT.FnName.userProgram [] name version) userFunctions
+            then
+              PT.EPipeFnCall(id, PT.FnName.fqUserProgram [] name version, [], [])
+            else
+              e
+          | None -> e
+        | _ -> e)
+
+    LibExecution.ProgramTypesAst.preTraversal
+      identity
+      resolvePipeExprNames
+      identity
+      (TypeName.resolveNames userTypes)
+      (FnName.resolveNames userFunctions)
+      identity
+      identity
+      e
+
+module UserFunction =
+  let resolveNames
+    (userFunctions : Set<PT.FnName.UserProgram>)
+    (userTypes : Set<PT.TypeName.UserProgram>)
+    (f : PT.UserFunction.T)
+    : PT.UserFunction.T =
+    { tlid = f.tlid
+      name = f.name
+      typeParams = f.typeParams
+      parameters =
+        f.parameters
+        |> List.map (fun p ->
+          { p with typ = TypeReference.resolveNames userTypes p.typ })
+      returnType = TypeReference.resolveNames userTypes f.returnType
+      description = f.description
+      deprecated = f.deprecated
+      body = Expr.resolveNames userFunctions userTypes f.body }
+
+
+module PackageFn =
+  let resolveNames (f : PT.PackageFn.T) : PT.PackageFn.T =
+    { tlid = f.tlid
+      id = f.id
+      name = f.name
+      typeParams = f.typeParams
+      parameters =
+        f.parameters
+        |> List.map (fun p ->
+          { p with typ = TypeReference.resolveNames Set.empty p.typ })
+      returnType = TypeReference.resolveNames Set.empty f.returnType
+      description = f.description
+      deprecated = f.deprecated
+      body = Expr.resolveNames Set.empty Set.empty f.body }
+
+
+module TypeDeclaration =
+  module EnumCase =
+    let resolveNames
+      (userTypes : Set<PT.TypeName.UserProgram>)
+      (t : PT.TypeDeclaration.EnumCase)
+      : PT.TypeDeclaration.EnumCase =
+      { name = t.name
+        fields =
+          t.fields
+          |> List.map (fun f ->
+            { f with typ = TypeReference.resolveNames userTypes f.typ })
+        description = t.description }
+
+
+  module RecordField =
+    let resolveNames
+      (userTypes : Set<PT.TypeName.UserProgram>)
+      (t : PT.TypeDeclaration.RecordField)
+      : PT.TypeDeclaration.RecordField =
+      { name = t.name
+        typ = TypeReference.resolveNames userTypes t.typ
+        description = t.description }
+
+  module Definition =
+    let resolveNames
+      (userTypes : Set<PT.TypeName.UserProgram>)
+      (t : PT.TypeDeclaration.Definition)
+      : PT.TypeDeclaration.Definition =
+      match t with
+      | PT.TypeDeclaration.Enum(firstCase, additionalCases) ->
+        PT.TypeDeclaration.Enum(
+          EnumCase.resolveNames userTypes firstCase,
+          additionalCases |> List.map (EnumCase.resolveNames userTypes)
+        )
+      | PT.TypeDeclaration.Record(firstField, additionalFields) ->
+        PT.TypeDeclaration.Record(
+          RecordField.resolveNames userTypes firstField,
+          additionalFields |> List.map (RecordField.resolveNames userTypes)
+        )
+      | PT.TypeDeclaration.Alias typ ->
+        PT.TypeDeclaration.Alias(TypeReference.resolveNames userTypes typ)
+
+  let resolveNames
+    (userTypes : Set<PT.TypeName.UserProgram>)
+    (t : PT.TypeDeclaration.T)
+    : PT.TypeDeclaration.T =
+    { definition = Definition.resolveNames userTypes t.definition
+      typeParams = t.typeParams }
+
+
+module UserType =
+  let resolveNames
+    (userTypes : Set<PT.TypeName.UserProgram>)
+    (t : PT.UserType.T)
+    : PT.UserType.T =
+    { tlid = t.tlid
+      name = t.name
+      declaration = TypeDeclaration.resolveNames userTypes t.declaration
+      description = ""
+      deprecated = PT.NotDeprecated }
+
+module PackageType =
+  let resolveNames (f : PT.PackageType.T) : PT.PackageType.T =
+    { tlid = f.tlid
+      id = f.id
+      name = f.name
+      description = f.description
+      deprecated = f.deprecated
+      declaration = TypeDeclaration.resolveNames Set.empty f.declaration }

--- a/backend/src/Parser/NameResolution.fs
+++ b/backend/src/Parser/NameResolution.fs
@@ -1,4 +1,4 @@
-module Parser.NameResolution
+module internal Parser.NameResolution
 
 open Prelude
 open Tablecloth

--- a/backend/src/Parser/Package.fs
+++ b/backend/src/Parser/Package.fs
@@ -1,4 +1,4 @@
-module Parser.Package
+module internal Parser.Package
 
 open FSharp.Compiler.Syntax
 
@@ -93,8 +93,8 @@ let parse (filename : string) (contents : string) : PackageModule =
     // At the toplevel, the module names will from the filenames
     let names = []
     let modul = parseDecls names decls
-    let fns = modul.fns |> List.map ProgramTypes.PackageFn.resolveNames
-    let types = modul.types |> List.map ProgramTypes.PackageType.resolveNames
+    let fns = modul.fns |> List.map NameResolution.PackageFn.resolveNames
+    let types = modul.types |> List.map NameResolution.PackageType.resolveNames
     { fns = fns; types = types }
   // in the parsed package, types are being read as user, as opposed to the package that's right there
   | decl ->

--- a/backend/src/Parser/Package.fs
+++ b/backend/src/Parser/Package.fs
@@ -5,13 +5,18 @@ open FSharp.Compiler.Syntax
 open Prelude
 open Tablecloth
 
+module WT = WrittenTypes
+module WT2PT = WrittenTypesToProgramTypes
 module PT = LibExecution.ProgramTypes
 
 open Utils
 
-type PackageModule = { fns : List<PT.PackageFn.T>; types : List<PT.PackageType.T> }
+type WTPackageModule = { fns : List<WT.PackageFn.T>; types : List<WT.PackageType.T> }
+let emptyWTModule = { fns = []; types = [] }
 
-let emptyModule = { fns = []; types = [] }
+type PTPackageModule = { fns : List<PT.PackageFn.T>; types : List<PT.PackageType.T> }
+
+let emptyPTModule = { fns = []; types = [] }
 
 
 /// Update a CanvasModule by parsing a single F# let binding
@@ -19,7 +24,7 @@ let emptyModule = { fns = []; types = [] }
 let parseLetBinding
   (modules : List<string>)
   (letBinding : SynBinding)
-  : PT.PackageFn.T =
+  : WT.PackageFn.T =
   match modules with
   | owner :: modules ->
     let modules = NonEmptyList.ofList modules
@@ -29,7 +34,7 @@ let parseLetBinding
       "Expected owner, and at least 1 other modules"
       [ "modules", modules; "binding", letBinding ]
 
-let parseTypeDef (modules : List<string>) (defn : SynTypeDefn) : PT.PackageType.T =
+let parseTypeDef (modules : List<string>) (defn : SynTypeDefn) : WT.PackageType.T =
   match modules with
   | owner :: modules ->
     let modules = NonEmptyList.ofList modules
@@ -43,9 +48,9 @@ let parseTypeDef (modules : List<string>) (defn : SynTypeDefn) : PT.PackageType.
 let rec parseDecls
   (modules : List<string>)
   (decls : List<SynModuleDecl>)
-  : PackageModule =
+  : WTPackageModule =
   List.fold
-    emptyModule
+    emptyWTModule
     (fun m decl ->
       match decl with
       | SynModuleDecl.Let(_, bindings, _) ->
@@ -79,7 +84,7 @@ let rec parseDecls
     decls
 
 
-let parse (filename : string) (contents : string) : PackageModule =
+let parse (filename : string) (contents : string) : PTPackageModule =
   match parseAsFSharpSourceFile filename contents with
   | ParsedImplFileInput(_,
                         _,
@@ -93,8 +98,14 @@ let parse (filename : string) (contents : string) : PackageModule =
     // At the toplevel, the module names will from the filenames
     let names = []
     let modul = parseDecls names decls
-    let fns = modul.fns |> List.map NameResolution.PackageFn.resolveNames
-    let types = modul.types |> List.map NameResolution.PackageType.resolveNames
+    let fns =
+      modul.fns
+      |> List.map WT2PT.PackageFn.toPT
+      |> List.map NameResolution.PackageFn.resolveNames
+    let types =
+      modul.types
+      |> List.map WT2PT.PackageType.toPT
+      |> List.map NameResolution.PackageType.resolveNames
     { fns = fns; types = types }
   // in the parsed package, types are being read as user, as opposed to the package that's right there
   | decl ->

--- a/backend/src/Parser/Package.fs
+++ b/backend/src/Parser/Package.fs
@@ -5,6 +5,7 @@ open FSharp.Compiler.Syntax
 open Prelude
 open Tablecloth
 
+module FS2WT = FSharpToWrittenTypes
 module WT = WrittenTypes
 module WT2PT = WrittenTypesToProgramTypes
 module PT = LibExecution.ProgramTypes
@@ -28,7 +29,7 @@ let parseLetBinding
   match modules with
   | owner :: modules ->
     let modules = NonEmptyList.ofList modules
-    ProgramTypes.PackageFn.fromSynBinding owner modules letBinding
+    FS2WT.PackageFn.fromSynBinding owner modules letBinding
   | _ ->
     Exception.raiseInternal
       "Expected owner, and at least 1 other modules"
@@ -38,7 +39,7 @@ let parseTypeDef (modules : List<string>) (defn : SynTypeDefn) : WT.PackageType.
   match modules with
   | owner :: modules ->
     let modules = NonEmptyList.ofList modules
-    ProgramTypes.PackageType.fromSynTypeDefn owner modules defn
+    FS2WT.PackageType.fromSynTypeDefn owner modules defn
   | _ ->
     Exception.raiseInternal
       "Expected owner, and at least 1 other modules"

--- a/backend/src/Parser/Parser.fs
+++ b/backend/src/Parser/Parser.fs
@@ -1,0 +1,46 @@
+/// Entrypoint to parsing functions
+module Parser.Parser
+
+open Prelude
+open Tablecloth
+
+module PT = LibExecution.ProgramTypes
+
+/// Returns an incomplete parse of a PT expression. Requires calling
+/// Expr.resolveNames before using
+let initialParse (filename : string) (code : string) : PT.Expr =
+  code
+  |> Utils.parseAsFSharpSourceFile filename
+  |> Utils.singleExprFromImplFile
+  |> ProgramTypes.Expr.fromSynExpr
+
+
+// Shortcut function for tests that ignore user functions and types
+let parseIgnoringUser (filename : string) (code : string) : PT.Expr =
+  code
+  |> initialParse filename
+  |> NameResolution.Expr.resolveNames Set.empty Set.empty
+
+let parseRTExpr
+  (fns : Set<PT.FnName.UserProgram>)
+  (types : Set<PT.TypeName.UserProgram>)
+  (filename : string)
+  (code : string)
+  : LibExecution.RuntimeTypes.Expr =
+  code
+  |> initialParse filename
+  |> NameResolution.Expr.resolveNames fns types
+  |> LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT
+
+let parsePTExpr (filename : string) (code : string) : PT.Expr =
+  code
+  |> initialParse filename
+  |> NameResolution.Expr.resolveNames Set.empty Set.empty
+
+
+let parsePackage
+  (path : string)
+  (contents : string)
+  : List<PT.PackageFn.T> * List<PT.PackageType.T> =
+  let pModule = Package.parse path contents
+  (pModule.fns, pModule.types)

--- a/backend/src/Parser/Parser.fs
+++ b/backend/src/Parser/Parser.fs
@@ -4,6 +4,7 @@ module Parser.Parser
 open Prelude
 open Tablecloth
 
+module FS2WT = FSharpToWrittenTypes
 module WT = WrittenTypes
 module WT2PT = WrittenTypesToProgramTypes
 module PT = LibExecution.ProgramTypes
@@ -14,7 +15,7 @@ let initialParse (filename : string) (code : string) : PT.Expr =
   code
   |> Utils.parseAsFSharpSourceFile filename
   |> Utils.singleExprFromImplFile
-  |> ProgramTypes.Expr.fromSynExpr
+  |> FS2WT.Expr.fromSynExpr
   |> WT2PT.Expr.toPT
 
 

--- a/backend/src/Parser/Parser.fs
+++ b/backend/src/Parser/Parser.fs
@@ -4,6 +4,8 @@ module Parser.Parser
 open Prelude
 open Tablecloth
 
+module WT = WrittenTypes
+module WT2PT = WrittenTypesToProgramTypes
 module PT = LibExecution.ProgramTypes
 
 /// Returns an incomplete parse of a PT expression. Requires calling
@@ -13,6 +15,7 @@ let initialParse (filename : string) (code : string) : PT.Expr =
   |> Utils.parseAsFSharpSourceFile filename
   |> Utils.singleExprFromImplFile
   |> ProgramTypes.Expr.fromSynExpr
+  |> WT2PT.Expr.toPT
 
 
 // Shortcut function for tests that ignore user functions and types

--- a/backend/src/Parser/Parser.fsproj
+++ b/backend/src/Parser/Parser.fsproj
@@ -14,9 +14,11 @@
   <ItemGroup>
     <Compile Include="Utils.fs" />
     <Compile Include="ProgramTypes.fs" />
+    <Compile Include="NameResolution.fs" />
     <Compile Include="TestModule.fs" />
     <Compile Include="Package.fs" />
     <Compile Include="CanvasV2.fs" />
+    <Compile Include="Parser.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/backend/src/Parser/Parser.fsproj
+++ b/backend/src/Parser/Parser.fsproj
@@ -15,7 +15,7 @@
     <Compile Include="Utils.fs" />
     <Compile Include="WrittenTypes.fs" />
     <Compile Include="WrittenTypesToProgramTypes.fs" />
-    <Compile Include="ProgramTypes.fs" />
+    <Compile Include="FSharpToWrittenTypes.fs" />
     <Compile Include="NameResolution.fs" />
     <Compile Include="TestModule.fs" />
     <Compile Include="Package.fs" />

--- a/backend/src/Parser/Parser.fsproj
+++ b/backend/src/Parser/Parser.fsproj
@@ -13,6 +13,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Utils.fs" />
+    <Compile Include="WrittenTypes.fs" />
+    <Compile Include="WrittenTypesToProgramTypes.fs" />
     <Compile Include="ProgramTypes.fs" />
     <Compile Include="NameResolution.fs" />
     <Compile Include="TestModule.fs" />

--- a/backend/src/Parser/ProgramTypes.fs
+++ b/backend/src/Parser/ProgramTypes.fs
@@ -1,4 +1,4 @@
-module Parser.ProgramTypes
+module internal Parser.ProgramTypes
 
 open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis
@@ -21,65 +21,6 @@ let (|Placeholder|_|) (input : PT.Expr) =
 
 let (|PipePlaceholder|_|) (input : PT.PipeExpr) =
   if input = pipePlaceholder then Some() else None
-
-module TypeName =
-  let resolveNames
-    (userTypes : Set<PT.TypeName.UserProgram>)
-    (name : PT.TypeName.T)
-    : PT.TypeName.T =
-    match name with
-    | PT.FQName.Package _ -> name
-    | PT.FQName.UserProgram n ->
-      match n.modules with
-      | "PACKAGE" :: owner :: package :: rest ->
-        PT.FQName.Package
-          { owner = owner
-            modules = NonEmptyList.ofList (package :: rest)
-            name = n.name
-            version = n.version }
-      | _ ->
-        if Set.contains n userTypes then
-          PT.FQName.UserProgram n
-        else
-          PT.FQName.BuiltIn
-            { name = n.name; version = n.version; modules = n.modules }
-    | PT.FQName.BuiltIn n ->
-      let userName : PT.TypeName.UserProgram =
-        { modules = n.modules; name = n.name; version = n.version }
-      if Set.contains userName userTypes then
-        PT.FQName.UserProgram(userName)
-      else
-        PT.FQName.BuiltIn(n)
-
-module FnName =
-  let resolveNames
-    (userFns : Set<PT.FnName.UserProgram>)
-    (name : PT.FnName.T)
-    : PT.FnName.T =
-    match name with
-    | PT.FQName.Package _ -> name
-    | PT.FQName.UserProgram n ->
-      match n.modules with
-      | "PACKAGE" :: owner :: package :: rest ->
-        PT.FQName.Package
-          { owner = owner
-            modules = NonEmptyList.ofList (package :: rest)
-            name = n.name
-            version = n.version }
-      | _ ->
-        if Set.contains n userFns then
-          PT.FQName.UserProgram n
-        else
-          PT.FQName.BuiltIn
-            { name = n.name; version = n.version; modules = n.modules }
-    | PT.FQName.BuiltIn n ->
-      let userName : PT.FnName.UserProgram =
-        { modules = n.modules; name = n.name; version = n.version }
-      if Set.contains userName userFns then
-        PT.FQName.UserProgram(userName)
-      else
-        PT.FQName.BuiltIn(n)
-
 
 module TypeReference =
 
@@ -169,32 +110,6 @@ module TypeReference =
     | SynType.LongIdent(SynLongIdent(names, _, _)) -> fromNamesAndTypeArgs names []
 
     | _ -> Exception.raiseInternal $"Unsupported type" [ "type", typ ]
-
-  let rec resolveNames
-    (userTypes : Set<PT.TypeName.UserProgram>)
-    (typ : PT.TypeReference)
-    : PT.TypeReference =
-    let c = resolveNames userTypes
-    match typ with
-    | PT.TCustomType(tn, args) ->
-      PT.TCustomType(TypeName.resolveNames userTypes tn, List.map c args)
-    | PT.TFn(args, ret) -> PT.TFn(List.map c args, c ret)
-    | PT.TTuple(first, second, theRest) ->
-      PT.TTuple(c first, c second, List.map c theRest)
-    | PT.TList arg -> PT.TList(c arg)
-    | PT.TDict valArg -> PT.TDict(c valArg)
-    | PT.TVariable _ -> typ
-    | PT.TDB arg -> PT.TDB(c arg)
-    | PT.TBool
-    | PT.TBytes
-    | PT.TInt
-    | PT.TString
-    | PT.TChar
-    | PT.TFloat
-    | PT.TDateTime
-    | PT.TUuid
-    | PT.TUnit
-    | PT.TPassword -> typ
 
 
 module SimpleTypeArgs =
@@ -838,51 +753,6 @@ module Expr =
       print (string ast)
       reraise ()
 
-  // Second pass of parsing, fixing the thing it's impossible to get right on the
-  // first pass, such as whether function names are user or stdlib names. Parse the
-  // whole program once, and then run this on any expressions, passing in User types
-  // and functions. It converts user types that are not in the list to Stdlib types.
-  // TODO: we need some sort of unambiguous way to refer to user types
-  let resolveNames
-    (userFunctions : Set<PT.FnName.UserProgram>)
-    (userTypes : Set<PT.TypeName.UserProgram>)
-    (e : PT.Expr)
-    : PT.Expr =
-    let resolvePipeExprNames =
-      (fun e ->
-        match e with
-        | PT.EPipeFnCall(id, name, typeArgs, args) ->
-          PT.EPipeFnCall(id, name, typeArgs, args)
-        | PT.EPipeEnum(id, typeName, caseName, fields) ->
-          PT.EPipeEnum(
-            id,
-            TypeName.resolveNames userTypes typeName,
-            caseName,
-            fields
-          )
-        // pipes with variables might be fn calls
-        | PT.EPipeVariable(id, name) ->
-          match parseFn name with
-          | Some(name, version) ->
-            if
-              Set.contains (PT.FnName.userProgram [] name version) userFunctions
-            then
-              PT.EPipeFnCall(id, PT.FnName.fqUserProgram [] name version, [], [])
-            else
-              e
-          | None -> e
-        | _ -> e)
-
-    LibExecution.ProgramTypesAst.preTraversal
-      identity
-      resolvePipeExprNames
-      identity
-      (TypeName.resolveNames userTypes)
-      (FnName.resolveNames userFunctions)
-      identity
-      identity
-      e
-
 module Function =
   type Parameter = { name : string; typ : PT.TypeReference }
 
@@ -986,23 +856,6 @@ module UserFunction =
       deprecated = PT.NotDeprecated
       body = f.body }
 
-  let resolveNames
-    (userFunctions : Set<PT.FnName.UserProgram>)
-    (userTypes : Set<PT.TypeName.UserProgram>)
-    (f : PT.UserFunction.T)
-    : PT.UserFunction.T =
-    { tlid = f.tlid
-      name = f.name
-      typeParams = f.typeParams
-      parameters =
-        f.parameters
-        |> List.map (fun p ->
-          { p with typ = TypeReference.resolveNames userTypes p.typ })
-      returnType = TypeReference.resolveNames userTypes f.returnType
-      description = f.description
-      deprecated = f.deprecated
-      body = Expr.resolveNames userFunctions userTypes f.body }
-
 
 module PackageFn =
   let fromSynBinding
@@ -1023,21 +876,6 @@ module PackageFn =
       deprecated = PT.NotDeprecated
       body = f.body }
 
-  let resolveNames (f : PT.PackageFn.T) : PT.PackageFn.T =
-    { tlid = f.tlid
-      id = f.id
-      name = f.name
-      typeParams = f.typeParams
-      parameters =
-        f.parameters
-        |> List.map (fun p ->
-          { p with typ = TypeReference.resolveNames Set.empty p.typ })
-      returnType = TypeReference.resolveNames Set.empty f.returnType
-      description = f.description
-      deprecated = f.deprecated
-      body = Expr.resolveNames Set.empty Set.empty f.body }
-
-
 module TypeDeclaration =
   module EnumCase =
     let private parseField (typ : SynField) : PT.TypeDeclaration.EnumField =
@@ -1055,17 +893,6 @@ module TypeDeclaration =
           { name = id.idText; fields = List.map parseField fields; description = "" }
         | _ -> Exception.raiseInternal $"Unsupported enum case" [ "case", case ]
 
-    let resolveNames
-      (userTypes : Set<PT.TypeName.UserProgram>)
-      (t : PT.TypeDeclaration.EnumCase)
-      : PT.TypeDeclaration.EnumCase =
-      { name = t.name
-        fields =
-          t.fields
-          |> List.map (fun f ->
-            { f with typ = TypeReference.resolveNames userTypes f.typ })
-        description = t.description }
-
 
   module RecordField =
     let parseField (field : SynField) : PT.TypeDeclaration.RecordField =
@@ -1073,14 +900,6 @@ module TypeDeclaration =
       | SynField(_, _, Some id, typ, _, _, _, _, _) ->
         { name = id.idText; typ = TypeReference.fromSynType typ; description = "" }
       | _ -> Exception.raiseInternal $"Unsupported field" [ "field", field ]
-
-    let resolveNames
-      (userTypes : Set<PT.TypeName.UserProgram>)
-      (t : PT.TypeDeclaration.RecordField)
-      : PT.TypeDeclaration.RecordField =
-      { name = t.name
-        typ = TypeReference.resolveNames userTypes t.typ
-        description = t.description }
 
   let fromFields typeDef (fields : List<SynField>) : PT.TypeDeclaration.Definition =
     match fields with
@@ -1153,31 +972,6 @@ module TypeDeclaration =
       | _ ->
         Exception.raiseInternal $"Unsupported type definition" [ "typeDef", typeDef ]
 
-    let resolveNames
-      (userTypes : Set<PT.TypeName.UserProgram>)
-      (t : PT.TypeDeclaration.Definition)
-      : PT.TypeDeclaration.Definition =
-      match t with
-      | PT.TypeDeclaration.Enum(firstCase, additionalCases) ->
-        PT.TypeDeclaration.Enum(
-          EnumCase.resolveNames userTypes firstCase,
-          additionalCases |> List.map (EnumCase.resolveNames userTypes)
-        )
-      | PT.TypeDeclaration.Record(firstField, additionalFields) ->
-        PT.TypeDeclaration.Record(
-          RecordField.resolveNames userTypes firstField,
-          additionalFields |> List.map (RecordField.resolveNames userTypes)
-        )
-      | PT.TypeDeclaration.Alias typ ->
-        PT.TypeDeclaration.Alias(TypeReference.resolveNames userTypes typ)
-
-  let resolveNames
-    (userTypes : Set<PT.TypeName.UserProgram>)
-    (t : PT.TypeDeclaration.T)
-    : PT.TypeDeclaration.T =
-    { definition = Definition.resolveNames userTypes t.definition
-      typeParams = t.typeParams }
-
 
 module UserType =
   let fromSynTypeDefn (typeDef : SynTypeDefn) : PT.UserType.T =
@@ -1196,16 +990,6 @@ module UserType =
       description = ""
       deprecated = PT.NotDeprecated
       declaration = { definition = definition; typeParams = typeParams } }
-
-  let resolveNames
-    (userTypes : Set<PT.TypeName.UserProgram>)
-    (t : PT.UserType.T)
-    : PT.UserType.T =
-    { tlid = t.tlid
-      name = t.name
-      declaration = TypeDeclaration.resolveNames userTypes t.declaration
-      description = ""
-      deprecated = PT.NotDeprecated }
 
 module PackageType =
   let fromSynTypeDefn
@@ -1228,14 +1012,6 @@ module PackageType =
       deprecated = PT.NotDeprecated
       declaration = { typeParams = typeParams; definition = definition } }
 
-  let resolveNames (f : PT.PackageType.T) : PT.PackageType.T =
-    { tlid = f.tlid
-      id = f.id
-      name = f.name
-      description = f.description
-      deprecated = f.deprecated
-      declaration = TypeDeclaration.resolveNames Set.empty f.declaration }
-
 
 /// Returns an incomplete parse of a PT expression. Requires calling
 /// Expr.resolveNames before using
@@ -1246,18 +1022,3 @@ let initialParse (filename : string) (code : string) : PT.Expr =
   |> Utils.parseAsFSharpSourceFile filename
   |> Utils.singleExprFromImplFile
   |> Expr.fromSynExpr
-
-// Shortcut function for tests that ignore user functions and types
-let parseIgnoringUser (filename : string) (code : string) : PT.Expr =
-  code |> initialParse filename |> Expr.resolveNames Set.empty Set.empty
-
-let parseRTExpr
-  (fns : Set<PT.FnName.UserProgram>)
-  (types : Set<PT.TypeName.UserProgram>)
-  (filename : string)
-  (code : string)
-  : LibExecution.RuntimeTypes.Expr =
-  code
-  |> initialParse filename
-  |> Expr.resolveNames fns types
-  |> LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT

--- a/backend/src/Parser/ProgramTypes.fs
+++ b/backend/src/Parser/ProgramTypes.fs
@@ -7,19 +7,20 @@ open FSharp.Compiler.Syntax
 open Prelude
 open Tablecloth
 
+module WT = WrittenTypes
 module PT = LibExecution.ProgramTypes
 
 open Utils
 
 // A placeholder is used to indicate what still needs to be filled
-let placeholder = PT.EString(12345678UL, [ PT.StringText "PLACEHOLDER VALUE" ])
-let pipePlaceholder = PT.EPipeVariable(12345678UL, "PIPE PLACEHOLDER VALUE")
+let placeholder = WT.EString(12345678UL, [ WT.StringText "PLACEHOLDER VALUE" ])
+let pipePlaceholder = WT.EPipeVariable(12345678UL, "PIPE PLACEHOLDER VALUE")
 
 // This is a "Partial active pattern" that you can use as a Pattern to match a Placeholder value
-let (|Placeholder|_|) (input : PT.Expr) =
+let (|Placeholder|_|) (input : WT.Expr) =
   if input = placeholder then Some() else None
 
-let (|PipePlaceholder|_|) (input : PT.PipeExpr) =
+let (|PipePlaceholder|_|) (input : WT.PipeExpr) =
   if input = pipePlaceholder then Some() else None
 
 module TypeReference =
@@ -34,7 +35,7 @@ module TypeReference =
   let rec fromNamesAndTypeArgs
     (names : List<Ident>)
     (typeArgs : List<SynType>)
-    : PT.TypeReference =
+    : WT.TypeReference =
     let modules =
       List.initial names
       |> Option.defaultValue []
@@ -42,30 +43,30 @@ module TypeReference =
     let name = List.last names |> Exception.unwrapOptionInternal "typeName" []
     match modules, parseTypeRef name.idText, typeArgs with
     // no type args
-    | [], ("Bool", 0), [] -> PT.TBool
-    | [], ("Bytes", 0), [] -> PT.TBytes
-    | [], ("Int", 0), [] -> PT.TInt
-    | [], ("String", 0), [] -> PT.TString
-    | [], ("Char", 0), [] -> PT.TChar
-    | [], ("Float", 0), [] -> PT.TFloat
-    | [], ("DateTime", 0), [] -> PT.TDateTime
-    | [], ("Uuid", 0), [] -> PT.TUuid
-    | [], ("Unit", 0), [] -> PT.TUnit
-    | [], ("Password", 0), [] -> PT.TPassword
+    | [], ("Bool", 0), [] -> WT.TBool
+    | [], ("Bytes", 0), [] -> WT.TBytes
+    | [], ("Int", 0), [] -> WT.TInt
+    | [], ("String", 0), [] -> WT.TString
+    | [], ("Char", 0), [] -> WT.TChar
+    | [], ("Float", 0), [] -> WT.TFloat
+    | [], ("DateTime", 0), [] -> WT.TDateTime
+    | [], ("Uuid", 0), [] -> WT.TUuid
+    | [], ("Unit", 0), [] -> WT.TUnit
+    | [], ("Password", 0), [] -> WT.TPassword
 
     // with type args
-    | [], ("List", 0), [ arg ] -> PT.TList(fromSynType arg)
-    | [], ("Dict", 0), [ valArg ] -> PT.TDict(fromSynType valArg)
+    | [], ("List", 0), [ arg ] -> WT.TList(fromSynType arg)
+    | [], ("Dict", 0), [ valArg ] -> WT.TDict(fromSynType valArg)
     // TYPESCLEANUP - don't use word Tuple here
     | [], ("Tuple", 0), first :: second :: theRest ->
-      PT.TTuple(fromSynType first, fromSynType second, List.map fromSynType theRest)
+      WT.TTuple(fromSynType first, fromSynType second, List.map fromSynType theRest)
     | modules, (name, version), args ->
       let tn =
         PT.FQName.UserProgram
           { modules = modules; name = PT.TypeName.TypeName name; version = version }
-      PT.TCustomType(tn, List.map fromSynType typeArgs)
+      WT.TCustomType(tn, List.map fromSynType typeArgs)
 
-  and fromSynType (typ : SynType) : PT.TypeReference =
+  and fromSynType (typ : SynType) : WT.TypeReference =
     let c = fromSynType
 
     match typ with
@@ -73,7 +74,7 @@ module TypeReference =
 
     // Variable types (i.e. "generic types")
     // e.g. `'a` in `'a -> bool`
-    | SynType.Var(SynTypar(id, _, _), _) -> PT.TVariable(id.idText)
+    | SynType.Var(SynTypar(id, _, _), _) -> WT.TVariable(id.idText)
 
     | SynType.Tuple(_, args, _) ->
       let args =
@@ -88,11 +89,11 @@ module TypeReference =
       | [ _ ] ->
         Exception.raiseInternal "Tuple type with only one arg" [ "type", typ ]
       | first :: second :: theRest ->
-        PT.TTuple(c first, c second, List.map c theRest)
+        WT.TTuple(c first, c second, List.map c theRest)
 
     // Function types
     // e.g. `'a -> bool` in `let friends (lambda: ('a -> bool)) = ...`
-    | SynType.Fun(arg, ret, _, _) -> PT.TFn([ c arg ], c ret)
+    | SynType.Fun(arg, ret, _, _) -> WT.TFn([ c arg ], c ret)
 
 
     // Named types. covers:
@@ -141,16 +142,16 @@ module SimpleTypeArgs =
           [ "typeParams", typeParams ]
 
 module LetPattern =
-  let rec fromSynPat (pat : SynPat) : PT.LetPattern =
+  let rec fromSynPat (pat : SynPat) : WT.LetPattern =
     let mapPat = fromSynPat
 
     match pat with
     | SynPat.Paren(subPat, _) -> mapPat subPat
-    | SynPat.Wild(_) -> PT.LPVariable(gid (), "_")
-    | SynPat.Named(SynIdent(name, _), _, _, _) -> PT.LPVariable(gid (), name.idText)
+    | SynPat.Wild(_) -> WT.LPVariable(gid (), "_")
+    | SynPat.Named(SynIdent(name, _), _, _, _) -> WT.LPVariable(gid (), name.idText)
 
     | SynPat.Tuple(_, (first :: second :: theRest), _) ->
-      PT.LetPattern.LPTuple(
+      WT.LetPattern.LPTuple(
         gid (),
         mapPat first,
         mapPat second,
@@ -162,38 +163,38 @@ module LetPattern =
 
 
 module MatchPattern =
-  let rec fromSynPat (pat : SynPat) : PT.MatchPattern =
+  let rec fromSynPat (pat : SynPat) : WT.MatchPattern =
     let id = gid ()
     let r = fromSynPat
 
-    let convertEnumArg (ast : SynPat) : List<PT.MatchPattern> =
+    let convertEnumArg (ast : SynPat) : List<WT.MatchPattern> =
       // if the arg is a tuple with one paren around it, it's just arguments to the
       // enum. But if it has two parens around it, it's a single tuple.
       // eg: (Foo(1, 2)) vs (Foo((1, 2)))
       match ast with
       | SynPat.Paren(SynPat.Paren(SynPat.Tuple(_, t1 :: t2 :: trest, _), _), _) ->
-        [ PT.MPTuple(gid (), r t1, r t2, List.map r trest) ]
+        [ WT.MPTuple(gid (), r t1, r t2, List.map r trest) ]
       | SynPat.Paren(SynPat.Tuple(_, args, _), _) -> List.map r args
       | SynPat.Tuple(_, args, _) -> List.map r args
       | e -> [ r e ]
 
     match pat with
-    | SynPat.Named(SynIdent(name, _), _, _, _) -> PT.MPVariable(id, name.idText)
-    | SynPat.Wild _ -> PT.MPVariable(gid (), "_") // wildcard, not blank
-    | SynPat.Const(SynConst.Int32 n, _) -> PT.MPInt(id, n)
-    | SynPat.Const(SynConst.Int64 n, _) -> PT.MPInt(id, int64 n)
-    | SynPat.Const(SynConst.UInt64 n, _) -> PT.MPInt(id, int64 n)
-    | SynPat.Const(SynConst.UserNum(n, "I"), _) -> PT.MPInt(id, parseInt64 n)
-    | SynPat.Const(SynConst.Char c, _) -> PT.MPChar(id, string c)
-    | SynPat.Const(SynConst.Bool b, _) -> PT.MPBool(id, b)
-    | SynPat.Const(SynConst.Unit, _) -> PT.MPUnit(id)
+    | SynPat.Named(SynIdent(name, _), _, _, _) -> WT.MPVariable(id, name.idText)
+    | SynPat.Wild _ -> WT.MPVariable(gid (), "_") // wildcard, not blank
+    | SynPat.Const(SynConst.Int32 n, _) -> WT.MPInt(id, n)
+    | SynPat.Const(SynConst.Int64 n, _) -> WT.MPInt(id, int64 n)
+    | SynPat.Const(SynConst.UInt64 n, _) -> WT.MPInt(id, int64 n)
+    | SynPat.Const(SynConst.UserNum(n, "I"), _) -> WT.MPInt(id, parseInt64 n)
+    | SynPat.Const(SynConst.Char c, _) -> WT.MPChar(id, string c)
+    | SynPat.Const(SynConst.Bool b, _) -> WT.MPBool(id, b)
+    | SynPat.Const(SynConst.Unit, _) -> WT.MPUnit(id)
     | SynPat.Null _ ->
       Exception.raiseInternal "null pattern not supported, use `()`" [ "pat", pat ]
     | SynPat.Paren(pat, _) -> r pat
     | SynPat.Const(SynConst.Double d, _) ->
       let sign, whole, fraction = readFloat d
-      PT.MPFloat(id, sign, whole, fraction)
-    | SynPat.Const(SynConst.String(s, _, _), _) -> PT.MPString(id, s)
+      WT.MPFloat(id, sign, whole, fraction)
+    | SynPat.Const(SynConst.String(s, _, _), _) -> WT.MPString(id, s)
     | SynPat.LongIdent(SynLongIdent(names, _, _), _, _, SynArgPats.Pats args, _, _) ->
       let enumName =
         List.last names |> Exception.unwrapOptionInternal "missing enum name" []
@@ -204,12 +205,12 @@ module MatchPattern =
           "Module in enum pattern casename. Only use the casename in Enum patterns"
           [ "pat", pat ]
       let args = List.map convertEnumArg args |> List.concat
-      PT.MPEnum(id, enumName.idText, args)
+      WT.MPEnum(id, enumName.idText, args)
     | SynPat.Tuple(_isStruct, (first :: second :: theRest), _range) ->
-      PT.MPTuple(id, r first, r second, List.map r theRest)
+      WT.MPTuple(id, r first, r second, List.map r theRest)
     | SynPat.ListCons(headPat, tailPat, _, _) ->
-      PT.MPListCons(id, r headPat, r tailPat)
-    | SynPat.ArrayOrList(_, pats, _) -> PT.MPList(id, List.map r pats)
+      WT.MPListCons(id, r headPat, r tailPat)
+    | SynPat.ArrayOrList(_, pats, _) -> WT.MPList(id, List.map r pats)
     | _ -> Exception.raiseInternal "unhandled pattern" [ "pattern", pat ]
 
 
@@ -247,24 +248,24 @@ module Expr =
 
   let private ops =
     Map.ofList
-      [ ("op_Addition", PT.ArithmeticPlus)
-        ("op_Subtraction", PT.ArithmeticMinus)
-        ("op_Multiply", PT.ArithmeticMultiply)
-        ("op_Division", PT.ArithmeticDivide)
-        ("op_Modulus", PT.ArithmeticModulo)
-        ("op_Concatenate", PT.ArithmeticPower)
-        ("op_GreaterThan", PT.ComparisonGreaterThan)
-        ("op_GreaterThanOrEqual", PT.ComparisonGreaterThanOrEqual)
-        ("op_LessThan", PT.ComparisonLessThan)
-        ("op_LessThanOrEqual", PT.ComparisonLessThanOrEqual)
-        ("op_EqualsEquals", PT.ComparisonEquals)
-        ("op_BangEquals", PT.ComparisonNotEquals)
-        ("op_PlusPlus", PT.StringConcat) ]
+      [ ("op_Addition", WT.ArithmeticPlus)
+        ("op_Subtraction", WT.ArithmeticMinus)
+        ("op_Multiply", WT.ArithmeticMultiply)
+        ("op_Division", WT.ArithmeticDivide)
+        ("op_Modulus", WT.ArithmeticModulo)
+        ("op_Concatenate", WT.ArithmeticPower)
+        ("op_GreaterThan", WT.ComparisonGreaterThan)
+        ("op_GreaterThanOrEqual", WT.ComparisonGreaterThanOrEqual)
+        ("op_LessThan", WT.ComparisonLessThan)
+        ("op_LessThanOrEqual", WT.ComparisonLessThanOrEqual)
+        ("op_EqualsEquals", WT.ComparisonEquals)
+        ("op_BangEquals", WT.ComparisonNotEquals)
+        ("op_PlusPlus", WT.StringConcat) ]
 
-  let rec fromSynExpr' (ast : SynExpr) : PT.Expr =
+  let rec fromSynExpr' (ast : SynExpr) : WT.Expr =
     let c = fromSynExpr'
 
-    let convertEnumArg (ast : SynExpr) : List<PT.Expr> =
+    let convertEnumArg (ast : SynExpr) : List<WT.Expr> =
       // if the arg is a tuple with one paren around it, it's just arguments to the
       // enum. But if it has two parens around it, it's a single tuple.
       // eg: (Foo(1, 2)) vs (Foo((1, 2)))
@@ -275,7 +276,7 @@ module Expr =
                                     _),
                       _,
                       _,
-                      _) -> [ PT.ETuple(gid (), c t1, c t2, List.map c trest) ]
+                      _) -> [ WT.ETuple(gid (), c t1, c t2, List.map c trest) ]
       | SynExpr.Paren(SynExpr.Tuple(_, args, _, _), _, _, _) -> List.map c args
       | SynExpr.Tuple(_, args, _, _) -> List.map c args
       | e -> [ c e ]
@@ -286,18 +287,18 @@ module Expr =
       | SynSimplePat.Id(name, _, _, _, _, _) -> nameOrBlank name.idText
       | _ -> Exception.raiseInternal "unsupported lambdaVar" [ "var", var ]
 
-    let synToPipeExpr (e : SynExpr) : PT.PipeExpr =
+    let synToPipeExpr (e : SynExpr) : WT.PipeExpr =
       match c e with
-      | PT.EApply(id, PT.FnTargetName name, typeArgs, args) ->
-        PT.EPipeFnCall(id, name, typeArgs, args)
-      | PT.EInfix(id, op, Placeholder, arg2) -> PT.EPipeInfix(id, op, arg2)
-      | PT.EInfix(id, op, arg1, Placeholder) -> PT.EPipeInfix(id, op, arg1)
-      | PT.EEnum(id, typeName, caseName, fields) ->
-        PT.EPipeEnum(id, typeName, caseName, fields)
-      | PT.EVariable(id, name) -> PT.EPipeVariable(id, name)
-      | PT.EEnum(id, typeName, caseName, fields) ->
-        PT.EPipeEnum(id, typeName, caseName, fields)
-      | PT.ELambda(id, vars, body) -> PT.EPipeLambda(id, vars, body)
+      | WT.EApply(id, WT.FnTargetName name, typeArgs, args) ->
+        WT.EPipeFnCall(id, name, typeArgs, args)
+      | WT.EInfix(id, op, Placeholder, arg2) -> WT.EPipeInfix(id, op, arg2)
+      | WT.EInfix(id, op, arg1, Placeholder) -> WT.EPipeInfix(id, op, arg1)
+      | WT.EEnum(id, typeName, caseName, fields) ->
+        WT.EPipeEnum(id, typeName, caseName, fields)
+      | WT.EVariable(id, name) -> WT.EPipeVariable(id, name)
+      | WT.EEnum(id, typeName, caseName, fields) ->
+        WT.EPipeEnum(id, typeName, caseName, fields)
+      | WT.ELambda(id, vars, body) -> WT.EPipeLambda(id, vars, body)
       | other ->
         Exception.raiseInternal
           "Expected a function, got something else."
@@ -311,30 +312,30 @@ module Expr =
     // Literals (ints, chars, bools, etc)
     | SynExpr.Null _ ->
       Exception.raiseInternal "null not supported, use `()`" [ "ast", ast ]
-    | SynExpr.Const(SynConst.Unit _, _) -> PT.EUnit id
-    | SynExpr.Const(SynConst.Int32 n, _) -> PT.EInt(id, n)
-    | SynExpr.Const(SynConst.Int64 n, _) -> PT.EInt(id, int64 n)
-    | SynExpr.Const(SynConst.UInt64 n, _) -> PT.EInt(id, int64 n)
-    | SynExpr.Const(SynConst.UserNum(n, "I"), _) -> PT.EInt(id, parseInt64 n)
-    | SynExpr.Const(SynConst.Char c, _) -> PT.EChar(id, string c)
-    | SynExpr.Const(SynConst.Bool b, _) -> PT.EBool(id, b)
+    | SynExpr.Const(SynConst.Unit _, _) -> WT.EUnit id
+    | SynExpr.Const(SynConst.Int32 n, _) -> WT.EInt(id, n)
+    | SynExpr.Const(SynConst.Int64 n, _) -> WT.EInt(id, int64 n)
+    | SynExpr.Const(SynConst.UInt64 n, _) -> WT.EInt(id, int64 n)
+    | SynExpr.Const(SynConst.UserNum(n, "I"), _) -> WT.EInt(id, parseInt64 n)
+    | SynExpr.Const(SynConst.Char c, _) -> WT.EChar(id, string c)
+    | SynExpr.Const(SynConst.Bool b, _) -> WT.EBool(id, b)
     | SynExpr.Const(SynConst.Double d, _) ->
       let sign, whole, fraction = readFloat d
-      PT.EFloat(id, sign, whole, fraction)
+      WT.EFloat(id, sign, whole, fraction)
 
 
     // Strings
     | SynExpr.Const(SynConst.String(s, _, _), _) ->
-      PT.EString(id, [ PT.StringText s ])
+      WT.EString(id, [ WT.StringText s ])
     | SynExpr.InterpolatedString(parts, _, _) ->
       let parts =
         parts
         |> List.filterMap (function
           | SynInterpolatedStringPart.String("", _) -> None
-          | SynInterpolatedStringPart.String(s, _) -> Some(PT.StringText s)
+          | SynInterpolatedStringPart.String(s, _) -> Some(WT.StringText s)
           | SynInterpolatedStringPart.FillExpr(e, _) ->
-            Some(PT.StringInterpolation(c e)))
-      PT.EString(id, parts)
+            Some(WT.StringInterpolation(c e)))
+      WT.EString(id, parts)
 
 
     // Simple identifiers/operators like `==`
@@ -346,7 +347,7 @@ module Expr =
         |> Exception.unwrapOptionInternal
           "can't find operation"
           [ "name", ident.idText ]
-      PT.EInfix(id, PT.InfixFnCall op, placeholder, placeholder)
+      WT.EInfix(id, WT.InfixFnCall op, placeholder, placeholder)
 
 
     // Binary Ops: && / ||
@@ -355,11 +356,11 @@ module Expr =
       ->
       let op =
         match ident.idText with
-        | "op_BooleanAnd" -> PT.BinOpAnd
-        | "op_BooleanOr" -> PT.BinOpOr
+        | "op_BooleanAnd" -> WT.BinOpAnd
+        | "op_BooleanOr" -> WT.BinOpOr
         | _ -> Exception.raiseInternal "unhandled operation" [ "name", ident.idText ]
 
-      PT.EInfix(id, PT.BinOp op, placeholder, placeholder)
+      WT.EInfix(id, WT.BinOp op, placeholder, placeholder)
 
 
     // Negation
@@ -367,18 +368,18 @@ module Expr =
       ident.idText = "op_UnaryNegation"
       ->
       let name = PT.FnName.fqBuiltIn [ "Int" ] "negate" 0
-      PT.EApply(id, PT.FnTargetName name, [], [])
+      WT.EApply(id, WT.FnTargetName name, [], [])
 
 
     // One word functions like `equals`
     | SynExpr.Ident ident when Set.contains ident.idText PT.FnName.oneWordFunctions ->
       match parseFn ident.idText with
       | Some(name, version) ->
-        PT.EApply(id, PT.FnTargetName(PT.FnName.fqBuiltIn [] name version), [], [])
-      | None -> PT.EVariable(id, ident.idText)
+        WT.EApply(id, WT.FnTargetName(PT.FnName.fqBuiltIn [] name version), [], [])
+      | None -> WT.EVariable(id, ident.idText)
 
     // List literals
-    | SynExpr.ArrayOrList(_, exprs, _) -> PT.EList(id, exprs |> List.map c)
+    | SynExpr.ArrayOrList(_, exprs, _) -> WT.EList(id, exprs |> List.map c)
 
     // a literal list is sometimes made up of nested Sequentials
     | SynExpr.ArrayOrListComputed(_, (SynExpr.Sequential _ as seq), _) ->
@@ -386,19 +387,19 @@ module Expr =
         match expr with
         | SynExpr.Sequential(_, _, expr1, expr2, _) -> expr1 :: seqAsList expr2
         | _ -> [ expr ]
-      PT.EList(id, seq |> seqAsList |> List.map c)
+      WT.EList(id, seq |> seqAsList |> List.map c)
 
     | SynExpr.ArrayOrListComputed(_,
                                   SynExpr.Tuple(_, first :: second :: theRest, _, _),
                                   _) ->
-      PT.ETuple(id, c first, c second, List.map c theRest)
+      WT.ETuple(id, c first, c second, List.map c theRest)
 
-    | SynExpr.ArrayOrListComputed(_, expr, _) -> PT.EList(id, [ c expr ])
+    | SynExpr.ArrayOrListComputed(_, expr, _) -> WT.EList(id, [ c expr ])
 
 
     // Tuples
     | SynExpr.Tuple(_, first :: second :: rest, _, _) ->
-      PT.ETuple(id, c first, c second, List.map c rest)
+      WT.ETuple(id, c first, c second, List.map c rest)
 
     // Enum values (EEnums)
     // TODO: remove this explicit handling
@@ -407,12 +408,12 @@ module Expr =
       List.contains name.idText [ "Nothing"; "Just" ]
       ->
       let typeName = PT.TypeName.fqBuiltIn [] "Option" 0
-      PT.EEnum(id, typeName, name.idText, convertEnumArg arg)
+      WT.EEnum(id, typeName, name.idText, convertEnumArg arg)
 
     // Enum values (EEnums)
     | SynExpr.Ident name when List.contains name.idText [ "Nothing"; "Just" ] ->
       let typeName = PT.TypeName.fqBuiltIn [] "Option" 0
-      PT.EEnum(id, typeName, name.idText, [])
+      WT.EEnum(id, typeName, name.idText, [])
 
 
     // Enum/FnCalls - e.g. `Result.Ok` or `Result.mapSecond`
@@ -431,9 +432,9 @@ module Expr =
 
       match parseFn name with
       | Some(name, version) ->
-        PT.EApply(
+        WT.EApply(
           gid (),
-          PT.FnTargetName(PT.FnName.fqUserProgram modules name version),
+          WT.FnTargetName(PT.FnName.fqUserProgram modules name version),
           [],
           []
         )
@@ -444,7 +445,7 @@ module Expr =
             List.last modules |> Exception.unwrapOptionInternal "empty list" []
           let (typ, version) = parseTypeName typename
           let modules = List.initial modules |> Option.unwrap []
-          PT.EEnum(
+          WT.EEnum(
             gid (),
             PT.TypeName.fqUserProgram modules typ version,
             enumName,
@@ -454,7 +455,7 @@ module Expr =
 
 
     // Enums are expected to be fully qualified
-    | SynExpr.Ident name -> PT.EVariable(id, name.idText)
+    | SynExpr.Ident name -> WT.EVariable(id, name.idText)
 
 
     // e.g. `Json.serialize<T>`
@@ -468,9 +469,9 @@ module Expr =
         |> Exception.unwrapOptionInternal
           "invalid fn name"
           [ "name", name.idText; "ast", ast ]
-      PT.EApply(
+      WT.EApply(
         gid (),
-        PT.FnTargetName(PT.FnName.fqUserProgram [] name version),
+        WT.FnTargetName(PT.FnName.fqUserProgram [] name version),
         typeArgs,
         []
       )
@@ -499,9 +500,9 @@ module Expr =
         let typeArgs =
           typeArgs |> List.map (fun synType -> TypeReference.fromSynType synType)
 
-        PT.EApply(
+        WT.EApply(
           gid (),
-          PT.FnTargetName(PT.FnName.fqUserProgram modules name version),
+          WT.FnTargetName(PT.FnName.fqUserProgram modules name version),
           typeArgs,
           []
         )
@@ -518,9 +519,9 @@ module Expr =
       | [] -> Exception.raiseInternal "empty list in LongIdent" []
       | var :: fields ->
         List.fold
-          (PT.EVariable(gid (), var.idText))
+          (WT.EVariable(gid (), var.idText))
           (fun acc (field : Ident) ->
-            PT.EFieldAccess(id, acc, nameOrBlank field.idText))
+            WT.EFieldAccess(id, acc, nameOrBlank field.idText))
           fields
 
     // (...).a.b
@@ -528,7 +529,7 @@ module Expr =
       List.fold
         (c expr)
         (fun acc (field : Ident) ->
-          PT.EFieldAccess(id, acc, nameOrBlank field.idText))
+          WT.EFieldAccess(id, acc, nameOrBlank field.idText))
         fields
 
     // Lambdas
@@ -551,16 +552,16 @@ module Expr =
         (outerVars @ nestedVars)
         |> List.map convertLambdaVar
         |> (List.map (fun name -> (gid (), name)))
-      PT.ELambda(id, vars, c body)
+      WT.ELambda(id, vars, c body)
 
 
     // if/else expressions
     | SynExpr.IfThenElse(cond, thenExpr, Some elseExpr, _, _, _, _) ->
-      PT.EIf(id, c cond, c thenExpr, c elseExpr)
+      WT.EIf(id, c cond, c thenExpr, c elseExpr)
 
     // if (no else) expression
     | SynExpr.IfThenElse(cond, thenExpr, None, _, _, _, _) ->
-      PT.EIf(id, c cond, c thenExpr, PT.EUnit(gid ()))
+      WT.EIf(id, c cond, c thenExpr, WT.EUnit(gid ()))
 
 
     // `let` bindings
@@ -571,7 +572,7 @@ module Expr =
                        _,
                        _) ->
 
-      PT.ELet(id, LetPattern.fromSynPat pat, c rhs, c body)
+      WT.ELet(id, LetPattern.fromSynPat pat, c rhs, c body)
 
 
     // `match` exprs:
@@ -584,9 +585,9 @@ module Expr =
     | SynExpr.Match(_, cond, cases, _, _) ->
       let convertCase
         (SynMatchClause(pat, _, expr, _, _, _) : SynMatchClause)
-        : PT.MatchPattern * PT.Expr =
+        : WT.MatchPattern * WT.Expr =
         (MatchPattern.fromSynPat pat, c expr)
-      PT.EMatch(id, c cond, List.map convertCase cases)
+      WT.EMatch(id, c cond, List.map convertCase cases)
 
 
     // Parens (eg `(5)`)
@@ -601,7 +602,7 @@ module Expr =
 
     // Sequential code: (a; b) -> let _ = a in b
     | SynExpr.Sequential(_, _, a, b, _) ->
-      PT.ELet(id, PT.LPVariable(gid (), "_"), c a, c b)
+      WT.ELet(id, WT.LPVariable(gid (), "_"), c a, c b)
 
 
     // Pipes (|>)
@@ -615,11 +616,11 @@ module Expr =
                   SynExpr.App(_, _, nestedPipes, arg, _),
                   _) when pipe.idText = "op_PipeRight" ->
       match c nestedPipes with
-      | PT.EPipe(id, arg1, PipePlaceholder, []) ->
+      | WT.EPipe(id, arg1, PipePlaceholder, []) ->
         // when we just built the lowest, the second one goes here
-        PT.EPipe(id, arg1, synToPipeExpr arg, [])
-      | PT.EPipe(id, arg1, arg2, rest) ->
-        PT.EPipe(id, arg1, arg2, rest @ [ synToPipeExpr arg ])
+        WT.EPipe(id, arg1, synToPipeExpr arg, [])
+      | WT.EPipe(id, arg1, arg2, rest) ->
+        WT.EPipe(id, arg1, arg2, rest @ [ synToPipeExpr arg ])
       // Exception.raiseInternal $"Pipe: {nestedPipes},\n\n{arg},\n\n{pipe}\n\n, {c arg})"
       | other ->
         Exception.raiseInternal
@@ -634,7 +635,7 @@ module Expr =
                   expr,
                   _) when pipe.idText = "op_PipeRight" ->
       // the very bottom on the pipe chain, this is just the first expression
-      PT.EPipe(id, c expr, pipePlaceholder, [])
+      WT.EPipe(id, c expr, pipePlaceholder, [])
 
     // e.g. MyMod.MyRecord
     | SynExpr.App(_,
@@ -646,8 +647,8 @@ module Expr =
         Exception.raiseInternal "Record should not have type args" [ "expr", expr ]
 
       match c expr with
-      | PT.ERecord(id, typeName, fields) -> PT.ERecord(id, typeName, fields)
-      | PT.EDict(id, fields) -> PT.EDict(id, fields)
+      | WT.ERecord(id, typeName, fields) -> WT.ERecord(id, typeName, fields)
+      | WT.EDict(id, fields) -> WT.EDict(id, fields)
       | _ -> Exception.raiseInternal "Not an expected record" [ "expr", expr ]
 
 
@@ -670,12 +671,12 @@ module Expr =
           | f -> Exception.raiseInternal "Not an expected field" [ "field", f ])
 
       if names = [ "Dict" ] then
-        PT.EDict(id, fields)
+        WT.EDict(id, fields)
       else
         // We use a user name here, and we'll resolve it in the post pass when we
         // have the types available
         let typeName = PT.TypeName.fqUserProgram modules typ version
-        PT.ERecord(id, typeName, fields)
+        WT.ERecord(id, typeName, fields)
 
     // Record update: {myRecord with x = 5 }
     | SynExpr.Record(_, Some(baseRecord, _), updates, _) ->
@@ -687,34 +688,34 @@ module Expr =
             (nameOrBlank name.idText, c expr)
           | f ->
             Exception.raiseInternal "Not an expected updates field" [ "field", f ])
-      PT.ERecordUpdate(id, c baseRecord, updates)
+      WT.ERecordUpdate(id, c baseRecord, updates)
 
     // Callers with multiple args are encoded as apps wrapping other apps.
     | SynExpr.App(_, _, funcExpr, arg, _) -> // function application (binops and fncalls)
       match c funcExpr with
-      | PT.EApply(id, name, typeArgs, args) ->
-        PT.EApply(id, name, typeArgs, args @ [ c arg ])
-      | PT.EInfix(id, op, Placeholder, arg2) -> PT.EInfix(id, op, c arg, arg2)
-      | PT.EInfix(id, op, arg1, Placeholder) -> PT.EInfix(id, op, arg1, c arg)
+      | WT.EApply(id, name, typeArgs, args) ->
+        WT.EApply(id, name, typeArgs, args @ [ c arg ])
+      | WT.EInfix(id, op, Placeholder, arg2) -> WT.EInfix(id, op, c arg, arg2)
+      | WT.EInfix(id, op, arg1, Placeholder) -> WT.EInfix(id, op, arg1, c arg)
       // A pipe with one entry
-      | PT.EPipe(id, arg1, PipePlaceholder, []) ->
-        PT.EPipe(id, arg1, synToPipeExpr arg, [])
+      | WT.EPipe(id, arg1, PipePlaceholder, []) ->
+        WT.EPipe(id, arg1, synToPipeExpr arg, [])
       // A pipe with more than one entry
-      | PT.EPipe(id, arg1, arg2, rest) ->
-        PT.EPipe(id, arg1, arg2, rest @ [ synToPipeExpr arg ])
-      | PT.EVariable(id, name) ->
+      | WT.EPipe(id, arg1, arg2, rest) ->
+        WT.EPipe(id, arg1, arg2, rest @ [ synToPipeExpr arg ])
+      | WT.EVariable(id, name) ->
         parseFn name
         |> Option.map (fun (name, version) ->
-          PT.EApply(
+          WT.EApply(
             id,
-            PT.FnTargetName(PT.FnName.fqUserProgram [] name version),
+            WT.FnTargetName(PT.FnName.fqUserProgram [] name version),
             [],
             [ c arg ]
           ))
         |> Option.orElseWith (fun () ->
           parseEnum name
           |> Option.map (fun name ->
-            PT.EEnum(
+            WT.EEnum(
               id,
               PT.TypeName.fqUserProgram [] name 0,
               name,
@@ -726,8 +727,8 @@ module Expr =
             "converted specific fncall exp", c funcExpr
             "argument", arg ]
       // Enums
-      | PT.EEnum(id, typeName, caseName, fields) ->
-        PT.EEnum(id, typeName, caseName, fields @ convertEnumArg arg)
+      | WT.EEnum(id, typeName, caseName, fields) ->
+        WT.EEnum(id, typeName, caseName, fields @ convertEnumArg arg)
 
       | e ->
         Exception.raiseInternal
@@ -745,7 +746,7 @@ module Expr =
         "Unsupported expression in parser"
         [ "ast", ast; "expr", expr ]
 
-  let fromSynExpr (ast : SynExpr) : PT.Expr =
+  let fromSynExpr (ast : SynExpr) : WT.Expr =
     try
       fromSynExpr' ast
     with e ->
@@ -754,15 +755,15 @@ module Expr =
       reraise ()
 
 module Function =
-  type Parameter = { name : string; typ : PT.TypeReference }
+  type Parameter = { name : string; typ : WT.TypeReference }
 
   type T =
     { name : string
       version : int
       parameters : List<Parameter>
       typeParams : List<string>
-      returnType : PT.TypeReference
-      body : PT.Expr }
+      returnType : WT.TypeReference
+      body : WT.Expr }
 
 
   let rec parseParamPattern (pat : SynPat) : Parameter =
@@ -771,7 +772,7 @@ module Function =
     match pat with
     | SynPat.Paren(pat, _) -> r pat
 
-    | SynPat.Const(SynConst.Unit, _) -> { name = "unit"; typ = PT.TUnit }
+    | SynPat.Const(SynConst.Unit, _) -> { name = "unit"; typ = WT.TUnit }
 
     | SynPat.Typed(SynPat.Named(SynIdent(id, _), _, _, _), typ, _) ->
       { name = id.idText; typ = TypeReference.fromSynType typ }
@@ -792,7 +793,7 @@ module Function =
 
   let parseReturnInfo
     (returnInfo : Option<SynBindingReturnInfo>)
-    : PT.TypeReference =
+    : WT.TypeReference =
     match returnInfo with
     | Some(SynBindingReturnInfo(typeName, _, _, _)) ->
       TypeReference.fromSynType typeName
@@ -842,7 +843,7 @@ module Function =
         body = Expr.fromSynExpr expr }
 
 module UserFunction =
-  let fromSynBinding (b : SynBinding) : PT.UserFunction.T =
+  let fromSynBinding (b : SynBinding) : WT.UserFunction.T =
     let f = Function.fromSynBinding b
     { tlid = gid ()
 
@@ -853,7 +854,7 @@ module UserFunction =
         |> List.map (fun p -> { name = p.name; description = ""; typ = p.typ })
       returnType = f.returnType
       description = ""
-      deprecated = PT.NotDeprecated
+      deprecated = WT.NotDeprecated
       body = f.body }
 
 
@@ -862,7 +863,7 @@ module PackageFn =
     (owner : string)
     (modules : NonEmptyList<string>)
     (b : SynBinding)
-    : PT.PackageFn.T =
+    : WT.PackageFn.T =
     let f = Function.fromSynBinding b
     { tlid = gid ()
       id = System.Guid.NewGuid()
@@ -873,19 +874,19 @@ module PackageFn =
         |> List.map (fun p -> { name = p.name; description = ""; typ = p.typ })
       returnType = f.returnType
       description = ""
-      deprecated = PT.NotDeprecated
+      deprecated = WT.NotDeprecated
       body = f.body }
 
 module TypeDeclaration =
   module EnumCase =
-    let private parseField (typ : SynField) : PT.TypeDeclaration.EnumField =
+    let private parseField (typ : SynField) : WT.TypeDeclaration.EnumField =
       match typ with
       | SynField(_, _, fieldName, typ, _, _, _, _, _) ->
         { typ = TypeReference.fromSynType typ
           label = fieldName |> Option.map (fun id -> id.idText)
           description = "" }
 
-    let parseCase (case : SynUnionCase) : PT.TypeDeclaration.EnumCase =
+    let parseCase (case : SynUnionCase) : WT.TypeDeclaration.EnumCase =
       match case with
       | SynUnionCase(_, SynIdent(id, _), typ, _, _, _, _) ->
         match typ with
@@ -895,13 +896,13 @@ module TypeDeclaration =
 
 
   module RecordField =
-    let parseField (field : SynField) : PT.TypeDeclaration.RecordField =
+    let parseField (field : SynField) : WT.TypeDeclaration.RecordField =
       match field with
       | SynField(_, _, Some id, typ, _, _, _, _, _) ->
         { name = id.idText; typ = TypeReference.fromSynType typ; description = "" }
       | _ -> Exception.raiseInternal $"Unsupported field" [ "field", field ]
 
-  let fromFields typeDef (fields : List<SynField>) : PT.TypeDeclaration.Definition =
+  let fromFields typeDef (fields : List<SynField>) : WT.TypeDeclaration.Definition =
     match fields with
     | [] ->
       Exception.raiseInternal
@@ -909,7 +910,7 @@ module TypeDeclaration =
         [ "typeDef", typeDef ]
     | firstField :: additionalFields ->
 
-      PT.TypeDeclaration.Record(
+      WT.TypeDeclaration.Record(
         RecordField.parseField firstField,
         List.map RecordField.parseField additionalFields
       )
@@ -918,7 +919,7 @@ module TypeDeclaration =
     let fromCases
       typeDef
       (cases : List<SynUnionCase>)
-      : PT.TypeDeclaration.Definition =
+      : WT.TypeDeclaration.Definition =
       let firstCase, additionalCases =
         match cases with
         | [] ->
@@ -927,7 +928,7 @@ module TypeDeclaration =
             [ "typeDef", typeDef ]
         | firstCase :: additionalCases -> firstCase, additionalCases
 
-      PT.TypeDeclaration.Enum(
+      WT.TypeDeclaration.Enum(
         EnumCase.parseCase firstCase,
         List.map EnumCase.parseCase additionalCases
       )
@@ -935,7 +936,7 @@ module TypeDeclaration =
 
     let fromSynTypeDefn
       (typeDef : SynTypeDefn)
-      : (List<string> * List<string> * PT.TypeDeclaration.Definition) =
+      : (List<string> * List<string> * WT.TypeDeclaration.Definition) =
       match typeDef with
       | SynTypeDefn(SynComponentInfo(_, typeParams, _, ids, _, _, _, _),
                     SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.TypeAbbrev(_, typ, _),
@@ -946,7 +947,7 @@ module TypeDeclaration =
                     _) ->
         SimpleTypeArgs.fromSynTyparDecls typeParams,
         ids |> List.map string,
-        PT.TypeDeclaration.Alias(TypeReference.fromSynType typ)
+        WT.TypeDeclaration.Alias(TypeReference.fromSynType typ)
 
       | SynTypeDefn(SynComponentInfo(_, typeParams, _, ids, _, _, _, _),
                     SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Record(_, fields, _),
@@ -974,7 +975,7 @@ module TypeDeclaration =
 
 
 module UserType =
-  let fromSynTypeDefn (typeDef : SynTypeDefn) : PT.UserType.T =
+  let fromSynTypeDefn (typeDef : SynTypeDefn) : WT.UserType.T =
     let (typeParams, names, definition) =
       TypeDeclaration.Definition.fromSynTypeDefn typeDef
     let (name, version) =
@@ -988,7 +989,7 @@ module UserType =
     { tlid = gid ()
       name = PT.TypeName.userProgram modules name version
       description = ""
-      deprecated = PT.NotDeprecated
+      deprecated = WT.NotDeprecated
       declaration = { definition = definition; typeParams = typeParams } }
 
 module PackageType =
@@ -996,7 +997,7 @@ module PackageType =
     (owner : string)
     (modules : NonEmptyList<string>)
     (typeDef : SynTypeDefn)
-    : PT.PackageType.T =
+    : WT.PackageType.T =
     let (typeParams, names, definition) =
       TypeDeclaration.Definition.fromSynTypeDefn typeDef
     let (name, version) =
@@ -1009,15 +1010,15 @@ module PackageType =
       id = System.Guid.NewGuid()
       name = PT.TypeName.package owner modules name version
       description = ""
-      deprecated = PT.NotDeprecated
+      deprecated = WT.NotDeprecated
       declaration = { typeParams = typeParams; definition = definition } }
 
 
-/// Returns an incomplete parse of a PT expression. Requires calling
+/// Returns an incomplete parse of a WT expression. Requires calling
 /// Expr.resolveNames before using
 // TODO it's hard to use the type system here since there's a lot of places we stash
-// PT.Expr, but that's even more reason to try and prevent partial parses.
-let initialParse (filename : string) (code : string) : PT.Expr =
+// WT.Expr, but that's even more reason to try and prevent partial parses.
+let initialParse (filename : string) (code : string) : WT.Expr =
   code
   |> Utils.parseAsFSharpSourceFile filename
   |> Utils.singleExprFromImplFile

--- a/backend/src/Parser/TestModule.fs
+++ b/backend/src/Parser/TestModule.fs
@@ -42,7 +42,7 @@ module UserDB =
     (userTypes : Set<PT.TypeName.UserProgram>)
     (db : PT.DB.T)
     : PT.DB.T =
-    { db with typ = PTP.TypeReference.resolveNames userTypes db.typ }
+    { db with typ = NameResolution.TypeReference.resolveNames userTypes db.typ }
 
 
 /// Extracts a test from a SynExpr.
@@ -123,9 +123,11 @@ let parseFile (parsedAsFSharp : ParsedImplFileInput) : T =
         decls
     let fnNames = m.fns |> List.map (fun fn -> fn.name) |> Set
     let typeNames = m.types |> List.map (fun t -> t.name) |> Set
-    let fixExpr = PTP.Expr.resolveNames fnNames typeNames
-    { fns = m.fns |> List.map (PTP.UserFunction.resolveNames fnNames typeNames)
-      types = m.types |> List.map (PTP.UserType.resolveNames typeNames)
+    let fixExpr = NameResolution.Expr.resolveNames fnNames typeNames
+    { fns =
+        m.fns
+        |> List.map (NameResolution.UserFunction.resolveNames fnNames typeNames)
+      types = m.types |> List.map (NameResolution.UserType.resolveNames typeNames)
       dbs = m.dbs |> List.map (UserDB.resolveNames typeNames)
       // We don't need to resolve names in nested modules as they are resolved
       // upon construction. TODO: But are the names ready when they do so?

--- a/backend/src/Parser/TestModule.fs
+++ b/backend/src/Parser/TestModule.fs
@@ -5,9 +5,9 @@ open FSharp.Compiler.Syntax
 open Prelude
 open Tablecloth
 
+module FS2WT = FSharpToWrittenTypes
 module WT = WrittenTypes
 module WT2PT = WrittenTypesToProgramTypes
-module PTP = ProgramTypes
 module PT = LibExecution.ProgramTypes
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module RT = LibExecution.RuntimeTypes
@@ -64,7 +64,7 @@ module UserDB =
       { tlid = gid ()
         name = id.idText
         version = 0
-        typ = PTP.TypeReference.fromSynType typ }
+        typ = FS2WT.TypeReference.fromSynType typ }
     | _ ->
       Exception.raiseInternal $"Unsupported db definition" [ "typeDef", typeDef ]
 
@@ -78,7 +78,7 @@ module UserDB =
 /// Extracts a test from a SynExpr.
 /// The test must be in the format `expected = actual`, otherwise an exception is raised
 let parseTest (ast : SynExpr) : WTTest =
-  let convert (x : SynExpr) : WT.Expr = PTP.Expr.fromSynExpr x
+  let convert (x : SynExpr) : WT.Expr = FS2WT.Expr.fromSynExpr x
 
   match ast with
   | SynExpr.App(_,
@@ -109,7 +109,7 @@ let parseFile (parsedAsFSharp : ParsedImplFileInput) : WTModule =
       if isDB then
         [ UserDB.fromSynTypeDefn typeDefn ], []
       else
-        [], [ PTP.UserType.fromSynTypeDefn typeDefn ]
+        [], [ FS2WT.UserType.fromSynTypeDefn typeDefn ]
 
   let rec parseModule (parent : WTModule) (decls : List<SynModuleDecl>) : WTModule =
     List.fold
@@ -121,7 +121,7 @@ let parseFile (parsedAsFSharp : ParsedImplFileInput) : WTModule =
       (fun m decl ->
         match decl with
         | SynModuleDecl.Let(_, bindings, _) ->
-          let newUserFns = List.map PTP.UserFunction.fromSynBinding bindings
+          let newUserFns = List.map FS2WT.UserFunction.fromSynBinding bindings
           { m with fns = m.fns @ newUserFns }
 
         | SynModuleDecl.Types(defns, _) ->

--- a/backend/src/Parser/Utils.fs
+++ b/backend/src/Parser/Utils.fs
@@ -1,4 +1,4 @@
-module Parser.Utils
+module internal Parser.Utils
 
 open FSharp.Compiler
 open FSharp.Compiler.CodeAnalysis

--- a/backend/src/Parser/WrittenTypes.fs
+++ b/backend/src/Parser/WrittenTypes.fs
@@ -1,0 +1,318 @@
+/// The types that the user writes. Think of this as the Syntax Tree.
+module Parser.WrittenTypes
+
+open Prelude
+
+// TODO: stop using ProgramTypes
+// We borrow this for now to use FQNames, but they will be removed soon
+module PT = LibExecution.ProgramTypes
+
+type LetPattern =
+  | LPVariable of id * name : string
+  | LPTuple of
+    id *
+    first : LetPattern *
+    second : LetPattern *
+    theRest : List<LetPattern>
+
+/// Used for pattern matching in a match statement
+type MatchPattern =
+  | MPVariable of id * string
+  | MPEnum of id * caseName : string * fieldPats : List<MatchPattern>
+  | MPInt of id * int64
+  | MPBool of id * bool
+  | MPChar of id * string
+  | MPString of id * string
+  | MPFloat of id * Sign * string * string
+  | MPUnit of id
+  | MPTuple of id * MatchPattern * MatchPattern * List<MatchPattern>
+  | MPList of id * List<MatchPattern>
+  | MPListCons of id * head : MatchPattern * tail : MatchPattern
+
+type BinaryOperation =
+  | BinOpAnd
+  | BinOpOr
+
+type InfixFnName =
+  | ArithmeticPlus
+  | ArithmeticMinus
+  | ArithmeticMultiply
+  | ArithmeticDivide
+  | ArithmeticModulo
+  | ArithmeticPower
+  | ComparisonGreaterThan
+  | ComparisonGreaterThanOrEqual
+  | ComparisonLessThan
+  | ComparisonLessThanOrEqual
+  | ComparisonEquals
+  | ComparisonNotEquals
+  | StringConcat
+
+type Infix =
+  | InfixFnCall of InfixFnName
+  | BinOp of BinaryOperation
+
+/// Darklang's available types
+/// - `int`
+/// - `List<T>`
+/// - user-defined enums
+/// - etc.
+type TypeReference =
+  | TInt
+  | TFloat
+  | TBool
+  | TUnit
+  | TString
+  | TList of TypeReference
+  | TTuple of TypeReference * TypeReference * List<TypeReference>
+  | TDict of TypeReference
+  | TDB of TypeReference
+  | TDateTime
+  | TChar
+  | TPassword
+  | TUuid
+  | TBytes
+  // A named variable, eg `a` in `List<a>`, matches anything
+  | TVariable of string // replaces TAny
+  | TFn of
+    List<TypeReference> *  // CLEANUP: NonEmptyList
+    TypeReference // replaces TLambda
+
+  /// A type defined by a standard library module, a canvas/user, or a package
+  /// e.g. `Result<Int, String>` is represented as `TCustomType("Result", [TInt, TString])`
+  /// `typeArgs` is the list of type arguments, if any
+  | TCustomType of PT.TypeName.T * typeArgs : List<TypeReference>
+
+
+/// Expressions - the main part of the language.
+type Expr =
+  | EInt of id * int64
+  | EBool of id * bool
+  | EString of id * List<StringSegment>
+  /// A character is an Extended Grapheme Cluster (hence why we use a string). This
+  /// is equivalent to one screen-visible "character" in Unicode.
+  | EChar of id * string
+  // Allow the user to have arbitrarily big numbers, even if they don't make sense as
+  // floats. The float is split as we want to preserve what the user entered.
+  // Strings are used as numbers lose the leading zeros (eg 7.00007)
+  | EFloat of id * Sign * string * string
+  | EUnit of id
+  | ELet of id * LetPattern * Expr * Expr
+  | EIf of id * Expr * Expr * Expr
+  | EInfix of id * Infix * Expr * Expr
+  // the id in the varname list is the analysis id, used to get a livevalue
+  // from the analysis engine
+  | ELambda of id * List<id * string> * Expr
+  | EFieldAccess of id * Expr * string
+  | EVariable of id * string
+  | EApply of id * FnTarget * typeArgs : List<TypeReference> * args : List<Expr>
+  | EList of id * List<Expr>
+  | EDict of id * List<string * Expr>
+  | ETuple of id * Expr * Expr * List<Expr>
+  | EPipe of id * Expr * PipeExpr * List<PipeExpr>
+
+  | ERecord of id * PT.TypeName.T * List<string * Expr>
+  | ERecordUpdate of id * record : Expr * updates : List<string * Expr>
+
+  // Enums include `Just`, `Nothing`, `Error`, `Ok`, as well
+  // as user-defined enums.
+  //
+  /// Given an Enum type of:
+  ///   `type MyEnum = A | B of int | C of int * (label: string) | D of MyEnum`
+  /// , this is the expression
+  ///   `C (1, "title")`
+  /// represented as
+  ///   `EEnum(Some UserType.MyEnum, "C", [EInt(1), EString("title")]`
+  /// TODO: the UserTypeName should eventually be a non-optional TypeName.
+  | EEnum of id * typeName : PT.TypeName.T * caseName : string * fields : List<Expr>
+
+  /// Supports `match` expressions
+  /// ```fsharp
+  /// match x + 2 with // arg
+  /// // cases
+  /// | pattern -> expr
+  /// | pattern -> expr
+  /// | ...
+  /// ```
+  | EMatch of id * arg : Expr * cases : List<MatchPattern * Expr>
+
+and StringSegment =
+  | StringText of string
+  | StringInterpolation of Expr
+
+and FnTarget =
+  | FnTargetName of PT.FnName.T
+  | FnTargetExpr of Expr
+
+and PipeExpr =
+  | EPipeVariable of id * string
+  | EPipeLambda of id * List<id * string> * Expr
+  | EPipeInfix of id * Infix * Expr
+  | EPipeFnCall of
+    id *
+    PT.FnName.T *
+    typeArgs : List<TypeReference> *
+    args : List<Expr>
+  | EPipeEnum of
+    id *
+    typeName : PT.TypeName.T *
+    caseName : string *
+    fields : List<Expr>
+
+module Expr =
+  let toID (expr : Expr) : id =
+    match expr with
+    | EInt(id, _)
+    | EBool(id, _)
+    | EString(id, _)
+    | EChar(id, _)
+    | EFloat(id, _, _, _)
+    | EUnit id
+    | ELet(id, _, _, _)
+    | EIf(id, _, _, _)
+    | EInfix(id, _, _, _)
+    | ELambda(id, _, _)
+    | EFieldAccess(id, _, _)
+    | EVariable(id, _)
+    | EApply(id, _, _, _)
+    | EList(id, _)
+    | EDict(id, _)
+    | ETuple(id, _, _, _)
+    | EPipe(id, _, _, _)
+    | ERecord(id, _, _)
+    | ERecordUpdate(id, _, _)
+    | EEnum(id, _, _, _)
+    | EMatch(id, _, _) -> id
+
+module PipeExpr =
+  let toID (expr : PipeExpr) : id =
+    match expr with
+    | EPipeVariable(id, _)
+    | EPipeLambda(id, _, _)
+    | EPipeInfix(id, _, _)
+    | EPipeFnCall(id, _, _, _)
+    | EPipeEnum(id, _, _, _) -> id
+
+
+/// A type defined by a standard library module, a canvas/user, or a package
+module TypeDeclaration =
+  type RecordField = { name : string; typ : TypeReference; description : string }
+
+  type EnumField =
+    { typ : TypeReference; label : Option<string>; description : string }
+
+  type EnumCase = { name : string; fields : List<EnumField>; description : string }
+
+  /// The right-hand-side of the declaration: eg List<'a>
+  type Definition =
+    /// `type MyAlias = Int`
+    | Alias of TypeReference
+
+    /// `type MyRecord = { a : int; b : string }`
+    | Record of firstField : RecordField * additionalFields : List<RecordField>
+
+    /// `type MyEnum = A | B of int | C of int * (label: string)`
+    | Enum of firstCase : EnumCase * additionalCases : List<EnumCase>
+
+  /// Combined the RHS definition, with the list of type parameters. Eg type
+  /// MyType<'a> = List<'a>
+  type T = { typeParams : List<string>; definition : Definition }
+
+
+// Used to mark whether a function/type has been deprecated, and if so,
+// details about possible replacements/alternatives, and reasoning
+type Deprecation<'name> =
+  | NotDeprecated
+
+  // The exact same thing is available under a new, preferred name
+  | RenamedTo of 'name
+
+  /// This has been deprecated and has a replacement we can suggest
+  | ReplacedBy of 'name
+
+  /// This has been deprecated and not replaced, provide a message for the user
+  | DeprecatedBecause of string
+
+
+module Handler =
+  type CronInterval =
+    | EveryDay
+    | EveryWeek
+    | EveryFortnight
+    | EveryHour
+    | Every12Hours
+    | EveryMinute
+
+  type Spec =
+    | HTTP of route : string * method : string
+    | Worker of name : string
+    | Cron of name : string * interval : CronInterval
+    | REPL of name : string
+
+  type T = { tlid : tlid; ast : Expr; spec : Spec }
+
+
+module DB =
+  type T = { tlid : tlid; name : string; version : int; typ : TypeReference }
+
+module UserType =
+  type T =
+    { tlid : tlid
+      name : PT.TypeName.UserProgram
+      declaration : TypeDeclaration.T
+      description : string
+      deprecated : Deprecation<PT.TypeName.T> }
+
+
+module UserFunction =
+  type Parameter = { name : string; typ : TypeReference; description : string }
+
+  type T =
+    { tlid : tlid
+      name : PT.FnName.UserProgram
+      typeParams : List<string>
+      parameters : List<Parameter>
+      returnType : TypeReference
+      description : string
+      deprecated : Deprecation<PT.FnName.T>
+      body : Expr }
+
+module Toplevel =
+  type T =
+    | TLHandler of Handler.T
+    | TLDB of DB.T
+    | TLFunction of UserFunction.T
+    | TLType of UserType.T
+
+  let toTLID (tl : T) : tlid =
+    match tl with
+    | TLHandler h -> h.tlid
+    | TLDB db -> db.tlid
+    | TLFunction f -> f.tlid
+    | TLType t -> t.tlid
+
+module Secret =
+  type T = { name : string; value : string; version : int }
+
+module PackageFn =
+  type Parameter = { name : string; typ : TypeReference; description : string }
+
+  type T =
+    { tlid : tlid
+      id : System.Guid
+      name : PT.FnName.Package
+      body : Expr
+      typeParams : List<string>
+      parameters : List<Parameter>
+      returnType : TypeReference
+      description : string
+      deprecated : Deprecation<PT.FnName.T> }
+
+module PackageType =
+  type T =
+    { tlid : tlid
+      id : System.Guid
+      name : PT.TypeName.Package
+      declaration : TypeDeclaration.T
+      description : string
+      deprecated : Deprecation<PT.TypeName.T> }

--- a/backend/src/Parser/WrittenTypesToProgramTypes.fs
+++ b/backend/src/Parser/WrittenTypesToProgramTypes.fs
@@ -1,0 +1,565 @@
+/// Conversion functions from WrittenTypes to ProgramTypes
+module Parser.WrittenTypesToProgramTypes
+
+open Prelude
+open Tablecloth
+
+module WT = WrittenTypes
+module PT = LibExecution.ProgramTypes
+
+module InfixFnName =
+  let toWT (name : PT.InfixFnName) : WT.InfixFnName =
+    match name with
+    | PT.ArithmeticPlus -> WT.ArithmeticPlus
+    | PT.ArithmeticMinus -> WT.ArithmeticMinus
+    | PT.ArithmeticMultiply -> WT.ArithmeticMultiply
+    | PT.ArithmeticDivide -> WT.ArithmeticDivide
+    | PT.ArithmeticModulo -> WT.ArithmeticModulo
+    | PT.ArithmeticPower -> WT.ArithmeticPower
+    | PT.ComparisonGreaterThan -> WT.ComparisonGreaterThan
+    | PT.ComparisonGreaterThanOrEqual -> WT.ComparisonGreaterThanOrEqual
+    | PT.ComparisonLessThan -> WT.ComparisonLessThan
+    | PT.ComparisonLessThanOrEqual -> WT.ComparisonLessThanOrEqual
+    | PT.ComparisonEquals -> WT.ComparisonEquals
+    | PT.ComparisonNotEquals -> WT.ComparisonNotEquals
+    | PT.StringConcat -> WT.StringConcat
+
+  let toPT (name : WT.InfixFnName) : PT.InfixFnName =
+    match name with
+    | WT.ArithmeticPlus -> PT.ArithmeticPlus
+    | WT.ArithmeticMinus -> PT.ArithmeticMinus
+    | WT.ArithmeticMultiply -> PT.ArithmeticMultiply
+    | WT.ArithmeticDivide -> PT.ArithmeticDivide
+    | WT.ArithmeticModulo -> PT.ArithmeticModulo
+    | WT.ArithmeticPower -> PT.ArithmeticPower
+    | WT.ComparisonGreaterThan -> PT.ComparisonGreaterThan
+    | WT.ComparisonGreaterThanOrEqual -> PT.ComparisonGreaterThanOrEqual
+    | WT.ComparisonLessThan -> PT.ComparisonLessThan
+    | WT.ComparisonLessThanOrEqual -> PT.ComparisonLessThanOrEqual
+    | WT.ComparisonEquals -> PT.ComparisonEquals
+    | WT.ComparisonNotEquals -> PT.ComparisonNotEquals
+    | WT.StringConcat -> PT.StringConcat
+
+module TypeReference =
+  let rec toWT (t : PT.TypeReference) : WT.TypeReference =
+    match t with
+    | PT.TInt -> WT.TInt
+    | PT.TFloat -> WT.TFloat
+    | PT.TBool -> WT.TBool
+    | PT.TUnit -> WT.TUnit
+    | PT.TString -> WT.TString
+    | PT.TList typ -> WT.TList(toWT typ)
+    | PT.TTuple(first, second, theRest) ->
+      WT.TTuple(toWT first, toWT second, List.map toWT theRest)
+    | PT.TDict typ -> WT.TDict(toWT typ)
+    | PT.TDB typ -> WT.TDB(toWT typ)
+    | PT.TDateTime -> WT.TDateTime
+    | PT.TChar -> WT.TChar
+    | PT.TPassword -> WT.TPassword
+    | PT.TUuid -> WT.TUuid
+    | PT.TCustomType(t, typeArgs) -> WT.TCustomType(t, List.map toWT typeArgs)
+    | PT.TBytes -> WT.TBytes
+    | PT.TVariable(name) -> WT.TVariable(name)
+    | PT.TFn(paramTypes, returnType) ->
+      WT.TFn(List.map toWT paramTypes, toWT returnType)
+
+  let rec toPT (t : WT.TypeReference) : PT.TypeReference =
+    match t with
+    | WT.TInt -> PT.TInt
+    | WT.TFloat -> PT.TFloat
+    | WT.TBool -> PT.TBool
+    | WT.TUnit -> PT.TUnit
+    | WT.TString -> PT.TString
+    | WT.TList typ -> PT.TList(toPT typ)
+    | WT.TTuple(firstType, secondType, otherTypes) ->
+      PT.TTuple(toPT firstType, toPT secondType, List.map toPT otherTypes)
+    | WT.TDict typ -> PT.TDict(toPT typ)
+    | WT.TDB typ -> PT.TDB(toPT typ)
+    | WT.TDateTime -> PT.TDateTime
+    | WT.TChar -> PT.TChar
+    | WT.TPassword -> PT.TPassword
+    | WT.TUuid -> PT.TUuid
+    | WT.TCustomType(t, typeArgs) -> PT.TCustomType(t, List.map toPT typeArgs)
+    | WT.TBytes -> PT.TBytes
+    | WT.TVariable(name) -> PT.TVariable(name)
+    | WT.TFn(paramTypes, returnType) ->
+      PT.TFn(List.map toPT paramTypes, toPT returnType)
+
+module BinaryOperation =
+  let toWT (op : PT.BinaryOperation) : WT.BinaryOperation =
+    match op with
+    | PT.BinOpAnd -> WT.BinOpAnd
+    | PT.BinOpOr -> WT.BinOpOr
+
+  let toPT (binop : WT.BinaryOperation) : PT.BinaryOperation =
+    match binop with
+    | WT.BinOpAnd -> PT.BinOpAnd
+    | WT.BinOpOr -> PT.BinOpOr
+
+module Infix =
+  let toPT (infix : WT.Infix) : PT.Infix =
+    match infix with
+    | WT.InfixFnCall(fn) -> PT.InfixFnCall(InfixFnName.toPT fn)
+    | WT.BinOp binop -> PT.BinOp(BinaryOperation.toPT binop)
+
+module LetPattern =
+  let rec toWT (p : PT.LetPattern) : WT.LetPattern =
+    match p with
+    | PT.LPVariable(id, str) -> WT.LPVariable(id, str)
+    | PT.LPTuple(id, first, second, theRest) ->
+      WT.LPTuple(id, toWT first, toWT second, List.map toWT theRest)
+
+  let rec toPT (p : WT.LetPattern) : PT.LetPattern =
+    match p with
+    | WT.LPVariable(id, str) -> PT.LPVariable(id, str)
+    | WT.LPTuple(id, first, second, theRest) ->
+      PT.LPTuple(id, toPT first, toPT second, List.map toPT theRest)
+
+module MatchPattern =
+  let rec toWT (p : PT.MatchPattern) : WT.MatchPattern =
+    match p with
+    | PT.MPVariable(id, str) -> WT.MPVariable(id, str)
+    | PT.MPEnum(id, caseName, fieldPats) ->
+      WT.MPEnum(id, caseName, List.map toWT fieldPats)
+    | PT.MPInt(id, i) -> WT.MPInt(id, i)
+    | PT.MPBool(id, b) -> WT.MPBool(id, b)
+    | PT.MPChar(id, c) -> WT.MPChar(id, c)
+    | PT.MPString(id, s) -> WT.MPString(id, s)
+    | PT.MPFloat(id, s, w, f) -> WT.MPFloat(id, s, w, f)
+    | PT.MPUnit id -> WT.MPUnit id
+    | PT.MPTuple(id, first, second, theRest) ->
+      WT.MPTuple(id, toWT first, toWT second, List.map toWT theRest)
+    | PT.MPList(id, pats) -> WT.MPList(id, List.map toWT pats)
+    | PT.MPListCons(id, head, tail) -> WT.MPListCons(id, toWT head, toWT tail)
+
+
+  let rec toPT (p : WT.MatchPattern) : PT.MatchPattern =
+    match p with
+    | WT.MPVariable(id, str) -> PT.MPVariable(id, str)
+    | WT.MPEnum(id, caseName, fieldPats) ->
+      PT.MPEnum(id, caseName, List.map toPT fieldPats)
+    | WT.MPInt(id, i) -> PT.MPInt(id, i)
+    | WT.MPBool(id, b) -> PT.MPBool(id, b)
+    | WT.MPChar(id, c) -> PT.MPChar(id, c)
+    | WT.MPString(id, s) -> PT.MPString(id, s)
+    | WT.MPFloat(id, s, w, f) -> PT.MPFloat(id, s, w, f)
+    | WT.MPUnit id -> PT.MPUnit id
+    | WT.MPTuple(id, first, second, theRest) ->
+      PT.MPTuple(id, toPT first, toPT second, List.map toPT theRest)
+    | WT.MPList(id, pats) -> PT.MPList(id, List.map toPT pats)
+    | WT.MPListCons(id, head, tail) -> PT.MPListCons(id, toPT head, toPT tail)
+
+
+module Expr =
+  let rec toWT (e : PT.Expr) : WT.Expr =
+    match e with
+    | PT.EChar(id, char) -> WT.EChar(id, char)
+    | PT.EInt(id, num) -> WT.EInt(id, num)
+    | PT.EString(id, segments) -> WT.EString(id, List.map stringSegmentToST segments)
+    | PT.EFloat(id, sign, whole, fraction) -> WT.EFloat(id, sign, whole, fraction)
+    | PT.EBool(id, b) -> WT.EBool(id, b)
+    | PT.EUnit id -> WT.EUnit id
+    | PT.EVariable(id, var) -> WT.EVariable(id, var)
+    | PT.EFieldAccess(id, obj, fieldname) -> WT.EFieldAccess(id, toWT obj, fieldname)
+    | PT.EApply(id, PT.FnTargetName name, typeArgs, args) ->
+      WT.EApply(
+        id,
+        WT.FnTargetName(name),
+        List.map TypeReference.toWT typeArgs,
+        List.map toWT args
+      )
+    | PT.EApply(id, PT.FnTargetExpr name, typeArgs, args) ->
+      WT.EApply(
+        id,
+        WT.FnTargetExpr(toWT name),
+        List.map TypeReference.toWT typeArgs,
+        List.map toWT args
+      )
+    | PT.EInfix(id, PT.InfixFnCall name, arg1, arg2) ->
+      WT.EInfix(id, WT.InfixFnCall(InfixFnName.toWT name), toWT arg1, toWT arg2)
+    | PT.EInfix(id, PT.BinOp(op), arg1, arg2) ->
+      WT.EInfix(id, WT.BinOp(BinaryOperation.toWT (op)), toWT arg1, toWT arg2)
+    | PT.ELambda(id, vars, body) -> WT.ELambda(id, vars, toWT body)
+    | PT.ELet(id, pat, rhs, body) ->
+      WT.ELet(id, LetPattern.toWT pat, toWT rhs, toWT body)
+    | PT.EIf(id, cond, thenExpr, elseExpr) ->
+      WT.EIf(id, toWT cond, toWT thenExpr, toWT elseExpr)
+    | PT.EList(id, exprs) -> WT.EList(id, List.map toWT exprs)
+    | PT.ETuple(id, first, second, theRest) ->
+      WT.ETuple(id, toWT first, toWT second, List.map toWT theRest)
+    | PT.ERecord(id, typeName, fields) ->
+      WT.ERecord(id, typeName, List.map (Tuple2.mapSecond toWT) fields)
+    | PT.ERecordUpdate(id, record, updates) ->
+      WT.ERecordUpdate(
+        id,
+        toWT record,
+        updates |> List.map (fun (name, expr) -> (name, toWT expr))
+      )
+    | PT.EPipe(pipeID, expr1, expr2, rest) ->
+      WT.EPipe(pipeID, toWT expr1, pipeExprToST expr2, List.map pipeExprToST rest)
+    | PT.EEnum(id, typeName, caseName, fields) ->
+      WT.EEnum(id, typeName, caseName, List.map toWT fields)
+    | PT.EMatch(id, mexpr, cases) ->
+      WT.EMatch(
+        id,
+        toWT mexpr,
+        List.map (Tuple2.mapFirst MatchPattern.toWT << Tuple2.mapSecond toWT) cases
+      )
+    | PT.EDict(id, fields) -> WT.EDict(id, List.map (Tuple2.mapSecond toWT) fields)
+
+  and stringSegmentToST (segment : PT.StringSegment) : WT.StringSegment =
+    match segment with
+    | PT.StringText text -> WT.StringText text
+    | PT.StringInterpolation expr -> WT.StringInterpolation(toWT expr)
+
+  and pipeExprToST (pipeExpr : PT.PipeExpr) : WT.PipeExpr =
+    match pipeExpr with
+    | PT.EPipeVariable(id, name) -> WT.EPipeVariable(id, name)
+    | PT.EPipeLambda(id, args, body) -> WT.EPipeLambda(id, args, toWT body)
+    | PT.EPipeInfix(id, PT.InfixFnCall name, first) ->
+      WT.EPipeInfix(id, WT.InfixFnCall(InfixFnName.toWT name), toWT first)
+    | PT.EPipeInfix(id, PT.BinOp(op), first) ->
+      WT.EPipeInfix(id, WT.BinOp(BinaryOperation.toWT (op)), toWT first)
+    | PT.EPipeFnCall(id, fnName, typeArgs, args) ->
+      WT.EPipeFnCall(
+        id,
+        fnName,
+        List.map TypeReference.toWT typeArgs,
+        List.map toWT args
+      )
+    | PT.EPipeEnum(id, typeName, caseName, fields) ->
+      WT.EPipeEnum(id, typeName, caseName, List.map toWT fields)
+
+  let rec toPT (e : WT.Expr) : PT.Expr =
+    match e with
+    | WT.EChar(id, char) -> PT.EChar(id, char)
+    | WT.EInt(id, num) -> PT.EInt(id, num)
+    | WT.EString(id, segment) -> PT.EString(id, List.map stringSegmentToPT segment)
+    | WT.EFloat(id, sign, whole, fraction) -> PT.EFloat(id, sign, whole, fraction)
+    | WT.EBool(id, b) -> PT.EBool(id, b)
+    | WT.EUnit id -> PT.EUnit id
+    | WT.EVariable(id, var) -> PT.EVariable(id, var)
+    | WT.EFieldAccess(id, obj, fieldname) -> PT.EFieldAccess(id, toPT obj, fieldname)
+    | WT.EApply(id, WT.FnTargetName name, typeArgs, args) ->
+      PT.EApply(
+        id,
+        PT.FnTargetName(name),
+        List.map TypeReference.toPT typeArgs,
+        List.map toPT args
+      )
+    | WT.EApply(id, WT.FnTargetExpr name, typeArgs, args) ->
+      PT.EApply(
+        id,
+        PT.FnTargetExpr(toPT name),
+        List.map TypeReference.toPT typeArgs,
+        List.map toPT args
+      )
+    | WT.ELambda(id, vars, body) -> PT.ELambda(id, vars, toPT body)
+    | WT.ELet(id, pat, rhs, body) ->
+      PT.ELet(id, LetPattern.toPT pat, toPT rhs, toPT body)
+    | WT.EIf(id, cond, thenExpr, elseExpr) ->
+      PT.EIf(id, toPT cond, toPT thenExpr, toPT elseExpr)
+    | WT.EList(id, exprs) -> PT.EList(id, List.map toPT exprs)
+    | WT.ETuple(id, first, second, theRest) ->
+      PT.ETuple(id, toPT first, toPT second, List.map toPT theRest)
+    | WT.ERecord(id, typeName, fields) ->
+      PT.ERecord(id, typeName, List.map (Tuple2.mapSecond toPT) fields)
+    | WT.ERecordUpdate(id, record, updates) ->
+      PT.ERecordUpdate(
+        id,
+        toPT record,
+        updates |> List.map (fun (name, expr) -> (name, toPT expr))
+      )
+    | WT.EPipe(pipeID, expr1, expr2, rest) ->
+      PT.EPipe(pipeID, toPT expr1, pipeExprToPT expr2, List.map pipeExprToPT rest)
+    | WT.EEnum(id, typeName, caseName, exprs) ->
+      PT.EEnum(id, typeName, caseName, List.map toPT exprs)
+    | WT.EMatch(id, mexpr, pairs) ->
+      PT.EMatch(
+        id,
+        toPT mexpr,
+        List.map (Tuple2.mapFirst MatchPattern.toPT << Tuple2.mapSecond toPT) pairs
+      )
+    | WT.EInfix(id, infix, arg1, arg2) ->
+      PT.EInfix(id, Infix.toPT infix, toPT arg1, toPT arg2)
+    | WT.EDict(id, pairs) -> PT.EDict(id, List.map (Tuple2.mapSecond toPT) pairs)
+
+  and stringSegmentToPT (segment : WT.StringSegment) : PT.StringSegment =
+    match segment with
+    | WT.StringText text -> PT.StringText text
+    | WT.StringInterpolation expr -> PT.StringInterpolation(toPT expr)
+
+  and pipeExprToPT (pipeExpr : WT.PipeExpr) : PT.PipeExpr =
+    match pipeExpr with
+    | WT.EPipeVariable(id, name) -> PT.EPipeVariable(id, name)
+    | WT.EPipeLambda(id, args, body) -> PT.EPipeLambda(id, args, toPT body)
+    | WT.EPipeInfix(id, infix, first) ->
+      PT.EPipeInfix(id, Infix.toPT infix, toPT first)
+    | WT.EPipeFnCall(id, fnName, typeArgs, args) ->
+      PT.EPipeFnCall(
+        id,
+        fnName,
+        List.map TypeReference.toPT typeArgs,
+        List.map toPT args
+      )
+    | WT.EPipeEnum(id, typeName, caseName, fields) ->
+      PT.EPipeEnum(id, typeName, caseName, List.map toPT fields)
+
+module Deprecation =
+  type Deprecation<'name> =
+    | NotDeprecated
+    | RenamedTo of 'name
+    | ReplacedBy of 'name
+    | DeprecatedBecause of string
+
+  let toWT
+    (f : 'name1 -> 'name2)
+    (d : PT.Deprecation<'name1>)
+    : WT.Deprecation<'name2> =
+    match d with
+    | PT.DeprecatedBecause str -> WT.DeprecatedBecause str
+    | PT.RenamedTo name -> WT.RenamedTo(f name)
+    | PT.ReplacedBy name -> WT.ReplacedBy(f name)
+    | PT.NotDeprecated -> WT.NotDeprecated
+
+  let toPT
+    (f : 'name1 -> 'name2)
+    (d : WT.Deprecation<'name1>)
+    : PT.Deprecation<'name2> =
+    match d with
+    | WT.NotDeprecated -> PT.NotDeprecated
+    | WT.RenamedTo name -> PT.RenamedTo(f name)
+    | WT.ReplacedBy name -> PT.ReplacedBy(f name)
+    | WT.DeprecatedBecause reason -> PT.DeprecatedBecause reason
+
+
+
+module TypeDeclaration =
+  module RecordField =
+    let toWT (f : PT.TypeDeclaration.RecordField) : WT.TypeDeclaration.RecordField =
+      { name = f.name; typ = TypeReference.toWT f.typ; description = f.description }
+
+    let toPT (f : WT.TypeDeclaration.RecordField) : PT.TypeDeclaration.RecordField =
+      { name = f.name; typ = TypeReference.toPT f.typ; description = f.description }
+
+  module EnumField =
+    let toWT (f : PT.TypeDeclaration.EnumField) : WT.TypeDeclaration.EnumField =
+      { typ = TypeReference.toWT f.typ
+        label = f.label
+        description = f.description }
+
+    let toPT (f : WT.TypeDeclaration.EnumField) : PT.TypeDeclaration.EnumField =
+      { typ = TypeReference.toPT f.typ
+        label = f.label
+        description = f.description }
+
+  module EnumCase =
+    let toWT (c : PT.TypeDeclaration.EnumCase) : WT.TypeDeclaration.EnumCase =
+      { name = c.name
+        fields = List.map EnumField.toWT c.fields
+        description = c.description }
+
+    let toPT (c : WT.TypeDeclaration.EnumCase) : PT.TypeDeclaration.EnumCase =
+      { name = c.name
+        fields = List.map EnumField.toPT c.fields
+        description = c.description }
+
+  module Definition =
+    let toWT (d : PT.TypeDeclaration.Definition) : WT.TypeDeclaration.Definition =
+      match d with
+      | PT.TypeDeclaration.Alias typ ->
+        WT.TypeDeclaration.Alias(TypeReference.toWT typ)
+      | PT.TypeDeclaration.Record(firstField, additionalFields) ->
+        WT.TypeDeclaration.Record(
+          RecordField.toWT firstField,
+          List.map RecordField.toWT additionalFields
+        )
+      | PT.TypeDeclaration.Enum(firstCase, additionalCases) ->
+        WT.TypeDeclaration.Enum(
+          EnumCase.toWT firstCase,
+          List.map EnumCase.toWT additionalCases
+        )
+
+    let toPT (d : WT.TypeDeclaration.Definition) : PT.TypeDeclaration.Definition =
+      match d with
+      | WT.TypeDeclaration.Alias typ ->
+        PT.TypeDeclaration.Alias(TypeReference.toPT typ)
+      | WT.TypeDeclaration.Record(firstField, additionalFields) ->
+        PT.TypeDeclaration.Record(
+          RecordField.toPT firstField,
+          List.map RecordField.toPT additionalFields
+        )
+      | WT.TypeDeclaration.Enum(firstCase, additionalCases) ->
+        PT.TypeDeclaration.Enum(
+          EnumCase.toPT firstCase,
+          List.map EnumCase.toPT additionalCases
+        )
+
+  let toWT (d : PT.TypeDeclaration.T) : WT.TypeDeclaration.T =
+    { typeParams = d.typeParams; definition = Definition.toWT d.definition }
+
+  let toPT (d : WT.TypeDeclaration.T) : PT.TypeDeclaration.T =
+    { typeParams = d.typeParams; definition = Definition.toPT d.definition }
+
+
+module Handler =
+  module CronInterval =
+    let toWT (ci : PT.Handler.CronInterval) : WT.Handler.CronInterval =
+      match ci with
+      | PT.Handler.EveryDay -> WT.Handler.EveryDay
+      | PT.Handler.EveryWeek -> WT.Handler.EveryWeek
+      | PT.Handler.EveryFortnight -> WT.Handler.EveryFortnight
+      | PT.Handler.EveryHour -> WT.Handler.EveryHour
+      | PT.Handler.Every12Hours -> WT.Handler.Every12Hours
+      | PT.Handler.EveryMinute -> WT.Handler.EveryMinute
+
+    let toPT (ci : WT.Handler.CronInterval) : PT.Handler.CronInterval =
+      match ci with
+      | WT.Handler.EveryDay -> PT.Handler.EveryDay
+      | WT.Handler.EveryWeek -> PT.Handler.EveryWeek
+      | WT.Handler.EveryFortnight -> PT.Handler.EveryFortnight
+      | WT.Handler.EveryHour -> PT.Handler.EveryHour
+      | WT.Handler.Every12Hours -> PT.Handler.Every12Hours
+      | WT.Handler.EveryMinute -> PT.Handler.EveryMinute
+
+  module Spec =
+    let toWT (s : PT.Handler.Spec) : WT.Handler.Spec =
+      match s with
+      | PT.Handler.HTTP(route, method) -> WT.Handler.HTTP(route, method)
+      | PT.Handler.Worker name -> WT.Handler.Worker name
+      | PT.Handler.Cron(name, interval) ->
+        WT.Handler.Cron(name, CronInterval.toWT interval)
+      | PT.Handler.REPL name -> WT.Handler.REPL name
+
+    let toPT (s : WT.Handler.Spec) : PT.Handler.Spec =
+      match s with
+      | WT.Handler.HTTP(route, method) -> PT.Handler.HTTP(route, method)
+      | WT.Handler.Worker name -> PT.Handler.Worker name
+      | WT.Handler.Cron(name, interval) ->
+        PT.Handler.Cron(name, CronInterval.toPT interval)
+      | WT.Handler.REPL name -> PT.Handler.REPL name
+
+  let toWT (h : PT.Handler.T) : WT.Handler.T =
+    { tlid = h.tlid; ast = Expr.toWT h.ast; spec = Spec.toWT h.spec }
+
+  let toPT (h : WT.Handler.T) : PT.Handler.T =
+    { tlid = h.tlid; ast = Expr.toPT h.ast; spec = Spec.toPT h.spec }
+
+module DB =
+  let toWT (db : PT.DB.T) : WT.DB.T =
+    { tlid = db.tlid
+      name = db.name
+      version = db.version
+      typ = TypeReference.toWT db.typ }
+
+  let toPT (db : WT.DB.T) : PT.DB.T =
+    { tlid = db.tlid
+      name = db.name
+      version = db.version
+      typ = TypeReference.toPT db.typ }
+
+module UserType =
+  let toWT (t : PT.UserType.T) : WT.UserType.T =
+    { tlid = t.tlid
+      name = t.name
+      declaration = TypeDeclaration.toWT t.declaration
+      description = t.description
+      deprecated = Deprecation.toWT identity t.deprecated }
+
+  let toPT (t : WT.UserType.T) : PT.UserType.T =
+    { tlid = t.tlid
+      name = t.name
+      declaration = TypeDeclaration.toPT t.declaration
+      description = t.description
+      deprecated = Deprecation.toPT identity t.deprecated }
+
+
+module UserFunction =
+  module Parameter =
+    let toWT (p : PT.UserFunction.Parameter) : WT.UserFunction.Parameter =
+      { name = p.name; typ = TypeReference.toWT p.typ; description = p.description }
+
+    let toPT (p : WT.UserFunction.Parameter) : PT.UserFunction.Parameter =
+      { name = p.name; typ = TypeReference.toPT p.typ; description = p.description }
+
+  let toWT (f : PT.UserFunction.T) : WT.UserFunction.T =
+    { tlid = f.tlid
+      name = f.name
+      typeParams = f.typeParams
+      parameters = List.map Parameter.toWT f.parameters
+      returnType = TypeReference.toWT f.returnType
+      description = f.description
+      deprecated = Deprecation.toWT identity f.deprecated
+      body = Expr.toWT f.body }
+
+  let toPT (f : WT.UserFunction.T) : PT.UserFunction.T =
+    { tlid = f.tlid
+      name = f.name
+      typeParams = f.typeParams
+      parameters = List.map Parameter.toPT f.parameters
+      returnType = TypeReference.toPT f.returnType
+      description = f.description
+      deprecated = Deprecation.toPT identity f.deprecated
+      body = Expr.toPT f.body }
+
+module Toplevel =
+  let toWT (tl : PT.Toplevel.T) : WT.Toplevel.T =
+    match tl with
+    | PT.Toplevel.TLHandler h -> WT.Toplevel.TLHandler(Handler.toWT h)
+    | PT.Toplevel.TLDB db -> WT.Toplevel.TLDB(DB.toWT db)
+    | PT.Toplevel.TLFunction f -> WT.Toplevel.TLFunction(UserFunction.toWT f)
+    | PT.Toplevel.TLType ut -> WT.Toplevel.TLType(UserType.toWT ut)
+
+  let toPT (tl : WT.Toplevel.T) : PT.Toplevel.T =
+    match tl with
+    | WT.Toplevel.TLHandler h -> PT.Toplevel.TLHandler(Handler.toPT h)
+    | WT.Toplevel.TLDB db -> PT.Toplevel.TLDB(DB.toPT db)
+    | WT.Toplevel.TLFunction f -> PT.Toplevel.TLFunction(UserFunction.toPT f)
+    | WT.Toplevel.TLType ut -> PT.Toplevel.TLType(UserType.toPT ut)
+
+module PackageFn =
+  module Parameter =
+    let toWT (p : PT.PackageFn.Parameter) : WT.PackageFn.Parameter =
+      { name = p.name; typ = TypeReference.toWT p.typ; description = p.description }
+
+    let toPT (p : WT.PackageFn.Parameter) : PT.PackageFn.Parameter =
+      { name = p.name; typ = TypeReference.toPT p.typ; description = p.description }
+
+  let toWT (fn : PT.PackageFn.T) : WT.PackageFn.T =
+    { name = fn.name
+      parameters = List.map Parameter.toWT fn.parameters
+      returnType = TypeReference.toWT fn.returnType
+      description = fn.description
+      deprecated = Deprecation.toWT identity fn.deprecated
+      body = Expr.toWT fn.body
+      typeParams = fn.typeParams
+      id = fn.id
+      tlid = fn.tlid }
+
+  let toPT (fn : WT.PackageFn.T) : PT.PackageFn.T =
+    { name = fn.name
+      parameters = List.map Parameter.toPT fn.parameters
+      returnType = TypeReference.toPT fn.returnType
+      description = fn.description
+      deprecated = Deprecation.toPT identity fn.deprecated
+      body = Expr.toPT fn.body
+      typeParams = fn.typeParams
+      id = fn.id
+      tlid = fn.tlid }
+
+module PackageType =
+  let toWT (pt : PT.PackageType.T) : WT.PackageType.T =
+    { name = pt.name
+      description = pt.description
+      declaration = TypeDeclaration.toWT pt.declaration
+      deprecated = Deprecation.toWT identity pt.deprecated
+      id = pt.id
+      tlid = pt.tlid }
+
+  let toPT (pt : WT.PackageType.T) : PT.PackageType.T =
+    { name = pt.name
+      description = pt.description
+      declaration = TypeDeclaration.toPT pt.declaration
+      deprecated = Deprecation.toPT identity pt.deprecated
+      id = pt.id
+      tlid = pt.tlid }

--- a/backend/tests/Tests/BwdServer.Tests.fs
+++ b/backend/tests/Tests/BwdServer.Tests.fs
@@ -191,11 +191,7 @@ let setupTestCanvas (testName : string) (test : Test) : Task<CanvasID * string> 
     let oplists =
       test.handlers
       |> List.map (fun handler ->
-        let (source : PT.Expr) =
-          Parser.ProgramTypes.initialParse "BwdServer.Tests.fs" handler.code
-          |> Parser.ProgramTypes.Expr.resolveNames Set.empty Set.empty
-
-        let gid = Prelude.gid
+        let source = Parser.Parser.parsePTExpr "BwdServer.Tests.fs" handler.code
 
         let spec =
           match handler.version with

--- a/backend/tests/Tests/Canvas.Tests.fs
+++ b/backend/tests/Tests/Canvas.Tests.fs
@@ -20,7 +20,7 @@ module PTParser = LibExecution.ProgramTypesParser
 module Account = LibBackend.Account
 
 let parse (code : string) : PT.Expr =
-  Parser.ProgramTypes.parseIgnoringUser "tests.canvas.fs" code
+  Parser.Parser.parseIgnoringUser "tests.canvas.fs" code
 
 let testDBOplistRoundtrip : Test =
   testTask "db oplist roundtrip" {

--- a/backend/tests/Tests/Cron.Tests.fs
+++ b/backend/tests/Tests/Cron.Tests.fs
@@ -17,7 +17,7 @@ module Canvas = LibBackend.Canvas
 module Serialize = LibBackend.Serialize
 
 let p (code : string) : PT.Expr =
-  Parser.ProgramTypes.parseIgnoringUser "cron.tests.fs" code
+  Parser.Parser.parseIgnoringUser "cron.tests.fs" code
 
 
 let testCronFetchActiveCrons =

--- a/backend/tests/Tests/HttpClient.Tests.fs
+++ b/backend/tests/Tests/HttpClient.Tests.fs
@@ -158,7 +158,7 @@ let makeTest versionName filename =
         |> Parser.TestModule.parseSingleTestFromFile "httpclient.tests.fs"
       let actualCode =
         test.actual
-        |> Parser.ProgramTypes.Expr.resolveNames Set.empty Set.empty
+        |> Parser.NameResolution.Expr.resolveNames Set.empty Set.empty
         |> PT2RT.Expr.toRT
 
       // Run the handler (call the HTTP client)
@@ -181,10 +181,9 @@ let makeTest versionName filename =
 
       let expectedCode =
         test.expected
-        |> Parser.ProgramTypes.Expr.resolveNames Set.empty Set.empty
+        |> Parser.NameResolution.Expr.resolveNames Set.empty Set.empty
         |> PT2RT.Expr.toRT
       let! expected = Exe.executeExpr state Map.empty expectedCode
-      let types = RT.Types.empty
       return Expect.equalDval actual expected $"Responses don't match"
   }
 

--- a/backend/tests/Tests/HttpClient.Tests.fs
+++ b/backend/tests/Tests/HttpClient.Tests.fs
@@ -156,15 +156,11 @@ let makeTest versionName filename =
         // compressed
         |> String.replace "LENGTH" (string response.body.Length)
         |> Parser.TestModule.parseSingleTestFromFile "httpclient.tests.fs"
-      let actualCode =
-        test.actual
-        |> Parser.NameResolution.Expr.resolveNames Set.empty Set.empty
-        |> PT2RT.Expr.toRT
 
       // Run the handler (call the HTTP client)
       // Note: this will update the corresponding value in `testCases` with the
       // actual request received
-      let! actual = Exe.executeExpr state Map.empty actualCode
+      let! actual = Exe.executeExpr state Map.empty test.actual
 
       // First check: expected HTTP request matches actual HTTP request
       let tc = testCases[dictKey]
@@ -179,11 +175,7 @@ let makeTest versionName filename =
       // Second check: expected result (Dval) matches actual result (Dval)
       let actual = normalizeDvalResult actual
 
-      let expectedCode =
-        test.expected
-        |> Parser.NameResolution.Expr.resolveNames Set.empty Set.empty
-        |> PT2RT.Expr.toRT
-      let! expected = Exe.executeExpr state Map.empty expectedCode
+      let! expected = Exe.executeExpr state Map.empty test.expected
       return Expect.equalDval actual expected $"Responses don't match"
   }
 

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -143,7 +143,7 @@ let fileTests () : Test =
 
     let rec moduleToTests
       (moduleName : string)
-      (modul : Parser.TestModule.T<PT.Expr>)
+      (modul : Parser.TestModule.PTModule)
       =
 
       let nestedModules =

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -141,7 +141,10 @@ let fileTests () : Test =
     let initializeCanvas = testName = "internal"
     let shouldSkip = String.startsWith "_" filename
 
-    let rec moduleToTests (moduleName : string) (modul : Parser.TestModule.T) =
+    let rec moduleToTests
+      (moduleName : string)
+      (modul : Parser.TestModule.T<PT.Expr>)
+      =
 
       let nestedModules =
         List.map (fun (name, m) -> moduleToTests name m) modul.modules

--- a/backend/tests/Tests/Parser.Tests.fs
+++ b/backend/tests/Tests/Parser.Tests.fs
@@ -15,7 +15,7 @@ let parserTests =
   let t name testStr expectedExpr =
     testTask name {
       let actual =
-        Parser.ProgramTypes.parseRTExpr Set.empty Set.empty "parser.tests.fs" testStr
+        Parser.Parser.parseRTExpr Set.empty Set.empty "parser.tests.fs" testStr
       return Expect.equalExprIgnoringIDs actual (PT2RT.Expr.toRT expectedExpr)
     }
   let id = 0UL // since we're ignoring IDs, just use the same one everywhere

--- a/backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/backend/tests/Tests/ProgramTypes.Tests.fs
@@ -23,7 +23,7 @@ let testPipesToRuntimeTypes =
   test "pipes to runtime types" {
     let actual =
       "value.age |> (-) 2 |> (+) value.age |> (<) 3"
-      |> Parser.ProgramTypes.parseRTExpr Set.empty Set.empty "programTypes.tests.fs"
+      |> Parser.Parser.parseRTExpr Set.empty Set.empty "programTypes.tests.fs"
 
     let expected =
       S.eFn

--- a/backend/tests/Tests/Queue.Tests.fs
+++ b/backend/tests/Tests/Queue.Tests.fs
@@ -27,7 +27,7 @@ module SR = LibBackend.QueueSchedulingRules
 module TCS = LibBackend.TraceCloudStorage
 
 let p (code : string) : PT.Expr =
-  Parser.ProgramTypes.parseIgnoringUser "Queue.Tests.fs" code
+  Parser.Parser.parseIgnoringUser "Queue.Tests.fs" code
 
 // This doesn't actually test input, since it's a cron handler and not an actual event handler
 

--- a/backend/tests/Tests/QueueSchedulingRules.Tests.fs
+++ b/backend/tests/Tests/QueueSchedulingRules.Tests.fs
@@ -20,7 +20,7 @@ module Serialize = LibBackend.Serialize
 module SR = LibBackend.QueueSchedulingRules
 
 let p (code : string) : PT.Expr =
-  Parser.ProgramTypes.parseIgnoringUser "queueschedulingrules.fs" code
+  Parser.Parser.parseIgnoringUser "queueschedulingrules.fs" code
 
 
 let testGetWorkerSchedulesForCanvas =

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -15,7 +15,7 @@ module S = TestUtils.RTShortcuts
 module Errors = LibExecution.Errors
 
 let p (code : string) : Expr =
-  Parser.ProgramTypes.parseRTExpr Set.empty Set.empty "sqlcompiler.tests.fs" code
+  Parser.Parser.parseRTExpr Set.empty Set.empty "sqlcompiler.tests.fs" code
 
 let compile
   (symtable : DvalMap)
@@ -126,7 +126,7 @@ let compileTests =
 let inlineWorksAtRoot =
   test "inlineWorksAtRoot" {
     let expr =
-      Parser.ProgramTypes.parseRTExpr
+      Parser.Parser.parseRTExpr
         Set.empty
         Set.empty
         "test.fs"


### PR DESCRIPTION
This adds WrittenTypes to the parser, using an exact clone of ProgramTypes.

Also renamed "Parser.ProgramTypes", which converted the F# ASTs into LibExecution.ProgramTypes types, to "Parser.FSharpToWrittenTypes".

There's a bit of clunkiness in here, planning to resolve it on future PRs.