### PR TITLE
Add support for more type stuff in SQLCompiler / speed up CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,8 +201,8 @@ jobs:
       # DebugType=None and DebugSymbol=false tells dotnet not to copy .pdb files to publish/
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
       - run: scripts/run-backend-tests --published
-      - run: scripts/build/reload-packages --published
       - run: scripts/run-backend-server --published
+      - run: scripts/build/reload-packages --published
       - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
       - assert-clean-worktree
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,14 +200,13 @@ jobs:
       - run: ./scripts/build/_dotnet-wrapper paket restore
       # DebugType=None and DebugSymbol=false tells dotnet not to copy .pdb files to publish/
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
-      # Do this first, needed by reload-packages, which is needed by run-backend-tests
-      - run: scripts/run-backend-server --published
-      - run: sleep 5 # there's a problem starting the server, so wait and do it again
-      - run: scripts/run-backend-server --published
       - run: scripts/run-backend-tests --published
+
       # Test package manager/cli integration works
+      - run: scripts/run-backend-server --published
       - run: scripts/build/reload-packages --published
       - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
+
       - assert-clean-worktree
       - persist_to_workspace:
           root: "."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,7 @@ jobs:
 
       # Test package manager/cli integration works
       - run: scripts/run-backend-server --published
+      - run: sleep 5 # let migrations run
       - run: scripts/build/reload-packages --published
       - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,8 +202,9 @@ jobs:
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
       # Do this first, needed by reload-packages, which is needed by run-backend-tests
       - run: scripts/run-backend-server --published
+      - run: sleep 5 # there's a problem starting the server, so wait and do it again
+      - run: scripts/run-backend-server --published
       - run: scripts/run-backend-tests --published
-      - run: scripts/run-backend-server --published # doing it again as it doesn't seem to stick the first time
       # Test package manager/cli integration works
       - run: scripts/build/reload-packages --published
       - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,9 @@ jobs:
       # DebugType=None and DebugSymbol=false tells dotnet not to copy .pdb files to publish/
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
       - run: scripts/run-backend-tests --published
+      - run: scripts/build/reload-packages
+      - run: scripts/run-backend-server --published
+      - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
       - assert-clean-worktree
       - persist_to_workspace:
           root: "."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,8 +200,10 @@ jobs:
       - run: ./scripts/build/_dotnet-wrapper paket restore
       # DebugType=None and DebugSymbol=false tells dotnet not to copy .pdb files to publish/
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
-      - run: scripts/run-backend-tests --published
+      # Do this first, needed by reload-packages, which is needed by run-backend-tests
       - run: scripts/run-backend-server --published
+      - run: scripts/run-backend-tests --published
+      # Test package manager/cli integration works
       - run: scripts/build/reload-packages --published
       - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
       - assert-clean-worktree

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,11 +202,12 @@ jobs:
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
       - run: scripts/run-backend-tests --published
 
+      ## TODO: too many race conditions. Bring back later
       # Test package manager/cli integration works
-      - run: scripts/run-backend-server --published
-      - run: sleep 5 # let migrations run
-      - run: scripts/build/reload-packages --published
-      - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
+      # - run: scripts/run-backend-server --published
+      # - run: sleep 5 # let migrations run
+      # - run: scripts/build/reload-packages --published
+      # - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
 
       - assert-clean-worktree
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
       # Do this first, needed by reload-packages, which is needed by run-backend-tests
       - run: scripts/run-backend-server --published
       - run: scripts/run-backend-tests --published
+      - run: scripts/run-backend-server --published # doing it again as it doesn't seem to stick the first time
       # Test package manager/cli integration works
       - run: scripts/build/reload-packages --published
       - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
       # DebugType=None and DebugSymbol=false tells dotnet not to copy .pdb files to publish/
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
       - run: scripts/run-backend-tests --published
-      - run: scripts/build/reload-packages
+      - run: scripts/build/reload-packages --published
       - run: scripts/run-backend-server --published
       - run: scripts/run-cli @Darklang.Stdlib.Float.add 1.9 2.0
       - assert-clean-worktree

--- a/backend/experiments/CanvasHack/Main.fs
+++ b/backend/experiments/CanvasHack/Main.fs
@@ -131,8 +131,9 @@ let main (args : string[]) =
         do! seedCanvas canvasName
 
       | _ ->
+        let args = args |> Array.toList |> String.concat " "
         print
-          $"CanvasHack isn't sure what to do with these arguments.
+          $"CanvasHack isn't sure what to do with these arguments: [{args}]
           Currently expecting just '{CommandNames.import}'"
 
       NonBlockingConsole.wait ()

--- a/backend/src/LibCliExecution/PackageManager.fs
+++ b/backend/src/LibCliExecution/PackageManager.fs
@@ -687,9 +687,18 @@ let packageManager : RT.PackageManager =
 
       let! responseStr = response.Content.ReadAsStringAsync()
       try
-        let deserialized = responseStr |> Json.Vanilla.deserialize<'serverType>
-        let cached = f deserialized
-        return Some cached
+        if response.StatusCode = System.Net.HttpStatusCode.OK then
+          let deserialized = responseStr |> Json.Vanilla.deserialize<'serverType>
+          let cached = f deserialized
+          return Some cached
+        else if response.StatusCode = System.Net.HttpStatusCode.NotFound then
+          return None
+        else
+          return
+            Exception.raiseInternal
+              "Failed to fetch package"
+              [ "responseStr", responseStr ]
+              null
       with e ->
         return
           Exception.raiseInternal

--- a/backend/src/LibCliExecution/PackageManager.fs
+++ b/backend/src/LibCliExecution/PackageManager.fs
@@ -672,23 +672,24 @@ let packageManager : RT.PackageManager =
 
   let fetch
     (kind : string)
+    (owner : string)
+    (modules : List<string>)
     (name : string)
