### PR TITLE
Improve JSON functionality part 1

### DIFF
--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -359,7 +359,7 @@ let parse
       | "NaN" -> DFloat System.Double.NaN
       | "Infinity" -> DFloat System.Double.PositiveInfinity
       | "-Infinity" -> DFloat System.Double.NegativeInfinity
-      | v -> Exception.raiseInternal "Invalid float" [ "value", v ]
+      | _ -> raiseCantMatchWithType TFloat j pathSoFar
       |> Ply
 
     | TChar, JsonValueKind.String -> DChar(j.GetString()) |> Ply

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -120,9 +120,7 @@ let rec serialize
       let ds = d1 :: d2 :: rest
 
       if List.length ts <> List.length ds then
-        Exception.raiseInternal
-          $"Not sure what to do with mismatched tuple ({ds} doesn't match {ts})"
-          []
+        Exception.raiseInternal $"with mismatched tuple ({ds} doesn't match {ts})" []
 
       let zipped = List.zip (t1 :: t2 :: trest) (d1 :: d2 :: rest)
       do!
@@ -218,6 +216,7 @@ let rec serialize
 
 
     // Not supported
+    // TODO these should be runtime errors
     | TVariable name, dv ->
       Exception.raiseInternal
         "Variable types (i.e. 'a in List<'a>) cannot not be used as arguments"
@@ -245,6 +244,7 @@ let rec serialize
     | TVariable _, _
     | TCustomType _, _
     | TDict _, _ ->
+      // Internal error as this shouldn't get past the typechecker
       Exception.raiseInternal
         "Can't currently serialize this type/value combination"
         [ "value", dv; "type", DString(LibExecution.DvalReprDeveloper.typeName typ) ]

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -362,7 +362,12 @@ let parse
       | _ -> raiseCantMatchWithType TFloat j pathSoFar
       |> Ply
 
-    | TChar, JsonValueKind.String -> DChar(j.GetString()) |> Ply
+    | TChar, JsonValueKind.String ->
+      match String.toEgcChar (j.GetString()) with
+      | Some c -> Ply(DChar c)
+      | None -> raiseCantMatchWithType TChar j pathSoFar
+
+
     | TString, JsonValueKind.String -> DString(j.GetString()) |> Ply
 
     | TBytes, JsonValueKind.String ->

--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -67,9 +67,6 @@ module TypeReference =
     // with type args
     | [], "List", [ arg ] -> WT.TList(fromSynType arg)
     | [], "Dict", [ valArg ] -> WT.TDict(fromSynType valArg)
-    // TYPESCLEANUP - don't use word Tuple here
-    | [], "Tuple", first :: second :: theRest ->
-      WT.TTuple(fromSynType first, fromSynType second, List.map fromSynType theRest)
     | _ -> WT.TCustomType(WT.Unresolved(names), List.map fromSynType typeArgs)
 
   and fromSynType (typ : SynType) : WT.TypeReference =

--- a/backend/src/Prelude/String.fs
+++ b/backend/src/Prelude/String.fs
@@ -11,6 +11,16 @@ let toEgcSeq (s : string) : seq<string> =
       yield tee.GetTextElement()
   }
 
+/// Return Some(c) if the string is a single EGC character, otherwise None
+let toEgcChar (str : string) : Option<string> =
+  let egcs = str |> toEgcSeq
+  match Seq.truncate 2 egcs |> Seq.toList with
+  | [] -> None
+  | [ char ] -> Some char
+  | _ -> None
+
+
+
 let splitOnNewline (str : string) : List<string> =
   if str = "" then
     []

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -275,8 +275,11 @@ Builtin.Json.serialize<Char> 'Ł' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"
 Builtin.Json.parse<Char> "\"Ł\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 'Ł'
 
 // not chars
-//Builtin.Json.serialize<Char> "test" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently serialize this type/value combination"
-//Builtin.Json.parse<Char> "\"test\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
+Builtin.Json.parse<Char> "\"test\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "Can't parse JSON `\"test\"` as type `Char` at path: `root`"
+
+Builtin.Json.parse<Char> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "Can't parse JSON `\"\"` as type `Char` at path: `root`"
 
 
 // Strings

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -1,765 +1,776 @@
-// Basic types
+// Unsupported stuff:
+// - TDB
+// - TFn
+// None of these are supported as <> type args in the parser,
+// so do we really have to do anything here?
+// It feels like a "no" to me - ignoring for now.
+
 
 // Units
-Builtin.Json.serialize<Unit> () = PACKAGE.Darklang.Stdlib.Result.Result.Ok "null"
-Builtin.Json.parse<Unit> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Ok()
+module Unit =
+  Builtin.Json.serialize<Unit> () = PACKAGE.Darklang.Stdlib.Result.Result.Ok "null"
+  Builtin.Json.parse<Unit> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Ok()
 
-Builtin.Json.parse<Int> "()" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+  module Errors =
+    Builtin.Json.parse<Int> "()" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Unit> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `0` as type `Unit` at path: `root`"
+    Builtin.Json.parse<Unit> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `0` as type `Unit` at path: `root`"
 
-Builtin.Json.parse<Unit> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"\"` as type `Unit` at path: `root`"
+    Builtin.Json.parse<Unit> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"\"` as type `Unit` at path: `root`"
 
-Builtin.Json.parse<Unit> "\"null\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"null\"` as type `Unit` at path: `root`"
+    Builtin.Json.parse<Unit> "\"null\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"null\"` as type `Unit` at path: `root`"
 
 
-// Bools
-Builtin.Json.serialize<Bool> true = PACKAGE.Darklang.Stdlib.Result.Result.Ok "true"
-Builtin.Json.serialize<Bool> false = PACKAGE.Darklang.Stdlib.Result.Result.Ok "false"
-Builtin.Json.parse<Bool> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Ok true
-Builtin.Json.parse<Bool> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Ok false
-Builtin.Json.parse<Bool> " true " = PACKAGE.Darklang.Stdlib.Result.Result.Ok true
-Builtin.Json.parse<Bool> " false " = PACKAGE.Darklang.Stdlib.Result.Result.Ok false
+module Bool =
+  Builtin.Json.serialize<Bool> true = PACKAGE.Darklang.Stdlib.Result.Result.Ok "true"
 
-Builtin.Json.parse<List<Bool>> "[true, true, false, true  ] " = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ true; true; false; true ]
+  Builtin.Json.serialize<Bool> false = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "false"
 
-Builtin.Json.parse<Bool> "tru" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+  Builtin.Json.parse<Bool> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Ok true
+  Builtin.Json.parse<Bool> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Ok false
+  Builtin.Json.parse<Bool> " true " = PACKAGE.Darklang.Stdlib.Result.Result.Ok true
+  Builtin.Json.parse<Bool> " false " = PACKAGE.Darklang.Stdlib.Result.Result.Ok false
 
-Builtin.Json.parse<Bool> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `null` as type `Bool` at path: `root`"
+  Builtin.Json.parse<List<Bool>> "[true, true, false, true  ] " = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    [ true; true; false; true ]
 
-Builtin.Json.parse<Bool> "" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+  module Errors =
+    Builtin.Json.parse<Bool> "tru" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Bool> "\"true\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"true\"` as type `Bool` at path: `root`"
+    Builtin.Json.parse<Bool> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `null` as type `Bool` at path: `root`"
 
-Builtin.Json.parse<Bool> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `0` as type `Bool` at path: `root`"
+    Builtin.Json.parse<Bool> "" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Bool> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `1` as type `Bool` at path: `root`"
+    Builtin.Json.parse<Bool> "\"true\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"true\"` as type `Bool` at path: `root`"
 
-Builtin.Json.parse<Bool> "False" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Bool> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `0` as type `Bool` at path: `root`"
 
-Builtin.Json.parse<Bool> "tRUE" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Bool> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `1` as type `Bool` at path: `root`"
 
+    Builtin.Json.parse<Bool> "False" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-// Ints
-// basic
-Builtin.Json.serialize<Int> 0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0"
-Builtin.Json.serialize<Int> 12345 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "12345"
+    Builtin.Json.parse<Bool> "tRUE" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.serialize<Int> -12345 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "-12345"
 
-// test the limits of int32 (-2147483648 to 2147483647)
-Builtin.Json.serialize<Int> -2147483648 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "-2147483648"
+module Int =
+  module Basic =
+    Builtin.Json.serialize<Int> 0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0"
+    Builtin.Json.serialize<Int> 12345 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "12345"
 
-Builtin.Json.serialize<Int> 2147483647 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "2147483647"
+    Builtin.Json.serialize<Int> -12345 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      "-12345"
 
-Builtin.Json.parse<Int> "-2147483648" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  -2147483648
-//TODO: this should fail but doesn't
-// Builtin.Json.parse<Int> "-2147483648" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 2147483648
-Builtin.Json.parse<Int> "2147483647" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  2147483647
-//Builtin.Json.serialize<Int> -2147483649 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"-2147483649\""
-//Builtin.Json.serialize<Int> 2147483648 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"2147483648\""
-//Builtin.Json.parse<Int> "\"-2147483649\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -2147483649
-//Builtin.Json.parse<Int> "\"2147483648\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 2147483648
+  module Int32Limits =
+    // test the limits of int32 (-2147483648 to 2147483647)
+    Builtin.Json.serialize<Int> -2147483648 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      "-2147483648"
 
-// test the limits of int64 (-9223372036854775808 to 9223372036854775807)
-//Builtin.Json.serialize<Int> 9223372036854775807 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "9223372036854775807"
-//Builtin.Json.parse<Int> "9223372036854775807" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9223372036854775807
-//Builtin.Json.serialize<Int> 9223372036854775808 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "9223372036854775808"
-//Builtin.Json.parse<Int> "9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9223372036854775808
-//Builtin.Json.serialize<Int> -9223372036854775808 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "-9223372036854775808"
-//Builtin.Json.parse<Int> "-9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -9223372036854775808
+    Builtin.Json.serialize<Int> 2147483647 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      "2147483647"
 
-// TODO: review Float.tests for more values to test against
+    Builtin.Json.parse<Int> "-2147483648" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      -2147483648
+    //TODO: this should fail but doesn't
+    // Builtin.Json.parse<Int> "-2147483648" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 2147483648
+    Builtin.Json.parse<Int> "2147483647" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      2147483647
+    //Builtin.Json.serialize<Int> -2147483649 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"-2147483649\""
+    //Builtin.Json.serialize<Int> 2147483648 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"2147483648\""
+    //Builtin.Json.parse<Int> "\"-2147483649\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -2147483649
+    //Builtin.Json.parse<Int> "\"2147483648\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 2147483648
 
-// not ints
-Builtin.Json.parse<Int> " " = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
-Builtin.Json.parse<Int> "4a" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+  module Int64Limits =
+    // test the limits of int64 (-9223372036854775808 to 9223372036854775807)
+    //Builtin.Json.serialize<Int> 9223372036854775807 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "9223372036854775807"
+    //Builtin.Json.parse<Int> "9223372036854775807" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9223372036854775807
+    //Builtin.Json.serialize<Int> 9223372036854775808 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "9223372036854775808"
+    //Builtin.Json.parse<Int> "9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9223372036854775808
+    //Builtin.Json.serialize<Int> -9223372036854775808 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "-9223372036854775808"
+    //Builtin.Json.parse<Int> "-9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -9223372036854775808
 
-Builtin.Json.parse<Int> "- 42" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+  module Errors =
 
-Builtin.Json.parse<Int> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `null` as type `Int` at path: `root`"
+    // TODO: review Float.tests for more values to test against
 
-Builtin.Json.parse<Int> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `true` as type `Int` at path: `root`"
+    // not ints
+    Builtin.Json.parse<Int> " " = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+    Builtin.Json.parse<Int> "4a" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
 
-Builtin.Json.parse<Int> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `false` as type `Int` at path: `root`"
+    Builtin.Json.parse<Int> "- 42" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Int> "\"42\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"42\"` as type `Int` at path: `root`"
+    Builtin.Json.parse<Int> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `null` as type `Int` at path: `root`"
 
-Builtin.Json.parse<Int> "[42]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `[42]` as type `Int` at path: `root`"
+    Builtin.Json.parse<Int> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `true` as type `Int` at path: `root`"
 
-Builtin.Json.parse<Int> "{ \"key\": 42 }" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `{ \"key\": 42 }` as type `Int` at path: `root`"
-//Builtin.Json.parse<Int> "42.5" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
-Builtin.Json.parse<Int> "\"42\n\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
-//Builtin.Json.parse<Int> "4\u0032" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+    Builtin.Json.parse<Int> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `false` as type `Int` at path: `root`"
 
+    Builtin.Json.parse<Int> "\"42\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"42\"` as type `Int` at path: `root`"
 
-// Floats
-Builtin.Json.serialize<Float> 0.0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0.0"
-Builtin.Json.serialize<Float> 1.0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "1.0"
-Builtin.Json.serialize<Float> 0.1 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0.1"
+    Builtin.Json.parse<Int> "[42]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `[42]` as type `Int` at path: `root`"
 
-Builtin.Json.serialize<Float> (2.0 / 3.0) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "0.6666666666666666"
+    Builtin.Json.parse<Int> "{ \"key\": 42 }" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `{ \"key\": 42 }` as type `Int` at path: `root`"
+    //Builtin.Json.parse<Int> "42.5" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
+    Builtin.Json.parse<Int> "\"42\n\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
+    //Builtin.Json.parse<Int> "4\u0032" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
 
-Builtin.Json.serialize<Float> 12345.67890 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "12345.6789"
 
-Builtin.Json.serialize<Float> -12345.67890 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "-12345.6789"
+module Float =
+  // TODO: test the upper/lower bounds
+  // TODO: test highly-precise numbers
+  // TODO: review Float.tests for more values to test against
 
-Builtin.Json.parse<Float> "0.0" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 0.0
+  Builtin.Json.serialize<Float> 0.0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0.0"
+  Builtin.Json.serialize<Float> 1.0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "1.0"
+  Builtin.Json.serialize<Float> 0.1 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0.1"
 
-Builtin.Json.parse<Float> "e" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+  Builtin.Json.serialize<Float> (2.0 / 3.0) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "0.6666666666666666"
 
-Builtin.Json.parse<Float> "pi" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+  Builtin.Json.serialize<Float> 12345.67890 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "12345.6789"
 
-Builtin.Json.parse<Float> "12345.67890" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  12345.67890
+  Builtin.Json.serialize<Float> -12345.67890 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "-12345.6789"
 
-Builtin.Json.parse<Float> "-12345.67890" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  -12345.67890
+  Builtin.Json.parse<Float> "0.0" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 0.0
 
-Builtin.Json.parse<Float> " 42.0 " = PACKAGE.Darklang.Stdlib.Result.Result.Ok 42.0
-Builtin.Json.parse<Float> " -42.0 " = PACKAGE.Darklang.Stdlib.Result.Result.Ok -42.0
-Builtin.Json.parse<Float> "1e3" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 1000.0 // PACKAGE.Darklang.Stdlib.Result.Result.Ok?
-Builtin.Json.parse<Float> "-1e3" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -1000.0 // PACKAGE.Darklang.Stdlib.Result.Result.Ok?
 
-// TODO: test the upper/lower bounds
+  Builtin.Json.parse<Float> "12345.67890" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    12345.67890
 
+  Builtin.Json.parse<Float> "-12345.67890" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    -12345.67890
 
-// TODO: test highly-precise numbers
-Builtin.Json.serialize<Float> 3.14159265358979323846 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "3.141592653589793"
+  Builtin.Json.parse<Float> " 42.0 " = PACKAGE.Darklang.Stdlib.Result.Result.Ok 42.0
+  Builtin.Json.parse<Float> " -42.0 " = PACKAGE.Darklang.Stdlib.Result.Result.Ok -42.0
+  Builtin.Json.parse<Float> "1e3" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 1000.0
+  Builtin.Json.parse<Float> "-1e3" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -1000.0
 
-Builtin.Json.serialize<Float> 1.618033988749895 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "1.618033988749895"
+  Builtin.Json.serialize<Float> 3.14159265358979323846 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "3.141592653589793"
 
+  Builtin.Json.serialize<Float> 1.618033988749895 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "1.618033988749895"
 
-// TODO: review Float.tests for more values to test against
+  Builtin.Json.parse<Float> "1.0000001" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    1.0000001
 
-Builtin.Json.parse<Float> "1.0000001" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  1.0000001
+  Builtin.Json.parse<Float> "-1.00000001" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    -1.00000001
 
-Builtin.Json.parse<Float> "-1.00000001" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  -1.00000001
+  Builtin.Json.parse<Float> "-2147483647.8" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    -2147483647.8
 
-Builtin.Json.parse<Float> "-2147483647.8" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  -2147483647.8
 
+  Builtin.Json.parse<Float> "17.55042081" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    17.55042081
 
-Builtin.Json.parse<Float> "17.55042081" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  17.55042081
+  Builtin.Json.parse<Float> "2147483647.000009" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    2147483647.000009
 
-Builtin.Json.parse<Float> "2147483647.000009" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  2147483647.000009
+  Builtin.Json.parse<Float> "-2367.9267" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    -2367.9267
 
-Builtin.Json.parse<Float> "-2367.9267" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  -2367.9267
+  Builtin.Json.parse<Float> "0.6999999999999999555910790149937383830547332763671875" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    0.6999999999999999555910790149937383830547332763671875
 
