### PR TITLE
Use NELists more

### DIFF
--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -510,7 +510,7 @@ let rec lambdaToSql
             : (Option<string> * NEList<string>) =
             match subExpr with
             | EFieldAccess(_, subExpr, childFieldName) ->
-              getPath (NEList.push pathSoFar childFieldName) subExpr
+              getPath (NEList.push childFieldName pathSoFar) subExpr
 
             | EVariable(_, v) -> (Some v, pathSoFar)
 

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -751,9 +751,10 @@ let rec eval'
                         let context =
                           TypeChecker.EnumField(
                             typeName,
-                            enumFieldType,
                             case.name,
                             i,
+                            List.length fields,
+                            enumFieldType,
                             None
                           )
 

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -202,6 +202,16 @@ module TypeName =
   let toString (name : T) : string =
     FQName.toString name (fun (TypeName name) -> name)
 
+  let toShortName (name : T) : string =
+    match name with
+    | FQName.BuiltIn { name = TypeName name; version = version }
+    | FQName.UserProgram { name = TypeName name; version = version }
+    | FQName.Package { name = TypeName name; version = version } ->
+      if version = 0 then name else $"{name}_v{version}"
+    | FQName.Unknown [] -> "[name not provided]"
+    | FQName.Unknown(head :: tail) ->
+      NEList.ofList head tail |> NEList.reverse |> NEList.last
+
 
 module FnName =
   type Name = FnName of string

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -32,9 +32,10 @@ type Context =
   | DictKey of key : string * typ : TypeReference * Location
   | EnumField of
     enumTypeName : TypeName.T *
-    fieldType : TypeReference *
     caseName : string *
-    paramIndex : int *  // nth argument to the enum constructor
+    fieldIndex : int *  // nth argument to the enum constructor
+    fieldCount : int *
+    fieldType : TypeReference *
     location : Location
   | DBQueryVariable of
     varName : string *
@@ -55,7 +56,7 @@ module Context =
     | FunctionCallResult(_, _, location) -> location
     | RecordField(_, _, _, location) -> location
     | DictKey(_, _, location) -> location
-    | EnumField(_, _, _, _, location) -> location
+    | EnumField(_, _, _, _, _, location) -> location
     | DBQueryVariable(_, _, location) -> location
     | DBSchemaType(_, _, location) -> location
     | ListIndex(_, _, parent) -> toLocation parent

--- a/backend/src/LibParser/WrittenTypes.fs
+++ b/backend/src/LibParser/WrittenTypes.fs
@@ -15,7 +15,44 @@ type Name =
   | KnownBuiltin of List<string> * string * int
   // Basically all names are unresolved at this point, and will be resolved during
   // WrittenTypesToProgramTypes
-  | Unresolved of List<string>
+  | Unresolved of NEList<string>
+
+// Ideally, we'd use a Name for the Enum typenames, like we do for ERecords and
+// EFnNames. However there are a number of problems of reusing it, that either
+// aren't problems for ERecord typenames and EFnNames, or conflict with them.
+//
+// The core problem that we're trying to model is that a Name is something the
+// user types, and the fact that users must type _something_. For DRecords or
+// EFnNames, that "at least 1 thing" is well modelled as an NEList, which avoids
+// a ton of error handling of impossible states from using empty lists (which
+// the users shouldn't even be able to type).
+//
+// However, in addition to the TypeName, EEnums have Casenames casenames (while
+// EFnName and DRecord typenames don't). If we use an NEList for the typename
+// alone, that doesn't allow someone to type `Ok`, which is allowed. (It doesn't
+// resolve to anything but we want to allow them to type it all the same.
+//
+// Looking at the four possible ways we could use Names to model EEnum:
+//
+// Name as List, plus separate casename field in EEnum:
+//  - ✅ supports [] + caseName which is valid for EEnums
+//  - ❌ supports [] for FnName and DRecord, which is invalid.
+//  - ✅ KnownBuiltin will work in EEnums
+
+// Name as List, including casename (no separate caseName field in EEnum):
+//  - 🤔 supports [] which is invalid but won't appear in practice so we can error
+//
+// Name as NEList, plus separate casename field in EEnum:
+//  - ❌ doesn't support [ "Ok" ] - can't do this
+//
+// Name as NEList, including casename (no separate caseName field in EEnum):
+//  - ❌ KnownBuiltin won't work as we won't have a caseName field, but we can
+//       error safely since we just won't do this
+//
+// Alternative: don't use Name for EEnum, and instead use List<string> plus a
+// separate caseName field.
+type UnresolvedEnumTypeName = List<string>
+
 
 type LetPattern =
   | LPVariable of id * name : string
