### PR TITLE
Package-fetching redux

### DIFF
--- a/backend/experiments/BwdDangerServer/DangerExecution.fs
+++ b/backend/experiments/BwdDangerServer/DangerExecution.fs
@@ -30,39 +30,6 @@ let builtIns : RT.BuiltIns =
   { types = types |> Map.fromListBy (fun typ -> typ.name)
     fns = fns |> Map.fromListBy (fun fn -> fn.name) }
 
-let packageFns () : Task<Map<RT.FnName.Package, RT.PackageFn.T>> =
-  (task {
-    let! packages = PackageManager.allFunctions ()
-
-    return
-      packages
-      |> List.map (fun (f : PT.PackageFn.T) ->
-        (f.name |> PT2RT.FnName.Package.toRT, PT2RT.PackageFn.toRT f))
-      |> Map.ofList
-  })
-
-let packageTypes () : Task<Map<RT.TypeName.Package, RT.PackageType.T>> =
-  (task {
-    let! packages = PackageManager.allTypes ()
-
-    return
-      packages
-      |> List.map (fun (t : PT.PackageType.T) ->
-        (t.name |> PT2RT.TypeName.Package.toRT, PT2RT.PackageType.toRT t))
-      |> Map.ofList
-  })
-
-let packageManager () : Task<RT.PackageManager> =
-  (task {
-    let! packageTypes = packageTypes ()
-    let! packageFns = packageFns ()
-
-    // TODO: this keeps a cached version so we're not loading them all the time.
-    // Of course, this won't be up to date if we add more functions. This should be
-    // some sort of LRU cache.
-    return { types = packageTypes; fns = packageFns }
-  })
-
 let createState
   (traceID : AT.TraceID.T)
   (tlid : tlid)
@@ -71,8 +38,6 @@ let createState
   (tracing : RT.Tracing)
   : Task<RT.ExecutionState> =
   task {
-    let! packageManager = packageManager ()
-
     let extraMetadata (state : RT.ExecutionState) : Metadata =
       [ "tlid", tlid
         "trace_id", traceID
@@ -91,7 +56,7 @@ let createState
     return
       Exe.createState
         builtIns
-        packageManager
+        PackageManager.packageManager
         tracing
         sendException
         notify
@@ -174,6 +139,7 @@ let reexecuteFunction
 /// Ensure library is ready to be called. Throws if it cannot initialize.
 let init () : Task<unit> =
   task {
-    let! (_ : RT.PackageManager) = packageManager ()
+    // TODO: potentially pre-load all available package stuff
+    //let! (_ : RT.PackageManager) = packageManager ()
     return ()
   }

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -52,7 +52,7 @@ let builtIns : RT.BuiltIns =
   { types = types |> Map.fromListBy (fun typ -> typ.name)
     fns = fns |> Map.fromListBy (fun fn -> fn.name) }
 
-let packageManager : RT.PackageManager = { fns = Map.empty; types = Map.empty }
+let packageManager : RT.PackageManager = RT.PackageManager.Empty
 
 
 let execute

--- a/backend/src/Cli/Libs/Cli.fs
+++ b/backend/src/Cli/Libs/Cli.fs
@@ -24,7 +24,7 @@ let builtIns : RT.BuiltIns =
   { types = types |> Tablecloth.Map.fromListBy (fun typ -> typ.name)
     fns = fns |> Tablecloth.Map.fromListBy (fun fn -> fn.name) }
 
-let packageManager : RT.PackageManager = { fns = Map.empty; types = Map.empty }
+let packageManager : RT.PackageManager = RT.PackageManager.Empty
 
 let execute
   (parentState : RT.ExecutionState)

--- a/backend/src/LibBackend/PackageManager.fs
+++ b/backend/src/LibBackend/PackageManager.fs
@@ -117,3 +117,36 @@ let allTypes () : Task<List<PT.PackageType.T>> =
       |> List.map (fun (id, def) ->
         BinarySerialization.deserializePackageType id def)
   }
+
+
+let packageManager : RT.PackageManager =
+  // maybe some cache here?
+
+  // TODO: this keeps a cached version so we're not loading them all the time.
+  // Of course, this won't be up to date if we add more functions. This should be
+  // some sort of LRU cache.
+  { getTypes =
+      fun () ->
+        task {
+          // TODO: fetch via HTTP call to `dark-packages` canvas/endpoint
+          let! packages = allTypes ()
+
+          return
+            packages
+            |> List.map (fun (t : PT.PackageType.T) ->
+              (t.name |> PT2RT.TypeName.Package.toRT, PT2RT.PackageType.toRT t))
+            |> Map.ofList
+        }
+
+    getFns =
+      fun () ->
+        task {
+          // TODO: fetch via HTTP call to `dark-packages` canvas/endpoint
+          let! packages = allFunctions ()
+
+          return
+            packages
+            |> List.map (fun (f : PT.PackageFn.T) ->
+              (f.name |> PT2RT.FnName.Package.toRT, PT2RT.PackageFn.toRT f))
+            |> Map.ofList
+        } }

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -755,7 +755,7 @@ let compileLambda
       |> partiallyEvaluate state paramName symtable
       |> Ply.TplPrimitives.runPlyAsTask
 
-    let types = ExecutionState.availableTypes state
+    let! types = ExecutionState.availableTypes state
 
     let sql, vars, _expectedType =
       lambdaToSql state.builtIns.fns types symtable paramName dbType TBool body

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1112,30 +1112,27 @@ and ExecutionState =
     onExecutionPath : bool }
 
 and Types =