-Builtin.Json.parse<Float> "0.6999999999999999555910790149937383830547332763671875" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  0.6999999999999999555910790149937383830547332763671875
+  Builtin.Json.parse<Float> "0.7999999999" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    0.7999999999
 
-Builtin.Json.parse<Float> "0.7999999999" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  0.7999999999
+  module Constants =
+    Builtin.Json.serialize<Float> Builtin.Test.negativeInfinity_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      "\"-Infinity\""
 
-Builtin.Json.serialize<Float> Builtin.Test.negativeInfinity_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"-Infinity\""
+    Builtin.Json.parse<Float> "\"-Infinity\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      Builtin.Test.negativeInfinity_v0
 
-Builtin.Json.parse<Float> "\"-Infinity\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  Builtin.Test.negativeInfinity_v0
+    Builtin.Json.serialize<Float> Builtin.Test.infinity_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      "\"Infinity\""
 
-Builtin.Json.serialize<Float> Builtin.Test.infinity_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"Infinity\""
+    Builtin.Json.parse<Float> "\"Infinity\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      Builtin.Test.infinity_v0
 
-Builtin.Json.parse<Float> "\"Infinity\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  Builtin.Test.infinity_v0
+    Builtin.Json.serialize<Float> Builtin.Test.nan_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      "\"NaN\""
 
-Builtin.Json.serialize<Float> Builtin.Test.nan_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"NaN\""
+    Builtin.Json.parse<Float> "\"NaN\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      Builtin.Test.nan_v0
 
-Builtin.Json.parse<Float> "\"NaN\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  Builtin.Test.nan_v0
 
-// not floats
-Builtin.Json.parse<Float> " -42 . 0 " = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
-//Builtin.Json.parse<Float> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently serialize this type/value combination"
-Builtin.Json.parse<Float> " " = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
 
-Builtin.Json.parse<Float> "4a" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+  module Errors =
 
-Builtin.Json.parse<Float> "- 42.0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Float> "e" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Float> "-141s" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Float> "pi" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Float> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `null` as type `Float` at path: `root`"
+    Builtin.Json.parse<Float> " -42 . 0 " = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Float> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `true` as type `Float` at path: `root`"
+    // TODO this should be allowed
+    //Builtin.Json.parse<Float> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently serialize this type/value combination"
 
-Builtin.Json.parse<Float> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `false` as type `Float` at path: `root`"
-// Builtin.Json.parse<Float> "\"42\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
-Builtin.Json.parse<Float> "[42]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `[42]` as type `Float` at path: `root`"
+    Builtin.Json.parse<Float> " " = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Float> "{ \"key\": 42 }" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `{ \"key\": 42 }` as type `Float` at path: `root`"
+    Builtin.Json.parse<Float> "4a" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Float> "\"42\n\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Float> "- 42.0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Float> "000000.9" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Float> "-141s" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Float> "-000000.9" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Float> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `null` as type `Float` at path: `root`"
 
-Builtin.Json.parse<Float> "-00000000.000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Float> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `true` as type `Float` at path: `root`"
 
-Builtin.Json.parse<Float> "00000000.000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+    Builtin.Json.parse<Float> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `false` as type `Float` at path: `root`"
 
-// This tests that we get a Result.Error when trying to parse a string, not an
-// internal exception
-Builtin.Json.parse<Float> "\"65.0\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"65.0\"` as type `Float` at path: `root`"
+    // TODO enable this test
+    // Builtin.Json.parse<Float> "\"42\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
 
+    Builtin.Json.parse<Float> "[42]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `[42]` as type `Float` at path: `root`"
 
-//Builtin.Json.parse<Float> "4\u0032" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+    Builtin.Json.parse<Float> "{ \"key\": 42 }" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `{ \"key\": 42 }` as type `Float` at path: `root`"
 
+    Builtin.Json.parse<Float> "\"42\n\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-// Chars
-//let charFromString (s: String) =
-//  (PACKAGE.Darklang.Stdlib.String.toList s) |> PACKAGE.Darklang.Stdlib.List.head |> Builtin.unwrap
+    Builtin.Json.parse<Float> "000000.9" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.serialize<Char> 'a' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"a\""
-Builtin.Json.parse<Char> "\"a\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 'a'
-//Builtin.Json.serialize<Char> ("😂" |> charFromString ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "😂"
-//Builtin.Json.parse<Char> "\"😂\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok '😂'
-//Builtin.Json.serialize<Char> '👩‍👩‍👧‍👦' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"👩‍👩‍👧‍👦\""
-//Builtin.Json.parse<Char> "\"👩‍👩‍👧‍👦\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok '👩‍👩‍👧‍👦'
-Builtin.Json.serialize<Char> 'Ł' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"Ł\""
-Builtin.Json.parse<Char> "\"Ł\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 'Ł'
+    Builtin.Json.parse<Float> "-000000.9" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-// not chars
-Builtin.Json.parse<Char> "\"test\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"test\"` as type `Char` at path: `root`"
+    Builtin.Json.parse<Float> "-00000000.000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
-Builtin.Json.parse<Char> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"\"` as type `Char` at path: `root`"
+    Builtin.Json.parse<Float> "00000000.000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
 
+    // This tests that we get a Result.Error when trying to parse a string, not an
+    // internal exception
+    Builtin.Json.parse<Float> "\"65.0\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"65.0\"` as type `Float` at path: `root`"
 
-// Strings
-Builtin.Json.serialize<String> "abc" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"abc\""
 
-Builtin.Json.parse<String> "\"abc\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "abc"
-Builtin.Json.serialize<String> "" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"\""
-Builtin.Json.parse<String> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok ""
+    //Builtin.Json.parse<Float> "4\u0032" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
 
-Builtin.Json.serialize<String> "żółw" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"żółw\""
 
-Builtin.Json.parse<String> "\"żółw\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "żółw"
-//Builtin.Json.serialize<String> "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
-Builtin.Json.parse<String> "\"👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
-//Builtin.Json.serialize<String> "👩‍👩‍👧‍👦" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"👩‍👩‍👧‍👦\""
-//Builtin.Json.parse<String> "\"👩‍👩‍👧‍👦\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "👩‍👩‍👧‍👦"
-// TODO: long strings
-Builtin.Json.serialize<String>
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\""
+module Char =
+  //let charFromString (s: String) =
+  //  (PACKAGE.Darklang.Stdlib.String.toList s) |> PACKAGE.Darklang.Stdlib.List.head |> Builtin.unwrap
 
-Builtin.Json.parse<String>
-  "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor."
+  Builtin.Json.serialize<Char> 'a' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"a\""
+  Builtin.Json.parse<Char> "\"a\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 'a'
+  //Builtin.Json.serialize<Char> ("😂" |> charFromString ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "😂"
+  //Builtin.Json.parse<Char> "\"😂\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok '😂'
+  //Builtin.Json.serialize<Char> '👩‍👩‍👧‍👦' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"👩‍👩‍👧‍👦\""
+  //Builtin.Json.parse<Char> "\"👩‍👩‍👧‍👦\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok '👩‍👩‍👧‍👦'
+  Builtin.Json.serialize<Char> 'Ł' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"Ł\""
+  Builtin.Json.parse<Char> "\"Ł\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 'Ł'
 
+  module Errors =
+    Builtin.Json.parse<Char> "\"test\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"test\"` as type `Char` at path: `root`"
 