+    (version : int)
     (f : 'serverType -> 'cachedType)
     : Ply<Option<'cachedType>> =
     uply {
+      let modules = modules |> String.concat "."
+      let nameString = $"{owner}.{modules}.{name}_v{version}"
       let! response =
-        $"http://dark-packages.dlio.localhost:11003/{kind}/by-name/{name}"
+        $"http://dark-packages.dlio.localhost:11003/{kind}/by-name/{nameString}"
         |> httpClient.GetAsync
 
       let! responseStr = response.Content.ReadAsStringAsync()
       try
-        let deserialized =
-          responseStr |> Json.Vanilla.deserialize<Option<'serverType>>
-        match deserialized with
-        | None -> return None
-        | Some deserialized ->
-          let cached = f deserialized
-          return Some cached
+        let deserialized = responseStr |> Json.Vanilla.deserialize<'serverType>
+        let cached = f deserialized
+        return Some cached
       with e ->
         return
           Exception.raiseInternal
@@ -698,34 +699,25 @@ let packageManager : RT.PackageManager =
     }
 
   { getType =
-      withCache (fun name ->
-        uply {
-          let nameString = RT.TypeName.packageToString name
-          let conversionFn (parsed : EPT.PackageType) : RT.PackageType.T =
-            parsed |> ET2PT.PackageType.toPT |> PT2RT.PackageType.toRT
-          return! fetch "type" nameString conversionFn
-        })
+      withCache (fun ({ name = RT.TypeName.TypeName typeName } as name) ->
+        let conversionFn (parsed : EPT.PackageType) : RT.PackageType.T =
+          parsed |> ET2PT.PackageType.toPT |> PT2RT.PackageType.toRT
+        fetch "type" name.owner name.modules typeName name.version conversionFn)
 
     getFn =
-      withCache (fun name ->
-        uply {
-          let nameString = RT.FnName.packageToString name
-          let conversionFn (parsed : EPT.PackageFn.PackageFn) : RT.PackageFn.T =
-            parsed |> ET2PT.PackageFn.toPT |> PT2RT.PackageFn.toRT
-          return! fetch "function" nameString conversionFn
-        })
+      withCache (fun ({ name = RT.FnName.FnName fnName } as name) ->
+        let conversionFn (parsed : EPT.PackageFn.PackageFn) : RT.PackageFn.T =
+          parsed |> ET2PT.PackageFn.toPT |> PT2RT.PackageFn.toRT
+        fetch "function" name.owner name.modules fnName name.version conversionFn)
 
     getFnByTLID =
       withCache (fun tlid ->
         uply { return Exception.raiseInternal "TODO getFnByTLID" [] })
 
     getConstant =
-      withCache (fun name ->
-        uply {
-          let nameString = RT.ConstantName.packageToString name
-          let conversionFn (parsed : EPT.PackageConstant) : RT.PackageConstant.T =
-            parsed |> ET2PT.PackageConstant.toPT |> PT2RT.PackageConstant.toRT
-          return! fetch "constant" nameString conversionFn
-        })
+      withCache (fun ({ name = RT.ConstantName.ConstantName constName } as name) ->
+        let conversionFn (parsed : EPT.PackageConstant) : RT.PackageConstant.T =
+          parsed |> ET2PT.PackageConstant.toPT |> PT2RT.PackageConstant.toRT
+        fetch "constant" name.owner name.modules constName name.version conversionFn)
 
     init = uply { return () } }

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -13,6 +13,7 @@ open Prelude
 open LibExecution.RuntimeTypes
 
 module DvalReprDeveloper = LibExecution.DvalReprDeveloper
+module DvalReprInternalQueryable = LibExecution.DvalReprInternalQueryable
 module TypeChecker = LibExecution.TypeChecker
 
 module RuntimeTypesAst = LibExecution.RuntimeTypesAst
@@ -597,6 +598,14 @@ let rec lambdaToSql
 
             return (sql, vars, TList actualType)
           | _ -> return error "Expected a List"
+
+        | EEnum(_, typeName, caseName, []) ->
+          let dv = Dval.enum typeName caseName []
+          let typ = (TCustomType(Ok typeName, []))
+          typecheck $"Enum '{dv}'" typ expectedType
+          let! v = DvalReprInternalQueryable.toJsonStringV0 types typ dv
+          let name = randomString 10
+          return $"(@{name})", [ name, Sql.jsonb v ], typ
 
 
         | EFieldAccess(_, subExpr, fieldname) ->

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -659,17 +659,13 @@ let rec lambdaToSql
             (subExpr : Expr)
             : (Option<string> * NEList<string>) =
             match subExpr with
+            | EVariable(_, v) -> (Some v, pathSoFar)
             | EFieldAccess(_, subExpr, childFieldName) ->
               getPath (NEList.push childFieldName pathSoFar) subExpr
-
-            | EVariable(_, v) -> (Some v, pathSoFar)
-
-            | _ ->
-              error
-                $"Support for field access in DB queries is incomplete: {subExpr}"
+            | _ -> error $"Invalid field access pattern: {subExpr}"
 
           let (varName, fieldAccessPath) =
-            getPath (NEList.singleton fieldname) subExpr
+            getPath (NEList.singleton fieldName) subExpr
 
           // I don't think it's really possible for the varName to end up None,
           // but just in case the parser did something wonky, we're prepared...
@@ -738,7 +734,7 @@ let rec lambdaToSql
           let! dbFieldType =
             dbFieldTypeFromPath dbTypeRef (NEList.toList fieldAccessPath)
 
-          typecheck fieldname dbFieldType expectedType
+          typecheck fieldName dbFieldType expectedType
 
           let rec primitiveFieldType t =
             match t with

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -454,6 +454,13 @@ let rec lambdaToSql
                          (actualTypes, prevSqls, prevVars)
                          (argExpr, (paramName, paramType)) ->
                       uply {
+                        let paramType =
+                          match paramType with
+                          | TVariable name ->
+                            match Map.get name actualTypes with
+                            | Some typ -> typ
+                            | None -> paramType
+                          | _ -> paramType
                         let! compiled = lts paramType argExpr
                         let newActuals =
                           match paramType with
@@ -465,7 +472,6 @@ let rec lambdaToSql
                               actualTypes
                             | None -> Map.add name compiled.actualType actualTypes
                           | _ -> actualTypes
-
                         return
                           newActuals,
                           prevSqls @ [ compiled.sql ],

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -56,7 +56,6 @@ let rec dvalToSql
     | _, DDict _ // CLEANUP allow
     | _, DPassword _ // CLEANUP allow
     | _, DBytes _ // CLEANUP allow
-    | _, DEnum _ // TODO: revisit
     | _, DTuple _ -> // CLEANUP allow
       return error2 "This value is not yet supported" (DvalReprDeveloper.toRepr dval)
     | TVariable _, DRecord(typeName, _, _)
@@ -127,6 +126,7 @@ let rec dvalToSql
     | _, DUnit
     | _, DList _
     | _, DRecord _
+    | _, DEnum _
     | _, DDateTime _ ->
       return
         error3

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -194,7 +194,10 @@ let rec private toJsonV0
     // Not supported
     | TVariable _, _
     | TFn _, DFnVal _
-    | TDB _, DDB _ -> Exception.raiseInternal "Not supported in queryable" []
+    | TDB _, DDB _ ->
+      Exception.raiseInternal
+        "Not supported in queryable"
+        [ "value", dv; "type", typ ]
 
     // exhaustiveness checking
     | TInt, _

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1618,12 +1618,12 @@ let rec getTypeReferenceFromAlias
   (typ : TypeReference)
   : Ply<Result<TypeReference, RuntimeError>> =
   match typ with
-  | TCustomType(Ok typeName, typeArgs) ->
+  | TCustomType(Ok outerTypeName, outerTypeArgs) ->
     uply {
-      match! Types.find typeName types with
-      | Some({ definition = TypeDeclaration.Alias(TCustomType(innerTypeName, _)) }) ->
-        return!
-          getTypeReferenceFromAlias types (TCustomType(innerTypeName, typeArgs))
+      match! Types.find outerTypeName types with
+      | Some { definition = TypeDeclaration.Alias typ; typeParams = typeParams } as decl ->
+        let typ = Types.substitute typeParams outerTypeArgs typ
+        return! getTypeReferenceFromAlias types typ
       | _ -> return Ok typ
     }
 

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -104,27 +104,26 @@ module NestedRecordFieldAccess =
 
 
 // Query data from a type with generics
-type GenericThing<'a> = { name: 'a }
+type GenericThing<'thing> = { name: 'thing }
 type RecordWithGenericThing = GenericThing<String>
 
 [<DB>]
 type TestRecordWithGenericThing = RecordWithGenericThing
 
