### PR TITLE
Add a new fromBytes that doesn't ignore errors

### DIFF
--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -421,6 +421,26 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "fromBytesRecoverable" 0
+      typeParams = []
+      parameters = [ Param.make "bytes" TBytes "" ]
+      returnType = TypeReference.option TString
+      description =
+        "Converts the UTF8-encoded byte sequence into a string. Errors will be ignored by replacing invalid characters"
+      fn =
+        (function
+        | _, _, [ DBytes bytes ] ->
+          try
+            let str = System.Text.UTF8Encoding(false, true).GetString bytes
+            Ply(Dval.optionSome (DString str))
+          with e ->
+            Ply(Dval.optionNone)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
     { name = fn "indexOf" 0
       typeParams = []
       parameters =

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -404,7 +404,7 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "fromBytes" 0
+    { name = fn "fromBytesWithReplacement" 0
       typeParams = []
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TString
@@ -421,7 +421,7 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "fromBytesRecoverable" 0
+    { name = fn "fromBytes" 0
       typeParams = []
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TypeReference.option TString

--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -49,7 +49,7 @@ let saveItemToCanvas
         $"Status: {PACKAGE.Darklang.Stdlib.Int.toString response.statusCode}"
 
       Builtin.print
-        $"Body: {response.body |> PACKAGE.Darklang.Stdlib.String.fromBytes}"
+        $"Body: {response.body |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement}"
 
       Builtin.print errMsg
       PACKAGE.Darklang.Stdlib.Result.Result.Error errMsg
@@ -68,7 +68,7 @@ let loadPackageFileIntoDarkCanvas
     filename
     |> Builtin.File.read
     |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.fromBytes
+    |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     |> Builtin.LocalExec.Packages.parse filename
     |> Builtin.unwrap
 

--- a/backend/testfiles/execution/stdlib/string.dark
+++ b/backend/testfiles/execution/stdlib/string.dark
@@ -252,15 +252,14 @@ module Base64Decode =
     "👱👱🏻👱🏼👱🏽👱🏾👱🏿"
 
 
-  // These produce strings of bytes which are technically legal it seems
-  PACKAGE.Darklang.Stdlib.String.base64Decode_v0 "-p" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "�"
+  PACKAGE.Darklang.Stdlib.String.base64Decode_v0 "-p" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    "Invalid UTF-8 string"
 
-  PACKAGE.Darklang.Stdlib.String.base64Decode_v0 "lI" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "�"
+  PACKAGE.Darklang.Stdlib.String.base64Decode_v0 "lI" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    "Invalid UTF-8 string"
 
-  PACKAGE.Darklang.Stdlib.String.base64Decode_v0 "5Sk" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "�)"
+  PACKAGE.Darklang.Stdlib.String.base64Decode_v0 "5Sk" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    "Invalid UTF-8 string"
 
 
 module Base64Encode =

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -31,7 +31,8 @@ let openAIcompletion
     let url = "http://dark-editor.dlio.localhost:11003/openai-apikey-yikes"
 
     match Builtin.HttpClient.request "get" url [] Builtin.Bytes.empty with
-    | Ok response -> response.body |> PACKAGE.Darklang.Stdlib.String.fromBytes
+    | Ok response ->
+      response.body |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
 
   let openAIRequest =
     OpenAIChatCompletionRequest
@@ -58,7 +59,7 @@ let openAIcompletion
     | Ok r ->
       match
         Builtin.Json.parse<OpenAIChatCompletionResponse> (
-          PACKAGE.Darklang.Stdlib.String.fromBytes r.body
+          PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
         )
       with
       | Ok r ->
@@ -89,14 +90,14 @@ let parseAndSerializeProgram
       response
       |> Builtin.unwrap
       |> (fun r -> r.body)
-      |> PACKAGE.Darklang.Stdlib.String.fromBytes
+      |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     )
   | 400 ->
     Error(
       response
       |> Builtin.unwrap
       |> (fun r -> r.body)
-      |> PACKAGE.Darklang.Stdlib.String.fromBytes
+      |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     )
   | _ ->
     Error(
@@ -184,7 +185,8 @@ let update (model: Model) (msg: Msg) : Model =
     match systemPrompt with
     | Ok response ->
       { response with
-          systemPrompt = PACKAGE.Darklang.Stdlib.String.fromBytes response.body }
+          systemPrompt =
+            PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement response.body }
     | Error err -> logErr "Couldn't load system prompt"
 
 
@@ -209,7 +211,7 @@ let update (model: Model) (msg: Msg) : Model =
         Builtin.Bytes.empty)
       |> Builtin.unwrap
       |> (fun r -> r.body)
-      |> PACKAGE.Darklang.Stdlib.String.fromBytes
+      |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
       |> PACKAGE.Darklang.Stdlib.String.append $"\n\n {userPrompt}"
 
     // I guess, until we have cmds or something,
@@ -451,7 +453,7 @@ let init () : Model =
         log "got response"
 
         response.body
-        |> PACKAGE.Darklang.Stdlib.String.fromBytes
+        |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
         |> PACKAGE.Darklang.Stdlib.String.split "\n\n"
 
       | Error err -> "Error getting response: " ++ err
@@ -470,7 +472,7 @@ let init () : Model =
         log "got response"
 
         response.body
-        |> PACKAGE.Darklang.Stdlib.String.fromBytes
+        |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
         |> PACKAGE.Darklang.Stdlib.String.split "\n\n"
 
       | Error err -> "Error getting response: " ++ err

--- a/canvases/dark-editor/main.dark
+++ b/canvases/dark-editor/main.dark
@@ -22,7 +22,7 @@ let _handler _req =
     | Ok f -> f
 
   PACKAGE.Darklang.Stdlib.Http.responseWithHtml
-    (PACKAGE.Darklang.Stdlib.String.fromBytes body)
+    (PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement body)
     200
 
 [<HttpHandler("GET", "/assets/:path")>]
@@ -80,7 +80,7 @@ let _handler _req =
 
   let program =
     Experiments.parseAndSerializeProgram
-      (PACKAGE.Darklang.Stdlib.String.fromBytes sourceInBytes)
+      (PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement sourceInBytes)
       "user-code.dark"
 
   match program with

--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -31,7 +31,7 @@ type PackageItemDB = PackageItem
 let _handler _req =
   let typeToSave =
     request.body
-    |> PACKAGE.Darklang.Stdlib.String.fromBytes
+    |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     |> Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
     |> Builtin.unwrap
 
@@ -56,7 +56,7 @@ let _handler _req =
 let _handler _req =
   let fnToSave =
     request.body
-    |> PACKAGE.Darklang.Stdlib.String.fromBytes
+    |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     |> Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>
     |> Builtin.unwrap
 
@@ -82,7 +82,7 @@ let _handler _req =
 let _handler _req =
   let constantToSave =
     request.body
-    |> PACKAGE.Darklang.Stdlib.String.fromBytes
+    |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     |> Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>
     |> Builtin.unwrap
 

--- a/canvases/dark-repl/assets/client.dark
+++ b/canvases/dark-repl/assets/client.dark
@@ -18,7 +18,7 @@ let parseAndSerializeProgram (userProgram: String) : String =
   response
   |> rUnwrap
   |> (fun r -> r.body)
-  |> PACKAGE.Darklang.Stdlib.String.fromBytes
+  |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
 
 let handleEvent
   (userProgramSource: String)

--- a/canvases/dark-repl/main.dark
+++ b/canvases/dark-repl/main.dark
@@ -60,7 +60,7 @@ let _handler _req =
 
   let program =
     Experiments.parseAndSerializeProgram
-      (PACKAGE.Darklang.Stdlib.String.fromBytes sourceInBytes)
+      (PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement sourceInBytes)
       "code.dark"
 
   match program with

--- a/packages/darklang/cli/cli.dark
+++ b/packages/darklang/cli/cli.dark
@@ -27,7 +27,7 @@ module Darklang =
           fns
           |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytes
+          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
           |> Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>>
           |> Builtin.unwrap
           |> PACKAGE.Darklang.Stdlib.Option.Option.Some
@@ -76,7 +76,7 @@ module Darklang =
           types
           |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytes
+          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
           |> Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>>
           |> Builtin.unwrap
           |> PACKAGE.Darklang.Stdlib.Option.Option.Some
@@ -127,7 +127,7 @@ module Darklang =
           constants
           |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytes
+          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
           |> Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>>
           |> Builtin.unwrap
           |> PACKAGE.Darklang.Stdlib.Option.Option.Some
@@ -185,7 +185,7 @@ module Darklang =
           modules
           |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytes
+          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
           |> Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Packages>
           |> Builtin.unwrap
           |> PACKAGE.Darklang.Stdlib.Option.Option.Some
@@ -228,7 +228,7 @@ module Darklang =
           packages
           |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytes
+          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
           |> Builtin.print
 
           0
@@ -254,7 +254,7 @@ module Darklang =
       let systemPrompt =
         (Builtin.File.read "canvases/dark-editor/system-prompt-cli.txt")
         |> Builtin.unwrap
-        |> PACKAGE.Darklang.Stdlib.String.fromBytes
+        |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
 
       let prompt = prompt ++ "\n" ++ systemPrompt
 
@@ -302,7 +302,7 @@ module Darklang =
           Builtin.print e
           1
         | Ok script ->
-          let script = PACKAGE.Darklang.Stdlib.String.fromBytes script
+          let script = PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement script
 
           match
             Builtin.Cli.parseAndExecuteScript
@@ -374,7 +374,7 @@ Options:
             categoryRequest
             |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
             |> Builtin.unwrap
-            |> PACKAGE.Darklang.Stdlib.String.fromBytes
+            |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
           else
             "Error" |> PACKAGE.Darklang.Stdlib.String.toBytes
 

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -127,8 +127,10 @@ module Darklang =
         : PACKAGE.Darklang.Stdlib.Result.Result<String, String> =
         match (Builtin.Bytes.base64Decode s) with
         | Ok bytes ->
-          (Builtin.String.fromBytes bytes)
-          |> PACKAGE.Darklang.Stdlib.Result.Result.Ok
+          match (Builtin.String.fromBytesRecoverable bytes) with
+          | Some str -> PACKAGE.Darklang.Stdlib.Result.Result.Ok str
+          | None ->
+            PACKAGE.Darklang.Stdlib.Result.Result.Error "Invalid UTF-8 string"
         | Error err -> PACKAGE.Darklang.Stdlib.Result.Result.Error err
 
 

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -127,7 +127,7 @@ module Darklang =
         : PACKAGE.Darklang.Stdlib.Result.Result<String, String> =
         match (Builtin.Bytes.base64Decode s) with
         | Ok bytes ->
-          match (Builtin.String.fromBytesRecoverable bytes) with
+          match (Builtin.String.fromBytes bytes) with
           | Some str -> PACKAGE.Darklang.Stdlib.Result.Result.Ok str
           | None ->
             PACKAGE.Darklang.Stdlib.Result.Result.Error "Invalid UTF-8 string"
@@ -337,7 +337,8 @@ module Darklang =
 
 
       /// Converts the UTF8-encoded byte sequence into a string. Errors will be ignored by replacing invalid characters
-      let fromBytes (bytes: Bytes) : String = Builtin.String.fromBytes bytes
+      let fromBytesWithReplacement (bytes: Bytes) : String =
+        Builtin.String.fromBytesWithReplacement bytes
 
 
       /// Checks if <param subject> starts with <param prefix>

--- a/packages/openai.dark
+++ b/packages/openai.dark
@@ -52,7 +52,7 @@ module OpenAI =
         | Ok r ->
           match
             Builtin.Json.parse<PACKAGE.OpenAI.Completion.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytes r.body
+              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
             )
           with
           | Ok r ->
@@ -157,7 +157,7 @@ module OpenAI =
         | Ok r ->
           match
             Builtin.Json.parse<PACKAGE.OpenAI.ChatCompletion.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytes r.body
+              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
             )
           with
           | Ok r ->
