### PR TITLE
Make Dval.record and .enum Ply functions (needed for type lookups)

### DIFF
--- a/backend/experiments/BwdDangerServer/DangerExecution.fs
+++ b/backend/experiments/BwdDangerServer/DangerExecution.fs
@@ -181,13 +181,13 @@ let executeHandler
           match! Exe.runtimeErrorToString state originalRTE with
           | Ok(RT.DString msg) ->
             let msg = $"Error: {msg}\n\nSource: {originalSource}"
-            return error msg
+            return! error msg
           | Ok result -> return result
           | Error(firstErrorSource, firstErrorRTE) ->
             let! firstErrorSource = sourceString firstErrorSource
             match! Exe.runtimeErrorToString state firstErrorRTE with
             | Ok(RT.DString msg) ->
-              return
+              return!
                 error (
                   $"An error occured trying to print a runtime error."
                   + $"\n\nThe formatting error occurred in {firstErrorSource}. The error was:\n{msg}"
@@ -197,7 +197,7 @@ let executeHandler
 
             | Error(secondErrorSource, secondErrorRTE) ->
               let! secondErrorSource = sourceString secondErrorSource
-              return
+              return!
                 error (
                   $"Two errors occured trying to print a runtime error."
                   + $"\n\nThe 2nd formatting error occurred in {secondErrorSource}. The error was:\n{secondErrorRTE}"

--- a/backend/experiments/BwdDangerServer/Server.fs
+++ b/backend/experiments/BwdDangerServer/Server.fs
@@ -317,13 +317,16 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
           // Do request
           use _ = Telemetry.child "executeHandler" []
 
-          let request = LibHttpMiddleware.Request.fromRequest url reqHeaders reqBody
+          let! request = LibHttpMiddleware.Request.fromRequest url reqHeaders reqBody
           let inputVars = routeVars |> Map |> Map.add "request" request
+
+          let! handler = PT2RT.Handler.toRT handler
+          let! canvas = Canvas.toProgram canvas
           let! (result, _) =
             CloudExe.executeHandler
               LibClientTypesToCloudTypes.Pusher.eventSerializer
-              (PT2RT.Handler.toRT handler)
-              (Canvas.toProgram canvas)
+              handler
+              canvas
               traceID
               inputVars
               (CloudExe.InitialExecution(desc, "request", request))

--- a/backend/src/BuiltinCli/Libs/Process.fs
+++ b/backend/src/BuiltinCli/Libs/Process.fs
@@ -58,7 +58,6 @@ let fns : List<BuiltInFn> =
             [ ("exitCode", DInt(p.ExitCode))
               ("stdout", DString(stdout))
               ("stderr", DString(stderr)) ]
-          |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -31,37 +31,43 @@ module CliRuntimeError =
   /// to RuntimeError
   module RTE =
     module Error =
-      let toDT (et : Error) : RT.Dval =
-        let caseName, fields =
-          match et with
-          | NoExpressionsToExecute -> "NoExpressionsToExecute", []
+      let toDT (et : Error) : Ply<RT.Dval> =
+        uply {
+          let! caseName, fields =
+            uply {
+              match et with
+              | NoExpressionsToExecute -> return "NoExpressionsToExecute", []
 
-          | UncaughtException(msg, metadata) ->
-            let metadata =
-              metadata
-              |> List.map (fun (k, v) -> DTuple(DString k, DString v, []))
-              |> Dval.list (
-                ValueType.Known(
-                  KTTuple(ValueType.Known KTString, ValueType.Known KTString, [])
-                )
-              )
+              | UncaughtException(msg, metadata) ->
+                let metadata =
+                  metadata
+                  |> List.map (fun (k, v) -> DTuple(DString k, DString v, []))
+                  |> Dval.list (
+                    ValueType.Known(
+                      KTTuple(ValueType.Known KTString, ValueType.Known KTString, [])
+                    )
+                  )
 
-            "UncaughtException", [ "msg", DString msg; "metadata", metadata ]
+                return
+                  "UncaughtException", [ "msg", DString msg; "metadata", metadata ]
 
-          | MultipleExpressionsToExecute exprs ->
-            "MultipleExpressionsToExecute",
-            [ "exprs", Dval.list VT.unknownTODO (List.map DString exprs) ]
+              | MultipleExpressionsToExecute exprs ->
+                return
+                  "MultipleExpressionsToExecute",
+                  [ "exprs", Dval.list VT.unknownTODO (List.map DString exprs) ]
 
-          | NonIntReturned actuallyReturned ->
-            "NonIntReturned",
-            [ "actuallyReturned", RT2DT.Dval.toDT actuallyReturned ]
+              | NonIntReturned actuallyReturned ->
+                let! actuallyReturned = RT2DT.Dval.toDT actuallyReturned
+                return "NonIntReturned", [ "actuallyReturned", actuallyReturned ]
+            }
 
-        let typeName = RT.RuntimeError.name [ "Cli" ] "Error" 0
-        Dval.enum typeName typeName (Some []) caseName []
+          let typeName = RT.RuntimeError.name [ "Cli" ] "Error" 0
+          return Dval.enum typeName typeName (Some []) caseName []
+        }
 
 
-    let toRuntimeError (e : Error) : RT.RuntimeError =
-      Error.toDT e |> RT.RuntimeError.fromDT
+    let toRuntimeError (e : Error) : Ply<RT.RuntimeError> =
+      Error.toDT e |> Ply.map RT.RuntimeError.fromDT
 
 let libExecutionContents =
   BuiltinExecution.Builtin.contents BuiltinExecution.Libs.HttpClient.defaultConfig
@@ -82,26 +88,35 @@ let execute
   (parentState : RT.ExecutionState)
   (mod' : LibParser.Canvas.PTCanvasModule)
   (symtable : Map<string, RT.Dval>)
-  : Task<Result<RT.Dval, DvalSource * RuntimeError>> =
+  : Ply<Result<RT.Dval, DvalSource * RuntimeError>> =
 
-  task {
-    let program : Program =
-      { canvasID = System.Guid.NewGuid()
-        internalFnsAllowed = false
-        fns =
+  uply {
+    let! (program : Program) =
+      uply {
+        let! fns =
           mod'.fns
-          |> List.map (fun fn -> PT2RT.UserFunction.toRT fn)
-          |> Map.fromListBy (fun fn -> fn.name)
-        types =
+          |> Ply.List.mapSequentially PT2RT.UserFunction.toRT
+          |> Ply.map (Map.fromListBy (fun fn -> fn.name))
+
+        let! types =
           mod'.types
-          |> List.map (fun typ -> PT2RT.UserType.toRT typ)
-          |> Map.fromListBy (fun typ -> typ.name)
-        constants =
+          |> Ply.List.mapSequentially PT2RT.UserType.toRT
+          |> Ply.map (Map.fromListBy (fun typ -> typ.name))
+
+        let! constants =
           mod'.constants
-          |> List.map (fun c -> PT2RT.UserConstant.toRT c)
-          |> Map.fromListBy (fun c -> c.name)
-        dbs = Map.empty
-        secrets = [] }
+          |> Ply.List.mapSequentially PT2RT.UserConstant.toRT
+          |> Ply.map (Map.fromListBy (fun c -> c.name))
+
+        return
+          { canvasID = System.Guid.NewGuid()
+            internalFnsAllowed = false
+            fns = fns
+            types = types
+            constants = constants
+            dbs = Map.empty
+            secrets = [] }
+      }
 
     let tracing = Exe.noTracing RT.Real
     let notify = parentState.notify
@@ -117,23 +132,17 @@ let execute
         program
 
     if mod'.exprs.Length = 1 then
-      return! Exe.executeExpr state symtable (PT2RT.Expr.toRT mod'.exprs[0])
+      let! expr = PT2RT.Expr.toRT mod'.exprs[0]
+      return! Exe.executeExpr state symtable expr
     else if mod'.exprs.Length = 0 then
-      return
-        Error(
-          (SourceNone,
-           CliRuntimeError.NoExpressionsToExecute
-           |> CliRuntimeError.RTE.toRuntimeError)
-        )
+      let! rte =
+        CliRuntimeError.NoExpressionsToExecute |> CliRuntimeError.RTE.toRuntimeError
+      return Error((SourceNone, rte))
     else // mod'.exprs.Length > 1
-      return
-        Error(
-          (SourceNone,
-           CliRuntimeError.MultipleExpressionsToExecute(
-             mod'.exprs |> List.map string
-           )
-           |> CliRuntimeError.RTE.toRuntimeError)
-        )
+      let! rte =
+        CliRuntimeError.MultipleExpressionsToExecute(mod'.exprs |> List.map string)
+        |> CliRuntimeError.RTE.toRuntimeError
+      return Error((SourceNone, rte))
   }
 
 let types : List<BuiltInType> = []
@@ -157,7 +166,7 @@ let fns : List<BuiltInFn> =
         (function
         | state, [], [ DString filename; DString code; DDict(_vtTODO, symtable) ] ->
           uply {
-            let exnError (e : exn) : RuntimeError =
+            let exnError (e : exn) : Ply<RuntimeError> =
               let msg = Exception.getMessages e |> String.concat "\n"
               let metadata =
                 Exception.toMetadata e |> List.map (fun (k, v) -> k, string v)
@@ -172,7 +181,8 @@ let fns : List<BuiltInFn> =
                   return!
                     LibParser.Canvas.parse nameResolver filename code |> Ply.map Ok
                 with e ->
-                  return Error(exnError e)
+                  let! err = exnError e
+                  return Error err
               }
 
             try
@@ -181,15 +191,14 @@ let fns : List<BuiltInFn> =
                 match! execute state mod' symtable with
                 | Ok(DInt i) -> return resultOk (DInt i)
                 | Ok result ->
-                  return
+                  return!
                     CliRuntimeError.NonIntReturned result
                     |> CliRuntimeError.RTE.toRuntimeError
-                    |> RuntimeError.toDT
-                    |> resultError
+                    |> Ply.map (RuntimeError.toDT >> resultError)
                 | Error(_, e) -> return e |> RuntimeError.toDT |> resultError
               | Error e -> return e |> RuntimeError.toDT |> resultError
             with e ->
-              return exnError e |> RuntimeError.toDT |> resultError
+              return! exnError e |> Ply.map (RuntimeError.toDT >> resultError)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -217,15 +226,13 @@ let fns : List<BuiltInFn> =
           uply {
             let err (msg : string) (metadata : List<string * string>) =
               let metadata = metadata |> List.map (fun (k, v) -> k, DString v)
-              resultError (
-                Dval.record
-                  (FQName.BuiltIn(typ [ "Cli" ] "ExecutionError" 0))
-                  (Some [])
-                  [ "msg", DString msg
-                    "metadata", Dval.dict VT.unknownTODO metadata ]
-              )
+              Dval.record
+                (FQName.BuiltIn(typ [ "Cli" ] "ExecutionError" 0))
+                (Some [])
+                [ "msg", DString msg; "metadata", Dval.dict VT.unknownTODO metadata ]
+              |> Ply.map resultError
 
-            let exnError (e : exn) : Dval =
+            let exnError (e : exn) : Ply<Dval> =
               let msg = Exception.getMessages e |> String.concat "\n"
               let metadata =
                 Exception.toMetadata e |> List.map (fun (k, v) -> k, string v)
@@ -313,7 +320,7 @@ let fns : List<BuiltInFn> =
                     return resultOk (DString asString)
               | _ -> return incorrectArgs ()
             with e ->
-              return exnError e
+              return! exnError e
           }
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -48,21 +48,20 @@ module CliRuntimeError =
                     )
                   )
 
-                return
-                  "UncaughtException", [ "msg", DString msg; "metadata", metadata ]
+                return "UncaughtException", [ DString msg; metadata ]
 
               | MultipleExpressionsToExecute exprs ->
                 return
                   "MultipleExpressionsToExecute",
-                  [ "exprs", Dval.list VT.unknownTODO (List.map DString exprs) ]
+                  [ Dval.list VT.unknownTODO (List.map DString exprs) ]
 
               | NonIntReturned actuallyReturned ->
                 let! actuallyReturned = RT2DT.Dval.toDT actuallyReturned
-                return "NonIntReturned", [ "actuallyReturned", actuallyReturned ]
+                return "NonIntReturned", [ actuallyReturned ]
             }
 
           let typeName = RT.RuntimeError.name [ "Cli" ] "Error" 0
-          return Dval.enum typeName typeName (Some []) caseName []
+          return! Dval.enum typeName typeName (Some []) caseName fields
         }
 
 

--- a/backend/src/BuiltinDarkInternal/Libs/Canvases.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Canvases.fs
@@ -175,19 +175,19 @@ let fns : List<BuiltInFn> =
           uply {
             let! canvas = Canvas.loadAll canvasID
 
-            let types =
+            let! types =
               canvas.userTypes
               |> Map.values
               |> Seq.toList
-              |> List.map PT2DT.UserType.toDT
-              |> Dval.list VT.unknownTODO
+              |> Ply.List.mapSequentially PT2DT.UserType.toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
 
-            let fns =
+            let! fns =
               canvas.userFunctions
               |> Map.values
               |> Seq.toList
-              |> List.map PT2DT.UserFunction.toDT
-              |> Dval.list VT.unknownTODO
+              |> Ply.List.mapSequentially PT2DT.UserFunction.toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
 
             // let dbs =
             //   Map.values canvas.dbs
@@ -213,12 +213,12 @@ let fns : List<BuiltInFn> =
             //       |> Some)
             //   |> Dval.list VT.unknownTODO
 
-            return
+            return!
               Dval.record
                 (FQName.BuiltIn(typ "Program" 0))
                 (Some [])
                 [ "types", types; "fns", fns ]
-              |> Dval.resultOk VT.unknownTODO VT.string
+              |> Ply.map (Dval.resultOk VT.unknownTODO VT.string)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinDarkInternal/Libs/Secrets.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Secrets.fs
@@ -44,16 +44,17 @@ let fns : List<BuiltInFn> =
           uply {
             let! secrets = Secret.getCanvasSecrets canvasID
             let typeName = FQName.BuiltIn(typ "Secret" 0)
-            return
+
+            return!
               secrets
-              |> List.map (fun s ->
+              |> Ply.List.mapSequentially (fun s ->
                 Dval.record
                   typeName
                   (Some [])
                   [ "name", DString s.name
                     "value", DString s.value
                     "version", DInt s.version ])
-              |> Dval.list (ValueType.Known(KTCustomType(typeName, [])))
+              |> Ply.map (Dval.list (ValueType.Known(KTCustomType(typeName, []))))
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -264,7 +264,7 @@ let fns : List<BuiltInFn> =
                   match! Interpreter.applyFnVal state 0UL b [] args with
                   | DUnit -> return ()
                   | dv ->
-                    return
+                    return!
                       TypeChecker.raiseFnValResultNotExpectedType
                         SourceNone
                         dv
@@ -302,7 +302,7 @@ let fns : List<BuiltInFn> =
                 match! Interpreter.applyFnVal state 0UL b [] args with
                 | DBool v -> return v
                 | v ->
-                  return
+                  return!
                     TypeChecker.raiseFnValResultNotExpectedType SourceNone v TBool
               }
             let! result = Ply.Map.filterSequentially f o
@@ -357,7 +357,7 @@ let fns : List<BuiltInFn> =
                         []) -> return None
                 | v ->
                   let expectedType = TypeReference.option varB
-                  return
+                  return!
                     TypeChecker.raiseFnValResultNotExpectedType
                       SourceNone
                       v

--- a/backend/src/BuiltinExecution/Libs/HttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/HttpClient.fs
@@ -425,12 +425,12 @@ let fns (config : Configuration) : List<BuiltInFn> =
                 let typ =
                   FQName.BuiltIn(TypeName.builtIn [ "HttpClient" ] "Response" 0)
 
-                return
+                return!
                   [ ("statusCode", DInt(int64 response.statusCode))
                     ("headers", responseHeaders)
                     ("body", DBytes response.body) ]
                   |> Dval.record typ (Some [])
-                  |> resultOk
+                  |> Ply.map resultOk
 
               // TODO: include a DvalSource rather than SourceNone
               | Error(BadUrl details) -> return resultErrorStr $"Bad URL: {details}"

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -506,7 +506,7 @@ let parse
                 })
               |> Ply.List.flatten
 
-            return Dval.record typeName VT.typeArgsTODO' fields
+            return! Dval.record typeName VT.typeArgsTODO' fields
       }
 
 

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -466,7 +466,7 @@ let parse
                   convert typ pathSoFar j) // TODO revisit if we need to do anything with path
                 |> Ply.List.flatten
 
-              return Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+              return! Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
 
             | _ -> return Exception.raiseInternal "TODO" []
 

--- a/backend/src/BuiltinExecution/Libs/List.fs
+++ b/backend/src/BuiltinExecution/Libs/List.fs
@@ -398,7 +398,7 @@ let fns : List<BuiltInFn> =
               | DInt i when i = 1L || i = 0L || i = -1L -> return int i
               | DInt i -> return raise (Sort.InvalidSortComparatorInt i)
               | v ->
-                return TypeChecker.raiseFnValResultNotExpectedType SourceNone v TInt
+                return! TypeChecker.raiseFnValResultNotExpectedType SourceNone v TInt
             }
 
           uply {
@@ -461,7 +461,7 @@ let fns : List<BuiltInFn> =
                 match result with
                 | DBool b -> return b
                 | v ->
-                  return
+                  return!
                     TypeChecker.raiseFnValResultNotExpectedType SourceNone v TBool
               }
 
@@ -522,7 +522,7 @@ let fns : List<BuiltInFn> =
                         "None",
                         []) -> return None
                 | v ->
-                  return
+                  return!
                     TypeChecker.raiseFnValResultNotExpectedType
                       SourceNone
                       v

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -49,15 +49,14 @@ let fns : List<BuiltInFn> =
            |> Ply.List.mapSequentially (fun te ->
              let args = NEList.singleton (DChar te)
              Interpreter.applyFnVal state 0UL b [] args)
-           |> Ply.map (fun dvals ->
+           |> Ply.bind (fun dvals ->
              dvals
-             |> List.map (function
-               | DChar c -> c
+             |> Ply.List.mapSequentially (function
+               | DChar c -> Ply c
                | dv ->
                  TypeChecker.raiseFnValResultNotExpectedType SourceNone dv TChar)
-             |> String.concat ""
-             |> String.normalize
-             |> DString))
+             |> Ply.map (fun parts ->
+               parts |> String.concat "" |> String.normalize |> DString)))
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/src/BwdServer/Server.fs
+++ b/backend/src/BwdServer/Server.fs
@@ -323,13 +323,16 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
           // Do request
           use _ = Telemetry.child "executeHandler" []
 
-          let request = LibHttpMiddleware.Request.fromRequest url reqHeaders reqBody
+          let! request = LibHttpMiddleware.Request.fromRequest url reqHeaders reqBody
           let inputVars = routeVars |> Map |> Map.add "request" request
+
+          let! handler = PT2RT.Handler.toRT handler
+          let! canvas = Canvas.toProgram canvas
           let! (result, _) =
             CloudExe.executeHandler
               LibClientTypesToCloudTypes.Pusher.eventSerializer
-              (PT2RT.Handler.toRT handler)
-              (Canvas.toProgram canvas)
+              handler
+              canvas
               traceID
               inputVars
               (CloudExe.InitialExecution(desc, "request", request))

--- a/backend/src/LibCloud/PackageManager.fs
+++ b/backend/src/LibCloud/PackageManager.fs
@@ -187,28 +187,28 @@ let packageManager : RT.PackageManager =
       fun name ->
         uply {
           let! typ = name |> PT2RT.TypeName.Package.fromRT |> getType
-          return Option.map PT2RT.PackageType.toRT typ
+          return! Ply.Option.map PT2RT.PackageType.toRT typ
         }
 
     getFn =
       fun name ->
         uply {
           let! typ = name |> PT2RT.FnName.Package.fromRT |> getFn
-          return Option.map PT2RT.PackageFn.toRT typ
+          return! Ply.Option.map PT2RT.PackageFn.toRT typ
         }
 
     getFnByTLID =
       fun tlid ->
         uply {
           let! typ = tlid |> getFnByTLID
-          return Option.map PT2RT.PackageFn.toRT typ
+          return! Ply.Option.map PT2RT.PackageFn.toRT typ
         }
 
     getConstant =
       fun name ->
         uply {
           let! typ = name |> PT2RT.ConstantName.Package.fromRT |> getConstant
-          return Option.map PT2RT.PackageConstant.toRT typ
+          return! Ply.Option.map PT2RT.PackageConstant.toRT typ
         }
 
     init = uply { return () } }

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -597,7 +597,7 @@ let rec lambdaToSql
           | _ -> return error "Expected a List"
 
         | EEnum(_, typeName, caseName, []) ->
-          let dv =
+          let! dv =
             LibExecution.Dval.enum typeName typeName VT.typeArgsTODO' caseName []
           let typ = (TCustomType(Ok typeName, []))
           typecheck $"Enum '{dv}'" typ expectedType