-  { builtInTypes : Map<TypeName.BuiltIn, BuiltInType>
-    packageTypes : Map<TypeName.Package, PackageType.T>
-    userProgramTypes : Map<TypeName.UserProgram, UserType.T> }
+  { builtIn : Map<TypeName.BuiltIn, BuiltInType>
+    package : Map<TypeName.Package, PackageType.T>
+    userProgram : Map<TypeName.UserProgram, UserType.T> }
 
 module ExecutionState =
   let availableTypes (state : ExecutionState) : Types =
-    { builtInTypes = state.builtIns.types
-      packageTypes = state.packageManager.types
-      userProgramTypes = state.program.types }
+    { builtIn = state.builtIns.types
+      package = state.packageManager.types
+      userProgram = state.program.types }
 
 module Types =
-  let empty =
-    { builtInTypes = Map.empty
-      packageTypes = Map.empty
-      userProgramTypes = Map.empty }
+  let empty = { builtIn = Map.empty; package = Map.empty; userProgram = Map.empty }
 
   let find (name : TypeName.T) (types : Types) : Option<TypeDeclaration.T> =
     match name with
     | FQName.BuiltIn b ->
-      Map.tryFind b types.builtInTypes |> Option.map (fun t -> t.declaration)
+      Map.tryFind b types.builtIn |> Option.map (fun t -> t.declaration)
     | FQName.UserProgram user ->
-      Map.tryFind user types.userProgramTypes |> Option.map (fun t -> t.declaration)
+      Map.tryFind user types.userProgram |> Option.map (fun t -> t.declaration)
     | FQName.Package pkg ->
-      Map.tryFind pkg types.packageTypes |> Option.map (fun t -> t.declaration)
+      Map.tryFind pkg types.package |> Option.map (fun t -> t.declaration)
 
   // Swap concrete types for type parameters
   let rec substitute

--- a/backend/src/LocalExec/Libs/Cli.fs
+++ b/backend/src/LocalExec/Libs/Cli.fs
@@ -24,7 +24,7 @@ let builtIns : RT.BuiltIns =
   { types = types |> Tablecloth.Map.fromListBy (fun typ -> typ.name)
     fns = fns |> Tablecloth.Map.fromListBy (fun fn -> fn.name) }
 
-let packageManager : RT.PackageManager = { types = Map.empty; fns = Map.empty }
+let packageManager : RT.PackageManager = RT.PackageManager.Empty
 
 
 let execute

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -24,7 +24,7 @@ let builtIns : RT.BuiltIns =
     fns = fns |> Map.fromListBy (fun fn -> fn.name) }
 
 // TODO
