### PR TITLE
Move several constants from builtins to package space

### DIFF
--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -401,7 +401,7 @@ module Const =
         List.map toRT fields
       )
     | PT.Const.CEnum(Error msg, caseName, fields) ->
-      RT.DError(RT.SourceNone, "Invalid const name: {msg}")
+      RT.DError(RT.SourceNone, $"Invalid const name: {msg}")
 
 module TypeDeclaration =
   module RecordField =

--- a/backend/src/StdLibExecution/Libs/Math.fs
+++ b/backend/src/StdLibExecution/Libs/Math.fs
@@ -18,15 +18,7 @@ let fn = fn modules
 let constant = constant modules
 
 let constants : List<BuiltInConstant> =
-  [ { name = constant "pi" 0
-      typ = TFloat
-      description =
-        "Returns an approximation for the mathematical constant {{π}},
-        the ratio of a circle's circumference to its diameter."
-      body = DFloat System.Math.PI
-      deprecated = NotDeprecated }
-
-    { name = constant "tau" 0
+  [ { name = constant "tau" 0
       typ = TFloat
       description =
         "Returns an approximation for the mathematical constant {{τ}}, the number of

--- a/backend/src/StdLibExecution/Libs/String.fs
+++ b/backend/src/StdLibExecution/Libs/String.fs
@@ -22,12 +22,7 @@ let fn = fn modules
 let constant = constant modules
 
 let types : List<BuiltInType> = []
-let constants : List<BuiltInConstant> =
-  [ { name = constant "newline" 0
-      typ = TString
-      description = "Returns a string containing a single '\n'"
-      body = DString "\n"
-      deprecated = NotDeprecated } ]
+let constants : List<BuiltInConstant> = []
 
 
 let fns : List<BuiltInFn> =

--- a/backend/testfiles/execution/stdlib/crypto.dark
+++ b/backend/testfiles/execution/stdlib/crypto.dark
@@ -28,7 +28,7 @@ Bytes.hexEncode_v0 (
 (let scope = "20150830/us-east-1/iam/aws4_request" in
  let content = "f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59" in
  let strs = [ "AWS4-HMAC-SHA256"; "20150830T123600Z"; scope; content ] in
- let strToSign = String.join_v0 strs String.newline_v0 in
+ let strToSign = String.join_v0 strs PACKAGE.Darklang.Stdlib.String.newline in
  let secret = String.toBytes_v0 "AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY" in
  let data = String.toBytes_v0 "20150830" in
  let date = Crypto.sha256hmac_v0 secret data in

--- a/backend/testfiles/execution/stdlib/math.dark
+++ b/backend/testfiles/execution/stdlib/math.dark
@@ -16,29 +16,33 @@ Math.atan2_v0 1.0 -1.0 = 2.35619449019
 Math.atan2_v0 1.0 1.0 = 0.785398163397
 
 Math.cos_v0 0.0 = 1.0
-Math.cos_v0 Math.pi_v0 = -1.0
+Math.cos_v0 PACKAGE.Darklang.Stdlib.Math.pi = -1.0
 
 Math.cosh_v0 0.0 = 1.0
 
-Math.degrees_v0 -180.0 = Float.negate_v0 Math.pi
-Math.degrees_v0 360.0 = Float.multiply_v0 2.0 Math.pi
+Math.degrees_v0 -180.0 = Float.negate_v0 PACKAGE.Darklang.Stdlib.Math.pi
+Math.degrees_v0 360.0 = Float.multiply_v0 2.0 PACKAGE.Darklang.Stdlib.Math.pi
 
-Math.pi_v0 = 3.14159265359
+PACKAGE.Darklang.Stdlib.Math.pi = 3.14159265359
 
-Math.radians_v0 (Float.negate_v0 3.141592653589793) = Float.negate_v0 Math.pi
-Math.radians_v0 6.283185307179586 = Float.multiply_v0 2.0 Math.pi
+Math.radians_v0 (Float.negate_v0 3.141592653589793) = Float.negate_v0
+  PACKAGE.Darklang.Stdlib.Math.pi
 
-Math.sin_v0 (Float.divide_v0 Math.pi_v0 2.0) = 1.0
+Math.radians_v0 6.283185307179586 = Float.multiply_v0
+  2.0
+  PACKAGE.Darklang.Stdlib.Math.pi
+
+Math.sin_v0 (Float.divide_v0 PACKAGE.Darklang.Stdlib.Math.pi 2.0) = 1.0
 Math.sin_v0 0.0 = 0.0
 
 Math.sinh_v0 0.0 = 0.0
 Math.sinh_v0 1.0 = 1.17520119364
 
-Math.tan_v0 (Float.divide_v0 Math.pi_v0 4.0) = 1.0
+Math.tan_v0 (Float.divide_v0 PACKAGE.Darklang.Stdlib.Math.pi 4.0) = 1.0
 Math.tan_v0 0.0 = 0.0
 Math.tanh_v0 0.0 = 0.0
 
-Math.tau_v0 = Float.multiply_v0 2.0 Math.pi
+PACKAGE.Darklang.Stdlib.Math.tau = Float.multiply_v0 2.0 PACKAGE.Darklang.Stdlib.Math.pi
 
-Math.turns_v0 (Float.negate_v0 0.5) = Float.negate_v0 Math.pi
-Math.turns_v0 1.0 = Float.multiply_v0 2.0 Math.pi
+Math.turns_v0 (Float.negate_v0 0.5) = Float.negate_v0 PACKAGE.Darklang.Stdlib.Math.pi
+Math.turns_v0 1.0 = Float.multiply_v0 2.0 PACKAGE.Darklang.Stdlib.Math.pi

--- a/backend/testfiles/execution/stdlib/math.dark
+++ b/backend/testfiles/execution/stdlib/math.dark
@@ -42,7 +42,9 @@ Math.tan_v0 (Float.divide_v0 PACKAGE.Darklang.Stdlib.Math.pi 4.0) = 1.0
 Math.tan_v0 0.0 = 0.0
 Math.tanh_v0 0.0 = 0.0
 
-PACKAGE.Darklang.Stdlib.Math.tau = Float.multiply_v0 2.0 PACKAGE.Darklang.Stdlib.Math.pi
+PACKAGE.Darklang.Stdlib.Math.tau = Float.multiply_v0
+  2.0
+  PACKAGE.Darklang.Stdlib.Math.pi
 
 Math.turns_v0 (Float.negate_v0 0.5) = Float.negate_v0 PACKAGE.Darklang.Stdlib.Math.pi
 Math.turns_v0 1.0 = Float.multiply_v0 2.0 PACKAGE.Darklang.Stdlib.Math.pi

--- a/backend/testfiles/execution/stdlib/string.dark
+++ b/backend/testfiles/execution/stdlib/string.dark
@@ -257,7 +257,7 @@ module IsEmpty =
 
 
 module NewLine =
-  String.newline_v0 = "\n"
+  PACKAGE.Darklang.Stdlib.String.newline = "\n"
 
 
 module Length =

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -2,6 +2,7 @@ module Darklang =
   module Stdlib =
     module List =
 
+      /// Drops the last value from <param list>
       let dropLast (list: List<'a>) : List<'a> =
         match list with
         | [] -> []
@@ -12,6 +13,7 @@ module Darklang =
             List.append_v0
               (List.singleton_v0 head)
               (PACKAGE.Darklang.Stdlib.List.dropLast tail)
+
 
       /// Returns {{Some}} the head (first value) of a list.
       /// Returns {{None}} if the list is empty.
@@ -118,6 +120,7 @@ module Darklang =
               PACKAGE.Darklang.Stdlib.Option.Option.Some head
             else
               PACKAGE.Darklang.Stdlib.List.getAt tail (index - 1)
+
 
       /// Returns {{true}} if <param value> is in the list
       let ``member`` (list: List<'a>) (value: 'a) : Bool =

--- a/packages/darklang/stdlib/math.dark
+++ b/packages/darklang/stdlib/math.dark
@@ -9,5 +9,4 @@ module Darklang =
 
       /// Returns an approximation for the mathematical constant {{τ}}, the number of
       /// radians in one turn. Equivalent to {{Float.multiply Math.pi 2}}.
-      // let tau = Float.multiply_v0 2.0 PACKAGE.Darklang.Stdlib.Math.pi
       let tau = 6.283185307179586

--- a/packages/darklang/stdlib/math.dark
+++ b/packages/darklang/stdlib/math.dark
@@ -1,0 +1,13 @@
+module Darklang =
+  module Stdlib =
+    module Math =
+
+      // Returns an approximation for the mathematical constant {{π}},
+      // the ratio of a circle's circumference to its diameter.
+      let pi = 3.141592653589793
+
+
+      /// Returns an approximation for the mathematical constant {{τ}}, the number of
+      /// radians in one turn. Equivalent to {{Float.multiply Math.pi 2}}.
+      // let tau = Float.multiply_v0 2.0 PACKAGE.Darklang.Stdlib.Math.pi
+      let tau = 6.283185307179586

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -2,6 +2,9 @@ module Darklang =
   module Stdlib =
     module String =
 
+      /// Returns a string containing a single '\n'
+      let newline = "\n"
+
       /// Truncates the string <param s> to the specified <param length> and appends an ellipsis ("...")
       /// to it if the original string exceeds the given length. Otherwise, returns the original string.
       let ellipsis (s: String) (length: Int) : String =


### PR DESCRIPTION
Changelog:

```
Packages
- Move constants to packages
```
This PR moves constants to packages.

We are unable to move `List.empty`, `Bytes.empty`, and `Dict.empty` since our current support is limited to types with literal representations, excluding List and Dict constants due to their lack of implicit types