--- a/backend/src/LibCloudExecution/CloudExecution.fs
+++ b/backend/src/LibCloudExecution/CloudExecution.fs
@@ -144,7 +144,7 @@ let executeHandler
       | RT.SourceNone -> Ply "No source"
       | RT.SourceID(tlid, id) -> sourceOf tlid id
 
-    let error (msg : string) : RT.Dval =
+    let error (msg : string) : Ply<RT.Dval> =
       let typeName =
         RT.FQName.Package
           { owner = "Darklang"
@@ -179,13 +179,13 @@ let executeHandler
           match! Exe.runtimeErrorToString state originalRTE with
           | Ok(RT.DString msg) ->
             let msg = $"Error: {msg}\n\nSource: {originalSource}"
-            return error msg
+            return! error msg
           | Ok result -> return result
           | Error(firstErrorSource, firstErrorRTE) ->
             let! firstErrorSource = sourceString firstErrorSource
             match! Exe.runtimeErrorToString state firstErrorRTE with
             | Ok(RT.DString msg) ->
-              return
+              return!
                 error (
                   $"An error occured trying to print a runtime error."
                   + $"\n\nThe formatting error occurred in {firstErrorSource}. The error was:\n{msg}"
@@ -194,7 +194,7 @@ let executeHandler
             | Ok result -> return result
             | Error(secondErrorSource, secondErrorRTE) ->
               let! secondErrorSource = sourceString secondErrorSource
-              return
+              return!
                 error (
                   $"Two errors occured trying to print a runtime error."
                   + $"\n\nThe 2nd formatting error occurred in {secondErrorSource}. The error was:\n{secondErrorRTE}"

--- a/backend/src/LibExecution/Dval.fs
+++ b/backend/src/LibExecution/Dval.fs
@@ -24,6 +24,11 @@
 ///   (Dval.enum, Dval.record, maybe others)
 module LibExecution.Dval
 
+open FSharp.Control.Tasks
+open System.Threading.Tasks
+
+open Prelude
+
 open LibExecution.RuntimeTypes
 module VT = ValueType
 
@@ -215,9 +220,13 @@ let dictFromMap (valueType : ValueType) (entries : Map<string, Dval>) : Dval =
 /// note: if provided, the typeArgs must match the # of typeArgs expected by the type
 let record
   (sourceTypeName : TypeName.TypeName)
-  (typeArgs : Option<List<ValueType>>)
+  (sourceTypeArgs : Option<List<ValueType>>)
+  // CLEANUP consider Ply<List<string * Dval>> for the sake of the consumers of this
+  // It would make for much cleaner code, but I'm not sure if it's more right or more
+  // wrong than the current set-up. Seems like it'd yield RTEs
+  // at a higher level of Dvals than the current setup.
   (fields : List<string * Dval>)
-  : Dval =
+  : Ply<Dval> =
   let resolvedTypeName = sourceTypeName // TODO: alias lookup
 
   let fields =
@@ -242,11 +251,11 @@ let record
   // - ensure fields match the expected shape (defined by type args and field defs)
   //   - this process should also effect the type args of the resultant Dval
   let typeArgs =
-    match typeArgs with
+    match sourceTypeArgs with
     | Some _typeArgs -> [] //typeArgs // VTTODO uncomment when Interpreter respects this
     | None -> VT.typeArgsTODO
 
-  DRecord(resolvedTypeName, sourceTypeName, typeArgs, fields)
+  DRecord(resolvedTypeName, sourceTypeName, typeArgs, fields) |> Ply
 
 
 

--- a/backend/src/LibExecution/Dval.fs
+++ b/backend/src/LibExecution/Dval.fs
@@ -266,7 +266,7 @@ let enum
   (typeArgs : Option<List<ValueType>>) // note: must match the count expected by the typeName
   (caseName : string)
   (fields : List<Dval>)
-  : Dval =
+  : Ply<Dval> =
   // TODO:
   // - pass in a (types: Types) arg
   // - use it to determine type args of resultant Dval
@@ -277,7 +277,7 @@ let enum
     | Some _typeArgs -> [] //typeArgs VTTODO uncomment when Interpreter respects this
     | None -> VT.typeArgsTODO
 
-  DEnum(resolvedTypeName, sourceTypeName, typeArgs, caseName, fields)
+  DEnum(resolvedTypeName, sourceTypeName, typeArgs, caseName, fields) |> Ply
 
 
 /// VTTODO

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -350,7 +350,7 @@ let parseJsonV0 (types : Types) (typ : TypeReference) (str : string) : Ply<Dval>
                 |> Ply.List.flatten
 
               // TYPESCLEANUP: I don't think the original is name right here?
-              return Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+              return! Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
           | _, _ ->
             return
               Exception.raiseInternal

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -45,9 +45,9 @@ module ExecutionError =
           "Error"
           0
 
-      let case (caseName : string) (fields : List<Dval>) : RuntimeError =
+      let case (caseName : string) (fields : List<Dval>) : Ply<RuntimeError> =
         Dval.enum typeName typeName (Some []) caseName fields
-        |> RuntimeError.executionError
+        |> Ply.map RuntimeError.executionError
 
       let! (caseName, fields) =
         uply {
@@ -70,7 +70,7 @@ module ExecutionError =
             return "ConstDoesntExist", [ name ]
         }
 
-      return case caseName fields
+      return! case caseName fields
     }
 
   let raise (source : DvalSource) (e : Error) : Ply<'a> =
@@ -715,7 +715,7 @@ let rec eval
               []
               (List.zip case.fields fields)
 
-          return
+          return!
             Dval.enum
               resolvedTypeName
               sourceTypeName

--- a/backend/src/LibExecution/NameResolutionError.fs
+++ b/backend/src/LibExecution/NameResolutionError.fs
@@ -70,7 +70,7 @@ module RTE =
       | _ -> Exception.raiseInternal "Invalid NameType" []
 
   module Error =
-    let toDT (e : Error) : RT.Dval =
+    let toDT (e : Error) : Ply<RT.Dval> =
       let errorTypeName = RT.RuntimeError.name [ "NameResolution" ] "Error" 0
       let fields =
         [ "errorType", ErrorType.toDT e.errorType
@@ -93,8 +93,8 @@ module RTE =
 
       | _ -> Exception.raiseInternal "Expected DRecord" []
 
-  let toRuntimeError (e : Error) : RT.RuntimeError =
-    Error.toDT e |> RT.RuntimeError.nameResolutionError
+  let toRuntimeError (e : Error) : Ply<RT.RuntimeError> =
+    Error.toDT e |> Ply.map RT.RuntimeError.nameResolutionError
 
   let fromRuntimeError (re : RT.RuntimeError) : Error =
     // TODO: this probably doesn't unwrap the type

--- a/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
@@ -65,7 +65,7 @@ module FQName =
       (nameValueType : ValueType)
       (nameMapper : 'name -> Dval)
       (u : PT.FQName.BuiltIn<'name>)
-      : Dval =
+      : Ply<Dval> =
       Dval.record
         (ptTyp [ "FQName" ] "BuiltIn" 0)
         (Some [ nameValueType ])
@@ -89,7 +89,7 @@ module FQName =
       (nameValueType : ValueType)
       (nameMapper : 'name -> Dval)
       (u : PT.FQName.UserProgram<'name>)
-      : Dval =
+      : Ply<Dval> =
       Dval.record
         (ptTyp [ "FQName" ] "UserProgram" 0)
         (Some [ nameValueType ])
@@ -118,7 +118,7 @@ module FQName =
       (nameValueType : ValueType)
       (nameMapper : 'name -> Dval)
       (u : PT.FQName.Package<'name>)
-      : Dval =
+      : Ply<Dval> =
       Dval.record
         (ptTyp [ "FQName" ] "Package" 0)
         (Some [ nameValueType ])
@@ -145,16 +145,25 @@ module FQName =
     (nameValueType : ValueType)
     (nameMapper : 'name -> Dval)
     (u : PT.FQName.FQName<'name>)
-    : Dval =
-    let caseName, fields =
-      match u with
-      | PT.FQName.UserProgram u ->
-        "UserProgram", [ UserProgram.toDT nameValueType nameMapper u ]
-      | PT.FQName.Package u -> "Package", [ Package.toDT nameValueType nameMapper u ]
-      | PT.FQName.BuiltIn u -> "BuiltIn", [ BuiltIn.toDT nameValueType nameMapper u ]
+    : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match u with
+          | PT.FQName.UserProgram u ->
+            let! name = UserProgram.toDT nameValueType nameMapper u
+            return "UserProgram", [ name ]
+          | PT.FQName.Package u ->
+            let! name = Package.toDT nameValueType nameMapper u
+            return "Package", [ name ]
+          | PT.FQName.BuiltIn u ->
+            let! name = BuiltIn.toDT nameValueType nameMapper u
+            return "BuiltIn", [ name ]
+        }
 
-    let typeName = ptTyp [ "FQName" ] "FQName" 0
-    Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+      let typeName = ptTyp [ "FQName" ] "FQName" 0
+      return Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+    }
 
   let fromDT (nameMapper : Dval -> 'name) (d : Dval) : PT.FQName.FQName<'name> =
     match d with
@@ -185,25 +194,26 @@ module TypeName =
       | _ -> Exception.raiseInternal "Invalid TypeName" []
 
   module BuiltIn =
-    let toDT (u : PT.TypeName.BuiltIn) : Dval =
+    let toDT (u : PT.TypeName.BuiltIn) : Ply<Dval> =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : PT.TypeName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : PT.TypeName.UserProgram) : Dval =
+    let toDT (u : PT.TypeName.UserProgram) : Ply<Dval> =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : PT.TypeName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : PT.TypeName.Package) : Dval =
+    let toDT (u : PT.TypeName.Package) : Ply<Dval> =
       FQName.Package.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : PT.TypeName.Package = FQName.Package.fromDT Name.fromDT d
 
 
-  let toDT (u : PT.TypeName.TypeName) : Dval = FQName.toDT Name.valueType Name.toDT u
+  let toDT (u : PT.TypeName.TypeName) : Ply<Dval> =
+    FQName.toDT Name.valueType Name.toDT u
 
   let fromDT (d : Dval) : PT.TypeName.TypeName = FQName.fromDT Name.fromDT d
 
@@ -226,23 +236,24 @@ module FnName =
       | _ -> Exception.raiseInternal "Invalid FnName" []
 
   module BuiltIn =
-    let toDT (u : PT.FnName.BuiltIn) : Dval =
+    let toDT (u : PT.FnName.BuiltIn) : Ply<Dval> =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : PT.FnName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : PT.FnName.UserProgram) : Dval =
+    let toDT (u : PT.FnName.UserProgram) : Ply<Dval> =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : PT.FnName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : PT.FnName.Package) : Dval =
+    let toDT (u : PT.FnName.Package) : Ply<Dval> =
       FQName.Package.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : PT.FnName.Package = FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : PT.FnName.FnName) : Dval = FQName.toDT Name.valueType Name.toDT u
+  let toDT (u : PT.FnName.FnName) : Ply<Dval> =
+    FQName.toDT Name.valueType Name.toDT u
   let fromDT (d : Dval) : PT.FnName.FnName = FQName.fromDT Name.fromDT d
 
 module ConstantName =
@@ -264,27 +275,27 @@ module ConstantName =
       | _ -> Exception.raiseInternal "Invalid ConstantName" []
 
   module BuiltIn =
-    let toDT (u : PT.ConstantName.BuiltIn) : Dval =
+    let toDT (u : PT.ConstantName.BuiltIn) : Ply<Dval> =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : PT.ConstantName.BuiltIn =
       FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : PT.ConstantName.UserProgram) : Dval =
+    let toDT (u : PT.ConstantName.UserProgram) : Ply<Dval> =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : PT.ConstantName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : PT.ConstantName.Package) : Dval =
+    let toDT (u : PT.ConstantName.Package) : Ply<Dval> =
       FQName.Package.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : PT.ConstantName.Package =
       FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : PT.ConstantName.ConstantName) : Dval =
+  let toDT (u : PT.ConstantName.ConstantName) : Ply<Dval> =
     FQName.toDT Name.valueType Name.toDT u
 
   let fromDT (d : Dval) : PT.ConstantName.ConstantName = FQName.fromDT Name.fromDT d
@@ -292,14 +303,22 @@ module ConstantName =
 module NameResolution =
   let toDT
     (nameValueType : ValueType)
-    (f : 'p -> Dval)
+    (f : 'p -> Ply<Dval>)
     (result : PT.NameResolution<'p>)
-    : Dval =
-    let errType = VT.unknownTODO // NameResolutionError
+    : Ply<Dval> =
+    uply {
+      let errType = VT.unknownTODO // NameResolutionError
 
-    match result with
-    | Ok name -> Dval.resultOk nameValueType errType (f name)
-    | Error err -> Dval.resultError nameValueType errType (err |> NRE.RTE.Error.toDT)
+      match result with
+      | Ok name ->
+        let! name = f name
+        return Dval.resultOk nameValueType errType name
+      | Error err ->
+        return!
+          err
+          |> NRE.RTE.Error.toDT
+          |> Ply.map (Dval.resultError nameValueType errType)
+    }
 
   let fromDT (f : Dval -> 'a) (d : Dval) : PT.NameResolution<'a> =
     match d with
@@ -312,42 +331,65 @@ module NameResolution =
     | _ -> Exception.raiseInternal "Invalid NameResolution" []
 
 module TypeReference =
-  let rec toDT (t : PT.TypeReference) : Dval =
-    let caseName, fields =
-      match t with
-      | PT.TVariable name -> "TVariable", [ DString name ]
+  let rec toDT (t : PT.TypeReference) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match t with
+          | PT.TVariable name -> return "TVariable", [ DString name ]
 
-      | PT.TUnit -> "TUnit", []
-      | PT.TBool -> "TBool", []
-      | PT.TInt -> "TInt", []
-      | PT.TFloat -> "TFloat", []
-      | PT.TChar -> "TChar", []
-      | PT.TString -> "TString", []
-      | PT.TDateTime -> "TDateTime", []
-      | PT.TUuid -> "TUuid", []
-      | PT.TBytes -> "TBytes", []
+          | PT.TUnit -> return "TUnit", []
+          | PT.TBool -> return "TBool", []
+          | PT.TInt -> return "TInt", []
+          | PT.TFloat -> return "TFloat", []
+          | PT.TChar -> return "TChar", []
+          | PT.TString -> return "TString", []
+          | PT.TDateTime -> return "TDateTime", []
+          | PT.TUuid -> return "TUuid", []
+          | PT.TBytes -> return "TBytes", []
 
-      | PT.TList inner -> "TList", [ toDT inner ]
+          | PT.TList inner ->
+            let! inner = toDT inner
+            return "TList", [ inner ]
 
-      | PT.TTuple(first, second, theRest) ->
-        "TTuple",
-        [ toDT first; toDT second; Dval.list VT.unknownTODO (List.map toDT theRest) ]
+          | PT.TTuple(first, second, theRest) ->
+            let! first = toDT first
+            let! second = toDT second
+            let! theRest =
+              theRest
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "TTuple", [ first; second; theRest ]
 
-      | PT.TDict inner -> "TDict", [ toDT inner ]
+          | PT.TDict inner ->
+            let! inner = toDT inner
+            return "TDict", [ inner ]
 
-      | PT.TCustomType(typeName, typeArgs) ->
-        "TCustomType",
-        [ NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
-          Dval.list VT.unknownTODO (List.map toDT typeArgs) ]
+          | PT.TCustomType(typeName, typeArgs) ->
+            let! typeName = NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "TCustomType", [ typeName; typeArgs ]
 
-      | PT.TDB inner -> "TDB", [ toDT inner ]
-      | PT.TFn(args, ret) ->
-        "TFn",
-        [ Dval.list VT.unknownTODO (args |> NEList.toList |> List.map toDT)
-          toDT ret ]
+          | PT.TDB inner ->
+            let! inner = toDT inner
+            return "TDB", [ inner ]
 
-    let typeName = ptTyp [] "TypeReference" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+          | PT.TFn(args, ret) ->
+            let! args =
+              args
+              |> NEList.toList
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            let! ret = toDT ret
+            return "TFn", [ args; ret ]
+        }
+
+      let typeName = ptTyp [] "TypeReference" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let rec fromDT (d : Dval) : PT.TypeReference =
     match d with
@@ -550,14 +592,20 @@ module Infix =
 
 
 module StringSegment =
-  let toDT (exprToDT : PT.Expr -> Dval) (s : PT.StringSegment) : Dval =
-    let caseName, fields =
-      match s with
-      | PT.StringText text -> "StringText", [ DString text ]
-      | PT.StringInterpolation expr -> "StringInterpolation", [ exprToDT expr ]
+  let toDT (exprToDT : PT.Expr -> Ply<Dval>) (s : PT.StringSegment) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match s with
+          | PT.StringText text -> return "StringText", [ DString text ]
+          | PT.StringInterpolation expr ->
+            let! expr = exprToDT expr
+            return "StringInterpolation", [ expr ]
+        }
 
-    let typeName = ptTyp [] "StringSegment" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+      let typeName = ptTyp [] "StringSegment" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let fromDT (exprFromDT : Dval -> PT.Expr) (d : Dval) : PT.StringSegment =
     match d with
@@ -568,44 +616,61 @@ module StringSegment =
 
 
 module PipeExpr =
-  let toDT (exprToDT : PT.Expr -> Dval) (s : PT.PipeExpr) : Dval =
-    let caseName, fields =
-      match s with
-      | PT.EPipeVariable(id, varName, exprs) ->
-        "EPipeVariable",
-        [ DInt(int64 id)
-          DString varName
-          Dval.list VT.unknownTODO (List.map exprToDT exprs) ]
-      | PT.EPipeLambda(id, args, body) ->
-        let variables =
-          args
-          |> NEList.toList
-          |> List.map (fun (id, varName) ->
-            DTuple(DInt(int64 id), DString varName, []))
-          |> Dval.list VT.unknownTODO
+  let toDT (exprToDT : PT.Expr -> Ply<Dval>) (s : PT.PipeExpr) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match s with
+          | PT.EPipeVariable(id, varName, exprs) ->
+            let! exprs =
+              exprs
+              |> Ply.List.mapSequentially exprToDT
+              |> Ply.map (Dval.list VT.unknownTODO)
 
-        "EPipeLambda", [ DInt(int64 id); variables; exprToDT body ]
+            return "EPipeVariable", [ DInt(int64 id); DString varName; exprs ]
+
+          | PT.EPipeLambda(id, args, body) ->
+            let variables =
+              args
+              |> NEList.toList
+              |> List.map (fun (id, varName) ->
+                DTuple(DInt(int64 id), DString varName, []))
+              |> Dval.list VT.unknownTODO
+
+            let! body = exprToDT body
+
+            return "EPipeLambda", [ DInt(int64 id); variables; body ]
 
 
-      | PT.EPipeInfix(id, infix, expr) ->
-        "EPipeInfix", [ DInt(int64 id); Infix.toDT infix; exprToDT expr ]
+          | PT.EPipeInfix(id, infix, expr) ->
+            let! expr = exprToDT expr
+            return "EPipeInfix", [ DInt(int64 id); Infix.toDT infix; expr ]
 
-      | PT.EPipeFnCall(id, fnName, typeArgs, args) ->
-        "EPipeFnCall",
-        [ DInt(int64 id)
-          NameResolution.toDT VT.unknownTODO FnName.toDT fnName
-          Dval.list VT.unknownTODO (List.map TypeReference.toDT typeArgs)
-          Dval.list VT.unknownTODO (List.map exprToDT args) ]
+          | PT.EPipeFnCall(id, fnName, typeArgs, args) ->
+            let! name = NameResolution.toDT VT.unknownTODO FnName.toDT fnName
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially TypeReference.toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            let! args =
+              args
+              |> Ply.List.mapSequentially exprToDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EPipeFnCall", [ DInt(int64 id); name; typeArgs; args ]
 
-      | PT.EPipeEnum(id, typeName, caseName, fields) ->
-        "EPipeEnum",
-        [ DInt(int64 id)
-          NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
-          DString caseName
-          Dval.list VT.unknownTODO (List.map exprToDT fields) ]
+          | PT.EPipeEnum(id, typeName, caseName, fields) ->
+            let! typeName = NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
+            let! fields =
+              fields
+              |> Ply.List.mapSequentially exprToDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return
+              "EPipeEnum", [ DInt(int64 id); typeName; DString caseName; fields ]
+        }
 
-    let typeName = ptTyp [] "PipeExpr" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+      let typeName = ptTyp [] "PipeExpr" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let fromDT (exprFromDT : Dval -> PT.Expr) (d : Dval) : PT.PipeExpr =
     match d with
@@ -659,128 +724,185 @@ module PipeExpr =
 
 
 module Expr =
-  let rec toDT (e : PT.Expr) : Dval =
-    let caseName, fields =
-      match e with
-      | PT.EUnit id -> "EUnit", [ DInt(int64 id) ]
+  let rec toDT (e : PT.Expr) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match e with
+          | PT.EUnit id -> return "EUnit", [ DInt(int64 id) ]
 
-      // simple data
-      | PT.EBool(id, b) -> "EBool", [ DInt(int64 id); DBool b ]
-      | PT.EInt(id, i) -> "EInt", [ DInt(int64 id); DInt i ]
-      | PT.EFloat(id, sign, whole, remainder) ->
-        "EFloat",
-        [ DInt(int64 id); Sign.toDT sign; DString whole; DString remainder ]
-      | PT.EChar(id, c) -> "EChar", [ DInt(int64 id); DString c ]
-      | PT.EString(id, segments) ->
-        "EString",
-        [ DInt(int64 id)
-          Dval.list VT.unknownTODO (List.map (StringSegment.toDT toDT) segments) ]
+          // simple data
+          | PT.EBool(id, b) -> return "EBool", [ DInt(int64 id); DBool b ]
+          | PT.EInt(id, i) -> return "EInt", [ DInt(int64 id); DInt i ]
+          | PT.EFloat(id, sign, whole, remainder) ->
+            return
+              "EFloat",
+              [ DInt(int64 id); Sign.toDT sign; DString whole; DString remainder ]
 
-      // structures of data
-      | PT.EList(id, inner) ->
-        "EList", [ DInt(int64 id); Dval.list VT.unknownTODO (List.map toDT inner) ]
+          | PT.EChar(id, c) -> return "EChar", [ DInt(int64 id); DString c ]
+          | PT.EString(id, segments) ->
+            let! segments =
+              segments
+              |> Ply.List.mapSequentially (StringSegment.toDT toDT)
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EString", [ DInt(int64 id); segments ]
 
-      | PT.EDict(id, pairs) ->
-        "EDict",
-        [ DInt(int64 id)
-          Dval.list
-            VT.unknownTODO
-            (List.map (fun (k, v) -> DTuple(DString k, toDT v, [])) pairs) ]
+          // structures of data
+          | PT.EList(id, items) ->
+            let! items =
+              items
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EList", [ DInt(int64 id); items ]
 
-      | PT.ETuple(id, first, second, theRest) ->
-        "ETuple",
-        [ DInt(int64 id)
-          toDT first
-          toDT second
-          Dval.list VT.unknownTODO (List.map toDT theRest) ]
+          | PT.EDict(id, pairs) ->
+            let! pairs =
+              pairs
+              |> Ply.List.mapSequentially (fun (k, v) ->
+                uply {
+                  let! v = toDT v
+                  return DTuple(DString k, v, [])
+                })
+              |> Ply.map (Dval.list VT.unknownTODO)
 
-      | PT.ERecord(id, name, fields) ->
-        let fields =
-          fields
-          |> List.map (fun (name, expr) -> DTuple(DString name, toDT expr, []))
+            return "EDict", [ DInt(int64 id); pairs ]
 
-        "ERecord",
-        [ DInt(int64 id)
-          NameResolution.toDT VT.unknownTODO TypeName.toDT name
-          Dval.list VT.unknownTODO (fields) ]
+          | PT.ETuple(id, first, second, theRest) ->
+            let! first = toDT first
+            let! second = toDT second
+            let! theRest =
+              theRest
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "ETuple", [ DInt(int64 id); first; second; theRest ]
 
-      | PT.EEnum(id, typeName, caseName, fields) ->
-        "EEnum",
-        [ DInt(int64 id)
-          NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
-          DString caseName
-          Dval.list VT.unknownTODO (List.map toDT fields) ]
+          | PT.ERecord(id, typeName, fields) ->
+            let! typeName = NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
 
-      // declaring and accessing variables
-      | PT.ELet(id, lp, expr, body) ->
-        "ELet", [ DInt(int64 id); LetPattern.toDT lp; toDT expr; toDT body ]
+            let! fields =
+              fields
+              |> Ply.List.mapSequentially (fun (name, expr) ->
+                uply {
+                  let! expr = toDT expr
+                  return DTuple(DString name, expr, [])
+                })
+              |> Ply.map (Dval.list VT.unknownTODO)
 
-      | PT.EFieldAccess(id, expr, fieldName) ->
-        "EFieldAccess", [ DInt(int64 id); toDT expr; DString fieldName ]
+            return "ERecord", [ DInt(int64 id); typeName; fields ]
 
-      | PT.EVariable(id, varName) -> "EVariable", [ DInt(int64 id); DString varName ]
+          | PT.EEnum(id, typeName, caseName, fields) ->
+            let! typeName = NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
+            let! fields =
+              fields
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EEnum", [ DInt(int64 id); typeName; DString caseName; fields ]
 
+          // declaring and accessing variables
+          | PT.ELet(id, lp, expr, body) ->
+            let! expr = toDT expr
+            let! body = toDT body
+            return "ELet", [ DInt(int64 id); LetPattern.toDT lp; expr; body ]
 
-      // control flow
-      | PT.EIf(id, cond, thenExpr, elseExpr) ->
-        let elseExpr = elseExpr |> Option.map toDT |> Dval.option VT.unknownTODO
-        "EIf", [ DInt(int64 id); toDT cond; toDT thenExpr; elseExpr ]
+          | PT.EFieldAccess(id, expr, fieldName) ->
+            let! expr = toDT expr
+            return "EFieldAccess", [ DInt(int64 id); expr; DString fieldName ]
 
-      | PT.EMatch(id, arg, cases) ->
-        let cases =
-          cases
-          |> List.map (fun (pattern, expr) ->
-            DTuple(MatchPattern.toDT pattern, toDT expr, []))
-
-        "EMatch", [ DInt(int64 id); toDT arg; Dval.list VT.unknownTODO (cases) ]
-
-      | PT.EPipe(id, expr, pipeExprs) ->
-        "EPipe",
-        [ DInt(int64 id)
-          toDT expr
-          Dval.list VT.unknownTODO (List.map (PipeExpr.toDT toDT) pipeExprs) ]
+          | PT.EVariable(id, varName) ->
+            return "EVariable", [ DInt(int64 id); DString varName ]
 
 
-      // function calls
-      | PT.EInfix(id, infix, lhs, rhs) ->
-        "EInfix", [ DInt(int64 id); Infix.toDT infix; toDT lhs; toDT rhs ]
+          // control flow
+          | PT.EIf(id, cond, thenExpr, elseExpr) ->
+            let! cond = toDT cond
+            let! thenExpr = toDT thenExpr
+            let! elseExpr =
+              elseExpr |> Ply.Option.map toDT |> Ply.map (Dval.option VT.unknownTODO)
+            return "EIf", [ DInt(int64 id); cond; thenExpr; elseExpr ]
 
-      | PT.ELambda(id, args, body) ->
-        let variables =
-          args
-          |> NEList.toList
-          |> List.map (fun (id, varName) ->
-            DTuple(DInt(int64 id), DString varName, []))
-          |> Dval.list VT.unknownTODO
+          | PT.EMatch(id, arg, cases) ->
+            let! arg = toDT arg
 
-        "ELambda", [ DInt(int64 id); variables; toDT body ]
+            let! cases =
+              cases
+              |> Ply.List.mapSequentially (fun (pattern, expr) ->
+                uply {
+                  let! expr = toDT expr
+                  return DTuple(MatchPattern.toDT pattern, expr, [])
+                })
+              |> Ply.map (Dval.list VT.unknownTODO)
 
-      | PT.EConstant(id, name) ->
-        "EConstant",
-        [ DInt(int64 id); NameResolution.toDT VT.unknownTODO ConstantName.toDT name ]
+            return "EMatch", [ DInt(int64 id); arg; cases ]
 
-      | PT.EApply(id, name, typeArgs, args) ->
-        "EApply",
-        [ DInt(int64 id)
-          toDT name
-          Dval.list VT.unknownTODO (List.map TypeReference.toDT typeArgs)
-          Dval.list VT.unknownTODO (args |> NEList.toList |> List.map toDT) ]
+          | PT.EPipe(id, expr, pipeExprs) ->
+            let! expr = toDT expr
+            let! pipeExprs =
+              pipeExprs
+              |> Ply.List.mapSequentially (PipeExpr.toDT toDT)
+              |> Ply.map (Dval.list VT.unknownTODO)
 
-      | PT.EFnName(id, name) ->
-        "EFnName",
-        [ DInt(int64 id); NameResolution.toDT VT.unknownTODO FnName.toDT name ]
+            return "EPipe", [ DInt(int64 id); expr; pipeExprs ]
 
-      | PT.ERecordUpdate(id, record, updates) ->
-        let updates =
-          updates
-          |> NEList.toList
-          |> List.map (fun (name, expr) -> DTuple(DString name, toDT expr, []))
 
-        "ERecordUpdate",
-        [ DInt(int64 id); toDT record; Dval.list VT.unknownTODO (updates) ]
+          // function calls
+          | PT.EInfix(id, infix, lhs, rhs) ->
+            let! lhs = toDT lhs
+            let! rhs = toDT rhs
+            return "EInfix", [ DInt(int64 id); Infix.toDT infix; lhs; rhs ]
 
-    let typeName = ptTyp [] "Expr" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+          | PT.ELambda(id, args, body) ->
+            let variables =
+              args
+              |> NEList.toList
+              |> List.map (fun (id, varName) ->
+                DTuple(DInt(int64 id), DString varName, []))
+              |> Dval.list VT.unknownTODO
+
+            let! body = toDT body
+
+            return "ELambda", [ DInt(int64 id); variables; body ]
+
+          | PT.EConstant(id, name) ->
+            let! name = NameResolution.toDT VT.unknownTODO ConstantName.toDT name
+            return "EConstant", [ DInt(int64 id); name ]
+
+          | PT.EApply(id, name, typeArgs, args) ->
+            let! name = toDT name
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially TypeReference.toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            let! args =
+              args
+              |> NEList.toList
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EApply", [ DInt(int64 id); name; typeArgs; args ]
+
+          | PT.EFnName(id, name) ->
+            let! name = NameResolution.toDT VT.unknownTODO FnName.toDT name
+            return "EFnName", [ DInt(int64 id); name ]
+
+          | PT.ERecordUpdate(id, record, updates) ->
+            let! record = toDT record
+
+            let! updates =
+              updates
+              |> NEList.toList
+              |> Ply.List.mapSequentially (fun (name, expr) ->
+                uply {
+                  let! expr = toDT expr
+                  return DTuple(DString name, expr, [])
+                })
+
+            return
+              "ERecordUpdate",
+              [ DInt(int64 id); record; Dval.list VT.unknownTODO (updates) ]
+        }
+
+      let typeName = ptTyp [] "Expr" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let rec fromDT (d : Dval) : PT.Expr =
     match d with
@@ -914,34 +1036,58 @@ module Expr =
 
 
 module Const =
-  let rec toDT (c : PT.Const) : Dval =
-    let caseName, fields =
-      match c with
-      | PT.Const.CInt i -> "CInt", [ DInt i ]
-      | PT.Const.CBool b -> "CBool", [ DBool b ]
-      | PT.Const.CString s -> "CString", [ DString s ]
-      | PT.Const.CChar c -> "CChar", [ DChar c ]
-      | PT.Const.CFloat(sign, w, f) ->
-        "CFloat", [ Sign.toDT sign; DString w; DString f ]
-      | PT.Const.CUnit -> "CUnit", []
-      | PT.Const.CTuple(first, second, rest) ->
-        "CTuple",
-        [ toDT first; toDT second; Dval.list VT.unknownTODO (List.map toDT rest) ]
-      | PT.Const.CEnum(typeName, caseName, fields) ->
-        "CEnum",
-        [ NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
-          DString caseName
-          Dval.list VT.unknownTODO (List.map toDT fields) ]
-      | PT.Const.CList(inner) ->
-        "CList", [ Dval.list VT.unknownTODO (List.map toDT inner) ]
-      | PT.Const.CDict(pairs) ->
-        "CDict",
-        [ Dval.list
-            VT.unknownTODO
-            (pairs |> List.map (fun (k, v) -> DTuple(DString k, toDT v, []))) ]
+  let rec toDT (c : PT.Const) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match c with
+          | PT.Const.CUnit -> return "CUnit", []
+          | PT.Const.CBool b -> return "CBool", [ DBool b ]
+          | PT.Const.CInt i -> return "CInt", [ DInt i ]
+          | PT.Const.CFloat(sign, w, f) ->
+            return "CFloat", [ Sign.toDT sign; DString w; DString f ]
+          | PT.Const.CChar c -> return "CChar", [ DChar c ]
+          | PT.Const.CString s -> return "CString", [ DString s ]
 
-    let typeName = ptTyp [] "Const" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+          | PT.Const.CTuple(first, second, theRest) ->
+            let! first = toDT first
+            let! second = toDT second
+            let! theRest =
+              theRest
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "CTuple", [ first; second; theRest ]
+
+          | PT.Const.CEnum(typeName, caseName, fields) ->
+            let! typeName = NameResolution.toDT VT.unknownTODO TypeName.toDT typeName
+            let! fields =
+              fields
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return ("CEnum", [ typeName; DString caseName; fields ])
+
+          | PT.Const.CList inner ->
+            let! items =
+              inner
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "CList", [ items ]
+
+          | PT.Const.CDict pairs ->
+            let! pairs =
+              pairs
+              |> Ply.List.mapSequentially (fun (k, v) ->
+                uply {
+                  let! v = toDT v
+                  return DTuple(DString k, v, [])
+                })
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "CDict", [ pairs ]
+        }
+
+      let typeName = ptTyp [] "Const" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let rec fromDT (d : Dval) : PT.Const =
     match d with
@@ -983,17 +1129,28 @@ module Const =
     | _ -> Exception.raiseInternal "Invalid Const" []
 
 module Deprecation =
-  let toDT (inner : 'a -> Dval) (d : PT.Deprecation<'a>) : Dval =
-    let (caseName, fields) =
-      match d with
-      | PT.Deprecation.NotDeprecated -> "NotDeprecated", []
-      | PT.Deprecation.RenamedTo replacement -> "RenamedTo", [ inner replacement ]
-      | PT.Deprecation.ReplacedBy replacement -> "ReplacedBy", [ inner replacement ]
-      | PT.Deprecation.DeprecatedBecause reason ->
-        "DeprecatedBecause", [ DString reason ]
+  let toDT (inner : 'a -> Ply<Dval>) (d : PT.Deprecation<'a>) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match d with
+          | PT.Deprecation.NotDeprecated -> return "NotDeprecated", []
 
-    let typeName = ptTyp [] "Deprecation" 0
-    Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+          | PT.Deprecation.RenamedTo replacement ->
+            let! replacement = inner replacement
+            return "RenamedTo", [ replacement ]
+
+          | PT.Deprecation.ReplacedBy replacement ->
+            let! replacement = inner replacement
+            return "ReplacedBy", [ replacement ]
+
+          | PT.Deprecation.DeprecatedBecause reason ->
+            return "DeprecatedBecause", [ DString reason ]
+        }
+
+      let typeName = ptTyp [] "Deprecation" 0
+      return Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+    }
 
   let fromDT (inner : Dval -> 'a) (d : Dval) : PT.Deprecation<'a> =
     match d with
@@ -1010,13 +1167,17 @@ module Deprecation =
 
 module TypeDeclaration =
   module RecordField =
-    let toDT (rf : PT.TypeDeclaration.RecordField) : Dval =
-      Dval.record
-        (ptTyp [ "TypeDeclaration" ] "RecordField" 0)
-        (Some [])
-        [ "name", DString rf.name
-          "typ", TypeReference.toDT rf.typ
-          "description", DString rf.description ]
+    let toDT (rf : PT.TypeDeclaration.RecordField) : Ply<Dval> =
+      uply {
+        let! typ = TypeReference.toDT rf.typ
+        return!
+          Dval.record
+            (ptTyp [ "TypeDeclaration" ] "RecordField" 0)
+            (Some [])
+            [ "name", DString rf.name
+              "typ", typ
+              "description", DString rf.description ]
+      }
 
     let fromDT (d : Dval) : PT.TypeDeclaration.RecordField =
       match d with
@@ -1030,13 +1191,17 @@ module TypeDeclaration =
       | _ -> Exception.raiseInternal "Invalid RecordField" []
 
   module EnumField =
-    let toDT (ef : PT.TypeDeclaration.EnumField) : Dval =
-      Dval.record
-        (ptTyp [ "TypeDeclaration" ] "EnumField" 0)
-        (Some [])
-        [ "typ", TypeReference.toDT ef.typ
-          "label", ef.label |> Option.map DString |> Dval.option VT.string
-          "description", DString ef.description ]
+    let toDT (ef : PT.TypeDeclaration.EnumField) : Ply<Dval> =
+      uply {
+        let! typ = TypeReference.toDT ef.typ
+        return!
+          Dval.record
+            (ptTyp [ "TypeDeclaration" ] "EnumField" 0)
+            (Some [])
+            [ "typ", typ
+              "label", ef.label |> Option.map DString |> Dval.option VT.string
+              "description", DString ef.description ]
+      }
 
     let fromDT (d : Dval) : PT.TypeDeclaration.EnumField =
       match d with
@@ -1059,13 +1224,21 @@ module TypeDeclaration =
 
 
   module EnumCase =
-    let toDT (ec : PT.TypeDeclaration.EnumCase) : Dval =
-      Dval.record
-        (ptTyp [ "TypeDeclaration" ] "EnumCase" 0)
-        (Some [])
-        [ "name", DString ec.name
-          "fields", Dval.list VT.unknownTODO (List.map EnumField.toDT ec.fields)
-          "description", DString ec.description ]
+    let toDT (ec : PT.TypeDeclaration.EnumCase) : Ply<Dval> =
+      uply {
+        let! fields =
+          ec.fields
+          |> Ply.List.mapSequentially EnumField.toDT
+          |> Ply.map (Dval.list VT.unknownTODO)
+
+        return!
+          Dval.record
+            (ptTyp [ "TypeDeclaration" ] "EnumCase" 0)
+            (Some [])
+            [ "name", DString ec.name
+              "fields", fields
+              "description", DString ec.description ]
+      }
 
     let fromDT (d : Dval) : PT.TypeDeclaration.EnumCase =
       match d with
@@ -1080,27 +1253,35 @@ module TypeDeclaration =
 
 
   module Definition =
-    let toDT (d : PT.TypeDeclaration.Definition) : Dval =
-      let caseName, fields =
-        match d with
-        | PT.TypeDeclaration.Alias typeRef -> "Alias", [ TypeReference.toDT typeRef ]
+    let toDT (d : PT.TypeDeclaration.Definition) : Ply<Dval> =
+      uply {
+        let! (caseName, fields) =
+          uply {
+            match d with
+            | PT.TypeDeclaration.Alias typeRef ->
+              let! typeRef = TypeReference.toDT typeRef
+              return "Alias", [ typeRef ]
 
-        | PT.TypeDeclaration.Record fields ->
-          "Record",
-          [ fields
-            |> NEList.toList
-            |> List.map RecordField.toDT
-            |> Dval.list VT.unknownTODO ]
+            | PT.TypeDeclaration.Record fields ->
+              let! fields =
+                fields
+                |> NEList.toList
+                |> Ply.List.mapSequentially RecordField.toDT
+                |> Ply.map (Dval.list VT.unknownTODO)
+              return "Record", [ fields ]
 
-        | PT.TypeDeclaration.Enum cases ->
-          "Enum",
-          [ cases
-            |> NEList.toList
-            |> List.map EnumCase.toDT
-            |> Dval.list VT.unknownTODO ]
+            | PT.TypeDeclaration.Enum cases ->
+              let! cases =
+                cases
+                |> NEList.toList
+                |> Ply.List.mapSequentially EnumCase.toDT
+                |> Ply.map (Dval.list VT.unknownTODO)
+              return "Enum", [ cases ]
+          }
 
-      let typeName = ptTyp [ "TypeDeclaration" ] "Definition" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+        let typeName = ptTyp [ "TypeDeclaration" ] "Definition" 0
+        return Dval.enum typeName typeName (Some []) caseName fields
+      }
 
     let fromDT (d : Dval) : PT.TypeDeclaration.Definition =
       match d with
@@ -1118,12 +1299,17 @@ module TypeDeclaration =
       | _ -> Exception.raiseInternal "Invalid TypeDeclaration.Definition" []
 
 
-  let toDT (td : PT.TypeDeclaration.T) : Dval =
-    Dval.record
-      (ptTyp [ "TypeDeclaration" ] "TypeDeclaration" 0)
-      (Some [])
-      [ "typeParams", Dval.list VT.unknownTODO (List.map DString td.typeParams)
-        "definition", Definition.toDT td.definition ]
+  let toDT (td : PT.TypeDeclaration.T) : Ply<Dval> =
+    uply {
+      let! definition = Definition.toDT td.definition
+
+      return!
+        Dval.record
+          (ptTyp [ "TypeDeclaration" ] "TypeDeclaration" 0)
+          (Some [])
+          [ "typeParams", Dval.list VT.unknownTODO (List.map DString td.typeParams)
+            "definition", definition ]
+    }
 
   let fromDT (d : Dval) : PT.TypeDeclaration.T =
     match d with
@@ -1187,13 +1373,16 @@ module Handler =
       | DEnum(_, _, [], "REPL", [ DString name ]) -> PT.Handler.Spec.REPL(name)
       | _ -> Exception.raiseInternal "Invalid Spec" []
 
-  let toDT (h : PT.Handler.T) : Dval =
-    Dval.record
-      (ptTyp [ "Handler" ] "Handler" 0)
-      (Some [])
-      [ "tlid", DInt(int64 h.tlid)
-        "ast", Expr.toDT h.ast
-        "spec", Spec.toDT h.spec ]
+  let toDT (h : PT.Handler.T) : Ply<Dval> =
+    uply {
+      let! ast = Expr.toDT h.ast
+
+      return!
+        Dval.record
+          (ptTyp [ "Handler" ] "Handler" 0)
+          (Some [])
+          [ "tlid", DInt(int64 h.tlid); "ast", ast; "spec", Spec.toDT h.spec ]
+    }
 
   let fromDT (d : Dval) : PT.Handler.T =
     match d with
@@ -1208,14 +1397,19 @@ module Handler =
 
 
 module DB =
-  let toDT (db : PT.DB.T) : Dval =
-    Dval.record
-      (ptTyp [] "DB" 0)
-      (Some [])
-      [ "tlid", DInt(int64 db.tlid)
-        "name", DString db.name
-        "version", DInt db.version
-        "typ", TypeReference.toDT db.typ ]
+  let toDT (db : PT.DB.T) : Ply<Dval> =
+    uply {
+      let! typ = TypeReference.toDT db.typ
+
+      return!
+        Dval.record
+          (ptTyp [] "DB" 0)
+          (Some [])
+          [ "tlid", DInt(int64 db.tlid)
+            "name", DString db.name
+            "version", DInt db.version
+            "typ", typ ]
+    }
 
   let fromDT (d : Dval) : PT.DB.T =
     match d with
@@ -1230,15 +1424,22 @@ module DB =
 
 
 module UserType =
-  let toDT (userType : PT.UserType.T) : Dval =
-    Dval.record
-      (ptTyp [] "UserType" 0)
-      (Some [])
-      [ "tlid", DInt(int64 userType.tlid)
-        "name", TypeName.UserProgram.toDT userType.name
-        "description", DString userType.description
-        "declaration", TypeDeclaration.toDT userType.declaration
-        "deprecated", Deprecation.toDT TypeName.toDT userType.deprecated ]
+  let toDT (userType : PT.UserType.T) : Ply<Dval> =
+    uply {
+      let! name = TypeName.UserProgram.toDT userType.name
+      let! declaration = TypeDeclaration.toDT userType.declaration
+      let! deprecated = Deprecation.toDT TypeName.toDT userType.deprecated
+
+      return!
+        Dval.record
+          (ptTyp [] "UserType" 0)
+          (Some [])
+          [ "tlid", DInt(int64 userType.tlid)
+            "name", name
+            "description", DString userType.description
+            "declaration", declaration
+            "deprecated", deprecated ]
+    }
 
   let fromDT (d : Dval) : PT.UserType.T =
     match d with
@@ -1261,13 +1462,17 @@ module UserType =
 
 module UserFunction =
   module Parameter =
-    let toDT (p : PT.UserFunction.Parameter) : Dval =
-      Dval.record
-        (ptTyp [ "UserFunction" ] "Parameter" 0)
-        (Some [])
-        [ "name", DString p.name
-          "typ", TypeReference.toDT p.typ
-          "description", DString p.description ]
+    let toDT (p : PT.UserFunction.Parameter) : Ply<Dval> =
+      uply {
+        let! typ = TypeReference.toDT p.typ
+        return!
+          Dval.record
+            (ptTyp [ "UserFunction" ] "Parameter" 0)
+            (Some [])
+            [ "name", DString p.name
+              "typ", typ
+              "description", DString p.description ]
+      }
 
     let fromDT (d : Dval) : PT.UserFunction.Parameter =
       match d with
@@ -1281,21 +1486,32 @@ module UserFunction =
       | _ -> Exception.raiseInternal "Invalid UserFunction.Parameter" []
 
 
-  let toDT (userFn : PT.UserFunction.T) : Dval =
-    Dval.record
-      (ptTyp [ "UserFunction" ] "UserFunction" 0)
-      (Some [])
-      [ "tlid", DInt(int64 userFn.tlid)
-        "name", FnName.UserProgram.toDT userFn.name
-        "typeParams", Dval.list VT.unknownTODO (List.map DString userFn.typeParams)
-        "parameters",
-        Dval.list
-          VT.unknownTODO
-          (userFn.parameters |> NEList.toList |> List.map Parameter.toDT)
-        "returnType", TypeReference.toDT userFn.returnType
-        "body", Expr.toDT userFn.body
-        "description", DString userFn.description
-        "deprecated", Deprecation.toDT FnName.toDT userFn.deprecated ]
+  let toDT (userFn : PT.UserFunction.T) : Ply<Dval> =
+    uply {
+      let! name = FnName.UserProgram.toDT userFn.name
+      let! parameters =
+        userFn.parameters
+        |> NEList.toList
+        |> Ply.List.mapSequentially Parameter.toDT
+        |> Ply.map (Dval.list VT.unknownTODO)
+      let! returnType = TypeReference.toDT userFn.returnType
+      let! body = Expr.toDT userFn.body
+      let! deprecated = Deprecation.toDT FnName.toDT userFn.deprecated
+
+      return!
+        Dval.record
+          (ptTyp [ "UserFunction" ] "UserFunction" 0)
+          (Some [])
+          [ "tlid", DInt(int64 userFn.tlid)
+            "name", name
+            "typeParams",
+            Dval.list VT.unknownTODO (List.map DString userFn.typeParams)
+            "parameters", parameters
+            "returnType", returnType
+            "body", body
+            "description", DString userFn.description
+            "deprecated", deprecated ]
+    }
 
   let fromDT (d : Dval) : PT.UserFunction.T =
     match d with
@@ -1326,15 +1542,22 @@ module UserFunction =
     | _ -> Exception.raiseInternal "Invalid UserFunction" []
 
 module UserConstant =
-  let toDT (userConstant : PT.UserConstant.T) : Dval =
-    Dval.record
-      (ptTyp [] "UserConstant" 0)
-      (Some [])
-      [ "tlid", DInt(int64 userConstant.tlid)
-        "name", ConstantName.UserProgram.toDT userConstant.name
-        "body", Const.toDT userConstant.body
-        "description", DString userConstant.description
-        "deprecated", Deprecation.toDT ConstantName.toDT userConstant.deprecated ]
+  let toDT (userConstant : PT.UserConstant.T) : Ply<Dval> =
+    uply {
+      let! name = ConstantName.UserProgram.toDT userConstant.name
+      let! body = Const.toDT userConstant.body
+      let! deprecated = Deprecation.toDT ConstantName.toDT userConstant.deprecated
+
+      return!
+        Dval.record
+          (ptTyp [] "UserConstant" 0)
+          (Some [])
+          [ "tlid", DInt(int64 userConstant.tlid)
+            "name", name
+            "body", body
+            "description", DString userConstant.description
+            "deprecated", deprecated ]
+    }
 
   let fromDT (d : Dval) : PT.UserConstant.T =
     match d with
@@ -1356,7 +1579,7 @@ module UserConstant =
     | _ -> Exception.raiseInternal "Invalid UserConstant" []
 
 module Secret =
-  let toDT (s : PT.Secret.T) : Dval =
+  let toDT (s : PT.Secret.T) : Ply<Dval> =
     Dval.record
       (ptTyp [] "Secret" 0)
       (Some [])
@@ -1375,16 +1598,22 @@ module Secret =
 
 
 module PackageType =
-  let toDT (p : PT.PackageType.T) : Dval =
-    Dval.record
-      (ptTyp [] "PackageType" 0)
-      (Some [])
-      [ "tlid", DInt(int64 p.tlid)
-        "id", DUuid p.id
-        "name", TypeName.Package.toDT p.name
-        "declaration", TypeDeclaration.toDT p.declaration
-        "description", DString p.description
-        "deprecated", Deprecation.toDT TypeName.toDT p.deprecated ]
+  let toDT (p : PT.PackageType.T) : Ply<Dval> =
+    uply {
+      let! name = TypeName.Package.toDT p.name
+      let! declaration = TypeDeclaration.toDT p.declaration
+      let! deprecated = Deprecation.toDT TypeName.toDT p.deprecated
+      return!
+        Dval.record
+          (ptTyp [] "PackageType" 0)
+          (Some [])
+          [ "tlid", DInt(int64 p.tlid)
+            "id", DUuid p.id
+            "name", name
+            "declaration", declaration
+            "description", DString p.description
+            "deprecated", deprecated ]
+    }
 
   let fromDT (d : Dval) : PT.PackageType.T =
     match d with
@@ -1409,13 +1638,17 @@ module PackageType =
 
 module PackageFn =
   module Parameter =
-    let toDT (p : PT.PackageFn.Parameter) : Dval =
-      Dval.record
-        (ptTyp [ "PackageFn" ] "Parameter" 0)
-        (Some [])
-        [ "name", DString p.name
-          "typ", TypeReference.toDT p.typ
-          "description", DString p.description ]
+    let toDT (p : PT.PackageFn.Parameter) : Ply<Dval> =
+      uply {
+        let! typ = TypeReference.toDT p.typ
+        return!
+          Dval.record
+            (ptTyp [ "PackageFn" ] "Parameter" 0)
+            (Some [])
+            [ "name", DString p.name
+              "typ", typ
+              "description", DString p.description ]
+      }
 
     let fromDT (d : Dval) : PT.PackageFn.Parameter =
       match d with
@@ -1428,22 +1661,31 @@ module PackageFn =
 
       | _ -> Exception.raiseInternal "Invalid PackageFn.Parameter" []
 
-  let toDT (p : PT.PackageFn.T) : Dval =
-    Dval.record
-      (ptTyp [ "PackageFn" ] "PackageFn" 0)
-      (Some [])
-      [ "tlid", DInt(int64 p.tlid)
-        "id", DUuid p.id
-        "name", FnName.Package.toDT p.name
-        "body", Expr.toDT p.body
-        "typeParams", Dval.list VT.unknownTODO (List.map DString p.typeParams)
-        "parameters",
-        Dval.list
-          VT.unknownTODO
-          (p.parameters |> NEList.toList |> List.map Parameter.toDT)
-        "returnType", TypeReference.toDT p.returnType
-        "description", DString p.description
-        "deprecated", Deprecation.toDT FnName.toDT p.deprecated ]
+  let toDT (p : PT.PackageFn.T) : Ply<Dval> =
+    uply {
+      let! name = FnName.Package.toDT p.name
+      let! body = Expr.toDT p.body
+      let! parameters =
+        p.parameters
+        |> NEList.toList
+        |> Ply.List.mapSequentially Parameter.toDT
+        |> Ply.map (Dval.list VT.unknownTODO)
+      let! returnType = TypeReference.toDT p.returnType
+      let! deprecated = Deprecation.toDT FnName.toDT p.deprecated
+      return!
+        Dval.record
+          (ptTyp [ "PackageFn" ] "PackageFn" 0)
+          (Some [])
+          [ "tlid", DInt(int64 p.tlid)
+            "id", DUuid p.id
+            "name", name
+            "body", body
+            "typeParams", List.map DString p.typeParams |> Dval.list VT.unknownTODO
+            "parameters", parameters
+            "returnType", returnType
+            "description", DString p.description
+            "deprecated", deprecated ]
+    }
 
   let fromDT (d : Dval) : PT.PackageFn.T =
     match d with
@@ -1477,16 +1719,22 @@ module PackageFn =
     | _ -> Exception.raiseInternal "Invalid PackageFn" []
 
 module PackageConstant =
-  let toDT (p : PT.PackageConstant.T) : Dval =
-    Dval.record
-      (ptTyp [] "PackageConstant" 0)
-      (Some [])
-      [ "tlid", DInt(int64 p.tlid)
-        "id", DUuid p.id
-        "name", ConstantName.Package.toDT p.name
-        "body", Const.toDT p.body
-        "description", DString p.description
-        "deprecated", Deprecation.toDT ConstantName.toDT p.deprecated ]
+  let toDT (p : PT.PackageConstant.T) : Ply<Dval> =
+    uply {
+      let! name = ConstantName.Package.toDT p.name
+      let! body = Const.toDT p.body
+      let! deprecated = Deprecation.toDT ConstantName.toDT p.deprecated
+      return!
+        Dval.record
+          (ptTyp [] "PackageConstant" 0)
+          (Some [])
+          [ "tlid", DInt(int64 p.tlid)
+            "id", DUuid p.id
+            "name", name
+            "body", body
+            "description", DString p.description
+            "deprecated", deprecated ]
+    }
 
   let fromDT (d : Dval) : PT.PackageConstant.T =
     match d with

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -56,36 +56,52 @@ module TypeName =
 
 
 module NameResolution =
-  let toRT (f : 'a -> 'b) (nr : PT.NameResolution<'a>) : RT.NameResolution<'b> =
-    match nr with
-    | Ok x -> Ok(f x)
-    | Error e -> Error(NameResolutionError.RTE.toRuntimeError e)
+  let toRT (f : 'a -> 'b) (nr : PT.NameResolution<'a>) : Ply<RT.NameResolution<'b>> =
+    uply {
+      match nr with
+      | Ok x -> return Ok(f x)
+      | Error e ->
+        let! rte = NameResolutionError.RTE.toRuntimeError e
+        return Error rte
+    }
 
 module TypeReference =
-  let rec toRT (t : PT.TypeReference) : RT.TypeReference =
-    match t with
-    | PT.TInt -> RT.TInt
-    | PT.TFloat -> RT.TFloat
-    | PT.TBool -> RT.TBool
-    | PT.TUnit -> RT.TUnit
-    | PT.TString -> RT.TString
-    | PT.TList typ -> RT.TList(toRT typ)
-    | PT.TTuple(firstType, secondType, otherTypes) ->
-      RT.TTuple(toRT firstType, toRT secondType, List.map toRT otherTypes)
-    | PT.TDict typ -> RT.TDict(toRT typ)
-    | PT.TDB typ -> RT.TDB(toRT typ)
-    | PT.TDateTime -> RT.TDateTime
-    | PT.TChar -> RT.TChar
-    | PT.TUuid -> RT.TUuid
-    | PT.TCustomType(typeName, typeArgs) ->
-      RT.TCustomType(
-        NameResolution.toRT TypeName.toRT typeName,
-        List.map toRT typeArgs
-      )
-    | PT.TBytes -> RT.TBytes
-    | PT.TVariable(name) -> RT.TVariable(name)
-    | PT.TFn(paramTypes, returnType) ->
-      RT.TFn(NEList.map toRT paramTypes, toRT returnType)
+  let rec toRT (t : PT.TypeReference) : Ply<RT.TypeReference> =
+    uply {
+      match t with
+      | PT.TInt -> return RT.TInt
+      | PT.TFloat -> return RT.TFloat
+      | PT.TBool -> return RT.TBool
+      | PT.TUnit -> return RT.TUnit
+      | PT.TString -> return RT.TString
+      | PT.TList inner ->
+        let! inner = toRT inner
+        return RT.TList(inner)
+      | PT.TTuple(first, second, theRest) ->
+        let! first = toRT first
+        let! second = toRT second
+        let! theRest = theRest |> Ply.List.mapSequentially toRT
+        return RT.TTuple(first, second, theRest)
+      | PT.TDict typ ->
+        let! typ = toRT typ
+        return RT.TDict typ
+      | PT.TDB typ ->
+        let! typ = toRT typ
+        return RT.TDB typ
+      | PT.TDateTime -> return RT.TDateTime
+      | PT.TChar -> return RT.TChar
+      | PT.TUuid -> return RT.TUuid
+      | PT.TCustomType(typeName, typeArgs) ->
+        let! typeName = NameResolution.toRT TypeName.toRT typeName
+        let! typeArgs = Ply.List.mapSequentially toRT typeArgs
+        return RT.TCustomType(typeName, typeArgs)
+      | PT.TBytes -> return RT.TBytes
+      | PT.TVariable(name) -> return RT.TVariable(name)
+      | PT.TFn(paramTypes, returnType) ->
+        let! paramTypes = Ply.NEList.mapSequentially toRT paramTypes
+        let! returnType = toRT returnType
+        return RT.TFn(paramTypes, returnType)
+    }
 
 module FnName =
   module BuiltIn =
@@ -226,221 +242,333 @@ module MatchPattern =
     | PT.MPListCons(id, head, tail) -> RT.MPListCons(id, toRT head, toRT tail)
 
 module Expr =
-  let rec toRT (e : PT.Expr) : RT.Expr =
-    match e with
-    | PT.EChar(id, char) -> RT.EChar(id, char)
-    | PT.EInt(id, num) -> RT.EInt(id, num)
-    | PT.EString(id, segments) -> RT.EString(id, List.map stringSegmentToRT segments)
-    | PT.EFloat(id, sign, whole, fraction) ->
-      let whole = if whole = "" then "0" else whole
-      let fraction = if fraction = "" then "0" else fraction
-      RT.EFloat(id, makeFloat sign whole fraction)
-    | PT.EBool(id, b) -> RT.EBool(id, b)
-    | PT.EUnit id -> RT.EUnit id
-    | PT.EConstant(id, Ok name) -> RT.EConstant(id, ConstantName.toRT name)
-    | PT.EConstant(id, Error err) ->
-      RT.EError(id, NameResolutionError.RTE.toRuntimeError err, [])
-    | PT.EVariable(id, var) -> RT.EVariable(id, var)
-    | PT.EFieldAccess(id, obj, fieldname) -> RT.EFieldAccess(id, toRT obj, fieldname)
-    | PT.EApply(id, fnName, typeArgs, args) ->
-      RT.EApply(
-        id,
-        toRT fnName,
-        List.map TypeReference.toRT typeArgs,
-        NEList.map toRT args
-      )
-    | PT.EFnName(id, Ok name) -> RT.EFnName(id, FnName.toRT name)
-    | PT.EFnName(id, Error err) ->
-      RT.EError(id, NameResolutionError.RTE.toRuntimeError err, [])
-    | PT.EInfix(id, PT.InfixFnCall fnName, arg1, arg2) ->
-      let (modules, fn, version) = InfixFnName.toFnName fnName
-      let name =
-        RT.FQName.BuiltIn(
-          { modules = modules; name = RT.FnName.FnName fn; version = version }
-        )
-      RT.EApply(
-        id,
-        RT.EFnName(id, name),
-        [],
-        NEList.ofList (toRT arg1) [ toRT arg2 ]
-      )
-    | PT.EInfix(id, PT.BinOp PT.BinOpAnd, expr1, expr2) ->
-      RT.EAnd(id, toRT expr1, toRT expr2)
-    | PT.EInfix(id, PT.BinOp PT.BinOpOr, expr1, expr2) ->
-      RT.EOr(id, toRT expr1, toRT expr2)
-    | PT.ELambda(id, vars, body) ->
-      let vars = vars |> NEList.filter (fun (name, v) -> v <> "")
-      match vars with
-      | [] ->
-        RT.EError(
-          id,
-          RT.RuntimeError.oldError "Lambda must have at least one argument",
-          []
-        )
-      | head :: tail -> RT.ELambda(id, NEList.ofList head tail, toRT body)
-    | PT.ELet(id, pattern, rhs, body) ->
-      RT.ELet(id, LetPattern.toRT pattern, toRT rhs, toRT body)
-    | PT.EIf(id, cond, thenExpr, elseExpr) ->
-      RT.EIf(id, toRT cond, toRT thenExpr, Option.map toRT elseExpr)
-    | PT.EList(id, exprs) -> RT.EList(id, List.map toRT exprs)
-    | PT.ETuple(id, first, second, theRest) ->
-      RT.ETuple(id, toRT first, toRT second, List.map toRT theRest)
-    | PT.ERecord(id, Ok typeName, fields) ->
-      match fields with
-      | [] ->
-        RT.EError(
-          id,
-          RT.RuntimeError.oldError "Record must have at least one field",
-          fields |> List.map Tuple2.second |> List.map toRT
-        )
-      | head :: tail ->
-        RT.ERecord(
-          id,
-          TypeName.toRT typeName,
-          NEList.ofList head tail |> NEList.map (Tuple2.mapSecond toRT)
-        )
-    | PT.ERecord(id, Error err, fields) ->
-      RT.EError(
-        id,
-        NameResolutionError.RTE.toRuntimeError err,
-        fields |> List.map Tuple2.second |> List.map toRT
-      )
+  let rec toRT (e : PT.Expr) : Ply<RT.Expr> =
+    uply {
+      match e with
+      | PT.EChar(id, char) -> return RT.EChar(id, char)
+      | PT.EInt(id, num) -> return RT.EInt(id, num)
 
-    | PT.ERecordUpdate(id, record, updates) ->
-      RT.ERecordUpdate(id, toRT record, NEList.map (Tuple2.mapSecond toRT) updates)
-    | PT.EPipe(pipeID, expr1, rest) ->
-      // Convert v |> fn1 a |> fn2 |> fn3 b c
-      // into fn3 (fn2 (fn1 v a)) b c
-      let folder (prev : RT.Expr) (next : PT.PipeExpr) : RT.Expr =
+      | PT.EString(id, segments) ->
+        let! segments = Ply.List.mapSequentially stringSegmentToRT segments
+        return RT.EString(id, segments)
 
-        let applyFn (expr : RT.Expr) (args : List<RT.Expr>) =
-          let typeArgs = []
-          RT.EApply(pipeID, expr, typeArgs, NEList.ofList prev args)
+      | PT.EFloat(id, sign, whole, fraction) ->
+        let whole = if whole = "" then "0" else whole
+        let fraction = if fraction = "" then "0" else fraction
+        return RT.EFloat(id, makeFloat sign whole fraction)
+      | PT.EBool(id, b) -> return RT.EBool(id, b)
+      | PT.EUnit id -> return RT.EUnit id
 
-        match next with
-        | PT.EPipeFnCall(id, Error err, _typeArgs, exprs) ->
-          RT.EError(
-            id,
-            NameResolutionError.RTE.toRuntimeError err,
-            prev :: List.map toRT exprs
+      | PT.EConstant(id, Ok name) -> return RT.EConstant(id, ConstantName.toRT name)
+      | PT.EConstant(id, Error err) ->
+        let! err = NameResolutionError.RTE.toRuntimeError err
+        return RT.EError(id, err, [])
+
+      | PT.EVariable(id, var) -> return RT.EVariable(id, var)
+
+      | PT.EFieldAccess(id, obj, fieldname) ->
+        let! obj = toRT obj
+        return RT.EFieldAccess(id, obj, fieldname)
+
+      | PT.EApply(id, fnName, typeArgs, args) ->
+        let! fnName = toRT fnName
+        let! typeArgs = Ply.List.mapSequentially TypeReference.toRT typeArgs
+        let! args = Ply.NEList.mapSequentially toRT args
+        return RT.EApply(id, fnName, typeArgs, args)
+
+      | PT.EFnName(id, Ok name) -> return RT.EFnName(id, FnName.toRT name)
+      | PT.EFnName(id, Error err) ->
+        let! err = NameResolutionError.RTE.toRuntimeError err
+        return RT.EError(id, err, [])
+
+      // CLEANUP tidy infix stuff - extract to another fn?
+      | PT.EInfix(id, PT.InfixFnCall fnName, left, right) ->
+        let (modules, fn, version) = InfixFnName.toFnName fnName
+        let name =
+          RT.FQName.BuiltIn(
+            { modules = modules; name = RT.FnName.FnName fn; version = version }
           )
-        | PT.EPipeFnCall(id, Ok fnName, typeArgs, exprs) ->
-          RT.EApply(
-            id,
-            RT.EFnName(id, FnName.toRT fnName),
-            List.map TypeReference.toRT typeArgs,
-            NEList.ofList prev (List.map toRT exprs)
-          )
-        | PT.EPipeInfix(id, PT.InfixFnCall fnName, expr) ->
-          let (modules, fn, version) = InfixFnName.toFnName fnName
-          let name =
-            PT.FQName.BuiltIn(
-              { modules = modules; name = PT.FnName.FnName fn; version = version }
+        let! left = toRT left
+        let! right = toRT right
+        return RT.EApply(id, RT.EFnName(id, name), [], NEList.ofList left [ right ])
+      | PT.EInfix(id, PT.BinOp PT.BinOpAnd, left, right) ->
+        let! left = toRT left
+        let! right = toRT right
+        return RT.EAnd(id, left, right)
+      | PT.EInfix(id, PT.BinOp PT.BinOpOr, left, right) ->
+        let! left = toRT left
+        let! right = toRT right
+        return RT.EOr(id, left, right)
+
+      | PT.ELambda(id, vars, body) ->
+        let vars = vars |> NEList.filter (fun (name, v) -> v <> "")
+        match vars with
+        | [] ->
+          return
+            RT.EError(
+              id,
+              RT.RuntimeError.oldError "Lambda must have at least one argument",
+              []
             )
-          let typeArgs = []
-          RT.EApply(
-            id,
-            RT.EFnName(id, FnName.toRT name),
-            typeArgs,
-            NEList.doubleton prev (toRT expr)
-          )
-        // Binops work pretty naturally here
-        | PT.EPipeInfix(id, PT.BinOp op, expr) ->
-          match op with
-          | PT.BinOpAnd -> RT.EAnd(id, prev, toRT expr)
-          | PT.BinOpOr -> RT.EOr(id, prev, toRT expr)
-        | PT.EPipeEnum(id, Ok typeName, caseName, fields) ->
-          let fields' = prev :: List.map toRT fields
-          RT.EEnum(id, TypeName.toRT typeName, caseName, fields')
-        | PT.EPipeEnum(id, Error err, _caseName, fields) ->
-          RT.EError(
-            id,
-            NameResolutionError.RTE.toRuntimeError err,
-            prev :: List.map toRT fields
-          )
-        | PT.EPipeVariable(id, name, exprs) ->
-          let exprs = List.map toRT exprs
-          applyFn (RT.EVariable(id, name)) exprs
-        | PT.EPipeLambda(id, vars, body) ->
-          applyFn (RT.ELambda(id, vars, toRT body)) []
+        | head :: tail ->
+          let! body = toRT body
+          return RT.ELambda(id, NEList.ofList head tail, body)
 
-      let init = toRT expr1
-      List.fold folder init rest
+      | PT.ELet(id, pattern, rhs, body) ->
+        let! rhs = toRT rhs
+        let! body = toRT body
+        return RT.ELet(id, LetPattern.toRT pattern, rhs, body)
 
-    | PT.EMatch(id, mexpr, pairs) ->
-      match pairs with
-      | [] ->
-        RT.EError(
-          id,
-          RT.RuntimeError.oldError "Match must have at least one case",
-          [ toRT mexpr ]
-        )
-      | head :: tail ->
-        RT.EMatch(
-          id,
-          toRT mexpr,
-          NEList.ofList head tail
-          |> NEList.map (Tuple2.mapFirst MatchPattern.toRT << Tuple2.mapSecond toRT)
-        )
-    | PT.EEnum(id, Ok typeName, caseName, fields) ->
-      RT.EEnum(id, TypeName.toRT typeName, caseName, List.map toRT fields)
-    | PT.EEnum(id, Error err, _caseName, fields) ->
-      RT.EError(id, NameResolutionError.RTE.toRuntimeError err, List.map toRT fields)
-    | PT.EDict(id, fields) -> RT.EDict(id, List.map (Tuple2.mapSecond toRT) fields)
+      | PT.EIf(id, cond, thenExpr, elseExpr) ->
+        let! cond = toRT cond
+        let! thenExpr = toRT thenExpr
+        let! elseExpr = elseExpr |> Ply.Option.map toRT
+        return RT.EIf(id, cond, thenExpr, elseExpr)
+
+      | PT.EList(id, exprs) ->
+        let! exprs = Ply.List.mapSequentially toRT exprs
+        return RT.EList(id, exprs)
+
+      | PT.ETuple(id, first, second, theRest) ->
+        let! first = toRT first
+        let! second = toRT second
+        let! theRest = Ply.List.mapSequentially toRT theRest
+        return RT.ETuple(id, first, second, theRest)
+
+      | PT.ERecord(id, Ok typeName, fields) ->
+        return!
+          uply {
+            match fields with
+            | [] ->
+              let! fields =
+                fields |> List.map Tuple2.second |> Ply.List.mapSequentially toRT
+              return
+                RT.EError(
+                  id,
+                  RT.RuntimeError.oldError "Record must have at least one field",
+                  fields
+                )
+            | head :: tail ->
+              let! fields =
+                NEList.ofList head tail
+                |> Ply.NEList.mapSequentially (fun (name, expr) ->
+                  uply {
+                    let! expr = toRT expr
+                    return (name, expr)
+                  })
+              return RT.ERecord(id, TypeName.toRT typeName, fields)
+          }
+      | PT.ERecord(id, Error err, fields) ->
+        let! err = NameResolutionError.RTE.toRuntimeError err
+        let! fields =
+          fields |> List.map Tuple2.second |> Ply.List.mapSequentially toRT
+        return RT.EError(id, err, fields)
+
+      | PT.ERecordUpdate(id, record, updates) ->
+        let! record = toRT record
+        let! updates =
+          updates
+          |> Ply.NEList.mapSequentially (fun (fieldName, update) ->
+            uply {
+              let! update = toRT update
+              return (fieldName, update)
+            })
+        return RT.ERecordUpdate(id, record, updates)
+
+      | PT.EPipe(pipeID, expr1, rest) ->
+        // Convert v |> fn1 a |> fn2 |> fn3 b c
+        // into fn3 (fn2 (fn1 v a)) b c
+        let folder (prev : RT.Expr) (next : PT.PipeExpr) : Ply<RT.Expr> =
+
+          let applyFn (expr : RT.Expr) (args : List<RT.Expr>) =
+            let typeArgs = []
+            RT.EApply(pipeID, expr, typeArgs, NEList.ofList prev args)
+          uply {
+            match next with
+            | PT.EPipeFnCall(id, Error err, _typeArgs, exprs) ->
+              let! err = NameResolutionError.RTE.toRuntimeError err
+              let! addlExprs = Ply.List.mapSequentially toRT exprs
+              return RT.EError(id, err, prev :: addlExprs)
+            | PT.EPipeFnCall(id, Ok fnName, typeArgs, exprs) ->
+              let! typeArgs = Ply.List.mapSequentially TypeReference.toRT typeArgs
+              let! exprs =
+                exprs
+                |> Ply.List.mapSequentially toRT
+                |> Ply.map (NEList.ofList prev)
+              return
+                RT.EApply(id, RT.EFnName(id, FnName.toRT fnName), typeArgs, exprs)
+            | PT.EPipeInfix(id, PT.InfixFnCall fnName, expr) ->
+              let (modules, fn, version) = InfixFnName.toFnName fnName
+              let name =
+                PT.FQName.BuiltIn(
+                  { modules = modules
+                    name = PT.FnName.FnName fn
+                    version = version }
+                )
+              let typeArgs = []
+              let! addlExpr = toRT expr
+              return
+                RT.EApply(
+                  id,
+                  RT.EFnName(id, FnName.toRT name),
+                  typeArgs,
+                  NEList.doubleton prev addlExpr
+                )
+            // Binops work pretty naturally here
+            | PT.EPipeInfix(id, PT.BinOp op, expr) ->
+              match op with
+              | PT.BinOpAnd ->
+                let! expr = toRT expr
+                return RT.EAnd(id, prev, expr)
+              | PT.BinOpOr ->
+                let! expr = toRT expr
+                return RT.EOr(id, prev, expr)
+            | PT.EPipeEnum(id, Ok typeName, caseName, fields) ->
+              let! addlFields = Ply.List.mapSequentially toRT fields
+              return
+                RT.EEnum(id, TypeName.toRT typeName, caseName, prev :: addlFields)
+            | PT.EPipeEnum(id, Error err, _caseName, fields) ->
+              let! err = NameResolutionError.RTE.toRuntimeError err
+              let! addlFields = Ply.List.mapSequentially toRT fields
+              return RT.EError(id, err, prev :: addlFields)
+            | PT.EPipeVariable(id, name, exprs) ->
+              let! exprs = Ply.List.mapSequentially toRT exprs
+              return applyFn (RT.EVariable(id, name)) exprs
+            | PT.EPipeLambda(id, vars, body) ->
+              let! body = toRT body
+              return applyFn (RT.ELambda(id, vars, body)) []
+          }
+
+        let! init = toRT expr1
+        return! Ply.List.foldSequentially folder init rest
+
+      | PT.EMatch(id, mexpr, pairs) ->
+        match pairs with
+        | [] ->
+          let! mexpr = toRT mexpr
+          return
+            RT.EError(
+              id,
+              RT.RuntimeError.oldError "Match must have at least one case",
+              [ mexpr ]
+            )
+        | head :: tail ->
+          let! mexpr = toRT mexpr
+          let! cases =
+            NEList.ofList head tail
+            |> Ply.NEList.mapSequentially (fun (mp, expr) ->
+              uply {
+                let! expr = toRT expr
+                return (MatchPattern.toRT mp, expr)
+              })
+          return RT.EMatch(id, mexpr, cases)
+
+      | PT.EEnum(id, Ok typeName, caseName, fields) ->
+        let! fields = Ply.List.mapSequentially toRT fields
+        return RT.EEnum(id, TypeName.toRT typeName, caseName, fields)
+      | PT.EEnum(id, Error err, _caseName, fields) ->
+        let! err = NameResolutionError.RTE.toRuntimeError err
+        let! fields = Ply.List.mapSequentially toRT fields
+        return RT.EError(id, err, fields)
+
+      | PT.EDict(id, fields) ->
+        let! fields =
+          fields
+          |> Ply.List.mapSequentially (fun (k, v) ->
+            uply {
+              let! v = toRT v
+              return (k, v)
+            })
+        return RT.EDict(id, fields)
+    }
 
 
-
-  and stringSegmentToRT (segment : PT.StringSegment) : RT.StringSegment =
+  and stringSegmentToRT (segment : PT.StringSegment) : Ply<RT.StringSegment> =
     match segment with
-    | PT.StringText text -> RT.StringText text
-    | PT.StringInterpolation expr -> RT.StringInterpolation(toRT expr)
+    | PT.StringText text -> Ply(RT.StringText text)
+    | PT.StringInterpolation expr ->
+      uply {
+        let! expr = toRT expr
+        return RT.StringInterpolation expr
+      }
 
 module Const =
 
-  let rec toRT (c : PT.Const) : RT.Const =
-    match c with
-    | PT.Const.CInt i -> RT.CInt i
-    | PT.Const.CBool b -> RT.CBool b
-    | PT.Const.CString s -> RT.CString s
-    | PT.Const.CChar c -> RT.CChar c
-    | PT.Const.CFloat(sign, w, f) -> RT.CFloat(sign, w, f)
-    | PT.Const.CUnit -> RT.CUnit
-    | PT.Const.CTuple(first, second, rest) ->
-      RT.CTuple(toRT first, toRT second, List.map toRT rest)
-    | PT.Const.CEnum(typeName, caseName, fields) ->
-      RT.CEnum(
-        NameResolution.toRT TypeName.toRT typeName,
-        caseName,
-        List.map toRT fields
-      )
-    | PT.Const.CList items -> RT.CList(List.map toRT items)
-    | PT.Const.CDict items -> RT.CDict(List.map (Tuple2.mapSecond toRT) items)
+  let rec toRT (c : PT.Const) : Ply<RT.Const> =
+    uply {
+      match c with
+      | PT.Const.CInt i -> return RT.CInt i
+      | PT.Const.CBool b -> return RT.CBool b
+      | PT.Const.CString s -> return RT.CString s
+      | PT.Const.CChar c -> return RT.CChar c
+      | PT.Const.CFloat(sign, w, f) -> return RT.CFloat(sign, w, f)
+      | PT.Const.CUnit -> return RT.CUnit
+      | PT.Const.CTuple(first, second, rest) ->
+        let! first = toRT first
+        let! second = toRT second
+        let! rest = Ply.List.mapSequentially toRT rest
+        return RT.CTuple(first, second, rest)
+      | PT.Const.CEnum(typeName, caseName, fields) ->
+        let! typeName = NameResolution.toRT TypeName.toRT typeName
+        let! fields = Ply.List.mapSequentially toRT fields
+        return RT.CEnum(typeName, caseName, fields)
+      | PT.Const.CList items ->
+        let! items = Ply.List.mapSequentially toRT items
+        return RT.CList items
+      | PT.Const.CDict entries ->
+        let! entries =
+          entries
+          |> Ply.List.mapSequentially (fun (k, v) ->
+            uply {
+              let! v = toRT v
+              return (k, v)
+            })
+        return RT.CDict entries
+    }
 
 module TypeDeclaration =
   module RecordField =
-    let toRT (f : PT.TypeDeclaration.RecordField) : RT.TypeDeclaration.RecordField =
-      { name = f.name; typ = TypeReference.toRT f.typ }
+    let toRT
+      (f : PT.TypeDeclaration.RecordField)
+      : Ply<RT.TypeDeclaration.RecordField> =
+      uply {
+        let! typ = TypeReference.toRT f.typ
+        return { name = f.name; typ = typ }
+      }
 
   module EnumField =
-    let toRT (f : PT.TypeDeclaration.EnumField) : RT.TypeReference =
+    let toRT (f : PT.TypeDeclaration.EnumField) : Ply<RT.TypeReference> =
       TypeReference.toRT f.typ
 
   module EnumCase =
-    let toRT (c : PT.TypeDeclaration.EnumCase) : RT.TypeDeclaration.EnumCase =
-      { name = c.name; fields = List.map EnumField.toRT c.fields }
+    let toRT (c : PT.TypeDeclaration.EnumCase) : Ply<RT.TypeDeclaration.EnumCase> =
+      uply {
+        let! fields = Ply.List.mapSequentially EnumField.toRT c.fields
+        return { name = c.name; fields = fields }
+      }
 
   module Definition =
-    let toRT (d : PT.TypeDeclaration.Definition) : RT.TypeDeclaration.Definition =
-      match d with
-      | PT.TypeDeclaration.Definition.Alias(typ) ->
-        RT.TypeDeclaration.Alias(TypeReference.toRT typ)
-      | PT.TypeDeclaration.Record fields ->
-        RT.TypeDeclaration.Record(NEList.map RecordField.toRT fields)
-      | PT.TypeDeclaration.Enum cases ->
-        RT.TypeDeclaration.Enum(NEList.map EnumCase.toRT cases)
+    let toRT
+      (d : PT.TypeDeclaration.Definition)
+      : Ply<RT.TypeDeclaration.Definition> =
+      uply {
+        match d with
+        | PT.TypeDeclaration.Definition.Alias(typ) ->
+          let! typ = TypeReference.toRT typ
+          return RT.TypeDeclaration.Alias typ
+        | PT.TypeDeclaration.Record fields ->
+          let! fields = Ply.NEList.mapSequentially RecordField.toRT fields
+          return RT.TypeDeclaration.Record fields
+        | PT.TypeDeclaration.Enum cases ->
+          let! cases = Ply.NEList.mapSequentially EnumCase.toRT cases
+          return RT.TypeDeclaration.Enum cases
+      }
 
-  let toRT (t : PT.TypeDeclaration.T) : RT.TypeDeclaration.T =
-    { typeParams = t.typeParams; definition = Definition.toRT t.definition }
+  let toRT (t : PT.TypeDeclaration.T) : Ply<RT.TypeDeclaration.T> =
+    uply {
+      let! def = Definition.toRT t.definition
+      return { typeParams = t.typeParams; definition = def }
+    }
 
 
 module Handler =
@@ -463,49 +591,83 @@ module Handler =
         RT.Handler.Cron(name, CronInterval.toRT interval)
       | PT.Handler.REPL name -> RT.Handler.REPL name
 
-  let toRT (h : PT.Handler.T) : RT.Handler.T =
-    { tlid = h.tlid; ast = Expr.toRT h.ast; spec = Spec.toRT h.spec }
+  let toRT (h : PT.Handler.T) : Ply<RT.Handler.T> =
+    uply {
+      let! ast = Expr.toRT h.ast
+      return { tlid = h.tlid; ast = ast; spec = Spec.toRT h.spec }
+    }
 
 module DB =
-  let toRT (db : PT.DB.T) : RT.DB.T =
-    { tlid = db.tlid
-      name = db.name
-      version = db.version
-      typ = TypeReference.toRT db.typ }
+  let toRT (db : PT.DB.T) : Ply<RT.DB.T> =
+    uply {
+      let! typ = TypeReference.toRT db.typ
+      return { tlid = db.tlid; name = db.name; version = db.version; typ = typ }
+    }
 
 module UserType =
-  let toRT (t : PT.UserType.T) : RT.UserType.T =
-    { tlid = t.tlid
-      name = TypeName.UserProgram.toRT t.name
-      declaration = TypeDeclaration.toRT t.declaration }
+  let toRT (t : PT.UserType.T) : Ply<RT.UserType.T> =
+    uply {
+      let! decl = TypeDeclaration.toRT t.declaration
+      return
+        { tlid = t.tlid
+          name = TypeName.UserProgram.toRT t.name
+          declaration = decl }
+    }
 
 module UserConstant =
-  let toRT (c : PT.UserConstant.T) : RT.UserConstant.T =
-    { tlid = c.tlid
-      name = ConstantName.UserProgram.toRT c.name
-      body = Const.toRT c.body }
+  let toRT (c : PT.UserConstant.T) : Ply<RT.UserConstant.T> =
+    uply {
+      let! body = Const.toRT c.body
+      return
+        { tlid = c.tlid; name = ConstantName.UserProgram.toRT c.name; body = body }
+    }
 
 module UserFunction =
   module Parameter =
-    let toRT (p : PT.UserFunction.Parameter) : RT.UserFunction.Parameter =
-      { name = p.name; typ = TypeReference.toRT p.typ }
+    let toRT (p : PT.UserFunction.Parameter) : Ply<RT.UserFunction.Parameter> =
+      uply {
+        let! typ = TypeReference.toRT p.typ
+        return { name = p.name; typ = typ }
+      }
 
-  let toRT (f : PT.UserFunction.T) : RT.UserFunction.T =
-    { tlid = f.tlid
-      name = FnName.UserProgram.toRT f.name
-      typeParams = f.typeParams
-      parameters = NEList.map Parameter.toRT f.parameters
-      returnType = TypeReference.toRT f.returnType
-      body = Expr.toRT f.body }
+  let toRT (f : PT.UserFunction.T) : Ply<RT.UserFunction.T> =
+    uply {
+      let! parameters = Ply.NEList.mapSequentially Parameter.toRT f.parameters
+      let! returnType = TypeReference.toRT f.returnType
+      let! body = Expr.toRT f.body
+      return
+        { tlid = f.tlid
+          name = FnName.UserProgram.toRT f.name
+          typeParams = f.typeParams
+          parameters = parameters
+          returnType = returnType
+          body = body }
+    }
 
 module Toplevel =
-  let toRT (tl : PT.Toplevel.T) : RT.Toplevel.T =
-    match tl with
-    | PT.Toplevel.TLHandler h -> RT.Toplevel.TLHandler(Handler.toRT h)
-    | PT.Toplevel.TLDB db -> RT.Toplevel.TLDB(DB.toRT db)
-    | PT.Toplevel.TLFunction f -> RT.Toplevel.TLFunction(UserFunction.toRT f)
-    | PT.Toplevel.TLType t -> RT.Toplevel.TLType(UserType.toRT t)
-    | PT.Toplevel.TLConstant c -> RT.Toplevel.TLConstant(UserConstant.toRT c)
+  let toRT (tl : PT.Toplevel.T) : Ply<RT.Toplevel.T> =
+    uply {
+      match tl with
+      | PT.Toplevel.TLHandler h ->
+        let! h = Handler.toRT h
+        return RT.Toplevel.TLHandler h
+
+      | PT.Toplevel.TLDB db ->
+        let! db = DB.toRT db
+        return RT.Toplevel.TLDB db
+
+      | PT.Toplevel.TLFunction f ->
+        let! f = UserFunction.toRT f
+        return RT.Toplevel.TLFunction f
+
+      | PT.Toplevel.TLType t ->
+        let! t = UserType.toRT t
+        return RT.Toplevel.TLType t
+
+      | PT.Toplevel.TLConstant c ->
+        let! c = UserConstant.toRT c
+        return RT.Toplevel.TLConstant c
+    }
 
 module Secret =
   let toRT (s : PT.Secret.T) : RT.Secret.T =
@@ -513,22 +675,36 @@ module Secret =
 
 module PackageFn =
   module Parameter =
-    let toRT (p : PT.PackageFn.Parameter) : RT.PackageFn.Parameter =
-      { name = p.name; typ = TypeReference.toRT p.typ }
+    let toRT (p : PT.PackageFn.Parameter) : Ply<RT.PackageFn.Parameter> =
+      uply {
+        let! typ = TypeReference.toRT p.typ
+        return { name = p.name; typ = typ }
+      }
 
-  let toRT (f : PT.PackageFn.T) : RT.PackageFn.T =
-    { name = FnName.Package.toRT f.name
-      tlid = f.tlid
-      body = Expr.toRT f.body
-      typeParams = f.typeParams
-      parameters = NEList.map Parameter.toRT f.parameters
-      returnType = TypeReference.toRT f.returnType }
+  let toRT (f : PT.PackageFn.T) : Ply<RT.PackageFn.T> =
+    uply {
+      let! body = Expr.toRT f.body
+      let! parameters = Ply.NEList.mapSequentially Parameter.toRT f.parameters
+      let! returnType = TypeReference.toRT f.returnType
+      return
+        { name = FnName.Package.toRT f.name
+          tlid = f.tlid
+          body = body
+          typeParams = f.typeParams
+          parameters = parameters
+          returnType = returnType }
+    }
 
 module PackageType =
-  let toRT (t : PT.PackageType.T) : RT.PackageType.T =
-    { name = TypeName.Package.toRT t.name
-      declaration = TypeDeclaration.toRT t.declaration }
+  let toRT (t : PT.PackageType.T) : Ply<RT.PackageType.T> =
+    uply {
+      let! decl = TypeDeclaration.toRT t.declaration
+      return { name = TypeName.Package.toRT t.name; declaration = decl }
+    }
 
 module PackageConstant =
-  let toRT (c : PT.PackageConstant.T) : RT.PackageConstant.T =
-    { name = ConstantName.Package.toRT c.name; body = Const.toRT c.body }
+  let toRT (c : PT.PackageConstant.T) : Ply<RT.PackageConstant.T> =
+    uply {
+      let! body = Const.toRT c.body
+      return { name = ConstantName.Package.toRT c.name; body = body }
+    }

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -45,7 +45,7 @@ module FQName =
       (nameValueType : ValueType)
       (nameMapper : 'name -> Dval)
       (u : FQName.BuiltIn<'name>)
-      : Dval =
+      : Ply<Dval> =
       Dval.record
         (rtTyp [ "FQName" ] "BuiltIn" 0)
         (Some [ nameValueType ])
@@ -69,7 +69,7 @@ module FQName =
       (nameValueType : ValueType)
       (nameMapper : 'name -> Dval)
       (u : FQName.UserProgram<'name>)
-      : Dval =
+      : Ply<Dval> =
       Dval.record
         (rtTyp [ "FQName" ] "UserProgram" 0)
         (Some [ nameValueType ])
@@ -93,7 +93,7 @@ module FQName =
       (nameValueType : ValueType)
       (nameMapper : 'name -> Dval)
       (u : FQName.Package<'name>)
-      : Dval =
+      : Ply<Dval> =
       Dval.record
         (rtTyp [ "FQName" ] "Package" 0)
         (Some [ nameValueType ])
@@ -124,16 +124,25 @@ module FQName =
     (nameValueType : ValueType)
     (nameMapper : 'name -> Dval)
     (u : FQName.FQName<'name>)
-    : Dval =
-    let caseName, fields =
-      match u with
-      | FQName.UserProgram u ->
-        "UserProgram", [ UserProgram.toDT nameValueType nameMapper u ]
-      | FQName.Package u -> "Package", [ Package.toDT nameValueType nameMapper u ]
-      | FQName.BuiltIn u -> "BuiltIn", [ BuiltIn.toDT nameValueType nameMapper u ]
+    : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match u with
+          | FQName.UserProgram u ->
+            let! name = UserProgram.toDT nameValueType nameMapper u
+            return "UserProgram", [ name ]
+          | FQName.Package u ->
+            let! name = Package.toDT nameValueType nameMapper u
+            return "Package", [ name ]
+          | FQName.BuiltIn u ->
+            let! name = BuiltIn.toDT nameValueType nameMapper u
+            return "BuiltIn", [ name ]
+        }
 
-    let typeName = rtTyp [ "FQName" ] "FQName" 0
-    Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+      let typeName = rtTyp [ "FQName" ] "FQName" 0
+      return Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
+    }
 
   let fromDT (nameMapper : Dval -> 'name) (d : Dval) : FQName.FQName<'name> =
     match d with
@@ -164,23 +173,24 @@ module TypeName =
       | _ -> Exception.raiseInternal "Invalid TypeName" []
 
   module BuiltIn =
-    let toDT (u : TypeName.BuiltIn) : Dval =
+    let toDT (u : TypeName.BuiltIn) : Ply<Dval> =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : TypeName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : TypeName.UserProgram) : Dval =
+    let toDT (u : TypeName.UserProgram) : Ply<Dval> =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : TypeName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : TypeName.Package) : Dval =
+    let toDT (u : TypeName.Package) : Ply<Dval> =
       FQName.Package.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : TypeName.Package = FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : TypeName.TypeName) : Dval = FQName.toDT Name.valueType Name.toDT u
+  let toDT (u : TypeName.TypeName) : Ply<Dval> =
+    FQName.toDT Name.valueType Name.toDT u
   let fromDT (d : Dval) : TypeName.TypeName = FQName.fromDT Name.fromDT d
 
 
@@ -202,22 +212,22 @@ module FnName =
       | _ -> Exception.raiseInternal "Invalid FnName" []
 
   module BuiltIn =
-    let toDT (u : FnName.BuiltIn) : Dval =
+    let toDT (u : FnName.BuiltIn) : Ply<Dval> =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : FnName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : FnName.UserProgram) : Dval =
+    let toDT (u : FnName.UserProgram) : Ply<Dval> =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : FnName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : FnName.Package) : Dval =
+    let toDT (u : FnName.Package) : Ply<Dval> =
       FQName.Package.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : FnName.Package = FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : FnName.FnName) : Dval = FQName.toDT Name.valueType Name.toDT u
+  let toDT (u : FnName.FnName) : Ply<Dval> = FQName.toDT Name.valueType Name.toDT u
   let fromDT (d : Dval) : FnName.FnName = FQName.fromDT Name.fromDT d
 
 
@@ -240,25 +250,25 @@ module ConstantName =
       | _ -> Exception.raiseInternal "Invalid ConstantName" []
 
   module BuiltIn =
-    let toDT (u : ConstantName.BuiltIn) : Dval =
+    let toDT (u : ConstantName.BuiltIn) : Ply<Dval> =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : ConstantName.BuiltIn =
       FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : ConstantName.UserProgram) : Dval =
+    let toDT (u : ConstantName.UserProgram) : Ply<Dval> =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : ConstantName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : ConstantName.Package) : Dval =
+    let toDT (u : ConstantName.Package) : Ply<Dval> =
       FQName.Package.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : ConstantName.Package =
       FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : ConstantName.ConstantName) : Dval =
+  let toDT (u : ConstantName.ConstantName) : Ply<Dval> =
     FQName.toDT Name.valueType Name.toDT u
   let fromDT (d : Dval) : ConstantName.ConstantName = FQName.fromDT Name.fromDT d
 
@@ -266,14 +276,20 @@ module ConstantName =
 module NameResolution =
   let toDT
     (nameValueType : ValueType)
-    (f : 'p -> Dval)
+    (f : 'p -> Ply<Dval>)
     (result : NameResolution<'p>)
-    : Dval =
-    let errType = VT.unknownTODO // NameResolutionError
+    : Ply<Dval> =
+    uply {
+      let errType = VT.unknownTODO // NameResolutionError
 
-    match result with
-    | Ok name -> Dval.resultOk nameValueType errType (f name)
-    | Error err -> Dval.resultError nameValueType errType (RuntimeError.toDT err)
+      match result with
+      | Ok name ->
+        let! name = f name
+        return Dval.resultOk nameValueType errType name
+      | Error err ->
+        return!
+          RuntimeError.toDT err |> Ply.map (Dval.resultError nameValueType errType)
+    }
 
   let fromDT (f : Dval -> 'a) (d : Dval) : NameResolution<'a> =
     match d with
@@ -286,41 +302,65 @@ module NameResolution =
 module TypeReference =
   let valueType = ValueType.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.TypeReference
 
-  let rec toDT (t : TypeReference) : Dval =
-    let caseName, fields =
-      match t with
-      | TVariable name -> "TVariable", [ DString name ]
+  let rec toDT (t : TypeReference) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match t with
+          | TVariable name -> return "TVariable", [ DString name ]
 
-      | TUnit -> "TUnit", []
-      | TBool -> "TBool", []
-      | TInt -> "TInt", []
-      | TFloat -> "TFloat", []
-      | TChar -> "TChar", []
-      | TString -> "TString", []
-      | TDateTime -> "TDateTime", []
-      | TUuid -> "TUuid", []
-      | TBytes -> "TBytes", []
+          | TUnit -> return "TUnit", []
+          | TBool -> return "TBool", []
+          | TInt -> return "TInt", []
+          | TFloat -> return "TFloat", []
+          | TChar -> return "TChar", []
+          | TString -> return "TString", []
+          | TDateTime -> return "TDateTime", []
+          | TUuid -> return "TUuid", []
+          | TBytes -> return "TBytes", []
 
-      | TList inner -> "TList", [ toDT inner ]
+          | TList inner ->
+            let! inner = toDT inner
+            return "TList", [ inner ]
 
-      | TTuple(first, second, theRest) ->
-        "TTuple",
-        [ toDT first; toDT second; Dval.list VT.unknownTODO (List.map toDT theRest) ]
+          | TTuple(first, second, theRest) ->
+            let! first = toDT first
+            let! second = toDT second
+            let! theRest =
+              theRest
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "TTuple", [ first; second; theRest ]
 
-      | TDict inner -> "TDict", [ toDT inner ]
+          | TDict inner ->
+            let! inner = toDT inner
+            return "TDict", [ inner ]
 
-      | TCustomType(typeName, typeArgs) ->
-        "TCustomType",
-        [ NameResolution.toDT ValueType.unknownTODO TypeName.toDT typeName
-          Dval.list VT.unknownTODO (List.map toDT typeArgs) ]
+          | TCustomType(typeName, typeArgs) ->
+            let! typeName =
+              NameResolution.toDT ValueType.unknownTODO TypeName.toDT typeName
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "TCustomType", [ typeName; typeArgs ]
 
-      | TDB inner -> "TDB", [ toDT inner ]
-      | TFn(args, ret) ->
-        "TFn",
-        [ Dval.list VT.unknownTODO (List.map toDT (NEList.toList args)); toDT ret ]
+          | TDB inner ->
+            let! inner = toDT inner
+            return "TDB", [ inner ]
+          | TFn(args, ret) ->
+            let! args =
+              args
+              |> NEList.toList
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            let! ret = toDT ret
+            return "TFn", [ args; ret ]
+        }
 
-    let typeName = rtTyp [] "TypeReference" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+      let typeName = rtTyp [] "TypeReference" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let rec fromDT (d : Dval) : TypeReference =
     match d with
@@ -355,11 +395,15 @@ module TypeReference =
     | _ -> Exception.raiseInternal "Invalid TypeReference" [ "typeRef", d ]
 
 module Param =
-  let toDT (p : Param) : Dval =
-    Dval.record
-      (rtTyp [] "Param" 0)
-      (Some [])
-      [ ("name", DString p.name); ("typ", TypeReference.toDT p.typ) ]
+  let toDT (p : Param) : Ply<Dval> =
+    uply {
+      let! typ = TypeReference.toDT p.typ
+      return!
+        Dval.record
+          (rtTyp [] "Param" 0)
+          (Some [])
+          [ ("name", DString p.name); ("typ", typ) ]
+    }
 
 
 module LetPattern =
@@ -448,14 +492,20 @@ module MatchPattern =
 
 
 module StringSegment =
-  let toDT (exprToDT : Expr -> Dval) (s : StringSegment) : Dval =
-    let caseName, fields =
-      match s with
-      | StringText text -> "StringText", [ DString text ]
-      | StringInterpolation expr -> "StringInterpolation", [ exprToDT expr ]
+  let toDT (exprToDT : Expr -> Ply<Dval>) (s : StringSegment) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match s with
+          | StringText text -> return "StringText", [ DString text ]
+          | StringInterpolation expr ->
+            let! expr = exprToDT expr
+            return "StringInterpolation", [ expr ]
+        }
 
-    let typeName = rtTyp [] "StringSegment" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+      let typeName = rtTyp [] "StringSegment" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let fromDT (exprFromDT : Dval -> Expr) (d : Dval) : StringSegment =
     match d with
@@ -468,120 +518,174 @@ module StringSegment =
 module Expr =
   let valueType = VT.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.Expr
 
-  let rec toDT (e : Expr) : Dval =
-    let caseName, fields =
-      match e with
-      | EUnit id -> "EUnit", [ DInt(int64 id) ]
+  let rec toDT (e : Expr) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match e with
+          | EUnit id -> return "EUnit", [ DInt(int64 id) ]
 
-      // simple data
-      | EBool(id, b) -> "EBool", [ DInt(int64 id); DBool b ]
-      | EInt(id, i) -> "EInt", [ DInt(int64 id); DInt i ]
-      | EFloat(id, f) -> "EFloat", [ DInt(int64 id); DFloat f ]
-      | EChar(id, c) -> "EChar", [ DInt(int64 id); DString c ]
-      | EString(id, segments) ->
-        "EString",
-        [ DInt(int64 id)
-          Dval.list VT.unknownTODO (List.map (StringSegment.toDT toDT) segments) ]
+          // simple data
+          | EBool(id, b) -> return "EBool", [ DInt(int64 id); DBool b ]
+          | EInt(id, i) -> return "EInt", [ DInt(int64 id); DInt i ]
+          | EFloat(id, f) -> return "EFloat", [ DInt(int64 id); DFloat f ]
+          | EChar(id, c) -> return "EChar", [ DInt(int64 id); DString c ]
+          | EString(id, segments) ->
+            let! segments =
+              segments
+              |> Ply.List.mapSequentially (StringSegment.toDT toDT)
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EString", [ DInt(int64 id); segments ]
 
-      // structures of data
-      | EList(id, inner) ->
-        "EList", [ DInt(int64 id); Dval.list valueType (List.map toDT inner) ]
+          // structures of data
+          | EList(id, exprs) ->
+            let! exprs =
+              exprs |> Ply.List.mapSequentially toDT |> Ply.map (Dval.list valueType)
+            return "EList", [ DInt(int64 id); exprs ]
 
-      | EDict(id, pairs) ->
-        "EDict",
-        [ DInt(int64 id)
-          Dval.list
-            VT.unknownTODO
-            (List.map (fun (k, v) -> DTuple(DString k, toDT v, [])) pairs) ]
+          | EDict(id, entries) ->
+            let! entries =
+              entries
+              |> Ply.List.mapSequentially (fun (k, v) ->
+                uply {
+                  let! v = toDT v
+                  return DTuple(DString k, v, [])
+                })
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EDict", [ DInt(int64 id); entries ]
 
-      | ETuple(id, first, second, theRest) ->
-        "ETuple",
-        [ DInt(int64 id)
-          toDT first
-          toDT second
-          Dval.list VT.unknownTODO (List.map toDT theRest) ]
+          | ETuple(id, first, second, theRest) ->
+            let! first = toDT first
+            let! second = toDT second
+            let! theRest =
+              theRest
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "ETuple", [ DInt(int64 id); first; second; theRest ]
 
-      | ERecord(id, name, fields) ->
-        let fields =
-          (NEList.toList fields)
-          |> List.map (fun (name, expr) -> DTuple(DString name, toDT expr, []))
+          | ERecord(id, typeName, fields) ->
+            let! typeName = TypeName.toDT typeName
+            let! fields =
+              fields
+              |> NEList.toList
+              |> Ply.List.mapSequentially (fun (name, expr) ->
+                uply {
+                  let! expr = toDT expr
+                  return DTuple(DString name, expr, [])
+                })
+            return
+              "ERecord",
+              [ DInt(int64 id); typeName; Dval.list VT.unknownTODO fields ]
 
-        "ERecord",
-        [ DInt(int64 id); TypeName.toDT name; Dval.list VT.unknownTODO fields ]
+          | EEnum(id, typeName, caseName, fields) ->
+            let! typeName = TypeName.toDT typeName
+            let! fields =
+              fields
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list valueType)
+            return "EEnum", [ DInt(int64 id); typeName; DString caseName; fields ]
 
-      | EEnum(id, typeName, caseName, fields) ->
-        "EEnum",
-        [ DInt(int64 id)
-          TypeName.toDT typeName
-          DString caseName
-          Dval.list valueType (List.map toDT fields) ]
+          // declaring and accessing variables
+          | ELet(id, lp, expr, body) ->
+            let! expr = toDT expr
+            let! body = toDT body
+            return "ELet", [ DInt(int64 id); LetPattern.toDT lp; expr; body ]
 
-      // declaring and accessing variables
-      | ELet(id, lp, expr, body) ->
-        "ELet", [ DInt(int64 id); LetPattern.toDT lp; toDT expr; toDT body ]
+          | EFieldAccess(id, expr, fieldName) ->
+            let! expr = toDT expr
+            return "EFieldAccess", [ DInt(int64 id); expr; DString fieldName ]
 
-      | EFieldAccess(id, expr, fieldName) ->
-        "EFieldAccess", [ DInt(int64 id); toDT expr; DString fieldName ]
-
-      | EVariable(id, varName) -> "EVariable", [ DInt(int64 id); DString varName ]
-
-
-      // control flow
-      | EIf(id, cond, thenExpr, elseExpr) ->
-        let elseExpr = elseExpr |> Option.map toDT |> Dval.option valueType
-        "EIf", [ DInt(int64 id); toDT cond; toDT thenExpr; elseExpr ]
-
-      | EMatch(id, arg, cases) ->
-        let cases =
-          (NEList.toList cases)
-          |> List.map (fun (pattern, expr) ->
-            DTuple(MatchPattern.toDT pattern, toDT expr, []))
-
-        "EMatch", [ DInt(int64 id); toDT arg; Dval.list VT.unknownTODO cases ]
-
-
-
-      | ELambda(id, args, body) ->
-        let variables =
-          (NEList.toList args)
-          |> List.map (fun (id, varName) ->
-            DTuple(DInt(int64 id), DString varName, []))
-          |> Dval.list VT.unknownTODO
-
-        "ELambda", [ DInt(int64 id); variables; toDT body ]
-
-      | EConstant(id, name) ->
-        "EConstant", [ DInt(int64 id); ConstantName.toDT name ]
-
-      | EApply(id, name, typeArgs, args) ->
-        "EApply",
-        [ DInt(int64 id)
-          toDT name
-          Dval.list TypeReference.valueType (List.map TypeReference.toDT typeArgs)
-          Dval.list TypeReference.valueType (List.map toDT (NEList.toList args)) ]
-
-      | EFnName(id, name) -> "EFnName", [ DInt(int64 id); FnName.toDT name ]
-
-      | ERecordUpdate(id, record, updates) ->
-        let updates =
-          NEList.toList updates
-          |> List.map (fun (name, expr) -> DTuple(DString name, toDT expr, []))
-
-        "ERecordUpdate",
-        [ DInt(int64 id); toDT record; Dval.list VT.unknownTODO updates ]
-
-      | EAnd(id, left, right) -> "EAnd", [ DInt(int64 id); toDT left; toDT right ]
-      | EOr(id, left, right) -> "EOr", [ DInt(int64 id); toDT left; toDT right ]
-      // Let the error straight through
-      | EError(id, rtError, exprs) ->
-        "EError",
-        [ DInt(int64 id)
-          RuntimeTypes.RuntimeError.toDT rtError
-          List.map toDT exprs |> Dval.list valueType ]
+          | EVariable(id, varName) ->
+            return "EVariable", [ DInt(int64 id); DString varName ]
 
 
-    let typeName = rtTyp [] "Expr" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+          // control flow
+          | EIf(id, cond, thenExpr, elseExpr) ->
+            let! cond = toDT cond
+            let! thenExpr = toDT thenExpr
+            let! elseExpr =
+              elseExpr |> Ply.Option.map toDT |> Ply.map (Dval.option valueType)
+            return "EIf", [ DInt(int64 id); cond; thenExpr; elseExpr ]
+
+          | EMatch(id, arg, cases) ->
+            let! arg = toDT arg
+            let! cases =
+              cases
+              |> NEList.toList
+              |> Ply.List.mapSequentially (fun (pattern, expr) ->
+                uply {
+                  let! expr = toDT expr
+                  return DTuple(MatchPattern.toDT pattern, expr, [])
+                })
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "EMatch", [ DInt(int64 id); arg; cases ]
+
+
+          | ELambda(id, args, body) ->
+            let variables =
+              (NEList.toList args)
+              |> List.map (fun (id, varName) ->
+                DTuple(DInt(int64 id), DString varName, []))
+              |> Dval.list VT.unknownTODO
+            let! body = toDT body
+            return "ELambda", [ DInt(int64 id); variables; body ]
+
+          | EConstant(id, name) ->
+            let! name = ConstantName.toDT name
+            return "EConstant", [ DInt(int64 id); name ]
+
+          | EApply(id, expr, typeArgs, args) ->
+            let! expr = toDT expr
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially TypeReference.toDT
+              |> Ply.map (Dval.list TypeReference.valueType)
+            let! args =
+              args
+              |> NEList.toList
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list TypeReference.valueType)
+            return "EApply", [ DInt(int64 id); expr; typeArgs; args ]
+
+          | EFnName(id, name) ->
+            let! name = FnName.toDT name
+            return "EFnName", [ DInt(int64 id); name ]
+
+          | ERecordUpdate(id, record, updates) ->
+            let! record = toDT record
+            let! updates =
+              NEList.toList updates
+              |> Ply.List.mapSequentially (fun (name, expr) ->
+                uply {
+                  let! expr = toDT expr
+                  return DTuple(DString name, expr, [])
+                })
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "ERecordUpdate", [ DInt(int64 id); record; updates ]
+
+          | EAnd(id, left, right) ->
+            let! left = toDT left
+            let! right = toDT right
+            return "EAnd", [ DInt(int64 id); left; right ]
+
+          | EOr(id, left, right) ->
+            let! left = toDT left
+            let! right = toDT right
+            return "EOr", [ DInt(int64 id); left; right ]
+
+          // Let the error straight through
+          | EError(id, rtError, exprs) ->
+            let! exprs =
+              exprs |> Ply.List.mapSequentially toDT |> Ply.map (Dval.list valueType)
+            return
+              "EError",
+              [ DInt(int64 id); RuntimeTypes.RuntimeError.toDT rtError; exprs ]
+        }
+
+
+      let typeName = rtTyp [] "Expr" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
   let rec fromDT (d : Dval) : Expr =
     match d with
@@ -744,7 +848,7 @@ module Expr =
 
 
 module RuntimeError =
-  let toDT (e : RuntimeError) : Dval =
+  let toDT (e : RuntimeError) : Ply<Dval> =
     e |> RuntimeTypes.RuntimeError.toDT |> Dval.toDT
 
   let fromDT (d : Dval) : RuntimeError =
@@ -755,43 +859,61 @@ module Dval =
   let valueType = VT.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.Dval.Dval
 
   module KnownType =
-    let toDT (kt : KnownType) : Dval =
-      let caseName, fields =
-        match kt with
-        | KTUnit -> "KTUnit", []
-        | KTBool -> "KTBool", []
-        | KTInt -> "KTInt", []
-        | KTFloat -> "KTFloat", []
-        | KTChar -> "KTChar", []
-        | KTString -> "KTString", []
-        | KTUuid -> "KTUuid", []
-        | KTDateTime -> "KTDateTime", []
-        | KTBytes -> "KTBytes", []
+    let toDT (kt : KnownType) : Ply<Dval> =
+      uply {
+        let! (caseName, fields) =
+          uply {
+            match kt with
+            | KTUnit -> return "KTUnit", []
+            | KTBool -> return "KTBool", []
+            | KTInt -> return "KTInt", []
+            | KTFloat -> return "KTFloat", []
+            | KTChar -> return "KTChar", []
+            | KTString -> return "KTString", []
+            | KTUuid -> return "KTUuid", []
+            | KTDateTime -> return "KTDateTime", []
+            | KTBytes -> return "KTBytes", []
 
-        | KTList inner -> "KTList", [ ValueType.toDT inner ]
-        | KTTuple(first, second, theRest) ->
-          "KTTuple",
-          [ ValueType.toDT first
-            ValueType.toDT second
-            Dval.list ValueType.valueType (List.map ValueType.toDT theRest) ]
-        | KTDict inner -> "KTDict", [ ValueType.toDT inner ]
+            | KTList inner ->
+              let! inner = ValueType.toDT inner
+              return "KTList", [ inner ]
+            | KTTuple(first, second, theRest) ->
+              let! first = ValueType.toDT first
+              let! second = ValueType.toDT second
+              let! theRest =
+                theRest
+                |> Ply.List.mapSequentially ValueType.toDT
+                |> Ply.map (Dval.list ValueType.valueType)
+              return "KTTuple", [ first; second; theRest ]
+            | KTDict inner ->
+              let! inner = ValueType.toDT inner
+              return "KTDict", [ inner ]
 
-        | KTCustomType(typeName, typeArgs) ->
-          "KTCustomType",
-          [ TypeName.toDT typeName
-            Dval.list ValueType.valueType (List.map ValueType.toDT typeArgs) ]
+            | KTCustomType(typeName, typeArgs) ->
+              let! typeName = TypeName.toDT typeName
+              let! typeArgs =
+                typeArgs
+                |> Ply.List.mapSequentially ValueType.toDT
+                |> Ply.map (Dval.list ValueType.valueType)
+              return "KTCustomType", [ typeName; typeArgs ]
 
-        | KTFn(args, ret) ->
-          "KTFn",
-          [ Dval.list
-              ValueType.valueType
-              (List.map ValueType.toDT (NEList.toList args))
-            ValueType.toDT ret ]
+            | KTFn(args, ret) ->
+              let! args =
+                args
+                |> NEList.toList
+                |> Ply.List.mapSequentially ValueType.toDT
+                |> Ply.map (Dval.list ValueType.valueType)
+              let! ret = ValueType.toDT ret
+              return "KTFn", [ args; ret ]
 
-        | KTDB d -> "KTDB", [ ValueType.toDT d ]
+            | KTDB d ->
+              let! d = ValueType.toDT d
+              return "KTDB", [ d ]
+          }
 
-      let typeName = rtTyp [] "KnownType" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+        let typeName = rtTyp [] "KnownType" 0
+        return Dval.enum typeName typeName (Some []) caseName fields
+      }
 
     let fromDT (d : Dval) : KnownType =
       match d with
@@ -831,14 +953,20 @@ module Dval =
   module ValueType =
     let valueType = VT.unknownTODO
 
-    let toDT (vt : ValueType) : Dval =
-      let caseName, fields =
-        match vt with
-        | ValueType.Unknown -> "Unknown", []
-        | ValueType.Known kt -> "Known", [ KnownType.toDT kt ]
+    let toDT (vt : ValueType) : Ply<Dval> =
+      uply {
+        let! (caseName, fields) =
+          uply {
+            match vt with
+            | ValueType.Unknown -> return "Unknown", []
+            | ValueType.Known kt ->
+              let! kt = KnownType.toDT kt
+              return "Known", [ kt ]
+          }
 
-      let typeName = rtTyp [] "ValueType" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+        let typeName = rtTyp [] "ValueType" 0
+        return Dval.enum typeName typeName (Some []) caseName fields
+      }
 
     let fromDT (d : Dval) : ValueType =
       match d with
@@ -866,22 +994,31 @@ module Dval =
 
 
   module LambdaImpl =
-    let toDT (l : LambdaImpl) : Dval =
-      let typeName = rtTyp [] "LambdaImpl" 0
-
-      let fields =
-        [ "typeSymbolTable",
-          DDict(VT.unknownTODO, Map.map TypeReference.toDT l.typeSymbolTable)
-          "symtable", DDict(VT.unknownTODO, Map.map Dval.toDT l.symtable)
-          "parameters",
-          Dval.list
-            VT.unknownTODO
-            (List.map
-              (fun (id, name) -> DTuple(DInt(int64 id), DString name, []))
-              (NEList.toList l.parameters))
-          "body", Expr.toDT l.body ]
-
-      Dval.record typeName (Some []) fields
+    let toDT (l : LambdaImpl) : Ply<Dval> =
+      uply {
+        let! tst =
+          l.typeSymbolTable
+          |> Ply.Map.mapSequentially TypeReference.toDT
+          |> Ply.map (Dval.dictFromMap VT.unknownTODO)
+        let! symtable =
+          l.symtable
+          |> Ply.Map.mapSequentially Dval.toDT
+          |> Ply.map (Dval.dictFromMap VT.unknownTODO)
+        let parameters =
+          l.parameters
+          |> NEList.toList
+          |> List.map (fun (id, name) -> DTuple(DInt(int64 id), DString name, []))
+          |> Dval.list VT.unknownTODO
+        let! body = Expr.toDT l.body
+        return!
+          Dval.record
+            (rtTyp [] "LambdaImpl" 0)
+            (Some [])
+            [ "typeSymbolTable", tst
+              "symtable", symtable
+              "parameters", parameters
+              "body", body ]
+      }
 
     let fromDT (d : Dval) : LambdaImpl =
       match d with
@@ -911,14 +1048,22 @@ module Dval =
       | _ -> Exception.raiseInternal "Invalid LambdaImpl" []
 
   module FnValImpl =
-    let toDT (fnValImpl : FnValImpl) : Dval =
-      let caseName, fields =
-        match fnValImpl with
-        | Lambda lambda -> "Lambda", [ LambdaImpl.toDT lambda ]
-        | NamedFn fnName -> "NamedFn", [ FnName.toDT fnName ]
+    let toDT (fnValImpl : FnValImpl) : Ply<Dval> =
+      uply {
+        let! (caseName, fields) =
+          uply {
+            match fnValImpl with
+            | Lambda lambda ->
+              let! lambda = LambdaImpl.toDT lambda
+              return "Lambda", [ lambda ]
+            | NamedFn fnName ->
+              let! fnName = FnName.toDT fnName
+              return "NamedFn", [ fnName ]
+          }
 
-      let typeName = rtTyp [] "FnValImpl" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+        let typeName = rtTyp [] "FnValImpl" 0
+        return Dval.enum typeName typeName (Some []) caseName fields
+      }
 
     let fromDT (d : Dval) : FnValImpl =
       match d with
@@ -926,50 +1071,85 @@ module Dval =
       | DEnum(_, _, [], "NamedFn", [ fnName ]) -> NamedFn(FnName.fromDT fnName)
       | _ -> Exception.raiseInternal "Invalid FnValImpl" []
 
-  let rec toDT (dv : Dval) : Dval =
-    let caseName, fields =
-      match dv with
-      | DUnit -> "DUnit", []
-      | DBool b -> "DBool", [ DBool b ]
-      | DInt i -> "DInt", [ DInt i ]
-      | DFloat f -> "DFloat", [ DFloat f ]
-      | DChar c -> "DChar", [ DChar c ]
-      | DString s -> "DString", [ DString s ]
-      | DUuid u -> "DUuid", [ DUuid u ]
-      | DDateTime d -> "DDateTime", [ DDateTime d ]
-      | DBytes b -> "DBytes", [ DBytes b ]
+  let rec toDT (dv : Dval) : Ply<Dval> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match dv with
+          | DUnit -> return "DUnit", []
+          | DBool b -> return "DBool", [ DBool b ]
+          | DInt i -> return "DInt", [ DInt i ]
+          | DFloat f -> return "DFloat", [ DFloat f ]
+          | DChar c -> return "DChar", [ DChar c ]
+          | DString s -> return "DString", [ DString s ]
+          | DUuid u -> return "DUuid", [ DUuid u ]
+          | DDateTime d -> return "DDateTime", [ DDateTime d ]
+          | DBytes b -> return "DBytes", [ DBytes b ]
 
 
-      | DList(vt, l) ->
-        "DList", [ ValueType.toDT vt; Dval.list VT.unknownTODO (List.map toDT l) ]
-      | DTuple(first, second, theRest) ->
-        "DTuple",
-        [ toDT first; toDT second; Dval.list VT.unknownTODO (List.map toDT theRest) ]
+          | DList(vt, items) ->
+            let! vt = ValueType.toDT vt
+            let! items =
+              items
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "DList", [ vt; items ]
 
-      | DFnVal fnImpl -> "DFnVal", [ FnValImpl.toDT fnImpl ]
+          | DTuple(first, second, theRest) ->
+            let! first = toDT first
+            let! second = toDT second
+            let! theRest =
+              theRest
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return "DTuple", [ first; second; theRest ]
 
-      | DDB name -> "DDB", [ DString name ]
+          | DFnVal fnImpl ->
+            let! fnImpl = FnValImpl.toDT fnImpl
+            return "DFnVal", [ fnImpl ]
 
-      | DDict(vt, map) ->
-        "DDict", [ ValueType.toDT vt; DDict(VT.unknownTODO, Map.map toDT map) ]
+          | DDB name -> return "DDB", [ DString name ]
 
-      | DRecord(runtimeTypeName, sourceTypeName, typeArgs, map) ->
-        "DRecord",
-        [ TypeName.toDT runtimeTypeName
-          TypeName.toDT sourceTypeName
-          typeArgs |> List.map ValueType.toDT |> Dval.list ValueType.valueType
-          DDict(VT.unknownTODO, Map.map toDT map) ]
+          | DDict(vt, entries) ->
+            let! vt = ValueType.toDT vt
+            let! entries =
+              entries
+              |> Ply.Map.mapSequentially toDT
+              |> Ply.map (Dval.dictFromMap VT.unknownTODO)
+            return "DDict", [ vt; entries ]
 
-      | DEnum(runtimeTypeName, sourceTypeName, typeArgs, caseName, fields) ->
-        "DEnum",
-        [ TypeName.toDT runtimeTypeName
-          TypeName.toDT sourceTypeName
-          typeArgs |> List.map ValueType.toDT |> Dval.list ValueType.valueType
-          DString caseName
-          Dval.list VT.unknownTODO (List.map toDT fields) ]
+          | DRecord(runtimeTypeName, sourceTypeName, typeArgs, fields) ->
+            let! runtimeTypeName = TypeName.toDT runtimeTypeName
+            let! sourceTypeName = TypeName.toDT sourceTypeName
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially ValueType.toDT
+              |> Ply.map (Dval.list ValueType.valueType)
+            let! fields =
+              fields
+              |> Ply.Map.mapSequentially toDT
+              |> Ply.map (Dval.dictFromMap VT.unknownTODO)
+            return "DRecord", [ runtimeTypeName; sourceTypeName; typeArgs; fields ]
 
-    let typeName = rtTyp [ "Dval" ] "Dval" 0
-    Dval.enum typeName typeName (Some []) caseName fields
+          | DEnum(runtimeTypeName, sourceTypeName, typeArgs, caseName, fields) ->
+            let! runtimeTypeName = TypeName.toDT runtimeTypeName
+            let! sourceTypeName = TypeName.toDT sourceTypeName
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially ValueType.toDT
+              |> Ply.map (Dval.list ValueType.valueType)
+            let! fields =
+              fields
+              |> Ply.List.mapSequentially toDT
+              |> Ply.map (Dval.list VT.unknownTODO)
+            return
+              "DEnum",
+              [ runtimeTypeName; sourceTypeName; typeArgs; DString caseName; fields ]
+        }
+
+      let typeName = rtTyp [ "Dval" ] "Dval" 0
+      return Dval.enum typeName typeName (Some []) caseName fields
+    }
 
 
   let fromDT (d : Dval) : Dval =

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -165,7 +165,7 @@ module Error =
           }
 
         let typeName = RuntimeError.name [ "TypeChecker" ] "Context" 0