@@ -211,7 +211,7 @@ module OpenAI =
         | Ok r ->
           match
             Builtin.Json.parse<PACKAGE.OpenAI.ChatCompletion.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytes r.body
+              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
             )
           with
           | Ok r ->
@@ -267,7 +267,7 @@ module OpenAI =
         | Ok r ->
           match
             Builtin.Json.parse<PACKAGE.OpenAI.ImageGeneration.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytes r.body
+              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
             )
           with
           | Ok r ->
@@ -313,7 +313,7 @@ module OpenAI =
       match modelResponse with
       | Ok r ->
         r.body
-        |> PACKAGE.Darklang.Stdlib.String.fromBytes
+        |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
         |> PACKAGE.Darklang.Stdlib.Result.Result.Ok
       | Error e ->
         PACKAGE.Darklang.Stdlib.Result.Result.Error(
@@ -336,7 +336,7 @@ module OpenAI =
       match modelResponse with
       | Ok r ->
         r.body
-        |> PACKAGE.Darklang.Stdlib.String.fromBytes
+        |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
         |> PACKAGE.Darklang.Stdlib.Result.Result.Ok
       | Error e ->
         PACKAGE.Darklang.Stdlib.Result.Result.Error(


### PR DESCRIPTION


No changelog

This adds a new fromBytes that doesn't ignore errors and uses it in String.base64Decode
