### PR TITLE
Expand the Standard Library: Option and Result

### DIFF
--- a/backend/testfiles/execution/stdlib/option.dark
+++ b/backend/testfiles/execution/stdlib/option.dark
@@ -372,3 +372,48 @@ PACKAGE.Darklang.Stdlib.Option.join_v0 (
 ) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.join_v0 PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.combine_v0
+  [ PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 4
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 3 ] = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  [ 6; 5; 4; 3 ]
+
+PACKAGE.Darklang.Stdlib.Option.combine_v0
+  [ PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 4
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 3 ] = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.combine_v0
+  [ PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None ] = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.values
+  [ PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 4
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 3 ] = [ 6; 5; 4; 3 ]
+
+PACKAGE.Darklang.Stdlib.Option.values
+  [ PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 4
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 3 ] = [ 6; 4; 3 ]
+
+PACKAGE.Darklang.Stdlib.Option.values
+  [ PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None ] = [ 6 ]
+
+PACKAGE.Darklang.Stdlib.Option.values
+  [ PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+    PACKAGE.Darklang.Stdlib.Option.Option.None ] = []

--- a/backend/testfiles/execution/stdlib/option.dark
+++ b/backend/testfiles/execution/stdlib/option.dark
@@ -22,6 +22,113 @@ PACKAGE.Darklang.Stdlib.Option.andThen_v0
       PACKAGE.Darklang.Stdlib.Int.divide_v0 x 2
     )) = PACKAGE.Darklang.Stdlib.Option.Option.Some 4
 
+PACKAGE.Darklang.Stdlib.Option.andThen_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 8)
+  (fun x ->
+    PACKAGE.Darklang.Stdlib.Option.Option.Some(
+      PACKAGE.Darklang.Stdlib.Int.divide_v0 x 0
+    )) = Builtin.Test.derrorMessage "Division by zero"
+
+
+PACKAGE.Darklang.Stdlib.Option.andThen2_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (fun x y -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y)) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  11
+
+PACKAGE.Darklang.Stdlib.Option.andThen2_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x y -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen2_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (fun x y -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen2_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x y -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.andThen3_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 7)
+  (fun x y z -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z)) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  18
+
+
+PACKAGE.Darklang.Stdlib.Option.andThen3_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 7)
+  (fun x y z -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen3_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 7)
+  (fun x y z -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen3_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x y z -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen3_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x y z -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.andThen4_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 7)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 8)
+  (fun x y z w -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z + w)) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  26
+
+
+PACKAGE.Darklang.Stdlib.Option.andThen4_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 7)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 8)
+  (fun x y z w -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z + w)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen4_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 7)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 8)
+  (fun x y z w -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z + w)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen4_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 8)
+  (fun x y z w -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z + w)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen4_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 7)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x y z w -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z + w)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.andThen4_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x y z w -> PACKAGE.Darklang.Stdlib.Option.Option.Some(x + y + z + w)) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
 
 PACKAGE.Darklang.Stdlib.Option.map
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 4)
@@ -54,6 +161,126 @@ PACKAGE.Darklang.Stdlib.Option.map2_v0
   (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
+PACKAGE.Darklang.Stdlib.Option.map3_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.Some 7
+
+PACKAGE.Darklang.Stdlib.Option.map3_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map3_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map3_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map3_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.map4_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.Some 4
+
+PACKAGE.Darklang.Stdlib.Option.map4_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map4_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map4_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map4_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map4_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.map5_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 4)
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.Some 0
+
+PACKAGE.Darklang.Stdlib.Option.map5_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 4)
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.map5_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.mapWithDefault_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  6
+  (fun x -> x + 1) = 6
+
+PACKAGE.Darklang.Stdlib.Option.mapWithDefault_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  6
+  (fun x -> x + 1) = 6
+
+PACKAGE.Darklang.Stdlib.Option.mapWithDefault_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5)
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x -> x + 1) = 6
+
+PACKAGE.Darklang.Stdlib.Option.mapWithDefault_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun x -> x + 1) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
 PACKAGE.Darklang.Stdlib.Option.withDefault_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
   5 = 6
@@ -61,3 +288,81 @@ PACKAGE.Darklang.Stdlib.Option.withDefault_v0
 PACKAGE.Darklang.Stdlib.Option.withDefault_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   5 = 5
+
+
+PACKAGE.Darklang.Stdlib.Option.isSome_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6) = true
+
+PACKAGE.Darklang.Stdlib.Option.isSome_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None = false
+
+
+PACKAGE.Darklang.Stdlib.Option.isNone_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6) = false
+
+PACKAGE.Darklang.Stdlib.Option.isNone_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None = true
+
+
+PACKAGE.Darklang.Stdlib.Option.toResult_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  5 = PACKAGE.Darklang.Stdlib.Result.Result.Ok 6
+
+PACKAGE.Darklang.Stdlib.Option.toResult_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  "error" = PACKAGE.Darklang.Stdlib.Result.Result.Error "error"
+
+
+PACKAGE.Darklang.Stdlib.Option.and_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+
+PACKAGE.Darklang.Stdlib.Option.and_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.and_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.and_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.or_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+
+PACKAGE.Darklang.Stdlib.Option.or_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
+  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+
+PACKAGE.Darklang.Stdlib.Option.or_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+
+PACKAGE.Darklang.Stdlib.Option.or_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None
+  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+PACKAGE.Darklang.Stdlib.Option.toList_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6) = [6]
+
+PACKAGE.Darklang.Stdlib.Option.toList_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None = []
+
+
+PACKAGE.Darklang.Stdlib.Option.join_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some(
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+   )) = PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+
+PACKAGE.Darklang.Stdlib.Option.join_v0
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some(
+    PACKAGE.Darklang.Stdlib.Option.Option.None
+   )) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+PACKAGE.Darklang.Stdlib.Option.join_v0
+  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None

--- a/backend/testfiles/execution/stdlib/option.dark
+++ b/backend/testfiles/execution/stdlib/option.dark
@@ -241,8 +241,7 @@ PACKAGE.Darklang.Stdlib.Option.map5_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 4)
-  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.Some
-  0
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.Some 0
 
 PACKAGE.Darklang.Stdlib.Option.map5_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)

--- a/backend/testfiles/execution/stdlib/option.dark
+++ b/backend/testfiles/execution/stdlib/option.dark
@@ -241,7 +241,8 @@ PACKAGE.Darklang.Stdlib.Option.map5_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 4)
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.Some 0
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  0
 
 PACKAGE.Darklang.Stdlib.Option.map5_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
@@ -290,18 +291,18 @@ PACKAGE.Darklang.Stdlib.Option.withDefault_v0
   5 = 5
 
 
-PACKAGE.Darklang.Stdlib.Option.isSome_v0
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6) = true
+PACKAGE.Darklang.Stdlib.Option.isSome_v0 (
+  PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+) = true
 