-        return Dval.enum typeName typeName (Some []) caseName fields
+        return! Dval.enum typeName typeName (Some []) caseName fields
       }
 
 
@@ -187,10 +187,9 @@ module Error =
         }
 
       let typeName = RuntimeError.name [ "TypeChecker" ] "Error" 0
-      return
-        RuntimeError.typeCheckerError (
-          Dval.enum typeName typeName (Some []) caseName fields
-        )
+      return!
+        Dval.enum typeName typeName (Some []) caseName fields
+        |> Ply.map RuntimeError.typeCheckerError
     }
 
 let raiseValueNotExpectedType

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -67,6 +67,7 @@ module Context =
 
 type Error =
   | ValueNotExpectedType of
+    // CLEANUP consider reordering fields to (context * expectedType * actualValue)
     actualValue : Dval *
     expectedType : TypeReference *
     Context
@@ -90,110 +91,131 @@ module Error =
 
 
   module Context =
-    let rec toDT (context : Context) : Dval =
-      let (caseName, fields) =
-        match context with
-        | FunctionCallParameter(fnName, param, paramIndex, location) ->
-          "FunctionCallParameter",
-          [ RT2DT.FnName.toDT fnName
-            RT2DT.Param.toDT param
-            DInt paramIndex
-            Location.toDT location ]
+    let rec toDT (context : Context) : Ply<Dval> =
+      uply {
+        let! (caseName, fields) =
+          uply {
+            match context with
+            | FunctionCallParameter(fnName, param, paramIndex, location) ->
+              let! fnName = RT2DT.FnName.toDT fnName
+              let! param = RT2DT.Param.toDT param
+              return
+                "FunctionCallParameter",
+                [ fnName; param; DInt paramIndex; Location.toDT location ]
 
-        | FunctionCallResult(fnName, returnType, location) ->
-          "FunctionCallResult",
-          [ RT2DT.FnName.toDT fnName
-            RT2DT.TypeReference.toDT returnType
-            Location.toDT location ]
+            | FunctionCallResult(fnName, returnType, location) ->
+              let! fnName = RT2DT.FnName.toDT fnName
+              let! returnType = RT2DT.TypeReference.toDT returnType
+              return
+                "FunctionCallResult", [ fnName; returnType; Location.toDT location ]
 
-        | RecordField(recordTypeName, fieldName, fieldType, location) ->
-          "RecordField",
-          [ RT2DT.TypeName.toDT recordTypeName
-            DString fieldName
-            RT2DT.TypeReference.toDT fieldType
-            Location.toDT location ]
+            | RecordField(recordTypeName, fieldName, fieldType, location) ->
+              let! typeName = RT2DT.TypeName.toDT recordTypeName
+              let! fieldType = RT2DT.TypeReference.toDT fieldType
+              return
+                "RecordField",
+                [ typeName; DString fieldName; fieldType; Location.toDT location ]
 
-        | DictKey(key, typ, location) ->
-          "DictKey",
-          [ DString key; RT2DT.TypeReference.toDT typ; Location.toDT location ]
+            | DictKey(key, typ, location) ->
+              let! typ = RT2DT.TypeReference.toDT typ
+              return "DictKey", [ DString key; typ; Location.toDT location ]
 
-        | EnumField(enumTypeName,
-                    caseName,
-                    fieldIndex,
-                    fieldCount,
-                    fieldType,
-                    location) ->
-          "EnumField",
-          [ RT2DT.TypeName.toDT enumTypeName
-            DString caseName
-            DInt fieldIndex
-            DInt fieldCount
-            RT2DT.TypeReference.toDT fieldType
-            Location.toDT location ]
+            | EnumField(enumTypeName,
+                        caseName,
+                        fieldIndex,
+                        fieldCount,
+                        fieldType,
+                        location) ->
+              let! typeName = RT2DT.TypeName.toDT enumTypeName
+              let! fieldType = RT2DT.TypeReference.toDT fieldType
+              return
+                "EnumField",
+                [ typeName
+                  DString caseName
+                  DInt fieldIndex
+                  DInt fieldCount
+                  fieldType
+                  Location.toDT location ]
 
-        | DBQueryVariable(varName, expected, location) ->
-          "DBQueryVariable",
-          [ DString varName
-            RT2DT.TypeReference.toDT expected
-            Location.toDT location ]
+            | DBQueryVariable(varName, expected, location) ->
+              let! expected = RT2DT.TypeReference.toDT expected
+              return
+                "DBQueryVariable",
+                [ DString varName; expected; Location.toDT location ]
 
-        | DBSchemaType(name, expectedType, location) ->
-          "DBSchemaType",
-          [ DString name
-            RT2DT.TypeReference.toDT expectedType
-            Location.toDT location ]
+            | DBSchemaType(name, expectedType, location) ->
+              let! expectedType = RT2DT.TypeReference.toDT expectedType
+              return
+                "DBSchemaType",
+                [ DString name; expectedType; Location.toDT location ]
 
-        | ListIndex(index, listTyp, parent) ->
-          "ListIndex", [ DInt index; RT2DT.TypeReference.toDT listTyp; toDT parent ]
+            | ListIndex(index, listTyp, parent) ->
+              let! listType = RT2DT.TypeReference.toDT listTyp
+              let! parent = toDT parent
+              return "ListIndex", [ DInt index; listType; parent ]
 
-        | TupleIndex(index, elementType, parent) ->
-          "TupleIndex",
-          [ DInt index; RT2DT.TypeReference.toDT elementType; toDT parent ]
+            | TupleIndex(index, elementType, parent) ->
+              let! elType = RT2DT.TypeReference.toDT elementType
+              let! parent = toDT parent
+              return "TupleIndex", [ DInt index; elType; parent ]
 
-        | FnValResult(returnType, location) ->
-          "FnValResult",
-          [ RT2DT.TypeReference.toDT returnType; Location.toDT location ]
+            | FnValResult(returnType, location) ->
+              let! returnType = RT2DT.TypeReference.toDT returnType
+              return "FnValResult", [ returnType; Location.toDT location ]
+          }
 
-      let typeName = RuntimeError.name [ "TypeChecker" ] "Context" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+        let typeName = RuntimeError.name [ "TypeChecker" ] "Context" 0
+        return Dval.enum typeName typeName (Some []) caseName fields
+      }
 
 
-  let toRuntimeError (e : Error) : RuntimeError =
-    let caseName, fields =
-      match e with
-      | ValueNotExpectedType(actualValue, expectedType, context) ->
-        "ValueNotExpectedType",
-        [ actualValue |> RT2DT.Dval.toDT
-          expectedType |> RT2DT.TypeReference.toDT
-          Context.toDT context ]
+  let toRuntimeError (e : Error) : Ply<RuntimeError> =
+    uply {
+      let! (caseName, fields) =
+        uply {
+          match e with
+          | ValueNotExpectedType(actualValue, expectedType, context) ->
+            let! actualValue = actualValue |> RT2DT.Dval.toDT
+            let! expectedType = expectedType |> RT2DT.TypeReference.toDT
+            let! context = Context.toDT context
+            return "ValueNotExpectedType", [ actualValue; expectedType; context ]
 
-      | TypeDoesntExist(typeName, context) ->
-        "TypeDoesntExist", [ RT2DT.TypeName.toDT typeName; Context.toDT context ]
+          | TypeDoesntExist(typeName, context) ->
+            let! typeName = RT2DT.TypeName.toDT typeName
+            let! context = Context.toDT context
+            return "TypeDoesntExist", [ typeName; context ]
+        }
 
-    let typeName = RuntimeError.name [ "TypeChecker" ] "Error" 0
-    RuntimeError.typeCheckerError (
-      Dval.enum typeName typeName (Some []) caseName fields
-    )
+      let typeName = RuntimeError.name [ "TypeChecker" ] "Error" 0
+      return
+        RuntimeError.typeCheckerError (
+          Dval.enum typeName typeName (Some []) caseName fields
+        )
+    }
 
 let raiseValueNotExpectedType
   (source : DvalSource)
   (dv : Dval)
   (typ : TypeReference)
   (context : Context)
