### PR TITLE
Inline package functions in the sqlCompiler

### DIFF
--- a/backend/src/BuiltinExecution/Builtin.fs
+++ b/backend/src/BuiltinExecution/Builtin.fs
@@ -17,7 +17,8 @@ let typeRenames =
 
 let contents (httpConfig : Libs.HttpClient.Configuration) : Builtin.Contents =
   Builtin.combine
-    [ Libs.Bytes.contents
+    [ Libs.Bool.contents
+      Libs.Bytes.contents
       Libs.Char.contents
       Libs.DateTime.contents
       Libs.Dict.contents

--- a/backend/src/BuiltinExecution/BuiltinExecution.fsproj
+++ b/backend/src/BuiltinExecution/BuiltinExecution.fsproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <None Include="paket.references" />
     <Compile Include="Libs/Bytes.fs" />
+    <Compile Include="Libs/Bool.fs" />
     <Compile Include="Libs/Char.fs" />
     <Compile Include="Libs/Crypto.fs" />
     <Compile Include="Libs/Password.fs" />

--- a/backend/src/BuiltinExecution/Libs/Bool.fs
+++ b/backend/src/BuiltinExecution/Libs/Bool.fs
@@ -27,8 +27,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "not"
       previewable = Pure
-      deprecated = NotDeprecated }
-  ]
+      deprecated = NotDeprecated } ]
 
 
 let contents = (fns, types, constants)

--- a/backend/src/BuiltinExecution/Libs/Bool.fs
+++ b/backend/src/BuiltinExecution/Libs/Bool.fs
@@ -1,0 +1,34 @@
+module BuiltinExecution.Libs.Bool
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+open Prelude
+open LibExecution.RuntimeTypes
+open LibExecution.Builtin.Shortcuts
+
+let fn = fn [ "Bool" ]
+
+let varA = TVariable "a"
+
+let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
+
+let fns : List<BuiltInFn> =
+  // CLEANUP: Maybe Expose ENot
+  [ { name = fn "not" 0
+      typeParams = []
+      parameters = [ Param.make "b" TBool "" ]
+      returnType = TBool
+      description =
+        "Returns the inverse of <param b>: {{true}} if <param b> is {{false}} and {{false}} if <param b> is {{true}}"
+      fn =
+        (function
+        | _, _, [ DBool b ] -> Ply(DBool(not b))
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlFunction "not"
+      previewable = Pure
+      deprecated = NotDeprecated }
+  ]
+
+
+let contents = (fns, types, constants)

--- a/backend/src/BuiltinExecution/Libs/List.fs
+++ b/backend/src/BuiltinExecution/Libs/List.fs
@@ -277,6 +277,20 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "length" 0
+      typeParams = []
+      parameters = [ Param.make "list" (TList varA) "" ]
+      returnType = TInt
+      description = "Returns the number of values in <param list>"
+      fn =
+        (function
+        | _, _, [ DList(vt, l) ] -> Ply(Dval.int (l.Length))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
     // TODO: type check to ensure `varA` is "comparable"
     { name = fn "unique" 0
       typeParams = []

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -459,9 +459,7 @@ let fns : List<BuiltInFn> =
           let index = str.IndexOf(search)
           Ply(DInt index)
         | _ -> incorrectArgs ())
-      sqlSpec =
-        SqlCallback2(fun str search ->
-          $"strpos({str}, {search}) - 1")
+      sqlSpec = SqlCallback2(fun str search -> $"strpos({str}, {search}) - 1")
       previewable = Pure
       deprecated = NotDeprecated }
 

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -450,19 +450,18 @@ let fns : List<BuiltInFn> =
             "searchFor"
             TString
             "The string to search for within <param str>" ]
-      returnType = TypeReference.option TInt
+      returnType = TInt
       description =
-        "Returns {{Some index}} of the first occurrence of <param searchFor> in <param str>, or returns {{None}} if <param searchFor> does not occur."
+        "Returns the index of the first occurrence of <param searchFor> in <param str>, or returns -1 if <param searchFor> does not occur."
       fn =
         (function
         | _, _, [ DString str; DString search ] ->
           let index = str.IndexOf(search)
-          if index = -1 then
-            Ply(Dval.optionNone)
-          else
-            Ply(Dval.optionSome (DInt index))
+          Ply(DInt index)
         | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplemented
+      sqlSpec =
+        SqlCallback2(fun str search ->
+          $"strpos({str}, {search}) - 1")
       previewable = Pure
       deprecated = NotDeprecated }
 

--- a/backend/src/LibCloud/PackageManager.fs
+++ b/backend/src/LibCloud/PackageManager.fs
@@ -9,7 +9,6 @@ open Npgsql
 open Prelude
 
 open Db
-open Ply
 
 module BinarySerialization = LibBinarySerialization.BinarySerialization
 module PT = LibExecution.ProgramTypes

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -240,8 +240,7 @@ let rec inline'
                 List.zip parameters arguments
                 |> List.map (fun ((name, _), arg) -> name, arg)
                 |> Map.ofList
-              let! inlinedBody = inline' fns paramName paramToArgMap body
-              return inlinedBody
+              return! inline' fns paramName paramToArgMap body
             | None -> return expr
           | _ -> return expr
         }