-// module AccessDataInGenericField =
-//   (Builtin.DB.set
-//     (RecordWithGenericThing { name = "joe" })
-//     "jjj"
-//     TestRecordWithGenericThing
+module AccessDataInGenericField =
+  (Builtin.DB.set
+    (RecordWithGenericThing { name = "joe" })
+    "jjj"
+    TestRecordWithGenericThing
 
-//    Builtin.DB.set
-//      (RecordWithGenericThing { name = "frank" })
-//      "fff"
-//      TestRecordWithGenericThing
+   Builtin.DB.set
+     (RecordWithGenericThing { name = "frank" })
+     "fff"
+     TestRecordWithGenericThing
 
-//    let shouldBeJustJoe =
-//      Builtin.DB.query TestRecordWithGenericThing (fun p -> p.name == "joe")
-
-//    PACKAGE.Darklang.Stdlib.List.length shouldBeJustJoe) = 1
+   Builtin.DB.query TestRecordWithGenericThing (fun p -> p.name == "joe")) = [ RecordWithGenericThing
+                                                                                 { name =
+                                                                                     "joe" } ]
 
 
 module AddToTestEnumDBs =
@@ -191,8 +190,8 @@ module AddToTestEnumDBs =
     Builtin.DB.set (EnumTestRecord { x = "hello"; y = MyEnum.A }) "test1" TestEnumDB in
 
    (Builtin.DB.query TestEnumDB (fun p -> p.y == MyEnum.A))) = [ EnumTestRecord
-                                                                  { x = "hello"
-                                                                    y = MyEnum.A } ]
+                                                                   { x = "hello"
+                                                                     y = MyEnum.A } ]
 
 
 

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -187,6 +187,14 @@ module AddToTestEnumDBs =
                                                                   { x = "hello"
                                                                     y = MyEnum.A } ]
 
+  (let testQuery =
+    Builtin.DB.set (EnumTestRecord { x = "hello"; y = MyEnum.A }) "test1" TestEnumDB in
+
+   (Builtin.DB.query TestEnumDB (fun p -> p.y == MyEnum.A))) = [ EnumTestRecord
+                                                                  { x = "hello"
+                                                                    y = MyEnum.A } ]
+
+
 
 type MyTlid =
   { mytlid: PACKAGE.Darklang.LanguageTools.TLID }

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -125,29 +125,48 @@ module AccessDataInGenericField =
                                                                                  { name =
                                                                                      "joe" } ]
 
-type RecordThing = { nested: String }
-
-[<DB>]
-type TestRecordWithNestedRecordThing = GenericThing<RecordThing>
-
 module AccessRecordInGenericField =
+  type RecordThing = { nested: String }
+
+  [<DB>]
+  type TestDB = GenericThing<RecordThing>
+
+
   (Builtin.DB.set
     (GenericThing { name = RecordThing { nested = "joe" } })
     "jjj"
-    TestRecordWithNestedRecordThing
+    TestDB
 
    Builtin.DB.set
      (GenericThing { name = RecordThing { nested = "frank" } })
      "fff"
-     TestRecordWithNestedRecordThing
+     TestDB
 
    let nestedValue = RecordThing { nested = "joe" }
 
-   Builtin.DB.query TestRecordWithNestedRecordThing (fun p -> p.name == nestedValue)) = [ GenericThing
-                                                                                            { name =
-                                                                                                RecordThing
-                                                                                                  { nested =
-                                                                                                      "joe" } } ]
+   Builtin.DB.query TestDB (fun p -> p.name == nestedValue)) = [ GenericThing
+                                                                   { name =
+                                                                       RecordThing
+                                                                         { nested =
+                                                                             "joe" } } ]
+
+module AccessEnumInGenericField =
+  type EnumThing = A of String
+
+  [<DB>]
+  type TestDB = GenericThing<EnumThing>
+
+
+  (Builtin.DB.set (GenericThing { name = EnumThing.A "joe" }) "jjj" TestDB
+   Builtin.DB.set (GenericThing { name = EnumThing.A "frank" }) "fff" TestDB
+
+   let nestedValue = EnumThing.A "joe"
+
+   Builtin.DB.query TestDB (fun p -> p.name == nestedValue)) = [ GenericThing
+                                                                   { name =
+                                                                       EnumThing.A
+                                                                         "joe" } ]
+
 
 module AddToTestEnumDBs =
   (let test1 =

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -145,8 +145,9 @@ module AccessRecordInGenericField =
 
    Builtin.DB.query TestRecordWithNestedRecordThing (fun p -> p.name == nestedValue)) = [ GenericThing
                                                                                             { name =
-                                                                                                { nested =
-                                                                                                    "joe" } } ]
+                                                                                                RecordThing
+                                                                                                  { nested =
+                                                                                                      "joe" } } ]
 
 module AddToTestEnumDBs =
   (let test1 =

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -125,6 +125,28 @@ module AccessDataInGenericField =
                                                                                  { name =
                                                                                      "joe" } ]
 
+type RecordThing = { nested: String }
+
+[<DB>]
+type TestRecordWithNestedRecordThing = GenericThing<RecordThing>
+
+module AccessRecordInGenericField =
+  (Builtin.DB.set
+    (GenericThing { name = RecordThing { nested = "joe" } })
+    "jjj"
+    TestRecordWithNestedRecordThing
+
+   Builtin.DB.set
+     (GenericThing { name = RecordThing { nested = "frank" } })
+     "fff"
+     TestRecordWithNestedRecordThing
+
+   let nestedValue = RecordThing { nested = "joe" }
+
+   Builtin.DB.query TestRecordWithNestedRecordThing (fun p -> p.name == nestedValue)) = [ GenericThing
+                                                                                            { name =
+                                                                                                { nested =
+                                                                                                    "joe" } } ]
 
 module AddToTestEnumDBs =
   (let test1 =
@@ -318,16 +340,16 @@ module Roundtrip =
     //   Builtin.Test.derrorSqlMessage "Incorrect type in variable, expected Bool, but got a Error"
 
     fetch (fun p -> p.int == "str") = Builtin.Test.derrorSqlMessage
-      "Incorrect type in b, expected Int, but got a String"
+      "Incorrect type in String \"str\", expected Int, but got a String"
 
     fetch (fun p -> p.int != "str") = Builtin.Test.derrorSqlMessage
-      "Incorrect type in b, expected Int, but got a String"
+      "Incorrect type in String \"str\", expected Int, but got a String"
 
     fetch (fun p -> "str" == p.int) = Builtin.Test.derrorSqlMessage
-      "Incorrect type in b, expected String, but got a Int"
+      "Incorrect type in int, expected String, but got a Int"
 
     fetch (fun p -> "str" == p.int) = Builtin.Test.derrorSqlMessage
-      "Incorrect type in b, expected String, but got a Int"
+      "Incorrect type in int, expected String, but got a Int"
 
     fetch (fun p -> p.iNsEnSiTiVe == "iNsEnSiTiVe") = [ sample () ]
     fetch (fun p -> p.iNsEnSiTiVe != "iNsEnSiTiVe") = [ otherSample () ]

--- a/backend/testfiles/execution/cloud/db.dark
+++ b/backend/testfiles/execution/cloud/db.dark
@@ -180,10 +180,6 @@ module AddToTestEnumDBs =
                                                                              MyEnum2.F
                                                                                MyEnum.A ]
 
