### PR TITLE
Migrate base64encode and base64decode from Bytes to a Base64 module

### DIFF
--- a/backend/src/BuiltinExecution/Builtin.fs
+++ b/backend/src/BuiltinExecution/Builtin.fs
@@ -18,6 +18,7 @@ let typeRenames =
 let contents (httpConfig : Libs.HttpClient.Configuration) : Builtin.Contents =
   Builtin.combine
     [ Libs.Bool.contents
+      Libs.Base64.contents
       Libs.Bytes.contents
       Libs.Char.contents
       Libs.DateTime.contents

--- a/backend/src/BuiltinExecution/BuiltinExecution.fsproj
+++ b/backend/src/BuiltinExecution/BuiltinExecution.fsproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />
+    <Compile Include="Libs/Base64.fs" />
     <Compile Include="Libs/Bytes.fs" />
     <Compile Include="Libs/Bool.fs" />
     <Compile Include="Libs/Char.fs" />

--- a/backend/src/BuiltinExecution/Libs/Base64.fs
+++ b/backend/src/BuiltinExecution/Libs/Base64.fs
@@ -60,7 +60,7 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "encode" 0
+    { name = fn "urlEncode" 0
       typeParams = []
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TString

--- a/backend/src/BuiltinExecution/Libs/Base64.fs
+++ b/backend/src/BuiltinExecution/Libs/Base64.fs
@@ -1,0 +1,83 @@
+module BuiltinExecution.Libs.Base64
+
+open System
+open System.Text
+open System.Text.RegularExpressions
+
+open Prelude
+open LibExecution.RuntimeTypes
+open LibExecution.Builtin.Shortcuts
+
+module Dval = LibExecution.Dval
+
+
+let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
+
+let modules = [ "Base64" ]
+let fn = fn modules
+
+let fns : List<BuiltInFn> =
+  [ { name = fn "decode" 0
+      typeParams = []
+      parameters = [ Param.make "s" TString "" ]
+      returnType = TypeReference.result TBytes TString
+      description =
+        "Base64 decodes a string. Works with both the URL-safe and standard Base64
+         alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html)
+         sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
+         [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
+      fn =
+        (function
+        | _, _, [ DString s ] ->
+          let base64FromUrlEncoded (str : string) : string =
+            let initial = str.Replace('-', '+').Replace('_', '/')
+            let length = initial.Length
+
+            if length % 4 = 2 then $"{initial}=="
+            else if length % 4 = 3 then $"{initial}="
+            else initial
+
+          if s = "" then
+            // This seems like we should allow it
+            [||] |> DBytes |> Dval.resultOk |> Ply
+          elif Regex.IsMatch(s, @"\s") then
+            // dotnet ignores whitespace but we don't allow it
+            "Not a valid base64 string" |> DString |> Dval.resultError |> Ply
+          else
+            try
+              s
+              |> base64FromUrlEncoded
+              |> Convert.FromBase64String
+              |> DBytes
+              |> Dval.resultOk
+              |> Ply
+            with e ->
+              Ply(Dval.resultError (DString("Not a valid base64 string")))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "encode" 0
+      typeParams = []
+      parameters = [ Param.make "bytes" TBytes "" ]
+      returnType = TString
+      description =
+        "Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding
+         with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648
+         section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
+      fn =
+        (function
+        | _, _, [ DBytes bytes ] ->
+          // Differs from Base64.encodeToUrlSafe as this version has padding
+          System.Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_')
+          |> DString
+          |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated } ]
+
+let contents = (fns, types, constants)

--- a/backend/src/BuiltinExecution/Libs/Bytes.fs
+++ b/backend/src/BuiltinExecution/Libs/Bytes.fs
@@ -24,70 +24,7 @@ let constants : List<BuiltInConstant> =
       deprecated = NotDeprecated } ]
 
 let fns : List<BuiltInFn> =
-  [ { name = fn "base64Decode" 0
-      typeParams = []
-      parameters = [ Param.make "s" TString "" ]
-      returnType = TypeReference.result TBytes TString
-      description =
-        "Base64 decodes a string. Works with both the URL-safe and standard Base64
-         alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html)
-         sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
-         [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
-      fn =
-        (function
-        | _, _, [ DString s ] ->
-          let base64FromUrlEncoded (str : string) : string =
-            let initial = str.Replace('-', '+').Replace('_', '/')
-            let length = initial.Length
-
-            if length % 4 = 2 then $"{initial}=="
-            else if length % 4 = 3 then $"{initial}="
-            else initial
-
-          if s = "" then
-            // This seems like we should allow it
-            [||] |> DBytes |> Dval.resultOk |> Ply
-          elif Regex.IsMatch(s, @"\s") then
-            // dotnet ignores whitespace but we don't allow it
-            "Not a valid base64 string" |> DString |> Dval.resultError |> Ply
-          else
-            try
-              s
-              |> base64FromUrlEncoded
-              |> Convert.FromBase64String
-              |> DBytes
-              |> Dval.resultOk
-              |> Ply
-            with e ->
-              Ply(Dval.resultError (DString("Not a valid base64 string")))
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplemented
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "base64Encode" 0
-      typeParams = []
-      parameters = [ Param.make "bytes" TBytes "" ]
-      returnType = TString
-      description =
-        "Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding
-         with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648
-         section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
-      fn =
-        (function
-        | _, _, [ DBytes bytes ] ->
-          // Differs from Base64.encodeToUrlSafe as this version has padding
-          System.Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_')
-          |> DString
-          |> Ply
-        | _ -> incorrectArgs ())
-      sqlSpec = NotYetImplemented
-      previewable = Pure
-      deprecated = NotDeprecated }
-
-
-    { name = fn "hexEncode" 0
+  [ { name = fn "hexEncode" 0
       typeParams = []
       parameters = [ Param.make "bytes" TBytes "" ]
       returnType = TString

--- a/backend/src/BuiltinExecution/Libs/Bytes.fs
+++ b/backend/src/BuiltinExecution/Libs/Bytes.fs
@@ -64,6 +64,45 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "append" 0
+      typeParams = []
+      parameters = [ Param.make "bytes1" TBytes ""; Param.make "bytes2" TBytes "" ]
+      returnType = TBytes
+      description = "Returns the concatenation of <param bytes1> and <param bytes2>"
+      fn =
+        (function
+        | _, _, [ DBytes bytes1; DBytes bytes2 ] ->
+          bytes2 |> Array.append bytes1 |> DBytes |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "containsSegment" 0
+      typeParams = []
+      parameters = [ Param.make "bytes" TBytes ""; Param.make "segment" TBytes "" ]
+      returnType = TBool
+      description = "Returns true if <param bytes> contains <param segment>"
+      fn =
+        (function
+        | _, _, [ DBytes bytes; DBytes segment ] ->
+          let segmentLength = Array.length segment
+          let limit = (Array.length bytes) - segmentLength
+
+          let rec searchSegmentFromIndex idx =
+            if idx > limit then false
+            else if Array.sub bytes idx segmentLength = segment then true
+            else searchSegmentFromIndex (idx + 1)
+
+          (searchSegmentFromIndex 0) |> DBool |> Ply
+
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
       deprecated = NotDeprecated } ]
 
 let contents = (fns, types, constants)

--- a/backend/src/BuiltinExecution/Libs/Bytes.fs
+++ b/backend/src/BuiltinExecution/Libs/Bytes.fs
@@ -82,7 +82,7 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "containsSegment" 0
+    { name = fn "contains" 0
       typeParams = []
       parameters = [ Param.make "bytes" TBytes ""; Param.make "segment" TBytes "" ]
       returnType = TBool

--- a/backend/src/LibExecution/RuntimeTypesAst.fs
+++ b/backend/src/LibExecution/RuntimeTypesAst.fs
@@ -300,7 +300,6 @@ let rec postTraversalAsync
       | TUuid
       | TDateTime
       | TBytes
-      | TPassword
       | TVariable _
       | TString -> return typeRef
       | TList tr ->

--- a/backend/testfiles/execution/language/big.dark
+++ b/backend/testfiles/execution/language/big.dark
@@ -1,7 +1,7 @@
 module BigTestCase =
   (let str = "a string to be used as the test case" in
    let bytes = PACKAGE.Darklang.Stdlib.String.toBytes_v0 str in
-   let base64Encode = PACKAGE.Darklang.Stdlib.Bytes.base64Encode_v0 bytes in
+   let base64Encode = PACKAGE.Darklang.Stdlib.Base64.encode_v0 bytes in
    let hexEncode = PACKAGE.Darklang.Stdlib.Bytes.hexEncode_v0 bytes in
    let sl = PACKAGE.Darklang.Stdlib.String.length str in
    let bl = PACKAGE.Darklang.Stdlib.Bytes.length bytes in

--- a/backend/testfiles/execution/language/big.dark
+++ b/backend/testfiles/execution/language/big.dark
@@ -1,7 +1,7 @@
 module BigTestCase =
   (let str = "a string to be used as the test case" in
    let bytes = PACKAGE.Darklang.Stdlib.String.toBytes_v0 str in
-   let base64Encode = PACKAGE.Darklang.Stdlib.Base64.encode_v0 bytes in
+   let base64Encode = PACKAGE.Darklang.Stdlib.Base64.urlEncode_v0 bytes in
    let hexEncode = PACKAGE.Darklang.Stdlib.Bytes.hexEncode_v0 bytes in
    let sl = PACKAGE.Darklang.Stdlib.String.length str in
    let bl = PACKAGE.Darklang.Stdlib.Bytes.length bytes in

--- a/backend/testfiles/execution/stdlib/bytes.dark
+++ b/backend/testfiles/execution/stdlib/bytes.dark
@@ -225,3 +225,60 @@ PACKAGE.Darklang.Stdlib.Bytes.hexEncode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0
     "dlkjkd329823333333333fjfidjsfudsdhs}{||!|!|!|!!$%^&^&﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽"
 ) = "646C6B6A6B64333239383233333333333333333333666A6669646A73667564736468737D7B7C7C217C217C217C212124255E265E26EFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BDEFB7BD"
+
+
+PACKAGE.Darklang.Stdlib.Bytes.append_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 " world") = PACKAGE.Darklang.Stdlib.String.toBytes_v0
+  "hello world"
+
+PACKAGE.Darklang.Stdlib.Bytes.append_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️🇵🇷") = PACKAGE.Darklang.Stdlib.String.toBytes_v0
+  "👱👱🏻👱🏼👱🏽👱🏾👱🏿👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️🇵🇷"
+
+PACKAGE.Darklang.Stdlib.Bytes.append_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 " النص") = PACKAGE.Darklang.Stdlib.String.toBytes_v0
+  "اختبار النص"
+
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "world") = true
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello") = true
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world") = true
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world!") = false
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱🏿👱🏾👱🏽👱🏼") = false
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼") = true
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار النص")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار") = true
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار النص")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "نص") = true
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚") = true
+
+PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇")
+  (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̔ͮ̇͐̇") = false

--- a/backend/testfiles/execution/stdlib/bytes.dark
+++ b/backend/testfiles/execution/stdlib/bytes.dark
@@ -185,27 +185,27 @@ PACKAGE.Darklang.Stdlib.Base64.decode "_w" = PACKAGE.Darklang.Stdlib.Result.Resu
 
 
 
-PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.urlEncode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "abcdef"
 ) = "YWJjZGVm"
 
-PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.urlEncode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇"
 ) = "WsykzZTNp8yRzJPDpM2WzK3MiMyHbM2uzJLNq8enzJfNmsyab8yZzJTNrsyHzZDMhw=="
 
-PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.urlEncode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار النص"
 ) = "2KfYrtiq2KjYp9ixINin2YTZhti1"
 
-PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.urlEncode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽"
 ) = "77e977e977e977e977e977e977e977e977e977e977e977e977e977e977e977e9"
 
-PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.urlEncode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿"
 ) = "8J-RsfCfkbHwn4-78J-RsfCfj7zwn5Gx8J-PvfCfkbHwn4--8J-RsfCfj78="
 
-PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.urlEncode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️🇵🇷"
 ) = "8J-RqOKAjeKdpO-4j-KAjfCfkovigI3wn5Go8J-RqeKAjfCfkanigI3wn5Gn4oCN8J-RpvCfj7PvuI_igI3imqfvuI_wn4e18J-Htw=="
 