-PACKAGE.Darklang.Stdlib.Option.isSome_v0
-  PACKAGE.Darklang.Stdlib.Option.Option.None = false
+PACKAGE.Darklang.Stdlib.Option.isSome_v0 PACKAGE.Darklang.Stdlib.Option.Option.None = false
 
 
-PACKAGE.Darklang.Stdlib.Option.isNone_v0
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6) = false
+PACKAGE.Darklang.Stdlib.Option.isNone_v0 (
+  PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+) = false
 
-PACKAGE.Darklang.Stdlib.Option.isNone_v0
-  PACKAGE.Darklang.Stdlib.Option.Option.None = true
+PACKAGE.Darklang.Stdlib.Option.isNone_v0 PACKAGE.Darklang.Stdlib.Option.Option.None = true
 
 
 PACKAGE.Darklang.Stdlib.Option.toResult_v0
@@ -315,7 +316,8 @@ PACKAGE.Darklang.Stdlib.Option.toResult_v0
 
 PACKAGE.Darklang.Stdlib.Option.and_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  5
 
 PACKAGE.Darklang.Stdlib.Option.and_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
@@ -332,37 +334,41 @@ PACKAGE.Darklang.Stdlib.Option.and_v0
 
 PACKAGE.Darklang.Stdlib.Option.or_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  6
 
 PACKAGE.Darklang.Stdlib.Option.or_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 6)
-  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  6
 
 PACKAGE.Darklang.Stdlib.Option.or_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+  (PACKAGE.Darklang.Stdlib.Option.Option.Some 5) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  5
 
 PACKAGE.Darklang.Stdlib.Option.or_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
-PACKAGE.Darklang.Stdlib.Option.toList_v0
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some 6) = [6]
+PACKAGE.Darklang.Stdlib.Option.toList_v0 (
+  PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+) = [ 6 ]
 
-PACKAGE.Darklang.Stdlib.Option.toList_v0
-  PACKAGE.Darklang.Stdlib.Option.Option.None = []
+PACKAGE.Darklang.Stdlib.Option.toList_v0 PACKAGE.Darklang.Stdlib.Option.Option.None = []
 
 
-PACKAGE.Darklang.Stdlib.Option.join_v0
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some(
+PACKAGE.Darklang.Stdlib.Option.join_v0 (
+  PACKAGE.Darklang.Stdlib.Option.Option.Some(
     PACKAGE.Darklang.Stdlib.Option.Option.Some 6
-   )) = PACKAGE.Darklang.Stdlib.Option.Option.Some 6
+  )
+) = PACKAGE.Darklang.Stdlib.Option.Option.Some 6
 
-PACKAGE.Darklang.Stdlib.Option.join_v0
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some(
+PACKAGE.Darklang.Stdlib.Option.join_v0 (
+  PACKAGE.Darklang.Stdlib.Option.Option.Some(
     PACKAGE.Darklang.Stdlib.Option.Option.None
-   )) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  )
+) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
-PACKAGE.Darklang.Stdlib.Option.join_v0
-  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None
+PACKAGE.Darklang.Stdlib.Option.join_v0 PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Option.Option.None

--- a/backend/testfiles/execution/stdlib/option.dark
+++ b/backend/testfiles/execution/stdlib/option.dark
@@ -143,53 +143,53 @@ PACKAGE.Darklang.Stdlib.Option.map
 PACKAGE.Darklang.Stdlib.Option.map2_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.Some 9
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.Some 9
 
 PACKAGE.Darklang.Stdlib.Option.map2_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
   PACKAGE.Darklang.Stdlib.Option.Option.None
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map2_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map2_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
 PACKAGE.Darklang.Stdlib.Option.map3_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.Some 7
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.Some 7
 
 PACKAGE.Darklang.Stdlib.Option.map3_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map3_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map3_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map3_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
 PACKAGE.Darklang.Stdlib.Option.map4_v0
@@ -197,42 +197,42 @@ PACKAGE.Darklang.Stdlib.Option.map4_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.Some 4
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.Some 4
 
 PACKAGE.Darklang.Stdlib.Option.map4_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 10)
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map4_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map4_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map4_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map4_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
 PACKAGE.Darklang.Stdlib.Option.map5_v0
@@ -241,7 +241,7 @@ PACKAGE.Darklang.Stdlib.Option.map5_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 4)
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.Some
   0
 
 PACKAGE.Darklang.Stdlib.Option.map5_v0
@@ -250,7 +250,7 @@ PACKAGE.Darklang.Stdlib.Option.map5_v0
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 2)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 3)
   (PACKAGE.Darklang.Stdlib.Option.Option.Some 4)
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 PACKAGE.Darklang.Stdlib.Option.map5_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
@@ -258,7 +258,7 @@ PACKAGE.Darklang.Stdlib.Option.map5_v0
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
   PACKAGE.Darklang.Stdlib.Option.Option.None
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
 PACKAGE.Darklang.Stdlib.Option.mapWithDefault_v0

--- a/backend/testfiles/execution/stdlib/result.dark
+++ b/backend/testfiles/execution/stdlib/result.dark
@@ -77,27 +77,27 @@ PACKAGE.Darklang.Stdlib.Result.fromOption
 PACKAGE.Darklang.Stdlib.Result.map2_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map2_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map2_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error2"
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error2"
 
 PACKAGE.Darklang.Stdlib.Result.map2_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b) -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9
+  (fun a b -> a - b) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9
 
 PACKAGE.Darklang.Stdlib.Result.map2_v0
   (Builtin.Test.okWithTypeError "err")
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b) -> a - b) = Builtin.Test.derrorMessage "err"
+  (fun a b -> a - b) = Builtin.Test.derrorMessage "err"
 
 
 

--- a/backend/testfiles/execution/stdlib/result.dark
+++ b/backend/testfiles/execution/stdlib/result.dark
@@ -105,31 +105,31 @@ PACKAGE.Darklang.Stdlib.Result.map3_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map3_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map3_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error2"
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error2"
 
 PACKAGE.Darklang.Stdlib.Result.map3_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error3"
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error3"
 
 PACKAGE.Darklang.Stdlib.Result.map3_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 8