@@ -250,16 +249,16 @@ let rec inline'
         inline' fns paramName newMap body
       | EVariable(_, name) as expr when name <> paramName ->
         match Map.get name symtable with
-        | Some found -> uply { return found }
+        | Some found -> Ply found
         | None ->
           // the variable might be in the symtable, so put it back to fill in later
-          uply { return expr }
+          Ply expr
       | EFieldAccess(id, expr, fieldname) ->
         uply {
           let! newexpr = inline' fns paramName symtable expr
           return EFieldAccess(id, newexpr, fieldname)
         }
-      | expr -> uply { return expr }
+      | expr -> Ply expr
 
     )
     identityPly

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -686,21 +686,6 @@ let rec lambdaToSql
           | _ ->
             return
               error $"We do not support this type of DB field yet: {dbFieldType}"
-        | EIf(_, cond, then_, else_) ->
-          let! cond = lts TBool cond
-          let! then_ = lts expectedType then_
-          let! else_ =
-            match else_ with
-            | Some e -> lts expectedType e
-            | None -> error $"We do not yet support compiling this code: {expr}"
-          typecheck "if condition" cond.actualType TBool
-          typecheck "if then" then_.actualType expectedType
-          typecheck "if else" else_.actualType expectedType
-          return
-            ($"(CASE WHEN {cond.sql} THEN {then_.sql} ELSE {else_.sql} END)",
-             cond.vars @ then_.vars @ else_.vars,
-             expectedType)
-
         | _ -> return error $"We do not yet support compiling this code: {expr}"
       }
 

--- a/backend/src/LibExecution/RuntimeTypesAst.fs
+++ b/backend/src/LibExecution/RuntimeTypesAst.fs
@@ -318,7 +318,7 @@ let rec postTraversalAsync
         return TDB(tr)
       | TCustomType(name, trs) ->
         let! trs = Ply.List.mapSequentially r trs
-        let! name = Ply.Result.mapSequentially fqtnFn name
+        let! name = Ply.Result.map fqtnFn name
         return TCustomType(name, trs)
       | TDict(tr) ->
         let! tr = r tr
@@ -347,7 +347,7 @@ let rec postTraversalAsync
       | EChar _
       | EUnit _
       | EVariable _
-      | EFloat _ -> uply { return expr }
+      | EFloat _ -> Ply expr
       | EAnd(id, left, right) ->
         uply {
           let! left = r left
@@ -388,7 +388,7 @@ let rec postTraversalAsync
         uply {
           let! cond = r cond
           let! ifexpr = r ifexpr
-          let! elseexpr = Ply.Option.mapSequentially r elseexpr
+          let! elseexpr = Ply.Option.map r elseexpr
           return EIf(id, cond, ifexpr, elseexpr)
         }
       | EMatch(id, mexpr, pairs) ->

--- a/backend/src/LibExecution/RuntimeTypesAst.fs
+++ b/backend/src/LibExecution/RuntimeTypesAst.fs
@@ -231,3 +231,260 @@ let rec postTraversal
      )
    | EError(id, msg, exprs) -> EError(id, msg, List.map f exprs))
   |> exprFn
