### PR TITLE
Move ProgramTypes out of Darklang.StdLib

### DIFF
--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -13,11 +13,11 @@ let listPackageFilesOnDisk (dir: String) : List<String> =
 
 
 let saveFunctionToCanvas
-  (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T)
+  (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T)
   : Unit =
   let reqBody =
     p
-    |> Json.serialize<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T>
+    |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T>
     |> unwrap
     |> String.toBytes
 
@@ -30,10 +30,12 @@ let saveFunctionToCanvas
 
   ()
 
-let saveTypeToCanvas (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T) : Unit =
+let saveTypeToCanvas
+  (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T)
+  : Unit =
   let reqBody =
     p
-    |> Json.serialize<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T>
+    |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T>
     |> unwrap
     |> String.toBytes
 

--- a/backend/src/StdLibDarkInternal/Helpers/ProgramTypesToDarkTypes.fs
+++ b/backend/src/StdLibDarkInternal/Helpers/ProgramTypesToDarkTypes.fs
@@ -13,7 +13,7 @@ let stdlibTyp
   : TypeName.T =
   TypeName.fqPackage
     "Darklang"
-    (NonEmptyList.ofList ([ "Stdlib" ] @ submodules))
+    (NonEmptyList.ofList ([ "LanguageTools" ] @ submodules))
     name
     version
 

--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -1,4 +1,4 @@
-type PackageFns = PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T
+type PackageFns = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T
 
 // CLEANUP : reference package type directly
 [<DB>]
@@ -37,7 +37,7 @@ let _handler _req =
   PACKAGE.Darklang.Stdlib.Http.response (String.toBytes allFns) 200
 
 
-type PackageTypes = PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T
+type PackageTypes = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T
 
 // CLEANUP : reference package type directly
 [<DB>]

--- a/packages/darklang/languageTools/programTypes.dark
+++ b/packages/darklang/languageTools/programTypes.dark
@@ -1,5 +1,5 @@
 module Darklang =
-  module Stdlib =
+  module LanguageTools =
     module ProgramTypes =
       /// Used to name where type/function/etc lives, eg a BuiltIn module, a User module,
       /// or a Package module.
@@ -26,10 +26,12 @@ module Darklang =
             version: Int }
 
         type T<'name> =
-          | BuiltIn of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<'name>
+          | BuiltIn of
+            PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.BuiltIn<'name>
           | UserProgram of
-            PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<'name>
-          | Package of PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<'name>
+            PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.UserProgram<'name>
+          | Package of
+            PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package<'name>
 
 
 
@@ -37,31 +39,31 @@ module Darklang =
         type Name = TypeName of String
 
         type T =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.T<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Name>
 
         type BuiltIn =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.BuiltIn<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Name>
 
         type UserProgram =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.UserProgram<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Name>
 
         type Package =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Name>
 
       module FnName =
         type Name = FnName of String
 
         type T =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.T<PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.T<PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name>
 
         type BuiltIn =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn<PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.BuiltIn<PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name>
 
         type UserProgram =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram<PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.UserProgram<PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name>
 
         type Package =
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package<PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Name>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package<PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name>
 
       /// Darklang's available types (int, List<T>, user-defined types, etc.)
       type TypeReference =
@@ -79,35 +81,35 @@ module Darklang =
         | TBytes
         | TPassword
 
-        | TList of PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+        | TList of PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
 
         | TTuple of
-          PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference *
-          List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference *
+          List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference>
 
-        | TDict of PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+        | TDict of PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
 
         /// A type defined by a standard library module, a canvas/user, or a package
         /// e.g. `PACKAGE.Darklang.Stdlib.Result.Result<Int, String>` is represented as `TCustomType("Result", [TInt, TString])`
         /// `typeArgs` is the list of type arguments, if any
         | TCustomType of
-          PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T *
-          typeArgs: List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T *
+          typeArgs: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference>
 