+  (fun a b c -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 8
 
 
 PACKAGE.Darklang.Stdlib.Result.map4_v0
@@ -137,7 +137,7 @@ PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map4_v0
@@ -145,7 +145,7 @@ PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map4_v0
@@ -153,7 +153,7 @@ PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "error4"
 
 PACKAGE.Darklang.Stdlib.Result.map4_v0
@@ -161,7 +161,7 @@ PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 6
+  (fun a b c d -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 6
 
 
 PACKAGE.Darklang.Stdlib.Result.map5_v0
@@ -170,7 +170,7 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error5")
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map5_v0
@@ -179,7 +179,7 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map5_v0
@@ -188,7 +188,7 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error5")
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "error5"
 
 PACKAGE.Darklang.Stdlib.Result.map5_v0
@@ -197,8 +197,7 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 3)
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  3
+  (fun a b c d e -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 3
 
 
 

--- a/backend/testfiles/execution/stdlib/result.dark
+++ b/backend/testfiles/execution/stdlib/result.dark
@@ -101,6 +101,117 @@ PACKAGE.Darklang.Stdlib.Result.map2_v0
 
 
 
+PACKAGE.Darklang.Stdlib.Result.map3_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+
+PACKAGE.Darklang.Stdlib.Result.map3_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+
+PACKAGE.Darklang.Stdlib.Result.map3_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error2"
+
+PACKAGE.Darklang.Stdlib.Result.map3_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error3"
+
+PACKAGE.Darklang.Stdlib.Result.map3_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (fun (a, b, c) -> a - b - c) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 8
+
+
+PACKAGE.Darklang.Stdlib.Result.map4_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+
+PACKAGE.Darklang.Stdlib.Result.map4_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+
+PACKAGE.Darklang.Stdlib.Result.map4_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error4"
+
+PACKAGE.Darklang.Stdlib.Result.map4_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 6
+
+
+PACKAGE.Darklang.Stdlib.Result.map5_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error5")
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+
+PACKAGE.Darklang.Stdlib.Result.map5_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+
+PACKAGE.Darklang.Stdlib.Result.map5_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "error5")
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error5"
+
+PACKAGE.Darklang.Stdlib.Result.map5_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 3)
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 3
+
+
+
+PACKAGE.Darklang.Stdlib.Result.mapWithDefault_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test")
+  5
+  (fun x -> x + 1) = 5
+
+PACKAGE.Darklang.Stdlib.Result.mapWithDefault_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok 6)
+  5
+  (fun x -> x + 1) = 7
+
+PACKAGE.Darklang.Stdlib.Result.mapWithDefault_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test2")
+  (fun x -> x + 1) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+
+
+
 PACKAGE.Darklang.Stdlib.Result.mapError
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "test")
   (fun x -> PACKAGE.Darklang.Stdlib.String.append x "-appended") = PACKAGE.Darklang.Stdlib.Result.Result.Error
@@ -141,3 +252,73 @@ PACKAGE.Darklang.Stdlib.Result.withDefault_v0
 PACKAGE.Darklang.Stdlib.Result.withDefault_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 6)
   5 = 6
+
+
+
+PACKAGE.Darklang.Stdlib.Result.isOk_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test"
+) = true
+
+PACKAGE.Darklang.Stdlib.Result.isOk_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+) = false
+
+
+PACKAGE.Darklang.Stdlib.Result.isError_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test"
+) = false
+
+PACKAGE.Darklang.Stdlib.Result.isError_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+) = true
+
+
+PACKAGE.Darklang.Stdlib.Result.and_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+
+PACKAGE.Darklang.Stdlib.Result.and_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+
+PACKAGE.Darklang.Stdlib.Result.and_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+
+PACKAGE.Darklang.Stdlib.Result.and_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+
+
+PACKAGE.Darklang.Stdlib.Result.or_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+
+PACKAGE.Darklang.Stdlib.Result.or_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+
+PACKAGE.Darklang.Stdlib.Result.or_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+
+PACKAGE.Darklang.Stdlib.Result.or_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+) (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+

--- a/backend/testfiles/execution/stdlib/result.dark
+++ b/backend/testfiles/execution/stdlib/result.dark
@@ -137,21 +137,24 @@ PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error2")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
-  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error4"
+  (fun (a, b, c, d) -> a - b - c - d) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "error4"
 
 PACKAGE.Darklang.Stdlib.Result.map4_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
@@ -167,7 +170,8 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error5")
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error1")
@@ -175,7 +179,8 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error3")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error4")
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error1"
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "error1"
 
 PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
@@ -183,7 +188,8 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "error5")
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error "error5"
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "error5"
 
 PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 10)
@@ -191,7 +197,8 @@ PACKAGE.Darklang.Stdlib.Result.map5_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
   (PACKAGE.Darklang.Stdlib.Result.Result.Ok 3)
-  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Ok 3
+  (fun (a, b, c, d, e) -> a - b - c - d - e) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  3
 
 
 
@@ -273,52 +280,43 @@ PACKAGE.Darklang.Stdlib.Result.isError_v0 (
 ) = true
 
 
-PACKAGE.Darklang.Stdlib.Result.and_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+PACKAGE.Darklang.Stdlib.Result.and_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  "test2"
 
-PACKAGE.Darklang.Stdlib.Result.and_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
+PACKAGE.Darklang.Stdlib.Result.and_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "test2"
 
-PACKAGE.Darklang.Stdlib.Result.and_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+PACKAGE.Darklang.Stdlib.Result.and_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "test1"
 
-PACKAGE.Darklang.Stdlib.Result.and_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+PACKAGE.Darklang.Stdlib.Result.and_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "test1"
 
 
-PACKAGE.Darklang.Stdlib.Result.or_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+PACKAGE.Darklang.Stdlib.Result.or_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  "test1"
 
-PACKAGE.Darklang.Stdlib.Result.or_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1"
+PACKAGE.Darklang.Stdlib.Result.or_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  "test1"
 
-PACKAGE.Darklang.Stdlib.Result.or_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2"
+PACKAGE.Darklang.Stdlib.Result.or_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Ok "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  "test2"
 
