### PR TITLE
Fix queue tests

### DIFF
--- a/backend/src/LibCloud/Cron.fs
+++ b/backend/src/LibCloud/Cron.fs
@@ -109,7 +109,7 @@ let checkAndScheduleWorkForCron (cron : CronScheduleData) : Task<bool> =
       // trigger execution
       if Config.triggerCrons then
         do!
-          Queue.enqueue
+          Queue.enqueueNow
             cron.canvasID
             "CRON"
             cron.cronName

--- a/backend/src/QueueWorker/QueueWorker.fs
+++ b/backend/src/QueueWorker/QueueWorker.fs
@@ -279,12 +279,13 @@ let run () : Task<unit> =
 
     let maxEventsFn = LD.queueMaxConcurrentEventsPerWorker
     while not shouldShutdown do
+      let timeout = System.TimeSpan.FromSeconds 5
       try
         // TODO: include memory and CPU usage checks in here
         let runningCount = initialCount - semaphore.CurrentCount
         let remainingSlots = maxEventsFn () - runningCount
         if remainingSlots > 0 then
-          let! notifications = EQ.dequeue remainingSlots
+          let! notifications = EQ.dequeue timeout remainingSlots
           if notifications = [] then
             do! Task.Delay(LD.queueDelayBetweenPullsInMillis ())
           else

--- a/backend/src/StdLibCloudExecution/Libs/Event.fs
+++ b/backend/src/StdLibCloudExecution/Libs/Event.fs
@@ -30,7 +30,7 @@ let fns : List<BuiltInFn> =
             do!
               // the "_" exists because handlers in the DB have 3 fields (eg Http, /path, GET),
               // but we don't need a 3rd one for workers
-              Queue.enqueue canvasID "WORKER" name "_" data
+              Queue.enqueueNow canvasID "WORKER" name "_" data
 
             return data
           }

--- a/backend/tests/Tests/Queue.Tests.fs
+++ b/backend/tests/Tests/Queue.Tests.fs
@@ -126,7 +126,9 @@ let init () : unit =
   thread.Name <- "Queue.Tests worker"
   thread.Start()
 
-
+/// Tests that need to check that something isn't going to be run can wait until the
+/// queue is empty (locked/blocked items will be checked and then dropped) to prove
+/// that something isn't going to be run.
 let waitUntilQueueEmpty () : Task<unit> =
   task {
     let initialTime = Instant.now ()

--- a/backend/tests/Tests/Queue.Tests.fs
+++ b/backend/tests/Tests/Queue.Tests.fs
@@ -43,9 +43,13 @@ let initializeCanvas (name : string) : Task<CanvasID * tlid> =
     return canvasID, h.tlid
   }
 
-let enqueue (canvasID : CanvasID) : Task<unit> =
-  let input = RT.DUnit // crons take inputs, so this could be anything
-  EQ.enqueue canvasID "WORKER" "test" "_" input
+
+let enqueueAtTime (canvasID : CanvasID) (time : Instant) : Task<unit> =
+  // crons take inputs, so this could be anything
+  EQ.enqueueAtTime canvasID "WORKER" "test" "_" time RT.DUnit
+
+let enqueueNow (canvasID : CanvasID) : Task<unit> =
+  enqueueAtTime canvasID (Instant.now ())
 
 
 let checkExecutedTraces (canvasID : CanvasID) (count : int) : Task<unit> =
@@ -60,32 +64,29 @@ let checkExecutedTraces (canvasID : CanvasID) (count : int) : Task<unit> =
     Expect.hasLength traceIDs count "wrong execution count"
   }
 
-let checkSuccess
+let rec waitForSuccess
   (canvasID : CanvasID)
   (tlid : tlid)
