### PR TITLE
wip: fetch package things by name

### DIFF
--- a/backend/src/StdLibExecution/Libs/NoModule.fs
+++ b/backend/src/StdLibExecution/Libs/NoModule.fs
@@ -405,6 +405,41 @@ let fns : List<BuiltInFn> =
     //   sqlSpec = NotYetImplemented
     //   previewable = Pure
     //   deprecated = NotDeprecated }
+
+
+
+
+    { name = fn "print" 0
+      typeParams = []
+      parameters = [ Param.make "value" TString "The value to be printed." ]
+      returnType = TUnit
+      description = "Prints the given <param value> to the standard output."
+      fn =
+        (function
+        | _, _, [ DString str ] ->
+          print str
+          Ply(DUnit)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+    { name = fn "debug" 0
+      typeParams = []
+      parameters =
+        [ Param.make "value" (TVariable "a") "The value to be printed."
+          Param.make "label" TString "The label to be printed." ]
+      returnType = TVariable "a"
+      description = "Prints the given <param value> to the standard output"
+      fn =
+        (function
+        | _, _, [ value; DString label ] ->
+          print $"DEBUG: {label} - {value}"
+          Ply value
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Impure
+      deprecated = NotDeprecated }
     ]
 
 let contents = (fns, types, constants)

--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -122,3 +122,72 @@ let _handler _req =
     |> String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response respBody 200
+
+
+// WIP
+type ParsedName =
+  { owner: String
+    modules: List<String>
+    name: String
+    version: Int }
+
+let parseName
+  (name: String)
+  : PACKAGE.Darklang.Stdlib.Result.Result<ParsedName, Unit> =
+  let parts = String.split name "."
+  print "1"
+
+  match parts with
+  // at least 3 parts: owner | name | version
+  | ownerName :: firstModuleName :: theRest ->
+    print "2"
+
+    match List.reverse theRest with
+    | moduleNameAndMaybeVersion :: modulesAfterTheFirstInReverse ->
+      print "3"
+
+      let modules =
+        List.append [ firstModuleName ] (List.reverse modulesAfterTheFirstInReverse)
+
+      print "4"
+
+      let parsed =
+        ParsedName
+          { owner = ownerName
+            modules = modules
+            name = moduleNameAndMaybeVersion
+            version = 0 }
+
+      print "4.5"
+
+      PACKAGE.Darklang.Stdlib.Result.Result.Ok parsed
+
+[<HttpHandler("GET", "/type/by-name/:name")>]
+let _handler _req =
+  let parsedName = (parseName name) |> unwrap
+  print "5"
+
+  print ((Json.serialize<ParsedName> parsedName) |> unwrap)
+
+  let foundType =
+    DB.query PackageTypeDB (fun typ ->
+      (typ.name.owner == parsedName.owner)
+      && (typ.name.modules == parsedName.modules)
+      && (typ.name.name == parsedName.name)
+      && (typ.name.version == parsedName.version))
+
+  print ("found" ++ (foundType |> List.length |> Int.toString))
+
+  match foundType with
+  | [] -> PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "not found") 404
+
+  | [ single ] ->
+    let response =
+      (Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType.T>
+        single)
+      |> unwrap
+
+    PACKAGE.Darklang.Stdlib.Http.response (String.toBytes response) 200
+
+  | _multiple ->
+    PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "multiple found") 409


### PR DESCRIPTION
Changelog:

```
Area of change
- details
```


This is currently blocked by:
```fsharp
DB.query PackageTypeDB (fun typ ->
      (typ.name.owner == parsedName.owner)
      && (typ.name.modules == parsedName.modules)
      && (typ.name.name == parsedName.name)
      && (typ.name.version == parsedName.version))
```

as the type of the inner `.name.name` is generic, and resolved typeArgs aren't available in lambdaToSql yet.