### PR TITLE
Fix bad reformat which made tests disappear

### DIFF
--- a/backend/testfiles/execution/language/type-alias.dark
+++ b/backend/testfiles/execution/language/type-alias.dark
@@ -1,15 +1,15 @@
 // simple alias
 type Id = String
 
-type Something = { ID : Id; Data : String }
+type Something = { ID: Id; Data: String }
 Something { ID = "2"; Data = "test" } = Something { ID = "2"; Data = "test" }
-Something { ID = 2; Data = "test" } =
+
 // TODO: would be better if this indicated that it was an Id originally
-Test.runtimeError
-  "Alias.Something's `ID` field should be a String. However, an Int (2) was passed instead.\n\nExpected: ({ ID: Alias.Id; ... })\nActual: an Int: 2"
+Something { ID = 2; Data = "test" } = Test.runtimeError
+  "Something's `ID` field should be a String. However, an Int (2) was passed instead.\n\nExpected: ({ ID: Id; ... })\nActual: an Int: 2"
 
 // record alias
-type Person = { name : String }
+type Person = { name: String }
 type MyPerson = Person
 type MyPerson2 = Person
 
@@ -23,7 +23,7 @@ type MyPerson2 = Person
 //(MyPerson{ name = "test" } == Person{ name = "test" }) = true
 //(MyPerson{ name = "test" } == MyPerson2{ name = "test" }) = true
 
-let getName (p : MyPerson) : String = p.name
+let getName (p: MyPerson) : String = p.name
 getName (MyPerson { name = "test" }) = "test"
 
 // enum alias
@@ -31,51 +31,110 @@ type UserRole =
   | Admin
   | User
   | Guest
-type User = { id : Id; name : String; role : UserRole }
+
+type User =
+  { id: Id; name: String; role: UserRole }
+
 type Admin = User
 
-Admin { id = "1"; name = "Alice"; role = UserRole.Admin } = Admin
-  { id = "1"; name = "Alice"; role = UserRole.Admin }
-User { id = "2"; name = "Bob"; role = UserRole.User } = User
-  { id = "2"; name = "Bob"; role = UserRole.User }
-User { id = "3"; name = "Charlie"; role = UserRole.Guest } = User
-  { id = "3"; name = "Charlie"; role = UserRole.Guest }
+Admin
+  { id = "1"
+    name = "Alice"
+    role = UserRole.Admin } = Admin
+  { id = "1"
+    name = "Alice"
+    role = UserRole.Admin }
 
-let getUserRole (u : User) : UserRole = u.role
-getUserRole (User { id = "1"; name = "Alice"; role = UserRole.Admin }) = UserRole.Admin
-getUserRole (User { id = "2"; name = "Bob"; role = UserRole.User }) = UserRole.User
-getUserRole (User { id = "3"; name = "Charlie"; role = UserRole.Guest }) = UserRole.Guest
+User
+  { id = "2"
+    name = "Bob"
+    role = UserRole.User } = User
+  { id = "2"
+    name = "Bob"
+    role = UserRole.User }
 
-let isAdmin (u : User) : Bool = u.role == UserRole.Admin
-isAdmin (Admin { id = "1"; name = "Alice"; role = UserRole.Admin }) = true
+User
+  { id = "3"
+    name = "Charlie"
+    role = UserRole.Guest } = User
+  { id = "3"
+    name = "Charlie"
+    role = UserRole.Guest }
+
+let getUserRole (u: User) : UserRole = u.role
+
+getUserRole (
+  User
+    { id = "1"
+      name = "Alice"
+      role = UserRole.Admin }
+) = UserRole.Admin
+
+getUserRole (
+  User
+    { id = "2"
+      name = "Bob"
+      role = UserRole.User }
+) = UserRole.User
+
+getUserRole (
+  User
+    { id = "3"
+      name = "Charlie"
+      role = UserRole.Guest }
+) = UserRole.Guest
+
+let isAdmin (u: User) : Bool = u.role == UserRole.Admin
+
+isAdmin (
+  Admin
+    { id = "1"
+      name = "Alice"
+      role = UserRole.Admin }
+) = true
 
 // nested alias
 type UserCredential = (String * Id)
 type EmployeeCredential = UserCredential
