### PR TITLE
naive (temp) caching for package managers to hold us over

### DIFF
--- a/backend/src/LibBackend/PackageManager.fs
+++ b/backend/src/LibBackend/PackageManager.fs
@@ -120,7 +120,7 @@ let allTypes : Task<List<PT.PackageType.T>> =
 
 open System
 
-let cachedTask (expiration: TimeSpan) (f: Task<'a>): Task<'a> =
+let cachedTask (expiration : TimeSpan) (f : Task<'a>) : Task<'a> =
   let mutable value = None
   let mutable lastUpdate = DateTime.MinValue
 

--- a/backend/src/StdLibDarkInternal/Libs/Packages.fs
+++ b/backend/src/StdLibDarkInternal/Libs/Packages.fs
@@ -40,10 +40,10 @@ let fns : List<BuiltInFn> =
         function
         | _, _, [ DUnit ] ->
           uply {
-            let! packages = LibBackend.PackageManager.allTypes ()
+            let! packages = LibBackend.PackageManager.allTypes
             let packages = List.map PT2DT.PackageType.toDT packages
 
-            let! fns = LibBackend.PackageManager.allFunctions ()
+            let! fns = LibBackend.PackageManager.allFunctions
             let fns = List.map PT2DT.PackageFn.toDT fns
 
             return

--- a/packages/darklang/stdlib/packages.dark
+++ b/packages/darklang/stdlib/packages.dark
@@ -2,4 +2,4 @@ module Darklang =
   module Stdlib =
     type Packages =
       { types: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T>
-        fns: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFunction.T> }
+        fns: List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T> }


### PR DESCRIPTION
This adds pretty naive caching for our package managers (both DB-based and the web-based one for CLI that accesses the `dark-packages` canvas). Still fetches in bulk, but caches results for a minute. Reasonable for now? Makes things much faster for me, anyway.