### PR TITLE
Fix packages-canvas 

### DIFF
--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -154,7 +154,7 @@ let t
             let errorMessageFn =
               RT.FnName.fqPackage
                 "Darklang"
-                [ "LanguageTools"; "RuntimeErrors"; "Error" ]
+                [ "LanguageTools"; "RuntimeErrors"; "ErrorSegment" ]
                 "toErrorMessage"
                 0
 


### PR DESCRIPTION
No changelog

Not merge-able 

I was getting the following error (see screenshot) when trying to access some dark-packages canvas endpoints (http://dark-packages.dlio.localhost:11003/functions and http://dark-packages.dlio.localhost:11003/types)
This PR fixes it

<img width="1395" alt="Screenshot 2023-09-13 at 19 31 39" src="https://github.com/darklang/dark/assets/87861924/8e40dbf6-00a8-45b1-9c34-0d96fb597816">