+
+
+
+let rec postTraversalAsync
+  (exprFn : Expr -> Ply.Ply<Expr>)
+  (typeRefFn : TypeReference -> Ply.Ply<TypeReference>)
+  (fqtnFn : TypeName.TypeName -> Ply.Ply<TypeName.TypeName>)
+  (fqfnFn : FnName.FnName -> Ply.Ply<FnName.FnName>)
+  (fqcnFn : ConstantName.ConstantName -> Ply.Ply<ConstantName.ConstantName>)
+  (letPatternFn : LetPattern -> Ply.Ply<LetPattern>)
+  (matchPatternFn : MatchPattern -> Ply.Ply<MatchPattern>)
+  (expr : Expr)
+  : Ply.Ply<Expr> =
+
+  let rec postTraversalLetPattern (pat : LetPattern) : Ply.Ply<LetPattern> =
+    uply {
+      let! pat = letPatternFn pat
+      let r = postTraversalLetPattern
+      match pat with
+      | LPVariable _
+      | LPUnit _ -> return pat
+      | LPTuple(id, p1, p2, pats) ->
+        let! p1 = r p1
+        let! p2 = r p2
+        let! pats = Ply.List.mapSequentially r pats
+        return LPTuple(id, p1, p2, pats)
+    }
+
+  let rec postTraverseMatchPattern (pat : MatchPattern) : Ply.Ply<MatchPattern> =
+    uply {
+      let! pat = matchPatternFn pat
+
+      let r = postTraverseMatchPattern
+      match pat with
+      | MPVariable _
+      | MPInt _
+      | MPBool _
+      | MPString _
+      | MPChar _
+      | MPFloat _
+      | MPUnit _ -> return pat
+      | MPList(id, pats) ->
+        let! pats = Ply.List.mapSequentially r pats
+        return MPList(id, pats)
+      | MPTuple(id, p1, p2, pats) ->
+        let! p1 = r p1
+        let! p2 = r p2
+        let! pats = Ply.List.mapSequentially r pats
+        return MPTuple(id, p1, p2, pats)
+      | MPEnum(id, name, pats) ->
+        let! pats = Ply.List.mapSequentially r pats
+        return MPEnum(id, name, pats)
+      | MPListCons(id, head, tail) ->
+        let! head = r head
+        let! tail = r tail
+        return MPListCons(id, head, tail)
+    }
+
+  let rec postTraversalTypeRef (typeRef : TypeReference) : Ply.Ply<TypeReference> =
+    uply {
+      let! typeRef = typeRefFn typeRef
+      let r = postTraversalTypeRef
+      match typeRef with
+      | TInt
+      | TBool
+      | TUnit
+      | TFloat
+      | TChar
+      | TUuid
+      | TDateTime
+      | TBytes
+      | TPassword
+      | TVariable _
+      | TString -> return typeRef
+      | TList tr ->
+        let! tr = r tr
+        return TList(tr)
+      | TTuple(tr1, tr2, trs) ->
+        let! tr1 = r tr1
+        let! tr2 = r tr2
+        let! trs = Ply.List.mapSequentially r trs
+        return TTuple(tr1, tr2, trs)
+      | TDB tr ->
+        let! tr = r tr
+        return TDB(tr)
+      | TCustomType(name, trs) ->
+        let! trs = Ply.List.mapSequentially r trs
+        let! name = Ply.Result.mapSequentially fqtnFn name
+        return TCustomType(name, trs)
+      | TDict(tr) ->
+        let! tr = r tr
+        return TDict(tr)
+      | TFn(trs, tr) ->
+        let! trs = Ply.NEList.mapSequentially r trs
+        let! tr = r tr
+        return TFn(trs, tr)
+    }
+
+  uply {
+    let r = postTraversalAsync exprFn typeRefFn fqtnFn fqfnFn fqcnFn letPatternFn matchPatternFn
+
+    let! expr =
+      match expr with
+      | EInt _
+      | EBool _
+      | EChar _
+      | EUnit _
+      | EVariable _
+      | EFloat _ ->  uply { return expr }
+      | EAnd(id, left, right) ->
+          uply {
+              let! left = r left
+              let! right = r right
+              return EAnd(id, left, right)
+          }
+      | EOr(id, left, right) ->
+          uply {
+              let! left = r left
+              let! right = r right
+              return EOr(id, left, right)
+          }
+      | ELambda(id, names, expr) ->
+          uply {
+              let! expr = r expr
+              return ELambda(id, names, expr)
+          }
+      | ELet(id, pat, rhs, next) ->
+          uply {
+              let! pat = postTraversalLetPattern pat
+              let! rhs = r rhs
+              let! next = r next
+              return ELet(id, pat, rhs, next)
+          }
+      | EList(id, exprs) ->
+          uply {
+              let! exprs = Ply.List.mapSequentially r exprs
+              return EList(id, exprs)
+          }
+      | ETuple(id, first, second, theRest) ->
+          uply {
+              let! first = r first
+              let! second = r second
+              let! theRest = Ply.List.mapSequentially r theRest
+              return ETuple(id, first, second, theRest)
+          }
+      | EIf(id, cond, ifexpr, elseexpr) ->
+          uply {
+              let! cond = r cond
+              let! ifexpr = r ifexpr
+              let! elseexpr = Ply.Option.mapSequentially r elseexpr
+              return EIf(id, cond, ifexpr, elseexpr)
+          }
+      | EMatch(id, mexpr, pairs) ->
+          uply {
+              let! mexpr = r mexpr
+              let! pairs =
+                  Ply.NEList.mapSequentially
+                      (fun (pattern, expr) ->
+                          uply {
+                              let! pattern = postTraverseMatchPattern pattern
+                              let! expr = r expr
+                              return (pattern, expr)
+                          })
+                      pairs
+              return EMatch(id, mexpr, pairs)
+          }
+
+      | ERecord(id, typeName, fields) ->
+          uply {
+              let! fields =
+                  Ply.NEList.mapSequentially
+                      (fun (name, expr) ->
+                          uply {
+                              let! expr = r expr
+                              return (name, expr)
+                          })
+                      fields
+              return ERecord(id, typeName, fields)
+          }
+      | ERecordUpdate(id, record, updates) ->
+          uply {
+              let! record = r record
+              let! updates =
+                  Ply.NEList.mapSequentially
+                      (fun (name, expr) ->
+                          uply {
+                              let! expr = r expr
+                              return (name, expr)
+                          })
+                      updates
+              return ERecordUpdate(id, record, updates)
+          }
+      | EApply(id, name, typeArgs, args) ->
+          uply {
+              let! name = r name
+              let! typeArgs = Ply.List.mapSequentially postTraversalTypeRef typeArgs
+              let! args = Ply.NEList.mapSequentially r args
+              return EApply(id, name, typeArgs, args)
+          }
+      | EError(id, msg, exprs) ->
+          uply {
+              let! exprs = Ply.List.mapSequentially r exprs
+              return EError(id, msg, exprs)
+          }
+      | EDict(id, pairs) ->
+          uply {
+              let! pairs =
+                  Ply.List.mapSequentially
+                      (fun (k, v) ->
+                          uply {
+                              let! v = r v
+                              return (k, v)
+                          })
+                      pairs
+              return EDict(id, pairs)
+          }
+      | EFnName(id, name) ->
+          uply {
+              let! name = fqfnFn name
+              return EFnName(id, name)
+          }
+      | EConstant(id, name) ->
+          uply {
+              let! name = fqcnFn name
+              return EConstant(id, name)
+          }
+      | EEnum(id, typeName, caseName, fields) ->
+          uply {
+              let! typeName = fqtnFn typeName
+              let! fields = Ply.List.mapSequentially r fields
+              return EEnum(id, typeName, caseName, fields)
+          }
+      | EFieldAccess(id, expr, fieldname) ->
+          uply {
+              let! expr = r expr
+              return EFieldAccess(id, expr, fieldname)
+          }
+
+
+      | EString(id, strs) ->
+          uply {
+              let! strs =
+                  Ply.List.mapSequentially
+                      (fun s ->
+                          uply {
+                              match s with
+                              | StringText t -> return (StringText t)
+                              | StringInterpolation e ->
+                                  let! e = r e
+                                  return (StringInterpolation(e))
+                          })
+                      strs
+              return EString(id, strs)
+          }
+
+    return! exprFn expr
+  }