-  (result : Result<EQ.T * EQ.Notification, string * EQ.Notification>)
-  =
+  (count : int)
+  : Task<unit> =
   task {
-    match result with
-    | Ok(event, _notification) ->
-      // TODO: is there a way to count/test the number of messages in the queue?
-      let! event = EQ.loadEvent event.canvasID event.id
-      Expect.isNone event "should have been deleted"
-    | Error _ -> Expect.isOk result "should have processed"
-
+    let! eventIDs = EQ.loadEventIDs canvasID ("WORKER", "test", "_")
     let! traceIDs = TCS.Test.listAllTraceIDs canvasID
+    if List.length eventIDs <> 0 || List.length traceIDs <> count then
+      do! Task.Delay 50
+      return! waitForSuccess canvasID tlid count
+    else
+      let! trace =
+        traceIDs
+        |> List.head
+        |> Exception.unwrapOptionInternal "expectedID" []
+        |> TCS.getTraceData canvasID tlid
 
-    let! trace =
-      traceIDs
-      |> List.head
-      |> Exception.unwrapOptionInternal "expectedID" []
-      |> TCS.getTraceData canvasID tlid
-
-    let shapeIsAsExpected =
-      match (Tuple2.second trace).functionResults with
-      | [ (_, _, _, _, RT.DDateTime _) ] -> true
-      | _ -> false
-    Expect.isTrue shapeIsAsExpected "should have a date here"
+      let shapeIsAsExpected =
+        match (Tuple2.second trace).functionResults with
+        | [ (_, _, _, _, RT.DDateTime _) ] -> true
+        | _ -> false
+      Expect.isTrue shapeIsAsExpected "should have a date here"
   }
 
 
@@ -96,42 +97,49 @@ let checkSavedEvents (canvasID : CanvasID) (count : int) =
     Expect.hasLength queueIDs count "wrong stored event count"
   }
 
-let rec dequeueAndProcess () : Task<Result<_, _>> =
+let mutable queueLastEmptyAt = Instant.MinValue
+
+
+let init () : unit =
+  let timeout = System.TimeSpan.FromMilliseconds 10
+  let processContinuouslyInBackground () : unit =
+    task {
+      while true do
+        match! EQ.dequeue timeout 1 with
+        | [ notification ] ->
+          let! _ = QueueWorker.processNotification notification
+          return ()
+        | [] ->
+          queueLastEmptyAt <- Instant.now ()
+          do! Task.Delay 100
+        | results ->
+          return!
+            Exception.raiseInternal
+              "got more than 1"
+              [ "count", List.length results ]
+
+        return ()
+    }
+    |> fun x -> x.Result
+  let thread = System.Threading.Thread processContinuouslyInBackground
+  thread.IsBackground <- true
+  thread.Name <- "Queue.Tests worker"
+  thread.Start()
+
+
+let waitUntilQueueEmpty () : Task<unit> =
   task {
-    match! EQ.dequeue 1 with
-    | [ notification ] -> return! QueueWorker.processNotification notification
-    | [] ->
-      do! Task.Delay 1000
-      return! dequeueAndProcess ()
-    | results ->
-      return!
-        Exception.raiseInternal "got more than 1" [ "count", List.length results ]
+    let initialTime = Instant.now ()
+    while initialTime > queueLastEmptyAt do
+      do! Task.Delay 10
   }
-
-let rec dequeueAndProcessMany (count : int) : Task<List<Result<_, _>>> =
-  task {
-    let! messages = EQ.dequeue count
-    let! theseResults =
-      Task.mapSequentially (fun n -> QueueWorker.processNotification n) messages
-
-    // We aren't guaranteed to get `count` of them, so keep going
-    let receivedCount = List.length messages
-    let! moreResults =
-      if receivedCount < count then
-        dequeueAndProcessMany (count - receivedCount)
-      else
-        Task.FromResult []
-    return theseResults @ moreResults
-  }
-
 
 
 let testSuccess =
   testTask "event queue success" {
     let! (canvasID : CanvasID, tlid) = initializeCanvas "event-queue-success"
-    do! enqueue canvasID
-    let! result = dequeueAndProcess ()
-    do! checkSuccess canvasID tlid result
+    do! enqueueNow canvasID
+    do! waitForSuccess canvasID tlid 1
     do! checkExecutedTraces canvasID 1
     do! checkSavedEvents canvasID 0
   }
