### PR TITLE
Cleanups after DError change

### DIFF
--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -360,47 +360,35 @@ let fns : List<BuiltInFn> =
         (function
         | state, _, [ DDict(_vtTODO, o); DFnVal b ] ->
           uply {
-            let abortReason = ref None
-
             let f (key : string) (data : Dval) : Ply<Option<Dval>> =
               uply {
-                let run = abortReason.Value = None
+                let args = NEList.ofList (DString key) [ data ]
+                let! result = Interpreter.applyFnVal state 0UL b [] args
 
-                if run then
-                  let args = NEList.ofList (DString key) [ data ]
-                  let! result = Interpreter.applyFnVal state 0UL b [] args
-
-                  match result with
-                  | DEnum(FQName.Package { owner = "Darklang"
-                                           modules = [ "Stdlib"; "Option" ]
-                                           name = TypeName.TypeName "Option"
-                                           version = 0 },
-                          _,
-                          "Some",
-                          [ o ]) -> return Some o
-                  | DEnum(FQName.Package { owner = "Darklang"
-                                           modules = [ "Stdlib"; "Option" ]
-                                           name = TypeName.TypeName "Option"
-                                           version = 0 },
-                          _,
-                          "None",
-                          []) -> return None
-                  | v ->
+                match result with
+                | DEnum(FQName.Package { owner = "Darklang"
+                                         modules = [ "Stdlib"; "Option" ]
+                                         name = TypeName.TypeName "Option"
+                                         version = 0 },
+                        _,
+                        "Some",
+                        [ o ]) -> return Some o
+                | DEnum(FQName.Package { owner = "Darklang"
+                                         modules = [ "Stdlib"; "Option" ]
+                                         name = TypeName.TypeName "Option"
+                                         version = 0 },
+                        _,
+                        "None",
+                        []) -> return None
+                | v ->
+                  return
                     raiseString (
                       Errors.expectedLambdaType "fn" (TypeReference.option varB) v
                     )
-
-                    return None
-
-                else
-                  return None
               }
 
             let! result = Ply.Map.filterMapSequentially f o
-
-            match abortReason.Value with
-            | None -> return result |> Map.toList |> Dval.dict valueTypeTODO
-            | Some v -> return v
+            return result |> Map.toList |> Dval.dict valueTypeTODO
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -192,7 +192,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, _, [ DDict(_vtTODO, o); DString s ] ->
-          Map.tryFind s o |> Dval.option |> Ply
+          Map.find s o |> Dval.option |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/NoModule.fs
+++ b/backend/src/BuiltinExecution/Libs/NoModule.fs
@@ -30,15 +30,13 @@ let rec equals (a : Dval) (b : Dval) : bool =
   | DDict(_vtTODO1, a), DDict(_vtTODO2, b) ->
     Map.count a = Map.count b
     && Map.forall
-      (fun k v ->
-        Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false)
+      (fun k v -> Map.find k b |> Option.map (equals v) |> Option.defaultValue false)
       a
   | DRecord(tn1, _, _typeArgsTODO1, a), DRecord(tn2, _, _typeArgsTODO2, b) ->
     tn1 = tn2 // these should be the fully resolved type
     && Map.count a = Map.count b
     && Map.forall
-      (fun k v ->
-        Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false)
+      (fun k v -> Map.find k b |> Option.map (equals v) |> Option.defaultValue false)
       a
   | DFnVal a, DFnVal b ->
     match a, b with
@@ -83,8 +81,7 @@ and equalsLambdaImpl (impl1 : LambdaImpl) (impl2 : LambdaImpl) : bool =
 and equalsSymtable (a : Symtable) (b : Symtable) : bool =
   Map.count a = Map.count b
   && Map.forall
-    (fun k v ->
-      Map.tryFind k b |> Option.map (equals v) |> Option.defaultValue false)
+    (fun k v -> Map.find k b |> Option.map (equals v) |> Option.defaultValue false)
     a
 
 and equalsExpr (expr1 : Expr) (expr2 : Expr) : bool =

--- a/backend/src/LibCloud/Canvas.fs
+++ b/backend/src/LibCloud/Canvas.fs
@@ -342,35 +342,35 @@ let loadTLIDsWithDBs (id : CanvasID) (tlids : List<tlid>) : Task<T> =
 
 let getToplevel (tlid : tlid) (c : T) : Option<Serialize.Deleted * PT.Toplevel.T> =
   let handler () =
-    Map.tryFind tlid c.handlers
+    Map.find tlid c.handlers
     |> Option.map (fun h -> (Serialize.NotDeleted, PT.Toplevel.TLHandler h))
 
   let deletedHandler () =
-    Map.tryFind tlid c.deletedHandlers
+    Map.find tlid c.deletedHandlers
     |> Option.map (fun h -> (Serialize.Deleted, PT.Toplevel.TLHandler h))
 
   let db () =
-    Map.tryFind tlid c.dbs
+    Map.find tlid c.dbs
     |> Option.map (fun h -> (Serialize.NotDeleted, PT.Toplevel.TLDB h))
 
   let deletedDB () =
-    Map.tryFind tlid c.deletedDBs
+    Map.find tlid c.deletedDBs
     |> Option.map (fun h -> (Serialize.Deleted, PT.Toplevel.TLDB h))
 
   let userFunction () =
-    Map.tryFind tlid c.userFunctions
+    Map.find tlid c.userFunctions
     |> Option.map (fun h -> (Serialize.NotDeleted, PT.Toplevel.TLFunction h))
 
   let deletedUserFunction () =
-    Map.tryFind tlid c.deletedUserFunctions
+    Map.find tlid c.deletedUserFunctions
     |> Option.map (fun h -> (Serialize.Deleted, PT.Toplevel.TLFunction h))
 
   let userType () =
-    Map.tryFind tlid c.userTypes
+    Map.find tlid c.userTypes
     |> Option.map (fun h -> (Serialize.NotDeleted, PT.Toplevel.TLType h))
 
   let deletedUserType () =
-    Map.tryFind tlid c.deletedUserTypes
+    Map.find tlid c.deletedUserTypes
     |> Option.map (fun h -> (Serialize.Deleted, PT.Toplevel.TLType h))
 
   handler ()

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -821,13 +821,13 @@ let partiallyEvaluate
 
     // This isn't really a good implementation, but right now we only do
     // straight-line code here, so it should work
-    let symtable = ref symtable
+    let mutable symtable = symtable
 
     let exec (expr : Expr) : Ply.Ply<Expr> =
       uply {
         let newName = "dark_generated_" + randomString 8
-        let! value = LibExecution.Interpreter.eval state tst symtable.Value expr
-        symtable.Value <- Map.add newName value symtable.Value
+        let! value = LibExecution.Interpreter.eval state tst symtable expr
+        symtable <- Map.add newName value symtable
         return (EVariable(gid (), newName))
       }
 
@@ -1012,7 +1012,7 @@ let partiallyEvaluate
       }
 
     let! result = postTraversal body
-    return (symtable.Value, result)
+    return (symtable, result)
   }
 
 