-let packageManager : RT.PackageManager = { fns = Map.empty; types = Map.empty }
+let packageManager : RT.PackageManager = RT.PackageManager.Empty
 
 
 let defaultTLID = 7UL

--- a/backend/src/StdLibExecution/Libs/Json.fs
+++ b/backend/src/StdLibExecution/Libs/Json.fs
@@ -487,16 +487,18 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [ typeArg ], [ arg ] ->
-          // TODO: somehow collect list of TVariable -> TypeReference
-          // "'b = Int",
-          // so we can Json.serialize<'b>, if 'b is in the surrounding context
+          uply {
+            // TODO: somehow collect list of TVariable -> TypeReference
+            // "'b = Int",
+            // so we can Json.serialize<'b>, if 'b is in the surrounding context
 
-          try
-            let types = ExecutionState.availableTypes state
-            let response = writeJson (fun w -> serialize types w typeArg arg)
-            Ply(Dval.resultOk (DString response))
-          with ex ->
-            Ply(Dval.resultError (DString ex.Message))
+            try
+              let! types = ExecutionState.availableTypes state
+              let response = writeJson (fun w -> serialize types w typeArg arg)
+              return Dval.resultOk (DString response)
+            with ex ->
+              return Dval.resultError (DString ex.Message)
+          }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
@@ -511,10 +513,13 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, [ typeArg ], [ DString arg ] ->
-          let types = ExecutionState.availableTypes state
-          match parse types typeArg arg with
-          | Ok v -> Ply(Dval.resultOk v)
-          | Error e -> Ply(Dval.resultError (DString e))
+          uply {
+            let! types = ExecutionState.availableTypes state
+
+            match parse types typeArg arg with
+            | Ok v -> return Dval.resultOk v
+            | Error e -> return Dval.resultError (DString e)
+          }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/src/StdLibExecution/Libs/NoModule.fs
+++ b/backend/src/StdLibExecution/Libs/NoModule.fs
@@ -281,8 +281,10 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, _, [ a; b ] ->
-          let types = ExecutionState.availableTypes state
-          equals types a b |> DBool |> Ply
+          uply {
+            let! types = ExecutionState.availableTypes state
+            return equals types a b |> DBool
+          }
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "="
       previewable = Pure
@@ -297,8 +299,10 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | state, _, [ a; b ] ->
-          let availableTypes = ExecutionState.availableTypes state
-          equals availableTypes a b |> not |> DBool |> Ply
+          uply {
+            let! availableTypes = ExecutionState.availableTypes state
+            return equals availableTypes a b |> not |> DBool
+          }
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<>"
       previewable = Pure

--- a/backend/src/Wasm/EvalHelpers.fs
+++ b/backend/src/Wasm/EvalHelpers.fs
@@ -12,9 +12,10 @@ let getStateForEval
   : ExecutionState =
 
   let builtIns : BuiltIns =
-    let builtInFns, builtInTypes = stdlib
-    { types = builtInTypes |> List.map (fun typ -> typ.name, typ) |> Map
-      fns = builtInFns |> List.map (fun fn -> fn.name, fn) |> Map }
+    let fns, types = stdlib
+
+    { types = types |> List.map (fun typ -> typ.name, typ) |> Map
+      fns = fns |> List.map (fun fn -> fn.name, fn) |> Map }
 
   // TODO
   let packageManager : PackageManager = { fns = Map.empty; types = Map.empty }

--- a/backend/src/Wasm/EvalHelpers.fs
+++ b/backend/src/Wasm/EvalHelpers.fs
@@ -18,7 +18,7 @@ let getStateForEval
       fns = fns |> List.map (fun fn -> fn.name, fn) |> Map }
 
   // TODO