-        | TDB of PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+        | TDB of PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
 
         | TFn of
-          List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference> *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+          List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference> *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
 
       type LetPattern =
         | LPVariable of PACKAGE.Darklang.Stdlib.ID * name: String
         | LPTuple of
           PACKAGE.Darklang.Stdlib.ID *
-          first: PACKAGE.Darklang.Stdlib.ProgramTypes.LetPattern *
-          second: PACKAGE.Darklang.Stdlib.ProgramTypes.LetPattern *
-          theRest: List<PACKAGE.Darklang.Stdlib.ProgramTypes.LetPattern>
+          first: PACKAGE.Darklang.LanguageTools.ProgramTypes.LetPattern *
+          second: PACKAGE.Darklang.LanguageTools.ProgramTypes.LetPattern *
+          theRest: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.LetPattern>
 
 
       /// Used for pattern matching in a match statement
@@ -127,22 +129,22 @@ module Darklang =
 
         | MPList of
           PACKAGE.Darklang.Stdlib.ID *
-          List<PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern>
+          List<PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern>
         | MPListCons of
           PACKAGE.Darklang.Stdlib.ID *
-          head: PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern *
-          tail: PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern
+          head: PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern *
+          tail: PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern
 
         | MPTuple of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern *
-          List<PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern *
+          List<PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern>
 
         | MPEnum of
           PACKAGE.Darklang.Stdlib.ID *
           caseName: String *
-          fieldPats: List<PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern>
+          fieldPats: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern>
 
 
       type BinaryOperation =
@@ -165,17 +167,17 @@ module Darklang =
         | StringConcat
 
       type Infix =
-        | InfixFnCall of PACKAGE.Darklang.Stdlib.ProgramTypes.InfixFnName
-        | BinOp of PACKAGE.Darklang.Stdlib.ProgramTypes.BinaryOperation
+        | InfixFnCall of PACKAGE.Darklang.LanguageTools.ProgramTypes.InfixFnName
+        | BinOp of PACKAGE.Darklang.LanguageTools.ProgramTypes.BinaryOperation
 
 
       type StringSegment =
         | StringText of String
-        | StringInterpolation of PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+        | StringInterpolation of PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
       type FnTarget =
-        | FnTargetName of PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T
-        | FnTargetExpr of PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+        | FnTargetName of PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.T
+        | FnTargetExpr of PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
 
       type PipeExpr =
@@ -184,24 +186,24 @@ module Darklang =
         | EPipeLambda of
           PACKAGE.Darklang.Stdlib.ID *
           List<PACKAGE.Darklang.Stdlib.ID * String> *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
         | EPipeInfix of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Infix *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Infix *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
         | EPipeFnCall of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T *
-          typeArgs: List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference> *
-          args: List<PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.T *
+          typeArgs: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference> *
+          args: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
         | EPipeEnum of
           PACKAGE.Darklang.Stdlib.ID *
-          typeName: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T *
+          typeName: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T *
           caseName: String *
-          fields: List<PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          fields: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
       // module PipeExpr =
       //   let toID (expr : PipeExpr) : id =
@@ -238,29 +240,29 @@ module Darklang =
 
         | EString of
           PACKAGE.Darklang.Stdlib.ID *
-          List<PACKAGE.Darklang.Stdlib.ProgramTypes.StringSegment>
+          List<PACKAGE.Darklang.LanguageTools.ProgramTypes.StringSegment>
 
 
         // structures of data
 
         | EList of
           PACKAGE.Darklang.Stdlib.ID *
-          List<PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          List<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
         | EDict of
           PACKAGE.Darklang.Stdlib.ID *
-          List<String * PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          List<String * PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
         | ETuple of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
           List<Expr>
 
         | ERecord of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T *
-          List<String * PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T *
+          List<String * PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
         // Enums include `Just`, `Nothing`, `Error`, `Ok`, as well
         // as user-defined enums.