@@ -105,7 +142,12 @@ type Expr =
   | EPipe of id * Expr * PipeExpr * List<PipeExpr>
   | ERecord of id * Name * List<string * Expr>
   | ERecordUpdate of id * record : Expr * updates : List<string * Expr>
-  | EEnum of id * Name * caseName : string * fields : List<Expr> // Name includes both CaseName and TypeName
+
+  | EEnum of
+    id *
+    typeName : UnresolvedEnumTypeName *
+    caseName : string *
+    fields : List<Expr>
   | EMatch of id * arg : Expr * cases : List<MatchPattern * Expr>
   | EFnName of id * Name
 
@@ -118,7 +160,11 @@ and PipeExpr =
 
   | EPipeLambda of id * List<id * string> * Expr
 
-  | EPipeEnum of id * typeName : Name * caseName : string * fields : List<Expr>
+  | EPipeEnum of
+    id *
+    typeName : UnresolvedEnumTypeName *
+    caseName : string *
+    fields : List<Expr>
 
   | EPipeFnCall of
     id *
@@ -144,7 +190,7 @@ type Const =
   | CFloat of Sign * string * string
   | CUnit
   | CTuple of first : Const * second : Const * rest : List<Const>
-  | CEnum of Name * caseName : string * List<Const>
+  | CEnum of typeName : UnresolvedEnumTypeName * caseName : string * List<Const>
 
 
 module TypeDeclaration =