--- a/backend/src/Prelude/Ply.fs
+++ b/backend/src/Prelude/Ply.fs
@@ -233,3 +233,24 @@ module Map =
         })
       Map.empty
       dict
+
+// TODO : Add more functions
+module Result =
+  let mapSequentially
+    (f : 'a -> Ply<'b>)
+    (result : Result<'a, 'err>)
+    : Ply<Result<'b, 'err>> =
+    match result with
+    | Ok v -> map (fun v -> Ok v) (f v)
+    | Error err -> Ply (Error err)
+
+// TODO : Add more functions
+module Option =
+  let mapSequentially
+    (f : 'a -> Ply<'b>)
+    (option : Option<'a>)
+    : Ply<Option<'b>> =
+    match option with
+    | Some v -> map (fun v -> Some v) (f v)
+    | None -> Ply None
+

--- a/backend/src/Prelude/Ply.fs
+++ b/backend/src/Prelude/Ply.fs
@@ -234,19 +234,16 @@ module Map =
       Map.empty
       dict
 
-// TODO : Add more functions
+
 module Result =
-  let mapSequentially
-    (f : 'a -> Ply<'b>)
-    (result : Result<'a, 'err>)
-    : Ply<Result<'b, 'err>> =
+  let map (f : 'a -> Ply<'b>) (result : Result<'a, 'err>) : Ply<Result<'b, 'err>> =
     match result with
     | Ok v -> map (fun v -> Ok v) (f v)
     | Error err -> Ply(Error err)
 
-// TODO : Add more functions
+
 module Option =
-  let mapSequentially (f : 'a -> Ply<'b>) (option : Option<'a>) : Ply<Option<'b>> =
+  let map (f : 'a -> Ply<'b>) (option : Option<'a>) : Ply<Option<'b>> =
     match option with
     | Some v -> map (fun v -> Some v) (f v)
     | None -> Ply None

--- a/backend/src/Prelude/Ply.fs
+++ b/backend/src/Prelude/Ply.fs
@@ -242,15 +242,11 @@ module Result =
     : Ply<Result<'b, 'err>> =
     match result with
     | Ok v -> map (fun v -> Ok v) (f v)
-    | Error err -> Ply (Error err)
+    | Error err -> Ply(Error err)
 
 // TODO : Add more functions
 module Option =
-  let mapSequentially
-    (f : 'a -> Ply<'b>)
-    (option : Option<'a>)
-    : Ply<Option<'b>> =
+  let mapSequentially (f : 'a -> Ply<'b>) (option : Option<'a>) : Ply<Option<'b>> =
     match option with
     | Some v -> map (fun v -> Some v) (f v)
     | None -> Ply None
-

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -995,12 +995,12 @@ module PartialEvaluation =
 
 
 module QueryOne =
-  (let _ = prepFriends () in
-   Builtin.DB.queryOne PersonDB (fun p -> p.name == "bob")) = PACKAGE.Darklang.Stdlib.Option.Option.None
+  (let _ = prepFriends () in Builtin.DB.queryOne PersonDB (fun p -> p.name == "bob")) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
   (let _ = prepFriends () in
-    Builtin.DB.queryOne PersonDB (fun p -> p.name == "Rachel"))
-    |> PACKAGE.Darklang.Stdlib.Option.map (fun v -> v.name) = PACKAGE.Darklang.Stdlib.Option.Option.Some "Rachel"
+   Builtin.DB.queryOne PersonDB (fun p -> p.name == "Rachel"))
+  |> PACKAGE.Darklang.Stdlib.Option.map (fun v -> v.name) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+    "Rachel"
 
 
   // interpolated

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -892,12 +892,13 @@ module PartialEvaluation =
                                                                                          "Ross" ]
 
   // fieldAccesses inside query
-  (friends (fun p ->
-    let x = YL { y = ZL { z = AL { a = [ 1; 2; 3; 4; 5 ] } } }
-    (PACKAGE.Darklang.Stdlib.List.length_v0 x.y.z.a) < p.height)) = [ " Chandler "
-                                                                      "GrumpyCat"
-                                                                      "Rachel"
-                                                                      "Ross" ]
+  // TODO: Fix this test - infinite recursion
+  // (friends (fun p ->
+  //   let x = YL { y = ZL { z = AL { a = [ 1; 2; 3; 4; 5 ] } } }
+  //   (PACKAGE.Darklang.Stdlib.List.length_v0 x.y.z.a) < p.height)) = [ " Chandler "
+  //                                                                     "GrumpyCat"
+  //                                                                     "Rachel"
+  //                                                                     "Ross" ]
 
   // tuple destructuring inside query
   (friends (fun p ->

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -892,13 +892,12 @@ module PartialEvaluation =
                                                                                          "Ross" ]
 
   // fieldAccesses inside query
-  // TODO: Fix this test - infinite recursion
-  // (friends (fun p ->
-  //   let x = YL { y = ZL { z = AL { a = [ 1; 2; 3; 4; 5 ] } } }
-  //   (PACKAGE.Darklang.Stdlib.List.length_v0 x.y.z.a) < p.height)) = [ " Chandler "
-  //                                                                     "GrumpyCat"
-  //                                                                     "Rachel"
-  //                                                                     "Ross" ]
+  (friends (fun p ->
+    let x = YL { y = ZL { z = AL { a = [ 1; 2; 3; 4; 5 ] } } }
+    (PACKAGE.Darklang.Stdlib.List.length_v0 x.y.z.a) < p.height)) = [ " Chandler "
+                                                                      "GrumpyCat"
+                                                                      "Rachel"
+                                                                      "Ross" ]
 
   // tuple destructuring inside query
   (friends (fun p ->

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -754,6 +754,7 @@ module FindAll =
   // sql injection
   friendsError (fun p -> "; select * from users;" == p.name) = []
 
+
 module CompiledFunctions =
   (friends (fun p -> PACKAGE.Darklang.Stdlib.Float.lessThan_v0 90.0 p.income)) = [ "Ross" ]
 
@@ -762,6 +763,18 @@ module CompiledFunctions =
                                                                             "Rachel" ]
 
   (friends (fun p -> PACKAGE.Darklang.Stdlib.Float.greaterThan_v0 p.income 90.0)) = [ "Ross" ]
+
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Float.divide_v0 p.income 2.0 == 50.0)) = [ "Ross" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Float.multiply_v0 p.income 2.0 == 200.0)) = [ "Ross" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Float.power p.income 2.0 == 10000.0)) = [ "Ross" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Float.add p.income 0.0 == 0.0)) = [ "GrumpyCat" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Float.subtract p.income 3.0 == 80.0)) = [ " Chandler " ]
+
 
   (friends (fun p ->
     PACKAGE.Darklang.Stdlib.Float.greaterThanOrEqualTo_v0 82.10 p.income)) = [ "GrumpyCat"
@@ -778,6 +791,17 @@ module CompiledFunctions =
 
   (friends (fun p -> PACKAGE.Darklang.Stdlib.Int.greaterThan_v0 p.height 65)) = [ " Chandler "
                                                                                   "Ross" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Int.add p.height 1 == 11)) = [ "GrumpyCat" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Int.subtract p.height 3 == 69)) = [ " Chandler " ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Int.multiply_v0 p.height 2 == 146)) = [ "Ross" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.Int.divide_v0 p.height 2 == 5)) = [ "GrumpyCat" ]