-  : 'a =
-  raiseRTE source (ValueNotExpectedType(dv, typ, context) |> Error.toRuntimeError)
+  : Ply<'a> =
+  ValueNotExpectedType(dv, typ, context)
+  |> Error.toRuntimeError
+  |> Ply.map (raiseRTE source)
 
 let raiseFnValResultNotExpectedType
   (source : DvalSource)
   (dv : Dval)
   (typ : TypeReference)
-  : 'a =
+  : Ply<'a> =
   let location =
     match source with
     | SourceNone -> None
     | SourceID(tlid, id) -> Some(tlid, id)
   let context = FnValResult(typ, location)
-  raiseRTE source (ValueNotExpectedType(dv, typ, context) |> Error.toRuntimeError)
+  ValueNotExpectedType(dv, typ, context)
+  |> Error.toRuntimeError
+  |> Ply.map (raiseRTE source)
 
 
 
@@ -311,10 +333,10 @@ let rec unify
       | TList expected, DList(actual, _dvs) ->
         match! valueTypeUnifies tst expected actual with
         | false ->
-          return
+          return!
             ValueNotExpectedType(value, TList expected, context)
             |> Error.toRuntimeError
-            |> Error
+            |> Ply.map Error
 
         | true -> return! Ply()
 
@@ -335,10 +357,10 @@ let rec unify
         let ts = t1 :: t2 :: tRest
         let vs = v1 :: v2 :: vRest
         if List.length ts <> List.length vs then