@@ -139,47 +147,20 @@ let testSuccess =
 let testSuccessThree =
   testTask "event queue success three" {
     let! (canvasID : CanvasID, tlid) = initializeCanvas "event-queue-success-three"
-    do! enqueue canvasID
-    do! enqueue canvasID
-    do! enqueue canvasID
-    do! checkExecutedTraces canvasID 0
-    do! checkSavedEvents canvasID 3
-    let! result = dequeueAndProcess ()
-    do! checkSuccess canvasID tlid result
-    do! checkExecutedTraces canvasID 1
-    do! checkSavedEvents canvasID 2
-    let! result = dequeueAndProcess ()
-    do! checkSuccess canvasID tlid result
-    do! checkExecutedTraces canvasID 2
-    do! checkSavedEvents canvasID 1
-    let! result = dequeueAndProcess ()
-    do! checkSuccess canvasID tlid result
+    do! enqueueNow canvasID
+    do! enqueueNow canvasID
+    do! enqueueNow canvasID
+    do! waitForSuccess canvasID tlid 3
     do! checkExecutedTraces canvasID 3
     do! checkSavedEvents canvasID 0
-  }
-
-let testSuccessThreeAtOnce =
-  testTask "event queue success three at once" {
-    let! (canvasID : CanvasID, tlid) =
-      initializeCanvas "event-queue-success-three-at-once"
-    do! enqueue canvasID
-    do! enqueue canvasID
-    do! enqueue canvasID
-    do! checkExecutedTraces canvasID 0
-    do! checkSavedEvents canvasID 3
-    let! results = dequeueAndProcessMany 3
-    let results = List.toArray results
-    do! checkExecutedTraces canvasID 3
-    do! checkSavedEvents canvasID 0
-    do! checkSuccess canvasID tlid results[0]
-    do! checkSuccess canvasID tlid results[1]
-    do! checkSuccess canvasID tlid results[2]
   }
 
 let testSuccessLockExpired =
   testTask "success lock expired" {
     let! (canvasID : CanvasID, tlid) = initializeCanvas "success-lock-expired"
-    do! enqueue canvasID
+
+    // Create the event, but don't have it run yet
+    do! enqueueAtTime canvasID (Instant.now () + Duration.FromSeconds 3L)
 
     // Lock it
     let earlier = Instant.now () + Duration.FromMinutes -6L
@@ -191,8 +172,8 @@ let testSuccessLockExpired =
           "newValue", Sql.instantWithTimeZone earlier ]
       |> Sql.executeStatementAsync
 
-    let! result = dequeueAndProcess ()
-    do! checkSuccess canvasID tlid result
+    // Wait for it to run
+    do! waitForSuccess canvasID tlid 1
     do! checkExecutedTraces canvasID 1
     do! checkSavedEvents canvasID 0
   }