+
+  // TODO: This test should pass, but it is causing an infinite recursion
+  // (friends (fun p -> (PACKAGE.Darklang.Stdlib.Int.power p.height 2) == PACKAGE.Darklang.Stdlib.Result.Result.Ok(100))) = [ "GrumpyCat" ]
 
   (friends (fun p -> PACKAGE.Darklang.Stdlib.String.toLowercase p.name == "rachel")) = [ "Rachel" ]
   (friends (fun p -> PACKAGE.Darklang.Stdlib.String.toUppercase p.name == "RACHEL")) = [ "Rachel" ]
@@ -821,9 +845,6 @@ module CompiledFunctions =
   (friends (fun p -> PACKAGE.Darklang.Stdlib.Bool.or_v0 p.human p.human)) = [ " Chandler "
                                                                               "Rachel"
                                                                               "Ross" ]
-
-  // can't test xor. We do not yet support compiling this code: EIf
-  // (friends (fun p -> PACKAGE.Darklang.Stdlib.Bool.xor_v0 p.human p.human)) = []
 
   (friends (fun p ->
     PACKAGE.Darklang.Stdlib.Bool.not_v0 (
@@ -971,6 +992,24 @@ module PartialEvaluation =
   (friends (fun p ->
     let (a0, a1, a2, a3, ((b, c), d)) = (0, 1, 2, 3, ((5, "aa"), 'a'))
     b < p.height)) = [ " Chandler "; "GrumpyCat"; "Rachel"; "Ross" ]
+
+
+module QueryOne =
+  (let _ = prepFriends () in
+   Builtin.DB.queryOne PersonDB (fun p -> p.name == "bob")) = PACKAGE.Darklang.Stdlib.Option.Option.None
+
+  (let _ = prepFriends () in
+    Builtin.DB.queryOne PersonDB (fun p -> p.name == "Rachel"))
+    |> PACKAGE.Darklang.Stdlib.Option.map (fun v -> v.name) = PACKAGE.Darklang.Stdlib.Option.Option.Some "Rachel"
+
+
+  // interpolated
+  (let _ = prepFriends ()
+   let test = "ache"
+
+   (Builtin.DB.queryOne PersonDB (fun p -> p.name == $"R{test}l"))
+   |> PACKAGE.Darklang.Stdlib.Option.map (fun v -> v.name)) = PACKAGE.Darklang.Stdlib.Option.Option.Some
+    "Rachel"
 
 
 module QueryOneWithKey =

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -220,6 +220,9 @@ module Roundtrip =
       uuid: Uuid
       resultOk: PACKAGE.Darklang.Stdlib.Result.Result<Int, String>
       resultError: PACKAGE.Darklang.Stdlib.Result.Result<Int, String>
+      option: PACKAGE.Darklang.Stdlib.Option.Option<Int>
+      tuple: (Int * String)
+      record: MyTlid
       list: List<Int>
       datetime: DateTime
       unit: Unit }
@@ -243,6 +246,9 @@ module Roundtrip =
         char = 'c'
         resultOk = PACKAGE.Darklang.Stdlib.Result.Result.Ok 5
         resultError = PACKAGE.Darklang.Stdlib.Result.Result.Error "test"
+        option = PACKAGE.Darklang.Stdlib.Option.Option.Some 5
+        record = MyTlid { mytlid = 1234 }
+        tuple = (1, "hello")
         emojiChar = (Builtin.Test.toChar "👍") |> Builtin.unwrap
         uuid =
           (PACKAGE.Darklang.Stdlib.Uuid.parse "00000050-0000-0000-0000-000000000000")
@@ -270,6 +276,9 @@ module Roundtrip =
         char = 'd'
         resultOk = PACKAGE.Darklang.Stdlib.Result.Result.Ok 6
         resultError = PACKAGE.Darklang.Stdlib.Result.Result.Error "other test"
+        option = PACKAGE.Darklang.Stdlib.Option.Option.None
+        record = MyTlid { mytlid = 1235 }
+        tuple = (2, "goodbye")
         emojiChar = 'e'
         uuid =
           (PACKAGE.Darklang.Stdlib.Uuid.parse "55555555-5555-5555-5555-555555555555")
@@ -281,7 +290,7 @@ module Roundtrip =
       // dont test password because hashing it twice will get different values
       }
 
-  // TODO: Add roundtrip for records, unit, tuple, option, result, bytes
+  // TODO: Add roundtrip for bytes (Bytes values not supported yet)
   (let v = sample ()
    let z = Builtin.DB.set v "all" SampleDB in
    (z, Builtin.DB.get "all" SampleDB)) = (sample (),
@@ -704,6 +713,12 @@ module FindAll =
                                                               "Rachel"
                                                               "Ross" ]
 
+  // inlining package functions
+  (friends (fun p ->
+    let x = p.height in true && PACKAGE.Darklang.Stdlib.Int.greaterThan_v0 x 32)) = [ " Chandler "
+                                                                                      "Rachel"
+                                                                                      "Ross" ]
+
   // pipes
   (friends (fun p -> p.height |> (*) 2 |> (<) 40)) = [ "GrumpyCat" ]
 
@@ -807,6 +822,36 @@ module CompiledFunctions =
                                                                               "Rachel"
                                                                               "Ross" ]
 
