### PR TITLE
Reference package types directly in dark-packages canvas

### DIFF
--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -1,23 +1,24 @@
-// CLEANUP : reference package types directly
-type PackageType = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T
-type PackageFn = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T
-type PackageConstant = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant.T
+[<DB>]
+type PackageTypeDB = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T
 
 [<DB>]
-type PackageTypeDB = PackageType
+type PackageFnDB = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T
 
 [<DB>]
-type PackageFnDB = PackageFn
+type PackageConstantDB =
+  PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant.T
 
-[<DB>]
-type PackageConstantDB = PackageConstant
 
 [<HttpHandler("POST", "/types")>]
 let _handler _req =
-  let typ = request.body |> String.fromBytes |> Json.parse<PackageType> |> unwrap
+  let typ =
+    request.body
+    |> String.fromBytes
+    |> Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T>
+    |> unwrap
 
   let typeToSave =
-    PackageType
+    PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T
       { tlid = typ.tlid
         id = typ.id
         name = typ.name
@@ -33,10 +34,14 @@ let _handler _req =
 
 [<HttpHandler("POST", "/functions")>]
 let _handler _req =
-  let fn = request.body |> String.fromBytes |> Json.parse<PackageFn> |> unwrap
+  let fn =
+    request.body
+    |> String.fromBytes
+    |> Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T>
+    |> unwrap
 
   let fnToSave =
-    PackageFn
+    PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T
       { tlid = fn.tlid
         id = fn.id
         name = fn.name
@@ -54,10 +59,14 @@ let _handler _req =
 
 [<HttpHandler("POST", "/constants")>]
 let _handler _req =
-  let c = request.body |> String.fromBytes |> Json.parse<PackageConstant> |> unwrap
+  let c =
+    request.body
+    |> String.fromBytes
+    |> Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant.T>
+    |> unwrap
 
   let constantToSave =
-    PackageConstant
+    PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant.T
       { tlid = c.tlid
         id = c.id
         name = c.name
@@ -75,22 +84,44 @@ let _handler _req =
 let _handler _req =
   let stats =
     [ ("types", (DB.getAll PackageTypeDB) |> List.length)
-      ("fns", (DB.getAll PackageFnDB) |> List.length) ]
+      ("constants", (DB.getAll PackageFnDB) |> List.length)
+      ("fns", (DB.getAll PackageConstantDB) |> List.length) ]
     |> Dict.fromListOverwritingDuplicates_v0
 
   let body = (Json.serialize<Dict<Int>> stats) |> unwrap |> String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response body 200
 
+
 [<HttpHandler("GET", "/types")>]
 let _handler _req =
-  let allTypes =
-    (DB.getAll PackageTypeDB) |> Json.serialize<List<PackageType>> |> unwrap
+  let respBody =
+    (DB.getAll PackageTypeDB)
+    |> Json.serialize<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T>>
+    |> unwrap
+    |> String.toBytes
 
-  PACKAGE.Darklang.Stdlib.Http.response (String.toBytes allTypes) 200
+  PACKAGE.Darklang.Stdlib.Http.response respBody 200
+
+[<HttpHandler("GET", "/constants")>]
+let _handler _req =
+  let respBody =
+    (DB.getAll PackageConstantDB)
+    |> Json.serialize<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant.T>>
+    |> unwrap
+    |> String.toBytes
+
+  PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
 [<HttpHandler("GET", "/functions")>]
 let _handler _req =
-  let allFns = (DB.getAll PackageFnDB) |> Json.serialize<List<PackageFn>> |> unwrap
+  let respBody =
+    (DB.getAll PackageFnDB)
+    |> Json.serialize<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.T>>
+    |> unwrap
+    |> String.toBytes
+
+  PACKAGE.Darklang.Stdlib.Http.response respBody 200
+
 
   PACKAGE.Darklang.Stdlib.Http.response (String.toBytes allFns) 200


### PR DESCRIPTION
No changelog

No need to alias these types