-          return
+          return!
             ValueNotExpectedType(value, expected, context)
             |> Error.toRuntimeError
-            |> Error
+            |> Ply.map Error
         else
           // let! results =
           //   List.zip ts vs
@@ -360,13 +382,15 @@ let rec unify
         | Ok typeName ->
           match! Types.find typeName types with
           | None ->
-            return
-              TypeDoesntExist(typeName, context) |> Error.toRuntimeError |> Error
+            return!
+              TypeDoesntExist(typeName, context)
+              |> Error.toRuntimeError
+              |> Ply.map Error
           | Some ut ->
             let err =
               ValueNotExpectedType(value, expected, context)
               |> Error.toRuntimeError
-              |> Error
+              |> Ply.map Error
 
             match ut, value with
             | { definition = TypeDeclaration.Alias aliasType }, _ ->
@@ -378,7 +402,7 @@ let rec unify
                 return! unify context types tst resolvedAliasType value
 
             | { definition = TypeDeclaration.Record _ },
-              DRecord(tn, _, _valueTypesTODO, dmap) ->
+              DRecord(tn, _, _valueTypesTODO, _fields) ->
               // TYPESCLEANUP: this search should no longer be required
               let! aliasedType =
                 getTypeReferenceFromAlias types (TCustomType(Ok tn, []))
