### PR TITLE
Add a copy of List.iter and List.flatten to LocalExec

### DIFF
--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -19,7 +19,7 @@ let fns : List<BuiltInFn> =
       typeParams = []
       parameters =
         [ Param.make "list" (TList varA) ""
-          Param.makeWithArgs "fn" (TFn([ varA ], TUnit)) "" [ "element" ] ]
+          Param.makeWithArgs "fn" (TFn(NEList.singleton varA, TUnit)) "" [ "element" ] ]
       returnType = TUnit
       description =
         "Applies the given function <param fn> to each element of the <param list>."
@@ -31,7 +31,8 @@ let fns : List<BuiltInFn> =
               l
               |> Ply.List.iterSequentially (fun e ->
                 uply {
-                  match! Interpreter.applyFnVal state 0UL b [] [ e ] with
+                  let args = NEList.singleton e
+                  match! Interpreter.applyFnVal state 0UL b [] args with
                   | DUnit -> return ()
                   | DError _ as dv -> return Errors.foundFakeDval dv
                   | v ->

--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -1,0 +1,71 @@
+module LocalExec.Libs.List
+
+open Prelude
+open LibExecution.RuntimeTypes
+open LibExecution.StdLib.Shortcuts
+
+
+module Errors = LibExecution.Errors
+module Interpreter = LibExecution.Interpreter
+
+let varA = TVariable "a"
+
+let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
+
+
+let fns : List<BuiltInFn> =
+  [ { name = fn [ "LocalExec"; "StdLib"; "List" ] "iter" 0
+      typeParams = []
+      parameters =
+        [ Param.make "list" (TList varA) ""
+          Param.makeWithArgs "fn" (TFn([ varA ], TUnit)) "" [ "element" ] ]
+      returnType = TUnit
+      description =
+        "Applies the given function <param fn> to each element of the <param list>."
+      fn =
+        (function
+        | state, _, [ DList l; DFnVal b ] ->
+          uply {
+            do!
+              l
+              |> Ply.List.iterSequentially (fun e ->
+                uply {
+                  match! Interpreter.applyFnVal state 0UL b [] [ e ] with
+                  | DUnit -> return ()
+                  | DError _ as dv -> return Errors.foundFakeDval dv
+                  | v ->
+                    Exception.raiseCode (Errors.expectedLambdaValue "fn" "unit" v)
+                })
+            return DUnit
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn [ "LocalExec"; "StdLib"; "List" ] "flatten" 0
+      typeParams = []
+      parameters = [ Param.make "list" (TList(TList varA)) "" ]
+      returnType = TList varA
+      description =
+        "Returns a single list containing the values of every list directly in <param
+         list> (does not recursively flatten nested lists)"
+      fn =
+        (function
+        | _, _, [ DList l ] ->
+          let f acc i =
+            match i with
+            | DList l -> List.append acc l
+            | _ -> Exception.raiseCode "Flattening non-lists"
+
+          List.fold f [] l |> DList |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+    ]
+
+let contents = (fns, types, constants)

--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -1,3 +1,7 @@
+// Note: These functions are used within the 'Load packages from disk to the canvas DB' process,
+// and PACKAGE functions cannot be used at that stage.
+// They can be removed once we have a live package manager in place
+
 module LocalExec.Libs.List
 
 open Prelude

--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -15,11 +15,15 @@ let constants : List<BuiltInConstant> = []
 
 
 let fns : List<BuiltInFn> =
-  [ { name = fn [ "LocalExec"; "StdLib"; "List" ] "iter" 0
+  [ { name = fn [ "LocalExec"; "BuiltIns"; "List" ] "iter" 0
       typeParams = []
       parameters =
         [ Param.make "list" (TList varA) ""
-          Param.makeWithArgs "fn" (TFn(NEList.singleton varA, TUnit)) "" [ "element" ] ]
+          Param.makeWithArgs
+            "fn"
+            (TFn(NEList.singleton varA, TUnit))
+            ""
+            [ "element" ] ]
       returnType = TUnit
       description =
         "Applies the given function <param fn> to each element of the <param list>."
@@ -46,7 +50,7 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn [ "LocalExec"; "StdLib"; "List" ] "flatten" 0
+    { name = fn [ "LocalExec"; "BuiltIns"; "List" ] "flatten" 0
       typeParams = []
       parameters = [ Param.make "list" (TList(TList varA)) "" ]
       returnType = TList varA

--- a/backend/src/LocalExec/LocalExec.fsproj
+++ b/backend/src/LocalExec/LocalExec.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="Libs/Cli.fs" />
     <Compile Include="Libs/Packages.fs" />
     <Compile Include="Libs/Packages2.fs" />
+    <Compile Include="Libs/List.fs" />
     <Compile Include="StdLib.fs" />
     <Compile Include="LocalExec.fs" />
   </ItemGroup>

--- a/backend/src/LocalExec/StdLib.fs
+++ b/backend/src/LocalExec/StdLib.fs
@@ -19,6 +19,7 @@ let contents : StdLib.Contents =
     [ Libs.Packages.contents
       Libs.Packages2.contents
       Libs.Cli.contents
+      Libs.List.contents
       StdLibCloudExecution.Libs.HttpClient.contents ]
     fnRenames
     typeRenames

--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -5,7 +5,7 @@ let listDirectoryRecursive (dir: String) : List<String> =
   let nested =
     dirs
     |> List.map (fun d -> listDirectoryRecursive d)
-    |> LocalExec.StdLib.List.flatten
+    |> LocalExec.BuiltIns.List.flatten
 
   dirs |> List.append files |> List.append nested
 
@@ -99,12 +99,12 @@ let loadPackageFileIntoDarkCanvas (filename: String) : Unit =
     |> LocalExec.Packages.parse filename
     |> unwrap
 
-  package.fns |> LocalExec.StdLib.List.iter (fun fn -> saveFunctionToCanvas fn)
+  package.fns |> LocalExec.BuiltIns.List.iter (fun fn -> saveFunctionToCanvas fn)
 
-  package.types |> LocalExec.StdLib.List.iter (fun t -> saveTypeToCanvas t)
+  package.types |> LocalExec.BuiltIns.List.iter (fun t -> saveTypeToCanvas t)
 
   package.constants
-  |> LocalExec.StdLib.List.iter (fun t -> saveConstantToCanvas t)
+  |> LocalExec.BuiltIns.List.iter (fun t -> saveConstantToCanvas t)
 
 
 let printPackageFunction (p: LocalExec.Packages.Function) : Unit =
@@ -122,13 +122,13 @@ let printPackageConstant (p: LocalExec.Packages.Constant) : Unit =
 
 let printAllPackages () : Unit =
   let functions = LocalExec.Packages.listFunctions ()
-  functions |> LocalExec.StdLib.List.iter (fun p -> printPackageFunction p)
+  functions |> LocalExec.BuiltIns.List.iter (fun p -> printPackageFunction p)
 
   let types = LocalExec.Packages.listTypes ()
-  types |> LocalExec.StdLib.List.iter (fun p -> printPackageType p)
+  types |> LocalExec.BuiltIns.List.iter (fun p -> printPackageType p)
 
   let constants = LocalExec.Packages.listConstants ()
-  constants |> LocalExec.StdLib.List.iter (fun p -> printPackageConstant p)
+  constants |> LocalExec.BuiltIns.List.iter (fun p -> printPackageConstant p)
 
 
 // Running scripts
@@ -190,7 +190,7 @@ let main (args: List<String>) : Int =
     LocalExec.Packages.clear ()
     let files = listPackageFilesOnDisk "/home/dark/app/packages"
 
-    LocalExec.StdLib.List.iter files (fun f ->
+    LocalExec.BuiltIns.List.iter files (fun f ->
       print $"Loading {f}"
       loadPackageFile f)
 
@@ -206,7 +206,7 @@ let main (args: List<String>) : Int =
 
     // TODO: clear packages from dark canvas first?
 
-    LocalExec.StdLib.List.iter files (fun f ->
+    LocalExec.BuiltIns.List.iter files (fun f ->
       print $"Loading {f}"
       loadPackageFileIntoDarkCanvas f)
 

--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -1,7 +1,7 @@
 let listDirectoryRecursive (dir: String) : List<String> =
   let contents = Directory.list dir
   let (files, dirs) = contents |> List.partition (fun x -> File.isNormal x)
-  let nested = dirs |> List.map (fun d -> listDirectoryRecursive d) |> List.flatten
+  let nested = dirs |> List.map (fun d -> listDirectoryRecursive d) |> LocalExec.StdLib.List.flatten
   dirs |> List.append files |> List.append nested
 
 
@@ -94,11 +94,11 @@ let loadPackageFileIntoDarkCanvas (filename: String) : Unit =
     |> LocalExec.Packages.parse filename
     |> unwrap
 
-  package.fns |> List.iter (fun fn -> saveFunctionToCanvas fn)
+  package.fns |> LocalExec.StdLib.List.iter (fun fn -> saveFunctionToCanvas fn)
 
-  package.types |> List.iter (fun t -> saveTypeToCanvas t)
+  package.types |> LocalExec.StdLib.List.iter (fun t -> saveTypeToCanvas t)
 
-  package.constants |> List.iter (fun t -> saveConstantToCanvas t)
+  package.constants |> LocalExec.StdLib.List.iter (fun t -> saveConstantToCanvas t)
 
 
 let printPackageFunction (p: LocalExec.Packages.Function) : Unit =
@@ -116,13 +116,13 @@ let printPackageConstant (p: LocalExec.Packages.Constant) : Unit =
 
 let printAllPackages () : Unit =
   let functions = LocalExec.Packages.listFunctions ()
-  functions |> List.iter (fun p -> printPackageFunction p)
+  functions |> LocalExec.StdLib.List.iter (fun p -> printPackageFunction p)
 
   let types = LocalExec.Packages.listTypes ()
-  types |> List.iter (fun p -> printPackageType p)
+  types |> LocalExec.StdLib.List.iter (fun p -> printPackageType p)
 
   let constants = LocalExec.Packages.listConstants ()
-  constants |> List.iter (fun p -> printPackageConstant p)
+  constants |> LocalExec.StdLib.List.iter (fun p -> printPackageConstant p)
 
 
 // Running scripts
@@ -184,7 +184,7 @@ let main (args: List<String>) : Int =
     LocalExec.Packages.clear ()
     let files = listPackageFilesOnDisk "/home/dark/app/packages"
 
-    List.iter files (fun f ->
+    LocalExec.StdLib.List.iter files (fun f ->
       print $"Loading {f}"
       loadPackageFile f)
 
@@ -200,7 +200,7 @@ let main (args: List<String>) : Int =
 
     // TODO: clear packages from dark canvas first?
 
-    List.iter files (fun f ->
+    LocalExec.StdLib.List.iter files (fun f ->
       print $"Loading {f}"
       loadPackageFileIntoDarkCanvas f)
 

--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -1,7 +1,12 @@
 let listDirectoryRecursive (dir: String) : List<String> =
   let contents = Directory.list dir
   let (files, dirs) = contents |> List.partition (fun x -> File.isNormal x)
-  let nested = dirs |> List.map (fun d -> listDirectoryRecursive d) |> LocalExec.StdLib.List.flatten
+
+  let nested =
+    dirs
+    |> List.map (fun d -> listDirectoryRecursive d)
+    |> LocalExec.StdLib.List.flatten
+
   dirs |> List.append files |> List.append nested
 
 
@@ -98,7 +103,8 @@ let loadPackageFileIntoDarkCanvas (filename: String) : Unit =
 
   package.types |> LocalExec.StdLib.List.iter (fun t -> saveTypeToCanvas t)
 
-  package.constants |> LocalExec.StdLib.List.iter (fun t -> saveConstantToCanvas t)
+  package.constants
+  |> LocalExec.StdLib.List.iter (fun t -> saveConstantToCanvas t)
 
 
 let printPackageFunction (p: LocalExec.Packages.Function) : Unit =

--- a/backend/testfiles/execution/stdlib/list.dark
+++ b/backend/testfiles/execution/stdlib/list.dark
@@ -45,7 +45,8 @@ List.dropWhile_v0 [] (fun item -> item < 3) = []
 
 List.empty_v0 = []
 
-(PACKAGE.Darklang.Stdlib.List.iter [ 1; 2; 3 ] (fun x -> Test.incrementSideEffectCounter ())
+(PACKAGE.Darklang.Stdlib.List.iter [ 1; 2; 3 ] (fun x ->
+  Test.incrementSideEffectCounter ())
 
  Test.sideEffectCount ()) = 3
 

--- a/backend/testfiles/execution/stdlib/list.dark
+++ b/backend/testfiles/execution/stdlib/list.dark
@@ -45,26 +45,26 @@ List.dropWhile_v0 [] (fun item -> item < 3) = []
 
 List.empty_v0 = []
 
-(List.iter [ 1; 2; 3 ] (fun x -> Test.incrementSideEffectCounter ())
+(PACKAGE.Darklang.Stdlib.List.iter [ 1; 2; 3 ] (fun x -> Test.incrementSideEffectCounter ())
 
  Test.sideEffectCount ()) = 3
 
-(List.iter [ 1; 2; 3; 4; 5 ] (fun x ->
+(PACKAGE.Darklang.Stdlib.List.iter [ 1; 2; 3; 4; 5 ] (fun x ->
   if x % 2 == 0 then
     Test.incrementSideEffectCounter ())
 
  Test.sideEffectCount ()) = 2
 
-(List.iter [] (fun x -> Test.incrementSideEffectCounter ())
+(PACKAGE.Darklang.Stdlib.List.iter [] (fun x -> Test.incrementSideEffectCounter ())
  Test.sideEffectCount ()) = 0
 
-(List.iter [ 10; 20; 30 ] (fun x ->
+(PACKAGE.Darklang.Stdlib.List.iter [ 10; 20; 30 ] (fun x ->
   Test.incrementSideEffectCounter ()
   Test.incrementSideEffectCounter ())
 
  Test.sideEffectCount ()) = 6
 
-(List.iter [ 1; 2; 3 ] (fun x ->
+(PACKAGE.Darklang.Stdlib.List.iter [ 1; 2; 3 ] (fun x ->
   if x > 2 then
     Test.incrementSideEffectCounter ())
 
@@ -120,13 +120,13 @@ List.findFirst [ 1; -33; 3; -2; 12 ] (fun x -> (x < 0 && x % 2 == 0)) = PACKAGE.
   -2
 
 // CLEANUP once DList contains typeRefs, this test may be uncommented and the error message updated:
-// List.flatten_v0 [1;2;3] =
+// PACKAGE.Darklang.Stdlib.List.flatten_v0 [1;2;3] =
 //   Test.runtimeError "In List.flatten's 1st argument (`list`), the value should be a List<List<'a>>. However, a List<Int> ([1; 2; 3]) was passed instead.\n\nExpected: List<List<'a>>\nActual: List<Int>: [1; 2; 3]"
-List.flatten_v0 [ [ 1 ]; [ 2 ]; [ 3 ] ] = [ 1; 2; 3 ]
-List.flatten_v0 [ [ 1 ]; [ [ 2; 3 ] ] ] = [ 1; [ 2; 3 ] ]
-List.flatten_v0 [ [ [] ] ] = [ [] ]
-List.flatten_v0 [ [] ] = []
-List.flatten_v0 [] = []
+PACKAGE.Darklang.Stdlib.List.flatten_v0 [ [ 1 ]; [ 2 ]; [ 3 ] ] = [ 1; 2; 3 ]
+PACKAGE.Darklang.Stdlib.List.flatten_v0 [ [ 1 ]; [ [ 2; 3 ] ] ] = [ 1; [ 2; 3 ] ]
+PACKAGE.Darklang.Stdlib.List.flatten_v0 [ [ [] ] ] = [ [] ]
+PACKAGE.Darklang.Stdlib.List.flatten_v0 [ [] ] = []
+PACKAGE.Darklang.Stdlib.List.flatten_v0 [] = []
 
 List.fold_v0 [ "a"; "b"; "c"; "d" ] "x" (fun accum curr -> accum ++ curr) = "xabcd"
 

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -77,14 +77,13 @@ module Darklang =
             (PACKAGE.Darklang.Stdlib.List.range (lowest + 1) highest)
 
 
-      // CLEANUP: this is blocked from being used until we have a live and stable package manager
-      // /// Returns a single list containing the values of every list directly in <paramlist>
-      // /// (does not recursively flatten nested lists)
-      // let flatten (list: List<List<'a>>) : List<'a> =
-      //   match list with
-      //   | [] -> []
-      //   | head :: tail ->
-      //     List.append_v0 head (PACKAGE.Darklang.Stdlib.List.flatten tail)
+      /// Returns a single list containing the values of every list directly in <paramlist>
+      /// (does not recursively flatten nested lists)
+      let flatten (list: List<List<'a>>) : List<'a> =
+        match list with
+        | [] -> []
+        | head :: tail ->
+          List.append_v0 head (PACKAGE.Darklang.Stdlib.List.flatten tail)
 
 
       /// Returns true if <param list> has no values
@@ -94,14 +93,13 @@ module Darklang =
         | _ -> false
 
 
-      // CLEANUP: this is blocked from being used until we have a live and stable package manager
-      // /// Applies the given function <param fn> to each element of the <param list>.
-      // let iter (list: List<'a>) (f: 'a -> Unit) : Unit =
-      //   match list with
-      //   | [] -> ()
-      //   | head :: tail ->
-      //     head |> f
-      //     PACKAGE.Darklang.Stdlib.List.iter tail f
+      /// Applies the given function <param fn> to each element of the <param list>.
+      let iter (list: List<'a>) (f: 'a -> Unit) : Unit =
+        match list with
+        | [] -> ()
+        | head :: tail ->
+          head |> f
+          PACKAGE.Darklang.Stdlib.List.iter tail f
 
 
       /// Returns {{Some value}} at <param index> in <param list> if <param index> is

--- a/scripts/deployment/buildcontainers.dark
+++ b/scripts/deployment/buildcontainers.dark
@@ -16,7 +16,7 @@ let main () : Int =
   let dockerfiles =
     (Directory.list "containers")
     |> List.map (fun directory -> Directory.list directory)
-    |> List.flatten
+    |> PACKAGE.Darklang.Stdlib.List.flatten
     |> List.filter (fun filePath -> String.endsWith filePath "Dockerfile")
 
   let imageIds =


### PR DESCRIPTION

No changelog

#5020 follow-up
This PR adds a copy of both List.iter and List.flatten to LocalExec. Reason being, we are unable to use PACKAGE functions during the 'load from disk into DB' process.