@@ -274,22 +276,22 @@ module Darklang =
         /// TODO: the UserTypeName should eventually be a non-optional TypeName.
         | EEnum of
           PACKAGE.Darklang.Stdlib.ID *
-          typeName: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T *
+          typeName: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T *
           caseName: String *
-          fields: List<PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          fields: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
 
         // declaring and accessing variables
 
         | ELet of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.LetPattern *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.LetPattern *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
         | EFieldAccess of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
           String
 
         | EVariable of PACKAGE.Darklang.Stdlib.ID * String
@@ -299,52 +301,52 @@ module Darklang =
 
         | EIf of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
         | EMatch of
           PACKAGE.Darklang.Stdlib.ID *
-          arg: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
+          arg: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
           cases:
-            List<PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern *
-            PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+            List<PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern *
+            PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
         | EPipe of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.PipeExpr *
-          List<PACKAGE.Darklang.Stdlib.ProgramTypes.PipeExpr>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.PipeExpr *
+          List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PipeExpr>
 
 
         // function calls
 
         | EInfix of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Infix *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Infix *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
         | ELambda of
           PACKAGE.Darklang.Stdlib.ID *
           List<PACKAGE.Darklang.Stdlib.ID * String> *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
 
         | EApply of
           PACKAGE.Darklang.Stdlib.ID *
-          PACKAGE.Darklang.Stdlib.ProgramTypes.FnTarget *
-          typeArgs: List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference> *
-          args: List<PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          PACKAGE.Darklang.LanguageTools.ProgramTypes.FnTarget *
+          typeArgs: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference> *
+          args: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
         | ERecordUpdate of
           PACKAGE.Darklang.Stdlib.ID *
-          record: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          updates: List<String * PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+          record: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          updates: List<String * PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
 
       module Expr =
         let toID
-          (expr: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr)
+          (expr: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr)
           : PACKAGE.Darklang.Stdlib.ID =
           match expr with
           | EUnit id -> id
@@ -389,41 +391,42 @@ module Darklang =
       module TypeDeclaration =
         type RecordField =
           { name: String
-            typ: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+            typ: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
             description: String }
 
         type EnumField =
-          { typ: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+          { typ: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
             label: PACKAGE.Darklang.Stdlib.Option.Option<String>
             description: String }
 
         type EnumCase =
           { name: String
             fields:
-              List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.EnumField>
+              List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.EnumField>
             description: String }
 
         type Definition =
           /// Alias/abbreviation of an existing type with an alternative name, to capture some meaning
-          | Alias of PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+          | Alias of PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
 
           /// `type MyRecord = { a : int; b : String }`
           | Record of
             firstField:
-              PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.RecordField *
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.RecordField *
             additionalFields:
-              List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.RecordField>
+              List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.RecordField>
 
           /// `type MyEnum = A | B of int | C of int * (label: String)`
           | Enum of
-            firstCase: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.EnumCase *
+            firstCase:
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.EnumCase *
             additionalCases:
-              List<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.EnumCase>
+              List<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.EnumCase>
 
         type T =
           { typeParams: List<String>
             definition:
-              PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.Definition }
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.Definition }
 
       module Handler =
         type CronInterval =
@@ -439,13 +442,14 @@ module Darklang =
           | Worker of name: String
           | Cron of
             name: String *
-            interval: PACKAGE.Darklang.Stdlib.ProgramTypes.Handler.CronInterval
+            interval:
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.Handler.CronInterval
           | REPL of name: String
 
         type T =
           { tlid: PACKAGE.Darklang.Stdlib.TLID
-            ast: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
-            spec: PACKAGE.Darklang.Stdlib.ProgramTypes.Handler.Spec }
+            ast: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
+            spec: PACKAGE.Darklang.LanguageTools.ProgramTypes.Handler.Spec }
 
 
       module DB =