@@ -386,32 +410,32 @@ let rec unify
               | Ok(TCustomType(Error rte, _)) -> return Error rte
               | Ok(TCustomType(Ok concreteTn, typeArgs)) ->
                 if concreteTn <> typeName then
-                  return
+                  return!
                     ValueNotExpectedType(value, expected, context)
                     |> Error.toRuntimeError
-                    |> Error
+                    |> Ply.map Error
                 else
                   // CLEANUP DRecord should include a TypeReference, in which case
                   // the type-checking here would just be a `tField = dField` check.
                   // (the construction of that DRecord should have already checked
                   // that the fields match)
                   return Ok()
-              | _ -> return err
+              | _ -> return! err
 
             | { definition = TypeDeclaration.Enum cases },
               DEnum(tn, _, _typeArgsDEnumTODO, caseName, valFields) ->
               // TODO: deal with aliased type?
               if tn <> typeName then
-                return
+                return!
                   ValueNotExpectedType(value, expected, context)
                   |> Error.toRuntimeError
-                  |> Error
+                  |> Ply.map Error
               else
                 let matchingCase : Option<TypeDeclaration.EnumCase> =
                   cases |> NEList.find (fun c -> c.name = caseName)
 
                 match matchingCase with
-                | None -> return err
+                | None -> return! err
                 | Some case ->
                   if List.length case.fields = List.length valFields then
                     // let! unified =
