### PR TITLE
Start maintaining map of resolved type parameters

### DIFF
--- a/backend/src/LibCloud/UserDB.fs
+++ b/backend/src/LibCloud/UserDB.fs
@@ -230,7 +230,13 @@ let doQuery
       | _ -> Exception.raiseInternal "wrong number of args" [ "args", b.parameters ]
 
     let! sql, vars =
-      SqlCompiler.compileLambda state b.symtable paramName db.typ b.body
+      SqlCompiler.compileLambda
+        state
+        b.typeArgTable
+        b.symtable
+        paramName
+        db.typ
+        b.body
 
     return
       Sql.query

--- a/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
+++ b/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
@@ -172,7 +172,11 @@ module FormatV0 =
     | DUnit -> RT.DUnit
     | DLambda ->
       RT.DFnVal(
-        RT.Lambda { parameters = []; symtable = Map []; body = RT.Expr.EUnit 0UL }
+        RT.Lambda
+          { typeArgTable = Map []
+            symtable = Map []
+            parameters = []
+            body = RT.Expr.EUnit 0UL }
       )
     | DIncomplete SourceNone -> RT.DIncomplete RT.SourceNone
     | DIncomplete(SourceID(tlid, id)) -> RT.DIncomplete(RT.SourceID(tlid, id))

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -58,7 +58,8 @@ let executeExpr
   : Task<RT.Dval> =
   task {
     let symtable = Interpreter.withGlobals state inputVars
-    let! result = Interpreter.eval state symtable expr
+    let typeArgTable = Map.empty
+    let! result = Interpreter.eval state typeArgTable symtable expr
     // Does nothing in non-tests
     state.test.postTestExecutionHook state.test result
     return result
@@ -73,7 +74,8 @@ let executeFunction
   (args : List<RT.Dval>)
   : Task<RT.Dval> =
   task {
-    let! result = Interpreter.callFn state callerID name typeArgs args
+    let typeArgTable = Map.empty
+    let! result = Interpreter.callFn state typeArgTable callerID name typeArgs args
     // Does nothing in non-tests
     state.test.postTestExecutionHook state.test result
     return result

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -474,7 +474,11 @@ and MatchPattern =
 
 type DvalMap = Map<string, Dval>
 
-and LambdaImpl = { parameters : List<id * string>; symtable : Symtable; body : Expr }
+and LambdaImpl =
+  { typeArgTable : TypeArgTable
+    symtable : Symtable
+    parameters : List<id * string>
+    body : Expr }
 
 and FnValImpl =
   | Lambda of LambdaImpl // A fn value
@@ -549,8 +553,23 @@ and [<NoComparison>] Dval =
 
 and DvalTask = Ply<Dval>
 
+/// our record of any variable bindings in scope
+///
+/// i.e. within the execution of `x+y` in
+///  `let x = 1; let y = 2; x + y`
+/// , we would have a Symtable of
+///   `{ "x" => DInt 1; "y" => DInt 2 }`
 and Symtable = Map<string, Dval>
 
+/// Our record of any type arguments in scope
+///
+/// i.e. within the execution of
+///   `let serialize<'a> (x : 'a) : string = ...`,
+/// called with inputs
+///   `serialize<int> 1`,
+/// we would have a TypeArgTable of
+///  { "a" => TInt }
+and TypeArgTable = Map<string, TypeReference>
 
 
 // Record the source of an incomplete or error. Would be useful to add more

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -79,7 +79,7 @@ type Error =
 let rec unify
   (context : Context)
   (types : Types)
-  (typeArgSymbolTable : Map<string, TypeReference>)
+  (typeArgSymbolTable : TypeArgTable)
   (expected : TypeReference)
   (value : Dval)
   : Ply<Result<unit, Error>> =
@@ -259,7 +259,7 @@ and unifyRecordFields
   (recordType : TypeName.T)
   (context : Context)
   (types : Types)
-  (typeArgSymbolTable : Map<string, TypeReference>)
+  (typeArgSymbolTable : TypeArgTable)
   (defs : List<TypeDeclaration.RecordField>)
   (values : DvalMap)
   : Ply<Result<unit, Error>> =
@@ -315,7 +315,7 @@ and unifyRecordFields
 
 let checkFunctionCall
   (types : Types)
-  (typeArgSymbolTable : Map<string, TypeReference>)
+  (typeArgSymbolTable : TypeArgTable)
   (fn : Fn)
   (args : List<Dval>)
   : Ply<Result<unit, Error>> =
@@ -332,7 +332,7 @@ let checkFunctionCall
 
 let checkFunctionReturnType
   (types : Types)
-  (typeArgSymbolTable : Map<string, TypeReference>)
+  (typeArgSymbolTable : TypeArgTable)
   (fn : Fn)
   (result : Dval)
   : Ply<Result<unit, Error>> =

--- a/backend/src/Prelude/Prelude.fs
+++ b/backend/src/Prelude/Prelude.fs
@@ -266,13 +266,10 @@ module NEList =
     { head = head; tail = l.head :: l.tail }
 
   let reverse (l : NEList<'a>) : NEList<'a> =
-    match toList l with
+    match l |> toList |> List.rev with
     | [] -> Exception.raiseInternal "Unexpected empty NEList" []
-    | head :: tail ->
-      let reversedTail = List.rev tail
-      match tail with
-      | [] -> { head = head; tail = [] }
-      | first :: rest -> { head = first; tail = rest @ [ head ] }
+    | head :: tail -> { head = head; tail = tail }
+
 
 
 // ----------------------

--- a/backend/src/Wasm/DarkEditor.fs
+++ b/backend/src/Wasm/DarkEditor.fs
@@ -76,6 +76,7 @@ let LoadClient (canvasName : string) : Task<string> =
       Ply.toTask (
         LibExecution.Interpreter.callFn
           state
+          Map.empty
           (gid ())
           (FnName.fqUserProgram [] "init" 0)
           []
@@ -112,6 +113,7 @@ let HandleEvent (serializedEvent : string) : Task<string> =
       Ply.toTask (
         LibExecution.Interpreter.callFn
           state
+          Map.empty
           (gid ())
           (FnName.fqUserProgram [] "handleEvent" 0)
           []

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -1,3 +1,4 @@
+// really simple data stores of Records
 type X = { x: String }
 
 [<DB>]
@@ -21,6 +22,9 @@ type SortedX = { x: String; sortBy: Int }
 [<DB>]
 type SortedXDB = SortedX
 
+// simple data stores of Enums
+// , and Records containing Enums
+
 type MyEnum =
   | A
   | B
@@ -33,12 +37,6 @@ type MyEnum2 =
 
 type EnumTestRecord = { x: String; y: MyEnum }
 
-type InnerRecord = { age: Int }
-type OuterRecord = { name: String; details: InnerRecord }
-type AliasOfRecord = OuterRecord
-
-[<DB>]
-
 [<DB>]
 type TestEnumDB = EnumTestRecord
 
@@ -48,51 +46,82 @@ type TestEnumDB2 = MyEnum
 [<DB>]
 type TestEnumDB3 = MyEnum2
 
+
+// Nested field accessing
+type VeryInnerRecord = { age: Int }
+type AliasOfVeryInnerRecord = VeryInnerRecord
+type InnerRecord = { numbers: AliasOfVeryInnerRecord }
+type OuterRecord = { name: String; details: InnerRecord }
+type AliasOfRecord = OuterRecord
+
 [<DB>]
 type TestNestedRecord = OuterRecord
 
 [<DB>]
 type TestNestedAliasRecord = AliasOfRecord
 
-
-module NestedRecordQuerying =
+module NestedRecordFieldAccess =
+  // can use lambda like (fun p -> p.details.numbers.age)
   (DB.set
     (OuterRecord
       { name = "joe"
-        details = InnerRecord { age = 41 } })
+        details = InnerRecord { numbers = AliasOfVeryInnerRecord { age = 41 } } })
     "jjj"
     TestNestedRecord
 
    DB.set
      (OuterRecord
        { name = "frank"
-         details = InnerRecord { age = 22 } })
+         details = InnerRecord { numbers = VeryInnerRecord { age = 22 } } })
      "fff"
      TestNestedRecord
 
-   let shouldBeJustJoe = DB.query TestNestedRecord (fun p -> p.details.age == 41)
+   let shouldBeJustJoe =
+     DB.query TestNestedRecord (fun p -> p.details.numbers.age == 41)
+
    List.length shouldBeJustJoe) = 1
 
+  // same as above, but with aliases
   (DB.set
     (AliasOfRecord
       { name = "jeremy"
-        details = InnerRecord { age = 38 } })
+        details = InnerRecord { numbers = VeryInnerRecord { age = 38 } } })
     "ignored"
     TestNestedAliasRecord
 
    DB.set
      (AliasOfRecord
        { name = "josephine"
-         details = InnerRecord { age = 29 } })
+         details = InnerRecord { numbers = AliasOfVeryInnerRecord { age = 29 } } })
      "alsoIgnored"
      TestNestedAliasRecord
 
    let shouldBeJustJeremy =
