### PR TITLE
Stop recursive run-time type-checks

### DIFF
--- a/backend/testfiles/execution/stdlib/dict.dark
+++ b/backend/testfiles/execution/stdlib/dict.dark
@@ -12,8 +12,11 @@ Dict.fromListOverwritingDuplicates_v0 [("duplicate_key",1); ("b",2); ("duplicate
 Dict.fromListOverwritingDuplicates_v0 [("a",1); ("b",2); ("c",3)] = (Dict { c = 3 ; b = 2 ; a= 1 })
 Dict.fromListOverwritingDuplicates_v0 [] = (Dict {})
 Dict.fromListOverwritingDuplicates_v0 [Test.runtimeError ""] = Test.runtimeError ""
-Dict.fromListOverwritingDuplicates_v0 [("a",1); 2; ("c",3)] =
-  Test.runtimeError "In Dict.fromListOverwritingDuplicates's 1st argument (`entries`), the nested value `entries[1]` should be a (String, 'b). However, an Int (2) was passed instead.\n\nExpected: (String, 'b)\nActual: an Int: 2"
+Dict.fromListOverwritingDuplicates_v0 [(1, 2)] =
+  // CLEANUP this error message is the goal once Dvals include typeRefs:
+  // In Dict.fromListOverwritingDuplicates's 1st argument (`entries`), the nested value `entries[1]` should be a (String, 'b). However, an Int (2) was passed instead.\n\nExpected: (String, 'b)\nActual: an Int: 2
+  Test.runtimeError "Expected `key` to be a `String`, but it was `1`"
+Dict.fromListOverwritingDuplicates_v0 [1] = Test.runtimeError "All list items must be `(key, value)`"
 
 
 // CLEANUP the first test here feels surprising - should it error or something?
@@ -23,10 +26,11 @@ Dict.fromList_v0 [("Content-Length",0); ("Server", "dark") ] = PACKAGE.Darklang.
 Dict.fromList_v0 [] = PACKAGE.Darklang.Stdlib.Option.Option.Just (Dict {})
 Dict.fromList_v0 [Test.runtimeError ""] = Test.runtimeError ""
 
+
 Dict.fromList_v0 [(1,1)] =
-  Test.runtimeError "In Dict.fromList's 1st argument (`entries`), the nested value `entries[0][0]` should be a String. However, an Int (1) was passed instead.\n\nExpected: String\nActual: an Int: 1"
-Dict.fromList_v0 [("a",1); ("b",2); ("c",3,3)] =
-  Test.runtimeError "In Dict.fromList's 1st argument (`entries`), the nested value `entries[2]` should be a (String, 'b). However, a (String, Int, Int) ((\"c\", 3...) was passed instead.\n\nExpected: (String, 'b)\nActual: a (String, Int, Int): (\"c\", 3, 3)"
+  // CLEANUP this error message is the goal once Dvals include typeRefs:
+  //Test.runtimeError "In Dict.fromList's 1st argument (`entries`), the nested value `entries[0][0]` should be a String. However, an Int (1) was passed instead.\n\nExpected: String\nActual: an Int: 1"
+  Test.runtimeError "Expected `key` to be a `String`, but it was `1`"
 
 Dict.get (Dict { key1 = "val1" }) "key1" = PACKAGE.Darklang.Stdlib.Option.Option.Just "val1"
 

--- a/backend/testfiles/execution/stdlib/float.dark
+++ b/backend/testfiles/execution/stdlib/float.dark
@@ -134,8 +134,6 @@ Float.sqrt_v0 0.0 = 0.0
 Float.subtract_v0 1.0 0.2 = 0.8
 
 Float.sum_v0 [1.0;0.2] = 1.2
-Float.sum_v0 [1.0;"a"] =
-  Test.runtimeError "In Float.sum's 1st argument (`a`), the nested value `a[1]` should be a Float. However, a String (\"a\") was passed instead.\n\nExpected: Float\nActual: a String: \"a\""
 
 Test.nan_v0 == Test.nan_v0 = false
 

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -29,7 +29,10 @@ module NoInternal =
 
 // type errors for bad `headers` are OK
 HttpClient.request "get" "https://darklang.com" [1] Bytes.empty =
-  Test.runtimeError "In HttpClient.request's 3rd argument (`headers`), the nested value `headers[0]` should be a (String, String). However, an Int (1) was passed instead.\n\nExpected: (String, String)\nActual: an Int: 1"
+  // CLEANUP this would be better once DList includes typeRefs:
+  //Test.runtimeError "In HttpClient.request's 3rd argument (`headers`), the value should be a List<String * String>. However, a List<Int> ([1]) was passed instead.\n\nExpected: List<String * String>\nActual: an List<Int>: [1]"
+  Test.runtimeError "Expected request headers to be a `List<String*String>`, but got: 1"
+
 HttpClient.request "get" "https://darklang.com" [("", "")] Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error "Empty request header key provided"
 
 // type errors for bad `method` are OK

--- a/backend/testfiles/execution/stdlib/int.dark
+++ b/backend/testfiles/execution/stdlib/int.dark
@@ -170,8 +170,6 @@ Int.divide_v0 1 0 = Test.runtimeError "Division by zero"
 ((List.range_v0 1 100) |> List.map_v0 (fun x -> Int.random 0 2) |> List.unique_v0) = [0; 1; 2]
 
 Int.sum_v0 [1;2] = 3
-Int.sum_v0 [1.0;2] =
-  Test.runtimeError "In Int.sum's 1st argument (`a`), the nested value `a[0]` should be an Int. However, a Float (1.0) was passed instead.\n\nExpected: Int\nActual: a Float: 1.0"
 
 
 Int.parse_v0 "0" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 0

--- a/backend/testfiles/execution/stdlib/list.dark
+++ b/backend/testfiles/execution/stdlib/list.dark
@@ -1,3 +1,9 @@
+// CLEANUP the following tests should fail on having mixed types
+//[1; 2.3] = Test.runtimeError "Cannot form a list of mixed types - the 2nd element does not match the type of previous elements"
+//[(1,10);10;(3,30)] = Test.runtimeError "Cannot form a list of mixed types ..."
+//[(1,10);(2,20);(3,30,40)] = Test.runtimeError "Cannot form a list of mixed types"
+
+
 List.all_v0 [] (fun item -> item < 3) = true
 List.all_v0 [2] (fun item -> item < 3) = true
 List.all_v0 [1; 2] (fun item -> item < 3) = true
@@ -67,8 +73,9 @@ List.findFirst [1;2;3;1;4] (fun x -> x > 1 ) = PACKAGE.Darklang.Stdlib.Option.Op
 List.findFirst [0; 5; -6; -10; ] (fun x -> x < 0) = PACKAGE.Darklang.Stdlib.Option.Option.Just -6
 List.findFirst [1; -33; 3; -2; 12] (fun x -> (x < 0 && x % 2 == 0)) = PACKAGE.Darklang.Stdlib.Option.Option.Just -2
 
-List.flatten_v0 [1;2;3] =
-  Test.runtimeError "In List.flatten's 1st argument (`list`), the nested value `list[0]` should be a List<'a>. However, an Int (1) was passed instead.\n\nExpected: List<'a>\nActual: an Int: 1"
+// CLEANUP once DList contains typeRefs, this test may be uncommented and the error message updated:
+// List.flatten_v0 [1;2;3] =
+//   Test.runtimeError "In List.flatten's 1st argument (`list`), the value should be a List<List<'a>>. However, a List<Int> ([1; 2; 3]) was passed instead.\n\nExpected: List<List<'a>>\nActual: List<Int>: [1; 2; 3]"
 List.flatten_v0 [[1];[2];[3]] = [ 1; 2; 3 ]
 List.flatten_v0 [[1];[[2;3]]] = [ 1; [ 2; 3 ] ]
 List.flatten_v0 [[[]]] = [ [] ]
@@ -223,11 +230,6 @@ List.unique_v0 [6;2.0] = Test.runtimeError "List.unique: Unable to sort list, pe
 
 List.unzip_v0 [(1,10);(2,20);(3,30)] = ( [ 1; 2; 3 ], [ 10; 20; 30 ] )
 List.unzip_v0 [(10,6)] = ([10],[6])
-// TODO these error messages should have types in them
-List.unzip_v0 [(1,10);10;(3,30)] =
-  Test.runtimeError "In List.unzip's 1st argument (`pairs`), the nested value `pairs[1]` should be an ('a, 'b). However, an Int (10) was passed instead.\n\nExpected: ('a, 'b)\nActual: an Int: 10"
-List.unzip_v0 [(1,10);(2,20);(3,30,40)] =
-  Test.runtimeError "In List.unzip's 1st argument (`pairs`), the nested value `pairs[2]` should be an ('a, 'b). However, an (Int, Int, Int) ((3, 30,...) was passed instead.\n\nExpected: ('a, 'b)\nActual: an (Int, Int, Int): (3, 30, 40)"
 
 List.zipShortest_v0 [10;20;30] [1;2;3] = [ (10, 1); (20, 2); (30, 3) ]
 List.zipShortest_v0 [10;20;30] ["a";"bc";"d"] = [ (10, "a"); (20, "bc"); (30, "d")]

--- a/backend/testfiles/execution/stdlib/string.dark
+++ b/backend/testfiles/execution/stdlib/string.dark
@@ -34,8 +34,6 @@ String.join_v0 ["🧟‍♀️🧟‍♂️"; "🧟‍♀️🧑🏽‍🦰"] ""
 String.join_v0 ["👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️"; "‍⚧️‍️🇵🇷"] "" = "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
 String.join_v0 ["🧟‍♀️🧟‍♂️‍"; "🧟‍♀️🧑🏽‍🦰‍‍"] "" = "🧟‍♀️🧟‍♂️‍🧟‍♀️🧑🏽‍🦰‍‍"
 String.join_v0 ["🧑🏽‍🦰‍"; "🧑🏼‍💻‍‍"] "" = "🧑🏽‍🦰‍🧑🏼‍💻‍‍"
-String.join_v0 ["a"; 0] "" =
-  Test.runtimeError "In String.join's 1st argument (`l`), the nested value `l[1]` should be a String. However, an Int (0) was passed instead.\n\nExpected: String\nActual: an Int: 0"
 
 
 Bytes.length (String.toBytes_v0 "🧑🏽‍🦰🧑🏼‍💻🧑🏻‍🍼✋✋🏻✋🏿") = 62
@@ -253,7 +251,12 @@ String.slugify "{|}~\x7F" = ""
 String.fromList [] = ""
 String.fromList [c "a"] = "a"
 String.fromList [c "👩‍👩‍👧‍👦"; c "🏳️‍⚧️‍️"; c "👱🏾"; c "Z̤͔ͧ̑̓"] = "👩‍👩‍👧‍👦🏳️‍⚧️‍️👱🏾Z̤͔ͧ̑̓"
-String.fromList ["a"] = Test.runtimeError "In String.fromList's 1st argument (`l`), the nested value `l[0]` should be a Char. However, a String (\"a\") was passed instead.\n\nExpected: Char\nActual: a String: \"a\""
+String.fromList ["a"] =
+  // CLEANUP when DList contains typeRef:
+  //Test.runtimeError "In String.fromList's 1st argument (`l`), the value should be a List<Char>. However, a List<String> ([\"a\"]) was passed instead.\n\nExpected: List<Char>\nActual: a List<String>: [\"a\"]"
+  // Note: the below error comes from the implementation itself, not normal typechecking,
+  //   otherwise we could expect the message to include `[\"a\"] instead of `\"a\"`.
+  Test.runtimeError "Expected `l` to be a `List<Char>`, but it was `\"a\"`"
 
 
 String.toList "" = []


### PR DESCRIPTION
Recursive run-time type-checks are hurting performance badly. That feature was a recent addition, and this PR guts it (for now).

See https://www.notion.so/darklang/Type-checking-notes-490ff2d80ba240eb80cb37ade394f793