@@ -435,8 +459,8 @@ let rec unify
                     // that the fields match)
                     return Ok()
                   else
-                    return err
-            | _, _ -> return err
+                    return! err
+            | _, _ -> return! err
 
       // See https://github.com/darklang/dark/issues/4239#issuecomment-1175182695
       // TODO: exhaustiveness check
@@ -456,10 +480,10 @@ let rec unify
       | TChar, _
       | TDB _, _
       | TBytes, _ ->
-        return
+        return!
           ValueNotExpectedType(value, expected, context)
           |> Error.toRuntimeError
-          |> Error
+          |> Ply.map Error
   }
 
 

--- a/backend/src/LibHttpMiddleware/Http.fs
+++ b/backend/src/LibHttpMiddleware/Http.fs
@@ -22,7 +22,7 @@ module Request =
     (uri : string)
     (headers : List<string * string>)
     (body : byte array)
-    : RT.Dval =
+    : Ply<RT.Dval> =
     let headers =
       headers
       |> lowercaseHeaderKeys

--- a/backend/src/LibParser/Parser.fs
+++ b/backend/src/LibParser/Parser.fs
@@ -34,7 +34,7 @@ let parseRTExpr
   : Ply<LibExecution.RuntimeTypes.Expr> =
   code
   |> parsePTExpr resolver filename