-     DB.query TestNestedAliasRecord (fun p -> p.details.age == 38)
+     DB.query TestNestedAliasRecord (fun p -> p.details.numbers.age == 38)
 
    List.length shouldBeJustJeremy) = 1
 
 
+
+// Query data from a type with generics
+type GenericThing<'a> = { name: 'a }
+type RecordWithGenericThing = GenericThing<String>
+
+[<DB>]
+type TestRecordWithGenericThing = RecordWithGenericThing
+
+// module AccessDataInGenericField =
+//   (DB.set (RecordWithGenericThing { name = "joe" }) "jjj" TestRecordWithGenericThing
+
+//    DB.set
+//      (RecordWithGenericThing { name = "frank" })
+//      "fff"
+//      TestRecordWithGenericThing
+
+//    let shouldBeJustJoe =
+//      DB.query TestRecordWithGenericThing (fun p -> p.name == "joe")
+
+//    List.length shouldBeJustJoe) = 1
 
 
 module AddToTestEnumDBs =

--- a/backend/testfiles/execution/language/elambda.dark
+++ b/backend/testfiles/execution/language/elambda.dark
@@ -22,3 +22,11 @@ List.push_v0 [] (fun x -> -4.611686018e+18) = [ (fun x -> -4.611686018e+18) ]
 
 (let y = (fun c -> if c > 2 then Test.runtimeError "err" else 18) in
  [ 1; 2; 3; 4 ] |> List.map_v0 y) = Test.runtimeError "err"