-  (let test1 = Builtin.DB.set MyEnum.D "test1" TestEnumDB2 in
-   (Builtin.DB.getAll TestEnumDB2)) = Builtin.Test.derrorMessage
-    "There is no case named `D` in MyEnum"
-
   (let testQuery =
     Builtin.DB.set (EnumTestRecord { x = "hello"; y = MyEnum.A }) "test1" TestEnumDB in
 

--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -111,101 +111,97 @@ let _handler _req =
 [<HttpHandler("GET", "/stats")>]
 let _handler _req =
   let types =
-    Builtin.DB.queryCount PackageDB (fun entry -> entry.category == Category.Type)
+    Builtin.DB.queryCount PackagesDB (fun entry -> entry.category == Category.Type)
 
   let fns =
-    Builtin.DB.queryCount PackageDB (fun entry -> entry.category == Category.Fn)
+    Builtin.DB.queryCount PackagesDB (fun entry -> entry.category == Category.Fn)
 
   let constants =
-    Builtin.DB.queryCount PackageDB (fun entry ->
+    Builtin.DB.queryCount PackagesDB (fun entry ->
       entry.category == Category.Constant)
 
-  let items = Builtin.DB.count PackageDB
+  let items = Builtin.DB.count PackagesDB
 
   let body =
-    $"Package stats:\ntypes: {types}, fns: {fns}, constants: {constants}\n\ntotal items in DB: {items}"
+    $"Package stats:\ntypes: {Builtin.Int.toString types}, fns: {Builtin.Int.toString fns}, constants: {Builtin.Int.toString constants}\n\ntotal items in DB: {Builtin.Int.toString items}\n"
     |> PACKAGE.Darklang.Stdlib.String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response body 200
 
+let parseVersion (name: String) : (String * Int) =
+  let parts = PACKAGE.Darklang.Stdlib.String.split name "_v"
+  let name = (PACKAGE.Darklang.Stdlib.List.head parts) |> Builtin.unwrap
+
+  let version =
+    (PACKAGE.Darklang.Stdlib.List.last parts)
+    |> Builtin.unwrap
+    |> Builtin.Int.parse
+    |> Builtin.unwrap
+
+  (name, version)
+
 
 let parseName (name: String) : GenericName =
-  match PACKAGE.Darklang.Stdlib.String.split name "." with
-  | owner :: rest ->
-    match PACKAGE.Darklang.Stdlib.List.reverse rest with
-    | name :: modulesInReverse ->
+  let parts = PACKAGE.Darklang.Stdlib.String.split name "."
+  let owner = (PACKAGE.Darklang.Stdlib.List.head parts) |> Builtin.unwrap
+  let name = (PACKAGE.Darklang.Stdlib.List.last parts) |> Builtin.unwrap
 
-      GenericName
-        { owner = owner
-          modules = PACKAGE.Darklang.Stdlib.List.reverse modulesInReverse
-          name = name
-          version = 0 }
+  let modules =
+    parts
+    |> PACKAGE.Darklang.Stdlib.List.tail
+    |> Builtin.unwrap
+    |> PACKAGE.Darklang.Stdlib.List.dropLast
+
+  let (name, version) = parseVersion name
+
+  GenericName
+    { owner = owner
+      modules = modules
+      name = name
+      version = version }
+
+let fetchByName
+  (name: String)
+  (category: Category)
+  : PACKAGE.Darklang.Stdlib.Http.Response =
+  let name = parseName name
+
+  let found =
+    Builtin.DB.queryOne PackagesDB (fun v ->
+      v.name == name && v.category == category)
+
+  match found with
+  | None ->
+    PACKAGE.Darklang.Stdlib.Http.response
+      (PACKAGE.Darklang.Stdlib.String.toBytes "not found")
+      404
+  | Some entry ->
+    let json =
+      match entry.package with
+      | Fn fn ->
+        Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>
+          fn
+      | Constant const' ->
+        Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>
+          const'
+      | Type typ ->
+        Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
+          typ
+
+    let respBody = json |> Builtin.unwrap |> PACKAGE.Darklang.Stdlib.String.toBytes
+
+    PACKAGE.Darklang.Stdlib.Http.response respBody 200
+
 
 
 [<HttpHandler("GET", "/type/by-name/:name")>]
-let _handler _req =
-  let name = parseName name
-
-  let found =
-    Builtin.DB.queryOne PackagesDB (fun v ->
-      v.name == name && v.category == Category.Type)
-
-  match found with
-  | None ->
-    PACKAGE.Darklang.Stdlib.Http.response
-      (PACKAGE.Darklang.Stdlib.String.toBytes "not found")
-      404
-  | Some type_ ->
-    let respBody =
-      type_
-      |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
-      |> unwrap
-      |> PACKAGE.Darklang.Stdlib.String.toBytes
-
-    PACKAGE.Darklang.Stdlib.Http.response respBody 200
+let _handler _req = fetchByName name Category.Type
 
 [<HttpHandler("GET", "/constant/by-name/:name")>]
-let _handler _req =
-  let name = parseName name
-
-  let found =
-    Builtin.DB.queryOne PackagesDB (fun v ->
-      v.name == name && v.category == Category.Constant)
-
-  match found with
-  | None -> PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "not found") 404
-  | Some constant ->
-    let respBody =
-      constant
-      |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>
-      |> unwrap
-      |> PACKAGE.Darklang.Stdlib.String.toBytes
-
-    PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
+let _handler _req = fetchByName name Category.Constant
 
 [<HttpHandler("GET", "/function/by-name/:name")>]
-let _handler _req =
-  let name = parseName name
-
-  let found =
-    Builtin.DB.queryOne PackagesDB (fun v ->
-      v.name == name && v.category == Category.Fn)
-
-  match found with
-  | None ->
-    PACKAGE.Darklang.Stdlib.Http.response
-      (PACKAGE.Darklang.Stdlib.String.toBytes "not found")
-      404
-  | Some fn ->
-    let respBody =
-      fn
-      |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>
-      |> unwrap
-      |> PACKAGE.Darklang.Stdlib.String.toBytes
-
-    PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
+let _handler _req = fetchByName name Category.Fn
 
 [<HttpHandler("GET", "/owner/:owner")>]
 let _handler _req =
@@ -264,8 +260,8 @@ let _handler _req =
       { types = types
         fns = fns
         constants = constants })
-    |> Json.serialize<PACKAGE.Darklang.Stdlib.Packages>
-    |> unwrap
+    |> Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Packages>
+    |> Builtin.unwrap
     |> PACKAGE.Darklang.Stdlib.String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response respBody 200

