### PR TITLE
Nested field access db query

### DIFF
--- a/backend/src/Prelude/Prelude.fs
+++ b/backend/src/Prelude/Prelude.fs
@@ -238,6 +238,7 @@ type System.Exception with
 /// Non-empty list
 type NEList<'a> = { head : 'a; tail : List<'a> }
 
+/// Non-empty list
 module NEList =
   let toList (l : NEList<'a>) : List<'a> = l.head :: l.tail
 
@@ -256,12 +257,22 @@ module NEList =
     | [] -> Exception.raiseInternal msg metadata
     | head :: tail -> { head = head; tail = tail }
 
-
-
   let ofSeq (head : 'a) (seq : seq<'a>) : NEList<'a> =
     { head = head; tail = List.ofSeq seq }
 
   let singleton (head : 'a) : NEList<'a> = { head = head; tail = [] }
+
+  let push (l : NEList<'a>) (head : 'a) : NEList<'a> =
+    { head = head; tail = l.head :: l.tail }
+
+  let reverse (l : NEList<'a>) : NEList<'a> =
+    match toList l with
+    | [] -> Exception.raiseInternal "Unexpected empty NEList" []
+    | head :: tail ->
+      let reversedTail = List.rev tail
+      match tail with
+      | [] -> { head = head; tail = [] }
+      | first :: rest -> { head = first; tail = rest @ [ head ] }
 
 
 // ----------------------

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -33,6 +33,12 @@ type MyEnum2 =
 
 type EnumTestRecord = { x: String; y: MyEnum }
 
+type InnerRecord = { age: Int }
+type OuterRecord = { name: String; details: InnerRecord }
+
+
+[<DB>]
+
 [<DB>]
 type TestEnumDB = EnumTestRecord
 
@@ -41,6 +47,29 @@ type TestEnumDB2 = MyEnum
 
 [<DB>]
 type TestEnumDB3 = MyEnum2
+
+[<DB>]
+type TestNestedRecord = OuterRecord
+
+module NestedRecordQuerying =
+  (DB.set
+    (OuterRecord
+      { name = "joe"
+        details = InnerRecord { age = 41 } })
+    "jjj"
+    TestNestedRecord
+
+   let _ =
+     DB.set
+       (OuterRecord
+         { name = "frank"
+           details = InnerRecord { age = 22 } })
+       "fff"
+       TestNestedRecord
+
+   let shouldBeJustJoe = DB.query TestNestedRecord (fun p -> p.details.age == 41)
+   List.length shouldBeJustJoe) = 1
+
 
 module AddToTestEnumDBs =
   (let test1 =


### PR DESCRIPTION
Changelog:

```
Language and Standard Library
- DB.query now supports nested field access of DB data
  i.e. `DB.query (\item -> item.details.age > 22)`
```