@@ -453,7 +457,7 @@ module Darklang =
           { tlid: PACKAGE.Darklang.Stdlib.TLID
             name: String
             version: Int
-            typ: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference }
+            typ: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference }
 
 
       /// A type that a User defined within a Canvas
@@ -463,32 +467,32 @@ module Darklang =
           tlid: Int // TODO: tlid should probably be an alias of TInt
 
           /// Name
-          name: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.UserProgram
+          name: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.UserProgram
 
-          declaration: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.T
+          declaration: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.T
 
           deprecated:
-            PACKAGE.Darklang.Stdlib.ProgramTypes.Deprecation<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T>
+            PACKAGE.Darklang.LanguageTools.ProgramTypes.Deprecation<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T>
         }
 
 
       module UserFunction =
         type Parameter =
           { name: String
-            typ: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+            typ: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
             description: String }
 
         type T =
           { tlid: PACKAGE.Darklang.Stdlib.TLID
-            name: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.UserProgram
+            name: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.UserProgram
             typeParams: List<String>
             parameters:
-              List<PACKAGE.Darklang.Stdlib.ProgramTypes.UserFunction.Parameter>
-            returnType: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+              List<PACKAGE.Darklang.LanguageTools.ProgramTypes.UserFunction.Parameter>
+            returnType: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
             description: String
             deprecated:
-              PACKAGE.Darklang.Stdlib.ProgramTypes.Deprecation<PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T>
-            body: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr }
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.Deprecation<PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.T>
+            body: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr }
 
 
       // module Toplevel =
@@ -517,28 +521,29 @@ module Darklang =
         type T =
           { tlid: PACKAGE.Darklang.Stdlib.TLID
             id: Uuid
-            name: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package
-            declaration: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.T
+            name: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Package
+            declaration:
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.T
             description: String
             deprecated:
-              PACKAGE.Darklang.Stdlib.ProgramTypes.Deprecation<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T> }
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.Deprecation<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T> }
 
 
       module PackageFn =
         type Parameter =
           { name: String
-            typ: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+            typ: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
             description: String }
 
         type T =
           { tlid: PACKAGE.Darklang.Stdlib.TLID
             id: Uuid
-            name: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Package
-            body: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr
+            name: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Package
+            body: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr
             typeParams: List<String>
             parameters:
-              List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.Parameter>
-            returnType: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference
+              List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.Parameter>
+            returnType: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference
             description: String
             deprecated:
-              PACKAGE.Darklang.Stdlib.ProgramTypes.Deprecation<PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T> }
+              PACKAGE.Darklang.LanguageTools.ProgramTypes.Deprecation<PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.T> }

--- a/packages/darklang/prettyPrinter/packages.dark
+++ b/packages/darklang/prettyPrinter/packages.dark
@@ -8,13 +8,13 @@ module Darklang =
 
       type Module =
         { name: String
-          types: List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T>
-          fns: List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T>
+          types: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T>
+          fns: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T>
           submodules: List<PACKAGE.Darklang.PrettyPrinter.Packages.Module> }
 
       let withType
         (ms: List<PACKAGE.Darklang.PrettyPrinter.Packages.Module>)
-        (t: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T)
+        (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T)
         : List<PACKAGE.Darklang.PrettyPrinter.Packages.Module> =
         match t.name.modules with
         | [] ->
@@ -90,7 +90,7 @@ module Darklang =
 
       let withFn
         (ms: List<PACKAGE.Darklang.PrettyPrinter.Packages.Module>)
-        (f: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T)
+        (f: PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T)
         : List<PACKAGE.Darklang.PrettyPrinter.Packages.Module> =
         match f.name.modules with
         | [] ->

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -11,7 +11,7 @@ module Darklang =
         module BuiltIn =
           let fullForReference
             (namePart: String)
-            (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.BuiltIn)
+            (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.BuiltIn)
             : String =
             let modulesPart =
               match t.modules with