@@ -243,42 +243,42 @@ PACKAGE.Darklang.Stdlib.Bytes.append_v0
   "اختبار النص"
 
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "world") = true
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello") = true
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world") = true
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "hello world!") = false
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱🏿👱🏾👱🏽👱🏼") = false
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼") = true
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار النص")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار") = true
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار النص")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "نص") = true
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚") = true
 
-PACKAGE.Darklang.Stdlib.Bytes.containsSegment_v0
+PACKAGE.Darklang.Stdlib.Bytes.contains_v0
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇")
   (PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̔ͮ̇͐̇") = false

--- a/backend/testfiles/execution/stdlib/bytes.dark
+++ b/backend/testfiles/execution/stdlib/bytes.dark
@@ -7,114 +7,105 @@ PACKAGE.Darklang.Stdlib.Bytes.length (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "abcdef"
 ) = 6
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "white space" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+PACKAGE.Darklang.Stdlib.Base64.decode "white space" = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "Not a valid base64 string"
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Kw" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "+")
+PACKAGE.Darklang.Stdlib.Base64.decode "Kw" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  PACKAGE.Darklang.Stdlib.String.toBytes_v0 "+"
+)
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "yLo" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "yLo" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Ⱥ")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "xbzDs8WCdw" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "xbzDs8WCdw" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "żółw")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "LyotKygmQDk4NTIx" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "LyotKygmQDk4NTIx" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "/*-+(&@98521")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "illegal-chars&@:" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+PACKAGE.Darklang.Stdlib.Base64.decode "illegal-chars&@:" = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "Not a valid base64 string"
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "x" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+PACKAGE.Darklang.Stdlib.Base64.decode "x" = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "Not a valid base64 string"
 // empty case
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "")
+PACKAGE.Darklang.Stdlib.Base64.decode "" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  PACKAGE.Darklang.Stdlib.String.toBytes_v0 ""
+)
 // Test cases from the spec with padding added
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zg" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zg" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  PACKAGE.Darklang.Stdlib.String.toBytes_v0 "f"
+)
+
+PACKAGE.Darklang.Stdlib.Base64.decode "Zg==" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "f")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zg==" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "f")
-
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm8" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm8" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "fo")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm8=" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm8=" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "fo")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9v" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9v" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "foo")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYg" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9vYg" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "foob")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYg==" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9vYg==" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "foob")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYmE" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9vYmE" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "fooba")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYmE=" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9vYmE=" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "fooba")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYmFy" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9vYmFy" = PACKAGE
   .Darklang
   .Stdlib
   .Result
@@ -122,35 +113,35 @@ PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYmFy" = PACKAGE
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "foobar")
 // "Impossible cases" from apache
 // https://commons.apache.org/proper/commons-codec/xref-test/org/apache/commons/codec/binary/Base64Test.html
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "ZE==" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "ZE==" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "d")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "ZmC=" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "ZmC=" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "f`")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYE==" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9vYE==" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "foo`")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "Zm9vYmC=" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "Zm9vYmC=" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "foob`")
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode
+PACKAGE.Darklang.Stdlib.Base64.decode
   "ZnJvbT0wNi8wNy8yMDEzIHF1ZXJ5PSLOms6xzrvPjs-CIM6_z4HOr8-DzrHPhM61Ig" = PACKAGE
   .Darklang
   .Stdlib
@@ -161,7 +152,7 @@ PACKAGE.Darklang.Stdlib.Bytes.base64Decode
       "from=06/07/2013 query=\"Καλώς ορίσατε\""
   )
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode
+PACKAGE.Darklang.Stdlib.Base64.decode
   "8J-RsfCfkbHwn4-78J-RsfCfj7zwn5Gx8J-PvfCfkbHwn4--8J-RsfCfj78" = PACKAGE
   .Darklang
   .Stdlib
@@ -169,64 +160,52 @@ PACKAGE.Darklang.Stdlib.Bytes.base64Decode
   .Result
   .Ok(PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿")
 // These produce strings of bytes which are technically legal it seems
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "-p" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Builtin.Test.asBytes_v0 [ 250 ])
+PACKAGE.Darklang.Stdlib.Base64.decode "-p" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  Builtin.Test.asBytes_v0 [ 250 ]
+)
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "lI" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Builtin.Test.asBytes_v0 [ 148 ])
+PACKAGE.Darklang.Stdlib.Base64.decode "lI" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  Builtin.Test.asBytes_v0 [ 148 ]
+)
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "5Sk" = PACKAGE
+PACKAGE.Darklang.Stdlib.Base64.decode "5Sk" = PACKAGE
   .Darklang
   .Stdlib
   .Result
   .Result
   .Ok(Builtin.Test.asBytes_v0 [ 229; 41 ])
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "AA" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Builtin.Test.asBytes_v0 [ 0 ])
+PACKAGE.Darklang.Stdlib.Base64.decode "AA" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  Builtin.Test.asBytes_v0 [ 0 ]
+)
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Decode "_w" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Builtin.Test.asBytes_v0 [ 255 ])
+PACKAGE.Darklang.Stdlib.Base64.decode "_w" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  Builtin.Test.asBytes_v0 [ 255 ]
+)
 
 
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "abcdef"
 ) = "YWJjZGVm"
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "Z̤͔ͧ̑̓ä͖̭̈̇lͮ̒ͫǧ̗͚̚o̙̔ͮ̇͐̇"
 ) = "WsykzZTNp8yRzJPDpM2WzK3MiMyHbM2uzJLNq8enzJfNmsyab8yZzJTNrsyHzZDMhw=="
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "اختبار النص"
 ) = "2KfYrtiq2KjYp9ixINin2YTZhti1"
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽﷽"
 ) = "77e977e977e977e977e977e977e977e977e977e977e977e977e977e977e977e9"
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👱👱🏻👱🏼👱🏽👱🏾👱🏿"
 ) = "8J-RsfCfkbHwn4-78J-RsfCfj7zwn5Gx8J-PvfCfkbHwn4--8J-RsfCfj78="
 
-PACKAGE.Darklang.Stdlib.Bytes.base64Encode_v0 (
+PACKAGE.Darklang.Stdlib.Base64.encode_v0 (
   PACKAGE.Darklang.Stdlib.String.toBytes_v0 "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️🇵🇷"
 ) = "8J-RqOKAjeKdpO-4j-KAjfCfkovigI3wn5Go8J-RqeKAjfCfkanigI3wn5Gn4oCN8J-RpvCfj7PvuI_igI3imqfvuI_wn4e18J-Htw=="
 

--- a/backend/testfiles/execution/stdlib/string.dark
+++ b/backend/testfiles/execution/stdlib/string.dark
@@ -92,47 +92,45 @@ module ToBytes =
 
 module FromBytesWithReplacement =
   PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "w6I") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "w6I") |> Builtin.unwrap
   ) = "â"
 
   PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "aGVsbG8g8J+YgA==")
-    |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "aGVsbG8g8J+YgA==") |> Builtin.unwrap
   ) = "hello 😀"
 
   PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "ww==") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "ww==") |> Builtin.unwrap
   ) = "�"
 
   PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "7aCA") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "7aCA") |> Builtin.unwrap
   ) = "���"
 
   PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "aMM=") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "aMM=") |> Builtin.unwrap
   ) = "h�"
 
 
 module FromBytes =
   PACKAGE.Darklang.Stdlib.String.fromBytes_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "w6I") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "w6I") |> Builtin.unwrap
   ) = PACKAGE.Darklang.Stdlib.Option.Option.Some("â")
 
   PACKAGE.Darklang.Stdlib.String.fromBytes_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "aGVsbG8g8J+YgA==")
-    |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "aGVsbG8g8J+YgA==") |> Builtin.unwrap
   ) = PACKAGE.Darklang.Stdlib.Option.Option.Some("hello 😀")
 
   PACKAGE.Darklang.Stdlib.String.fromBytes_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "ww==") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "ww==") |> Builtin.unwrap
   ) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
   PACKAGE.Darklang.Stdlib.String.fromBytes_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "7aCA") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "7aCA") |> Builtin.unwrap
   ) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
   PACKAGE.Darklang.Stdlib.String.fromBytes_v0 (
-    (PACKAGE.Darklang.Stdlib.Bytes.base64Decode_v0 "aMM=") |> Builtin.unwrap
+    (PACKAGE.Darklang.Stdlib.Base64.decode_v0 "aMM=") |> Builtin.unwrap
   ) = PACKAGE.Darklang.Stdlib.Option.Option.None
 
 

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -373,7 +373,7 @@ module Darklang =
             typeStr ++ typeArgsPart ++ " {" ++ inl ++ elems ++ nl ++ "}"
 
           | DDict d ->
-            if d == Builtin.Dict.empty then
+            if d == PACKAGE.Darklang.Stdlib.Dict.empty then
               "{}"
             else
               let strs =

--- a/packages/darklang/stdlib/base64.dark
+++ b/packages/darklang/stdlib/base64.dark
@@ -1,0 +1,16 @@
+module Darklang =
+  module Stdlib =
+    module Base64 =
+
+      /// Base64 decodes a string. Works with both the URL-safe and standard Base64
+      /// alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html)
+      /// sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
+      /// [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5).
+      let decode (s: String) : PACKAGE.Darklang.Stdlib.Result.Result<Bytes, String> =
+        Builtin.Base64.decode s
+
+
+      /// Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding
+      /// with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648
+      /// section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5).
+      let encode (bytes: Bytes) : String = Builtin.Base64.encode bytes

--- a/packages/darklang/stdlib/base64.dark
+++ b/packages/darklang/stdlib/base64.dark
@@ -13,4 +13,4 @@ module Darklang =
       /// Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding
       /// with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648
       /// section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5).
-      let encode (bytes: Bytes) : String = Builtin.Base64.encode bytes
+      let urlEncode (bytes: Bytes) : String = Builtin.Base64.urlEncode bytes

--- a/packages/darklang/stdlib/bytes.dark
+++ b/packages/darklang/stdlib/bytes.dark
@@ -9,3 +9,13 @@ module Darklang =
 
       /// Returns the number of bytes in <param bytes>
       let length (bytes: Bytes) : Int = Builtin.Bytes.length bytes
+
+
+      /// Returns the concatenation of <param bytes1> and <param bytes2>
+      let append (bytes1: Bytes) (bytes2: Bytes) : Bytes =
+        Builtin.Bytes.append bytes1 bytes2
+
+
+      /// Returns true if <param bytes> contains <param segment>
+      let containsSegment (bytes: Bytes) (segment: Bytes) : Bool =
+        Builtin.Bytes.containsSegment bytes segment

--- a/packages/darklang/stdlib/bytes.dark
+++ b/packages/darklang/stdlib/bytes.dark
@@ -17,5 +17,5 @@ module Darklang =
 
 
       /// Returns true if <param bytes> contains <param segment>
-      let containsSegment (bytes: Bytes) (segment: Bytes) : Bool =
-        Builtin.Bytes.containsSegment bytes segment
+      let contains (bytes: Bytes) (segment: Bytes) : Bool =
+        Builtin.Bytes.contains bytes segment

--- a/packages/darklang/stdlib/bytes.dark
+++ b/packages/darklang/stdlib/bytes.dark
@@ -2,22 +2,6 @@ module Darklang =
   module Stdlib =
     module Bytes =
 
-      /// Base64 decodes a string. Works with both the URL-safe and standard Base64
-      /// alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html)
-      /// sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
-      /// [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5).
-      let base64Decode
-        (s: String)
-        : PACKAGE.Darklang.Stdlib.Result.Result<Bytes, String> =
-        Builtin.Bytes.base64Decode s
-
-
-      /// Base64URL encodes <param bytes> with {{=}} padding. Uses URL-safe encoding
-      /// with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648
-      /// section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5).
-      let base64Encode (bytes: Bytes) : String = Builtin.Bytes.base64Encode bytes
-
-
       /// Hex (Base16) encodes <param bytes> using an uppercase alphabet. Complies
       /// with [RFC 4648 section 8](https://www.rfc-editor.org/rfc/rfc4648.html#section-8).
       let hexEncode (bytes: Bytes) : String = Builtin.Bytes.hexEncode bytes

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -112,7 +112,7 @@ module Darklang =
       /// {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in
       /// [RFC 4648 section 5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)
       let base64Encode (s: String) : String =
-        let encoded = s |> Builtin.String.toBytes |> Builtin.Base64.encode
+        let encoded = s |> Builtin.String.toBytes |> Builtin.Base64.urlEncode
         PACKAGE.Darklang.Stdlib.String.replaceAll encoded "=" ""
 
 
@@ -140,7 +140,7 @@ module Darklang =
         let sha384Hash =
           Builtin.Crypto.sha384_v0 (PACKAGE.Darklang.Stdlib.String.toBytes_v0 s)
 
-        sha384Hash |> PACKAGE.Darklang.Stdlib.Base64.encode
+        sha384Hash |> PACKAGE.Darklang.Stdlib.Base64.urlEncode
 
 
       /// Generate a <type String> of length <param length> from random characters

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -112,7 +112,7 @@ module Darklang =
       /// {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in
       /// [RFC 4648 section 5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)
       let base64Encode (s: String) : String =
-        let encoded = s |> Builtin.String.toBytes |> Builtin.Bytes.base64Encode
+        let encoded = s |> Builtin.String.toBytes |> Builtin.Base64.encode
         PACKAGE.Darklang.Stdlib.String.replaceAll encoded "=" ""
 
 
@@ -125,7 +125,7 @@ module Darklang =
       let base64Decode
         (s: String)
         : PACKAGE.Darklang.Stdlib.Result.Result<String, String> =
-        match (Builtin.Bytes.base64Decode s) with
+        match (Builtin.Base64.decode s) with
         | Ok bytes ->
           match (Builtin.String.fromBytes bytes) with
           | Some str -> PACKAGE.Darklang.Stdlib.Result.Result.Ok str
@@ -140,7 +140,7 @@ module Darklang =
         let sha384Hash =
           Builtin.Crypto.sha384_v0 (PACKAGE.Darklang.Stdlib.String.toBytes_v0 s)
 
-        sha384Hash |> PACKAGE.Darklang.Stdlib.Bytes.base64Encode
+        sha384Hash |> PACKAGE.Darklang.Stdlib.Base64.encode
 
 
       /// Generate a <type String> of length <param length> from random characters


### PR DESCRIPTION
Changelog:

```
Stdlib improvements
- Migrate Bytes.base64encode and Bytes.base64decode to a separate Base64 module
- Add Bytes.append and Bytes.containsSegment
```
