### PR TITLE
Split ExecutionState.libraries into .builtIns and .packageManager

### DIFF
--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -41,20 +41,18 @@ let info () =
 // Execution
 // ---------------------
 
-let (builtInFns, builtInTypes) =
-  LibExecution.StdLib.combine
-    [ StdLibExecution.StdLib.contents
-      StdLibCli.StdLib.contents
-      Cli.StdLib.contents ]
-    []
-    []
+let builtIns : RT.BuiltIns =
+  let (fns, types) =
+    LibExecution.StdLib.combine
+      [ StdLibExecution.StdLib.contents
+        StdLibCli.StdLib.contents
+        Cli.StdLib.contents ]
+      []
+      []
+  { types = types |> Map.fromListBy (fun typ -> typ.name)
+    fns = fns |> Map.fromListBy (fun fn -> fn.name) }
 
-
-let libraries : RT.Libraries =
-  { builtInTypes = builtInTypes |> Map.fromListBy (fun typ -> typ.name)
-    builtInFns = builtInFns |> Map.fromListBy (fun fn -> fn.name)
-    packageFns = Map.empty
-    packageTypes = Map.empty }
+let packageManager : RT.PackageManager = { fns = Map.empty; types = Map.empty }
 
 
 let execute
@@ -91,7 +89,15 @@ let execute
       printException "Internal error" metadata exn
 
     let state =
-      Exe.createState libraries tracing sendException notify 7UL program config
+      Exe.createState
+        builtIns
+        packageManager
+        tracing
+        sendException
+        notify
+        7UL
+        program
+        config
 
     if mod'.exprs.Length = 1 then
       return! Exe.executeExpr state symtable (PT2RT.Expr.toRT mod'.exprs[0])

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -758,14 +758,7 @@ let compileLambda
     let types = ExecutionState.availableTypes state
 
     let sql, vars, _expectedType =
-      lambdaToSql
-        state.libraries.builtInFns
-        types
-        symtable
-        paramName
-        dbType
-        TBool
-        body
+      lambdaToSql state.builtIns.fns types symtable paramName dbType TBool body
 
     return (sql, vars)
   }

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -29,7 +29,8 @@ let noTestContext : RT.TestContext =
     postTestExecutionHook = fun _ _ -> () }
 
 let createState
-  (libraries : RT.Libraries)
+  (builtIns : RT.BuiltIns)
+  (packageManager : RT.PackageManager)
   (tracing : RT.Tracing)
   (reportException : RT.ExceptionReporter)
   (notify : RT.Notifier)
@@ -37,7 +38,8 @@ let createState
   (program : RT.Program)
   (config : RT.Config)
   : RT.ExecutionState =