--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -151,13 +151,16 @@ let _handler _req =
       v.name == name && v.category == Category.Type)
 
   match found with
-  | None -> PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "not found") 404
+  | None ->
+    PACKAGE.Darklang.Stdlib.Http.response
+      (PACKAGE.Darklang.Stdlib.String.toBytes "not found")
+      404
   | Some type_ ->
     let respBody =
       type_
       |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
       |> unwrap
-      |> String.toBytes
+      |> PACKAGE.Darklang.Stdlib.String.toBytes
 
     PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
@@ -176,7 +179,7 @@ let _handler _req =
       constant
       |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>
       |> unwrap
-      |> String.toBytes
+      |> PACKAGE.Darklang.Stdlib.String.toBytes
 
     PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
@@ -190,13 +193,16 @@ let _handler _req =
       v.name == name && v.category == Category.Fn)
 
   match found with
-  | None -> PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "not found") 404
+  | None ->
+    PACKAGE.Darklang.Stdlib.Http.response
+      (PACKAGE.Darklang.Stdlib.String.toBytes "not found")
+      404
   | Some fn ->
     let respBody =
       fn
       |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>
       |> unwrap
-      |> String.toBytes
+      |> PACKAGE.Darklang.Stdlib.String.toBytes
 
     PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
@@ -260,6 +266,6 @@ let _handler _req =
         constants = constants })
     |> Json.serialize<PACKAGE.Darklang.Stdlib.Packages>
     |> unwrap
-    |> String.toBytes
+    |> PACKAGE.Darklang.Stdlib.String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response respBody 200

--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -1,52 +1,50 @@
 type PackageItem =
+  | Fn of PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn
+  | Type of PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType
+  | Constant of PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant
+
+type Category =
   | Fn
   | Type
   | Constant
-  | Module
 
-type NameToCategory =
+type GenericName =
   { owner: String
-    name: String
     modules: List<String>
-    category: PackageItem }
+    name: String
+    version: Int }
 
-
-[<DB>]
-type NamesDB = NameToCategory
-
-[<DB>]
-type PackageTypeDB = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType
-
-[<DB>]
-type PackageFnDB = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn
+type Entry =
+  { name: GenericName
+    package: PackageItem
+    category: Category }
 
 [<DB>]
-type PackageConstantDB = PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant
-
-[<DB>]
-type PackageItemDB = PackageItem
-
+type PackagesDB = Entry
 
 [<HttpHandler("POST", "/types")>]
 let _handler _req =
-  let typeToSave =
+  let value =
     request.body
     |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     |> Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
     |> Builtin.unwrap
 
   let item =
-    NameToCategory
-      { owner = typeToSave.name.owner
-        name =
-          typeToSave.name.name
-          |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.name
-        modules = typeToSave.name.modules
-        category = PackageItem.Type }
+    Entry
+      { name =
+          GenericName
+            { name =
+                value.name.name
+                |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.TypeName.name
+              modules = value.name.modules
+              owner = value.name.owner
+              version = value.name.version }
+        package = PackageItem.Type value
+        category = Category.Type }
 
-  let key = Builtin.DB.generateKey_v0 () // TODO: use `id` instead
-  Builtin.DB.set typeToSave key PackageTypeDB
-  Builtin.DB.set item key NamesDB
+  let key = Builtin.DB.generateKey_v0 ()
+  Builtin.DB.set item key PackagesDB
 
   PACKAGE.Darklang.Stdlib.Http.response
     (PACKAGE.Darklang.Stdlib.String.toBytes "added")
@@ -54,51 +52,55 @@ let _handler _req =
 
 [<HttpHandler("POST", "/functions")>]
 let _handler _req =
-  let fnToSave =
+  let value =
     request.body
     |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     |> Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>
     |> Builtin.unwrap
 
   let item =
-    NameToCategory
-      { owner = fnToSave.name.owner
-        name =
-          fnToSave.name.name
-          |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.name
-        modules = fnToSave.name.modules
-        category = PackageItem.Fn }
+    Entry
+      { name =
+          GenericName
+            { name =
+                value.name.name
+                |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.FnName.name
+              modules = value.name.modules
+              owner = value.name.owner
+              version = value.name.version }
+        package = PackageItem.Fn value
+        category = Category.Fn }
 
-  let key = Builtin.DB.generateKey_v0 () // TODO: use `id` instead
-  Builtin.DB.set fnToSave key PackageFnDB
-  Builtin.DB.set item key NamesDB
+  let key = Builtin.DB.generateKey_v0 ()
+  Builtin.DB.set item key PackagesDB
 
   PACKAGE.Darklang.Stdlib.Http.response
     (PACKAGE.Darklang.Stdlib.String.toBytes "added")
     200
 
-
 [<HttpHandler("POST", "/constants")>]
 let _handler _req =
-  let constantToSave =
+  let value =
     request.body
     |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
     |> Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>
     |> Builtin.unwrap
 
-
   let item =
-    NameToCategory
-      { owner = constantToSave.name.owner
-        name =
-          (constantToSave.name.name
-           |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.ConstantName.name)
-        modules = constantToSave.name.modules
-        category = PackageItem.Constant }
+    Entry
+      { name =
+          GenericName
+            { name =
+                value.name.name
+                |> PACKAGE.Darklang.PrettyPrinter.ProgramTypes.ConstantName.name
+              modules = value.name.modules
+              owner = value.name.owner
+              version = value.name.version }
+        package = PackageItem.Constant value
+        category = Category.Constant }
 
-  let key = Builtin.DB.generateKey_v0 () // TODO: use `id` instead
-  Builtin.DB.set constantToSave key PackageConstantDB
-  Builtin.DB.set item key NamesDB
+  let key = Builtin.DB.generateKey_v0 ()
+  Builtin.DB.set item key PackagesDB
 
   PACKAGE.Darklang.Stdlib.Http.response
     (PACKAGE.Darklang.Stdlib.String.toBytes "added")
@@ -109,80 +111,31 @@ let _handler _req =
 [<HttpHandler("GET", "/stats")>]
 let _handler _req =
   let types =
-    (Builtin.DB.getAll PackageTypeDB)
-    |> PACKAGE.Darklang.Stdlib.List.length
-    |> PACKAGE.Darklang.Stdlib.Int.toString
+    Builtin.DB.queryCount PackageDB (fun entry -> entry.category == Category.Type)
 
   let fns =
-    (Builtin.DB.getAll PackageFnDB)
-    |> PACKAGE.Darklang.Stdlib.List.length
-    |> PACKAGE.Darklang.Stdlib.Int.toString
+    Builtin.DB.queryCount PackageDB (fun entry -> entry.category == Category.Fn)
 
   let constants =
-    (Builtin.DB.getAll PackageConstantDB)
-    |> PACKAGE.Darklang.Stdlib.List.length
-    |> PACKAGE.Darklang.Stdlib.Int.toString
+    Builtin.DB.queryCount PackageDB (fun entry ->
+      entry.category == Category.Constant)
 