-  |> Ply.map LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT
+  |> Ply.bind LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT
 
 type Packages =
   List<PT.PackageFn.T> * List<PT.PackageType.T> * List<PT.PackageConstant.T>

--- a/backend/src/LibParser/TestModule.fs
+++ b/backend/src/LibParser/TestModule.fs
@@ -270,11 +270,13 @@ let parseSingleTestFromFile
       |> singleExprFromImplFile
       |> parseTest
 
-    let! actual = wtTest.actual |> WT2PT.Expr.toPT resolver []
-    let! expected = wtTest.expected |> WT2PT.Expr.toPT resolver []
+    let! actual =
+      wtTest.actual |> WT2PT.Expr.toPT resolver [] |> Ply.bind PT2RT.Expr.toRT
+    let! expected =
+      wtTest.expected |> WT2PT.Expr.toPT resolver [] |> Ply.bind PT2RT.Expr.toRT
     return
-      { actual = actual |> PT2RT.Expr.toRT
-        expected = expected |> PT2RT.Expr.toRT
+      { actual = actual
+        expected = expected
         lineNumber = wtTest.lineNumber
         name = wtTest.name }
   }

--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -45,7 +45,12 @@ let fns : List<BuiltInFn> =
                   | DUnit -> return ()
                   | v ->
                     let context = TypeChecker.Context.FnValResult(TUnit, None)
-                    TypeChecker.raiseValueNotExpectedType SourceNone v TUnit context
+                    return!
+                      TypeChecker.raiseValueNotExpectedType
+                        SourceNone
+                        v
+                        TUnit
+                        context
                 })
             return DUnit
           }

--- a/backend/src/LocalExec/Libs/Packages.fs
+++ b/backend/src/LocalExec/Libs/Packages.fs
@@ -142,9 +142,9 @@ let fns : List<BuiltInFn> =
                  read.string "modules",
                  read.int "version"))
 
-            let fns =
+            let! fns =
               fns
-              |> List.map (fun (owner, fnname, modules, version) ->
+              |> Ply.List.mapSequentially (fun (owner, fnname, modules, version) ->
                 Dval.record
                   (FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Function" 0))
                   (Some [])
@@ -189,20 +189,21 @@ let fns : List<BuiltInFn> =
                  read.string "modules",
                  read.int "version"))
 
-            let types =
+            let! types =
               types
-              |> List.map (fun (owner, typename, modules, version) ->
-                Dval.record
-                  (FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Type" 0))
-                  (Some [])
-                  [ ("owner", DString owner)
-                    ("modules",
-                     modules
-                     |> String.split "."
-                     |> List.map DString
-                     |> Dval.list VT.unknownTODO)
-                    ("name", DString typename)
-                    ("version", DInt version) ])
+              |> Ply.List.mapSequentially
+                (fun (owner, typename, modules, version) ->
+                  Dval.record
+                    (FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Type" 0))
+                    (Some [])
+                    [ ("owner", DString owner)
+                      ("modules",
+                       modules
+                       |> String.split "."
+                       |> List.map DString
+                       |> Dval.list VT.unknownTODO)
+                      ("name", DString typename)
+                      ("version", DInt version) ])
 
             return Dval.list VT.unknownTODO types
           }
@@ -236,9 +237,9 @@ let fns : List<BuiltInFn> =
                  read.string "modules",
                  read.int "version"))
 
-            let consts =
+            let! consts =
               consts
-              |> List.map (fun (owner, fnname, modules, version) ->
+              |> Ply.List.mapSequentially (fun (owner, fnname, modules, version) ->
                 Dval.record
                   (FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Constant" 0))
                   (Some [])

--- a/backend/src/LocalExec/Libs/Packages2.fs
+++ b/backend/src/LocalExec/Libs/Packages2.fs
@@ -73,20 +73,22 @@ let fns : List<BuiltInFn> =
             let! (fns, types, constants) =
               LibParser.Parser.parsePackageFile resolver path contents
 
-            let packagesFns = fns |> List.map (fun fn -> PT2DT.PackageFn.toDT fn)
-            let packagesTypes = types |> List.map PT2DT.PackageType.toDT
-            let packagesConstants = constants |> List.map PT2DT.PackageConstant.toDT
+            let! packagesFns =
+              fns |> Ply.List.mapSequentially (fun fn -> PT2DT.PackageFn.toDT fn)
+            let! packagesTypes =
+              types |> Ply.List.mapSequentially PT2DT.PackageType.toDT
+            let! packagesConstants =
+              constants |> Ply.List.mapSequentially PT2DT.PackageConstant.toDT
 
-            return
-              Dval.resultOk
-                VT.unknownTODO
-                VT.string
-                (Dval.record
-                  (FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Package" 0))
-                  (Some [])
-                  [ ("fns", Dval.list VT.unknownTODO packagesFns)
-                    ("types", Dval.list VT.unknownTODO packagesTypes)
-                    ("constants", Dval.list VT.unknownTODO packagesConstants) ])
+            return!
+              Dval.record
+                (FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Package" 0))
+                (Some [])
+                [ ("fns", Dval.list VT.unknownTODO packagesFns)
+                  ("types", Dval.list VT.unknownTODO packagesTypes)
+                  ("constants", Dval.list VT.unknownTODO packagesConstants) ]
+              |> Ply.map (Dval.resultOk VT.unknownTODO VT.string)
+
           }
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable

--- a/backend/src/QueueWorker/QueueWorker.fs
+++ b/backend/src/QueueWorker/QueueWorker.fs
@@ -200,11 +200,12 @@ let processNotification
 
                   // CLEANUP Set a time limit of 3m
                   try
-                    let program = Canvas.toProgram c
+                    let! handler = PT2RT.Handler.toRT h
+                    let! program = Canvas.toProgram c
                     let! (result, traceResults) =
                       CloudExecution.executeHandler
                         LibClientTypesToCloudTypes.Pusher.eventSerializer
-                        (PT2RT.Handler.toRT h)
+                        handler
                         program
                         traceID
                         (Map [ "event", event.value ])

--- a/backend/tests/TestUtils/LibTest.fs
+++ b/backend/tests/TestUtils/LibTest.fs
@@ -60,7 +60,6 @@ let fns : List<BuiltInFn> =
         | _, _, [ DString error ] ->
           let typeName = RuntimeError.name [ "Error" ] "ErrorMessage" 0
           Dval.enum typeName typeName (Some []) "ErrorString" [ DString error ]
-          |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
@@ -92,7 +91,7 @@ let fns : List<BuiltInFn> =
         | _, _, [ DString errorString ] ->
           let msg = LibCloud.SqlCompiler.errorTemplate + errorString
           let typeName = RuntimeError.name [ "Error" ] "ErrorMessage" 0
-          Dval.enum typeName typeName (Some []) "ErrorString" [ DString msg ] |> Ply
+          Dval.enum typeName typeName (Some []) "ErrorString" [ DString msg ]
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -279,6 +279,10 @@ let testManyTask (name : string) (fn : 'a -> Task<'b>) (values : List<'a * 'b>) 
         })
       values)
 
+let testManyPly (name : string) (fn : 'a -> Ply<'b>) (values : List<'a * 'b>) =
+  testManyTask name (fn >> Ply.toTask) values
+
+
 let testMany2Task
   (name : string)
   (fn : 'a -> 'b -> Task<'c>)

--- a/backend/tests/Tests/Execution.Tests.fs
+++ b/backend/tests/Tests/Execution.Tests.fs
@@ -71,9 +71,10 @@ let testExecFunctionTLIDs : Test =
     let! meta = initializeTestCanvas "exec-function-tlids"
     let name = "testFunction"
     let ps = NEList.singleton "param"
-    let fn =
+    let! (fn : UserFunction.T) =
       testUserFn name [] ps (PT.TVariable "a") (PT.EInt(gid (), 5))
       |> PT2RT.UserFunction.toRT
+      |> Ply.toTask
     let fns = Map.ofList [ (fn.name, fn) ]
     let! state = executionStateFor meta false false Map.empty Map.empty fns Map.empty
 

--- a/backend/tests/Tests/Parser.Tests.fs
+++ b/backend/tests/Tests/Parser.Tests.fs
@@ -17,7 +17,8 @@ let parserTests =
       let! actual =
         LibParser.Parser.parseRTExpr nameResolver "parser.tests.fs" testStr
         |> Ply.toTask
-      return Expect.equalExprIgnoringIDs actual (PT2RT.Expr.toRT expectedExpr)
+      let! expectedExpr = PT2RT.Expr.toRT expectedExpr |> Ply.toTask
+      return Expect.equalExprIgnoringIDs actual expectedExpr
     }
   let id = 0UL // since we're ignoring IDs, just use the same one everywhere
   testList

--- a/backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/backend/tests/Tests/ProgramTypes.Tests.fs
@@ -52,7 +52,8 @@ let testPipesToRuntimeTypes =
 let testProgramTypesToRuntimeTypes =
   let u = PT.EUnit(8UL)
   let ru = RT.EUnit(8UL)
-  testMany
+
+  testManyPly
     "program types to runtime types"
     PT2RT.Expr.toRT
     [ PT.EFloat(7UL, Positive, "", "0"), RT.EFloat(7UL, 0.0)

--- a/backend/tests/Tests/Serialization.DarkTypes.Tests.fs
+++ b/backend/tests/Tests/Serialization.DarkTypes.Tests.fs
@@ -36,12 +36,12 @@ module RoundtripTests =
     (testName : string)
     (typeName : RT.TypeName.TypeName)
     (original : 'a)
-    (toDT : 'a -> RT.Dval)
+    (toDT : 'a -> Ply<RT.Dval>)
     (fromDT : RT.Dval -> 'a)
     (customExpect : Option<'a -> 'a -> string -> unit>)
     =
     testTask testName {
-      let firstDT = original |> toDT
+      let! firstDT = original |> toDT |> Ply.toTask
 
       let context =
         LibExecution.TypeChecker.Context.FunctionCallResult(
@@ -86,7 +86,7 @@ module RoundtripTests =
     (testName : string)
     (typeName : RT.TypeName.TypeName)
     (original : List<'a>)
-    (toDT : 'a -> RT.Dval)
+    (toDT : 'a -> Ply<RT.Dval>)
     (fromDT : RT.Dval -> 'a)
     (customExpect : Option<'a -> 'a -> string -> unit>)
     =

--- a/backend/tests/Tests/Serialization.TestValues.fs
+++ b/backend/tests/Tests/Serialization.TestValues.fs
@@ -252,7 +252,7 @@ module RuntimeTypes =
         { modules = []; name = RT.TypeName.TypeName "MyType"; version = 0 }
     sampleDvals
     |> List.map (fun (name, (dv, t)) -> name, dv)
-    |> Dval.record typeName (Some [])
+    |> fun fields -> RT.DRecord(typeName, typeName, [], Map fields)
 
 
 module ProgramTypes =


### PR DESCRIPTION
Bit annoying, but a necessary step towards full type-checking of Dvals upon construction.

Most changes here are in PT2DT and RT2DT.