-  { libraries = libraries
+  { builtIns = builtIns
+    packageManager = packageManager
     tracing = tracing
     program = program
     config = config

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -774,11 +774,11 @@ and callFn
       let fn =
         match desc with
         | FQName.BuiltIn std ->
-          state.libraries.builtInFns.TryFind std |> Option.map builtInFnToFn
+          state.builtIns.fns.TryFind std |> Option.map builtInFnToFn
         | FQName.UserProgram u ->
           state.program.fns.TryFind u |> Option.map userFnToFn
         | FQName.Package pkg ->
-          state.libraries.packageFns.TryFind pkg |> Option.map packageFnToFn
+          state.packageManager.fns.TryFind pkg |> Option.map packageFnToFn
 
       match fn with
       | None -> return handleMissingFunction ()

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1058,13 +1058,15 @@ and TestContext =
     mutable expectedExceptionCount : int
     postTestExecutionHook : TestContext -> Dval -> unit }
 
-// Non-user-specific functionality needed to run code
-and Libraries =
-  { builtInFns : Map<FnName.BuiltIn, BuiltInFn>
-    builtInTypes : Map<TypeName.BuiltIn, BuiltInType>
+// Functionally written in F# and shipped with the executable
+and BuiltIns =
+  { types : Map<TypeName.BuiltIn, BuiltInType>
+    fns : Map<FnName.BuiltIn, BuiltInFn> }
 
-    packageFns : Map<FnName.Package, PackageFn.T>
-    packageTypes : Map<TypeName.Package, PackageType.T> }
+// Functionality written in Dark stored and managed outside of user space
+and PackageManager =
+  { types : Map<TypeName.Package, PackageType.T>
+    fns : Map<FnName.Package, PackageFn.T> }
 
 and ExceptionReporter = ExecutionState -> Metadata -> exn -> unit
 
@@ -1072,7 +1074,8 @@ and Notifier = ExecutionState -> string -> Metadata -> unit
 
 // All state used while running a program
 and ExecutionState =
-  { libraries : Libraries
+  { builtIns : BuiltIns
+    packageManager : PackageManager
     tracing : Tracing
     program : Program
     config : Config
@@ -1115,8 +1118,8 @@ and Types =
 
 module ExecutionState =
   let availableTypes (state : ExecutionState) : Types =
-    { builtInTypes = state.libraries.builtInTypes
-      packageTypes = state.libraries.packageTypes
+    { builtInTypes = state.builtIns.types
+      packageTypes = state.packageManager.types
       userProgramTypes = state.program.types }
 
 module Types =

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -13,18 +13,19 @@ module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module Exe = LibExecution.Execution
 module StdLibCli = StdLibCli.StdLib
 
-let (builtInFns, builtInTypes) =
-  LibExecution.StdLib.combine
-    [ StdLibExecution.StdLib.contents; StdLibCli.StdLib.contents; StdLib.contents ]
-    []
-    []
 
+let builtIns : RT.BuiltIns =
+  let (fns, types) =
+    LibExecution.StdLib.combine
+      [ StdLibExecution.StdLib.contents; StdLibCli.StdLib.contents; StdLib.contents ]
+      []
+      []
+  { types = types |> Map.fromListBy (fun typ -> typ.name)
+    fns = fns |> Map.fromListBy (fun fn -> fn.name) }
 
-let libraries : RT.Libraries =
-  { builtInTypes = builtInTypes |> Map.fromListBy (fun typ -> typ.name)
-    builtInFns = builtInFns |> Map.fromListBy (fun fn -> fn.name)
-    packageFns = Map.empty
-    packageTypes = Map.empty }
+// TODO
+let packageManager : RT.PackageManager = { fns = Map.empty; types = Map.empty }
+
 
 let defaultTLID = 7UL
 
@@ -71,7 +72,8 @@ let execute
 
     let state =
       Exe.createState
-        libraries
+        builtIns
+        packageManager
         tracing
         sendException
         notify

--- a/backend/src/StdLibDarkInternal/Libs/Documentation.fs
+++ b/backend/src/StdLibDarkInternal/Libs/Documentation.fs
@@ -51,7 +51,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, _, [ DUnit ] ->
           let typeNameToStr = LibExecution.DvalReprDeveloper.typeName
-          state.libraries.builtInFns
+          state.builtIns.fns
           |> Map.toList
           |> List.filter (fun (key, data) ->
             (not (FnName.isInternalFn key)) && data.deprecated = NotDeprecated)

--- a/backend/src/Wasm/EvalHelpers.fs
+++ b/backend/src/Wasm/EvalHelpers.fs
@@ -10,18 +10,14 @@ let getStateForEval
   (types : List<UserType.T>)
   (fns : List<UserFunction.T>)
   : ExecutionState =
-  let packageFns = Map.empty // TODO
-  let packageTypes = Map.empty // TODO
 
-  let libraries : Libraries =
+  let builtIns : BuiltIns =
     let builtInFns, builtInTypes = stdlib
+    { types = builtInTypes |> List.map (fun typ -> typ.name, typ) |> Map
+      fns = builtInFns |> List.map (fun fn -> fn.name, fn) |> Map }
 
-    { builtInTypes = builtInTypes |> List.map (fun typ -> typ.name, typ) |> Map
-
-      builtInFns = builtInFns |> List.map (fun fn -> fn.name, fn) |> Map
-
-      packageFns = packageFns
-      packageTypes = packageTypes }
+  // TODO
+  let packageManager : PackageManager = { fns = Map.empty; types = Map.empty }
 
   let config : Config = { allowLocalHttpAccess = true; httpclientTimeoutInMs = 5000 }
 
@@ -33,7 +29,8 @@ let getStateForEval
       types = Map.fromListBy (fun typ -> typ.name) types
       secrets = List.empty }
 
-  { libraries = libraries
+  { builtIns = builtIns
+    packageManager = packageManager
     tracing = LibExecution.Execution.noTracing Real
     program = program
     config = config

--- a/backend/tests/Tests/DvalRepr.Tests.fs
+++ b/backend/tests/Tests/DvalRepr.Tests.fs
@@ -22,7 +22,7 @@ module S = TestUtils.RTShortcuts
 
 let defaultTypes () =
   { RT.Types.empty with
-      packageTypes = TestUtils.TestUtils.libraries.Force().Result.packageTypes }
+      packageTypes = TestUtils.TestUtils.packageManager.Force().Result.types }
 
 let roundtrippableRoundtripsSuccessfully (dv : RT.Dval) : bool =
   dv

--- a/backend/tests/Tests/StdLib.Tests.fs
+++ b/backend/tests/Tests/StdLib.Tests.fs
@@ -63,8 +63,7 @@ let oldFunctionsAreDeprecated =
   testTask "old functions are deprecated" {
     let counts = ref Map.empty
 
-    let! (libraries : RT.Libraries) = Lazy.force libraries
-    let fns = libraries.builtInFns |> Map.values
+    let fns = builtIns.fns |> Map.values
 
     fns
     |> List.iter (fun fn ->
@@ -89,8 +88,7 @@ let oldTypesAreDeprecated =
   testTask "old types are deprecated" {
     let counts = ref Map.empty
 
-    let! (libraries : RT.Libraries) = Lazy.force libraries
-    let types = libraries.builtInTypes |> Map.values
+    let types = builtIns.types |> Map.values
 
     types
     |> List.iter (fun typ ->


### PR DESCRIPTION
Changelog:

```
Interpreter
- split RT.ExecutionState.libraries into .builtIns and .packageManager
```

towards package streaming