+  // can't test xor. We do not yet support compiling this code: EIf
+  // (friends (fun p -> PACKAGE.Darklang.Stdlib.Bool.xor_v0 p.human p.human)) = []
+
+  (friends (fun p ->
+    PACKAGE.Darklang.Stdlib.Bool.not_v0 (
+      PACKAGE.Darklang.Stdlib.Bool.and_v0 p.human p.human
+    ))) = [ "GrumpyCat" ]
+
+  (friends (fun p ->
+    PACKAGE.Darklang.Stdlib.Bool.and_v0
+      p.human
+      (PACKAGE.Darklang.Stdlib.Bool.not_v0 p.human))) = []
+
+  (friends (fun p ->
+    PACKAGE.Darklang.Stdlib.Bool.or_v0
+      p.human
+      (PACKAGE.Darklang.Stdlib.Bool.not_v0 p.human))) = [ " Chandler "
+                                                          "GrumpyCat"
+                                                          "Rachel"
+                                                          "Ross" ]
+
+  (friends (fun p -> PACKAGE.Darklang.Stdlib.String.reverse_v0 p.name == "lehcaR")) = [ "Rachel" ]
+
+  (friends (fun p ->
+    PACKAGE.Darklang.Stdlib.String.reverse_v0 (
+      (PACKAGE.Darklang.Stdlib.String.toLowercase p.name)
+      |> PACKAGE.Darklang.Stdlib.String.toUppercase
+    )
+    == "LEHCAR")) = [ "Rachel" ]
+
   (friends (fun p ->
     PACKAGE.Darklang.Stdlib.DateTime.lessThanOrEqualTo
       p.dob
@@ -860,12 +905,35 @@ module CompiledFunctions =
                                                                                   "Rachel" ]
 
   // Test package constants
+  // Bool
   (friends (fun p ->
     PACKAGE.Darklang.Stdlib.Bool.and_v0
       p.human
       PACKAGE.Darklang.Test.Constants.boolConst)) = [ " Chandler "
                                                       "Rachel"
                                                       "Ross" ]
+
+  // Float
+  (friends (fun p ->
+    PACKAGE.Darklang.Stdlib.Float.lessThanOrEqualTo
+      p.income
+      PACKAGE.Darklang.Test.Constants.floatConst)) = [ "GrumpyCat" ]
+
+  // Int
+  (friends (fun p ->
+    PACKAGE.Darklang.Stdlib.Int.greaterThanOrEqualTo
+      p.height
+      PACKAGE.Darklang.Test.Constants.intConst)) = [ " Chandler "
+                                                     "GrumpyCat"
+                                                     "Rachel"
+                                                     "Ross" ]
+
+  // String
+  (friends (fun p ->
+    PACKAGE.Darklang.Stdlib.String.contains_v0
+      p.name
+      PACKAGE.Darklang.Test.Constants.stringConst)) = []
+
 
 module PartialEvaluation =
   type A = { a: Int }

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -254,4 +254,4 @@ let partialEvaluation =
 
 
 let tests =
-  testList "SqlCompiler" [ inlineWorksAtRoot; partialEvaluation; compileTests ]
+  testList "SqlCompiler" [ inlineWorksAtRoot; inlineWorksWithNested; partialEvaluation; compileTests ]

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -158,7 +158,7 @@ let inlineWorksAtRoot =
         let! result = C.inline' fns "value" Map.empty expr
         return Expect.equalExprIgnoringIDs result expected
       }