@@ -28,7 +28,7 @@ module Darklang =
           let atDefinition
             // TODO: take in just typ and version - modules should have already been dealt with
             (namePart: String)
-            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram)
+            (u: PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.UserProgram)
             : String =
             match u.modules with
             | [] ->
@@ -40,7 +40,7 @@ module Darklang =
 
           let fullForReference
             (namePart: String)
-            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.UserProgram)
+            (u: PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.UserProgram)
             : String =
             let versionPart =
               if u.version == 0 then "" else $"_v{Int.toString u.version}"
@@ -52,7 +52,7 @@ module Darklang =
           let atDefinition
             // TODO: take in just owner, typ, and version - modules should have already been dealt with
             (namePart: String)
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package)
+            (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package)
             : String =
             let versionPart =
               if p.version == 0 then "" else $"_v{Int.toString p.version}"
@@ -61,7 +61,7 @@ module Darklang =
 
           let fullForReference
             (namePart: String)
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FQName.Package)
+            (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package)
             : String =
             let modulesPart = String.join p.modules "."
 
@@ -72,12 +72,12 @@ module Darklang =
 
 
       module TypeName =
-        let name (name: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Name) : String =
+        let name (name: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Name) : String =
           match name with
           | TypeName name -> name
 
         module BuiltIn =
-          let fullForReference (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.BuiltIn)
+          let fullForReference (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.BuiltIn)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.BuiltIn.fullForReference
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.name t.name)
@@ -85,14 +85,14 @@ module Darklang =
 
         module UserProgram =
           let atDefinition
-            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.UserProgram)
+            (u: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.UserProgram)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.UserProgram.atDefinition
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.name u.name)
               u
 
           let fullForReference
-            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.UserProgram)
+            (u: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.UserProgram)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.UserProgram.fullForReference
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.name u.name)
@@ -100,21 +100,21 @@ module Darklang =
 
         module Package =
           let atDefinition
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package)
+            (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Package)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.atDefinition
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.name p.name)
               p
 
           let fullForReference
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.Package)
+            (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Package)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.fullForReference
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.name p.name)
               p
 
         let atDefinition
-          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
+          (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T)
           : String =
           match t with
           | BuiltIn b ->
@@ -128,7 +128,7 @@ module Darklang =
               p
 
         let fullForReference
-          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T)
+          (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T)
           : String =
           match t with
           | BuiltIn b ->
@@ -143,13 +143,13 @@ module Darklang =
 
 
       module FnName =
-        let name (name: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Name) : String =
+        let name (name: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name) : String =
           match name with
           | FnName name -> name
 
         module BuiltIn =
           let fullForReference
-            (f: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.BuiltIn)
+            (f: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.BuiltIn)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.BuiltIn.fullForReference
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.name f.name)
@@ -157,14 +157,14 @@ module Darklang =
 
         module UserProgram =
           let atDefinition
-            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.UserProgram)
+            (u: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.UserProgram)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.UserProgram.atDefinition
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.name u.name)
               u
 
           let fullForReference
-            (u: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.UserProgram)
+            (u: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.UserProgram)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.UserProgram.fullForReference
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.name u.name)
@@ -172,21 +172,21 @@ module Darklang =
 
         module Package =
           let atDefinition
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Package)
+            (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Package)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.atDefinition
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.name p.name)
               p
 
           let fullForReference
-            (p: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.Package)
+            (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Package)
             : String =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FQName.Package.fullForReference
               (PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.name p.name)
               p
 
         let atDefinition
-          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T)
+          (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.T)
           : String =
           match t with
           | BuiltIn _b -> "why are you trying to print a stdlib type name _definition_?"
@@ -196,7 +196,7 @@ module Darklang =
               p
 
         let fullForReference
-          (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FnName.T)
+          (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.T)
           : String =
           match t with
           | BuiltIn b ->
@@ -211,7 +211,7 @@ module Darklang =
 
 
       let typeReference