-Builtin.Json.serialize<String> (PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+    Builtin.Json.parse<Char> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"\"` as type `Char` at path: `root`"
 
-Builtin.Json.parse<String>
-  "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100)
 
+module String =
+  Builtin.Json.serialize<String> "abc" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"abc\""
 
-// Datetimes
-let d (datestr: String) : DateTime =
-  (PACKAGE.Darklang.Stdlib.DateTime.parse datestr) |> Builtin.unwrap
+  Builtin.Json.parse<String> "\"abc\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "abc"
+  Builtin.Json.serialize<String> "" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"\""
+  Builtin.Json.parse<String> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok ""
 
-// now-ish
-Builtin.Json.serialize<DateTime> (d "2023-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"2023-07-28T22:42:36Z\""
+  Builtin.Json.serialize<String> "żółw" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"żółw\""
 
-Builtin.Json.parse<DateTime> "\"2023-07-28T22:42:36Z\"" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(d "2023-07-28T22:42:36Z")
+  Builtin.Json.parse<String> "\"żółw\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "żółw"
+  //Builtin.Json.serialize<String> "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
+  Builtin.Json.parse<String> "\"👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
+  //Builtin.Json.serialize<String> "👩‍👩‍👧‍👦" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"👩‍👩‍👧‍👦\""
+  //Builtin.Json.parse<String> "\"👩‍👩‍👧‍👦\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "👩‍👩‍👧‍👦"
+  // TODO: long strings
+  Builtin.Json.serialize<String>
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\""
 
-// epoch
-Builtin.Json.serialize<DateTime> (d "1969-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"1969-07-28T22:42:36Z\""
+  Builtin.Json.parse<String>
+    "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor."
 
-Builtin.Json.parse<DateTime> "\"1969-07-28T22:42:36Z\"" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(d "1969-07-28T22:42:36Z")
 
-// before epoch
-Builtin.Json.serialize<DateTime> (d "1402-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"1402-07-28T22:42:36Z\""
+  Builtin.Json.serialize<String> (PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
 
-Builtin.Json.parse<DateTime> "\"1402-07-28T22:42:36Z\"" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(d "1402-07-28T22:42:36Z")
+  Builtin.Json.parse<String>
+    "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100)
 
-// far in future
-Builtin.Json.serialize<DateTime> (d "3023-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"3023-07-28T22:42:36Z\""
 
-Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36Z\"" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(d "3023-07-28T22:42:36Z")
+module DateTime =
+  let d (datestr: String) : DateTime =
+    (PACKAGE.Darklang.Stdlib.DateTime.parse datestr) |> Builtin.unwrap
 
-// not dates (either malformatted, or missing stuff, or totally not dates)
-Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"3023-07-28T22:42:36\"` as type `DateTime` at path: `root`"
+  // now-ish
+  Builtin.Json.serialize<DateTime> (d "2023-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"2023-07-28T22:42:36Z\""
 
-Builtin.Json.parse<DateTime> "\"2023-07-28\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"2023-07-28\"` as type `DateTime` at path: `root`"
+  Builtin.Json.parse<DateTime> "\"2023-07-28T22:42:36Z\"" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(d "2023-07-28T22:42:36Z")
 
-Builtin.Json.parse<DateTime> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `1` as type `DateTime` at path: `root`"
+  // epoch
+  Builtin.Json.serialize<DateTime> (d "1969-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"1969-07-28T22:42:36Z\""
 
+  Builtin.Json.parse<DateTime> "\"1969-07-28T22:42:36Z\"" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(d "1969-07-28T22:42:36Z")
 
-// UUIDs
-let uuid (s: String) : Uuid =
-  (PACKAGE.Darklang.Stdlib.Uuid.parse_v0 s) |> Builtin.unwrap
+  // before epoch
+  Builtin.Json.serialize<DateTime> (d "1402-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"1402-07-28T22:42:36Z\""
 
-// empty
-Builtin.Json.serialize<Uuid> (uuid "00000000-0000-0000-0000-000000000000") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"00000000-0000-0000-0000-000000000000\""
+  Builtin.Json.parse<DateTime> "\"1402-07-28T22:42:36Z\"" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(d "1402-07-28T22:42:36Z")
 
-Builtin.Json.parse<Uuid> ("\"00000000-0000-0000-0000-000000000000\"") = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(uuid "00000000-0000-0000-0000-000000000000")
+  // far in future
+  Builtin.Json.serialize<DateTime> (d "3023-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"3023-07-28T22:42:36Z\""
 
-// normal
-Builtin.Json.serialize<Uuid> (uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\""
+  Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36Z\"" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(d "3023-07-28T22:42:36Z")
 
-Builtin.Json.parse<Uuid> ("\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"") = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
+  module Erorrs =
+    Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"3023-07-28T22:42:36\"` as type `DateTime` at path: `root`"
 
-Builtin.Json.serialize<Uuid> (uuid "11111111-2222-3333-4444-555555555555") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"11111111-2222-3333-4444-555555555555\""
+    Builtin.Json.parse<DateTime> "\"2023-07-28\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"2023-07-28\"` as type `DateTime` at path: `root`"
 
-Builtin.Json.parse<Uuid> ("\"11111111-2222-3333-4444-555555555555\"") = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(uuid "11111111-2222-3333-4444-555555555555")
+    Builtin.Json.parse<DateTime> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `1` as type `DateTime` at path: `root`"
 
-// not UUIDs
-// needs one more 0 at the end
-Builtin.Json.parse<Uuid> "\"00000000-0000-0000-0000-00000000000\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"00000000-0000-0000-0000-00000000000\"` as type `Uuid` at path: `root`"
 
+module Uuid =
+  let uuid (s: String) : Uuid =
+    (PACKAGE.Darklang.Stdlib.Uuid.parse_v0 s) |> Builtin.unwrap
 
-// Bytes
-Builtin.Json.serialize<Bytes> Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "\"\""
+  // empty
+  Builtin.Json.serialize<Uuid> (uuid "00000000-0000-0000-0000-000000000000") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"00000000-0000-0000-0000-000000000000\""
 
-Builtin.Json.parse<Bytes> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  Builtin.Bytes.empty
+  Builtin.Json.parse<Uuid> ("\"00000000-0000-0000-0000-000000000000\"") = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(uuid "00000000-0000-0000-0000-000000000000")
 
+  // normal
+  Builtin.Json.serialize<Uuid> (uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\""
 
-// Lists
-type Person = { Name: String; Age: Int }
-type MyString = String
+  Builtin.Json.parse<Uuid> ("\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"") = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
 
-Builtin.Json.serialize<List<Int>> [] = PACKAGE.Darklang.Stdlib.Result.Result.Ok "[]"
-Builtin.Json.parse<List<Int>> "[]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok []
+  Builtin.Json.serialize<Uuid> (uuid "11111111-2222-3333-4444-555555555555") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"11111111-2222-3333-4444-555555555555\""
 
-Builtin.Json.serialize<List<Int>> [ 1; 2; 3 ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[1,2,3]"
+  Builtin.Json.parse<Uuid> ("\"11111111-2222-3333-4444-555555555555\"") = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(uuid "11111111-2222-3333-4444-555555555555")
 
-Builtin.Json.parse<List<Int>> "[1,2,3]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ 1; 2; 3 ]
+  module Errors =
+    // needs one more 0 at the end
+    Builtin.Json.parse<Uuid> "\"00000000-0000-0000-0000-00000000000\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"00000000-0000-0000-0000-00000000000\"` as type `Uuid` at path: `root`"
 
-Builtin.Json.parse<List<Int>> "[1,2,3,]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
 
-Builtin.Json.serialize<List<List<List<Int>>>>
-  [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]"
+module Bytes =
+  // TODO check errors
+  Builtin.Json.serialize<Bytes> Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"\""
 
-Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ]
+  Builtin.Json.parse<Bytes> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    Builtin.Bytes.empty
 
-Builtin.Json.parse<List<Dict<String>>>
-  """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ Dict { name = "Alice"; role = "admin" }
-    Dict { name = "Bob"; role = "user" }
-    Dict { name = "Charlie"; role = "user" } ]
 
-Builtin.Json.serialize<List<Dict<String>>>
-  [ Dict { name = "Alice"; role = "admin" }
-    Dict { name = "Bob"; role = "user" }
-    Dict { name = "Charlie"; role = "user" } ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """[{"name":"Alice","role":"admin"},{"name":"Bob","role":"user"},{"name":"Charlie","role":"user"}]"""
 
-Builtin.Json.parse<List<Person>>
-  """[{"Name": "Alice", "Age": 42}, {"Name": "Bob", "Age": 27}, {"Name": "Charlie", "Age": 99}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ Person { Name = "Alice"; Age = 42 }
-    Person { Name = "Bob"; Age = 27 }
-    Person { Name = "Charlie"; Age = 99 } ]
+module List =
+  type Person = { Name: String; Age: Int }
+  type MyString = String
 
-Builtin.Json.serialize<List<Person>>
-  [ Person { Name = "Alice"; Age = 42 }
-    Person { Name = "Bob"; Age = 27 }
-    Person { Name = "Charlie"; Age = 99 } ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """[{"Age":42,"Name":"Alice"},{"Age":27,"Name":"Bob"},{"Age":99,"Name":"Charlie"}]"""
+  Builtin.Json.serialize<List<Int>> [] = PACKAGE.Darklang.Stdlib.Result.Result.Ok "[]"
+  Builtin.Json.parse<List<Int>> "[]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok []
 
-Builtin.Json.parse<List<Dict<MyString>>>
-  """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ Dict { name = "Alice"; role = "admin" }
-    Dict { name = "Bob"; role = "user" }
-    Dict { name = "Charlie"; role = "user" } ]
-
-// not proper lists
-Builtin.Json.serialize<List<Int>> [ 1, 2, "three" ] = Builtin.Test.derrorMessage
-  "Json.serialize's 1st argument (`arg`) should be a List<Int>. However, an (Int, Int, String) ((1, 2, \"th...) was passed instead.\n\nExpected: (arg: 'a)\nActual: an (Int, Int, String): (1, 2, \"three\")"
-
-Builtin.Json.parse<List<Int>> "[1, 2, \"three\"]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"three\"` as type `Int` at path: `root[2]`"
-
-Builtin.Json.parse<List<Int>> "[1, 2, ]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
-//Builtin.Json.serialize<List<List<List<Int>>>> [[[1, 2, 3], [4, 5.5, 6]], [[7, 8], [9, 0]]] = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
-//Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5.5,6]],[[7,8],[9,0]]]" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
-Builtin.Json.parse<List<Dict<Int>>>
-  """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"Alice\"` as type `Int` at path: `root[0].name`"
-
-
-// Tuples
-Builtin.Json.serialize<Tuple<Int, String, Int>> (1, "two", 3) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[1,\"two\",3]"
-
-Builtin.Json.serialize<Tuple<List<Int>, List<Person>>> (
-  [ 1; 2; 3 ],
-  [ Person { Name = "Alice"; Age = 42 } ]
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
-
-Builtin.Json.serialize<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>> (
-  (1, "two"),
-  (Person { Name = "Alice"; Age = 42 },
-   PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
-
-Builtin.Json.serialize<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>> (
-  ([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
-  (Person { Name = "Alice"; Age = 42 },
-   PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
-
-Builtin.Json.serialize<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>> (
-  Person { Name = "Alice"; Age = 42 },
-  PACKAGE.Darklang.Stdlib.Option.Option.Some 1
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
-
-Builtin.Json.serialize<Tuple<PACKAGE.Darklang.Stdlib.Option.Option<Int>, PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>> (
-  PACKAGE.Darklang.Stdlib.Option.Option.Some 1,
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok 2
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "[{\"Some\":[1]},{\"Ok\":[2]}]"
-
-Builtin.Json.serialize<Tuple<Char, Bool>> ('a', true) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[\"a\",true]"
-
-Builtin.Json.serialize<Tuple<DateTime, Uuid>> (
-  d "2023-07-28T22:42:36Z",
-  uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
-
-
-Builtin.Json.parse<Tuple<Int, String, Int>> "[1,\"two\",3]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok((1, "two", 3))
-
-Builtin.Json.parse<Tuple<List<Int>, List<Person>>>
-  "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(([ 1; 2; 3 ], [ Person { Name = "Alice"; Age = 42 } ]))
-
-Builtin.Json.parse<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>>
-  "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
-    ((1, "two"),
-     (Person { Name = "Alice"; Age = 42 },
-      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
-  )
-
-Builtin.Json.parse<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>>
-  "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
-    (([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
-     (Person { Name = "Alice"; Age = 42 },
-      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
-  )
-
-Builtin.Json.parse<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>
-  "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
+  Builtin.Json.serialize<List<Int>> [ 1; 2; 3 ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[1,2,3]"
+
+  Builtin.Json.parse<List<Int>> "[1,2,3]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    [ 1; 2; 3 ]
+
+  Builtin.Json.parse<List<Int>> "[1,2,3,]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    "not JSON"
+
+  Builtin.Json.serialize<List<List<List<Int>>>>
+    [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]"
+
+  Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ]
+
+  Builtin.Json.parse<List<Dict<String>>>
+    """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    [ Dict { name = "Alice"; role = "admin" }
+      Dict { name = "Bob"; role = "user" }
+      Dict { name = "Charlie"; role = "user" } ]
+
+  Builtin.Json.serialize<List<Dict<String>>>
+    [ Dict { name = "Alice"; role = "admin" }
+      Dict { name = "Bob"; role = "user" }
+      Dict { name = "Charlie"; role = "user" } ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """[{"name":"Alice","role":"admin"},{"name":"Bob","role":"user"},{"name":"Charlie","role":"user"}]"""
+
+  Builtin.Json.parse<List<Person>>
+    """[{"Name": "Alice", "Age": 42}, {"Name": "Bob", "Age": 27}, {"Name": "Charlie", "Age": 99}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    [ Person { Name = "Alice"; Age = 42 }
+      Person { Name = "Bob"; Age = 27 }
+      Person { Name = "Charlie"; Age = 99 } ]
+
+  Builtin.Json.serialize<List<Person>>
+    [ Person { Name = "Alice"; Age = 42 }
+      Person { Name = "Bob"; Age = 27 }
+      Person { Name = "Charlie"; Age = 99 } ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """[{"Age":42,"Name":"Alice"},{"Age":27,"Name":"Bob"},{"Age":99,"Name":"Charlie"}]"""
+
+  Builtin.Json.parse<List<Dict<MyString>>>
+    """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    [ Dict { name = "Alice"; role = "admin" }
+      Dict { name = "Bob"; role = "user" }
+      Dict { name = "Charlie"; role = "user" } ]
+
+  module Errors =
+    Builtin.Json.serialize<List<Int>> [ 1, 2, "three" ] = Builtin.Test.derrorMessage
+      "Json.serialize's 1st argument (`arg`) should be a List<Int>. However, an (Int, Int, String) ((1, 2, \"th...) was passed instead.\n\nExpected: (arg: 'a)\nActual: an (Int, Int, String): (1, 2, \"three\")"
+
+    Builtin.Json.parse<List<Int>> "[1, 2, \"three\"]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"three\"` as type `Int` at path: `root[2]`"
+
+    Builtin.Json.parse<List<Int>> "[1, 2, ]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "not JSON"
+    //Builtin.Json.serialize<List<List<List<Int>>>> [[[1, 2, 3], [4, 5.5, 6]], [[7, 8], [9, 0]]] = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
+    //Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5.5,6]],[[7,8],[9,0]]]" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
+    Builtin.Json.parse<List<Dict<Int>>>
+      """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"Alice\"` as type `Int` at path: `root[0].name`"
+
+module Tuples =
+  // TODO remove "Tuple" hack from the parser
+  Builtin.Json.serialize<Tuple<Int, String, Int>> (1, "two", 3) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[1,\"two\",3]"
+
+  Builtin.Json.serialize<Tuple<List<Int>, List<Person>>> (
+    [ 1; 2; 3 ],
+    [ Person { Name = "Alice"; Age = 42 } ]
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
+
+  Builtin.Json.serialize<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>> (
+    (1, "two"),
     (Person { Name = "Alice"; Age = 42 },
-     PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+    PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
+
+  Builtin.Json.serialize<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>> (
+    ([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
+    (Person { Name = "Alice"; Age = 42 },
+    PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
+
+  Builtin.Json.serialize<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>> (
+    Person { Name = "Alice"; Age = 42 },
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 1
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
+
+  Builtin.Json.serialize<Tuple<PACKAGE.Darklang.Stdlib.Option.Option<Int>, PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>> (
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 1,
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 2
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "[{\"Some\":[1]},{\"Ok\":[2]}]"
+
+  Builtin.Json.serialize<Tuple<Char, Bool>> ('a', true) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[\"a\",true]"
+
+  Builtin.Json.serialize<Tuple<DateTime, Uuid>> (
+    DateTime.d "2023-07-28T22:42:36Z",
+    Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
+
+  Builtin.Json.parse<Tuple<Int, String, Int>> "[1,\"two\",3]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok((1, "two", 3))
+
+  Builtin.Json.parse<Tuple<List<Int>, List<Person>>>
+    "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(([ 1; 2; 3 ], [ Person { Name = "Alice"; Age = 42 } ]))
+
+  Builtin.Json.parse<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>>
+    "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      ((1, "two"),
+      (Person { Name = "Alice"; Age = 42 },
+        PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
+    )
+
+  Builtin.Json.parse<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>>
+    "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      (([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
+      (Person { Name = "Alice"; Age = 42 },
+        PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
+    )
+
+  Builtin.Json.parse<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>
+    "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      (Person { Name = "Alice"; Age = 42 },
+      PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+    )
+
+  Builtin.Json.parse<Tuple<PACKAGE.Darklang.Stdlib.Option.Option<Int>, PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>>
+    "[{\"Some\":[1]},{\"Ok\":[2]}]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+    (PACKAGE.Darklang.Stdlib.Option.Option.Some 1,
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
   )
 
-Builtin.Json.parse<Tuple<PACKAGE.Darklang.Stdlib.Option.Option<Int>, PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>>
-  "[{\"Some\":[1]},{\"Ok\":[2]}]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-  (PACKAGE.Darklang.Stdlib.Option.Option.Some 1,
-   PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
-)
+  Builtin.Json.parse<Tuple<Char, Bool>> "[\"a\",true]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(('a', true))
 
-Builtin.Json.parse<Tuple<Char, Bool>> "[\"a\",true]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(('a', true))
-
-Builtin.Json.parse<Tuple<DateTime, Uuid>>
-  "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok((d "2023-07-28T22:42:36Z", uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"))
+  Builtin.Json.parse<Tuple<DateTime, Uuid>>
+    "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok((DateTime.d "2023-07-28T22:42:36Z", Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"))
 
 
-// not proper tuples
-Builtin.Json.parse<Tuple<String, String, Int>> """[1, "two", 3]""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `1` as type `String` at path: `root[0]`"
+  module Errors =
+    Builtin.Json.parse<Tuple<String, String, Int>> """[1, "two", 3]""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `1` as type `String` at path: `root[0]`"
 
-Builtin.Json.parse<Tuple<Tuple<List<Tuple<String, String>>, Bytes>, Tuple<Person, Dict<String>>>>
-  "[[[[2,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":1}]]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `2` as type `String` at path: `root[0][0][0][0]`"
+    Builtin.Json.parse<Tuple<Tuple<List<Tuple<String, String>>, Bytes>, Tuple<Person, Dict<String>>>>
+      "[[[[2,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":1}]]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `2` as type `String` at path: `root[0][0][0][0]`"
 
-Builtin.Json.parse<Tuple<List<Tuple<Int, List<String>>>, String>>
-  "[[[1,\"two\"],[3,\"four\"]],\"\"]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"two\"` as type `List<String>` at path: `root[0][0][1]`"
+    Builtin.Json.parse<Tuple<List<Tuple<Int, List<String>>>, String>>
+      "[[[1,\"two\"],[3,\"four\"]],\"\"]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"two\"` as type `List<String>` at path: `root[0][0][1]`"
 
-Builtin.Json.parse<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>
-  "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `\"one\"` as type `Int` at path: `root[1]`"
-
-
-// Options
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>>
-  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"None\":[]}"
-
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"None\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  PACKAGE.Darklang.Stdlib.Option.Option.None
-
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>> (
-  PACKAGE.Darklang.Stdlib.Option.Option.Some 1
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Some\":[1]}"
-
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"Some\":[1]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-
-// TODO: these might make good candidates for more ergonmic parsing
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `null` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
-
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `1` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
-
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<List<String>>> "[1,2,3]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Can't parse JSON `[1,2,3]` as type `PACKAGE.Darklang.Stdlib.Option.Option<List<String>>` at path: `root`"
-
-// TODO: more...
+    Builtin.Json.parse<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>
+      "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `\"one\"` as type `Int` at path: `root[1]`"
 
 
-// Results
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
+module Option =
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>>
+    PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"None\":[]}"
 
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err message\"]}"
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"None\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    PACKAGE.Darklang.Stdlib.Option.Option.None
 
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> "{\"Ok\":[1]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>> (
+    PACKAGE.Darklang.Stdlib.Option.Option.Some 1
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Some\":[1]}"
 
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>
-  "{\"Error\":[\"err message\"]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-)
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"Some\":[1]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
 
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<List<Tuple<Dict<String>, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b",
-       PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-      (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d",
-       PACKAGE.Darklang.Stdlib.Option.Option.None) ]
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}"
+  module Errors =
+    // TODO: these might make good candidates for more ergonmic parsing
+    Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `null` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
 
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<List<Tuple<Dict<String>, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>, String>>
-  "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b",
-         PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-        (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d",
-         PACKAGE.Darklang.Stdlib.Option.Option.None) ]
-  )
+    Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `1` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
 
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+    Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<List<String>>> "[1,2,3]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "Can't parse JSON `[1,2,3]` as type `PACKAGE.Darklang.Stdlib.Option.Option<List<String>>` at path: `root`"
+
+    // TODO: more...
+
+
+module Result =
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
     PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-  )
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[{\"Ok\":[1]}]}"
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
 
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err message\"]}"
+
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> "{\"Ok\":[1]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>
+    "{\"Error\":[\"err message\"]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
     PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
   )
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"Ok\":[{\"Error\":[\"err message\"]}]}"
 
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>>
-  "{\"Ok\":[{\"Ok\":[1]}]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-  )
-)
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<List<Tuple<Dict<String>, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>, String>> (
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b",
+        PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+        (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d",
+        PACKAGE.Darklang.Stdlib.Option.Option.None) ]
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}"
 
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>>
-  "{\"Ok\":[{\"Error\":[\"err message\"]}]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<List<Tuple<Dict<String>, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>, String>>
+    "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.Darklang.Stdlib.Result.Result.Ok
+        [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b",
+          PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+          (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d",
+          PACKAGE.Darklang.Stdlib.Option.Option.None) ]
+    )
+
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>> (
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+      PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+    )
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[{\"Ok\":[1]}]}"
+
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>> (
     PACKAGE.Darklang.Stdlib.Result.Result.Ok(
       PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
     )
-  )
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"Ok\":[{\"Error\":[\"err message\"]}]}"
 
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>, String>, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>>
+    "{\"Ok\":[{\"Ok\":[1]}]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
     PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-      PACKAGE.Darklang.Stdlib.Option.Option.Some(
-        PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-      )
+      PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
     )
   )
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}"
 
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>, String>, String>>
-  "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>>
+    "{\"Ok\":[{\"Error\":[\"err message\"]}]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+        PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
+      )
+    )
+
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>, String>, String>> (
     PACKAGE.Darklang.Stdlib.Result.Result.Ok(
       PACKAGE.Darklang.Stdlib.Result.Result.Ok(
         PACKAGE.Darklang.Stdlib.Option.Option.Some(
@@ -767,182 +778,162 @@ Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib
         )
       )
     )
-  )
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}"
+
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>, String>, String>>
+    "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+        PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+          PACKAGE.Darklang.Stdlib.Option.Option.Some(
+            PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+          )
+        )
+      )
+    )
+
+module Dict =
+
+  Builtin.Json.serialize<Dict<String>> (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """{"a":"b"}"""
+
+  Builtin.Json.parse<Dict<String>> """{"a":"b"}""" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+
+  Builtin.Json.serialize<Dict<String>> (Dict { a = "b"; c = "d" }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """{"a":"b","c":"d"}"""
+
+  Builtin.Json.parse<Dict<String>> """{"a":"b","c":"d"}""" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(Dict { a = "b"; c = "d" })
+
+  Builtin.Json.parse<Dict<Int>> """{1:"b",2:"d"}""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    "not JSON"
 
 
-// re: Dicts
-// we don't really have a reasonable way to fill in the <> here:
-// Builtin.Json.parse<???>
-// so let's ignore them for now, and focus on Records defined as "Custom types"
+module UserDefinedEnums =
+  // #### Enums
+  type PrettyLikely =
+    | Yeah
+    | Enh of reason: String * Int
 
-Builtin.Json.serialize<Dict<String>> (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """{"a":"b"}"""
+  type PrettyLikely2 =
+    | PrettyLikely of PrettyLikely
+    | Yes
+    | No
 
-Builtin.Json.parse<Dict<String>> """{"a":"b"}""" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+  Builtin.Json.serialize<PrettyLikely> PrettyLikely.Yeah = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"Yeah\":[]}"
 
-Builtin.Json.serialize<Dict<String>> (Dict { a = "b"; c = "d" }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """{"a":"b","c":"d"}"""
+  Builtin.Json.parse<PrettyLikely> "{\"Yeah\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    PrettyLikely.Yeah
 
-Builtin.Json.parse<Dict<String>> """{"a":"b","c":"d"}""" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Dict { a = "b"; c = "d" })
+  Builtin.Json.serialize<PrettyLikely> (PrettyLikely.Enh("printer broke", 7)) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"Enh\":[\"printer broke\",7]}"
 
-Builtin.Json.parse<Dict<Int>> """{1:"b",2:"d"}""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "not JSON"
+  Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PrettyLikely.Enh("printer broke", 7))
 
-// Unsupported stuff:
-// - TDB
-// - TFn
-// - TError
-// - THttpResponse
-// None of these are supported as <> type args in the parser,
-// so do we really have to do anything here?
-// It feels like a "no" to me - ignoring for now.
+  Builtin.Json.serialize<PrettyLikely2> (PrettyLikely2.PrettyLikely PrettyLikely.Yeah) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"PrettyLikely\":[{\"Yeah\":[]}]}"
 
+  Builtin.Json.parse<PrettyLikely2> "{\"PrettyLikely\":[{\"Yeah\":[]}]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PrettyLikely2.PrettyLikely PrettyLikely.Yeah)
 
-// ## Custom types
+  Builtin.Json.serialize<PrettyLikely2> (
+    PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7))
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}"
 
-// ### User-defined
+  Builtin.Json.parse<PrettyLikely2>
+    "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7)))
 
-// #### Enums
-type PrettyLikely =
-  | Yeah
-  | Enh of reason: String * Int
+  // TODO: more nesting...
 
-type PrettyLikely2 =
-  | PrettyLikely of PrettyLikely
-  | Yes
-  | No
-
-Builtin.Json.serialize<PrettyLikely> PrettyLikely.Yeah = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"Yeah\":[]}"
-
-Builtin.Json.parse<PrettyLikely> "{\"Yeah\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  PrettyLikely.Yeah
-
-Builtin.Json.serialize<PrettyLikely> (PrettyLikely.Enh("printer broke", 7)) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"Enh\":[\"printer broke\",7]}"
-
-Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PrettyLikely.Enh("printer broke", 7))
-
-Builtin.Json.serialize<PrettyLikely2> (PrettyLikely2.PrettyLikely PrettyLikely.Yeah) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"PrettyLikely\":[{\"Yeah\":[]}]}"
-
-Builtin.Json.parse<PrettyLikely2> "{\"PrettyLikely\":[{\"Yeah\":[]}]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PrettyLikely2.PrettyLikely PrettyLikely.Yeah)
-
-Builtin.Json.serialize<PrettyLikely2> (
-  PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7))
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}"
-
-Builtin.Json.parse<PrettyLikely2>
-  "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7)))
-
-// TODO: more nesting...
-
-// #### Records
 type Person = { Name: String; Age: Int }
+module UserDefinedRecords =
 
-Builtin.Json.serialize<Person> (Person { Name = "Bob"; Age = 42 }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """{"Age":42,"Name":"Bob"}"""
+  Builtin.Json.serialize<Person> (Person { Name = "Bob"; Age = 42 }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """{"Age":42,"Name":"Bob"}"""
 
-Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }""" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Person { Name = "Bob"; Age = 42 })
+  Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }""" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(Person { Name = "Bob"; Age = 42 })
 
-// can parse even if the JSON has _extra_ fields
-Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42, "Height": "6 ft" }""" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Person { Name = "Bob"; Age = 42 })
+  // can parse even if the JSON has _extra_ fields
+  Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42, "Height": "6 ft" }""" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(Person { Name = "Bob"; Age = 42 })
 
-(let personMaybe = Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }"""
+  (let personMaybe = Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }"""
 
- match personMaybe with
- | Ok person -> person.Age
- | Error _ -> 0) = 42
+  match personMaybe with
+  | Ok person -> person.Age
+  | Error _ -> 0) = 42
 
 
-type People =
-  { GroupName: String
-    People: List<Person> }
+  type People =
+    { GroupName: String
+      People: List<Person> }
 
-Builtin.Json.serialize<People> (
-  People
-    { GroupName = "Two Georges"
-      People =
-        [ Person { Name = "George A"; Age = 27 }
-          Person { Name = "George B"; Age = 42 } ] }
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}"""
-
-Builtin.Json.parse<People>
-  """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}""" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
+  Builtin.Json.serialize<People> (
     People
       { GroupName = "Two Georges"
         People =
           [ Person { Name = "George A"; Age = 27 }
             Person { Name = "George B"; Age = 42 } ] }
-  )
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}"""
+
+  Builtin.Json.parse<People>
+    """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}""" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      People
+        { GroupName = "Two Georges"
+          People =
+            [ Person { Name = "George A"; Age = 27 }
+              Person { Name = "George B"; Age = 42 } ] }
+    )
 
 
-type Combo<'e1, 'e2> = { e1: 'e1; e2: 'e2 }
+  type Combo<'e1, 'e2> = { e1: 'e1; e2: 'e2 }
 
-Builtin.Json.serialize<Combo<Person, Combo<People, Int>>> (
-  Combo
-    { e1 = Person { Name = "Bob"; Age = 42 }
-      e2 =
-        Combo
-          { e1 =
-              People
-                { GroupName = "Two Georges"
-                  People =
-                    [ Person { Name = "George A"; Age = 27 }
-                      Person { Name = "George B"; Age = 42 } ] }
-            e2 = 5 } }
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}"""
-
-Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
-  """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}""" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
+  Builtin.Json.serialize<Combo<Person, Combo<People, Int>>> (
     Combo
       { e1 = Person { Name = "Bob"; Age = 42 }
         e2 =
@@ -954,200 +945,219 @@ Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
                       [ Person { Name = "George A"; Age = 27 }
                         Person { Name = "George B"; Age = 42 } ] }
               e2 = 5 } }
-  )
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}"""
 
-(Combo
-  { e1 = Person { Name = "Bob"; Age = 42 }
-    e2 =
+  Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
+    """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}""" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
       Combo
-        { e1 =
-            People
-              { GroupName = "Two Georges"
-                People =
-                  [ Person { Name = "George A"; Age = 27 }
-                    Person { Name = "George B"; Age = 42 } ] }
-          e2 = 5 } })
-|> Builtin.Json.serialize<Combo<Person, Combo<People, Int>>>
-|> Builtin.unwrap
-|> Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
-|> Builtin.unwrap = (Combo
-  { e1 = Person { Name = "Bob"; Age = 42 }
-    e2 =
-      Combo
-        { e1 =
-            People
-              { GroupName = "Two Georges"
-                People =
-                  [ Person { Name = "George A"; Age = 27 }
-                    Person { Name = "George B"; Age = 42 } ] }
-          e2 = 5 } })
+        { e1 = Person { Name = "Bob"; Age = 42 }
+          e2 =
+            Combo
+              { e1 =
+                  People
+                    { GroupName = "Two Georges"
+                      People =
+                        [ Person { Name = "George A"; Age = 27 }
+                          Person { Name = "George B"; Age = 42 } ] }
+                e2 = 5 } }
+    )
+
+  (Combo
+    { e1 = Person { Name = "Bob"; Age = 42 }
+      e2 =
+        Combo
+          { e1 =
+              People
+                { GroupName = "Two Georges"
+                  People =
+                    [ Person { Name = "George A"; Age = 27 }
+                      Person { Name = "George B"; Age = 42 } ] }
+            e2 = 5 } })
+  |> Builtin.Json.serialize<Combo<Person, Combo<People, Int>>>
+  |> Builtin.unwrap
+  |> Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
+  |> Builtin.unwrap = (Combo
+    { e1 = Person { Name = "Bob"; Age = 42 }
+      e2 =
+        Combo
+          { e1 =
+              People
+                { GroupName = "Two Georges"
+                  People =
+                    [ Person { Name = "George A"; Age = 27 }
+                      Person { Name = "George B"; Age = 42 } ] }
+            e2 = 5 } })
+
+module UserDefinedAliases =
+
+  type MyInt = Int
+
+  Builtin.Json.serialize<MyInt> 42 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "42"
+  Builtin.Json.parse<MyInt> "42" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 42
+
+  type MyPerson = Person
+
+  Builtin.Json.serialize<MyPerson> (Person { Name = "Bob"; Age = 42 }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """{"Age":42,"Name":"Bob"}"""
+
+  Builtin.Json.parse<MyPerson> """{ "Name": "Bob", "Age": 42 }""" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(Person { Name = "Bob"; Age = 42 })
+
+  type MyPrettyLikely = UserDefinedEnums.PrettyLikely
+
+  Builtin.Json.serialize<MyPrettyLikely> (UserDefinedEnums.PrettyLikely.Enh("printer broke", 7)) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"Enh\":[\"printer broke\",7]}"
+
+  Builtin.Json.parse<MyPrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(UserDefinedEnums.PrettyLikely.Enh("printer broke", 7))
 
 
+  type Person1 = { Name: String; Age: Int }
+  type Person2 = { Name: String; Age: Int }
 
-// #### Aliases
-type MyInt = Int
-
-Builtin.Json.serialize<MyInt> 42 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "42"
-Builtin.Json.parse<MyInt> "42" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 42
-
-type MyPerson = Person
-
-Builtin.Json.serialize<MyPerson> (Person { Name = "Bob"; Age = 42 }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  """{"Age":42,"Name":"Bob"}"""
-
-Builtin.Json.parse<MyPerson> """{ "Name": "Bob", "Age": 42 }""" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(Person { Name = "Bob"; Age = 42 })
-
-type MyPrettyLikely = PrettyLikely
-
-Builtin.Json.serialize<MyPrettyLikely> (PrettyLikely.Enh("printer broke", 7)) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"Enh\":[\"printer broke\",7]}"
-
-Builtin.Json.parse<MyPrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PrettyLikely.Enh("printer broke", 7))
-
-
-type Person1 = { Name: String; Age: Int }
-type Person2 = { Name: String; Age: Int }
-
-Builtin.Json.serialize<Person2> (Person1 { Name = "Bob"; Age = 42 }) = Builtin.Test.derrorMessage
-  "Json.serialize's 1st argument (`arg`) should be a Person2. However, a Person1 (Person1 {...) was passed instead.
+  Builtin.Json.serialize<Person2> (Person1 { Name = "Bob"; Age = 42 }) = Builtin.Test.derrorMessage
+    "Json.serialize's 1st argument (`arg`) should be an UserDefinedAliases.Person2. However, an UserDefinedAliases.Person1 (UserDefine...) was passed instead.
 
 Expected: (arg: 'a)
-Actual: a Person1: Person1 {\n  Age: 42,\n  Name: \"Bob\"\n}"
+Actual: an UserDefinedAliases.Person1: UserDefinedAliases.Person1 {\n  Age: 42,\n  Name: \"Bob\"\n}"
 
-type StringResult<'a> = PACKAGE.Darklang.Stdlib.Result.Result<'a, String>
+  type StringResult<'a> = PACKAGE.Darklang.Stdlib.Result.Result<'a, String>
 
-Builtin.Json.serialize<StringResult<Int>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
+  Builtin.Json.serialize<StringResult<Int>> (
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
 
-Builtin.Json.serialize<StringResult<Int>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "err"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err\"]}"
-// Builtin.Json.serialize<StringResult<Int>> (PACKAGE.Darklang.Stdlib.Result.Result.Error 1) = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently serialize this type/value combination"
+  Builtin.Json.serialize<StringResult<Int>> (
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "err"
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err\"]}"
+  // Builtin.Json.serialize<StringResult<Int>> (PACKAGE.Darklang.Stdlib.Result.Result.Error 1) = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently serialize this type/value combination"
 
-// TODO: This test should fail but doesn't
-// Builtin.Json.serialize<StringResult<Int>> (PACKAGE.Darklang.Stdlib.Result.Result.Error 1) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":1}"
-
-
-// ### Package
-
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>>
-  PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"None\":[]}"
-
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"None\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  PACKAGE.Darklang.Stdlib.Option.Option.None
-
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
-
-Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err message\"]}"
-
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> "{\"Ok\":[1]}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
-
-Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>
-  "{\"Error\":[\"err message\"]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-  PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-)
+  // TODO: This test should fail but doesn't
+  // Builtin.Json.serialize<StringResult<Int>> (PACKAGE.Darklang.Stdlib.Result.Result.Error 1) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":1}"
 
 
-Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ID> 42 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "42"
+module Package =
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>>
+    PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"None\":[]}"
 
-Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ID> "42" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  42
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"None\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    PACKAGE.Darklang.Stdlib.Option.Option.None
 
-Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.Sign>
-  PACKAGE.Darklang.LanguageTools.Sign.Positive = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"Positive\":[]}"
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
+    PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
 
-Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.Sign> "{\"Positive\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  PACKAGE.Darklang.LanguageTools.Sign.Positive
+  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err message\"]}"
+
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> "{\"Ok\":[1]}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+
+  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>
+    "{\"Error\":[\"err message\"]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
+    PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
+  )
 
 
-Builtin.Json.serialize<PACKAGE.OpenAI.Completion.ResponseChoice> (
-  PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" }
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"text\":\"hello\"}"
+  Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ID> 42 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "42"
 
-Builtin.Json.parse<PACKAGE.OpenAI.Completion.ResponseChoice> "{\"text\":\"hello\"}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" })
+  Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ID> "42" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    42
 
-Builtin.Json.serialize<PACKAGE.OpenAI.Completion.Request> (
-  PACKAGE.OpenAI.Completion.Request
-    { model = "davinci"
-      prompt = "test"
-      max_tokens = 5
-      temperature = 0.7 }
-) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}"
+  Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.Sign>
+    PACKAGE.Darklang.LanguageTools.Sign.Positive = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"Positive\":[]}"
 
-Builtin.Json.parse<PACKAGE.OpenAI.Completion.Request>
-  "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
+  Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.Sign> "{\"Positive\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    PACKAGE.Darklang.LanguageTools.Sign.Positive
+
+
+  Builtin.Json.serialize<PACKAGE.OpenAI.Completion.ResponseChoice> (
+    PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" }
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"text\":\"hello\"}"
+
+  Builtin.Json.parse<PACKAGE.OpenAI.Completion.ResponseChoice> "{\"text\":\"hello\"}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" })
+
+  Builtin.Json.serialize<PACKAGE.OpenAI.Completion.Request> (
     PACKAGE.OpenAI.Completion.Request
       { model = "davinci"
         prompt = "test"
         max_tokens = 5
         temperature = 0.7 }
-  )
+  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}"
 
-Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
-  PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok("{\"InvalidPackageName\":[]}")
+  Builtin.Json.parse<PACKAGE.OpenAI.Completion.Request>
+    "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.OpenAI.Completion.Request
+        { model = "davinci"
+          prompt = "test"
+          max_tokens = 5
+          temperature = 0.7 }
+    )
 
-Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
-  "{\"NotFound\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound
+  Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
+    PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok("{\"InvalidPackageName\":[]}")
 
-Builtin.Json.serialize<List<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>>
-  [ PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName
-    (PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.MissingEnumModuleName
-      "Ok")
-    PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]"
+  Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
+    "{\"NotFound\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound
 
-Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>>
-  "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]" = PACKAGE
-  .Darklang
-  .Stdlib
-  .Result
-  .Result
-  .Ok(
+  Builtin.Json.serialize<List<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>>
     [ PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName
       (PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.MissingEnumModuleName
         "Ok")
-      PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ]
-  )
+      PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]"
+
+  Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>>
+    "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]" = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      [ PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName
+        (PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.MissingEnumModuleName
+          "Ok")
+        PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ]
+    )
 
 
 // from old tests - worth reviewing to see if we have missing cases

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -252,6 +252,12 @@ Builtin.Json.parse<Float> "-00000000.000" = PACKAGE.Darklang.Stdlib.Result.Resul
 Builtin.Json.parse<Float> "00000000.000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
   "not JSON"
 
+// This tests that we get a Result.Error when trying to parse a string, not an
+// internal exception
+Builtin.Json.parse<Float> "\"65.0\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "Can't parse JSON `\"65.0\"` as type `Float` at path: `root`"
+
+
 //Builtin.Json.parse<Float> "4\u0032" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
 
 

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -5,134 +5,124 @@
 // so do we really have to do anything here?
 // It feels like a "no" to me - ignoring for now.
 
+type Result<'ok, 'err> = PACKAGE.Darklang.Stdlib.Result.Result<'ok, 'err>
+type Option<'t> = PACKAGE.Darklang.Stdlib.Option.Option<'t>
 
-// Units
+
 module Unit =
-  Builtin.Json.serialize<Unit> () = PACKAGE.Darklang.Stdlib.Result.Result.Ok "null"
-  Builtin.Json.parse<Unit> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Ok()
+  Builtin.Json.serialize<Unit> () = Result.Ok "null"
+  Builtin.Json.parse<Unit> "null" = Result.Ok()
 
   module Errors =
-    Builtin.Json.parse<Int> "()" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Int> "()" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Unit> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Unit> "0" = Result.Error
       "Can't parse JSON `0` as type `Unit` at path: `root`"
 
-    Builtin.Json.parse<Unit> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Unit> "\"\"" = Result.Error
       "Can't parse JSON `\"\"` as type `Unit` at path: `root`"
 
-    Builtin.Json.parse<Unit> "\"null\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Unit> "\"null\"" = Result.Error
       "Can't parse JSON `\"null\"` as type `Unit` at path: `root`"
 
 
 module Bool =
-  Builtin.Json.serialize<Bool> true = PACKAGE.Darklang.Stdlib.Result.Result.Ok "true"
+  Builtin.Json.serialize<Bool> true = Result.Ok "true"
+  Builtin.Json.serialize<Bool> false = Result.Ok "false"
 
-  Builtin.Json.serialize<Bool> false = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "false"
+  Builtin.Json.parse<Bool> "true" = Result.Ok true
+  Builtin.Json.parse<Bool> "false" = Result.Ok false
+  Builtin.Json.parse<Bool> " true " = Result.Ok true
+  Builtin.Json.parse<Bool> " false " = Result.Ok false
 
-  Builtin.Json.parse<Bool> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Ok true
-  Builtin.Json.parse<Bool> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Ok false
-  Builtin.Json.parse<Bool> " true " = PACKAGE.Darklang.Stdlib.Result.Result.Ok true
-  Builtin.Json.parse<Bool> " false " = PACKAGE.Darklang.Stdlib.Result.Result.Ok false
-
-  Builtin.Json.parse<List<Bool>> "[true, true, false, true  ] " = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.parse<List<Bool>> "[true, true, false, true  ] " = Result.Ok
     [ true; true; false; true ]
 
   module Errors =
-    Builtin.Json.parse<Bool> "tru" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Bool> "tru" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Bool> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Bool> "null" = Result.Error
       "Can't parse JSON `null` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Bool> "" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Bool> "\"true\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Bool> "\"true\"" = Result.Error
       "Can't parse JSON `\"true\"` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Bool> "0" = Result.Error
       "Can't parse JSON `0` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Bool> "1" = Result.Error
       "Can't parse JSON `1` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "False" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Bool> "False" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Bool> "tRUE" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Bool> "tRUE" = Result.Error "not JSON"
 
 
 module Int =
   module Basic =
-    Builtin.Json.serialize<Int> 0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0"
-    Builtin.Json.serialize<Int> 12345 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "12345"
+    Builtin.Json.serialize<Int> 0 = Result.Ok "0"
+    Builtin.Json.serialize<Int> 12345 = Result.Ok "12345"
 
-    Builtin.Json.serialize<Int> -12345 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      "-12345"
+    Builtin.Json.serialize<Int> -12345 = Result.Ok "-12345"
 
   module Int32Limits =
     // test the limits of int32 (-2147483648 to 2147483647)
-    Builtin.Json.serialize<Int> -2147483648 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      "-2147483648"
+    Builtin.Json.serialize<Int> -2147483648 = Result.Ok "-2147483648"
 
-    Builtin.Json.serialize<Int> 2147483647 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      "2147483647"
+    Builtin.Json.serialize<Int> 2147483647 = Result.Ok "2147483647"
 
-    Builtin.Json.parse<Int> "-2147483648" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      -2147483648
-    //TODO: this should fail but doesn't
-    // Builtin.Json.parse<Int> "-2147483648" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 2147483648
-    Builtin.Json.parse<Int> "2147483647" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      2147483647
-    //Builtin.Json.serialize<Int> -2147483649 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"-2147483649\""
-    //Builtin.Json.serialize<Int> 2147483648 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"2147483648\""
-    //Builtin.Json.parse<Int> "\"-2147483649\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -2147483649
-    //Builtin.Json.parse<Int> "\"2147483648\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 2147483648
+    Builtin.Json.parse<Int> "-2147483648" = Result.Ok -2147483648
+
+    // TODO: this should fail but doesn't
+    // Builtin.Json.parse<Int> "-2147483648" = Result.Ok 2147483648
+    Builtin.Json.parse<Int> "2147483647" = Result.Ok 2147483647
+  //Builtin.Json.serialize<Int> -2147483649 = Result.Ok "\"-2147483649\""
+  //Builtin.Json.serialize<Int> 2147483648 = Result.Ok "\"2147483648\""
+  //Builtin.Json.parse<Int> "\"-2147483649\"" = Result.Ok -2147483649
+  //Builtin.Json.parse<Int> "\"2147483648\"" = Result.Ok 2147483648
 
   module Int64Limits =
-    // test the limits of int64 (-9223372036854775808 to 9223372036854775807)
-    //Builtin.Json.serialize<Int> 9223372036854775807 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "9223372036854775807"
-    //Builtin.Json.parse<Int> "9223372036854775807" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9223372036854775807
-    //Builtin.Json.serialize<Int> 9223372036854775808 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "9223372036854775808"
-    //Builtin.Json.parse<Int> "9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 9223372036854775808
-    //Builtin.Json.serialize<Int> -9223372036854775808 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "-9223372036854775808"
-    //Builtin.Json.parse<Int> "-9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -9223372036854775808
+    1 = 1 // allow it to parse
+  // test the limits of int64 (-9223372036854775808 to 9223372036854775807)
+  //Builtin.Json.serialize<Int> 9223372036854775807 = Result.Ok "9223372036854775807"
+  //Builtin.Json.parse<Int> "9223372036854775807" = Result.Ok 9223372036854775807
+  //Builtin.Json.serialize<Int> 9223372036854775808 = Result.Ok "9223372036854775808"
+  //Builtin.Json.parse<Int> "9223372036854775808" = Result.Ok 9223372036854775808
+  //Builtin.Json.serialize<Int> -9223372036854775808 = Result.Ok "-9223372036854775808"
+  //Builtin.Json.parse<Int> "-9223372036854775808" = Result.Ok -9223372036854775808
 
   module Errors =
 
     // TODO: review Float.tests for more values to test against
 
     // not ints
-    Builtin.Json.parse<Int> " " = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
-    Builtin.Json.parse<Int> "4a" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+    Builtin.Json.parse<Int> " " = Result.Error "not JSON"
+    Builtin.Json.parse<Int> "4a" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Int> "- 42" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Int> "- 42" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Int> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Int> "null" = Result.Error
       "Can't parse JSON `null` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Int> "true" = Result.Error
       "Can't parse JSON `true` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Int> "false" = Result.Error
       "Can't parse JSON `false` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "\"42\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Int> "\"42\"" = Result.Error
       "Can't parse JSON `\"42\"` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "[42]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Int> "[42]" = Result.Error
       "Can't parse JSON `[42]` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "{ \"key\": 42 }" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Int> "{ \"key\": 42 }" = Result.Error
       "Can't parse JSON `{ \"key\": 42 }` as type `Int` at path: `root`"
-    //Builtin.Json.parse<Int> "42.5" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
-    Builtin.Json.parse<Int> "\"42\n\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
-    //Builtin.Json.parse<Int> "4\u0032" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+    //Builtin.Json.parse<Int> "42.5" = Result.Error "Can't currently parse this type/value combination"
+    Builtin.Json.parse<Int> "\"42\n\"" = Result.Error "not JSON"
+//Builtin.Json.parse<Int> "4\u0032" = Result.Error "not JSON"
 
 
 module Float =
@@ -140,211 +130,174 @@ module Float =
   // TODO: test highly-precise numbers
   // TODO: review Float.tests for more values to test against
 
-  Builtin.Json.serialize<Float> 0.0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0.0"
-  Builtin.Json.serialize<Float> 1.0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "1.0"
-  Builtin.Json.serialize<Float> 0.1 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "0.1"
+  Builtin.Json.serialize<Float> 0.0 = Result.Ok "0.0"
+  Builtin.Json.serialize<Float> 1.0 = Result.Ok "1.0"
+  Builtin.Json.serialize<Float> 0.1 = Result.Ok "0.1"
 
-  Builtin.Json.serialize<Float> (2.0 / 3.0) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "0.6666666666666666"
+  Builtin.Json.serialize<Float> (2.0 / 3.0) = Result.Ok "0.6666666666666666"
 
-  Builtin.Json.serialize<Float> 12345.67890 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "12345.6789"
+  Builtin.Json.serialize<Float> 12345.67890 = Result.Ok "12345.6789"
+  Builtin.Json.serialize<Float> -12345.67890 = Result.Ok "-12345.6789"
 
-  Builtin.Json.serialize<Float> -12345.67890 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "-12345.6789"
-
-  Builtin.Json.parse<Float> "0.0" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 0.0
+  Builtin.Json.parse<Float> "0.0" = Result.Ok 0.0
 
 
-  Builtin.Json.parse<Float> "12345.67890" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    12345.67890
+  Builtin.Json.parse<Float> "12345.67890" = Result.Ok 12345.67890
 
-  Builtin.Json.parse<Float> "-12345.67890" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    -12345.67890
+  Builtin.Json.parse<Float> "-12345.67890" = Result.Ok -12345.67890
 
-  Builtin.Json.parse<Float> " 42.0 " = PACKAGE.Darklang.Stdlib.Result.Result.Ok 42.0
-  Builtin.Json.parse<Float> " -42.0 " = PACKAGE.Darklang.Stdlib.Result.Result.Ok -42.0
-  Builtin.Json.parse<Float> "1e3" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 1000.0
-  Builtin.Json.parse<Float> "-1e3" = PACKAGE.Darklang.Stdlib.Result.Result.Ok -1000.0
+  Builtin.Json.parse<Float> " 42.0 " = Result.Ok 42.0
+  Builtin.Json.parse<Float> " -42.0 " = Result.Ok -42.0
+  Builtin.Json.parse<Float> "1e3" = Result.Ok 1000.0
+  Builtin.Json.parse<Float> "-1e3" = Result.Ok -1000.0
 
-  Builtin.Json.serialize<Float> 3.14159265358979323846 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Float> 3.14159265358979323846 = Result.Ok
     "3.141592653589793"
 
-  Builtin.Json.serialize<Float> 1.618033988749895 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "1.618033988749895"
+  Builtin.Json.serialize<Float> 1.618033988749895 = Result.Ok "1.618033988749895"
 
-  Builtin.Json.parse<Float> "1.0000001" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    1.0000001
+  Builtin.Json.parse<Float> "1.0000001" = Result.Ok 1.0000001
 
-  Builtin.Json.parse<Float> "-1.00000001" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    -1.00000001
+  Builtin.Json.parse<Float> "-1.00000001" = Result.Ok -1.00000001
 
-  Builtin.Json.parse<Float> "-2147483647.8" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    -2147483647.8
+  Builtin.Json.parse<Float> "-2147483647.8" = Result.Ok -2147483647.8
 
 
-  Builtin.Json.parse<Float> "17.55042081" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    17.55042081
+  Builtin.Json.parse<Float> "17.55042081" = Result.Ok 17.55042081
 
-  Builtin.Json.parse<Float> "2147483647.000009" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    2147483647.000009
+  Builtin.Json.parse<Float> "2147483647.000009" = Result.Ok 2147483647.000009
 
-  Builtin.Json.parse<Float> "-2367.9267" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    -2367.9267
+  Builtin.Json.parse<Float> "-2367.9267" = Result.Ok -2367.9267
 
-  Builtin.Json.parse<Float> "0.6999999999999999555910790149937383830547332763671875" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.parse<Float> "0.6999999999999999555910790149937383830547332763671875" = Result.Ok
     0.6999999999999999555910790149937383830547332763671875
 
-  Builtin.Json.parse<Float> "0.7999999999" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    0.7999999999
+  Builtin.Json.parse<Float> "0.7999999999" = Result.Ok 0.7999999999
 
   module Constants =
-    Builtin.Json.serialize<Float> Builtin.Test.negativeInfinity_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    Builtin.Json.serialize<Float> Builtin.Test.negativeInfinity_v0 = Result.Ok
       "\"-Infinity\""
 
-    Builtin.Json.parse<Float> "\"-Infinity\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    Builtin.Json.parse<Float> "\"-Infinity\"" = Result.Ok
       Builtin.Test.negativeInfinity_v0
 
-    Builtin.Json.serialize<Float> Builtin.Test.infinity_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      "\"Infinity\""
+    Builtin.Json.serialize<Float> Builtin.Test.infinity_v0 = Result.Ok "\"Infinity\""
 
-    Builtin.Json.parse<Float> "\"Infinity\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      Builtin.Test.infinity_v0
+    Builtin.Json.parse<Float> "\"Infinity\"" = Result.Ok Builtin.Test.infinity_v0
 
-    Builtin.Json.serialize<Float> Builtin.Test.nan_v0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      "\"NaN\""
+    Builtin.Json.serialize<Float> Builtin.Test.nan_v0 = Result.Ok "\"NaN\""
 
-    Builtin.Json.parse<Float> "\"NaN\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      Builtin.Test.nan_v0
+    Builtin.Json.parse<Float> "\"NaN\"" = Result.Ok Builtin.Test.nan_v0
 
 
 
   module Errors =
 
-    Builtin.Json.parse<Float> "e" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "e" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "pi" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "pi" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> " -42 . 0 " = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> " -42 . 0 " = Result.Error "not JSON"
 
     // TODO this should be allowed
-    //Builtin.Json.parse<Float> "0" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently serialize this type/value combination"
+    //Builtin.Json.parse<Float> "0" = Result.Error "Can't currently serialize this type/value combination"
 
-    Builtin.Json.parse<Float> " " = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> " " = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "4a" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "4a" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "- 42.0" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "- 42.0" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "-141s" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "-141s" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Float> "null" = Result.Error
       "Can't parse JSON `null` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "true" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Float> "true" = Result.Error
       "Can't parse JSON `true` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "false" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Float> "false" = Result.Error
       "Can't parse JSON `false` as type `Float` at path: `root`"
 
     // TODO enable this test
-    // Builtin.Json.parse<Float> "\"42\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
+    // Builtin.Json.parse<Float> "\"42\"" = Result.Error "Can't currently parse this type/value combination"
 
-    Builtin.Json.parse<Float> "[42]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Float> "[42]" = Result.Error
       "Can't parse JSON `[42]` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "{ \"key\": 42 }" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Float> "{ \"key\": 42 }" = Result.Error
       "Can't parse JSON `{ \"key\": 42 }` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "\"42\n\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "\"42\n\"" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "000000.9" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "000000.9" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "-000000.9" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "-000000.9" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "-00000000.000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "-00000000.000" = Result.Error "not JSON"
 
-    Builtin.Json.parse<Float> "00000000.000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
+    Builtin.Json.parse<Float> "00000000.000" = Result.Error "not JSON"
 
     // This tests that we get a Result.Error when trying to parse a string, not an
     // internal exception
-    Builtin.Json.parse<Float> "\"65.0\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Float> "\"65.0\"" = Result.Error
       "Can't parse JSON `\"65.0\"` as type `Float` at path: `root`"
 
 
-    //Builtin.Json.parse<Float> "4\u0032" = PACKAGE.Darklang.Stdlib.Result.Result.Error "not JSON"
+//Builtin.Json.parse<Float> "4\u0032" = Result.Error "not JSON"
 
 
 module Char =
   //let charFromString (s: String) =
   //  (PACKAGE.Darklang.Stdlib.String.toList s) |> PACKAGE.Darklang.Stdlib.List.head |> Builtin.unwrap
 
-  Builtin.Json.serialize<Char> 'a' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"a\""
-  Builtin.Json.parse<Char> "\"a\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 'a'
-  //Builtin.Json.serialize<Char> ("😂" |> charFromString ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "😂"
-  //Builtin.Json.parse<Char> "\"😂\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok '😂'
-  //Builtin.Json.serialize<Char> '👩‍👩‍👧‍👦' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"👩‍👩‍👧‍👦\""
-  //Builtin.Json.parse<Char> "\"👩‍👩‍👧‍👦\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok '👩‍👩‍👧‍👦'
-  Builtin.Json.serialize<Char> 'Ł' = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"Ł\""
-  Builtin.Json.parse<Char> "\"Ł\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 'Ł'
+  Builtin.Json.serialize<Char> 'a' = Result.Ok "\"a\""
+  Builtin.Json.parse<Char> "\"a\"" = Result.Ok 'a'
+  //Builtin.Json.serialize<Char> ("😂" |> charFromString ) = Result.Ok "😂"
+  //Builtin.Json.parse<Char> "\"😂\"" = Result.Ok '😂'
+  //Builtin.Json.serialize<Char> '👩‍👩‍👧‍👦' = Result.Ok "\"👩‍👩‍👧‍👦\""
+  //Builtin.Json.parse<Char> "\"👩‍👩‍👧‍👦\"" = Result.Ok '👩‍👩‍👧‍👦'
+  Builtin.Json.serialize<Char> 'Ł' = Result.Ok "\"Ł\""
+  Builtin.Json.parse<Char> "\"Ł\"" = Result.Ok 'Ł'
 
   module Errors =
-    Builtin.Json.parse<Char> "\"test\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Char> "\"test\"" = Result.Error
       "Can't parse JSON `\"test\"` as type `Char` at path: `root`"
 
-    Builtin.Json.parse<Char> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Char> "\"\"" = Result.Error
       "Can't parse JSON `\"\"` as type `Char` at path: `root`"
 
 
 module String =
-  Builtin.Json.serialize<String> "abc" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "\"abc\""
+  Builtin.Json.serialize<String> "abc" = Result.Ok "\"abc\""
 
-  Builtin.Json.parse<String> "\"abc\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "abc"
-  Builtin.Json.serialize<String> "" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"\""
-  Builtin.Json.parse<String> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok ""
+  Builtin.Json.parse<String> "\"abc\"" = Result.Ok "abc"
+  Builtin.Json.serialize<String> "" = Result.Ok "\"\""
+  Builtin.Json.parse<String> "\"\"" = Result.Ok ""
 
-  Builtin.Json.serialize<String> "żółw" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "\"żółw\""
+  Builtin.Json.serialize<String> "żółw" = Result.Ok "\"żółw\""
 
-  Builtin.Json.parse<String> "\"żółw\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "żółw"
-  //Builtin.Json.serialize<String> "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
-  Builtin.Json.parse<String> "\"👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.parse<String> "\"żółw\"" = Result.Ok "żółw"
+  //Builtin.Json.serialize<String> "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = Result.Ok "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
+  Builtin.Json.parse<String> "\"👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷\"" = Result.Ok
     "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
-  //Builtin.Json.serialize<String> "👩‍👩‍👧‍👦" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "\"👩‍👩‍👧‍👦\""
-  //Builtin.Json.parse<String> "\"👩‍👩‍👧‍👦\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok "👩‍👩‍👧‍👦"
+  //Builtin.Json.serialize<String> "👩‍👩‍👧‍👦" = Result.Ok "\"👩‍👩‍👧‍👦\""
+  //Builtin.Json.parse<String> "\"👩‍👩‍👧‍👦\"" = Result.Ok "👩‍👩‍👧‍👦"
   // TODO: long strings
   Builtin.Json.serialize<String>
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." = Result.Ok
     "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\""
 
   Builtin.Json.parse<String>
-    "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\"" = Result.Ok
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor."
 
 
-  Builtin.Json.serialize<String> (PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<String> (PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100) = Result.Ok
     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
 
   Builtin.Json.parse<String>
-    "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+    "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"" = Result
     .Ok(PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100)
 
 
@@ -353,57 +306,45 @@ module DateTime =
     (PACKAGE.Darklang.Stdlib.DateTime.parse datestr) |> Builtin.unwrap
 
   // now-ish
-  Builtin.Json.serialize<DateTime> (d "2023-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<DateTime> (d "2023-07-28T22:42:36Z") = Result.Ok
     "\"2023-07-28T22:42:36Z\""
 
-  Builtin.Json.parse<DateTime> "\"2023-07-28T22:42:36Z\"" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(d "2023-07-28T22:42:36Z")
+  Builtin.Json.parse<DateTime> "\"2023-07-28T22:42:36Z\"" = Result.Ok(
+    d "2023-07-28T22:42:36Z"
+  )
 
   // epoch
-  Builtin.Json.serialize<DateTime> (d "1969-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<DateTime> (d "1969-07-28T22:42:36Z") = Result.Ok
     "\"1969-07-28T22:42:36Z\""
 
-  Builtin.Json.parse<DateTime> "\"1969-07-28T22:42:36Z\"" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(d "1969-07-28T22:42:36Z")
+  Builtin.Json.parse<DateTime> "\"1969-07-28T22:42:36Z\"" = Result.Ok(
+    d "1969-07-28T22:42:36Z"
+  )
 
   // before epoch
-  Builtin.Json.serialize<DateTime> (d "1402-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<DateTime> (d "1402-07-28T22:42:36Z") = Result.Ok
     "\"1402-07-28T22:42:36Z\""
 
-  Builtin.Json.parse<DateTime> "\"1402-07-28T22:42:36Z\"" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(d "1402-07-28T22:42:36Z")
+  Builtin.Json.parse<DateTime> "\"1402-07-28T22:42:36Z\"" = Result.Ok(
+    d "1402-07-28T22:42:36Z"
+  )
 
   // far in future
-  Builtin.Json.serialize<DateTime> (d "3023-07-28T22:42:36Z") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<DateTime> (d "3023-07-28T22:42:36Z") = Result.Ok
     "\"3023-07-28T22:42:36Z\""
 
-  Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36Z\"" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(d "3023-07-28T22:42:36Z")
+  Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36Z\"" = Result.Ok(
+    d "3023-07-28T22:42:36Z"
+  )
 
-  module Erorrs =
-    Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  module Errors =
+    Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36\"" = Result.Error
       "Can't parse JSON `\"3023-07-28T22:42:36\"` as type `DateTime` at path: `root`"
 
-    Builtin.Json.parse<DateTime> "\"2023-07-28\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<DateTime> "\"2023-07-28\"" = Result.Error
       "Can't parse JSON `\"2023-07-28\"` as type `DateTime` at path: `root`"
 
-    Builtin.Json.parse<DateTime> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<DateTime> "1" = Result.Error
       "Can't parse JSON `1` as type `DateTime` at path: `root`"
 
 
@@ -412,50 +353,39 @@ module Uuid =
     (PACKAGE.Darklang.Stdlib.Uuid.parse_v0 s) |> Builtin.unwrap
 
   // empty
-  Builtin.Json.serialize<Uuid> (uuid "00000000-0000-0000-0000-000000000000") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Uuid> (uuid "00000000-0000-0000-0000-000000000000") = Result.Ok
     "\"00000000-0000-0000-0000-000000000000\""
 
-  Builtin.Json.parse<Uuid> ("\"00000000-0000-0000-0000-000000000000\"") = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(uuid "00000000-0000-0000-0000-000000000000")
+  Builtin.Json.parse<Uuid> ("\"00000000-0000-0000-0000-000000000000\"") = Result.Ok(
+    uuid "00000000-0000-0000-0000-000000000000"
+  )
 
   // normal
-  Builtin.Json.serialize<Uuid> (uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Uuid> (uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = Result.Ok
     "\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\""
 
-  Builtin.Json.parse<Uuid> ("\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"") = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
+  Builtin.Json.parse<Uuid> ("\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"") = Result.Ok(
+    uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
+  )
 
-  Builtin.Json.serialize<Uuid> (uuid "11111111-2222-3333-4444-555555555555") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Uuid> (uuid "11111111-2222-3333-4444-555555555555") = Result.Ok
     "\"11111111-2222-3333-4444-555555555555\""
 
-  Builtin.Json.parse<Uuid> ("\"11111111-2222-3333-4444-555555555555\"") = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(uuid "11111111-2222-3333-4444-555555555555")
+  Builtin.Json.parse<Uuid> ("\"11111111-2222-3333-4444-555555555555\"") = Result.Ok(
+    uuid "11111111-2222-3333-4444-555555555555"
+  )
 
   module Errors =
     // needs one more 0 at the end
-    Builtin.Json.parse<Uuid> "\"00000000-0000-0000-0000-00000000000\"" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Uuid> "\"00000000-0000-0000-0000-00000000000\"" = Result.Error
       "Can't parse JSON `\"00000000-0000-0000-0000-00000000000\"` as type `Uuid` at path: `root`"
 
 
 module Bytes =
   // TODO check errors
-  Builtin.Json.serialize<Bytes> Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "\"\""
+  Builtin.Json.serialize<Bytes> Builtin.Bytes.empty = Result.Ok "\"\""
 
-  Builtin.Json.parse<Bytes> "\"\"" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    Builtin.Bytes.empty
+  Builtin.Json.parse<Bytes> "\"\"" = Result.Ok Builtin.Bytes.empty
 
 
 
@@ -463,27 +393,24 @@ module List =
   type Person = { Name: String; Age: Int }
   type MyString = String
 
-  Builtin.Json.serialize<List<Int>> [] = PACKAGE.Darklang.Stdlib.Result.Result.Ok "[]"
-  Builtin.Json.parse<List<Int>> "[]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok []
+  Builtin.Json.serialize<List<Int>> [] = Result.Ok "[]"
+  Builtin.Json.parse<List<Int>> "[]" = Result.Ok []
 
-  Builtin.Json.serialize<List<Int>> [ 1; 2; 3 ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "[1,2,3]"
+  Builtin.Json.serialize<List<Int>> [ 1; 2; 3 ] = Result.Ok "[1,2,3]"
 
-  Builtin.Json.parse<List<Int>> "[1,2,3]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    [ 1; 2; 3 ]
+  Builtin.Json.parse<List<Int>> "[1,2,3]" = Result.Ok [ 1; 2; 3 ]
 
-  Builtin.Json.parse<List<Int>> "[1,2,3,]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "not JSON"
+  Builtin.Json.parse<List<Int>> "[1,2,3,]" = Result.Error "not JSON"
 
   Builtin.Json.serialize<List<List<List<Int>>>>
-    [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ] = Result.Ok
     "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]"
 
-  Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]" = Result.Ok
     [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ]
 
   Builtin.Json.parse<List<Dict<String>>>
-    """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = Result.Ok
     [ Dict { name = "Alice"; role = "admin" }
       Dict { name = "Bob"; role = "user" }
       Dict { name = "Charlie"; role = "user" } ]
@@ -491,11 +418,11 @@ module List =
   Builtin.Json.serialize<List<Dict<String>>>
     [ Dict { name = "Alice"; role = "admin" }
       Dict { name = "Bob"; role = "user" }
-      Dict { name = "Charlie"; role = "user" } ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      Dict { name = "Charlie"; role = "user" } ] = Result.Ok
     """[{"name":"Alice","role":"admin"},{"name":"Bob","role":"user"},{"name":"Charlie","role":"user"}]"""
 
   Builtin.Json.parse<List<Person>>
-    """[{"Name": "Alice", "Age": 42}, {"Name": "Bob", "Age": 27}, {"Name": "Charlie", "Age": 99}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """[{"Name": "Alice", "Age": 42}, {"Name": "Bob", "Age": 27}, {"Name": "Charlie", "Age": 99}]""" = Result.Ok
     [ Person { Name = "Alice"; Age = 42 }
       Person { Name = "Bob"; Age = 27 }
       Person { Name = "Charlie"; Age = 99 } ]
@@ -503,11 +430,11 @@ module List =
   Builtin.Json.serialize<List<Person>>
     [ Person { Name = "Alice"; Age = 42 }
       Person { Name = "Bob"; Age = 27 }
-      Person { Name = "Charlie"; Age = 99 } ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      Person { Name = "Charlie"; Age = 99 } ] = Result.Ok
     """[{"Age":42,"Name":"Alice"},{"Age":27,"Name":"Bob"},{"Age":99,"Name":"Charlie"}]"""
 
   Builtin.Json.parse<List<Dict<MyString>>>
-    """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = Result.Ok
     [ Dict { name = "Alice"; role = "admin" }
       Dict { name = "Bob"; role = "user" }
       Dict { name = "Charlie"; role = "user" } ]
@@ -516,315 +443,213 @@ module List =
     Builtin.Json.serialize<List<Int>> [ 1, 2, "three" ] = Builtin.Test.derrorMessage
       "Json.serialize's 1st argument (`arg`) should be a List<Int>. However, an (Int, Int, String) ((1, 2, \"th...) was passed instead.\n\nExpected: (arg: 'a)\nActual: an (Int, Int, String): (1, 2, \"three\")"
 
-    Builtin.Json.parse<List<Int>> "[1, 2, \"three\"]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<List<Int>> "[1, 2, \"three\"]" = Result.Error
       "Can't parse JSON `\"three\"` as type `Int` at path: `root[2]`"
 
-    Builtin.Json.parse<List<Int>> "[1, 2, ]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-      "not JSON"
-    //Builtin.Json.serialize<List<List<List<Int>>>> [[[1, 2, 3], [4, 5.5, 6]], [[7, 8], [9, 0]]] = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
-    //Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5.5,6]],[[7,8],[9,0]]]" = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently parse this type/value combination"
+    Builtin.Json.parse<List<Int>> "[1, 2, ]" = Result.Error "not JSON"
+    //Builtin.Json.serialize<List<List<List<Int>>>> [[[1, 2, 3], [4, 5.5, 6]], [[7, 8], [9, 0]]] = Result.Error "Can't currently parse this type/value combination"
+    //Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5.5,6]],[[7,8],[9,0]]]" = Result.Error "Can't currently parse this type/value combination"
     Builtin.Json.parse<List<Dict<Int>>>
-      """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = Result.Error
       "Can't parse JSON `\"Alice\"` as type `Int` at path: `root[0].name`"
+
 
 module Tuples =
   // TODO remove "Tuple" hack from the parser
-  Builtin.Json.serialize<Tuple<Int, String, Int>> (1, "two", 3) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Tuple<Int, String, Int>> (1, "two", 3) = Result.Ok
     "[1,\"two\",3]"
 
   Builtin.Json.serialize<Tuple<List<Int>, List<Person>>> (
     [ 1; 2; 3 ],
     [ Person { Name = "Alice"; Age = 42 } ]
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
+  ) = Result.Ok "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
 
   Builtin.Json.serialize<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>> (
     (1, "two"),
     (Person { Name = "Alice"; Age = 42 },
-    PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
+     PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+  ) = Result.Ok "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
   Builtin.Json.serialize<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>> (
     ([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
     (Person { Name = "Alice"; Age = 42 },
-    PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+     PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+  ) = Result.Ok
     "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
-  Builtin.Json.serialize<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>> (
+  Builtin.Json.serialize<Tuple<Person, Option<Int>>> (
     Person { Name = "Alice"; Age = 42 },
-    PACKAGE.Darklang.Stdlib.Option.Option.Some 1
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
+    Option.Some 1
+  ) = Result.Ok "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
 
-  Builtin.Json.serialize<Tuple<PACKAGE.Darklang.Stdlib.Option.Option<Int>, PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>> (
-    PACKAGE.Darklang.Stdlib.Option.Option.Some 1,
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok 2
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "[{\"Some\":[1]},{\"Ok\":[2]}]"
+  Builtin.Json.serialize<Tuple<Option<Int>, Result<Int, String>>> (
+    Option.Some 1,
+    Result.Ok 2
+  ) = Result.Ok "[{\"Some\":[1]},{\"Ok\":[2]}]"
 
-  Builtin.Json.serialize<Tuple<Char, Bool>> ('a', true) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "[\"a\",true]"
+  Builtin.Json.serialize<Tuple<Char, Bool>> ('a', true) = Result.Ok "[\"a\",true]"
 
   Builtin.Json.serialize<Tuple<DateTime, Uuid>> (
     DateTime.d "2023-07-28T22:42:36Z",
     Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
+  ) = Result.Ok "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
 
-  Builtin.Json.parse<Tuple<Int, String, Int>> "[1,\"two\",3]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok((1, "two", 3))
-
-  Builtin.Json.parse<Tuple<List<Int>, List<Person>>>
-    "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(([ 1; 2; 3 ], [ Person { Name = "Alice"; Age = 42 } ]))
-
-  Builtin.Json.parse<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>>
-    "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      ((1, "two"),
-      (Person { Name = "Alice"; Age = 42 },
-        PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
-    )
-
-  Builtin.Json.parse<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>>
-    "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      (([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
-      (Person { Name = "Alice"; Age = 42 },
-        PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
-    )
-
-  Builtin.Json.parse<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>
-    "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      (Person { Name = "Alice"; Age = 42 },
-      PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-    )
-
-  Builtin.Json.parse<Tuple<PACKAGE.Darklang.Stdlib.Option.Option<Int>, PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>>
-    "[{\"Some\":[1]},{\"Ok\":[2]}]" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-    (PACKAGE.Darklang.Stdlib.Option.Option.Some 1,
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok 2)
+  Builtin.Json.parse<Tuple<Int, String, Int>> "[1,\"two\",3]" = Result.Ok(
+    (1, "two", 3)
   )
 
-  Builtin.Json.parse<Tuple<Char, Bool>> "[\"a\",true]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(('a', true))
+  Builtin.Json.parse<Tuple<List<Int>, List<Person>>>
+    "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]" = Result.Ok(
+    ([ 1; 2; 3 ], [ Person { Name = "Alice"; Age = 42 } ])
+  )
+
+  Builtin.Json.parse<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>>
+    "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = Result.Ok(
+    ((1, "two"),
+     (Person { Name = "Alice"; Age = 42 },
+      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
+  )
+
+  Builtin.Json.parse<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>>
+    "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = Result
+    .Ok(
+      (([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
+       (Person { Name = "Alice"; Age = 42 },
+        PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
+    )
+
+  Builtin.Json.parse<Tuple<Person, Option<Int>>>
+    "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]" = Result.Ok(
+    (Person { Name = "Alice"; Age = 42 }, Option.Some 1)
+  )
+
+  Builtin.Json.parse<Tuple<Option<Int>, Result<Int, String>>>
+    "[{\"Some\":[1]},{\"Ok\":[2]}]" = Result.Ok((Option.Some 1, Result.Ok 2))
+
+  Builtin.Json.parse<Tuple<Char, Bool>> "[\"a\",true]" = Result.Ok(('a', true))
 
   Builtin.Json.parse<Tuple<DateTime, Uuid>>
-    "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok((DateTime.d "2023-07-28T22:42:36Z", Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"))
+    "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]" = Result.Ok(
+    (DateTime.d "2023-07-28T22:42:36Z",
+     Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
+  )
 
 
   module Errors =
-    Builtin.Json.parse<Tuple<String, String, Int>> """[1, "two", 3]""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Tuple<String, String, Int>> """[1, "two", 3]""" = Result.Error
       "Can't parse JSON `1` as type `String` at path: `root[0]`"
 
     Builtin.Json.parse<Tuple<Tuple<List<Tuple<String, String>>, Bytes>, Tuple<Person, Dict<String>>>>
-      "[[[[2,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":1}]]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "[[[[2,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":1}]]" = Result.Error
       "Can't parse JSON `2` as type `String` at path: `root[0][0][0][0]`"
 
     Builtin.Json.parse<Tuple<List<Tuple<Int, List<String>>>, String>>
-      "[[[1,\"two\"],[3,\"four\"]],\"\"]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+      "[[[1,\"two\"],[3,\"four\"]],\"\"]" = Result.Error
       "Can't parse JSON `\"two\"` as type `List<String>` at path: `root[0][0][1]`"
 
-    Builtin.Json.parse<Tuple<Person, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>
-      "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Tuple<Person, Option<Int>>>
+      "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]" = Result.Error
       "Can't parse JSON `\"one\"` as type `Int` at path: `root[1]`"
 
 
 module Option =
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>>
-    PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"None\":[]}"
+  // TODO: more...
+  Builtin.Json.serialize<Option<Int>> Option.None = Result.Ok "{\"None\":[]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"None\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    PACKAGE.Darklang.Stdlib.Option.Option.None
+  Builtin.Json.parse<Option<Int>> "{\"None\":[]}" = Result.Ok Option.None
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>> (
-    PACKAGE.Darklang.Stdlib.Option.Option.Some 1
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Some\":[1]}"
+  Builtin.Json.serialize<Option<Int>> (Option.Some 1) = Result.Ok "{\"Some\":[1]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"Some\":[1]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
+  Builtin.Json.parse<Option<Int>> "{\"Some\":[1]}" = Result.Ok(Option.Some 1)
 
   module Errors =
     // TODO: these might make good candidates for more ergonmic parsing
-    Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "null" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Option<Int>> "null" = Result.Error
       "Can't parse JSON `null` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
 
-    Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Option<Int>> "1" = Result.Error
       "Can't parse JSON `1` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
 
-    Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<List<String>>> "[1,2,3]" = PACKAGE.Darklang.Stdlib.Result.Result.Error
+    Builtin.Json.parse<Option<List<String>>> "[1,2,3]" = Result.Error
       "Can't parse JSON `[1,2,3]` as type `PACKAGE.Darklang.Stdlib.Option.Option<List<String>>` at path: `root`"
 
-    // TODO: more...
 
 
 module Result =
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
+  Builtin.Json.serialize<Result<Int, String>> (Result.Ok 1) = Result.Ok
+    "{\"Ok\":[1]}"
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err message\"]}"
+  Builtin.Json.serialize<Result<Int, String>> (Result.Error "err message") = Result.Ok
+    "{\"Error\":[\"err message\"]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> "{\"Ok\":[1]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  Builtin.Json.parse<Result<Int, String>> "{\"Ok\":[1]}" = Result.Ok(Result.Ok 1)
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>
-    "{\"Error\":[\"err message\"]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-    PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
+  Builtin.Json.parse<Result<Int, String>> "{\"Error\":[\"err message\"]}" = Result.Ok(
+    Result.Error "err message"
   )
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<List<Tuple<Dict<String>, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok
-      [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b",
-        PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-        (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d",
-        PACKAGE.Darklang.Stdlib.Option.Option.None) ]
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Result<List<Tuple<Dict<String>, Option<Int>>>, String>> (
+    Result.Ok
+      [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b", Option.Some 1)
+        (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d", Option.None) ]
+  ) = Result.Ok
     "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<List<Tuple<Dict<String>, PACKAGE.Darklang.Stdlib.Option.Option<Int>>>, String>>
-    "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+  Builtin.Json.parse<Result<List<Tuple<Dict<String>, Option<Int>>>, String>>
+    "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}" = Result
     .Ok(
-      PACKAGE.Darklang.Stdlib.Result.Result.Ok
-        [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b",
-          PACKAGE.Darklang.Stdlib.Option.Option.Some 1)
-          (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d",
-          PACKAGE.Darklang.Stdlib.Option.Option.None) ]
+      Result.Ok
+        [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b", Option.Some 1)
+          (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d", Option.None) ]
     )
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-      PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-    )
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[{\"Ok\":[1]}]}"
+  Builtin.Json.serialize<Result<Result<Int, String>, String>> (
+    Result.Ok(Result.Ok 1)
+  ) = Result.Ok "{\"Ok\":[{\"Ok\":[1]}]}"
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-      PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-    )
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"Ok\":[{\"Error\":[\"err message\"]}]}"
+  Builtin.Json.serialize<Result<Result<Int, String>, String>> (
+    Result.Ok(Result.Error "err message")
+  ) = Result.Ok "{\"Ok\":[{\"Error\":[\"err message\"]}]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>>
-    "{\"Ok\":[{\"Ok\":[1]}]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-      PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-    )
+  Builtin.Json.parse<Result<Result<Int, String>, String>> "{\"Ok\":[{\"Ok\":[1]}]}" = Result
+    .Ok(Result.Ok(Result.Ok 1))
+
+  Builtin.Json.parse<Result<Result<Int, String>, String>>
+    "{\"Ok\":[{\"Error\":[\"err message\"]}]}" = Result.Ok(
+    Result.Ok(Result.Error "err message")
   )
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>, String>>
-    "{\"Ok\":[{\"Error\":[\"err message\"]}]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-        PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-      )
-    )
+  Builtin.Json.serialize<Result<Result<Option<Result<Int, String>>, String>, String>> (
+    Result.Ok(Result.Ok(Option.Some(Result.Ok 1)))
+  ) = Result.Ok "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}"
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>, String>, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-      PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-        PACKAGE.Darklang.Stdlib.Option.Option.Some(
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-        )
-      )
-    )
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}"
-
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.Option.Option<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>, String>, String>>
-    "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-        PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-          PACKAGE.Darklang.Stdlib.Option.Option.Some(
-            PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-          )
-        )
-      )
-    )
+  Builtin.Json.parse<Result<Result<PACKAGE.Darklang.Stdlib.Option.Option<Result<Int, String>>, String>, String>>
+    "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}" = Result.Ok(
+    Result.Ok(Result.Ok(Option.Some(Result.Ok 1)))
+  )
 
 module Dict =
 
-  Builtin.Json.serialize<Dict<String>> (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b") = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    """{"a":"b"}"""
+  Builtin.Json.serialize<Dict<String>> (
+    PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"
+  ) = Result.Ok """{"a":"b"}"""
 
-  Builtin.Json.parse<Dict<String>> """{"a":"b"}""" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+  Builtin.Json.parse<Dict<String>> """{"a":"b"}""" = Result.Ok(
+    PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"
+  )
 
-  Builtin.Json.serialize<Dict<String>> (Dict { a = "b"; c = "d" }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Dict<String>> (Dict { a = "b"; c = "d" }) = Result.Ok
     """{"a":"b","c":"d"}"""
 
-  Builtin.Json.parse<Dict<String>> """{"a":"b","c":"d"}""" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(Dict { a = "b"; c = "d" })
+  Builtin.Json.parse<Dict<String>> """{"a":"b","c":"d"}""" = Result.Ok(
+    Dict { a = "b"; c = "d" }
+  )
 
-  Builtin.Json.parse<Dict<Int>> """{1:"b",2:"d"}""" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "not JSON"
+  Builtin.Json.parse<Dict<Int>> """{1:"b",2:"d"}""" = Result.Error "not JSON"
 
 
 module UserDefinedEnums =
-  // #### Enums
+  // TODO: more nesting...
   type PrettyLikely =
     | Yeah
     | Enh of reason: String * Int
@@ -834,73 +659,55 @@ module UserDefinedEnums =
     | Yes
     | No
 
-  Builtin.Json.serialize<PrettyLikely> PrettyLikely.Yeah = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"Yeah\":[]}"
+  Builtin.Json.serialize<PrettyLikely> PrettyLikely.Yeah = Result.Ok "{\"Yeah\":[]}"
 
-  Builtin.Json.parse<PrettyLikely> "{\"Yeah\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    PrettyLikely.Yeah
+  Builtin.Json.parse<PrettyLikely> "{\"Yeah\":[]}" = Result.Ok PrettyLikely.Yeah
 
-  Builtin.Json.serialize<PrettyLikely> (PrettyLikely.Enh("printer broke", 7)) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<PrettyLikely> (PrettyLikely.Enh("printer broke", 7)) = Result.Ok
     "{\"Enh\":[\"printer broke\",7]}"
 
-  Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(PrettyLikely.Enh("printer broke", 7))
+  Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = Result.Ok(
+    PrettyLikely.Enh("printer broke", 7)
+  )
 
-  Builtin.Json.serialize<PrettyLikely2> (PrettyLikely2.PrettyLikely PrettyLikely.Yeah) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"PrettyLikely\":[{\"Yeah\":[]}]}"
+  Builtin.Json.serialize<PrettyLikely2> (
+    PrettyLikely2.PrettyLikely PrettyLikely.Yeah
+  ) = Result.Ok "{\"PrettyLikely\":[{\"Yeah\":[]}]}"
 
-  Builtin.Json.parse<PrettyLikely2> "{\"PrettyLikely\":[{\"Yeah\":[]}]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(PrettyLikely2.PrettyLikely PrettyLikely.Yeah)
+  Builtin.Json.parse<PrettyLikely2> "{\"PrettyLikely\":[{\"Yeah\":[]}]}" = Result.Ok(
+    PrettyLikely2.PrettyLikely PrettyLikely.Yeah
+  )
 
   Builtin.Json.serialize<PrettyLikely2> (
     PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7))
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}"
+  ) = Result.Ok "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}"
 
   Builtin.Json.parse<PrettyLikely2>
-    "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7)))
+    "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}" = Result.Ok(
+    PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7))
+  )
 
-  // TODO: more nesting...
 
 type Person = { Name: String; Age: Int }
+
 module UserDefinedRecords =
 
-  Builtin.Json.serialize<Person> (Person { Name = "Bob"; Age = 42 }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<Person> (Person { Name = "Bob"; Age = 42 }) = Result.Ok
     """{"Age":42,"Name":"Bob"}"""
 
-  Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }""" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(Person { Name = "Bob"; Age = 42 })
+  Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }""" = Result.Ok(
+    Person { Name = "Bob"; Age = 42 }
+  )
 
   // can parse even if the JSON has _extra_ fields
-  Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42, "Height": "6 ft" }""" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+  Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42, "Height": "6 ft" }""" = Result
     .Ok(Person { Name = "Bob"; Age = 42 })
 
   (let personMaybe = Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }"""
 
-  match personMaybe with
-  | Ok person -> person.Age
-  | Error _ -> 0) = 42
+   match personMaybe with
+   | Ok person -> person.Age
+   | Error _ -> 0) = 42
 
 
   type People =
@@ -913,15 +720,11 @@ module UserDefinedRecords =
         People =
           [ Person { Name = "George A"; Age = 27 }
             Person { Name = "George B"; Age = 42 } ] }
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  ) = Result.Ok
     """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}"""
 
   Builtin.Json.parse<People>
-    """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}""" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+    """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}""" = Result
     .Ok(
       People
         { GroupName = "Two Georges"
@@ -945,15 +748,11 @@ module UserDefinedRecords =
                       [ Person { Name = "George A"; Age = 27 }
                         Person { Name = "George B"; Age = 42 } ] }
               e2 = 5 } }
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  ) = Result.Ok
     """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}"""
 
   Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
-    """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}""" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+    """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}""" = Result
     .Ok(
       Combo
         { e1 = Person { Name = "Bob"; Age = 42 }
@@ -998,32 +797,27 @@ module UserDefinedAliases =
 
   type MyInt = Int
 
-  Builtin.Json.serialize<MyInt> 42 = PACKAGE.Darklang.Stdlib.Result.Result.Ok "42"
-  Builtin.Json.parse<MyInt> "42" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 42
+  Builtin.Json.serialize<MyInt> 42 = Result.Ok "42"
+  Builtin.Json.parse<MyInt> "42" = Result.Ok 42
 
   type MyPerson = Person
 
-  Builtin.Json.serialize<MyPerson> (Person { Name = "Bob"; Age = 42 }) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.serialize<MyPerson> (Person { Name = "Bob"; Age = 42 }) = Result.Ok
     """{"Age":42,"Name":"Bob"}"""
 
-  Builtin.Json.parse<MyPerson> """{ "Name": "Bob", "Age": 42 }""" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(Person { Name = "Bob"; Age = 42 })
+  Builtin.Json.parse<MyPerson> """{ "Name": "Bob", "Age": 42 }""" = Result.Ok(
+    Person { Name = "Bob"; Age = 42 }
+  )
 
   type MyPrettyLikely = UserDefinedEnums.PrettyLikely
 
-  Builtin.Json.serialize<MyPrettyLikely> (UserDefinedEnums.PrettyLikely.Enh("printer broke", 7)) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"Enh\":[\"printer broke\",7]}"
+  Builtin.Json.serialize<MyPrettyLikely> (
+    UserDefinedEnums.PrettyLikely.Enh("printer broke", 7)
+  ) = Result.Ok "{\"Enh\":[\"printer broke\",7]}"
 
-  Builtin.Json.parse<MyPrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(UserDefinedEnums.PrettyLikely.Enh("printer broke", 7))
+  Builtin.Json.parse<MyPrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = Result.Ok(
+    UserDefinedEnums.PrettyLikely.Enh("printer broke", 7)
+  )
 
 
   type Person1 = { Name: String; Age: Int }
@@ -1035,73 +829,50 @@ module UserDefinedAliases =
 Expected: (arg: 'a)
 Actual: an UserDefinedAliases.Person1: UserDefinedAliases.Person1 {\n  Age: 42,\n  Name: \"Bob\"\n}"
 
-  type StringResult<'a> = PACKAGE.Darklang.Stdlib.Result.Result<'a, String>
+  type StringResult<'a> = Result<'a, String>
 
-  Builtin.Json.serialize<StringResult<Int>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
+  Builtin.Json.serialize<StringResult<Int>> (Result.Ok 1) = Result.Ok "{\"Ok\":[1]}"
 
-  Builtin.Json.serialize<StringResult<Int>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Error "err"
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err\"]}"
-  // Builtin.Json.serialize<StringResult<Int>> (PACKAGE.Darklang.Stdlib.Result.Result.Error 1) = PACKAGE.Darklang.Stdlib.Result.Result.Error "Can't currently serialize this type/value combination"
+  Builtin.Json.serialize<StringResult<Int>> (Result.Error "err") = Result.Ok
+    "{\"Error\":[\"err\"]}"
+// Builtin.Json.serialize<StringResult<Int>> (Result.Error 1) = Result.Error "Can't currently serialize this type/value combination"
 
-  // TODO: This test should fail but doesn't
-  // Builtin.Json.serialize<StringResult<Int>> (PACKAGE.Darklang.Stdlib.Result.Result.Error 1) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":1}"
+// TODO: This test should fail but doesn't
+// Builtin.Json.serialize<StringResult<Int>> (Result.Error 1) = Result.Ok "{\"Error\":1}"
 
 
 module Package =
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Option.Option<Int>>
-    PACKAGE.Darklang.Stdlib.Option.Option.None = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"None\":[]}"
+  Builtin.Json.serialize<Option<Int>> Option.None = Result.Ok "{\"None\":[]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Option.Option<Int>> "{\"None\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    PACKAGE.Darklang.Stdlib.Option.Option.None
+  Builtin.Json.parse<Option<Int>> "{\"None\":[]}" = Result.Ok Option.None
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Ok\":[1]}"
+  Builtin.Json.serialize<Result<Int, String>> (Result.Ok 1) = Result.Ok
+    "{\"Ok\":[1]}"
 
-  Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> (
-    PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"Error\":[\"err message\"]}"
+  Builtin.Json.serialize<Result<Int, String>> (Result.Error "err message") = Result.Ok
+    "{\"Error\":[\"err message\"]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>> "{\"Ok\":[1]}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(PACKAGE.Darklang.Stdlib.Result.Result.Ok 1)
+  Builtin.Json.parse<Result<Int, String>> "{\"Ok\":[1]}" = Result.Ok(Result.Ok 1)
 
-  Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Result.Result<Int, String>>
-    "{\"Error\":[\"err message\"]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-    PACKAGE.Darklang.Stdlib.Result.Result.Error "err message"
+  Builtin.Json.parse<Result<Int, String>> "{\"Error\":[\"err message\"]}" = Result.Ok(
+    Result.Error "err message"
   )
 
-
-  Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ID> 42 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "42"
-
-  Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ID> "42" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    42
+  Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ID> 42 = Result.Ok "42"
+  Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ID> "42" = Result.Ok 42
 
   Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.Sign>
-    PACKAGE.Darklang.LanguageTools.Sign.Positive = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-    "{\"Positive\":[]}"
+    PACKAGE.Darklang.LanguageTools.Sign.Positive = Result.Ok "{\"Positive\":[]}"
 
-  Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.Sign> "{\"Positive\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.Sign> "{\"Positive\":[]}" = Result.Ok
     PACKAGE.Darklang.LanguageTools.Sign.Positive
 
 
   Builtin.Json.serialize<PACKAGE.OpenAI.Completion.ResponseChoice> (
     PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" }
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok "{\"text\":\"hello\"}"
+  ) = Result.Ok "{\"text\":\"hello\"}"
 
-  Builtin.Json.parse<PACKAGE.OpenAI.Completion.ResponseChoice> "{\"text\":\"hello\"}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+  Builtin.Json.parse<PACKAGE.OpenAI.Completion.ResponseChoice> "{\"text\":\"hello\"}" = Result
     .Ok(PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" })
 
   Builtin.Json.serialize<PACKAGE.OpenAI.Completion.Request> (
@@ -1110,15 +881,11 @@ module Package =
         prompt = "test"
         max_tokens = 5
         temperature = 0.7 }
-  ) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  ) = Result.Ok
     "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}"
 
   Builtin.Json.parse<PACKAGE.OpenAI.Completion.Request>
-    "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+    "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}" = Result
     .Ok(
       PACKAGE.OpenAI.Completion.Request
         { model = "davinci"
@@ -1128,30 +895,22 @@ module Package =
     )
 
   Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
-    PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+    PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName = Result
     .Ok("{\"InvalidPackageName\":[]}")
 
   Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
-    "{\"NotFound\":[]}" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+    "{\"NotFound\":[]}" = Result.Ok
     PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound
 
   Builtin.Json.serialize<List<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>>
     [ PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName
       (PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.MissingEnumModuleName
         "Ok")
-      PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ] = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+      PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ] = Result.Ok
     "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]"
 
   Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>>
-    "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]" = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
+    "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]" = Result
     .Ok(
       [ PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName
         (PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.MissingEnumModuleName
@@ -1188,21 +947,21 @@ module Package =
 //Builtin.Json.parse<TODO> "{\"Id\" : 1.}" = Builtin.Test.runtimeError "'}' is invalid within a number, immediately after a decimal point ('.'). Expected a digit ('0'-'9'). LineNumber: 0 | BytePositionInLine: 10.")"
 //Builtin.Json.parse<TODO> "{id : 555, edition : \"First\", author : \"Dennis Ritchie\"}" =  Builtin.Test.runtimeError "'i' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 1."
 
-//Builtin.Json.parse<TODO> "{ \"v\": 4611686018427387903 }" = PACKAGE.Darklang.Stdlib.Result.Result.Ok { v = 4611686018427387903L }
-//Builtin.Json.parse<TODO> "{ \"v\": 4611686018427387904 }" = PACKAGE.Darklang.Stdlib.Result.Result.Ok { v = 4611686018427387904L }
+//Builtin.Json.parse<TODO> "{ \"v\": 4611686018427387903 }" = Result.Ok { v = 4611686018427387903L }
+//Builtin.Json.parse<TODO> "{ \"v\": 4611686018427387904 }" = Result.Ok { v = 4611686018427387904L }
 
-//Builtin.Json.parse<TODO> "" = PACKAGE.Darklang.Stdlib.Result.Result.Error "JSON string was empty"
-//Builtin.Json.parse<TODO> "{3: false}" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'3' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 1."
+//Builtin.Json.parse<TODO> "" = Result.Error "JSON string was empty"
+//Builtin.Json.parse<TODO> "{3: false}" = Result.Error "'3' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 1."
 
-//Builtin.Json.parse<TODO> "{Id : 1.0}" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'I' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 1."
-//Builtin.Json.parse<TODO> "{\"Id\" : Infinity }" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'I' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 8."
-//Builtin.Json.parse<TODO> "{\"Id\" : -Infinity }" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'I' is invalid within a number, immediately after a sign character ('+' or '-'). Expected a digit ('0'-'9'). LineNumber: 0 | BytePositionInLine: 9."
-//Builtin.Json.parse<TODO> "{\"Id\" : NaN }" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'N' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 8."
-//Builtin.Json.parse<TODO> "{\"Id\" : 1.}" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'}' is invalid within a number, immediately after a decimal point ('.'). Expected a digit ('0'-'9'). LineNumber: 0 | BytePositionInLine: 10."
-//Builtin.Json.parse<TODO> "[ {\"date\" : \"2013-11-05\", locations : {Japan: 3, Germany: 1}} ]" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'l' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 26."
-//Builtin.Json.parse<TODO> "{\"id\" : 555, edition : \"First\", author : \"Dennis Ritchie\"}" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'e' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 13."
-//Builtin.Json.parse<TODO> "{\"id\" : 555, \"edition\" : 'First' }" = PACKAGE.Darklang.Stdlib.Result.Result.Error "''' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 25."
-//Builtin.Json.parse<TODO> "({\"id\" : 555, \"edition\" : \"First\", \"author\" : \"Dennis Ritchie\"})" = PACKAGE.Darklang.Stdlib.Result.Result.Error "'(' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0."
+//Builtin.Json.parse<TODO> "{Id : 1.0}" = Result.Error "'I' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 1."
+//Builtin.Json.parse<TODO> "{\"Id\" : Infinity }" = Result.Error "'I' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 8."
+//Builtin.Json.parse<TODO> "{\"Id\" : -Infinity }" = Result.Error "'I' is invalid within a number, immediately after a sign character ('+' or '-'). Expected a digit ('0'-'9'). LineNumber: 0 | BytePositionInLine: 9."
+//Builtin.Json.parse<TODO> "{\"Id\" : NaN }" = Result.Error "'N' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 8."
+//Builtin.Json.parse<TODO> "{\"Id\" : 1.}" = Result.Error "'}' is invalid within a number, immediately after a decimal point ('.'). Expected a digit ('0'-'9'). LineNumber: 0 | BytePositionInLine: 10."
+//Builtin.Json.parse<TODO> "[ {\"date\" : \"2013-11-05\", locations : {Japan: 3, Germany: 1}} ]" = Result.Error "'l' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 26."
+//Builtin.Json.parse<TODO> "{\"id\" : 555, edition : \"First\", author : \"Dennis Ritchie\"}" = Result.Error "'e' is an invalid start of a property name. Expected a '\"'. LineNumber: 0 | BytePositionInLine: 13."
+//Builtin.Json.parse<TODO> "{\"id\" : 555, \"edition\" : 'First' }" = Result.Error "''' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 25."
+//Builtin.Json.parse<TODO> "({\"id\" : 555, \"edition\" : \"First\", \"author\" : \"Dennis Ritchie\"})" = Result.Error "'(' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0."
 
 // ## Nested types (lists, tuples, records, etc.)
 // Builtin.Json.serialize<List<List<Int * List<MyType<String>> * Dict<MyType<List<Int>>>>>> = Ok "test"

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -5,6 +5,8 @@
 // so do we really have to do anything here?
 // It feels like a "no" to me - ignoring for now.
 
+type Person = { Name: String; Age: Int }
+
 type Result<'ok, 'err> = PACKAGE.Darklang.Stdlib.Result.Result<'ok, 'err>
 type Option<'t> = PACKAGE.Darklang.Stdlib.Option.Option<'t>
 
@@ -390,7 +392,6 @@ module Bytes =
 
 
 module List =
-  type Person = { Name: String; Age: Int }
   type MyString = String
 
   Builtin.Json.serialize<List<Int>> [] = Result.Ok "[]"
@@ -455,62 +456,59 @@ module List =
 
 
 module Tuples =
-  // TODO remove "Tuple" hack from the parser
-  Builtin.Json.serialize<Tuple<Int, String, Int>> (1, "two", 3) = Result.Ok
+  Builtin.Json.serialize<Int * String * Int> (1, "two", 3) = Result.Ok
     "[1,\"two\",3]"
 
-  Builtin.Json.serialize<Tuple<List<Int>, List<Person>>> (
+  Builtin.Json.serialize<List<Int> * List<Person>> (
     [ 1; 2; 3 ],
     [ Person { Name = "Alice"; Age = 42 } ]
   ) = Result.Ok "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
 
-  Builtin.Json.serialize<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>> (
+  Builtin.Json.serialize<(Int * String) * (Person * Dict<String>)> (
     (1, "two"),
     (Person { Name = "Alice"; Age = 42 },
      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
   ) = Result.Ok "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
-  Builtin.Json.serialize<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>> (
+  Builtin.Json.serialize<(List<Int * String> * Bytes) * (Person * Dict<String>)> (
     ([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
     (Person { Name = "Alice"; Age = 42 },
      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
   ) = Result.Ok
     "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
-  Builtin.Json.serialize<Tuple<Person, Option<Int>>> (
+  Builtin.Json.serialize<Person * Option<Int>> (
     Person { Name = "Alice"; Age = 42 },
     Option.Some 1
   ) = Result.Ok "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
 
-  Builtin.Json.serialize<Tuple<Option<Int>, Result<Int, String>>> (
+  Builtin.Json.serialize<Option<Int> * Result<Int, String>> (
     Option.Some 1,
     Result.Ok 2
   ) = Result.Ok "[{\"Some\":[1]},{\"Ok\":[2]}]"
 
-  Builtin.Json.serialize<Tuple<Char, Bool>> ('a', true) = Result.Ok "[\"a\",true]"
+  Builtin.Json.serialize<Char * Bool> ('a', true) = Result.Ok "[\"a\",true]"
 
-  Builtin.Json.serialize<Tuple<DateTime, Uuid>> (
+  Builtin.Json.serialize<DateTime * Uuid> (
     DateTime.d "2023-07-28T22:42:36Z",
     Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
   ) = Result.Ok "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
 
-  Builtin.Json.parse<Tuple<Int, String, Int>> "[1,\"two\",3]" = Result.Ok(
-    (1, "two", 3)
-  )
+  Builtin.Json.parse<Int * String * Int> "[1,\"two\",3]" = Result.Ok((1, "two", 3))
 
-  Builtin.Json.parse<Tuple<List<Int>, List<Person>>>
+  Builtin.Json.parse<List<Int> * List<Person>>
     "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]" = Result.Ok(
     ([ 1; 2; 3 ], [ Person { Name = "Alice"; Age = 42 } ])
   )
 
-  Builtin.Json.parse<Tuple<Tuple<Int, String>, Tuple<Person, Dict<String>>>>
+  Builtin.Json.parse<(Int * String) * (Person * Dict<String>)>
     "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = Result.Ok(
     ((1, "two"),
      (Person { Name = "Alice"; Age = 42 },
       PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
   )
 
-  Builtin.Json.parse<Tuple<Tuple<List<Tuple<Int, String>>, Bytes>, Tuple<Person, Dict<String>>>>
+  Builtin.Json.parse<(List<Int * String> * Bytes) * (Person * Dict<String>)>
     "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = Result
     .Ok(
       (([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
@@ -518,17 +516,17 @@ module Tuples =
         PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
     )
 
-  Builtin.Json.parse<Tuple<Person, Option<Int>>>
+  Builtin.Json.parse<Person * Option<Int>>
     "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]" = Result.Ok(
     (Person { Name = "Alice"; Age = 42 }, Option.Some 1)
   )
 
-  Builtin.Json.parse<Tuple<Option<Int>, Result<Int, String>>>
+  Builtin.Json.parse<Option<Int> * Result<Int, String>>
     "[{\"Some\":[1]},{\"Ok\":[2]}]" = Result.Ok((Option.Some 1, Result.Ok 2))
 
-  Builtin.Json.parse<Tuple<Char, Bool>> "[\"a\",true]" = Result.Ok(('a', true))
+  Builtin.Json.parse<Char * Bool> "[\"a\",true]" = Result.Ok(('a', true))
 
-  Builtin.Json.parse<Tuple<DateTime, Uuid>>
+  Builtin.Json.parse<DateTime * Uuid>
     "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]" = Result.Ok(
     (DateTime.d "2023-07-28T22:42:36Z",
      Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
@@ -536,18 +534,18 @@ module Tuples =
 
 
   module Errors =
-    Builtin.Json.parse<Tuple<String, String, Int>> """[1, "two", 3]""" = Result.Error
+    Builtin.Json.parse<String * String * Int> """[1, "two", 3]""" = Result.Error
       "Can't parse JSON `1` as type `String` at path: `root[0]`"
 
-    Builtin.Json.parse<Tuple<Tuple<List<Tuple<String, String>>, Bytes>, Tuple<Person, Dict<String>>>>
+    Builtin.Json.parse<((List<String * String>) * Bytes) * (Person * Dict<String>)>
       "[[[[2,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":1}]]" = Result.Error
       "Can't parse JSON `2` as type `String` at path: `root[0][0][0][0]`"
 
-    Builtin.Json.parse<Tuple<List<Tuple<Int, List<String>>>, String>>
+    Builtin.Json.parse<(List<Int * List<String>>) * String>
       "[[[1,\"two\"],[3,\"four\"]],\"\"]" = Result.Error
       "Can't parse JSON `\"two\"` as type `List<String>` at path: `root[0][0][1]`"
 
-    Builtin.Json.parse<Tuple<Person, Option<Int>>>
+    Builtin.Json.parse<Person * Option<Int>>
       "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]" = Result.Error
       "Can't parse JSON `\"one\"` as type `Int` at path: `root[1]`"
 
@@ -588,14 +586,14 @@ module Result =
     Result.Error "err message"
   )
 
-  Builtin.Json.serialize<Result<List<Tuple<Dict<String>, Option<Int>>>, String>> (
+  Builtin.Json.serialize<Result<List<Dict<String> * Option<Int>>, String>> (
     Result.Ok
       [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b", Option.Some 1)
         (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d", Option.None) ]
   ) = Result.Ok
     "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}"
 
-  Builtin.Json.parse<Result<List<Tuple<Dict<String>, Option<Int>>>, String>>
+  Builtin.Json.parse<Result<List<Dict<String> * Option<Int>>, String>>
     "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}" = Result
     .Ok(
       Result.Ok
@@ -687,8 +685,6 @@ module UserDefinedEnums =
     PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7))
   )
 
-
-type Person = { Name: String; Age: Int }
 
 module UserDefinedRecords =
 

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -15,7 +15,7 @@ module Darklang =
       let request
         (method: String)
         (uri: String)
-        (headers: List<Tuple<String, String>>)
+        (headers: List<String * String>)
         (body: Bytes)
         : PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.HttpClient.Response, String> =
         Builtin.HttpClient.request method uri headers body

--- a/packages/darklang/stdlib/tuple2.dark
+++ b/packages/darklang/stdlib/tuple2.dark
@@ -2,35 +2,35 @@ module Darklang =
   module Stdlib =
     module Tuple2 =
       /// Returns a pair with the given values
-      let create (first: 'a) (second: 'b) : Tuple<'a, 'b> = (first, second)
+      let create (first: 'a) (second: 'b) : 'a * 'b = (first, second)
 
 
       /// Returns the first value of a pair
-      let first (tuple: Tuple<'a, 'b>) : 'a =
+      let first (tuple: 'a * 'b) : 'a =
         let (first, _) = tuple
         first
 
 
       /// Returns the second value of a pair
-      let second (tuple: Tuple<'a, 'b>) : 'b =
+      let second (tuple: 'a * 'b) : 'b =
         let (_, second) = tuple
         second
 
 
       /// Returns a pair with the elements swapped
-      let swap (tuple: Tuple<'a, 'b>) : Tuple<'b, 'a> =
+      let swap (tuple: 'a * 'b) : 'b * 'a =
         let (first, second) = tuple
         (second, first)
 
 
       /// Transform the first value in a pair
-      let mapFirst (fn: 'a -> 'c) (tuple: Tuple<'a, 'b>) : Tuple<'c, 'b> =
+      let mapFirst (fn: 'a -> 'c) (tuple: 'a * 'b) : 'c * 'b =
         let (first, second) = tuple
         (fn first, second)
 
 
       /// Transform the second value in a pair
-      let mapSecond (fn: 'b -> 'c) (tuple: Tuple<'a, 'b>) : Tuple<'a, 'c> =
+      let mapSecond (fn: 'b -> 'c) (tuple: 'a * 'b) : 'a * 'c =
         let (first, second) = tuple
         (first, fn second)
 
@@ -39,7 +39,7 @@ module Darklang =
       let mapBoth
         (fnFirst: 'a -> 'c)
         (fnSecond: 'b -> 'd)
-        (tuple: Tuple<'a, 'b>)
-        : Tuple<'c, 'd> =
+        (tuple: 'a * 'b)
+        : 'c * 'd =
         let (first, second) = tuple
         (fnFirst first, fnSecond second)

--- a/packages/darklang/stdlib/tuple3.dark
+++ b/packages/darklang/stdlib/tuple3.dark
@@ -2,42 +2,42 @@ module Darklang =
   module Stdlib =
     module Tuple3 =
       /// Returns a triple with the given values
-      let create (first: 'a) (second: 'b) (third: 'c) : Tuple<'a, 'b, 'c> =
+      let create (first: 'a) (second: 'b) (third: 'c) : 'a * 'b * 'c =
         (first, second, third)
 
 
       /// Returns the first value of a triple
-      let first (tuple: Tuple<'a, 'b, 'c>) : 'a =
+      let first (tuple: 'a * 'b * 'c) : 'a =
         let (first, _, _) = tuple
         first
 
 
       /// Returns the second value of a triple
-      let second (tuple: Tuple<'a, 'b, 'c>) : 'b =
+      let second (tuple: 'a * 'b * 'c) : 'b =
         let (_, second, _) = tuple
         second
 
 
       /// Returns the third value of a triple
-      let third (tuple: Tuple<'a, 'b, 'c>) : 'c =
+      let third (tuple: 'a * 'b * 'c) : 'c =
         let (_, _, third) = tuple
         third
 
 
       /// Transform the first value in a triple
-      let mapFirst (fn: 'a -> 'd) (tuple: Tuple<'a, 'b, 'c>) : Tuple<'d, 'b, 'c> =
+      let mapFirst (fn: 'a -> 'd) (tuple: 'a * 'b * 'c) : 'd * 'b * 'c =
         let (first, second, third) = tuple
         (fn first, second, third)
 
 
       /// Transform the second value in a triple
-      let mapSecond (fn: 'b -> 'd) (tuple: Tuple<'a, 'b, 'c>) : Tuple<'a, 'd, 'c> =
+      let mapSecond (fn: 'b -> 'd) (tuple: 'a * 'b * 'c) : 'a * 'd * 'c =
         let (first, second, third) = tuple
         (first, fn second, third)
 
 
       /// Transform the third value in a triple
-      let mapThird (fn: 'c -> 'd) (tuple: Tuple<'a, 'b, 'c>) : Tuple<'a, 'b, 'd> =
+      let mapThird (fn: 'c -> 'd) (tuple: 'a * 'b * 'c) : 'a * 'b * 'd =
         let (first, second, third) = tuple
         (first, second, fn third)
 
@@ -47,7 +47,7 @@ module Darklang =
         (fnFirst: 'a -> 'd)
         (fnSecond: 'b -> 'e)
         (fnThird: 'c -> 'f)
-        (tuple: Tuple<'a, 'b, 'c>)
-        : Tuple<'d, 'e, 'f> =
+        (tuple: 'a * 'b * 'c)
+        : 'd * 'e * 'f =
         let (first, second, third) = tuple
         (fnFirst first, fnSecond second, fnThird third)


### PR DESCRIPTION
Fix some problems with JSON parsing:

- use Json errors (usually can't match with type) when user input doesn't match the stated type (we often used Exception.raiseInternal, but this is triggered by user code so that's not right)

- remove `Tuple<Int,String>` syntax in favor of `Int * String` (from everywhere, not just Json)

- add modules to json.dark

- add Option and Result alias to json.dark (removes a lot of boilerplate) 

- ensure (and test) that only valid characters are parsed