-    return (result |> Ply.toTask |> Async.AwaitTask |> Async.RunSynchronously)
+    return! result |> Ply.toTask
   }
 
 let inlineWorksWithNested =

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -135,7 +135,15 @@ let compileTests =
 
 let inlineWorksAtRoot =
   testTask "inlineWorksAtRoot" {
-    let! state = executionStateFor (System.Guid.NewGuid()) false false Map.empty Map.empty Map.empty Map.empty
+    let! state =
+      executionStateFor
+        (System.Guid.NewGuid())
+        false
+        false
+        Map.empty
+        Map.empty
+        Map.empty
+        Map.empty
     let fns = ExecutionState.availableFunctions state
     let! expr =
       LibParser.Parser.parseRTExpr
@@ -155,7 +163,15 @@ let inlineWorksAtRoot =
 
 let inlineWorksWithNested =
   testTask "inlineWorksWithNested" {
-    let! state = executionStateFor (System.Guid.NewGuid()) false false Map.empty Map.empty Map.empty Map.empty
+    let! state =
+      executionStateFor
+        (System.Guid.NewGuid())
+        false
+        false
+        Map.empty
+        Map.empty
+        Map.empty
+        Map.empty
     let fns = ExecutionState.availableFunctions state
     let! expr = p "let x = 5 in (let x = 6 in (3 + (let x = 7 in x)))"
 
@@ -238,6 +254,4 @@ let partialEvaluation =
 
 
 let tests =
-  testList
-    "SqlCompiler"
-    [ inlineWorksAtRoot; partialEvaluation; compileTests ]
+  testList "SqlCompiler" [ inlineWorksAtRoot; partialEvaluation; compileTests ]

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -135,6 +135,8 @@ let compileTests =
 
 let inlineWorksAtRoot =
   testTask "inlineWorksAtRoot" {
+    let! state = executionStateFor (System.Guid.NewGuid()) false false Map.empty Map.empty Map.empty Map.empty
+    let fns = ExecutionState.availableFunctions state
     let! expr =
       LibParser.Parser.parseRTExpr
         nameResolver
@@ -143,17 +145,27 @@ let inlineWorksAtRoot =
       |> Ply.toTask
 
     let! expected = p "3 + 5"
-    let result = C.inline' "value" Map.empty expr
-    return Expect.equalExprIgnoringIDs result expected
+    let result =
+      uply {
+        let! result = C.inline' fns "value" Map.empty expr
+        return Expect.equalExprIgnoringIDs result expected
+      }
+    return (result |> Ply.toTask |> Async.AwaitTask |> Async.RunSynchronously)
   }
 
 let inlineWorksWithNested =
   testTask "inlineWorksWithNested" {
+    let! state = executionStateFor (System.Guid.NewGuid()) false false Map.empty Map.empty Map.empty Map.empty
+    let fns = ExecutionState.availableFunctions state
     let! expr = p "let x = 5 in (let x = 6 in (3 + (let x = 7 in x)))"
 
     let! expected = p "3 + 7"
-    let result = C.inline' "value" Map.empty expr
-    return Expect.equalExprIgnoringIDs result expected
+    let result =
+      uply {
+        let! result = C.inline' fns "value" Map.empty expr
+        return Expect.equalExprIgnoringIDs result expected
+      }
+    return (result |> Ply.toTask |> Async.AwaitTask |> Async.RunSynchronously)
   }
 
 let partialEvaluation =
@@ -228,4 +240,4 @@ let partialEvaluation =
 let tests =
   testList
     "SqlCompiler"
-    [ inlineWorksAtRoot; inlineWorksWithNested; partialEvaluation; compileTests ]
+    [ inlineWorksAtRoot; partialEvaluation; compileTests ]

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -181,7 +181,7 @@ let inlineWorksWithNested =
         let! result = C.inline' fns "value" Map.empty expr
         return Expect.equalExprIgnoringIDs result expected
       }
-    return (result |> Ply.toTask |> Async.AwaitTask |> Async.RunSynchronously)
+    return! result |> Ply.toTask
   }
 
 let partialEvaluation =

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -254,4 +254,6 @@ let partialEvaluation =
 
 
 let tests =