-  let items =
-    (Builtin.DB.getAll NamesDB)
-    |> PACKAGE.Darklang.Stdlib.List.length
-    |> PACKAGE.Darklang.Stdlib.Int.toString
+  let items = Builtin.DB.count PackageDB
 
   let body =
-    $"Package stats:\ntypes: {types}, fns: {fns}, constants: {constants}\n\ntotal items in NamesDB: {items}"
+    $"Package stats:\ntypes: {types}, fns: {fns}, constants: {constants}\n\ntotal items in DB: {items}"
     |> PACKAGE.Darklang.Stdlib.String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response body 200
 
 
-// fetch all at once
-[<HttpHandler("GET", "/types")>]
-let _handler _req =
-  let respBody =
-    (Builtin.DB.getAll PackageTypeDB)
-    |> Builtin.Json.serialize<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>>
-    |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.toBytes
-
-  PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
-
-[<HttpHandler("GET", "/constants")>]
-let _handler _req =
-  let respBody =
-    (Builtin.DB.getAll PackageConstantDB)
-    |> Builtin.Json.serialize<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>>
-    |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.toBytes
-
-  PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
-
-[<HttpHandler("GET", "/functions")>]
-let _handler _req =
-  let respBody =
-    (Builtin.DB.getAll PackageFnDB)
-    |> Builtin.Json.serialize<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>>
-    |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.toBytes
-
-  PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
-
-// (WIP) fetch item by name
-type PackageNameParts =
-  { owner: String
-    modules: List<String>
-    name: String
-    version: Int }
-
-let nameToParts (name: String) : PackageNameParts =
+let parseName (name: String) : GenericName =
   match PACKAGE.Darklang.Stdlib.String.split name "." with
   | owner :: rest ->
     match PACKAGE.Darklang.Stdlib.List.reverse rest with
     | name :: modulesInReverse ->
 
-      PackageNameParts
+      GenericName
         { owner = owner
           modules = PACKAGE.Darklang.Stdlib.List.reverse modulesInReverse
           name = name
@@ -191,85 +144,69 @@ let nameToParts (name: String) : PackageNameParts =
 
 [<HttpHandler("GET", "/type/by-name/:name")>]
 let _handler _req =
-  let nameParts = nameToParts name
+  let name = parseName name
 
   let found =
-    (Builtin.DB.getAll PackageTypeDB)
-    // CLEANUP this should be in a Builtin.DB.query, but:
-    // - SqlCompiler isn't great with generics yet
-    //   (See `PT.FnName.Package` definition for reference)
-    // - Builtin.DB.query is generally _super slow_ as of time of writing
-    |> PACKAGE.Darklang.Stdlib.List.filter (fun typ ->
-      typ.name.owner == nameParts.owner
-      && typ.name.modules == nameParts.modules
-      && typ.name.version == nameParts.version
-      && (match typ.name.name with
-          | TypeName name -> name == nameParts.name))
-    |> PACKAGE.Darklang.Stdlib.List.head
+    Builtin.DB.queryOne PackagesDB (fun v ->
+      v.name == name && v.category == Category.Type)
 
-  let respBody =
-    found
-    |> Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>>
-    |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.toBytes
+  match found with
+  | None -> PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "not found") 404
+  | Some type_ ->
+    let respBody =
+      type_
+      |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
+      |> unwrap
+      |> String.toBytes
 
-  PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
+    PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
 [<HttpHandler("GET", "/constant/by-name/:name")>]
 let _handler _req =
-  let nameParts = nameToParts name
+  let name = parseName name
 
   let found =
-    (Builtin.DB.getAll PackageConstantDB)
-    |> PACKAGE.Darklang.Stdlib.List.filter (fun c ->
-      c.name.owner == nameParts.owner
-      && c.name.modules == nameParts.modules
-      && c.name.version == nameParts.version
-      && (match c.name.name with
-          | ConstantName name -> name == nameParts.name))
-    |> PACKAGE.Darklang.Stdlib.List.head
+    Builtin.DB.queryOne PackagesDB (fun v ->
+      v.name == name && v.category == Category.Constant)
 
-  let respBody =
-    found
-    |> Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>>
-    |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.toBytes
+  match found with
+  | None -> PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "not found") 404
+  | Some constant ->
+    let respBody =
+      constant
+      |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>
+      |> unwrap
+      |> String.toBytes
 
-  PACKAGE.Darklang.Stdlib.Http.response respBody 200
+    PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
 
 [<HttpHandler("GET", "/function/by-name/:name")>]
 let _handler _req =
-  let nameParts = nameToParts name
+  let name = parseName name
 
   let found =
-    (Builtin.DB.getAll PackageFnDB)
-    |> PACKAGE.Darklang.Stdlib.List.filter (fun fn ->
-      fn.name.owner == nameParts.owner
-      && fn.name.modules == nameParts.modules
-      && fn.name.version == nameParts.version
-      && (match fn.name.name with
-          | FnName name -> name == nameParts.name))
-    |> PACKAGE.Darklang.Stdlib.List.head
+    Builtin.DB.queryOne PackagesDB (fun v ->
+      v.name == name && v.category == Category.Fn)
 
-  let respBody =
-    found
-    |> Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>>
-    |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.toBytes
+  match found with
+  | None -> PACKAGE.Darklang.Stdlib.Http.response (String.toBytes "not found") 404
+  | Some fn ->
+    let respBody =
+      fn
+      |> Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>
+      |> unwrap
+      |> String.toBytes
 
-  PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
+    PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
 
 [<HttpHandler("GET", "/owner/:owner")>]
 let _handler _req =
   let allItems =
-    (Builtin.DB.getAll NamesDB)
-    |> PACKAGE.Darklang.Stdlib.List.filter (fun item -> item.owner == owner)
+    (Builtin.DB.query PackagesDB (fun v -> v.name.owner == owner))
     |> PACKAGE.Darklang.Stdlib.List.map (fun i ->
-      (i.owner, i.modules |> PACKAGE.Darklang.Stdlib.String.join ".", i.name))
+      (i.owner, i.modules |> String.join ".", i.name))
     |> PACKAGE.Darklang.Stdlib.List.map (fun m ->
       let (owner, modules, name) = m
       $"{owner}.{modules}.{name}")
@@ -298,61 +235,31 @@ let _handler _req =
     |> PACKAGE.Darklang.Stdlib.String.split "."
     |> PACKAGE.Darklang.Stdlib.List.drop 1
 