-let getUserID (credential : UserCredential) : Id = credential |> Tuple2.second
+let getUserID (credential: UserCredential) : Id = credential |> Tuple2.second
 getUserID (("Alice", "EMP123")) = "EMP123"
-getUserID (("Alice", 123)) = Test.runtimeError
-  "In Alias.getUserID's 1st argument (`credential`), the nested value `credential[1]` should be a String. However, an Int (123) was passed instead.\n\nExpected: Alias.Id\nActual: an Int: 123"
 
-type UserProfile = { credential : UserCredential; name : String; role : UserRole }
+getUserID (("Alice", 123)) = Test.runtimeError
+  "getUserID's return value should be a String. However, an Int (123) was passed instead.\n\nExpected: Id\nActual: an Int: 123"
+
+type UserProfile =
+  { credential: UserCredential
+    name: String
+    role: UserRole }
+
 type EmployeeProfile = UserProfile
-let getEmployeeName (profile : EmployeeProfile) : String = profile.name
+let getEmployeeName (profile: EmployeeProfile) : String = profile.name
+
 getEmployeeName (
   UserProfile
-    { credential = ("Alice", "EMP123"); name = "Alice"; role = UserRole.Admin }
+    { credential = ("Alice", "EMP123")
+      name = "Alice"
+      role = UserRole.Admin }
 ) = "Alice"
 
 // option alias
 type OptionName = PACKAGE.Darklang.Stdlib.Option.Option<String>
-type UserInfo = { id : Id; name : OptionName; roles : List<UserRole> }
-let userHasRole (user : UserInfo) (role : UserRole) : Bool =
+
+type UserInfo =
+  { id: Id
+    name: OptionName
+    roles: List<UserRole> }
+
+let userHasRole (user: UserInfo) (role: UserRole) : Bool =
   List.member_v0 user.roles role
+
 userHasRole
   (UserInfo
     { id = "1"
       name = PACKAGE.Darklang.Stdlib.Option.Option.Just "Alice"
       roles = [ UserRole.Admin; UserRole.User ] })
   UserRole.Admin = true
+
 userHasRole
   (UserInfo
     { id = "1"
@@ -84,19 +143,22 @@ userHasRole
   UserRole.Guest = false
 
 type UserRoleOption = PACKAGE.Darklang.Stdlib.Option.Option<UserRole>
-let getUserRoleAsOption (user : UserInfo) : UserRoleOption = user.roles |> List.head
+let getUserRoleAsOption (user: UserInfo) : UserRoleOption = user.roles |> List.head
+
 getUserRoleAsOption (
   UserInfo
     { id = "1"
       name = PACKAGE.Darklang.Stdlib.Option.Option.Just "Alice"
       roles = [ UserRole.Admin; UserRole.User ] }
 ) = PACKAGE.Darklang.Stdlib.Option.Option.Just UserRole.Admin
+
 getUserRoleAsOption (
   UserInfo
     { id = "1"
       name = PACKAGE.Darklang.Stdlib.Option.Option.Just "Alice"
       roles = [] }
 ) = PACKAGE.Darklang.Stdlib.Option.Option.Nothing
+
 (getUserRoleAsOption (
   UserInfo
     { id = "1"
@@ -107,13 +169,15 @@ getUserRoleAsOption (
 
 // list alias
 type IntegerList = List<Int>
-let isEmpty (il : IntegerList) : Bool = List.isEmpty_v0 il
+let isEmpty (il: IntegerList) : Bool = List.isEmpty_v0 il
 isEmpty ([]) = true
 isEmpty ([ 1; 2; 3 ]) = false
 
 // result alias
 type IntResult = PACKAGE.Darklang.Stdlib.Result.Result<Int, String>
-let getIntResultValue (ir : IntResult) : Int =
+
+let getIntResultValue (ir: IntResult) : Int =
   PACKAGE.Darklang.Stdlib.Result.withDefault_v0 ir 0
+
 getIntResultValue (PACKAGE.Darklang.Stdlib.Result.Result.Ok 5) = 5
 getIntResultValue (PACKAGE.Darklang.Stdlib.Result.Result.Error "error") = 0


### PR DESCRIPTION
The formatting of type-alias.dark somehow hid all but one test. This reformats it properly and also fixes some error messages from recent typechecker changes.