-  testList "SqlCompiler" [ inlineWorksAtRoot; inlineWorksWithNested; partialEvaluation; compileTests ]
+  testList
+    "SqlCompiler"
+    [ inlineWorksAtRoot; inlineWorksWithNested; partialEvaluation; compileTests ]

--- a/packages/darklang/stdlib/bool.dark
+++ b/packages/darklang/stdlib/bool.dark
@@ -4,13 +4,13 @@ module Darklang =
 
       /// Returns the inverse of <param b>: {{true}} if <param b>
       /// is {{false}} and {{false}} if <param b> is {{true}}
-      let not (b: Bool) : Bool = if b then false else true
+      let not (b: Bool) : Bool = Builtin.Bool.not b
 
       /// Returns {{true}} if both <param a> and <param b> are {{true}}
-      let ``and`` (a: Bool) (b: Bool) : Bool = if a then b else false
+      let ``and`` (a: Bool) (b: Bool) : Bool = a && b
 
       /// Returns {{true}} if either <param a> is true or <param b> is {{true}}
-      let ``or`` (a: Bool) (b: Bool) : Bool = if a then true else b
+      let ``or`` (a: Bool) (b: Bool) : Bool = a || b
 
       /// Returns {{true}} if exactly one of <param a> and <param b> is {{true}}. Returns {{false}} if both are {{true}} or neither is {{true}}
       let xor (a: Bool) (b: Bool) : Bool =

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -100,10 +100,7 @@ module Darklang =
 
 
       /// Returns the number of values in <param list>
-      let ``length`` (list: List<'a>) : Int =
-        match list with
-        | [] -> 0
-        | _ :: tail -> 1 + (PACKAGE.Darklang.Stdlib.List.length tail)
+      let ``length`` (list: List<'a>) : Int = Builtin.List.length_v0 list
 
 
       /// Returns a list of numbers where each element is {{1}} larger than the

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -190,9 +190,10 @@ module Darklang =
 
       /// Checks if <param lookingIn> contains <param searchingFor>
       let contains (lookingIn: String) (searchingFor: String) : Bool =
-        PACKAGE.Darklang.Stdlib.Option.isSome (
-          Builtin.String.indexOf lookingIn searchingFor
-        )
+        if (Builtin.String.indexOf lookingIn searchingFor) == -1 then
+          false
+        else
+          true
 
 
       /// Returns the substring of <param string> between the <param from> and <param to> indices.
@@ -369,7 +370,11 @@ module Darklang =
         (str: String)
         (searchFor: String)
         : PACKAGE.Darklang.Stdlib.Option.Option<Int> =
-        Builtin.String.indexOf str searchFor
+         if (Builtin.String.indexOf str searchFor) == -1 then
+           PACKAGE.Darklang.Stdlib.Option.Option.None
+         else
+           PACKAGE.Darklang.Stdlib.Option.Option.Some (Builtin.String.indexOf str searchFor)
+
 
 
       /// Returns the <param string> repeated for a specified <param count> times.

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -190,10 +190,7 @@ module Darklang =
 
       /// Checks if <param lookingIn> contains <param searchingFor>
       let contains (lookingIn: String) (searchingFor: String) : Bool =
-        if (Builtin.String.indexOf lookingIn searchingFor) == -1 then
-          false
-        else
-          true
+        Builtin.String.indexOf lookingIn searchingFor != -1
 
 
       /// Returns the substring of <param string> between the <param from> and <param to> indices.

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -370,10 +370,12 @@ module Darklang =
         (str: String)
         (searchFor: String)
         : PACKAGE.Darklang.Stdlib.Option.Option<Int> =
-         if (Builtin.String.indexOf str searchFor) == -1 then
-           PACKAGE.Darklang.Stdlib.Option.Option.None
-         else
-           PACKAGE.Darklang.Stdlib.Option.Option.Some (Builtin.String.indexOf str searchFor)
+        if (Builtin.String.indexOf str searchFor) == -1 then
+          PACKAGE.Darklang.Stdlib.Option.Option.None
+        else
+          PACKAGE.Darklang.Stdlib.Option.Option.Some(
+            Builtin.String.indexOf str searchFor
+          )
 
 
 


### PR DESCRIPTION
Changelog:

```
Area of change
- Inline package functions in the SQLCompiler
```

This PR:
- Inline package functions in the SQLCompiler
- Add an async version of RuntimeTypesAst.postTraversal function
- Temporarily add Builtin.Bool.not back until we expose `ENot`
- add some db tests for package constants and roundtrip tests for tuple, record, and option.