-        (t: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference)
+        (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference)
         : String =
         match t with
         | TVariable varName -> "'" ++ varName
@@ -268,14 +268,14 @@ module Darklang =
         | _ ->
           let s =
             match
-              Json.serialize<PACKAGE.Darklang.Stdlib.ProgramTypes.TypeReference> t
+              Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference> t
             with
             | Ok s -> s
             | Error e -> "Err" ++ e
 
           $"({s})"
 
-      let letPattern (lp: PACKAGE.Darklang.Stdlib.ProgramTypes.LetPattern) : String =
+      let letPattern (lp: PACKAGE.Darklang.LanguageTools.ProgramTypes.LetPattern) : String =
         match lp with
         | LPVariable(_id, name) -> name
         | LPTuple(_id, first, second, theRest) ->
@@ -286,7 +286,7 @@ module Darklang =
           |> fun parts -> "(" ++ parts ++ ")"
 
       let matchPattern
-        (mp: PACKAGE.Darklang.Stdlib.ProgramTypes.MatchPattern)
+        (mp: PACKAGE.Darklang.LanguageTools.ProgramTypes.MatchPattern)
         : String =
         match mp with
         | MPVariable(_id, name) -> name
@@ -340,7 +340,7 @@ module Darklang =
 
 
       let binaryOperation
-        (b: PACKAGE.Darklang.Stdlib.ProgramTypes.BinaryOperation)
+        (b: PACKAGE.Darklang.LanguageTools.ProgramTypes.BinaryOperation)
         : String =
         match b with
         // TODO: consider surrounding with spaces
@@ -348,7 +348,7 @@ module Darklang =
         | BinOpOr -> "||"
 
       let infixFnName
-        (i: PACKAGE.Darklang.Stdlib.ProgramTypes.InfixFnName)
+        (i: PACKAGE.Darklang.LanguageTools.ProgramTypes.InfixFnName)
         : String =
         match i with
         | ArithmeticPlus -> "+"
@@ -365,25 +365,25 @@ module Darklang =
         | ComparisonNotEquals -> "<>"
         | StringConcat -> "++"
 
-      let infix (i: PACKAGE.Darklang.Stdlib.ProgramTypes.Infix) : String =
+      let infix (i: PACKAGE.Darklang.LanguageTools.ProgramTypes.Infix) : String =
         match i with
         | InfixFnCall i -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.infixFnName i
         | BinOp b -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.binaryOperation b
 
       let stringSegment
-        (s: PACKAGE.Darklang.Stdlib.ProgramTypes.StringSegment)
+        (s: PACKAGE.Darklang.LanguageTools.ProgramTypes.StringSegment)
         : String =
         match s with
         | StringText text -> text
         | StringInterpolation expr ->
           $"{{{PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr expr}}}"
 
-      let fnTarget (t: PACKAGE.Darklang.Stdlib.ProgramTypes.FnTarget) : String =
+      let fnTarget (t: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnTarget) : String =
         match t with
         | FnTargetName name -> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.fullForReference name
         | FnTargetExpr expr ->  $"({PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr expr})"
 
-      let pipeExpr (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PipeExpr) : String =
+      let pipeExpr (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.PipeExpr) : String =
         match p with
         | EPipeVariable(_id, varName) -> varName
 
@@ -423,9 +423,9 @@ module Darklang =
           $"{fnNamePart}{typeArgsPart} {argsPart}"
 
         // PACKAGE.Darklang.Stdlib.ID *
-        // typeName: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeName.T *
+        // typeName: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.T *
         // caseName: String *
-        // fields: List<PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+        // fields: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
         | EPipeEnum(_id, typeName, caseName, fields) ->
           let typeNamePart =
             PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.fullForReference
@@ -443,7 +443,7 @@ module Darklang =
 
             $"{typeNamePart}.{caseName} {fieldPart}"
 