-PACKAGE.Darklang.Stdlib.Result.or_v0 (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
-) (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test2"
-
+PACKAGE.Darklang.Stdlib.Result.or_v0
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test1")
+  (PACKAGE.Darklang.Stdlib.Result.Result.Error "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "test2"

--- a/backend/testfiles/execution/stdlib/result.dark
+++ b/backend/testfiles/execution/stdlib/result.dark
@@ -320,3 +320,29 @@ PACKAGE.Darklang.Stdlib.Result.or_v0
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "test1")
   (PACKAGE.Darklang.Stdlib.Result.Result.Error "test2") = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "test2"
+
+
+PACKAGE.Darklang.Stdlib.Result.toList_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok "test"
+) = [ "test" ]
+
+PACKAGE.Darklang.Stdlib.Result.toList_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+) = []
+
+
+PACKAGE.Darklang.Stdlib.Result.join_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok "test"
+  )
+) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "test"
+
+PACKAGE.Darklang.Stdlib.Result.join_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+  )
+) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+
+PACKAGE.Darklang.Stdlib.Result.join_v0 (
+  PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test"

--- a/backend/testfiles/execution/stdlib/result.dark
+++ b/backend/testfiles/execution/stdlib/result.dark
@@ -345,3 +345,45 @@ PACKAGE.Darklang.Stdlib.Result.join_v0 (
 PACKAGE.Darklang.Stdlib.Result.join_v0 (
   PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
 ) = PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+
+
+PACKAGE.Darklang.Stdlib.Result.combine_v0
+  [ PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 2
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 3 ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  [ 1; 2; 3 ]
+
+PACKAGE.Darklang.Stdlib.Result.combine_v0
+  [ PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 3 ] = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "test"
+
+PACKAGE.Darklang.Stdlib.Result.combine_v0
+  [ PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "test2" ] = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "test1"
+
+PACKAGE.Darklang.Stdlib.Result.combine_v0 [] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  []
+
+
+PACKAGE.Darklang.Stdlib.Result.values_v0
+  [ PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 2
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 3 ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  [ 1; 2; 3 ]
+
+PACKAGE.Darklang.Stdlib.Result.values_v0
+  [ PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 3 ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  [ 1; 3 ]
+
+PACKAGE.Darklang.Stdlib.Result.values_v0
+  [ PACKAGE.Darklang.Stdlib.Result.Result.Error "test1"
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "test2" ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  []
+
+PACKAGE.Darklang.Stdlib.Result.values_v0 [] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  []

--- a/packages/darklang/stdlib/fun.dark
+++ b/packages/darklang/stdlib/fun.dark
@@ -1,0 +1,4 @@
+module Darklang =
+  module Stdlib =
+    module Fun =
+      let identity (value: 'a) : 'a = value

--- a/packages/darklang/stdlib/option.dark
+++ b/packages/darklang/stdlib/option.dark
@@ -225,3 +225,29 @@ module Darklang =
         match option with
         | Some v -> v
         | None -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+      /// Combines a list of options into a single option containing a list of unwrapped values.
+      /// If all options in the list are {{Some _}}, then return {{Some <list of unwrapped values>}}.
+      /// If any option is {{None}}, then return {{None}}.
+      let combine
+        (options: List<PACKAGE.Darklang.Stdlib.Option.Option<'a>>)
+        : PACKAGE.Darklang.Stdlib.Option.Option<List<'a>> =
+        PACKAGE.Darklang.Stdlib.List.fold
+          options
+          (PACKAGE.Darklang.Stdlib.Option.Option.Some [])
+          (fun acc option ->
+            PACKAGE.Darklang.Stdlib.Option.andThen2 acc option (fun acc value ->
+              PACKAGE.Darklang.Stdlib.Option.Option.Some(
+                PACKAGE.Darklang.Stdlib.List.append acc [ value ]
+              )))
+
+
+      /// Returns a list of all the values that are present, throwing away any Nothings
+      let values
+        (options: List<PACKAGE.Darklang.Stdlib.Option.Option<'a>>)
+        : List<'a> =
+        PACKAGE.Darklang.Stdlib.List.filterMap options (fun option ->
+          match option with
+          | Some v -> PACKAGE.Darklang.Stdlib.Option.Option.Some v
+          | None -> PACKAGE.Darklang.Stdlib.Option.Option.None)

--- a/packages/darklang/stdlib/option.dark
+++ b/packages/darklang/stdlib/option.dark
@@ -40,9 +40,15 @@ module Darklang =
       /// then return {{Some (fn <var v1> <var v2> <var v3>)}}. The lambda <param fn> should have three parameters,
       /// representing <var v1>, <var v2>, and <var v3>. But if any of <param option1>, <param option2>, or
       /// <param option3> are {{None}}, returns {{None}} without applying <param fn>.
-      let map3 (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>) (fn: 'a -> 'b -> 'c -> 'd) : PACKAGE.Darklang.Stdlib.Option.Option<'d> =
+      let map3
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>)
+        (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>)
+        (fn: 'a -> 'b -> 'c -> 'd)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'d> =
         match (option1, option2, option3) with
-        | Some v1, Some v2, Some v3 -> PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3)
+        | Some v1, Some v2, Some v3 ->
+          PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3)
         | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
@@ -51,9 +57,16 @@ module Darklang =
       /// then return {{Some (fn <var v1> <var v2> <var v3> <var v4>)}}. The lambda <param fn> should have four parameters,
       /// representing <var v1>, <var v2>, <var v3>, and <var v4>. But if any of <param option1>, <param option2>, <param option3>, or
       /// <param option4> are {{None}}, returns {{None}} without applying <param fn>.
-      let map4 (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>) (option4: PACKAGE.Darklang.Stdlib.Option.Option<'d>) (fn: 'a -> 'b -> 'c -> 'd -> 'e) : PACKAGE.Darklang.Stdlib.Option.Option<'e> =
+      let map4
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>)
+        (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>)
+        (option4: PACKAGE.Darklang.Stdlib.Option.Option<'d>)
+        (fn: 'a -> 'b -> 'c -> 'd -> 'e)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'e> =
         match (option1, option2, option3, option4) with
-        | Some v1, Some v2, Some v3, Some v4 -> PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3 v4)
+        | Some v1, Some v2, Some v3, Some v4 ->
+          PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3 v4)
         | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
@@ -62,14 +75,26 @@ module Darklang =
       /// then return {{Some (fn <var v1> <var v2> <var v3> <var v4> <var v5>)}}. The lambda <param fn> should have five parameters,
       /// representing <var v1>, <var v2>, <var v3>, <var v4>, and <var v5>. But if any of <param option1>, <param option2>, <param option3>, <param option4>, or
       /// <param option5> are {{None}}, returns {{None}} without applying <param fn>.
-      let map5 (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>) (option4: PACKAGE.Darklang.Stdlib.Option.Option<'d>) (option5: PACKAGE.Darklang.Stdlib.Option.Option<'e>) (fn: 'a -> 'b -> 'c -> 'd -> 'e -> 'f) : PACKAGE.Darklang.Stdlib.Option.Option<'f> =
+      let map5
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>)
+        (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>)
+        (option4: PACKAGE.Darklang.Stdlib.Option.Option<'d>)
+        (option5: PACKAGE.Darklang.Stdlib.Option.Option<'e>)
+        (fn: 'a -> 'b -> 'c -> 'd -> 'e -> 'f)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'f> =
         match (option1, option2, option3, option4, option5) with
-        | Some v1, Some v2, Some v3, Some v4, Some v5 -> PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3 v4 v5)
+        | Some v1, Some v2, Some v3, Some v4, Some v5 ->
+          PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3 v4 v5)
         | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
       /// If <param option> is {{Some <var value>}}, returns {{fn <var value>}}. The lambda <fn fn> is applied to <var value> and the result is wrapped in {{Some}}. Otherwise, returns {{None}}
-      let mapWithDefault (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (default_: 'b) (fn: 'a -> 'b) : 'b =
+      let mapWithDefault
+        (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (default_: 'b)
+        (fn: 'a -> 'b)
+        : 'b =
         match option with
         | Some v -> fn v
         | None -> default_
@@ -155,7 +180,10 @@ module Darklang =
 
 
       /// Turn a <type Option> into a <type Result>, using <param error> as the error message for Error. if <param option> is {{Some <var value>}}, returns {{Ok <var value>}}. Otherwise, returns {{Error <var error>}}
-      let toResult (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (error: 'e) : PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e> =
+      let toResult
+        (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (error: 'e)
+        : PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e> =
         match option with
         | Some v -> PACKAGE.Darklang.Stdlib.Result.Result.Ok v
         | None -> PACKAGE.Darklang.Stdlib.Result.Result.Error error
@@ -163,14 +191,20 @@ module Darklang =
 
       /// If <param option1> is {{Some _}}, then returns the value of <param option2>.
       /// Otherwise, returns {{None}}.
-      let ``and`` (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) : PACKAGE.Darklang.Stdlib.Option.Option<'b> =
+      let ``and``
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'b> =
         match option1 with
         | Some _ -> option2
         | None -> option1
 
 
       /// Returns <param option1> if it is {{Some _}}. Otherwise, returns <param option2>.
-      let ``or`` (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'a>) : PACKAGE.Darklang.Stdlib.Option.Option<'a> =
+      let ``or``
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'a> =
         match option1 with
         | Some _ -> option1
         | None -> option2
@@ -179,14 +213,15 @@ module Darklang =
       /// Returns a list containing the value of <param option> if it is {{Some _}}. Otherwise, returns an empty list.
       let toList (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>) : List<'a> =
         match option with
-        | Some v -> [v]
+        | Some v -> [ v ]
         | None -> []
 
 
       /// Flattens a nested option. If <param option> is {{Some (Some <var value>)}}, returns {{Some <var value>}}. If <param option> is {{Some None}}, returns {{None}}.
-      let join (option: PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Option.Option<'a>>) : PACKAGE.Darklang.Stdlib.Option.Option<'a> =
+      let join
+        (option:
+          PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Option.Option<'a>>)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'a> =
         match option with
         | Some v -> v
         | None -> PACKAGE.Darklang.Stdlib.Option.Option.None
-
-

--- a/packages/darklang/stdlib/option.dark
+++ b/packages/darklang/stdlib/option.dark
@@ -247,5 +247,4 @@ module Darklang =
       let values
         (options: List<PACKAGE.Darklang.Stdlib.Option.Option<'a>>)
         : List<'a> =
-        PACKAGE.Darklang.Stdlib.List.filterMap options (fun option ->
-          Fun.identity option)
+        PACKAGE.Darklang.Stdlib.List.filterMap options (fun option -> option)

--- a/packages/darklang/stdlib/option.dark
+++ b/packages/darklang/stdlib/option.dark
@@ -248,6 +248,4 @@ module Darklang =
         (options: List<PACKAGE.Darklang.Stdlib.Option.Option<'a>>)
         : List<'a> =
         PACKAGE.Darklang.Stdlib.List.filterMap options (fun option ->
-          match option with
-          | Some v -> PACKAGE.Darklang.Stdlib.Option.Option.Some v
-          | None -> PACKAGE.Darklang.Stdlib.Option.Option.None)
+          Fun.identity option)

--- a/packages/darklang/stdlib/option.dark
+++ b/packages/darklang/stdlib/option.dark
@@ -243,7 +243,7 @@ module Darklang =
               )))
 
 
-      /// Returns a list of all the values that are present, throwing away any Nothings
+      /// Returns a list of all the values that are {{Some _}}, and ignores all the {{None}} values.
       let values
         (options: List<PACKAGE.Darklang.Stdlib.Option.Option<'a>>)
         : List<'a> =

--- a/packages/darklang/stdlib/option.dark
+++ b/packages/darklang/stdlib/option.dark
@@ -35,6 +35,46 @@ module Darklang =
         | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
+      /// if all three arguments are {{Some}} (<param option1> is {{Some <var v1>}},
+      /// <param option2> is {{Some <var v2>}}, and <param option3> is {{Some <var v3>}}),
+      /// then return {{Some (fn <var v1> <var v2> <var v3>)}}. The lambda <param fn> should have three parameters,
+      /// representing <var v1>, <var v2>, and <var v3>. But if any of <param option1>, <param option2>, or
+      /// <param option3> are {{None}}, returns {{None}} without applying <param fn>.
+      let map3 (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>) (fn: 'a -> 'b -> 'c -> 'd) : PACKAGE.Darklang.Stdlib.Option.Option<'d> =
+        match (option1, option2, option3) with
+        | Some v1, Some v2, Some v3 -> PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3)
+        | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+      /// if all four arguments are {{Some}} (<param option1> is {{Some <var v1>}},
+      /// <param option2> is {{Some <var v2>}}, <param option3> is {{Some <var v3>}}, and <param option4> is {{Some <var v4>}}),
+      /// then return {{Some (fn <var v1> <var v2> <var v3> <var v4>)}}. The lambda <param fn> should have four parameters,
+      /// representing <var v1>, <var v2>, <var v3>, and <var v4>. But if any of <param option1>, <param option2>, <param option3>, or
+      /// <param option4> are {{None}}, returns {{None}} without applying <param fn>.
+      let map4 (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>) (option4: PACKAGE.Darklang.Stdlib.Option.Option<'d>) (fn: 'a -> 'b -> 'c -> 'd -> 'e) : PACKAGE.Darklang.Stdlib.Option.Option<'e> =
+        match (option1, option2, option3, option4) with
+        | Some v1, Some v2, Some v3, Some v4 -> PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3 v4)
+        | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+      /// if all five arguments are {{Some}} (<param option1> is {{Some <var v1>}},
+      /// <param option2> is {{Some <var v2>}}, <param option3> is {{Some <var v3>}}, <param option4> is {{Some <var v4>}}, and <param option5> is {{Some <var v5>}}),
+      /// then return {{Some (fn <var v1> <var v2> <var v3> <var v4> <var v5>)}}. The lambda <param fn> should have five parameters,
+      /// representing <var v1>, <var v2>, <var v3>, <var v4>, and <var v5>. But if any of <param option1>, <param option2>, <param option3>, <param option4>, or
+      /// <param option5> are {{None}}, returns {{None}} without applying <param fn>.
+      let map5 (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>) (option4: PACKAGE.Darklang.Stdlib.Option.Option<'d>) (option5: PACKAGE.Darklang.Stdlib.Option.Option<'e>) (fn: 'a -> 'b -> 'c -> 'd -> 'e -> 'f) : PACKAGE.Darklang.Stdlib.Option.Option<'f> =
+        match (option1, option2, option3, option4, option5) with
+        | Some v1, Some v2, Some v3, Some v4, Some v5 -> PACKAGE.Darklang.Stdlib.Option.Option.Some(fn v1 v2 v3 v4 v5)
+        | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+      /// If <param option> is {{Some <var value>}}, returns {{fn <var value>}}. The lambda <fn fn> is applied to <var value> and the result is wrapped in {{Some}}. Otherwise, returns {{None}}
+      let mapWithDefault (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (default_: 'b) (fn: 'a -> 'b) : 'b =
+        match option with
+        | Some v -> fn v
+        | None -> default_
+
+
       /// If <param option> is {{Some <var value>}}, returns {{fn <var value>}}. The
       /// lambda <fn fn> is applied to <var value> and the result is wrapped in
       /// {{Some}}. Otherwise, returns {{None}}
@@ -45,6 +85,48 @@ module Darklang =
         match option with
         | Some v -> fn v
         | None -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+      /// If both <param option1> and <param option2> are {{Some}}, returns {{fn <var value1, value2>}}.
+      /// The lambda <fn fn> is applied to <var value1> and <var value2> and the result is wrapped in
+      /// {{Some}}. Otherwise, returns {{None}}
+      let andThen2
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>)
+        (fn: 'a -> 'b -> PACKAGE.Darklang.Stdlib.Option.Option<'c>)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'c> =
+        match (option1, option2) with
+        | Some v1, Some v2 -> fn v1 v2
+        | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+      /// If all <param option1>, <param option2>, and <param option3> are {{Some}}, returns {{fn <var value1, value2, value3>}}.
+      /// The lambda <fn fn> is applied to <var value1>, <var value2>, and <var value3> and the result is wrapped in
+      /// {{Some}}. Otherwise, returns {{None}}
+      let andThen3
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>)
+        (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>)
+        (fn: 'a -> 'b -> 'c -> PACKAGE.Darklang.Stdlib.Option.Option<'d>)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'d> =
+        match (option1, option2, option3) with
+        | Some v1, Some v2, Some v3 -> fn v1 v2 v3
+        | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+
+      /// If all <param option1>, <param option2>, <param option3>, and <param option4> are {{Some}}, returns {{fn <var value1, value2, value3, value4>}}.
+      /// The lambda <fn fn> is applied to <var value1>, <var value2>, <var value3>, and <var value4> and the result is wrapped in
+      /// {{Some}}. Otherwise, returns {{None}}
+      let andThen4
+        (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>)
+        (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>)
+        (option3: PACKAGE.Darklang.Stdlib.Option.Option<'c>)
+        (option4: PACKAGE.Darklang.Stdlib.Option.Option<'d>)
+        (fn: 'a -> 'b -> 'c -> 'd -> PACKAGE.Darklang.Stdlib.Option.Option<'e>)
+        : PACKAGE.Darklang.Stdlib.Option.Option<'e> =
+        match (option1, option2, option3, option4) with
+        | Some v1, Some v2, Some v3, Some v4 -> fn v1 v2 v3 v4
+        | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
 
 
       /// If <param option> is {{Some <var value>}}, returns <var value>. Otherwise,
@@ -70,3 +152,41 @@ module Darklang =
         match option with
         | Some _ -> false
         | None -> true
+
+
+      /// Turn a <type Option> into a <type Result>, using <param error> as the error message for Error. if <param option> is {{Some <var value>}}, returns {{Ok <var value>}}. Otherwise, returns {{Error <var error>}}
+      let toResult (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (error: 'e) : PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e> =
+        match option with
+        | Some v -> PACKAGE.Darklang.Stdlib.Result.Result.Ok v
+        | None -> PACKAGE.Darklang.Stdlib.Result.Result.Error error
+
+
+      /// If <param option1> is {{Some _}}, then returns the value of <param option2>.
+      /// Otherwise, returns {{None}}.
+      let ``and`` (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'b>) : PACKAGE.Darklang.Stdlib.Option.Option<'b> =
+        match option1 with
+        | Some _ -> option2
+        | None -> option1
+
+
+      /// Returns <param option1> if it is {{Some _}}. Otherwise, returns <param option2>.
+      let ``or`` (option1: PACKAGE.Darklang.Stdlib.Option.Option<'a>) (option2: PACKAGE.Darklang.Stdlib.Option.Option<'a>) : PACKAGE.Darklang.Stdlib.Option.Option<'a> =
+        match option1 with
+        | Some _ -> option1
+        | None -> option2
+
+
+      /// Returns a list containing the value of <param option> if it is {{Some _}}. Otherwise, returns an empty list.
+      let toList (option: PACKAGE.Darklang.Stdlib.Option.Option<'a>) : List<'a> =
+        match option with
+        | Some v -> [v]
+        | None -> []
+
+
+      /// Flattens a nested option. If <param option> is {{Some (Some <var value>)}}, returns {{Some <var value>}}. If <param option> is {{Some None}}, returns {{None}}.
+      let join (option: PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Option.Option<'a>>) : PACKAGE.Darklang.Stdlib.Option.Option<'a> =
+        match option with
+        | Some v -> v
+        | None -> PACKAGE.Darklang.Stdlib.Option.Option.None
+
+

--- a/packages/darklang/stdlib/result.dark
+++ b/packages/darklang/stdlib/result.dark
@@ -222,3 +222,22 @@ module Darklang =
         match result1 with
         | Ok _ -> result1
         | Error _ -> result2
+
+
+      /// Returns a list containing <param value> if <param result> is {{Ok <var value>}}. Otherwise, returns an empty list.
+      let toList (result: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) : List<'t> =
+        match result with
+        | Ok value -> [ value ]
+        | Error _ -> []
+
+
+      /// Flattens a nested result. If <param result> is {{Ok (Ok <var value>)}},
+      /// returns {{Ok <var value>}}. If <param result> is {{Ok (Error <var msg>)}}, returns {{Error <var msg>}}.
+      /// If <param result> is {{Error <var msg>}}, returns {{Error <var msg>}}.
+      let join
+        (result:
+          PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>, 'e>)
+        : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
+        match result with
+        | Ok value -> value
+        | Error e -> PACKAGE.Darklang.Stdlib.Result.Result.Error e

--- a/packages/darklang/stdlib/result.dark
+++ b/packages/darklang/stdlib/result.dark
@@ -42,9 +42,15 @@ module Darklang =
       /// to <var v1>, <var v2>, and <var v3>, and the result is wrapped in {{Ok}}.
       /// Otherwise, returns the first of <param result1>, <param result2>, and
       /// <param result3> that is an error.
-      let map3 (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>) (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>) (fn: 'a -> 'b -> 'c -> 'd) : PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e> =
+      let map3
+        (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>)
+        (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>)
+        (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>)
+        (fn: 'a -> 'b -> 'c -> 'd)
+        : PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e> =
         match (result1, result2, result3) with
-        | (Ok v1, Ok v2, Ok v3) -> PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3)
+        | (Ok v1, Ok v2, Ok v3) ->
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3)
         | (Error e1, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e1
         | (_, Error e2, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
         | (_, _, Error e3) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e3
@@ -57,9 +63,16 @@ module Darklang =
       /// and the result is wrapped in {{Ok}}. Otherwise, returns the first of <param
       /// result1>, <param result2>, <param result3>, and <param result4> that is an
       /// error.
-      let map4 (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>) (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>) (result4: PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e>) (fn: 'a -> 'b -> 'c -> 'd -> 'f) : PACKAGE.Darklang.Stdlib.Result.Result<'f, 'e> =
+      let map4
+        (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>)
+        (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>)
+        (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>)
+        (result4: PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e>)
+        (fn: 'a -> 'b -> 'c -> 'd -> 'f)
+        : PACKAGE.Darklang.Stdlib.Result.Result<'f, 'e> =
         match (result1, result2, result3, result4) with
-        | (Ok v1, Ok v2, Ok v3, Ok v4) -> PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3 v4)
+        | (Ok v1, Ok v2, Ok v3, Ok v4) ->
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3 v4)
         | (Error e1, _, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e1
         | (_, Error e2, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
         | (_, _, Error e3, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e3
@@ -73,9 +86,17 @@ module Darklang =
       /// <var v1>, <var v2>, <var v3>, <var v4>, and <var v5>, and the result is
       /// wrapped in {{Ok}}. Otherwise, returns the first of <param result1>, <param
       /// result2>, <param result3>, <param result4>, and <param result5> that is an error.
-      let map5 (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>) (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>) (result4: PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e>) (result5: PACKAGE.Darklang.Stdlib.Result.Result<'f, 'e>) (fn: 'a -> 'b -> 'c -> 'd -> 'f -> 'g) : PACKAGE.Darklang.Stdlib.Result.Result<'g, 'e> =
+      let map5
+        (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>)
+        (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>)
+        (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>)
+        (result4: PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e>)
+        (result5: PACKAGE.Darklang.Stdlib.Result.Result<'f, 'e>)
+        (fn: 'a -> 'b -> 'c -> 'd -> 'f -> 'g)
+        : PACKAGE.Darklang.Stdlib.Result.Result<'g, 'e> =
         match (result1, result2, result3, result4, result5) with
-        | (Ok v1, Ok v2, Ok v3, Ok v4, Ok v5) -> PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3 v4 v5)
+        | (Ok v1, Ok v2, Ok v3, Ok v4, Ok v5) ->
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3 v4 v5)
         | (Error e1, _, _, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e1
         | (_, Error e2, _, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
         | (_, _, Error e3, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e3
@@ -184,15 +205,20 @@ module Darklang =
         | Error _ -> true
 
       /// Returns <param result2> if <param result1> is {{Ok <var value>}}. Otherwise, returns <param result1>.
-      let ``and`` (result1: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
+      let ``and``
+        (result1: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>)
+        (result2: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>)
+        : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
         match result1 with
         | Ok _ -> result2
         | Error _ -> result1
 
 
       /// Returns <param result1> if it is {{Ok _}}. Otherwise, returns <param result2>.
-      let ``or`` (result1: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
+      let ``or``
+        (result1: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>)
+        (result2: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>)
+        : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
         match result1 with
         | Ok _ -> result1
         | Error _ -> result2
-

--- a/packages/darklang/stdlib/result.dark
+++ b/packages/darklang/stdlib/result.dark
@@ -241,3 +241,39 @@ module Darklang =
         match result with
         | Ok value -> value
         | Error e -> PACKAGE.Darklang.Stdlib.Result.Result.Error e
+
+
+      /// Combines a list of results into a single list of unwrapped values.
+      /// If all of the results are {{Ok <var value>}}, returns {{Ok <list of unwrapped values>}}.
+      /// If any of the results are {{Error <var msg>}}, returns {{Error <var msg>}}.
+      let combine
+        (results: List<PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>>)
+        : PACKAGE.Darklang.Stdlib.Result.Result<List<'t>, 'e> =
+        results
+        |> PACKAGE.Darklang.Stdlib.List.fold
+          (PACKAGE.Darklang.Stdlib.Result.Result.Ok [])
+          (fun acc result ->
+            match (acc, result) with
+            | (Ok acc, Ok result) ->
+              PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+                PACKAGE.Darklang.Stdlib.List.pushBack acc result
+              )
+            | (Ok _, Error err) -> PACKAGE.Darklang.Stdlib.Result.Result.Error err
+            | (Error err, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error err)
+
+
+      /// Returns a list of all the values that are {{Ok <var value>}}, and ignores any values that are {{Error <var msg>}}.
+      let values
+        (results: List<PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>>)
+        : PACKAGE.Darklang.Stdlib.Result.Result<List<'t>, 'e> =
+        results
+        |> PACKAGE.Darklang.Stdlib.List.fold
+          (PACKAGE.Darklang.Stdlib.Result.Result.Ok [])
+          (fun acc result ->
+            match (acc, result) with
+            | (Ok acc, Ok result) ->
+              PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+                PACKAGE.Darklang.Stdlib.List.pushBack acc result
+              )
+            | (Ok _, Error _) -> acc
+            | (Error err, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error err)

--- a/packages/darklang/stdlib/result.dark
+++ b/packages/darklang/stdlib/result.dark
@@ -36,6 +36,65 @@ module Darklang =
         | (_, Error e2) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
 
 
+      /// If all three of <param result1>, <param result2>, and <param result3> are
+      /// {{Ok <var v1>}}, {{Ok <var v2>}}, and {{Ok <var v3>}}, returns
+      /// {{Ok (fn <var v1> <var v2> <var v3>)}} -- the lambda <param fn> is applied
+      /// to <var v1>, <var v2>, and <var v3>, and the result is wrapped in {{Ok}}.
+      /// Otherwise, returns the first of <param result1>, <param result2>, and
+      /// <param result3> that is an error.
+      let map3 (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>) (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>) (fn: 'a -> 'b -> 'c -> 'd) : PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e> =
+        match (result1, result2, result3) with
+        | (Ok v1, Ok v2, Ok v3) -> PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3)
+        | (Error e1, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e1
+        | (_, Error e2, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
+        | (_, _, Error e3) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e3
+
+
+      /// If all four of <param result1>, <param result2>, <param result3>, and
+      /// <param result4> are {{Ok <var v1>}}, {{Ok <var v2>}}, {{Ok <var v3>}}, and
+      /// {{Ok <var v4>}}, returns {{Ok (fn <var v1> <var v2> <var v3> <var v4>)}}
+      /// the lambda <param fn> is applied to <var v1>, <var v2>, <var v3>, and <var v4>,
+      /// and the result is wrapped in {{Ok}}. Otherwise, returns the first of <param
+      /// result1>, <param result2>, <param result3>, and <param result4> that is an
+      /// error.
+      let map4 (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>) (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>) (result4: PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e>) (fn: 'a -> 'b -> 'c -> 'd -> 'f) : PACKAGE.Darklang.Stdlib.Result.Result<'f, 'e> =
+        match (result1, result2, result3, result4) with
+        | (Ok v1, Ok v2, Ok v3, Ok v4) -> PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3 v4)
+        | (Error e1, _, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e1
+        | (_, Error e2, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
+        | (_, _, Error e3, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e3
+        | (_, _, _, Error e4) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e4
+
+
+      /// If all five of <param result1>, <param result2>, <param result3>, <param
+      /// result4>, and <param result5> are {{Ok <var v1>}}, {{Ok <var v2>}}, {{Ok
+      /// <var v3>}}, {{Ok <var v4>}}, and {{Ok <var v5>}}, returns {{Ok (fn <var v1>
+      /// <var v2> <var v3> <var v4> <var v5>)}} the lambda <param fn> is applied to
+      /// <var v1>, <var v2>, <var v3>, <var v4>, and <var v5>, and the result is
+      /// wrapped in {{Ok}}. Otherwise, returns the first of <param result1>, <param
+      /// result2>, <param result3>, <param result4>, and <param result5> that is an error.
+      let map5 (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>) (result3: PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e>) (result4: PACKAGE.Darklang.Stdlib.Result.Result<'d, 'e>) (result5: PACKAGE.Darklang.Stdlib.Result.Result<'f, 'e>) (fn: 'a -> 'b -> 'c -> 'd -> 'f -> 'g) : PACKAGE.Darklang.Stdlib.Result.Result<'g, 'e> =
+        match (result1, result2, result3, result4, result5) with
+        | (Ok v1, Ok v2, Ok v3, Ok v4, Ok v5) -> PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2 v3 v4 v5)
+        | (Error e1, _, _, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e1
+        | (_, Error e2, _, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
+        | (_, _, Error e3, _, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e3
+        | (_, _, _, Error e4, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e4
+        | (_, _, _, _, Error e5) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e5
+
+
+      /// Applies the function <param fn> to the value inside the {{Ok <var value>}} variant of <param result>
+      /// if it exists. If <param result> is an {{Error _}}, returns the provided <param default_>.
+      let mapWithDefault
+        (result: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>)
+        (default_: 'u)
+        (fn: 't -> 'u)
+        : 'u =
+        match result with
+        | Ok value -> fn value
+        | Error _ -> default_
+
+
       /// If <param result> is {{Error <var msg>}}, returns {{Error (fn <var msg>)}}.
       /// The lambda <param fn> is applied to <var msg> and the result is wrapped in
       /// {{Error}}. If <param result> is {{Ok <var value>}}, returns <param result>
@@ -47,23 +106,6 @@ module Darklang =
         match result with
         | Ok value -> PACKAGE.Darklang.Stdlib.Result.Result.Ok value
         | Error value -> PACKAGE.Darklang.Stdlib.Result.Result.Error(fn value)
-
-
-      /// If both <param result1> is {{Ok <var v1>}} and <param result2> is {{Ok <var
-      /// v2>}}, returns {{Ok (fn <var v1> <var v2>)}} -- the lambda <param fn> is
-      /// applied to <var v1> and <var v2>, and the result is wrapped in {{Ok}}.
-      /// Otherwise, returns the first of <param result1> and <param result2> that is
-      /// an error.
-      /// TODO: not supported as we don't yet support applying against variables with arguments
-      // let map2
-      //   (result1: PACKAGE.Darklang.Stdlib.Result.Result<'a, 'e>)
-      //   (result2: PACKAGE.Darklang.Stdlib.Result.Result<'b, 'e>)
-      //   (fn: 'a -> 'b -> 'c)
-      //   : PACKAGE.Darklang.Stdlib.Result.Result<'c, 'e> =
-      //   match (result1, result2) with
-      //   | (Ok v1, Ok v2) -> PACKAGE.Darklang.Stdlib.Result.Result.Ok(fn v1 v2)
-      //   | (Error e1, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e1
-      //   | (_, Error e2) -> PACKAGE.Darklang.Stdlib.Result.Result.Error e2
 
 
       /// If <param result> is {{Ok <var value>}}, returns {{fn <var value>}}. The
@@ -126,3 +168,31 @@ module Darklang =
               )
             | (Ok _, Error err) -> PACKAGE.Darklang.Stdlib.Result.Result.Error err
             | (Error err, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error err)
+
+
+      /// If <param result> is {{Ok <var value>}}, returns true. Otherwise, returns false.
+      let isOk (result: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) : Bool =
+        match result with
+        | Ok _ -> true
+        | Error _ -> false
+
+
+      /// If <param result> is {{Error <var msg>}}, returns true. Otherwise, returns false.
+      let isError (result: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) : Bool =
+        match result with
+        | Ok _ -> false
+        | Error _ -> true
+
+      /// Returns <param result2> if <param result1> is {{Ok <var value>}}. Otherwise, returns <param result1>.
+      let ``and`` (result1: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
+        match result1 with
+        | Ok _ -> result2
+        | Error _ -> result1
+
+
+      /// Returns <param result1> if it is {{Ok _}}. Otherwise, returns <param result2>.
+      let ``or`` (result1: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) (result2: PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>) : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
+        match result1 with
+        | Ok _ -> result1
+        | Error _ -> result2
+

--- a/packages/darklang/stdlib/result.dark
+++ b/packages/darklang/stdlib/result.dark
@@ -240,7 +240,7 @@ module Darklang =
         : PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e> =
         match result with
         | Ok value -> value
-        | Error e -> PACKAGE.Darklang.Stdlib.Result.Result.Error e
+        | Error _ -> result
 
 
       /// Combines a list of results into a single list of unwrapped values.
@@ -266,14 +266,22 @@ module Darklang =
       let values
         (results: List<PACKAGE.Darklang.Stdlib.Result.Result<'t, 'e>>)
         : PACKAGE.Darklang.Stdlib.Result.Result<List<'t>, 'e> =
-        results
-        |> PACKAGE.Darklang.Stdlib.List.fold
-          (PACKAGE.Darklang.Stdlib.Result.Result.Ok [])
-          (fun acc result ->
-            match (acc, result) with
-            | (Ok acc, Ok result) ->
-              PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-                PACKAGE.Darklang.Stdlib.List.pushBack acc result
-              )
-            | (Ok _, Error _) -> acc
-            | (Error err, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error err)
+        let folded =
+          results
+          |> PACKAGE.Darklang.Stdlib.List.fold
+            (PACKAGE.Darklang.Stdlib.Result.Result.Ok [])
+            (fun acc result ->
+              match (acc, result) with
+              | (Ok acc, Ok result) ->
+                PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+                  PACKAGE.Darklang.Stdlib.List.push acc result
+                )
+              | (Ok _, Error _) -> acc
+              | (Error err, _) -> PACKAGE.Darklang.Stdlib.Result.Result.Error err)
+
+        match folded with
+        | Ok list ->
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+            PACKAGE.Darklang.Stdlib.List.reverse list
+          )
+        | Error err -> PACKAGE.Darklang.Stdlib.Result.Result.Error err


### PR DESCRIPTION
Changelog:

```
Standard library
- Add new Option and Result functions to the standard library
```
This PR introduces new Option and Result functions to the standard library, along with some tests.

Result :
- [x] isOK
- [x] isError
- [x] map3
- [x] map4
- [x] map5
- [x] mapWithDefault
- [x] or
- [x] and
- [x] toList
- [x] join
- [x] combine
- [x] values

Option: 
- [x] isSome
- [x] isNone
- [x] mapWithDefault
- [x] map3
- [x] map4
- [x] map5
- [x] join
- [x] toResult
- [x] or
- [x] and
- [x] toList
- [x]  andThen2
- [x]  andThen3
- [x]  andThen4
- [x] combine
- [x] values