+
+(let t = true in List.all [ 1; 2 ] (fun _ -> t)) = true
+(let f = false in List.all [ 1; 2 ] (fun _ -> f)) = false
+
+(let x = 1
+ let f = fun _ -> x
+ let x = 2
+ List.map [ 1; 2; 3 ] f) = [ 1; 1; 1 ]

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -1032,6 +1032,7 @@ let interestingDvals : List<string * RT.Dval * RT.TypeReference> =
      DFnVal(
        Lambda
          { body = RT.EUnit(id 1234)
+           typeArgTable = Map.empty
            symtable = Map.empty
            parameters = [ (id 5678, "a") ] }
      ),
@@ -1082,6 +1083,7 @@ let interestingDvals : List<string * RT.Dval * RT.TypeReference> =
                  ) ]
              )
            symtable = Map.empty
+           typeArgTable = Map.empty
            parameters = [ (id 5678, "a") ] }
      ),
      TFn([ TInt ], TInt))

--- a/backend/tests/Tests/Execution.Tests.fs
+++ b/backend/tests/Tests/Execution.Tests.fs
@@ -339,6 +339,7 @@ let testLambdaPreview : Test =
              DFnVal(
                Lambda(
                  { parameters = [ (p2ID, "var") ]
+                   typeArgTable = Map.empty
                    symtable = Map.empty
                    body = EString(65UL, [ StringText "body" ]) }
                )

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -42,7 +42,8 @@ let compile
       executionStateFor canvasID false false Map.empty userTypes Map.empty Map.empty
 
     try
-      let! sql, args = C.compileLambda state symtable paramName typeReference expr
+      let! sql, args =
+        C.compileLambda state Map.empty symtable paramName typeReference expr
 
       let args = Map.ofList args
       return sql, args
@@ -162,7 +163,7 @@ let partialEvaluation =
             Map.empty
             Map.empty
         let expr = p expr
-        let result = C.partiallyEvaluate state "x" (Map vars) expr
+        let result = C.partiallyEvaluate state Map.empty (Map vars) "x" expr
         let! (dvals, result) = Ply.TplPrimitives.runPlyAsTask result
         match result with
         | EVariable(_, name) -> return (Map.find name dvals)

--- a/backend/tests/Tests/StdLib.Tests.fs
+++ b/backend/tests/Tests/StdLib.Tests.fs
@@ -60,7 +60,11 @@ let hardToRepresentTests =
          RT.DList []
 
          RT.DFnVal(
-           RT.Lambda { parameters = []; symtable = Map.empty; body = RT.EUnit 1UL }
+           RT.Lambda
+             { parameters = []
+               typeArgTable = Map.empty
+               symtable = Map.empty
+               body = RT.EUnit 1UL }
          ) ]),
       (RT.DError(RT.SourceNone, "Expected 0 arguments, got 2")),
       true ]


### PR DESCRIPTION
Changelog:

```
Interpreter
- start maintaining/using Map<String, TypeReference> of resolved type parameters, similar to symtable
```