-  let packageManager : PackageManager = { fns = Map.empty; types = Map.empty }
+  let packageManager : PackageManager = PackageManager.Empty
 
   let config : Config = { allowLocalHttpAccess = true; httpclientTimeoutInMs = 5000 }
 

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -131,27 +131,7 @@ let builtIns : RT.BuiltIns =
   { types = types |> Map.fromListBy (fun typ -> typ.name)
     fns = fns |> Map.fromListBy (fun fn -> fn.name) }
 
-/// Library function to be usable within tests.
-/// Includes normal StdLib fns, as well as test-specific fns.
-/// In the case of a fn existing in both places, the test fn is the one used.
-let packageManager : Lazy<Task<RT.PackageManager>> =
-  lazy
-    task {
-      let! packageFns = LibBackend.PackageManager.allFunctions ()
-      let packageFns =
-        packageFns
-        |> List.map (fun (f : PT.PackageFn.T) ->
-          (f.name |> PT2RT.FnName.Package.toRT, PT2RT.PackageFn.toRT f))
-        |> Map.ofList
-      let! packageTypes = LibBackend.PackageManager.allTypes ()
-      let packageTypes =
-        packageTypes
-        |> List.map (fun (t : PT.PackageType.T) ->
-          (t.name |> PT2RT.TypeName.Package.toRT, PT2RT.PackageType.toRT t))
-        |> Map.ofList
-
-      return { types = packageTypes; fns = packageFns }
-    }
+let packageManager : RT.PackageManager = LibBackend.PackageManager.packageManager
 
 let executionStateFor
   (canvasID : CanvasID)
@@ -218,7 +198,6 @@ let executionStateFor
     // things that notify, while Exceptions have historically been unexpected errors
     // in the tests and so are worth watching out for.
     let notifier : RT.Notifier = fun _state _msg _tags -> ()
-    let! packageManager = packageManager.Force()
 
     let state =
       Exe.createState

--- a/backend/tests/Tests/DvalRepr.Tests.fs
+++ b/backend/tests/Tests/DvalRepr.Tests.fs
@@ -22,7 +22,7 @@ module S = TestUtils.RTShortcuts
 
 let defaultTypes () =
   { RT.Types.empty with
-      packageTypes = TestUtils.TestUtils.packageManager.Force().Result.types }
+      package = TestUtils.TestUtils.packageManager.Force().Result.types }
 
 let roundtrippableRoundtripsSuccessfully (dv : RT.Dval) : bool =
   dv
@@ -42,7 +42,7 @@ let queryableRoundtripsSuccessfullyInRecord
 
   let types : RT.Types =
     { defaultTypes () with
-        userProgramTypes =
+        userProgram =
           Map
             [ typeName,
               { name = typeName
@@ -216,7 +216,7 @@ module Password =
 
       let availableTypes =
         { RT.Types.empty with
-            userProgramTypes =
+            userProgram =
               Map
                 [ typeName,
                   { tlid = 8UL

--- a/backend/tests/Tests/DvalRepr.Tests.fs
+++ b/backend/tests/Tests/DvalRepr.Tests.fs
@@ -21,8 +21,10 @@ module S = TestUtils.RTShortcuts
 
 
 let defaultTypes () =
-  { RT.Types.empty with
-      package = TestUtils.TestUtils.packageManager.Force().Result.types }
+  // with
+  //   package = TestUtils.TestUtils.packageManager.Force().Result.types
+  RT.Types.empty
+
 
 let roundtrippableRoundtripsSuccessfully (dv : RT.Dval) : bool =
   dv


### PR DESCRIPTION
Changelog:

```
Area of change
- details
```

Packages will shortly be stored/managed externally, in the `dark-packages` canvas.
We need to update our backend to fetch them as-needed.
The goal here is to fetch packages asynchronously, once, at the start of executing a `tlid`.

WIP. We still need to figure out:
- [ ] how to determine what types and functions need to be fetched
  (I think we'll need a `dependenciesFor` function, or something?)
  (so far this feels like it may take multiple http calls if managed by the consumer - so, maybe we migrate the dependency-collection logic to `dark-packages`?)
- [ ] (other things I forget right now - will follow up)