--- a/backend/src/LibCloudExecution/HttpClient.fs
+++ b/backend/src/LibCloudExecution/HttpClient.fs
@@ -76,7 +76,7 @@ module LocalAccess =
   let hasInstanceMetadataHeader (headers : List<string * string>) =
     let eq = String.equalsCaseInsensitive
     headers
-    |> List.tryFind (fun (k, v) ->
+    |> List.find (fun (k, v) ->
       let (k, v) = (String.trim k, String.trim v)
       (eq k "Metadata-Flavor" && eq v "Google")
       // Old but allowed https://cloud.google.com/compute/docs/metadata/overview#querying

--- a/backend/src/LibExecution/Builtin.fs
+++ b/backend/src/LibExecution/Builtin.fs
@@ -90,7 +90,7 @@ module Shortcuts =
   let fn = FnName.builtIn
   let typ = TypeName.builtIn
   let constant = ConstantName.builtIn
-  let incorrectArgs = Errors.incorrectArgs
+  let incorrectArgs = RuntimeTypes.incorrectArgs
 
   type Param = BuiltInParam
 

--- a/backend/src/LibExecution/Builtin.fs
+++ b/backend/src/LibExecution/Builtin.fs
@@ -28,7 +28,7 @@ let renameFunctions
     |> List.fold
       (fun renamedFns (oldName, newName) ->
         let newFn =
-          Map.tryFind newName (Map.mergeFavoringLeft renamedFns existingMap)
+          Map.find newName (Map.mergeFavoringLeft renamedFns existingMap)
           |> Exception.unwrapOptionInternal
             $"all fns should exist {oldName} -> {newName}"
             [ "oldName", oldName; "newName", newName ]
@@ -52,7 +52,7 @@ let renameTypes
     |> List.fold
       (fun renamedTypes (oldName, newName) ->
         let newType =
-          Map.tryFind newName (Map.mergeFavoringLeft renamedTypes existingMap)
+          Map.find newName (Map.mergeFavoringLeft renamedTypes existingMap)
           |> Exception.unwrapOptionInternal
             $"all types should exist {oldName} -> {newName}"
             [ "oldName", oldName; "newName", newName ]

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -143,7 +143,7 @@ let rec private toJsonV0
                 (fun (f : TypeDeclaration.RecordField) ->
                   uply {
                     w.WritePropertyName f.name
-                    let dval = Map.find f.name dm
+                    let dval = Map.findUnsafe f.name dm
                     let typ = Types.substitute decl.typeParams typeArgs f.typ
                     do! writeDval typ dval
                   })

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -304,7 +304,7 @@ let parseJsonV0 (types : Types) (typ : TypeReference) (str : string) : Ply<Dval>
                 fields
                 |> List.map (fun f ->
                   let dval =
-                    match Map.tryFind f.name objFields with
+                    match Map.find f.name objFields with
                     | Some j ->
                       let typ = Types.substitute decl.typeParams typeArgs f.typ
                       convert typ j

--- a/backend/src/LibExecution/Errors.fs
+++ b/backend/src/LibExecution/Errors.fs
@@ -5,18 +5,6 @@ open Prelude
 open RuntimeTypes
 
 // ------------------
-// Exception types
-// ------------------
-// We have a number of special exceptions that are used as control-flow to jump out
-// of Stdlib execution.
-// ------------------
-
-/// Standard error raised for calling a function with arguments of an incorrect type
-exception IncorrectArgs
-
-// CLEANUP add word 'exception' to exception names
-
-// ------------------
 // Messages
 // ------------------
 let expectedLambdaType
@@ -57,35 +45,3 @@ let resultWasntType (expected : TypeReference) (dv : Dval) : string =
   let actual = DvalReprDeveloper.toRepr dv
   let expected = DvalReprDeveloper.typeName expected
   $"Expected result to be a `{expected}`, but it was `{actual}`"
-
-
-// ------------------
-// Extremely common exceptions
-// ------------------
-
-/// When a function in called with the wrong number of arguments.
-/// Used in almost every function signature.
-let incorrectArgs () = raise IncorrectArgs
-
-let intInfixFns = Set [ "+"; "-"; "*"; ">"; ">="; "<="; "<"; "^"; "%" ]
-
-let incorrectArgsMsg (name : FnName.FnName) (p : Param) (actual : Dval) : string =
-  let actualRepr = DvalReprDeveloper.toRepr actual
-  let expectedTypeRepr = DvalReprDeveloper.typeName p.typ
-
-  let conversionMsg =
-    match p.typ, actual, name with
-    | TInt, DFloat _, FQName.BuiltIn({ name = FnName.FnName name } as b) when
-      b.modules = [ "Int" ] || (b.modules = [] && Set.contains name intInfixFns)
-      ->
-      let altfn = { b with modules = [ "Float" ] }
-
-      $". Try using {FnName.builtinToString altfn}, or use Float.truncate to truncate Floats to Ints."
-    | TInt, DString _, FQName.BuiltIn({ name = FnName.FnName name } as b) when
-      (b.modules = [ "Int" ] && name = "add") || (b.modules = [] && name = "+")
-      ->
-      ". Use ++ to concatenate"
-    | _ -> ""
-  $"{FnName.toString name} was expected to be called with a `{expectedTypeRepr}`"
-  + $" in {p.name}, but was actually called with {actualRepr}"
-  + conversionMsg

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -853,14 +853,12 @@ and execFn
                 try
                   return! f (state, typeArgs, NEList.toList args)
                 with e ->
-                  // TODO: IncorrectArgs - should be an internal error now
-                  // Code exceptions - should be RTE or internal error
-                  let context : Metadata =
-                    [ "fn", fnDesc; "args", args; "typeArgs", typeArgs; "id", id ]
                   match e with
                   | RuntimeErrorException(source, rte) -> return Exception.reraise e
                   | e ->
                     // TODO could we show the user the execution id here?
+                    let context : Metadata =
+                      [ "fn", fnDesc; "args", args; "typeArgs", typeArgs; "id", id ]
                     state.reportException state context e
                     // These are arbitrary errors, and could include sensitive
                     // information, so best not to show it to the user. If we'd

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -45,9 +45,6 @@ module Error =
   let matchExprPatternWrongType (expected : string) (actual : Dval) : RuntimeError =
     case "MatchExprPatternWrongType" [ DString expected; RT2DT.Dval.toDT actual ]
 
-  let matchExprPatternWrongShape : RuntimeError =
-    case "MatchExprPatternWrongShape" []
-
   let matchExprEnumPatternWrongCount
     (caseName : string)
     (expected : int)

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -741,8 +741,8 @@ and executeLambda
 
   else
     let paramSyms = NEList.zip parameters args |> NEList.toList |> Map
-    // paramSyms is higher priority
 
+    // paramSyms is higher priority
     let newSymtable = Map.mergeFavoringRight l.symtable paramSyms
 
     eval state l.typeSymbolTable newSymtable l.body

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -237,11 +237,11 @@ let rec eval
       let source = sourceID id
       match name with
       | FQName.UserProgram c ->
-        match state.program.constants.TryFind c with
+        match Map.find c state.program.constants with
         | None -> return Error.raise source (Error.ConstDoesntExist name)
         | Some constant -> return evalConst source constant.body
       | FQName.BuiltIn c ->
-        match state.builtIns.constants.TryFind c with
+        match Map.find c state.builtIns.constants with
         | None -> return Error.raise source (Error.ConstDoesntExist name)
         | Some constant -> return constant.body
       | FQName.Package c ->
@@ -761,9 +761,9 @@ and callFn
     let! fn =
       match desc with
       | FQName.BuiltIn std ->
-        state.builtIns.fns.TryFind std |> Option.map builtInFnToFn |> Ply
+        Map.find std state.builtIns.fns |> Option.map builtInFnToFn |> Ply
       | FQName.UserProgram u ->
-        state.program.fns.TryFind u |> Option.map userFnToFn |> Ply
+        Map.find u state.program.fns |> Option.map userFnToFn |> Ply
       | FQName.Package pkg ->
         uply {
           let! fn = state.packageManager.getFn pkg

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -57,7 +57,6 @@ module Error =
       "MatchExprEnumPatternWrongCount"
       [ DString caseName; DInt expected; DInt actual ]
 
-  let incomplete : RuntimeError = case "Incomplete" []
 
 let rec evalConst (source : DvalSource) (c : Const) : Dval =
   let r = evalConst source
@@ -760,7 +759,7 @@ and callFn
     let sourceID = SourceID(state.tlid, callerID)
     let handleMissingFunction () : Dval =
       // Functions which aren't implemented in the client may have results
-      // available, otherwise they just return incomplete.
+      // available, otherwise they error.
       let fnRecord = (state.tlid, desc, callerID)
       let fnResult = state.tracing.loadFnResult fnRecord args
 

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -210,6 +210,9 @@ let rec eval
 
   uply {
     match e with
+    | EString(_, [ StringText s ]) ->
+      // We expect strings to be normalized during parsing
+      return DString(s)
     | EString(id, segments) ->
       let! segments =
         segments

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -88,7 +88,7 @@ let rec evalConst (source : DvalSource) (c : Const) : Dval =
 
 /// Interprets an expression and reduces to a Dark value
 /// (or task that should result in such)
-let rec eval'
+let rec eval
   (state : ExecutionState)
   (tst : TypeSymbolTable)
   (st : Symtable)
@@ -403,7 +403,7 @@ let rec eval'
     | EFnName(_id, name) -> return DFnVal(NamedFn name)
 
     | EApply(id, fnTarget, typeArgs, exprs) ->
-      match! eval' state tst st fnTarget with
+      match! eval state tst st fnTarget with
       | DFnVal fnVal ->
         let! args = Ply.NEList.mapSequentially (eval state tst st) exprs
         return! applyFnVal state id fnVal typeArgs args
@@ -677,18 +677,7 @@ let rec eval'
       return raiseRTE (sourceID id) rte
   }
 
-/// Interprets an expression and reduces to a Dark value
-/// (or a task that results in a dval)
-and eval
-  (state : ExecutionState)
-  (tst : TypeSymbolTable)
-  (st : Symtable)
-  (e : Expr)
-  : DvalTask =
-  uply {
-    let! (result : Dval) = eval' state tst st e
-    return result
-  }
+
 
 /// Unwrap the dval, which we expect to be a function, and error if it's not
 and applyFnVal

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -414,7 +414,7 @@ let rec eval
       else
         match obj with
         | DRecord(_, typeName, _, o) ->
-          match Map.tryFind field o with
+          match Map.find field o with
           | Some v -> return v
           | None ->
             let typeStr = TypeName.toString typeName

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1299,12 +1299,10 @@ module Types =
     : Ply<Option<TypeDeclaration.T>> =
     match name with
     | FQName.BuiltIn b ->
-      Map.tryFind b types.builtIn |> Option.map (fun t -> t.declaration) |> Ply
+      Map.find b types.builtIn |> Option.map (fun t -> t.declaration) |> Ply
 
     | FQName.UserProgram user ->
-      Map.tryFind user types.userProgram
-      |> Option.map (fun t -> t.declaration)
-      |> Ply
+      Map.find user types.userProgram |> Option.map (fun t -> t.declaration) |> Ply
 
     | FQName.Package pkg ->
       types.package pkg |> Ply.map (Option.map (fun t -> t.declaration))

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -710,8 +710,15 @@ let raiseUntargetedRTE (rte : RuntimeError) =
 // TODO remove all usages of this in favor of better error cases
 let raiseString (s : string) : 'a = raiseUntargetedRTE (RuntimeError.oldError s)
 
+/// Internally in the runtime, we allow throwing RuntimeErrorExceptions. At the
+/// boundary, typically in Execution.fs, we will catch the exception, and return this
+/// type.
 type ExecutionResult = Result<Dval, DvalSource * RuntimeError>
 
+/// IncorrectArgs should never happen, as all functions are type-checked before
+/// calling. If it does happen, it means that the type parameters in the Fn structure
+/// do not match the args expected in the F# function definition.
+let incorrectArgs () = Exception.raiseInternal "IncorrectArgs" []
 
 
 

--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -193,7 +193,8 @@ module MatchPattern =
     | SynPat.Const(SynConst.Double d, _) ->
       let sign, whole, fraction = readFloat d
       WT.MPFloat(id, sign, whole, fraction)
-    | SynPat.Const(SynConst.String(s, _, _), _) -> WT.MPString(id, s)
+    | SynPat.Const(SynConst.String(s, _, _), _) ->
+      WT.MPString(id, String.normalize s)
     | SynPat.LongIdent(SynLongIdent(names, _, _), _, _, SynArgPats.Pats args, _, _) ->
       let enumName =
         List.last names |> Exception.unwrapOptionInternal "missing enum name" []
@@ -319,13 +320,14 @@ module Expr =
 
     // Strings
     | SynExpr.Const(SynConst.String(s, _, _), _) ->
-      WT.EString(id, [ WT.StringText s ])
+      WT.EString(id, [ WT.StringText(String.normalize s) ])
     | SynExpr.InterpolatedString(parts, _, _) ->
       let parts =
         parts
         |> List.filterMap (function
           | SynInterpolatedStringPart.String("", _) -> None
-          | SynInterpolatedStringPart.String(s, _) -> Some(WT.StringText s)
+          | SynInterpolatedStringPart.String(s, _) ->
+            Some(WT.StringText(String.normalize s))
           | SynInterpolatedStringPart.FillExpr(e, _) ->
             Some(WT.StringInterpolation(c e)))
       WT.EString(id, parts)

--- a/backend/src/LibService/ConfigDsl.fs
+++ b/backend/src/LibService/ConfigDsl.fs
@@ -69,7 +69,7 @@ let stringChoice name (options : (string * 'a) list) : 'a =
   let v = getEnvExn name |> lowercase name
 
   options
-  |> List.tryFind (fun (k, _) -> k = v)
+  |> List.find (fun (k, _) -> k = v)
   |> Option.map Tuple2.second
   |> Option.defaultWith (fun () ->
     let options = options |> List.map Tuple2.first |> String.concat ", "

--- a/backend/src/Prelude/Map.fs
+++ b/backend/src/Prelude/Map.fs
@@ -39,11 +39,11 @@ let all (f : 'v -> bool) (m : Map<'k, 'v>) : bool = Map.forall (fun _ v -> f v) 
 let map (f : 'a -> 'b) (m : Map<'k, 'a>) : Map<'k, 'b> = Map.map (fun _ v -> f v) m
 let mapWithIndex (f : 'k -> 'a -> 'b) (m : Map<'k, 'a>) : Map<'k, 'b> = Map.map f m
 
-let get (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.tryFind k m
+let get (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.find k m
 
 let findUnsafe (k : 'k) (m : Map<'k, 'v>) : 'v = Map.find k m
 
-let find (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.tryFind k m
+let find (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.find k m
 
 
 let update

--- a/backend/src/Prelude/Map.fs
+++ b/backend/src/Prelude/Map.fs
@@ -41,6 +41,11 @@ let mapWithIndex (f : 'k -> 'a -> 'b) (m : Map<'k, 'a>) : Map<'k, 'b> = Map.map 
 
 let get (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.tryFind k m
 
+let findUnsafe (k : 'k) (m : Map<'k, 'v>) : 'v = Map.find k m
+
+let find (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.tryFind k m
+
+
 let update
   (key : 'a)
   (f : Option<'b> -> Option<'b>)

--- a/backend/src/Prelude/Map.fs
+++ b/backend/src/Prelude/Map.fs
@@ -39,11 +39,11 @@ let all (f : 'v -> bool) (m : Map<'k, 'v>) : bool = Map.forall (fun _ v -> f v) 
 let map (f : 'a -> 'b) (m : Map<'k, 'a>) : Map<'k, 'b> = Map.map (fun _ v -> f v) m
 let mapWithIndex (f : 'k -> 'a -> 'b) (m : Map<'k, 'a>) : Map<'k, 'b> = Map.map f m
 
-let get (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.find k m
+let get (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.tryFind k m
 
 let findUnsafe (k : 'k) (m : Map<'k, 'v>) : 'v = Map.find k m
 
-let find (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.find k m
+let find (k : 'k) (m : Map<'k, 'v>) : Option<'v> = Map.tryFind k m
 
 
 let update

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -748,14 +748,14 @@ module Expect =
       // check keys from ls are in both, check matching values
       Map.iterWithIndex
         (fun key v1 ->
-          match Map.tryFind key rs with
+          match Map.find key rs with
           | Some v2 -> de (key :: path) v1 v2
           | None -> check (key :: path) ls rs)
         ls
       // check keys from rs are in both
       Map.iterWithIndex
         (fun key _ ->
-          match Map.tryFind key rs with
+          match Map.find key rs with
           | Some _ -> () // already checked
           | None -> check (key :: path) ls rs)
         rs
@@ -766,14 +766,14 @@ module Expect =
       // check keys from ls are in both, check matching values
       Map.iterWithIndex
         (fun key v1 ->
-          match Map.tryFind key rs with
+          match Map.find key rs with
           | Some v2 -> de (key :: path) v1 v2
           | None -> check (key :: path) ls rs)
         ls
       // check keys from rs are in both
       Map.iterWithIndex
         (fun key _ ->
-          match Map.tryFind key rs with
+          match Map.find key rs with
           | Some _ -> () // already checked
           | None -> check (key :: path) ls rs)
         rs

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -850,9 +850,9 @@ module Expect =
       Expect.equal a e (formatMsg "" path actual))
 
   let dvalEquality (left : Dval) (right : Dval) : bool =
-    let success = ref true
-    dvalEqualityBaseFn [] left right (fun _ _ _ -> success.Value <- false)
-    success.Value
+    let mutable success = true
+    dvalEqualityBaseFn [] left right (fun _ _ _ -> success <- false)
+    success
 
 let visitDval (f : Dval -> 'a) (dv : Dval) : List<'a> =
   let mutable state = []

--- a/backend/tests/Tests/Builtin.Tests.fs
+++ b/backend/tests/Tests/Builtin.Tests.fs
@@ -20,7 +20,7 @@ open TestUtils.TestUtils
 
 let oldFunctionsAreDeprecated =
   testTask "old functions are deprecated" {
-    let counts = ref Map.empty
+    let mutable counts = Map.empty
 
     let fns = localBuiltIns.fns |> Map.values
 
@@ -29,23 +29,23 @@ let oldFunctionsAreDeprecated =
       let key = RT.FnName.builtinToString { fn.name with version = 0 }
 
       if fn.deprecated = RT.NotDeprecated then
-        counts.Value <-
+        counts <-
           Map.update
             key
             (fun count -> count |> Option.defaultValue 0 |> (+) 1 |> Some)
-            counts.Value
+            counts
 
       ())
 
     Map.iter
       (fun name count ->
         Expect.equal count 1 $"{name} has more than one undeprecated function")
-      counts.Value
+      counts
   }
 
 let oldTypesAreDeprecated =
   testTask "old types are deprecated" {
-    let counts = ref Map.empty
+    let mutable counts = Map.empty
 
     let types = localBuiltIns.types |> Map.values
 
@@ -54,18 +54,18 @@ let oldTypesAreDeprecated =
       let key = RT.TypeName.builtinToString { typ.name with version = 0 }
 
       if typ.deprecated = RT.NotDeprecated then
-        counts.Value <-
+        counts <-
           Map.update
             key
             (fun count -> count |> Option.defaultValue 0 |> (+) 1 |> Some)
-            counts.Value
+            counts
 
       ())
 
     Map.iter
       (fun name count ->
         Expect.equal count 1 $"{name} has more than one undeprecated type")
-      counts.Value
+      counts
   }
 
 let tests = testList "builtin" [ oldFunctionsAreDeprecated; oldTypesAreDeprecated ]

--- a/backend/tests/Tests/Canvas.Tests.fs
+++ b/backend/tests/Tests/Canvas.Tests.fs
@@ -160,7 +160,7 @@ let testSetHandlerAfterDelete =
 
     let! (c1 : Canvas.T) = Canvas.loadAll canvasID
 
-    Expect.equal (c1.deletedHandlers.TryFind h1.tlid) (Some h1) "deleted in deleted"
+    Expect.equal (Map.find h1.tlid c1.deletedHandlers) (Some h1) "deleted in deleted"
     Expect.equal c1.deletedHandlers.Count 1 "only deleted in deleted"
     Expect.equal c1.handlers.Count 0 "deleted not in handlers"
 
@@ -171,9 +171,9 @@ let testSetHandlerAfterDelete =
 
     let! (c2 : Canvas.T) = Canvas.loadAll canvasID
 
-    Expect.equal (c2.deletedHandlers.TryFind h1.tlid) (Some h1) "deleted in deleted"
+    Expect.equal (Map.find h1.tlid c2.deletedHandlers) (Some h1) "deleted in deleted"
     Expect.equal c2.deletedHandlers.Count 1 "only deleted still in deleted"
-    Expect.equal (c2.handlers.TryFind h2.tlid) (Some h2) "live is in handlers"
+    Expect.equal (Map.find h2.tlid c2.handlers) (Some h2) "live is in handlers"
     Expect.equal c2.handlers.Count 1 "only live is in handlers"
   }
 
@@ -192,7 +192,7 @@ let testSetFunctionAfterDelete =
     let! (c1 : Canvas.T) = Canvas.loadAll canvasID
 
     Expect.equal
-      (c1.deletedUserFunctions.TryFind f1.tlid)
+      (Map.find f1.tlid c1.deletedUserFunctions)
       (Some f1)
       "deleted in deleted"
     Expect.equal c1.deletedUserFunctions.Count 1 "only deleted in deleted"
@@ -205,11 +205,11 @@ let testSetFunctionAfterDelete =
     let! (c2 : Canvas.T) = Canvas.loadAll canvasID
 
     Expect.equal
-      (c2.deletedUserFunctions.TryFind f1.tlid)
+      (Map.find f1.tlid c2.deletedUserFunctions)
       (Some f1)
       "deleted still in deleted"
     Expect.equal c2.deletedUserFunctions.Count 1 "only deleted still in deleted"
-    Expect.equal (c2.userFunctions.TryFind f2.tlid) (Some f2) "live is present"
+    Expect.equal (Map.find f2.tlid c2.userFunctions) (Some f2) "live is present"
     Expect.equal c2.userFunctions.Count 1 "only live is present"
   }
 

--- a/backend/tests/Tests/Prelude.Tests.fs
+++ b/backend/tests/Tests/Prelude.Tests.fs
@@ -35,10 +35,10 @@ let asyncTests =
         Expect.equal result (Some 3) ""
       }
       testTask "iterSequentially" {
-        let state = ref []
-        let fn (i : int) = delay (fun () -> state.Value <- i + 1 :: state.Value) i
+        let mutable state = []
+        let fn (i : int) = delay (fun () -> state <- i + 1 :: state) i
         do! Ply.List.iterSequentially fn [ 1; 2; 3; 4 ] |> Ply.toTask
-        Expect.equal state.Value [ 5; 4; 3; 2 ] ""
+        Expect.equal state [ 5; 4; 3; 2 ] ""
       } ]
 
 let mapTests =

--- a/backend/tests/Tests/SqlCompiler.Tests.fs
+++ b/backend/tests/Tests/SqlCompiler.Tests.fs
@@ -71,7 +71,7 @@ let matchSql
     (fun g ->
       match g.Count with // implicit full match counts for 1
       | 1 -> true
-      | 2 -> Map.find g[1].Value args = expected[0]
+      | 2 -> Map.findUnsafe g[1].Value args = expected[0]
       | _ -> Exception.raiseInternal "not supported yet" [ "count", g.Count ])
     "compare sql"
 
@@ -203,7 +203,7 @@ let partialEvaluation =
         let result = C.partiallyEvaluate state Map.empty (Map vars) "x" expr
         let! (dvals, result) = Ply.TplPrimitives.runPlyAsTask result
         match result with
-        | EVariable(_, name) -> return (Map.find name dvals)
+        | EVariable(_, name) -> return (Map.findUnsafe name dvals)
         | _ ->
           Expect.isTrue false "didn't match"
           return DUnit

--- a/canvases/builtin/prompt.txt
+++ b/canvases/builtin/prompt.txt
@@ -62,7 +62,7 @@ some examples:
           (uply {
             let! (dvals : List<Dval>) = dvals
 
-            match List.tryFind (fun dv -> Dval.isIncomplete dv) dvals with
+            match List.find (fun dv -> Dval.isIncomplete dv) dvals with
             | Some i -> return i
             | None ->
               let chars =

--- a/packages/darklang/languageTools/runtimeErrors/execution.dark
+++ b/packages/darklang/languageTools/runtimeErrors/execution.dark
@@ -3,11 +3,12 @@ module Darklang =
     module RuntimeErrors =
       module Execution =
         type Error =
-          | Incomplete
           | MatchExprUnmatched of RuntimeTypes.Dval.Dval
           | MatchExprPatternWrongShape
           | MatchExprPatternWrongType of String * RuntimeTypes.Dval.Dval
           | MatchExprEnumPatternWrongCount of String * expected: Int * actual: Int
+          | NonStringInStringInterpolation of RuntimeTypes.Dval.Dval
+          | ConstDoesntExist of RuntimeTypes.ConstantName.ConstantName
 
         let toSegments (e: Error) : ErrorOutput =
           match e with
@@ -81,6 +82,35 @@ module Darklang =
                 ErrorSegment.ErrorSegment.IndefiniteArticle
                 ErrorSegment.ErrorSegment.String patternType
                 ErrorSegment.ErrorSegment.String " pattern" ]
+
+            let extraExplanation = []
+
+            ErrorOutput
+              { summary = summary
+                extraExplanation = extraExplanation
+                actual = []
+                expected = [] }
+
+          // Expected String in string interpolation, got 1.0
+          | NonStringInStringInterpolation dv ->
+            let summary =
+              [ ErrorSegment.ErrorSegment.String
+                  "Expected String in string interpolation, got "
+                ErrorSegment.ErrorSegment.InlineValue dv ]
+
+            let extraExplanation = []
+
+            ErrorOutput
+              { summary = summary
+                extraExplanation = extraExplanation
+                actual = []
+                expected = [] }
+
+          | ConstDoesntExist name ->
+            let summary =
+              [ ErrorSegment.ErrorSegment.String "Constant "
+                ErrorSegment.ErrorSegment.ConstantName name
+                ErrorSegment.ErrorSegment.String " doesn't exist" ]
 
             let extraExplanation = []
 

--- a/packages/darklang/languageTools/runtimeErrors/execution.dark
+++ b/packages/darklang/languageTools/runtimeErrors/execution.dark
@@ -4,7 +4,6 @@ module Darklang =
       module Execution =
         type Error =
           | MatchExprUnmatched of RuntimeTypes.Dval.Dval
-          | MatchExprPatternWrongShape
           | MatchExprPatternWrongType of String * RuntimeTypes.Dval.Dval
           | MatchExprEnumPatternWrongCount of String * expected: Int * actual: Int
           | NonStringInStringInterpolation of RuntimeTypes.Dval.Dval
@@ -12,13 +11,6 @@ module Darklang =
 
         let toSegments (e: Error) : ErrorOutput =
           match e with
-          | Incomplete ->
-            ErrorOutput
-              { summary = [ ErrorSegment.ErrorSegment.String "Incomplete" ]
-                extraExplanation = []
-                actual = []
-                expected = [] }
-
           | MatchExprUnmatched dv ->
             let summary =
               [ ErrorSegment.ErrorSegment.String "No match for "
@@ -33,17 +25,6 @@ module Darklang =
                 actual = []
                 expected = [] }
 
-          | MatchExprPatternWrongShape ->
-            let summary =
-              [ ErrorSegment.ErrorSegment.String "Pattern has wrong shape" ]
-
-            let extraExplanation = []
-
-            ErrorOutput
-              { summary = summary
-                extraExplanation = extraExplanation
-                actual = []
-                expected = [] }
 
           | MatchExprEnumPatternWrongCount(caseName, expected, actual) ->
             let summary =
@@ -70,6 +51,7 @@ module Darklang =
                 extraExplanation = extraExplanation
                 actual = []
                 expected = [] }
+
 
           | MatchExprPatternWrongType(patternType, dv) ->
             let summary =

--- a/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
+++ b/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
@@ -32,6 +32,10 @@ module Darklang =
           | FieldName of String // records and enums
           | InlineFieldName of String // records and enums
 
+          // -- Constants
+          | ConstantName of
+            PACKAGE.Darklang.LanguageTools.RuntimeTypes.ConstantName.ConstantName
+
           // -- Variables
           | DBName of String
           | VarName of String
@@ -77,6 +81,8 @@ module Darklang =
                   | InlineParamName p -> p // Inline versions don't have quotes
                   | TypeName t ->
                     PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.typeName t
+                  | ConstantName c ->
+                    PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.constantName c
                   | ShortTypeName t ->
                     // TODO: make it short
                     PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.typeName t


### PR DESCRIPTION
A series of small cleanups mostly enabled by removing DError, with some drive-bys.

- Remove refs from our codebase (in favor of mutable variables, or removing where unused, eg in List.fs)
- `IncorrectArgs` replaced with `Exception.raiseInternal`
- remove remnants of `DIncomplete`
- make interpreter error handling a little more structured/typed
- In cases where we use Errors only to push around a RuntimeError which then gets raised, just raise immediately and simplify the code
- Refactor `EDict` handling
- Remove `eval'`
- Simplify (and optimize) `EString` handling
- Normalize strings during parsing
- Rename name/uses of `Map.find` with `Map.findUnsafe`
- Rename uses of `Map.tryFind` to `Map.find` (which now returns on option)