-  let fns = Builtin.DB.getAll PackageFnDB
-  let types = Builtin.DB.getAll PackageTypeDB
-  let constants = Builtin.DB.getAll PackageConstantDB
+  let fns =
+    Builtin.DB.query PackageDB (fun v ->
+      v.name.owner == owner
+      && v.name.modules == modules
+      && v.category == Category.Fn)
+
+  let types =
+    Builtin.DB.query PackageDB (fun v ->
+      v.name.owner == owner
+      && v.name.modules == modules
+      && v.category == Category.Type)
+
+  let constants =
+    Builtin.DB.query PackageDB (fun v ->
+      v.name.owner == owner
+      && v.name.modules == modules
+      && v.category == Category.Constant)
 
   let respBody =
     (PACKAGE.Darklang.Stdlib.Packages
-      { types =
-          types
-          |> PACKAGE.Darklang.Stdlib.List.filter (fun t ->
-            t.name.owner == owner && t.name.modules == modules)
-        fns =
-          fns
-          |> PACKAGE.Darklang.Stdlib.List.filter (fun f ->
-            f.name.owner == owner && f.name.modules == modules)
-        constants =
-          constants
-          |> PACKAGE.Darklang.Stdlib.List.filter (fun c ->
-            c.name.owner == owner && c.name.modules == modules) })
-    |> Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Packages>
-    |> Builtin.unwrap
-    |> PACKAGE.Darklang.Stdlib.String.toBytes
+      { types = types
+        fns = fns
+        constants = constants })
+    |> Json.serialize<PACKAGE.Darklang.Stdlib.Packages>
+    |> unwrap
+    |> String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response respBody 200
-
-
-[<HttpHandler("GET", "/category/:name")>]
-let _handler _req =
-  let fullName = name |> PACKAGE.Darklang.Stdlib.String.split "."
-
-  let owner = fullName |> PACKAGE.Darklang.Stdlib.List.head |> Builtin.unwrap
-
-  let name = fullName |> PACKAGE.Darklang.Stdlib.List.last |> Builtin.unwrap
-
-  let modules =
-    fullName
-    |> (PACKAGE.Darklang.Stdlib.List.drop 1)
-    |> PACKAGE.Darklang.Stdlib.List.dropLast
-
-
-  // CLEANUP: Use Builtin.DB.query instead - this is currently blocked by the unavailability of resolved typeArgs in lambdaToSql
-  let allItems =
-    (Builtin.DB.getAll NamesDB)
-    |> PACKAGE.Darklang.Stdlib.List.filter (fun item ->
-      item.owner == owner && item.modules == modules && item.name == name)
-    |> PACKAGE.Darklang.Stdlib.List.map (fun item -> item.category)
-    |> PACKAGE.Darklang.Stdlib.List.head
-
-  let respBody =
-    match allItems with
-    | Some Fn -> "fn"
-    | Some Type -> "type"
-    | Some Constant -> "constant"
-    | Some Module -> "module"
-    | None -> "not found"
-
-  PACKAGE.Darklang.Stdlib.Http.response
-    (respBody |> PACKAGE.Darklang.Stdlib.String.toBytes)
-    200

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -298,8 +298,6 @@ module Darklang =
           let indent = indent + 2
 
           let valueTypeName = valueTypeName dv
-          //let wrap (str: String) = $"<{valueTypeName}: {str}>"
-          // let justType = $"<{typename}>"
 
           match dv with
           | DUnit -> "()"
@@ -366,17 +364,19 @@ module Darklang =
             let typeStr = typeName typeName
             typeStr ++ " {" ++ inl ++ elems ++ nl ++ "}"
 
-          // | DDict o ->
-          //   if Map.isEmpty o then
-          //     "{}"
-          //   else
-          //     let strs =
-          //       o
-          //       |> Map.toList
-          //       |> PACKAGE.Darklang.Stdlib.List.map (fun (key, value) -> ($"{key}: {withIndent indent value}"))
+          | DDict d ->
+            if d == Builtin.Dict.empty then
+              "{}"
+            else
+              let strs =
+                d
+                |> PACKAGE.Darklang.Stdlib.Dict.toList
+                |> PACKAGE.Darklang.Stdlib.List.map (fun pair ->
+                  let (key, value) = pair
+                  $"{key}: {withIndent indent value}")
 
-          //     let elems = PACKAGE.Darklang.Stdlib.String.concat $",{inl}" strs
-          //     "{" + $"{inl}{elems}{nl}" + "}"
+              let elems = PACKAGE.Darklang.Stdlib.String.join strs $",{inl}"
+              "{" ++ inl ++ elems ++ nl ++ "}"
 
           | DEnum(_, typeName, caseName, fields) ->
             let short =

--- a/scripts/build/reload-packages
+++ b/scripts/build/reload-packages
@@ -40,18 +40,18 @@ else
   LOCALEXEC_EXE="backend/Build/out/LocalExec/Debug/net7.0/LocalExec"
 fi
 
-echo "Waiting for BwdDangerServer to be ready"
-until curl -s -o /dev/null "localhost:${DARK_CONFIG_BWDSERVER_DANGER_KUBERNETES_PORT}" ; do
-  printf '.'
-  sleep 0.1
-done
-
-
 echo -e "Loading packages into DB ${grey}($LOG_DB)${reset}"
 "${LOCALEXEC_EXE}" load-packages > $LOG_DB 2>&1
 
 
 if [[ "$TEST" != "true" ]]; then
+
+  echo "Waiting for BwdDangerServer to be ready"
+  until curl -s -o /dev/null "localhost:${DARK_CONFIG_BWDSERVER_DANGER_KUBERNETES_PORT}" ; do
+    printf '.'
+    sleep 0.1
+  done
+
   # make sure the target canvas exists and is cleared
   ./scripts/run-canvas-hack "${PUBLISHED_FLAG}" dark-packages
 

--- a/scripts/build/reload-packages
+++ b/scripts/build/reload-packages
@@ -18,9 +18,9 @@ do
     shift
     ;;
     --published)
-      PUBLISHED=true
-      PUBLISHED_FLAG=$i
-      ;;
+    PUBLISHED=true
+    PUBLISHED_FLAG=$i
+    ;;
   esac
 done
 
@@ -53,8 +53,8 @@ echo -e "Loading packages into DB ${grey}($LOG_DB)${reset}"
 
 if [[ "$TEST" != "true" ]]; then
   # make sure the target canvas exists and is cleared
-  ./scripts/run-canvas-hack $PUBLISHED_FLAG dark-packages
+  ./scripts/run-canvas-hack "${PUBLISHED_FLAG}" dark-packages
 
   echo -e "Loading packages into Dark canvas ${grey}($LOG_CANVAS)${reset}"
-  ./scripts/run-local-exec $PUBLISHED_FLAG load-packages-dark > $LOG_CANVAS 2>&1
+  ./scripts/run-local-exec "${PUBLISHED_FLAG}" load-packages-dark > $LOG_CANVAS 2>&1
 fi

--- a/scripts/build/reload-packages
+++ b/scripts/build/reload-packages
@@ -36,18 +36,15 @@ else
   LOCALEXEC_EXE="backend/Build/out/LocalExec/Debug/net7.0/LocalExec"
 fi
 
+echo "Waiting for BwdDangerServer to be ready"
+until curl -s -o /dev/null "localhost:${DARK_CONFIG_BWDSERVER_DANGER_KUBERNETES_PORT}" ; do
+  printf '.'
+  sleep 0.1
+done
+
+
 echo -e "Loading packages into DB ${grey}($LOG_DB)${reset}"
 "${LOCALEXEC_EXE}" load-packages > $LOG_DB 2>&1
-
-
-# todo: wait until the backend servers are running (ports is ready)
-# for name in "${@}"; do
-#   echo "Waiting for $name"
-#   until curl "localhost:${DARK_CONFIG_BWDSERVER_DANGER_KUBERNETES_PORT}" ; do
-#     printf '.'
-#     sleep 1
-#   done
-# done
 
 
 if [[ "$TEST" != "true" ]]; then