--- a/backend/src/Prelude/Prelude.fs
+++ b/backend/src/Prelude/Prelude.fs
@@ -262,20 +262,47 @@ module NEList =
 
   let singleton (head : 'a) : NEList<'a> = { head = head; tail = [] }
 
-  let push (l : NEList<'a>) (head : 'a) : NEList<'a> =
+  let push (head : 'a) (l : NEList<'a>) : NEList<'a> =
     { head = head; tail = l.head :: l.tail }
+
+  let pushBack (tail : 'a) (l : NEList<'a>) : NEList<'a> =
+    { head = l.head; tail = l.tail @ [ tail ] }
+
+  let prependList (list : List<'a>) (l : NEList<'a>) : NEList<'a> =
+    match list with
+    | [] -> l
+    | head :: tail -> { head = head; tail = tail @ toList l }
 
   let reverse (l : NEList<'a>) : NEList<'a> =
     match l |> toList |> List.rev with
     | [] -> Exception.raiseInternal "Unexpected empty NEList" []
     | head :: tail -> { head = head; tail = tail }
 
-
   let find (f : 'a -> bool) (l : NEList<'a>) : Option<'a> =
     if f l.head then Some l.head else List.tryFind f l.tail
 
+  let all (f : 'a -> bool) (l : NEList<'a>) : bool = f l.head && List.forall f l.tail
+
   let filter (f : 'a -> bool) (l : NEList<'a>) : List<'a> =
     if f l.head then l.head :: List.filter f l.tail else List.filter f l.tail
+
+  let last (l : NEList<'a>) : 'a =
+    match l.tail with
+    | [] -> l.head
+    | _ -> List.last l.tail
+
+  let initial (l : NEList<'a>) : List<'a> =
+    let rec listInitial (l : List<'a>) : List<'a> =
+      match l with
+      | [] -> []
+      | [ _ ] -> [] // drop the last one
+      | head :: head2 :: tail -> head :: listInitial (head2 :: tail)
+    match l.tail with
+    | [] -> [] // drop head
+    | _ -> l.head :: (listInitial l.tail)
+
+  let splitLast (l : NEList<'a>) : (List<'a> * 'a) = initial l, last l
+
 
 
 // ----------------------

--- a/backend/testfiles/execution/language/econstant.dark
+++ b/backend/testfiles/execution/language/econstant.dark
@@ -31,6 +31,7 @@ module UserDefined =
   let enumConst = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
   enumConst = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
   UserDefined.enumConst = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+  Ok 5 = Test.runtimeError "Missing module name" // check this is allowed in the parser
 
 
 module Package =

--- a/backend/testfiles/execution/language/type-alias.dark
+++ b/backend/testfiles/execution/language/type-alias.dark
@@ -168,10 +168,10 @@ module EnumWithTypeArgs =
   Outer2.B 5 = Outer1.B 5
 
   Outer1.B "b" = Test.runtimeError
-    "EnumWithTypeArgs.Outer1.B's 1st argument should be an Int. However, a String (\"b\") was passed instead.\n\nExpected: Int\nActual: a String: \"b\""
+    "EnumWithTypeArgs.Outer1.B's 1st argument should be an Int. However, a String (\"b\") was passed instead.\n\nExpected: Outer1.B (Int)\nActual: Outer1.B (String)"
 
   Outer2.A 5 = Test.runtimeError
-    "EnumWithTypeArgs.Outer2.A's 1st argument should be a String. However, an Int (5) was passed instead.\n\nExpected: String\nActual: an Int: 5"
+    "EnumWithTypeArgs.Outer2.A's 1st argument should be a String. However, an Int (5) was passed instead.\n\nExpected: Outer2.A (String)\nActual: Outer2.A (Int)"
 
 module EnumWithTypeArgsDifferentName =
   type Inner<'a, 'b> =
@@ -187,10 +187,10 @@ module EnumWithTypeArgsDifferentName =
   MostOutest.B "test" = Inner.B "test"
 
   MostOutest.A "not allowed" = Test.runtimeError
-    "EnumWithTypeArgsDifferentName.MostOutest.A's 1st argument should be an Int. However, a String (\"not al...) was passed instead.\n\nExpected: Int\nActual: a String: \"not allowed\""
+    "EnumWithTypeArgsDifferentName.MostOutest.A's 1st argument should be an Int. However, a String (\"not al...) was passed instead.\n\nExpected: MostOutest.A (Int)\nActual: MostOutest.A (String)"
 
   MostOutest.B 6 = Test.runtimeError
-    "EnumWithTypeArgsDifferentName.MostOutest.B's 1st argument should be a String. However, an Int (6) was passed instead.\n\nExpected: String\nActual: an Int: 6"
+    "EnumWithTypeArgsDifferentName.MostOutest.B's 1st argument should be a String. However, an Int (6) was passed instead.\n\nExpected: MostOutest.B (String)\nActual: MostOutest.B (Int)"
 
 
 module EnumWithRecursiveTypeArgs =

--- a/backend/testfiles/execution/language/type-enum.dark
+++ b/backend/testfiles/execution/language/type-enum.dark
@@ -37,7 +37,7 @@ module Errors =
     // (match MyEnum.C "test" with | D -> "PACKAGE.Darklang.Stdlib.Result.Result.Ok" | C _ -> v) = Test.runtimeError "TODO"
     // (match MyEnum.C "test" with | 5 -> "PACKAGE.Darklang.Stdlib.Result.Result.Ok" | C _ -> v) = Test.runtimeError "TODO"
     (MyEnum.C 5) = Test.runtimeError
-      "Errors.User.MyEnum.C's 1st argument should be a String. However, an Int (5) was passed instead.\n\nExpected: String\nActual: an Int: 5"
+      "Errors.User.MyEnum.C's 1st argument should be a String. However, an Int (5) was passed instead.\n\nExpected: MyEnum.C (String)\nActual: MyEnum.C (Int)"
 
 
 module Simple =
@@ -76,10 +76,10 @@ module MixedCases =
   (EnumOfMixedCases.Y 1 == EnumOfMixedCases.Y 1) = true
 
   EnumOfMixedCases.X 1 = Test.runtimeError
-    "MixedCases.EnumOfMixedCases.X's 1st argument should be a String. However, an Int (1) was passed instead.\n\nExpected: String\nActual: an Int: 1"
+    "MixedCases.EnumOfMixedCases.X's 1st argument should be a String. However, an Int (1) was passed instead.\n\nExpected: EnumOfMixedCases.X (String)\nActual: EnumOfMixedCases.X (Int)"
 
   EnumOfMixedCases.Y "test" = Test.runtimeError
-    "MixedCases.EnumOfMixedCases.Y's 1st argument should be an Int. However, a String (\"test\") was passed instead.\n\nExpected: Int\nActual: a String: \"test\""
+    "MixedCases.EnumOfMixedCases.Y's 1st argument should be an Int. However, a String (\"test\") was passed instead.\n\nExpected: EnumOfMixedCases.Y (Int)\nActual: EnumOfMixedCases.Y (String)"
 
   EnumOfMixedCases.Z 1 = Test.runtimeError "Case `Z` expected 2 fields but got 1"
   // Test ordering of evaluation


### PR DESCRIPTION
- Use NELists in more places
- Add a shorttypename for errors
- better errors for invalid types in enums:
```fsharp
Expected: MyEnum.X (String)
Actual: MyEnum.X (Int)
```