-      let expr (e: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr) : String =
+      let expr (e: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr) : String =
         match e with
         | EUnit _id -> "()"
 
@@ -483,7 +483,7 @@ module Darklang =
 
         // | EDict of
         //   PACKAGE.Darklang.Stdlib.ID *
-        //   List<String * PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+        //   List<String * PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
 
         | ETuple(_id, first, second, theRest) ->
           (List.append [ first; second ] theRest)
@@ -585,9 +585,9 @@ module Darklang =
 
         | EPipe(_id, expr, firstPipeExpr, otherPipeExprs) ->
           // PACKAGE.Darklang.Stdlib.ID *
-          // PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-          // PACKAGE.Darklang.Stdlib.ProgramTypes.PipeExpr *
-          // List<PACKAGE.Darklang.Stdlib.ProgramTypes.PipeExpr>
+          // PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+          // PACKAGE.Darklang.LanguageTools.ProgramTypes.PipeExpr *
+          // List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PipeExpr>
           let exprPart = PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr expr
 
           let firstPipePart = PACKAGE.Darklang.PrettyPrinter.ProgramTypes.pipeExpr firstPipeExpr
@@ -646,8 +646,8 @@ module Darklang =
             $"{fnNamePart}<{typeArgsPart}> {argsPart}"
 
         // PACKAGE.Darklang.Stdlib.ID *
-        // record: PACKAGE.Darklang.Stdlib.ProgramTypes.Expr *
-        // updates: List<String * PACKAGE.Darklang.Stdlib.ProgramTypes.Expr>
+        // record: PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr *
+        // updates: List<String * PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
         | ERecordUpdate(_id, record, updates) ->
           let recordPart = PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr record
 