--- a/scripts/build/reload-packages
+++ b/scripts/build/reload-packages
@@ -8,6 +8,7 @@ reset="\033[0m"
 
 TEST=false
 PUBLISHED=false
+PUBLISHED_FLAG=
 
 for i in "$@"
 do
@@ -16,7 +17,10 @@ do
     TEST=true
     shift
     ;;
-    --published) PUBLISHED=true ;;
+    --published)
+      PUBLISHED=true
+      PUBLISHED_FLAG=$i
+      ;;
   esac
 done
 
@@ -49,8 +53,8 @@ echo -e "Loading packages into DB ${grey}($LOG_DB)${reset}"
 
 if [[ "$TEST" != "true" ]]; then
   # make sure the target canvas exists and is cleared
-  ./scripts/run-canvas-hack dark-packages
+  ./scripts/run-canvas-hack $PUBLISHED_FLAG dark-packages
 
   echo -e "Loading packages into Dark canvas ${grey}($LOG_CANVAS)${reset}"
-  ./scripts/run-local-exec load-packages-dark > $LOG_CANVAS 2>&1
+  ./scripts/run-local-exec $PUBLISHED_FLAG load-packages-dark > $LOG_CANVAS 2>&1
 fi

--- a/scripts/build/reload-packages
+++ b/scripts/build/reload-packages
@@ -31,7 +31,7 @@ fi
 
 # Note: doesn't support release/published
 if [[ "$PUBLISHED" == "true" ]]; then
-  LOCALEXEC_EXE="backend/Build/out/LocalExec/Release/net7.0/linux-x64/publish/LocalExec"
+  LOCALEXEC_EXE="backend/Build/out/LocalExec/Release/net7.0/linux-x64/LocalExec"
 else
   LOCALEXEC_EXE="backend/Build/out/LocalExec/Debug/net7.0/LocalExec"
 fi

--- a/scripts/build/reload-packages
+++ b/scripts/build/reload-packages
@@ -53,8 +53,8 @@ if [[ "$TEST" != "true" ]]; then
   done
 
   # make sure the target canvas exists and is cleared
-  ./scripts/run-canvas-hack "${PUBLISHED_FLAG}" dark-packages
+  ./scripts/run-canvas-hack $PUBLISHED_FLAG dark-packages
 
   echo -e "Loading packages into Dark canvas ${grey}($LOG_CANVAS)${reset}"
-  ./scripts/run-local-exec "${PUBLISHED_FLAG}" load-packages-dark > $LOG_CANVAS 2>&1
+  ./scripts/run-local-exec $PUBLISHED_FLAG load-packages-dark > $LOG_CANVAS 2>&1
 fi

--- a/scripts/run-backend-server
+++ b/scripts/run-backend-server
@@ -93,6 +93,13 @@ do
 done
 echo "Done waiting for compiled servers"
 
+# Wait for cloud-storage-emulator (can be slow on CI)
+echo "Waiting for cloud-storage-emulator"
+until curl -s -o /dev/null "localhost:4444" ; do
+  printf '.'
+  sleep 0.1
+done
+
 grey="\033[1;30m"
 reset="\033[0m"
 

--- a/scripts/run-canvas-hack
+++ b/scripts/run-canvas-hack
@@ -4,7 +4,11 @@
 set -euo pipefail
 
 
-EXE="backend/Build/out/CanvasHack/Debug/net7.0/CanvasHack"
+if [[ "$PUBLISHED" == "true" ]]; then
+  EXE="backend/Build/out/CanvasHack/Release/net7.0/linux-x64/CanvasHack"
+else
+  EXE="backend/Build/out/CanvasHack/Debug/net7.0/CanvasHack"
+fi
 
 ./scripts/devcontainer/_wait-for-background-services postgresql
 

--- a/scripts/run-canvas-hack
+++ b/scripts/run-canvas-hack
@@ -4,14 +4,13 @@
 set -euo pipefail
 
 PUBLISHED=false
+CANVAS=
 
 for i in "$@"
 do
   case "${i}" in
-    --published)
-      PUBLISHED=true
-      shift
-      ;;
+    --published) PUBLISHED=true ;;
+    *) CANVAS="${i}" ;;
   esac
 done
 
@@ -34,8 +33,10 @@ do
   fi
 done
 
+set -x
+
 echo "Clearing canvas before loading from disk"
-./scripts/clear-canvas.sh $1
+./scripts/clear-canvas.sh "${CANVAS}"
 
 echo "Running canvashack"
-"${EXE}" "${@}"
+"${EXE}" "${CANVAS}"

--- a/scripts/run-canvas-hack
+++ b/scripts/run-canvas-hack
@@ -10,6 +10,7 @@ do
   case "${i}" in
     --published)
       PUBLISHED=true
+      shift
       ;;
   esac
 done

--- a/scripts/run-canvas-hack
+++ b/scripts/run-canvas-hack
@@ -3,6 +3,17 @@
 
 set -euo pipefail
 
+PUBLISHED=false
+
+for i in "$@"
+do
+  case "${i}" in
+    --published)
+      PUBLISHED=true
+      ;;
+  esac
+done
+
 
 if [[ "$PUBLISHED" == "true" ]]; then
   EXE="backend/Build/out/CanvasHack/Release/net7.0/linux-x64/CanvasHack"

--- a/scripts/run-local-exec
+++ b/scripts/run-local-exec
@@ -9,9 +9,9 @@ for i in "$@"
 do
   case "${i}" in
     --published)
-    PUBLISHED=true
-    shift
-    ;;
+      PUBLISHED=true
+      ;;
+    *) ARGS+=("${i}");;
   esac
 done
 
@@ -25,4 +25,4 @@ else
   EXE="backend/Build/out/LocalExec/Debug/net7.0/LocalExec"
 fi
 
-"${EXE}" "$@"
+"${EXE}" "${ARGS[@]}"

--- a/scripts/run-local-exec
+++ b/scripts/run-local-exec
@@ -20,7 +20,7 @@ done
 ./scripts/run-cloud-storage-emulator
 
 if [[ "$PUBLISHED" == "true" ]]; then
-  EXE="backend/Build/out/LocalExec/Release/net7.0/linux-x64/publish/LocalExec"
+  EXE="backend/Build/out/LocalExec/Release/net7.0/linux-x64/LocalExec"
 else
   EXE="backend/Build/out/LocalExec/Debug/net7.0/LocalExec"
 fi


### PR DESCRIPTION
I rewrote dark-packages, using more direct calls (`DB.query` vs `DB.getAll`). This led me on a journey:

- add support for querying EEnums in the SqlCompiler
- allow querying DRecords and DEnums in SqlCompiler
- more docs and more specific errors in SqlCompiler
- handle typeArgs in aliases and fields in SqlCompiler
- print errors better in the CLI
- refactor PackageManager fetching in the cli
- add fetching from packages in CI to find errors earlier

I also tried to enable testing the PackageManager in the CLI, but gave up.