@@ -200,9 +181,11 @@ let testSuccessLockExpired =
 let testFailLocked =
   testTask "fail locked" {
     let! (canvasID : CanvasID, _tlid) = initializeCanvas "fail-locked"
-    do! enqueue canvasID
 
-    // Delay it
+    // Create the event, but don't have it run yet
+    do! enqueueAtTime canvasID (Instant.now () + Duration.FromSeconds 3L)
+
+    // Lock it
     do!
       Sql.query
         "UPDATE queue_events_v0 SET locked_at = @newValue WHERE canvas_id = @canvasID"
@@ -211,24 +194,22 @@ let testFailLocked =
           "newValue", Sql.instantWithTimeZone (Instant.now ()) ]
       |> Sql.executeStatementAsync
 
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
   }
 
 let testSuccessBlockAndUnblock =
   testTask "block and unblock" {
-    let! (canvasID : CanvasID, _tlid) = initializeCanvas "block-and-unblock"
-    let! _id = enqueue canvasID
+    let! (canvasID : CanvasID, tlid) = initializeCanvas "block-and-unblock"
 
     // Block it
     do! EQ.blockWorker canvasID "test"
 
+    do! enqueueNow canvasID
+
     // Check blocked
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
 
@@ -236,23 +217,22 @@ let testSuccessBlockAndUnblock =
     do! EQ.unblockWorker canvasID "test"
 
     // Check unblocked
-    let! result = dequeueAndProcess ()
-    Expect.isOk result "should success"
+    do! waitForSuccess canvasID tlid 1
     do! checkExecutedTraces canvasID 1
     do! checkSavedEvents canvasID 0
   }
 
 let testSuccessPauseAndUnpause =
   testTask "pause and unpause" {
-    let! (canvasID : CanvasID, _tlid) = initializeCanvas "pause-and-unpause"
-    do! enqueue canvasID
-
+    let! (canvasID : CanvasID, tlid) = initializeCanvas "pause-and-unpause"
     // Pause it
     do! EQ.pauseWorker canvasID "test"
 
+    // Enqueue
+    do! enqueueNow canvasID
+
     // Check paused
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
 
@@ -260,8 +240,7 @@ let testSuccessPauseAndUnpause =
     do! EQ.unpauseWorker canvasID "test"
 
     // Check unpaused
-    let! result = dequeueAndProcess ()
-    Expect.isOk result "should success"
+    do! waitForSuccess canvasID tlid 1
     do! checkExecutedTraces canvasID 1
     do! checkSavedEvents canvasID 0
   }
@@ -269,14 +248,14 @@ let testSuccessPauseAndUnpause =
 let testFailPauseBlockAndUnpause =
   testTask "pause block and unpause" {
     let! (canvasID : CanvasID, _tlid) = initializeCanvas "pause-block-and-unpause"
-    do! enqueue canvasID
 
     // Pause it
     do! EQ.pauseWorker canvasID "test"
 
+    // Enqueue
+    do! enqueueNow canvasID
+
     // Check paused
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
 
@@ -285,24 +264,23 @@ let testFailPauseBlockAndUnpause =
     do! EQ.unpauseWorker canvasID "test"
 
     // Check still paused
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
-
   }
 
 let testFailPauseBlockAndUnblock =
   testTask "pause block and unblock" {
     let! (canvasID : CanvasID, _tlid) = initializeCanvas "pause-block-and-unblock"
-    do! enqueue canvasID
 
     // Pause it
     do! EQ.pauseWorker canvasID "test"
 
+    // Enqueue
+    do! enqueueNow canvasID
+
     // Check paused
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
 
@@ -311,8 +289,7 @@ let testFailPauseBlockAndUnblock =
     do! EQ.unblockWorker canvasID "test"
 
     // Check still paused
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
   }
@@ -320,14 +297,14 @@ let testFailPauseBlockAndUnblock =
 let testFailBlockPauseAndUnpause =
   testTask "block pause and unpause" {
     let! (canvasID : CanvasID, _tlid) = initializeCanvas "block-pause-and-unpause"
-    do! enqueue canvasID
 
     // Block it
     do! EQ.blockWorker canvasID "test"
 
+    do! enqueueNow canvasID
+
     // Check blocked
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
 
@@ -336,8 +313,7 @@ let testFailBlockPauseAndUnpause =
     do! EQ.unpauseWorker canvasID "test"
 
     // Check still blocked
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
   }