@@ -665,7 +665,7 @@ module Darklang =
 
       let deprecation<'name>
         (m: 'name -> String)
-        (d: PACKAGE.Darklang.Stdlib.ProgramTypes.Deprecation)
+        (d: PACKAGE.Darklang.LanguageTools.ProgramTypes.Deprecation)
         : String =
         match d with
         | NotDeprecated -> "NotDeprecated"
@@ -675,13 +675,13 @@ module Darklang =
 
       module TypeDeclaration =
         let recordField
-          (d: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.RecordField)
+          (d: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.RecordField)
           : String =
           // TODO: /// for description
           $"{d.name} : {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference d.typ}"
 
         let enumField
-          (d: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.EnumField)
+          (d: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.EnumField)
           : String =
           match d.label with
           | Nothing ->
@@ -690,7 +690,7 @@ module Darklang =
             $"{label}: {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference d.typ}"
 
         let enumCase
-          (d: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.EnumCase)
+          (d: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.EnumCase)
           : String =
           match d.fields with
           | [] -> "| " ++ d.name
@@ -706,7 +706,7 @@ module Darklang =
 
 
       let customType
-        (d: PACKAGE.Darklang.Stdlib.ProgramTypes.TypeDeclaration.T)
+        (d: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeDeclaration.T)
         : String =
         match d.definition with
         | Alias typeRef ->
@@ -733,7 +733,7 @@ module Darklang =
 
       module Handler =
         let cronInterval
-          (c: PACKAGE.Darklang.Stdlib.ProgramTypes.Handler.CronInterval)
+          (c: PACKAGE.Darklang.LanguageTools.ProgramTypes.Handler.CronInterval)
           : String =
           match c with
           | EveryDay -> "Every Day"
@@ -743,7 +743,7 @@ module Darklang =
           | Every12Hours -> "Every 12 Hours"
           | EveryMinute -> "Every Minute"
 
-        let spec (s: PACKAGE.Darklang.Stdlib.ProgramTypes.Handler.Spec) : String =
+        let spec (s: PACKAGE.Darklang.LanguageTools.ProgramTypes.Handler.Spec) : String =
           match s with
           | HTTP(route, method) -> $"[<HttpHandler({method}, {route})>]"
           | Worker name -> $"[<Worker({name})>]"
@@ -751,14 +751,14 @@ module Darklang =
             $"[<Cron({name}, {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.Handler.cronInterval interval})>]"
           | REPL name -> $"[<REPL({name})>]"
 
-      let handler (h: PACKAGE.Darklang.Stdlib.ProgramTypes.Handler.T) : String =
+      let handler (h: PACKAGE.Darklang.LanguageTools.ProgramTypes.Handler.T) : String =
         let specPart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.Handler.spec h.spec
 
         $"{specPart}\nlet _handler _ignored =\n  {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr h.ast}"
 
 
-      let db (db: PACKAGE.Darklang.Stdlib.ProgramTypes.DB.T) : String =
+      let db (db: PACKAGE.Darklang.LanguageTools.ProgramTypes.DB.T) : String =
         let versionPart =
           if db.version == 0 then
             ""
@@ -772,7 +772,7 @@ module Darklang =
 
 
       let userType
-        (userType: PACKAGE.Darklang.Stdlib.ProgramTypes.UserType)
+        (userType: PACKAGE.Darklang.LanguageTools.ProgramTypes.UserType)
         : String =
         let namePart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.UserProgram.atDefinition
@@ -794,7 +794,7 @@ module Darklang =
 
       module UserFunction =
         let parameter
-          (p: PACKAGE.Darklang.Stdlib.ProgramTypes.UserFunction.Parameter)
+          (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.UserFunction.Parameter)
           : String =
           // TODO: handle `description`
           let typPart =
@@ -803,7 +803,7 @@ module Darklang =
           $"({p.name}: {typPart})"
 
       let userFunction
-        (u: PACKAGE.Darklang.Stdlib.ProgramTypes.UserFunction.T)
+        (u: PACKAGE.Darklang.LanguageTools.ProgramTypes.UserFunction.T)
         : String =
         // TODO: do something with description and deprecated
         // TODO: shouldn't there be modules here somewhere?
@@ -841,12 +841,12 @@ module Darklang =
 
       module PackageFn =
         let parameter
-          (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.Parameter)
+          (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.Parameter)
           : String =
           // TODO: /// for description
           $"({p.name}: {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference p.typ})"
 
-      let packageFn (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFn.T) : String =
+      let packageFn (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T) : String =
         // TODO: handle `deprecated`, `description`
         let namePart =
           PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.Package.atDefinition
@@ -877,7 +877,7 @@ module Darklang =
 
 
       let packageType
-        (p: PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T)
+        (p: PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T)
         : String =
         // TODO: take care of deprecated and description
         let namePart =

--- a/packages/darklang/stdlib/canvas.dark
+++ b/packages/darklang/stdlib/canvas.dark
@@ -1,7 +1,7 @@
 module Darklang =
   module Canvas =
     type Program =
-      { types: List<PACKAGE.Darklang.Stdlib.ProgramTypes.UserType.T>
-        dbs: List<PACKAGE.Darklang.Stdlib.ProgramTypes.DB.T>
-        fns: List<PACKAGE.Darklang.Stdlib.ProgramTypes.UserFunction.T>
-        handlers: List<PACKAGE.Darklang.Stdlib.ProgramTypes.Handler.T> }
+      { types: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.UserType.T>
+        dbs: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.DB.T>
+        fns: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.UserFunction.T>
+        handlers: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.Handler.T> }

--- a/packages/darklang/stdlib/packages.dark
+++ b/packages/darklang/stdlib/packages.dark
@@ -1,5 +1,5 @@
 module Darklang =
   module Stdlib =
     type Packages =
-      { types: List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageType.T>
-        fns: List<PACKAGE.Darklang.Stdlib.ProgramTypes.PackageFunction.T> }
+      { types: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T>
+        fns: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFunction.T> }


### PR DESCRIPTION
No changelog

This moves ProgramTypes from Darklang.StdLib to Darklang.LanguageTools
