### PR TITLE
Fix Process.run builtin and package fn; add File.delete builtin; fix dark-packages ingest

### DIFF
--- a/backend/src/BuiltinCli/Libs/File.fs
+++ b/backend/src/BuiltinCli/Libs/File.fs
@@ -65,6 +65,31 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "delete" 0
+      typeParams = []
+      parameters = [ Param.make "path" TString "" ]
+      returnType = TypeReference.result TUnit TString
+      description = "Deletes the file specified by <param path>"
+      fn =
+        (function
+        | _, _, [ DString path ] ->
+          uply {
+            try
+              System.IO.File.Delete path
+              return Dval.resultOk KTUnit KTString DUnit
+            with e ->
+              return
+                Dval.resultError
+                  KTUnit
+                  KTString
+                  (DString $"Error deleting file: {e.Message}")
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
     { name = fn "append" 0
       typeParams = []
       parameters = [ Param.make "path" TString ""; Param.make "content" TBytes "" ]

--- a/backend/src/BuiltinCli/Libs/Process.fs
+++ b/backend/src/BuiltinCli/Libs/Process.fs
@@ -10,6 +10,7 @@ open LibExecution.RuntimeTypes
 module Dval = LibExecution.Dval
 module Builtin = LibExecution.Builtin
 open Builtin.Shortcuts
+open System.Runtime.InteropServices
 
 let types : List<BuiltInType> = []
 
@@ -17,9 +18,7 @@ let fns : List<BuiltInFn> =
   [ { name = fn [ "Process" ] "run" 0
       description = "Runs a process, return exitCode, stdout and stderr"
       typeParams = []
-      parameters =
-        [ Param.make "command" TString "The command to run"
-          Param.make "input" TString "The input to the command" ]
+      parameters = [ Param.make "command" TString "The command to run" ]
       returnType =
         TCustomType(
           Ok(TypeName.fqPackage "Darklang" [ "Stdlib"; "Process" ] "Result" 0),
@@ -28,9 +27,23 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, _, [ DString command ] ->
+          let cmdName, cmdArgs =
+            if RuntimeInformation.IsOSPlatform OSPlatform.Windows then
+              "cmd.exe", $"/c {command}"
+            else if
+              RuntimeInformation.IsOSPlatform OSPlatform.Linux
+              || RuntimeInformation.IsOSPlatform OSPlatform.OSX
+            then
+              "/bin/bash", $"-c \"{command}\""
+            else
+              raiseString
+                "Process.run not supported for your operating system (Linux, Windows, or Mac not detected)"
+
           let psi =
             System.Diagnostics.ProcessStartInfo(command)
             |> fun psi ->
+              psi.FileName <- cmdName
+              psi.Arguments <- cmdArgs
               psi.UseShellExecute <- false
               psi.RedirectStandardOutput <- true
               psi.RedirectStandardError <- true
@@ -39,6 +52,8 @@ let fns : List<BuiltInFn> =
 
           let p = System.Diagnostics.Process.Start(psi)
 
+          // TODO: read+return bytes, not strings, and update the corresponding `Process.Result` type
+          // (need an alternative to `p.StandardOutput.ReadToEnd()` here)
           let stdout = p.StandardOutput.ReadToEnd()
           let stderr = p.StandardError.ReadToEnd()
 

--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -227,7 +227,7 @@ let main (args: List<String>) : Int =
         PACKAGE.Darklang.Stdlib.List.fold
           files
           (PACKAGE.Darklang.Stdlib.Result.Result.Ok())
-          (fun (acc, f) ->
+          (fun acc f ->
             Builtin.print $"Loading {f}"
 
             match acc with

--- a/packages/darklang/cli/cli.dark
+++ b/packages/darklang/cli/cli.dark
@@ -305,14 +305,11 @@ module Darklang =
               script
               (Dict { args = args })
           with
-          | Ok i -> i
+          | Ok exitCode -> exitCode
           | Error e ->
-            Builtin.print $"Error executing script {scriptPath}"
-            Builtin.print e.msg
-
-            e.metadata
-            |> PACKAGE.Darklang.Stdlib.Dict.iter (fun (k, v) ->
-              Builtin.print $"  {k}: {v}")
+            Builtin.print (
+              PACKAGE.Darklang.LanguageTools.RuntimeErrors.Error.toString e
+            )
 
             1
 

--- a/packages/darklang/languageTools/programTypes.dark
+++ b/packages/darklang/languageTools/programTypes.dark
@@ -181,10 +181,7 @@ module Darklang =
       type PipeExpr =
         | EPipeVariable of PACKAGE.Darklang.LanguageTools.ID * String * List<Expr>
 
-        | EPipeLambda of
-          PACKAGE.Darklang.LanguageTools.ID *
-          List<PACKAGE.Darklang.LanguageTools.ID * String> *
-          Expr
+        | EPipeLambda of PACKAGE.Darklang.LanguageTools.ID * List<LetPattern> * Expr
 
         | EPipeInfix of PACKAGE.Darklang.LanguageTools.ID * Infix * Expr
 
@@ -275,7 +272,7 @@ module Darklang =
 
         | EInfix of ID * Infix * Expr * Expr
 
-        | ELambda of ID * List<ID * String> * Expr
+        | ELambda of ID * List<LetPattern> * Expr
 
         | EApply of ID * Expr * typeArgs: List<TypeReference> * args: List<Expr>
 

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -573,15 +573,13 @@ module Darklang =
 
           $"({varName} {exprs})"
 
-        | EPipeLambda(_id, args, body) ->
+        | EPipeLambda(_id, pats, body) ->
           let argsPart =
-            args
-            |> PACKAGE.Darklang.Stdlib.List.map (fun pair ->
-              PACKAGE.Darklang.Stdlib.Tuple2.second pair)
-            |> PACKAGE.Darklang.Stdlib.String.join " "
+            pats
+            |> Stdlib.List.map (fun lp -> letPattern lp)
+            |> Stdlib.String.join " "
 
-          let bodyPart = PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr body
-          $"fun {argsPart} -> {bodyPart}"
+          $"fun {argsPart} -> {expr body}"
 
         | EPipeInfix(_id, infix, expr) ->
           let infixPart = PACKAGE.Darklang.PrettyPrinter.ProgramTypes.infix infix
@@ -820,7 +818,7 @@ module Darklang =
 
           let pipeParts =
             pipeExprs
-            |> PACKAGE.Darklang.Stdlib.List.map (fun (pipeExpr) ->
+            |> PACKAGE.Darklang.Stdlib.List.map (fun pipeExpr ->
               PACKAGE.Darklang.PrettyPrinter.ProgramTypes.pipeExpr pipeExpr)
             |> PACKAGE.Darklang.Stdlib.String.join " \n|> "
 
@@ -840,11 +838,10 @@ module Darklang =
           // TODO: might need to wrap in parens
           $"({leftPart}) {infixPart} ({rightPart})"
 
-        | ELambda(_id, args, body) ->
-          let argsPart =
-            args
-            |> PACKAGE.Darklang.Stdlib.List.map (fun pair ->
-              PACKAGE.Darklang.Stdlib.Tuple2.second pair)
+        | ELambda(_id, pats, body) ->
+          let patsPart =
+            pats
+            |> PACKAGE.Darklang.Stdlib.List.map (fun pat -> letPattern pat)
             |> PACKAGE.Darklang.Stdlib.String.join " "
 
           let bodyPart = PACKAGE.Darklang.PrettyPrinter.ProgramTypes.expr body

--- a/packages/darklang/stdlib/process.dark
+++ b/packages/darklang/stdlib/process.dark
@@ -5,17 +5,12 @@ module Darklang =
       /// The result of running a process, typically with `Process.run`
       type Result =
         { exitCode: Int
-          stdout: Bytes
-          stderr: Bytes }
 
-      // Return Ok stdout+stderr, or Error exitCode+stdout+stderr
-      let runCommand
-        (command: String)
-        (input: String)
-        : PACKAGE.Darklang.Stdlib.Result.Result<String, Result> =
-        let result = Builtin.Process.run command input
+          // TODO bytes, not strings -- see internal note in Process.fs
+          stdout: String
+          stderr: String }
 
-        if result.exitCode == 0 then
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok(stdout ++ stderr)
-        else
-          PACKAGE.Darklang.Stdlib.Result.Result.Error result
+      /// Runs a local process (i.e. `Process.runCommand "ls ."`)
+      ///
+      /// TODO consider returning a Stdlib.Result.Result instead
+      let runCommand (command: String) : Result = Builtin.Process.run command

--- a/scripts/hello-world
+++ b/scripts/hello-world
@@ -1,5 +1,0 @@
-let helloWorld () : Int =
-  print "Hello World"
-  0
-
-helloWorld()

--- a/scripts/hello-world.dark
+++ b/scripts/hello-world.dark
@@ -1,0 +1,5 @@
+let helloWorld () : Int =
+  Builtin.print "Hello World"
+  0
+
+helloWorld ()


### PR DESCRIPTION
- fix some regressions preventing packages getting to the dark-packages canvas locally
- fix `Process.run` function -- I was unable to use the Process.run as-is
- adds a `File.delete` in StdLibCli, as I reached for it when writing a personal script