@@ -345,14 +321,15 @@ let testFailBlockPauseAndUnpause =
 let testFailBlockPauseAndUnblock =
   testTask "block pause and unblock" {
     let! (canvasID : CanvasID, _tlid) = initializeCanvas "block-pause-and-unblock"
-    do! enqueue canvasID
 
     // Block it
     do! EQ.blockWorker canvasID "test"
 
+    // Enqueue
+    do! enqueueNow canvasID
+
     // Check blocked
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
 
@@ -361,20 +338,21 @@ let testFailBlockPauseAndUnblock =
     do! EQ.unblockWorker canvasID "test"
 
     // Check still paused
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 0
     do! checkSavedEvents canvasID 1
   }
 
 let testUnpauseMulitpleTimesInSequence =
   testTask "unpause multiple times in sequence" {
-    let! (canvasID : CanvasID, _tlid) =
-      initializeCanvas "unpaise-multiple-times-in-secquence"
-    do! enqueue canvasID
+    let! (canvasID : CanvasID, tlid) =
+      initializeCanvas "unpause-multiple-times-in-secquence"
 
     // Block it
     do! EQ.blockWorker canvasID "test"
+
+    // Enqueue
+    do! enqueueNow canvasID
 
     // Pause and unblock  it
     do! EQ.unblockWorker canvasID "test"
@@ -387,38 +365,22 @@ let testUnpauseMulitpleTimesInSequence =
     do! EQ.unblockWorker canvasID "test"
     do! EQ.unblockWorker canvasID "test"
 
-    let! result = dequeueAndProcess ()
-    Expect.isOk result "should succeed"
-    do! checkExecutedTraces canvasID 1
-    do! checkSavedEvents canvasID 0
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
-    let! result = dequeueAndProcess ()
-    Expect.isError result "should fail"
+    do! waitForSuccess canvasID tlid 1
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 1
     do! checkSavedEvents canvasID 0
   }
 
 let testUnpauseMultipleTimesInParallel =
   testTask "unpause multiple times in parallel" {
-    let! (canvasID : CanvasID, _tlid) =
+    let! (canvasID : CanvasID, tlid) =
       initializeCanvas "unpause-multiple-times-in-parallel"
-    do! enqueue canvasID
 
     // Block it
     do! EQ.blockWorker canvasID "test"
+
+    // Enqueue
+    do! enqueueNow canvasID
 
     // Pause and unblock  it
     do! EQ.unblockWorker canvasID "test"
@@ -431,22 +393,8 @@ let testUnpauseMultipleTimesInParallel =
     do! EQ.unblockWorker canvasID "test"
     do! EQ.unblockWorker canvasID "test"
 
-    let resultTasks =
-      [ dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess ()
-        dequeueAndProcess () ]
-    let! results = Task.flatten resultTasks
-    let (success, failure) = List.partition Result.isOk results
-
-    Expect.hasLength success 1 "one success only succeed"
-    Expect.hasLength failure 9 "nine delayed or deleted"
+    do! waitForSuccess canvasID tlid 1
+    do! waitUntilQueueEmpty ()
     do! checkExecutedTraces canvasID 1
     do! checkSavedEvents canvasID 0
   }
@@ -455,25 +403,28 @@ let testUnpauseMultipleTimesInParallel =
 let testCount =
   testTask "count is right" {
     let! (canvasID : CanvasID, tlid) = initializeCanvas "count-is-correct"
-    do! enqueue canvasID
-    do! enqueue canvasID
-    do! enqueue canvasID
-    do! enqueue canvasID
-    do! enqueue canvasID
+    do! EQ.blockWorker canvasID "test"
+    do! enqueueNow canvasID
+    do! enqueueNow canvasID
+    do! enqueueNow canvasID
+    do! enqueueNow canvasID
+    do! enqueueNow canvasID
 
     let! count = LibCloud.Stats.workerStats canvasID tlid
     Expect.equal count 5 "count should be 5"
+
+    do! EQ.unblockWorker canvasID "test"
     do! checkSavedEvents canvasID 5
   }
 
 let tests =
+  init ()
   testSequencedGroup
     "Queue"
     (testList
       "Queue"
       [ testSuccess
         testSuccessThree
-        testSuccessThreeAtOnce
         testSuccessLockExpired
         testFailLocked
         testSuccessBlockAndUnblock


### PR DESCRIPTION
The queue tests were failing because each dequeueAndProcess was global, so as each test dequeued event, it wasn't guaranteed (though it was likely) that what it dequeued was the same thing it just enqueued.

The new logic takes this into account - a background thread just constantly dequeues and the tests can check properties about the queues.