### PR TITLE
backpedal a lot of Dval.record and .enum usage

### DIFF
--- a/backend/experiments/BwdDangerServer/Libs/Experiments.fs
+++ b/backend/experiments/BwdDangerServer/Libs/Experiments.fs
@@ -103,7 +103,7 @@ let fns : List<BuiltInFn> =
               let fns = List.map PT2RT.UserFunction.toRT canvas.fns
               let exprs = List.map PT2RT.Expr.toRT canvas.exprs
 
-              return!
+              return
                 [ "types", DString(Json.Vanilla.serialize types)
                   "fns", DString(Json.Vanilla.serialize fns)
                   "exprs", DString(Json.Vanilla.serialize exprs) ]
@@ -113,7 +113,7 @@ let fns : List<BuiltInFn> =
               let error = Exception.getMessages e |> String.concat " "
               let metadata = Exception.nestedMetadata e
               let metadataDval = metadata |> Map.ofList
-              return!
+              return
                 DString($"Error parsing code: {error} {metadataDval}") |> resultError
           }
         | _ -> incorrectArgs ()
@@ -139,9 +139,9 @@ let fns : List<BuiltInFn> =
                 RestrictedFileIO.readfileBytes
                   RestrictedFileIO.Config.BackendStatic
                   path
-              return! DBytes contents |> resultOk
+              return DBytes contents |> resultOk
             with e ->
-              return! DString($"Error reading file: {e.Message}") |> resultError
+              return DString($"Error reading file: {e.Message}") |> resultError
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -160,16 +160,14 @@ let fns : List<BuiltInFn> =
         let resultError = Dval.resultError VT.bytes VT.string
         (function
         | _, _, [ DString path ] ->
-          uply {
-            try
-              let contents =
-                RestrictedFileIO.readfileBytes
-                  RestrictedFileIO.Config.CanvasesFiles
-                  path
-              return! resultOk (DBytes contents)
-            with e ->
-              return! resultError (DString($"Error reading file: {e.Message}"))
-          }
+          try
+            let contents =
+              RestrictedFileIO.readfileBytes
+                RestrictedFileIO.Config.CanvasesFiles
+                path
+            resultOk (DBytes contents) |> Ply
+          with e ->
+            resultError (DString($"Error reading file: {e.Message}")) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/experiments/BwdDangerServer/Server.fs
+++ b/backend/experiments/BwdDangerServer/Server.fs
@@ -316,12 +316,11 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
           let! request = LibHttpMiddleware.Request.fromRequest url reqHeaders reqBody
           let inputVars = routeVars |> Map |> Map.add "request" request
 
-          let! handler = PT2RT.Handler.toRT handler
           let! canvas = Canvas.toProgram canvas
           let! (result, _) =
             CloudExe.executeHandler
               LibClientTypesToCloudTypes.Pusher.eventSerializer
-              handler
+              (PT2RT.Handler.toRT handler)
               canvas
               traceID
               inputVars

--- a/backend/src/BuiltinCli/Libs/Directory.fs
+++ b/backend/src/BuiltinCli/Libs/Directory.fs
@@ -42,18 +42,16 @@ let fns : List<BuiltInFn> =
       description =
         "Creates a new directory at the specified <param path>. If the directory already exists, no action is taken. Returns a Result type indicating success or failure."
       fn =
-        let resultOk = Dval.resultOk VT.unit VT.string
-        let resultError = Dval.resultError VT.unit VT.string
+        let resultOk r = Dval.resultOk VT.unit VT.string r |> Ply
+        let resultError r = Dval.resultError VT.unit VT.string r |> Ply
         (function
         | _, _, [ DString path ] ->
-          uply {
-            try
-              System.IO.Directory.CreateDirectory(path)
-              |> ignore<System.IO.DirectoryInfo>
-              return! resultOk DUnit
-            with e ->
-              return! resultError (DString e.Message)
-          }
+          try
+            System.IO.Directory.CreateDirectory(path)
+            |> ignore<System.IO.DirectoryInfo>
+            resultOk DUnit
+          with e ->
+            resultError (DString e.Message)
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
@@ -67,17 +65,15 @@ let fns : List<BuiltInFn> =
       description =
         "Deletes the directory at the specified <param path>. If <param recursive> is set to true, it will delete the directory and its contents. If set to false (default), it will only delete an empty directory. Returns a Result type indicating success or failure."
       fn =
-        let resultOk = Dval.resultOk VT.unit VT.string
-        let resultError = Dval.resultError VT.unit VT.string
+        let resultOk r = Dval.resultOk VT.unit VT.string r |> Ply
+        let resultError r = Dval.resultError VT.unit VT.string r |> Ply
         (function
         | _, _, [ DString path ] ->
-          uply {
-            try
-              System.IO.Directory.Delete(path, false)
-              return! resultOk DUnit
-            with e ->
-              return! resultError (DString e.Message)
-          }
+          try
+            System.IO.Directory.Delete(path, false)
+            resultOk DUnit
+          with e ->
+            resultError (DString e.Message)
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/BuiltinCli/Libs/Environment.fs
+++ b/backend/src/BuiltinCli/Libs/Environment.fs
@@ -30,9 +30,9 @@ let fns : List<BuiltInFn> =
           let envValue = System.Environment.GetEnvironmentVariable(varName)
 
           if isNull envValue then
-            Dval.optionNone VT.string
+            Dval.optionNone VT.string |> Ply
           else
-            Dval.optionSome VT.string (DString envValue)
+            Dval.optionSome VT.string (DString envValue) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/BuiltinCli/Libs/File.fs
+++ b/backend/src/BuiltinCli/Libs/File.fs
@@ -31,9 +31,9 @@ let fns : List<BuiltInFn> =
           uply {
             try
               let! contents = System.IO.File.ReadAllBytesAsync path
-              return! resultOk (DBytes contents)
+              return resultOk (DBytes contents)
             with e ->
-              return! resultError (DString($"Error reading file: {e.Message}"))
+              return resultError (DString($"Error reading file: {e.Message}"))
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -55,9 +55,9 @@ let fns : List<BuiltInFn> =
           uply {
             try
               do! System.IO.File.WriteAllBytesAsync(path, contents)
-              return! resultOk DUnit
+              return resultOk DUnit
             with e ->
-              return! resultError (DString($"Error writing file: {e.Message}"))
+              return resultError (DString($"Error writing file: {e.Message}"))
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -79,9 +79,9 @@ let fns : List<BuiltInFn> =
           uply {
             try
               do! System.IO.File.WriteAllBytesAsync(path, content)
-              return! resultOk DUnit
+              return resultOk DUnit
             with e ->
-              return! resultError (DString e.Message)
+              return resultError (DString e.Message)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -96,17 +96,15 @@ let fns : List<BuiltInFn> =
       description =
         "Creates a new temporary file with a unique name in the system's temporary directory. Returns a Result type containing the temporary file path or an error if the creation fails."
       fn =
-        let resultOk = Dval.resultOk VT.string VT.string
-        let resultError = Dval.resultError VT.string VT.string
+        let resultOk r = Dval.resultOk VT.string VT.string r |> Ply
+        let resultError r = Dval.resultError VT.string VT.string r |> Ply
         (function
         | _, _, [ DUnit ] ->
-          uply {
-            try
-              let tempPath = System.IO.Path.GetTempFileName()
-              return! resultOk (DString tempPath)
-            with e ->
-              return! resultError (DString e.Message)
-          }
+          try
+            let tempPath = System.IO.Path.GetTempFileName()
+            resultOk (DString tempPath)
+          with e ->
+            resultError (DString e.Message)
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
@@ -191,17 +189,15 @@ let fns : List<BuiltInFn> =
       description =
         "Returns the size of the file at the specified <param path> in bytes, or an error if the file does not exist or an error occurs"
       fn =
-        let resultOk = Dval.resultOk VT.int VT.string
-        let resultError = Dval.resultError VT.int VT.string
+        let resultOk r = Dval.resultOk VT.int VT.string r |> Ply
+        let resultError r = Dval.resultError VT.int VT.string r |> Ply
         (function
         | _, _, [ DString path ] ->
-          uply {
-            try
-              let fileInfo = System.IO.FileInfo(path)
-              return! resultOk (DInt fileInfo.Length)
-            with e ->
-              return! resultError (DString e.Message)
-          }
+          try
+            let fileInfo = System.IO.FileInfo(path)
+            resultOk (DInt fileInfo.Length)
+          with e ->
+            resultError (DString e.Message)
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -32,37 +32,31 @@ module CliRuntimeError =
   module RTE =
     module Error =
       let toDT (et : Error) : Ply<RT.Dval> =
-        uply {
-          let! caseName, fields =
-            uply {
-              match et with
-              | NoExpressionsToExecute -> return "NoExpressionsToExecute", []
+        let (caseName, fields) =
+          match et with
+          | NoExpressionsToExecute -> "NoExpressionsToExecute", []
 
-              | UncaughtException(msg, metadata) ->
-                let metadata =
-                  metadata
-                  |> List.map (fun (k, v) -> DTuple(DString k, DString v, []))
-                  |> Dval.list (
-                    ValueType.Known(
-                      KTTuple(ValueType.Known KTString, ValueType.Known KTString, [])
-                    )
-                  )
+          | UncaughtException(msg, metadata) ->
+            let metadata =
+              metadata
+              |> List.map (fun (k, v) -> DTuple(DString k, DString v, []))
+              |> Dval.list (
+                ValueType.Known(
+                  KTTuple(ValueType.Known KTString, ValueType.Known KTString, [])
+                )
+              )
 
-                return "UncaughtException", [ DString msg; metadata ]
+            "UncaughtException", [ DString msg; metadata ]
 
-              | MultipleExpressionsToExecute exprs ->
-                return
-                  "MultipleExpressionsToExecute",
-                  [ Dval.list VT.unknownTODO (List.map DString exprs) ]
+          | MultipleExpressionsToExecute exprs ->
+            "MultipleExpressionsToExecute",
+            [ Dval.list VT.unknownTODO (List.map DString exprs) ]
 
-              | NonIntReturned actuallyReturned ->
-                let! actuallyReturned = RT2DT.Dval.toDT actuallyReturned
-                return "NonIntReturned", [ actuallyReturned ]
-            }
+          | NonIntReturned actuallyReturned ->
+            "NonIntReturned", [ RT2DT.Dval.toDT actuallyReturned ]
 
-          let typeName = RT.RuntimeError.name [ "Cli" ] "Error" 0
-          return! Dval.enum typeName typeName (Some []) caseName fields
-        }
+        let typeName = RT.RuntimeError.name [ "Cli" ] "Error" 0
+        Dval.enum typeName typeName (Some []) caseName fields
 
 
     let toRuntimeError (e : Error) : Ply<RT.RuntimeError> =
@@ -90,32 +84,23 @@ let execute
   : Ply<Result<RT.Dval, DvalSource * RuntimeError>> =
 
   uply {
-    let! (program : Program) =
-      uply {
-        let! fns =
+    let (program : Program) =
+      { canvasID = System.Guid.NewGuid()
+        internalFnsAllowed = false
+        fns =
           mod'.fns
-          |> Ply.List.mapSequentially PT2RT.UserFunction.toRT
-          |> Ply.map (Map.fromListBy (fun fn -> fn.name))
-
-        let! types =
+          |> List.map PT2RT.UserFunction.toRT
+          |> Map.fromListBy (fun fn -> fn.name)
+        types =
           mod'.types
-          |> Ply.List.mapSequentially PT2RT.UserType.toRT
-          |> Ply.map (Map.fromListBy (fun typ -> typ.name))
-
-        let! constants =
+          |> List.map PT2RT.UserType.toRT
+          |> Map.fromListBy (fun typ -> typ.name)
+        constants =
           mod'.constants
-          |> Ply.List.mapSequentially PT2RT.UserConstant.toRT
-          |> Ply.map (Map.fromListBy (fun c -> c.name))
-
-        return
-          { canvasID = System.Guid.NewGuid()
-            internalFnsAllowed = false
-            fns = fns
-            types = types
-            constants = constants
-            dbs = Map.empty
-            secrets = [] }
-      }
+          |> List.map PT2RT.UserConstant.toRT
+          |> Map.fromListBy (fun c -> c.name)
+        dbs = Map.empty
+        secrets = [] }
 
     let tracing = Exe.noTracing RT.Real
     let notify = parentState.notify
@@ -131,7 +116,7 @@ let execute
         program
 
     if mod'.exprs.Length = 1 then
-      let! expr = PT2RT.Expr.toRT mod'.exprs[0]
+      let expr = PT2RT.Expr.toRT mod'.exprs[0]
       return! Exe.executeExpr state symtable expr
     else if mod'.exprs.Length = 0 then
       let! rte =
@@ -188,16 +173,16 @@ let fns : List<BuiltInFn> =
               match parsedScript with
               | Ok mod' ->
                 match! execute state mod' symtable with
-                | Ok(DInt i) -> return! resultOk (DInt i)
+                | Ok(DInt i) -> return resultOk (DInt i)
                 | Ok result ->
                   return!
                     CliRuntimeError.NonIntReturned result
                     |> CliRuntimeError.RTE.toRuntimeError
-                    |> Ply.bind (RuntimeError.toDT >> resultError)
-                | Error(_, e) -> return! e |> RuntimeError.toDT |> resultError
-              | Error e -> return! e |> RuntimeError.toDT |> resultError
+                    |> Ply.map (RuntimeError.toDT >> resultError)
+                | Error(_, e) -> return e |> RuntimeError.toDT |> resultError
+              | Error e -> return e |> RuntimeError.toDT |> resultError
             with e ->
-              return! exnError e |> Ply.bind (RuntimeError.toDT >> resultError)
+              return! exnError e |> Ply.map (RuntimeError.toDT >> resultError)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -223,13 +208,13 @@ let fns : List<BuiltInFn> =
         function
         | state, [], [ DString functionName; DList(_vtTODO, args) ] ->
           uply {
-            let err (msg : string) (metadata : List<string * string>) =
+            let err (msg : string) (metadata : List<string * string>) : Ply<Dval> =
               let metadata = metadata |> List.map (fun (k, v) -> k, DString v)
               Dval.record
                 (FQName.BuiltIn(typ [ "Cli" ] "ExecutionError" 0))
                 (Some [])
                 [ "msg", DString msg; "metadata", Dval.dict VT.unknownTODO metadata ]
-              |> Ply.bind resultError
+              |> Ply.map resultError
 
             let exnError (e : exn) : Ply<Dval> =
               let msg = Exception.getMessages e |> String.concat "\n"
@@ -308,7 +293,7 @@ let fns : List<BuiltInFn> =
                   | Error(_, e) ->
                     // TODO we should probably return the error here as-is, and handle by calling the
                     // toSegments on the error within the CLI
-                    return!
+                    return
                       e
                       |> RuntimeError.toDT
                       |> LibExecution.DvalReprDeveloper.toRepr
@@ -316,7 +301,7 @@ let fns : List<BuiltInFn> =
                       |> resultError
                   | Ok value ->
                     let asString = LibExecution.DvalReprDeveloper.toRepr value
-                    return! resultOk (DString asString)
+                    return resultOk (DString asString)
               | _ -> return incorrectArgs ()
             with e ->
               return! exnError e

--- a/backend/src/BuiltinCloudExecution/Libs/DB.fs
+++ b/backend/src/BuiltinCloudExecution/Libs/DB.fs
@@ -80,7 +80,7 @@ let fns : List<BuiltInFn> =
           uply {
             let db = state.program.dbs[dbname]
             let! result = UserDB.getOption state db key
-            return! Dval.option VT.unknownDbTODO result
+            return Dval.option VT.unknownDbTODO result
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -110,9 +110,9 @@ let fns : List<BuiltInFn> =
               |> UserDB.getMany state db
 
             if List.length items = List.length keys then
-              return! items |> Dval.list valueType |> Dval.optionSome optType
+              return items |> Dval.list valueType |> Dval.optionSome optType
             else
-              return! Dval.optionNone optType
+              return Dval.optionNone optType
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -368,8 +368,8 @@ let fns : List<BuiltInFn> =
               let! results = UserDB.query state db b
 
               match results with
-              | Ok [ (_, v) ] -> return! Dval.optionSome optType v
-              | Ok _ -> return! Dval.optionNone optType
+              | Ok [ (_, v) ] -> return Dval.optionSome optType v
+              | Ok _ -> return Dval.optionNone optType
               | Error rte -> return raiseUntargetedRTE rte
             with e ->
               return handleUnexpectedExceptionDuringQuery state dbname b e
@@ -397,8 +397,8 @@ let fns : List<BuiltInFn> =
 
               match results with
               | Ok [ (key, dv) ] ->
-                return! Dval.optionSome optType (DTuple(DString key, dv, []))
-              | Ok _ -> return! Dval.optionNone optType
+                return Dval.optionSome optType (DTuple(DString key, dv, []))
+              | Ok _ -> return Dval.optionNone optType
               | Error rte -> return raiseUntargetedRTE rte
             with e ->
               return handleUnexpectedExceptionDuringQuery state dbname b e

--- a/backend/src/BuiltinDarkInternal/Libs/Canvases.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Canvases.fs
@@ -175,19 +175,19 @@ let fns : List<BuiltInFn> =
           uply {
             let! canvas = Canvas.loadAll canvasID
 
-            let! types =
+            let types =
               canvas.userTypes
               |> Map.values
               |> Seq.toList
-              |> Ply.List.mapSequentially PT2DT.UserType.toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
+              |> List.map PT2DT.UserType.toDT
+              |> Dval.list VT.unknownTODO
 
-            let! fns =
+            let fns =
               canvas.userFunctions
               |> Map.values
               |> Seq.toList
-              |> Ply.List.mapSequentially PT2DT.UserFunction.toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
+              |> List.map PT2DT.UserFunction.toDT
+              |> Dval.list VT.unknownTODO
 
             // let dbs =
             //   Map.values canvas.dbs
@@ -218,7 +218,7 @@ let fns : List<BuiltInFn> =
                 (FQName.BuiltIn(typ "Program" 0))
                 (Some [])
                 [ "types", types; "fns", fns ]
-              |> Ply.bind (Dval.resultOk VT.unknownTODO VT.string)
+              |> Ply.map (Dval.resultOk VT.unknownTODO VT.string)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinDarkInternal/Libs/Domains.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Domains.fs
@@ -52,8 +52,8 @@ let fns : List<BuiltInFn> =
           uply {
             let! name = Canvas.canvasIDForDomain domain
             match name with
-            | Some name -> return! resultOk (DUuid name)
-            | None -> return! resultError (DString "Canvas not found")
+            | Some name -> return resultOk (DUuid name)
+            | None -> return resultError (DString "Canvas not found")
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinDarkInternal/Libs/Secrets.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Secrets.fs
@@ -100,9 +100,9 @@ let fns : List<BuiltInFn> =
           uply {
             try
               do! Secret.insert canvasID name value (int version)
-              return! resultOk DUnit
+              return resultOk DUnit
             with _ ->
-              return! resultError (DString "Error inserting secret")
+              return resultError (DString "Error inserting secret")
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinExecution/Libs/Base64.fs
+++ b/backend/src/BuiltinExecution/Libs/Base64.fs
@@ -29,8 +29,8 @@ let fns : List<BuiltInFn> =
          sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
          [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
-        let resultOk = Dval.resultOk VT.bytes VT.string
-        let resultError = Dval.resultError VT.bytes VT.string
+        let resultOk r = Dval.resultOk VT.bytes VT.string r |> Ply
+        let resultError r = Dval.resultError VT.bytes VT.string r |> Ply
         (function
         | _, _, [ DString s ] ->
           let base64FromUrlEncoded (str : string) : string =

--- a/backend/src/BuiltinExecution/Libs/Char.fs
+++ b/backend/src/BuiltinExecution/Libs/Char.fs
@@ -59,9 +59,9 @@ let fns : List<BuiltInFn> =
         | _, _, [ DChar c ] ->
           let charValue = int c.[0]
           if charValue >= 0 && charValue < 256 then
-            Dval.optionSome VT.int (DInt charValue)
+            Dval.optionSome VT.int (DInt charValue) |> Ply
           else
-            Dval.optionNone VT.int
+            Dval.optionNone VT.int |> Ply
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/DateTime.fs
+++ b/backend/src/BuiltinExecution/Libs/DateTime.fs
@@ -46,6 +46,7 @@ let fns : List<BuiltInFn> =
           |> Result.map DDateTime
           |> Result.mapError (fun () -> DString "Invalid date format")
           |> Dval.result VT.dateTime VT.string
+          |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -162,8 +162,8 @@ let fns : List<BuiltInFn> =
 
           match result with
           | Some map ->
-            map |> Map.toList |> Dval.dict dictType |> Dval.optionSome optType
-          | None -> Dval.optionNone optType
+            map |> Map.toList |> Dval.dict dictType |> Dval.optionSome optType |> Ply
+          | None -> Dval.optionNone optType |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -180,7 +180,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, _, [ DDict(_vtTODO, o); DString s ] ->
-          Map.find s o |> Dval.option VT.unknownTODO
+          Map.find s o |> Dval.option VT.unknownTODO |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Float.fs
+++ b/backend/src/BuiltinExecution/Libs/Float.fs
@@ -273,16 +273,16 @@ let fns : List<BuiltInFn> =
       description =
         "Returns the <type Float> value wrapped in a {{Result}} of the <type String>"
       fn =
-        let resultOk = Dval.resultOk VT.float VT.string
-        let resultError = Dval.resultError VT.float VT.string
+        let resultOk r = Dval.resultOk VT.float VT.string r |> Ply
+        let resultError r = Dval.resultError VT.float VT.string r |> Ply
         (function
         | _, _, [ DString s ] ->
-          (try
+          try
             float (s) |> DFloat |> resultOk
-           with e ->
-             "Expected a String representation of an IEEE float"
-             |> DString
-             |> resultError)
+          with e ->
+            "Expected a String representation of an IEEE float"
+            |> DString
+            |> resultError
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/HttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/HttpClient.fs
@@ -430,26 +430,26 @@ let fns (config : Configuration) : List<BuiltInFn> =
                     ("headers", responseHeaders)
                     ("body", DBytes response.body) ]
                   |> Dval.record typ (Some [])
-                  |> Ply.bind resultOk
+                  |> Ply.map resultOk
 
               // TODO: include a DvalSource rather than SourceNone
-              | Error(BadUrl details) -> return! resultErrorStr $"Bad URL: {details}"
-              | Error(Timeout) -> return! resultErrorStr $"Request timed out"
-              | Error(NetworkError) -> return! resultErrorStr $"Network error"
-              | Error(Other details) -> return! resultErrorStr details
+              | Error(BadUrl details) -> return resultErrorStr $"Bad URL: {details}"
+              | Error(Timeout) -> return resultErrorStr $"Request timed out"
+              | Error(NetworkError) -> return resultErrorStr $"Network error"
+              | Error(Other details) -> return resultErrorStr details
             }
 
           | Error reqHeadersErr, _ ->
             uply {
               match reqHeadersErr with
-              | BadInput details -> return! resultErrorStr details
+              | BadInput details -> return resultErrorStr details
               | TypeMismatch details ->
                 return raiseUntargetedRTE (RuntimeError.oldError details)
             }
 
           | _, None ->
             let error = "Expected valid HTTP method (e.g. 'get' or 'POST')"
-            uply { return! resultErrorStr error }
+            uply { return resultErrorStr error }
 
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -103,8 +103,8 @@ let fns : List<BuiltInFn> =
 
          Returns an {{Error}} if <param divisor> is {{0}}."
       fn =
-        let resultOk = Dval.resultOk VT.int VT.string
-        let resultError = Dval.resultError VT.int VT.string
+        let resultOk r = Dval.resultOk VT.int VT.string r |> Ply
+        let resultError r = Dval.resultError VT.int VT.string r |> Ply
         (function
         | _, _, [ DInt v; DInt d ] ->
           (try
@@ -178,8 +178,8 @@ let fns : List<BuiltInFn> =
         let resultError = Dval.resultError VT.int VT.string
         (function
         | _, _, [ DInt number; DInt exp as expdv ] ->
-          let okPipe r = r |> DInt |> resultOk
-          let errPipe e = e |> DString |> resultError
+          let okPipe r = r |> DInt |> resultOk |> Ply
+          let errPipe e = e |> DString |> resultError |> Ply
           (try
             if exp < 0L then argumentWasntPositive "exponent" expdv |> errPipe
             // TODO: do this in a package, and keep it simple here
@@ -346,12 +346,13 @@ let fns : List<BuiltInFn> =
         let resultError = Dval.resultError VT.int VT.string
         (function
         | _, _, [ DString s ] ->
-          (try
-            s |> System.Convert.ToInt64 |> DInt |> resultOk
-           with _e ->
-             $"Expected to parse String with only numbers, instead got \"{s}\""
-             |> DString
-             |> resultError)
+          try
+            s |> System.Convert.ToInt64 |> DInt |> resultOk |> Ply
+          with _e ->
+            $"Expected to parse String with only numbers, instead got \"{s}\""
+            |> DString
+            |> resultError
+            |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -598,7 +598,7 @@ let fns : List<BuiltInFn> =
             let types = ExecutionState.availableTypes state
             let! response =
               writeJson (fun w -> serialize types w typeToSerializeAs arg)
-            return! Dval.resultOk VT.string VT.string (DString response)
+            return Dval.resultOk VT.string VT.string (DString response)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -620,8 +620,8 @@ let fns : List<BuiltInFn> =
           let types = ExecutionState.availableTypes state
           uply {
             match! parse types typeArg arg with
-            | Ok v -> return! resultOk v
-            | Error e -> return! resultError (DString e)
+            | Ok v -> return resultOk v
+            | Error e -> return resultError (DString e)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinExecution/Libs/List.fs
+++ b/backend/src/BuiltinExecution/Libs/List.fs
@@ -405,11 +405,11 @@ let fns : List<BuiltInFn> =
             try
               let array = List.toArray list
               do! Sort.sort fn array
-              return! array |> Array.toList |> Dval.list vt |> resultOk
+              return array |> Array.toList |> Dval.list vt |> resultOk
             with Sort.InvalidSortComparatorInt i ->
               let message =
                 $"Expected comparator function to return -1, 0, or 1, but it returned {i}"
-              return! resultError (DString message)
+              return resultError (DString message)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -650,7 +650,7 @@ let fns : List<BuiltInFn> =
         | state, _, [ DList(_vtTODO1, l1); DList(_vtTODO2, l2); DFnVal b ] ->
           uply {
             if List.length l1 <> List.length l2 then
-              return! Dval.optionNone optType
+              return Dval.optionNone optType
             else
               let list = List.zip l1 l2
 
@@ -661,7 +661,7 @@ let fns : List<BuiltInFn> =
                     Interpreter.applyFnVal state 0UL b [] args)
                   list
 
-              return! Dval.optionSome optType (Dval.list VT.unknownTODO result)
+              return Dval.optionSome optType (Dval.list VT.unknownTODO result)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -680,14 +680,14 @@ let fns : List<BuiltInFn> =
       fn =
         let optType = VT.unknownTODO
         (function
-        | _, _, [ DList(_, []) ] -> Dval.optionNone optType
+        | _, _, [ DList(_, []) ] -> Dval.optionNone optType |> Ply
         | _, _, [ DList(_, l) ] ->
           // Will return <= (length - 1)
           // Maximum value is Int64.MaxValue which is half of UInt64.MaxValue, but
           // that won't affect this as we won't have a list that big for a long long
           // long time.
           let index = RNG.GetInt32(l.Length)
-          (List.tryItem index l) |> Dval.option optType
+          (List.tryItem index l) |> Dval.option optType |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure

--- a/backend/src/BuiltinExecution/Libs/Math.fs
+++ b/backend/src/BuiltinExecution/Libs/Math.fs
@@ -98,9 +98,9 @@ let fns : List<BuiltInFn> =
           let res = System.Math.Acos r in
 
           if System.Double.IsNaN res then
-            Dval.optionNone VT.float
+            Dval.optionNone VT.float |> Ply
           else
-            Dval.optionSome VT.float (DFloat res)
+            Dval.optionSome VT.float (DFloat res) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -125,9 +125,9 @@ let fns : List<BuiltInFn> =
           let res = System.Math.Asin r in
 
           if System.Double.IsNaN res then
-            Dval.optionNone VT.float
+            Dval.optionNone VT.float |> Ply
           else
-            Dval.optionSome VT.float (DFloat res)
+            Dval.optionSome VT.float (DFloat res) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -416,9 +416,9 @@ let fns : List<BuiltInFn> =
         | _, _, [ DBytes bytes ] ->
           try
             let str = System.Text.UTF8Encoding(false, true).GetString bytes
-            Dval.optionSome VT.string (DString str)
+            Dval.optionSome VT.string (DString str) |> Ply
           with e ->
-            Dval.optionNone VT.string
+            Dval.optionNone VT.string |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -457,10 +457,10 @@ let fns : List<BuiltInFn> =
         (function
         | _, _, [ DString str ] ->
           if str = "" then
-            Dval.optionNone VT.char
+            Dval.optionNone VT.char |> Ply
           else
             let head = String.toEgcSeq str |> Seq.head
-            Dval.optionSome VT.char (DChar head)
+            Dval.optionSome VT.char (DChar head) |> Ply
         | _ -> incorrectArgs ())
 
       sqlSpec = NotYetImplemented

--- a/backend/src/BuiltinExecution/Libs/Uuid.fs
+++ b/backend/src/BuiltinExecution/Libs/Uuid.fs
@@ -44,11 +44,12 @@ let fns : List<BuiltInFn> =
         (function
         | _, _, [ DString s ] ->
           match System.Guid.TryParse s with
-          | true, x -> x |> DUuid |> resultOk
+          | true, x -> x |> DUuid |> resultOk |> Ply
           | _ ->
             "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
             |> DString
             |> resultError
+            |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/X509.fs
+++ b/backend/src/BuiltinExecution/Libs/X509.fs
@@ -46,13 +46,13 @@ let fns : List<BuiltInFn> =
             let label = System.ReadOnlySpan<char>("PUBLIC KEY".ToCharArray())
             let chars = PemEncoding.Write(label, data)
             let str = new System.String(chars) + "\n"
-            str |> DString |> resultOk
+            str |> DString |> resultOk |> Ply
           with e ->
             // If it doesn't find BEGIN CERTIFICATE that, it errors with No
             // certificates. If it does find that, it tries to parse it, returning
             // X509: failed to parse certificate if it fails (either data is bullshit
             // or it's not an RSA cert).
-            resultError (DString "No certificates")
+            resultError (DString "No certificates") |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/BwdServer/Server.fs
+++ b/backend/src/BwdServer/Server.fs
@@ -322,12 +322,11 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
           let! request = LibHttpMiddleware.Request.fromRequest url reqHeaders reqBody
           let inputVars = routeVars |> Map |> Map.add "request" request
 
-          let! handler = PT2RT.Handler.toRT handler
           let! canvas = Canvas.toProgram canvas
           let! (result, _) =
             CloudExe.executeHandler
               LibClientTypesToCloudTypes.Pusher.eventSerializer
-              handler
+              (PT2RT.Handler.toRT handler)
               canvas
               traceID
               inputVars

--- a/backend/src/LibCliExecution/PackageManager.fs
+++ b/backend/src/LibCliExecution/PackageManager.fs
@@ -680,7 +680,7 @@ let packageManager : RT.PackageManager =
     (modules : List<string>)
     (name : string)
     (version : int)
-    (f : 'serverType -> Ply<'cachedType>)
+    (f : 'serverType -> 'cachedType)
     : Ply<Option<'cachedType>> =
     uply {
       let modules = modules |> String.concat "."
@@ -693,7 +693,7 @@ let packageManager : RT.PackageManager =
       try
         if response.StatusCode = System.Net.HttpStatusCode.OK then
           let deserialized = responseStr |> Json.Vanilla.deserialize<'serverType>
-          let! cached = f deserialized
+          let cached = f deserialized
           return Some cached
         else if response.StatusCode = System.Net.HttpStatusCode.NotFound then
           return None
@@ -713,13 +713,13 @@ let packageManager : RT.PackageManager =
 
   { getType =
       withCache (fun ({ name = RT.TypeName.TypeName typeName } as name) ->
-        let conversionFn (parsed : EPT.PackageType) : Ply<RT.PackageType.T> =
+        let conversionFn (parsed : EPT.PackageType) : RT.PackageType.T =
           parsed |> ET2PT.PackageType.toPT |> PT2RT.PackageType.toRT
         fetch "type" name.owner name.modules typeName name.version conversionFn)
 
     getFn =
       withCache (fun ({ name = RT.FnName.FnName fnName } as name) ->
-        let conversionFn (parsed : EPT.PackageFn.PackageFn) : Ply<RT.PackageFn.T> =
+        let conversionFn (parsed : EPT.PackageFn.PackageFn) : RT.PackageFn.T =
           parsed |> ET2PT.PackageFn.toPT |> PT2RT.PackageFn.toRT
         fetch "function" name.owner name.modules fnName name.version conversionFn)
 
@@ -729,9 +729,7 @@ let packageManager : RT.PackageManager =
 
     getConstant =
       withCache (fun ({ name = RT.ConstantName.ConstantName constName } as name) ->
-        let conversionFn
-          (parsed : EPT.PackageConstant)
-          : Ply<RT.PackageConstant.T> =
+        let conversionFn (parsed : EPT.PackageConstant) : RT.PackageConstant.T =
           parsed |> ET2PT.PackageConstant.toPT |> PT2RT.PackageConstant.toRT
         fetch "constant" name.owner name.modules constName name.version conversionFn)
 

--- a/backend/src/LibCloud/Canvas.fs
+++ b/backend/src/LibCloud/Canvas.fs
@@ -540,45 +540,32 @@ let healthCheck : LibService.Kubernetes.HealthCheck =
 
 let toProgram (c : T) : Ply<RT.Program> =
   uply {
-    let! dbs =
+    let dbs =
       c.dbs
       |> Map.values
-      |> Ply.List.mapSequentially (fun db ->
-        uply {
-          let! dbRT = PT2RT.DB.toRT db
-          return (db.name, dbRT)
-        })
-      |> Ply.map Map.ofList
+      |> List.map (fun db -> (db.name, PT2RT.DB.toRT db))
+      |> Map.ofList
 
-    let! userFns =
+    let userFns =
       c.userFunctions
       |> Map.values
-      |> Ply.List.mapSequentially (fun f ->
-        uply {
-          let! fn = PT2RT.UserFunction.toRT f
-          return (PT2RT.FnName.UserProgram.toRT f.name, fn)
-        })
-      |> Ply.map Map.ofList
+      |> List.map (fun f ->
+        (PT2RT.FnName.UserProgram.toRT f.name, PT2RT.UserFunction.toRT f))
+      |> Map.ofList
 
-    let! userTypes =
+    let userTypes =
       c.userTypes
       |> Map.values
-      |> Ply.List.mapSequentially (fun t ->
-        uply {
-          let! typ = PT2RT.UserType.toRT t
-          return (PT2RT.TypeName.UserProgram.toRT t.name, typ)
-        })
-      |> Ply.map Map.ofList
+      |> List.map (fun t ->
+        (PT2RT.TypeName.UserProgram.toRT t.name, PT2RT.UserType.toRT t))
+      |> Map.ofList
 
-    let! userConstants =
+    let userConstants =
       c.userConstants
       |> Map.values
-      |> Ply.List.mapSequentially (fun c ->
-        uply {
-          let! constant = PT2RT.UserConstant.toRT c
-          return (PT2RT.ConstantName.UserProgram.toRT c.name, constant)
-        })
-      |> Ply.map Map.ofList
+      |> List.map (fun c ->
+        (PT2RT.ConstantName.UserProgram.toRT c.name, PT2RT.UserConstant.toRT c))
+      |> Map.ofList
 
     let secrets = c.secrets |> Map.values |> List.map PT2RT.Secret.toRT
 

--- a/backend/src/LibCloud/PackageManager.fs
+++ b/backend/src/LibCloud/PackageManager.fs
@@ -187,28 +187,28 @@ let packageManager : RT.PackageManager =
       fun name ->
         uply {
           let! typ = name |> PT2RT.TypeName.Package.fromRT |> getType
-          return! Ply.Option.map PT2RT.PackageType.toRT typ
+          return Option.map PT2RT.PackageType.toRT typ
         }
 
     getFn =
       fun name ->
         uply {
           let! typ = name |> PT2RT.FnName.Package.fromRT |> getFn
-          return! Ply.Option.map PT2RT.PackageFn.toRT typ
+          return Option.map PT2RT.PackageFn.toRT typ
         }
 
     getFnByTLID =
       fun tlid ->
         uply {
           let! typ = tlid |> getFnByTLID
-          return! Ply.Option.map PT2RT.PackageFn.toRT typ
+          return Option.map PT2RT.PackageFn.toRT typ
         }
 
     getConstant =
       fun name ->
         uply {
           let! typ = name |> PT2RT.ConstantName.Package.fromRT |> getConstant
-          return! Ply.Option.map PT2RT.PackageConstant.toRT typ
+          return Option.map PT2RT.PackageConstant.toRT typ
         }
 
     init = uply { return () } }

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -49,26 +49,23 @@ module ExecutionError =
         Dval.enum typeName typeName (Some []) caseName fields
         |> Ply.map RuntimeError.executionError
 
-      let! (caseName, fields) =
-        uply {
-          match e with
-          | MatchExprEnumPatternWrongCount(caseName, expected, actual) ->
-            return
-              "MatchExprEnumPatternWrongCount",
-              [ DString caseName; DInt expected; DInt actual ]
-          | MatchExprPatternWrongType(expected, actual) ->
-            let! actual = RT2DT.Dval.toDT actual
-            return "MatchExprPatternWrongType", [ DString expected; actual ]
-          | MatchExprUnmatched dv ->
-            let! dv = RT2DT.Dval.toDT dv
-            return "MatchExprUnmatched", [ dv ]
-          | NonStringInStringInterpolation dv ->
-            let! dv = RT2DT.Dval.toDT dv
-            return "NonStringInStringInterpolation", [ dv ]
-          | ConstDoesntExist name ->
-            let! name = RT2DT.ConstantName.toDT name
-            return "ConstDoesntExist", [ name ]
-        }
+      let (caseName, fields) =
+        match e with
+        | MatchExprEnumPatternWrongCount(caseName, expected, actual) ->
+
+          "MatchExprEnumPatternWrongCount",
+          [ DString caseName; DInt expected; DInt actual ]
+        | MatchExprPatternWrongType(expected, actual) ->
+
+          "MatchExprPatternWrongType", [ DString expected; RT2DT.Dval.toDT actual ]
+        | MatchExprUnmatched dv ->
+
+          "MatchExprUnmatched", [ RT2DT.Dval.toDT dv ]
+        | NonStringInStringInterpolation dv ->
+
+          "NonStringInStringInterpolation", [ RT2DT.Dval.toDT dv ]
+        | ConstDoesntExist name ->
+          "ConstDoesntExist", [ RT2DT.ConstantName.toDT name ]
 
       return! case caseName fields
     }
@@ -122,7 +119,7 @@ let rec eval
       { errorType = errorType
         nameType = NameResolutionError.Type
         names = [ TypeName.toString typeName ] }
-    error |> NameResolutionError.RTE.toRuntimeError |> Ply.map (raiseRTE SourceNone)
+    error |> NameResolutionError.RTE.toRuntimeError |> raiseRTE SourceNone
 
   let recordMaybe
     (types : Types)

--- a/backend/src/LibExecution/NameResolutionError.fs
+++ b/backend/src/LibExecution/NameResolutionError.fs
@@ -28,8 +28,8 @@ type Error =
 /// to RuntimeError
 module RTE =
   module ErrorType =
-    let toDT (et : ErrorType) : Ply<RT.Dval> =
-      let caseName, fields =
+    let toDT (et : ErrorType) : RT.Dval =
+      let (caseName, fields) =
         match et with
         | NotFound -> "NotFound", []
         | ExpectedEnumButNot -> "ExpectedEnumButNot", []
@@ -39,7 +39,7 @@ module RTE =
         | InvalidPackageName -> "InvalidPackageName", []
 
       let typeName = RT.RuntimeError.name [ "NameResolution" ] "ErrorType" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+      RT.DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (dv : RT.Dval) : ErrorType =
       match dv with
@@ -52,15 +52,15 @@ module RTE =
       | _ -> Exception.raiseInternal "Invalid ErrorType" []
 
   module NameType =
-    let toDT (nt : NameType) : Ply<RT.Dval> =
-      let caseName, fields =
+    let toDT (nt : NameType) : RT.Dval =
+      let (caseName, fields) =
         match nt with
         | Function -> "Function", []
         | Type -> "Type", []
         | Constant -> "Constant", []
 
       let typeName = RT.RuntimeError.name [ "NameResolution" ] "NameType" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+      RT.DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (dv : RT.Dval) : NameType =
       match dv with
@@ -70,21 +70,16 @@ module RTE =
       | _ -> Exception.raiseInternal "Invalid NameType" []
 
   module Error =
-    let toDT (e : Error) : Ply<RT.Dval> =
-      uply {
-        let! errorType = ErrorType.toDT e.errorType
-        let! nameType = NameType.toDT e.nameType
-        return!
-          Dval.record
-            (RT.RuntimeError.name [ "NameResolution" ] "Error" 0)
-            (Some [])
-            [ "errorType", errorType
-              "nameType", nameType
-              "names",
-              (e.names
-               |> List.map RT.DString
-               |> Dval.list (RT.ValueType.Known RT.KTString)) ]
-      }
+    let toDT (e : Error) : RT.Dval =
+      let typeName = RT.RuntimeError.name [ "NameResolution" ] "Error" 0
+      let fields =
+        [ "errorType", ErrorType.toDT e.errorType
+          "nameType", NameType.toDT e.nameType
+          "names",
+          (e.names
+           |> List.map RT.DString
+           |> Dval.list (RT.ValueType.Known RT.KTString)) ]
+      RT.DRecord(typeName, typeName, [], Map fields)
 
     let fromDT (dv : RT.Dval) : Error =
       match dv with
@@ -97,8 +92,8 @@ module RTE =
 
       | _ -> Exception.raiseInternal "Expected DRecord" []
 
-  let toRuntimeError (e : Error) : Ply<RT.RuntimeError> =
-    Error.toDT e |> Ply.map RT.RuntimeError.nameResolutionError
+  let toRuntimeError (e : Error) : RT.RuntimeError =
+    Error.toDT e |> RT.RuntimeError.nameResolutionError
 
   let fromRuntimeError (re : RT.RuntimeError) : Error =
     // TODO: this probably doesn't unwrap the type

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -32,7 +32,6 @@ let errorsTyp
 
 
 
-
 module FQName =
   let ownerField m = m |> D.stringField "owner"
   let modulesField m = m |> D.stringListField "modules"
@@ -43,118 +42,85 @@ module FQName =
   module BuiltIn =
     let toDT
       (nameValueType : ValueType)
-      (nameMapper : 'name -> Ply<Dval>)
+      (nameMapper : 'name -> Dval)
       (u : FQName.BuiltIn<'name>)
-      : Ply<Dval> =
-      uply {
-        let! name = nameMapper u.name
-        return!
-          Dval.record
-            (rtTyp [ "FQName" ] "BuiltIn" 0)
-            (Some [ nameValueType ])
-            [ "modules", Dval.list VT.unknownTODO (List.map DString u.modules)
-              "name", name
-              "version", DInt u.version ]
-      }
+      : Dval =
+      let fields =
+        [ "modules", Dval.list VT.unknownTODO (List.map DString u.modules)
+          "name", nameMapper u.name
+          "version", DInt u.version ]
+      let typeName = rtTyp [ "FQName" ] "BuiltIn" 0
+      DRecord(typeName, typeName, [ nameValueType ], Map fields)
 
     let fromDT (nameMapper : Dval -> 'name) (d : Dval) : FQName.BuiltIn<'name> =
       match d with
-      | DRecord(_, _, _, m) ->
-        let modules = modulesField m
-        let name = nameField m |> nameMapper
-        let version = versionField m
-
-        { modules = modules; name = name; version = version }
-
+      | DRecord(_, _, _, fields) ->
+        { modules = modulesField fields
+          name = nameField fields |> nameMapper
+          version = versionField fields }
       | _ -> Exception.raiseInternal "Unexpected value" []
 
   module UserProgram =
     let toDT
       (nameValueType : ValueType)
-      (nameMapper : 'name -> Ply<Dval>)
+      (nameMapper : 'name -> Dval)
       (u : FQName.UserProgram<'name>)
-      : Ply<Dval> =
-      uply {
-        let! name = nameMapper u.name
-        return!
-          Dval.record
-            (rtTyp [ "FQName" ] "UserProgram" 0)
-            (Some [ nameValueType ])
-            [ "modules", Dval.list VT.unknownTODO (List.map DString u.modules)
-              "name", name
-              "version", DInt u.version ]
-      }
+      : Dval =
+      let fields =
+        [ "modules", Dval.list VT.unknownTODO (List.map DString u.modules)
+          "name", nameMapper u.name
+          "version", DInt u.version ]
+      let typeName = rtTyp [ "FQName" ] "UserProgram" 0
+      DRecord(typeName, typeName, [ nameValueType ], Map fields)
 
     let fromDT (nameMapper : Dval -> 'name) (v : Dval) : FQName.UserProgram<'name> =
       match v with
-      | DRecord(_, _, _, m) ->
-        let modules = modulesField m
-        let name = nameField m |> nameMapper
-        let version = versionField m
-
-        { modules = modules; name = name; version = version }
-
+      | DRecord(_, _, _, fields) ->
+        { modules = modulesField fields
+          name = nameField fields |> nameMapper
+          version = versionField fields }
       | _ -> Exception.raiseInternal "Unexpected value" []
 
   module Package =
     let toDT
       (nameValueType : ValueType)
-      (nameMapper : 'name -> Ply<Dval>)
+      (nameMapper : 'name -> Dval)
       (u : FQName.Package<'name>)
-      : Ply<Dval> =
-      uply {
-        let! name = nameMapper u.name
-        return!
-          Dval.record
-            (rtTyp [ "FQName" ] "Package" 0)
-            (Some [ nameValueType ])
-            [ "owner", DString u.owner
-              "modules", Dval.list VT.unknownTODO (List.map DString u.modules)
-              "name", name
-              "version", DInt u.version ]
-      }
+      : Dval =
+      let fields =
+        [ "owner", DString u.owner
+          "modules", Dval.list VT.unknownTODO (List.map DString u.modules)
+          "name", nameMapper u.name
+          "version", DInt u.version ]
+      let typeName = rtTyp [ "FQName" ] "Package" 0
+      DRecord(typeName, typeName, [ nameValueType ], Map fields)
 
     let fromDT (nameMapper : Dval -> 'name) (d : Dval) : FQName.Package<'name> =
       match d with
-      | DRecord(_, _, _, m) ->
-        let owner = ownerField m
-        let modules =
-          modulesField m
-          |> NEList.ofListUnsafe "Expected modules to be a non-empty list" []
-        let name = nameField m |> nameMapper
-        let version = versionField m
-
-        { owner = owner
-          modules = NEList.toList modules
-          name = name
-          version = version }
-
+      | DRecord(_, _, _, fields) ->
+        { owner = ownerField fields
+          modules =
+            modulesField fields
+            |> NEList.ofListUnsafe "Expected modules to be a non-empty list" []
+            |> NEList.toList
+          name = nameField fields |> nameMapper
+          version = versionField fields }
       | _ -> Exception.raiseInternal "Unexpected value" []
 
 
   let toDT
     (nameValueType : ValueType)
-    (nameMapper : 'name -> Ply<Dval>)
+    (nameMapper : 'name -> Dval)
     (u : FQName.FQName<'name>)
-    : Ply<Dval> =
-    uply {
-      let! (caseName, fields) =
-        uply {
-          match u with
-          | FQName.UserProgram u ->
-            let! name = UserProgram.toDT nameValueType nameMapper u
-            return "UserProgram", [ name ]
-          | FQName.Package u ->
-            let! name = Package.toDT nameValueType nameMapper u
-            return "Package", [ name ]
-          | FQName.BuiltIn u ->
-            let! name = BuiltIn.toDT nameValueType nameMapper u
-            return "BuiltIn", [ name ]
-        }
-
-      let typeName = rtTyp [ "FQName" ] "FQName" 0
-      return! Dval.enum typeName typeName VT.typeArgsTODO' caseName fields
-    }
+    : Dval =
+    let (caseName, fields) =
+      match u with
+      | FQName.UserProgram u ->
+        "UserProgram", [ UserProgram.toDT nameValueType nameMapper u ]
+      | FQName.Package u -> "Package", [ Package.toDT nameValueType nameMapper u ]
+      | FQName.BuiltIn u -> "BuiltIn", [ BuiltIn.toDT nameValueType nameMapper u ]
+    let typeName = rtTyp [ "FQName" ] "FQName" 0
+    DEnum(typeName, typeName, VT.typeArgsTODO, caseName, fields)
 
   let fromDT (nameMapper : Dval -> 'name) (d : Dval) : FQName.FQName<'name> =
     match d with
@@ -171,13 +137,12 @@ module TypeName =
   module Name =
     let valueType = VT.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.TypeName.Name
 
-    let toDT (u : TypeName.Name) : Ply<Dval> =
-      let caseName, fields =
+    let toDT (u : TypeName.Name) : Dval =
+      let (caseName, fields) =
         match u with
         | TypeName.TypeName name -> "TypeName", [ DString name ]
-
       let typeName = rtTyp [ "TypeName" ] "Name" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+      DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : TypeName.Name =
       match d with
@@ -185,24 +150,23 @@ module TypeName =
       | _ -> Exception.raiseInternal "Invalid TypeName" []
 
   module BuiltIn =
-    let toDT (u : TypeName.BuiltIn) : Ply<Dval> =
+    let toDT (u : TypeName.BuiltIn) : Dval =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : TypeName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : TypeName.UserProgram) : Ply<Dval> =
+    let toDT (u : TypeName.UserProgram) : Dval =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : TypeName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : TypeName.Package) : Ply<Dval> =
+    let toDT (u : TypeName.Package) : Dval =
       FQName.Package.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : TypeName.Package = FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : TypeName.TypeName) : Ply<Dval> =
-    FQName.toDT Name.valueType Name.toDT u
+  let toDT (u : TypeName.TypeName) : Dval = FQName.toDT Name.valueType Name.toDT u
   let fromDT (d : Dval) : TypeName.TypeName = FQName.fromDT Name.fromDT d
 
 
@@ -210,13 +174,12 @@ module FnName =
   module Name =
     let valueType = VT.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.FnName.Name
 
-    let toDT (u : FnName.Name) : Ply<Dval> =
-      let caseName, fields =
+    let toDT (u : FnName.Name) : Dval =
+      let (caseName, fields) =
         match u with
         | FnName.FnName name -> "FnName", [ DString name ]
-
       let typeName = rtTyp [ "FnName" ] "Name" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+      DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : FnName.Name =
       match d with
@@ -224,22 +187,22 @@ module FnName =
       | _ -> Exception.raiseInternal "Invalid FnName" []
 
   module BuiltIn =
-    let toDT (u : FnName.BuiltIn) : Ply<Dval> =
+    let toDT (u : FnName.BuiltIn) : Dval =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : FnName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : FnName.UserProgram) : Ply<Dval> =
+    let toDT (u : FnName.UserProgram) : Dval =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : FnName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : FnName.Package) : Ply<Dval> =
+    let toDT (u : FnName.Package) : Dval =
       FQName.Package.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : FnName.Package = FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : FnName.FnName) : Ply<Dval> = FQName.toDT Name.valueType Name.toDT u
+  let toDT (u : FnName.FnName) : Dval = FQName.toDT Name.valueType Name.toDT u
   let fromDT (d : Dval) : FnName.FnName = FQName.fromDT Name.fromDT d
 
 
@@ -247,13 +210,12 @@ module ConstantName =
   module Name =
     let valueType = VT.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.ConstantName.Name
 
-    let toDT (u : ConstantName.Name) : Ply<Dval> =
-      let caseName, fields =
+    let toDT (u : ConstantName.Name) : Dval =
+      let (caseName, fields) =
         match u with
         | ConstantName.ConstantName name -> "ConstantName", [ DString name ]
-
       let typeName = rtTyp [ "ConstantName" ] "Name" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+      DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : ConstantName.Name =
       match d with
@@ -262,25 +224,25 @@ module ConstantName =
       | _ -> Exception.raiseInternal "Invalid ConstantName" []
 
   module BuiltIn =
-    let toDT (u : ConstantName.BuiltIn) : Ply<Dval> =
+    let toDT (u : ConstantName.BuiltIn) : Dval =
       FQName.BuiltIn.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : ConstantName.BuiltIn =
       FQName.BuiltIn.fromDT Name.fromDT d
 
   module UserProgram =
-    let toDT (u : ConstantName.UserProgram) : Ply<Dval> =
+    let toDT (u : ConstantName.UserProgram) : Dval =
       FQName.UserProgram.toDT Name.valueType Name.toDT u
 
     let fromDT (d : Dval) : ConstantName.UserProgram =
       FQName.UserProgram.fromDT Name.fromDT d
 
   module Package =
-    let toDT (u : ConstantName.Package) : Ply<Dval> =
+    let toDT (u : ConstantName.Package) : Dval =
       FQName.Package.toDT Name.valueType Name.toDT u
     let fromDT (d : Dval) : ConstantName.Package =
       FQName.Package.fromDT Name.fromDT d
 
-  let toDT (u : ConstantName.ConstantName) : Ply<Dval> =
+  let toDT (u : ConstantName.ConstantName) : Dval =
     FQName.toDT Name.valueType Name.toDT u
   let fromDT (d : Dval) : ConstantName.ConstantName = FQName.fromDT Name.fromDT d
 
@@ -288,20 +250,14 @@ module ConstantName =
 module NameResolution =
   let toDT
     (nameValueType : ValueType)
-    (f : 'p -> Ply<Dval>)
+    (f : 'p -> Dval)
     (result : NameResolution<'p>)
-    : Ply<Dval> =
-    uply {
-      let errType = VT.unknownTODO // NameResolutionError
+    : Dval =
+    let errType = VT.unknownTODO // NameResolutionError
 
-      match result with
-      | Ok name ->
-        let! name = f name
-        return! Dval.resultOk nameValueType errType name
-      | Error err ->
-        return!
-          RuntimeError.toDT err |> Ply.bind (Dval.resultError nameValueType errType)
-    }
+    match result with
+    | Ok name -> Dval.resultOk nameValueType errType (f name)
+    | Error err -> RuntimeError.toDT err |> Dval.resultError nameValueType errType
 
   let fromDT (f : Dval -> 'a) (d : Dval) : NameResolution<'a> =
     match d with
@@ -314,65 +270,46 @@ module NameResolution =
 module TypeReference =
   let valueType = ValueType.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.TypeReference
 
-  let rec toDT (t : TypeReference) : Ply<Dval> =
-    uply {
-      let! (caseName, fields) =
-        uply {
-          match t with
-          | TVariable name -> return "TVariable", [ DString name ]
+  let rec toDT (t : TypeReference) : Dval =
+    let (caseName, fields) =
+      match t with
+      | TVariable name -> "TVariable", [ DString name ]
 
-          | TUnit -> return "TUnit", []
-          | TBool -> return "TBool", []
-          | TInt -> return "TInt", []
-          | TFloat -> return "TFloat", []
-          | TChar -> return "TChar", []
-          | TString -> return "TString", []
-          | TDateTime -> return "TDateTime", []
-          | TUuid -> return "TUuid", []
-          | TBytes -> return "TBytes", []
+      | TUnit -> "TUnit", []
+      | TBool -> "TBool", []
+      | TInt -> "TInt", []
+      | TFloat -> "TFloat", []
+      | TChar -> "TChar", []
+      | TString -> "TString", []
+      | TDateTime -> "TDateTime", []
+      | TUuid -> "TUuid", []
+      | TBytes -> "TBytes", []
 
-          | TList inner ->
-            let! inner = toDT inner
-            return "TList", [ inner ]
+      | TList inner -> "TList", [ toDT inner ]
 
-          | TTuple(first, second, theRest) ->
-            let! first = toDT first
-            let! second = toDT second
-            let! theRest =
-              theRest
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "TTuple", [ first; second; theRest ]
+      | TTuple(first, second, theRest) ->
+        "TTuple",
+        [ toDT first
+          toDT second
+          theRest |> List.map toDT |> Dval.list VT.unknownTODO ]
 
-          | TDict inner ->
-            let! inner = toDT inner
-            return "TDict", [ inner ]
+      | TDict inner -> "TDict", [ toDT inner ]
 
-          | TCustomType(typeName, typeArgs) ->
-            let! typeName =
-              NameResolution.toDT ValueType.unknownTODO TypeName.toDT typeName
-            let! typeArgs =
-              typeArgs
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "TCustomType", [ typeName; typeArgs ]
+      | TCustomType(typeName, typeArgs) ->
+        "TCustomType",
+        [ NameResolution.toDT ValueType.unknownTODO TypeName.toDT typeName
+          typeArgs |> List.map toDT |> Dval.list VT.unknownTODO ]
 
-          | TDB inner ->
-            let! inner = toDT inner
-            return "TDB", [ inner ]
-          | TFn(args, ret) ->
-            let! args =
-              args
-              |> NEList.toList
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            let! ret = toDT ret
-            return "TFn", [ args; ret ]
-        }
+      | TDB inner ->
+        let inner = toDT inner
+        "TDB", [ inner ]
+      | TFn(args, ret) ->
+        "TFn",
+        [ args |> NEList.toList |> List.map toDT |> Dval.list VT.unknownTODO
+          toDT ret ]
 
-      let typeName = rtTyp [] "TypeReference" 0
-      return! Dval.enum typeName typeName (Some []) caseName fields
-    }
+    let typeName = rtTyp [] "TypeReference" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
   let rec fromDT (d : Dval) : TypeReference =
     match d with
@@ -407,39 +344,26 @@ module TypeReference =
     | _ -> Exception.raiseInternal "Invalid TypeReference" [ "typeRef", d ]
 
 module Param =
-  let toDT (p : Param) : Ply<Dval> =
-    uply {
-      let! typ = TypeReference.toDT p.typ
-      return!
-        Dval.record
-          (rtTyp [] "Param" 0)
-          (Some [])
-          [ ("name", DString p.name); ("typ", typ) ]
-    }
+  let toDT (p : Param) : Dval =
+    let fields = [ ("name", DString p.name); ("typ", TypeReference.toDT p.typ) ]
+    let typeName = rtTyp [] "Param" 0
+    DRecord(typeName, typeName, [], Map fields)
 
 
 module LetPattern =
-  let rec toDT (p : LetPattern) : Ply<Dval> =
-    uply {
-      let! (caseName, fields) =
-        uply {
-          match p with
-          | LPVariable(id, name) ->
-            return "LPVariable", [ DInt(int64 id); DString name ]
-          | LPUnit id -> return "LPUnit", [ DInt(int64 id) ]
-          | LPTuple(id, first, second, theRest) ->
-            let! first = toDT first
-            let! second = toDT second
-            let! theRest =
-              theRest
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "LPTuple", [ DInt(int64 id); first; second; theRest ]
-        }
+  let rec toDT (p : LetPattern) : Dval =
+    let (caseName, fields) =
+      match p with
+      | LPVariable(id, name) -> "LPVariable", [ DInt(int64 id); DString name ]
+      | LPUnit id -> "LPUnit", [ DInt(int64 id) ]
+      | LPTuple(id, first, second, theRest) ->
+        let first = toDT first
+        let second = toDT second
+        let theRest = theRest |> List.map toDT |> Dval.list VT.unknownTODO
+        "LPTuple", [ DInt(int64 id); first; second; theRest ]
 
-      let typeName = rtTyp [] "LetPattern" 0
-      return! Dval.enum typeName typeName (Some []) caseName fields
-    }
+    let typeName = rtTyp [] "LetPattern" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
   let rec fromDT (d : Dval) : LetPattern =
     match d with
@@ -452,50 +376,37 @@ module LetPattern =
 
 
 module MatchPattern =
-  let rec toDT (p : MatchPattern) : Ply<Dval> =
-    uply {
-      let! (caseName, fields) =
-        uply {
-          match p with
-          | MPVariable(id, name) ->
-            return "MPVariable", [ DInt(int64 id); DString name ]
+  let rec toDT (p : MatchPattern) : Dval =
+    let (caseName, fields) =
+      match p with
+      | MPVariable(id, name) -> "MPVariable", [ DInt(int64 id); DString name ]
 
-          | MPUnit id -> return "MPUnit", [ DInt(int64 id) ]
-          | MPBool(id, b) -> return "MPBool", [ DInt(int64 id); DBool b ]
-          | MPInt(id, i) -> return "MPInt", [ DInt(int64 id); DInt i ]
-          | MPFloat(id, f) -> return "MPFloat", [ DInt(int64 id); DFloat f ]
-          | MPChar(id, c) -> return "MPChar", [ DInt(int64 id); DString c ]
-          | MPString(id, s) -> return "MPString", [ DInt(int64 id); DString s ]
+      | MPUnit id -> "MPUnit", [ DInt(int64 id) ]
+      | MPBool(id, b) -> "MPBool", [ DInt(int64 id); DBool b ]
+      | MPInt(id, i) -> "MPInt", [ DInt(int64 id); DInt i ]
+      | MPFloat(id, f) -> "MPFloat", [ DInt(int64 id); DFloat f ]
+      | MPChar(id, c) -> "MPChar", [ DInt(int64 id); DString c ]
+      | MPString(id, s) -> "MPString", [ DInt(int64 id); DString s ]
 
-          | MPList(id, inner) ->
-            let! inner =
-              inner
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "MPList", [ DInt(int64 id); inner ]
-          | MPListCons(id, head, tail) ->
-            let! head = toDT head
-            let! tail = toDT tail
-            return "MPListCons", [ DInt(int64 id); head; tail ]
-          | MPTuple(id, first, second, theRest) ->
-            let! first = toDT first
-            let! second = toDT second
-            let! theRest =
-              theRest
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "MPTuple", [ DInt(int64 id); first; second; theRest ]
-          | MPEnum(id, caseName, fieldPats) ->
-            let! fieldPats =
-              fieldPats
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "MPEnum", [ DInt(int64 id); DString caseName; fieldPats ]
-        }
+      | MPList(id, inner) ->
+        "MPList",
+        [ DInt(int64 id); inner |> List.map toDT |> Dval.list VT.unknownTODO ]
+      | MPListCons(id, head, tail) ->
+        "MPListCons", [ DInt(int64 id); toDT head; toDT tail ]
 
-      let typeName = rtTyp [] "MatchPattern" 0
-      return! Dval.enum typeName typeName (Some []) caseName fields
-    }
+      | MPTuple(id, first, second, theRest) ->
+        "MPTuple",
+        [ DInt(int64 id)
+          toDT first
+          toDT second
+          theRest |> List.map toDT |> Dval.list VT.unknownTODO ]
+
+      | MPEnum(id, caseName, fieldPats) ->
+        let fieldPats = fieldPats |> List.map toDT |> Dval.list VT.unknownTODO
+        "MPEnum", [ DInt(int64 id); DString caseName; fieldPats ]
+
+    let typeName = rtTyp [] "MatchPattern" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
   let rec fromDT (d : Dval) : MatchPattern =
     match d with
@@ -513,32 +424,28 @@ module MatchPattern =
       MPList(uint64 id, List.map fromDT inner)
     | DEnum(_, _, [], "MPListCons", [ DInt id; head; tail ]) ->
       MPListCons(uint64 id, fromDT head, fromDT tail)
+
     | DEnum(_, _, [], "MPTuple", [ DInt id; first; second; DList(_vtTODO, theRest) ]) ->
       MPTuple(uint64 id, fromDT first, fromDT second, List.map fromDT theRest)
+
     | DEnum(_,
             _,
             [],
             "MPEnum",
             [ DInt id; DString caseName; DList(_vtTODO, fieldPats) ]) ->
       MPEnum(uint64 id, caseName, List.map fromDT fieldPats)
+
     | _ -> Exception.raiseInternal "Invalid MatchPattern" []
 
 
 module StringSegment =
-  let toDT (exprToDT : Expr -> Ply<Dval>) (s : StringSegment) : Ply<Dval> =
-    uply {
-      let! (caseName, fields) =
-        uply {
-          match s with
-          | StringText text -> return "StringText", [ DString text ]
-          | StringInterpolation expr ->
-            let! expr = exprToDT expr
-            return "StringInterpolation", [ expr ]
-        }
-
-      let typeName = rtTyp [] "StringSegment" 0
-      return! Dval.enum typeName typeName (Some []) caseName fields
-    }
+  let toDT (exprToDT : Expr -> Dval) (s : StringSegment) : Dval =
+    let (caseName, fields) =
+      match s with
+      | StringText text -> "StringText", [ DString text ]
+      | StringInterpolation expr -> "StringInterpolation", [ exprToDT expr ]
+    let typeName = rtTyp [] "StringSegment" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
   let fromDT (exprFromDT : Dval -> Expr) (d : Dval) : StringSegment =
     match d with
@@ -551,182 +458,127 @@ module StringSegment =
 module Expr =
   let valueType = VT.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.Expr
 
-  let rec toDT (e : Expr) : Ply<Dval> =
-    uply {
-      let! (caseName, fields) =
-        uply {
-          match e with
-          | EUnit id -> return "EUnit", [ DInt(int64 id) ]
+  let rec toDT (e : Expr) : Dval =
+    let (caseName, fields) =
+      match e with
+      | EUnit id -> "EUnit", [ DInt(int64 id) ]
 
-          // simple data
-          | EBool(id, b) -> return "EBool", [ DInt(int64 id); DBool b ]
-          | EInt(id, i) -> return "EInt", [ DInt(int64 id); DInt i ]
-          | EFloat(id, f) -> return "EFloat", [ DInt(int64 id); DFloat f ]
-          | EChar(id, c) -> return "EChar", [ DInt(int64 id); DString c ]
-          | EString(id, segments) ->
-            let! segments =
-              segments
-              |> Ply.List.mapSequentially (StringSegment.toDT toDT)
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "EString", [ DInt(int64 id); segments ]
+      | EBool(id, b) -> "EBool", [ DInt(int64 id); DBool b ]
+      | EInt(id, i) -> "EInt", [ DInt(int64 id); DInt i ]
+      | EFloat(id, f) -> "EFloat", [ DInt(int64 id); DFloat f ]
+      | EChar(id, c) -> "EChar", [ DInt(int64 id); DString c ]
+      | EString(id, segments) ->
+        "EString",
+        [ DInt(int64 id)
+          segments |> List.map (StringSegment.toDT toDT) |> Dval.list VT.unknownTODO ]
 
-          // structures of data
-          | EList(id, exprs) ->
-            let! exprs =
-              exprs |> Ply.List.mapSequentially toDT |> Ply.map (Dval.list valueType)
-            return "EList", [ DInt(int64 id); exprs ]
+      | EList(id, exprs) ->
+        "EList", [ DInt(int64 id); exprs |> List.map toDT |> Dval.list valueType ]
 
-          | EDict(id, entries) ->
-            let! entries =
-              entries
-              |> Ply.List.mapSequentially (fun (k, v) ->
-                uply {
-                  let! v = toDT v
-                  return DTuple(DString k, v, [])
-                })
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "EDict", [ DInt(int64 id); entries ]
+      | EDict(id, entries) ->
+        let entries =
+          entries
+          |> List.map (fun (k, v) ->
+            let v = toDT v
+            DTuple(DString k, v, []))
+          |> Dval.list VT.unknownTODO
+        "EDict", [ DInt(int64 id); entries ]
 
-          | ETuple(id, first, second, theRest) ->
-            let! first = toDT first
-            let! second = toDT second
-            let! theRest =
-              theRest
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "ETuple", [ DInt(int64 id); first; second; theRest ]
+      | ETuple(id, first, second, theRest) ->
+        "ETuple",
+        [ DInt(int64 id)
+          toDT first
+          toDT second
+          theRest |> List.map toDT |> Dval.list VT.unknownTODO ]
 
-          | ERecord(id, typeName, fields) ->
-            let! typeName = TypeName.toDT typeName
-            let! fields =
-              fields
-              |> NEList.toList
-              |> Ply.List.mapSequentially (fun (name, expr) ->
-                uply {
-                  let! expr = toDT expr
-                  return DTuple(DString name, expr, [])
-                })
-            return
-              "ERecord",
-              [ DInt(int64 id); typeName; Dval.list VT.unknownTODO fields ]
+      | ERecord(id, typeName, fields) ->
+        let fields =
+          fields
+          |> NEList.toList
+          |> List.map (fun (name, expr) -> DTuple(DString name, toDT expr, []))
+          |> Dval.list VT.unknownTODO
+        "ERecord", [ DInt(int64 id); TypeName.toDT typeName; fields ]
 
-          | EEnum(id, typeName, caseName, fields) ->
-            let! typeName = TypeName.toDT typeName
-            let! fields =
-              fields
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list valueType)
-            return "EEnum", [ DInt(int64 id); typeName; DString caseName; fields ]
+      | EEnum(id, typeName, caseName, fields) ->
+        "EEnum",
+        [ DInt(int64 id)
+          TypeName.toDT typeName
+          DString caseName
+          fields |> List.map toDT |> Dval.list valueType ]
 
-          // declaring and accessing variables
-          | ELet(id, lp, expr, body) ->
-            let! lp = LetPattern.toDT lp
-            let! expr = toDT expr
-            let! body = toDT body
-            return "ELet", [ DInt(int64 id); lp; expr; body ]
+      // declaring and accessing variables
+      | ELet(id, lp, expr, body) ->
+        "ELet", [ DInt(int64 id); LetPattern.toDT lp; toDT expr; toDT body ]
 
-          | EFieldAccess(id, expr, fieldName) ->
-            let! expr = toDT expr
-            return "EFieldAccess", [ DInt(int64 id); expr; DString fieldName ]
+      | EFieldAccess(id, expr, fieldName) ->
+        "EFieldAccess", [ DInt(int64 id); toDT expr; DString fieldName ]
 
-          | EVariable(id, varName) ->
-            return "EVariable", [ DInt(int64 id); DString varName ]
+      | EVariable(id, varName) -> "EVariable", [ DInt(int64 id); DString varName ]
 
 
-          // control flow
-          | EIf(id, cond, thenExpr, elseExpr) ->
-            let! cond = toDT cond
-            let! thenExpr = toDT thenExpr
-            let! elseExpr =
-              elseExpr |> Ply.Option.map toDT |> Ply.bind (Dval.option valueType)
-            return "EIf", [ DInt(int64 id); cond; thenExpr; elseExpr ]
+      // control flow
+      | EIf(id, cond, thenExpr, elseExpr) ->
+        let cond = toDT cond
+        let thenExpr = toDT thenExpr
+        let elseExpr = elseExpr |> Option.map toDT |> Dval.option valueType
+        "EIf", [ DInt(int64 id); cond; thenExpr; elseExpr ]
 
-          | EMatch(id, arg, cases) ->
-            let! arg = toDT arg
-            let! cases =
-              cases
-              |> NEList.toList
-              |> Ply.List.mapSequentially (fun (pattern, expr) ->
-                uply {
-                  let! pattern = MatchPattern.toDT pattern
-                  let! expr = toDT expr
-                  return DTuple(pattern, expr, [])
-                })
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "EMatch", [ DInt(int64 id); arg; cases ]
+      | EMatch(id, arg, cases) ->
+        let cases =
+          cases
+          |> NEList.toList
+          |> List.map (fun (pattern, expr) ->
+            DTuple(MatchPattern.toDT pattern, toDT expr, []))
+          |> Dval.list VT.unknownTODO
+        "EMatch", [ DInt(int64 id); toDT arg; cases ]
 
 
-          | ELambda(id, args, body) ->
-            let variables =
-              (NEList.toList args)
-              |> List.map (fun (id, varName) ->
-                DTuple(DInt(int64 id), DString varName, []))
-              |> Dval.list VT.unknownTODO
-            let! body = toDT body
-            return "ELambda", [ DInt(int64 id); variables; body ]
+      | ELambda(id, args, body) ->
+        let variables =
+          (NEList.toList args)
+          |> List.map (fun (id, varName) ->
+            DTuple(DInt(int64 id), DString varName, []))
+          |> Dval.list VT.unknownTODO
+        "ELambda", [ DInt(int64 id); variables; toDT body ]
 
-          | EConstant(id, name) ->
-            let! name = ConstantName.toDT name
-            return "EConstant", [ DInt(int64 id); name ]
+      | EConstant(id, name) ->
+        "EConstant", [ DInt(int64 id); ConstantName.toDT name ]
 
-          | EApply(id, expr, typeArgs, args) ->
-            let! expr = toDT expr
-            let! typeArgs =
-              typeArgs
-              |> Ply.List.mapSequentially TypeReference.toDT
-              |> Ply.map (Dval.list TypeReference.valueType)
-            let! args =
-              args
-              |> NEList.toList
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list TypeReference.valueType)
-            return "EApply", [ DInt(int64 id); expr; typeArgs; args ]
+      | EApply(id, expr, typeArgs, args) ->
+        let typeArgs =
+          typeArgs
+          |> List.map TypeReference.toDT
+          |> Dval.list TypeReference.valueType
+        let args =
+          args |> NEList.toList |> List.map toDT |> Dval.list TypeReference.valueType
+        "EApply", [ DInt(int64 id); toDT expr; typeArgs; args ]
 
-          | EFnName(id, name) ->
-            let! name = FnName.toDT name
-            return "EFnName", [ DInt(int64 id); name ]
+      | EFnName(id, name) -> "EFnName", [ DInt(int64 id); FnName.toDT name ]
 
-          | ERecordUpdate(id, record, updates) ->
-            let! record = toDT record
-            let! updates =
-              NEList.toList updates
-              |> Ply.List.mapSequentially (fun (name, expr) ->
-                uply {
-                  let! expr = toDT expr
-                  return DTuple(DString name, expr, [])
-                })
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "ERecordUpdate", [ DInt(int64 id); record; updates ]
+      | ERecordUpdate(id, record, updates) ->
+        let updates =
+          NEList.toList updates
+          |> List.map (fun (name, expr) -> DTuple(DString name, toDT expr, []))
+          |> Dval.list VT.unknownTODO
+        "ERecordUpdate", [ DInt(int64 id); toDT record; updates ]
 
-          | EAnd(id, left, right) ->
-            let! left = toDT left
-            let! right = toDT right
-            return "EAnd", [ DInt(int64 id); left; right ]
+      | EAnd(id, left, right) -> "EAnd", [ DInt(int64 id); toDT left; toDT right ]
 
-          | EOr(id, left, right) ->
-            let! left = toDT left
-            let! right = toDT right
-            return "EOr", [ DInt(int64 id); left; right ]
+      | EOr(id, left, right) -> "EOr", [ DInt(int64 id); toDT left; toDT right ]
 
-          // Let the error straight through
-          | EError(id, rtError, exprs) ->
-            let! exprs =
-              exprs |> Ply.List.mapSequentially toDT |> Ply.map (Dval.list valueType)
-            return
-              "EError",
-              [ DInt(int64 id); RuntimeTypes.RuntimeError.toDT rtError; exprs ]
-        }
+      // Let the error straight through
+      | EError(id, rtError, exprs) ->
+        let exprs = exprs |> List.map toDT |> Dval.list valueType
+        "EError", [ DInt(int64 id); RuntimeTypes.RuntimeError.toDT rtError; exprs ]
 
 
-      let typeName = rtTyp [] "Expr" 0
-      return! Dval.enum typeName typeName (Some []) caseName fields
-    }
+    let typeName = rtTyp [] "Expr" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
   let rec fromDT (d : Dval) : Expr =
     match d with
     | DEnum(_, _, [], "EUnit", [ DInt id ]) -> EUnit(uint64 id)
 
-    // simple data
     | DEnum(_, _, [], "EBool", [ DInt id; DBool b ]) -> EBool(uint64 id, b)
     | DEnum(_, _, [], "EInt", [ DInt id; DInt i ]) -> EInt(uint64 id, i)
     | DEnum(_, _, [], "EFloat", [ DInt id; DFloat f ]) -> EFloat(uint64 id, f)
@@ -735,9 +587,9 @@ module Expr =
       EString(uint64 id, List.map (StringSegment.fromDT fromDT) segments)
 
 
-    // structures of data
     | DEnum(_, _, [], "EList", [ DInt id; DList(_vtTODO, inner) ]) ->
       EList(uint64 id, List.map fromDT inner)
+
     | DEnum(_, _, [], "EDict", [ DInt id; DList(_vtTODO, pairsList) ]) ->
       let pairs =
         pairsList
@@ -767,7 +619,6 @@ module Expr =
           fields
       )
 
-
     | DEnum(_,
             _,
             [],
@@ -775,7 +626,6 @@ module Expr =
             [ DInt id; typeName; DString caseName; DList(_vtTODO, fields) ]) ->
       EEnum(uint64 id, TypeName.fromDT typeName, caseName, List.map fromDT fields)
 
-    // declaring and accessing variables
     | DEnum(_, _, [], "ELet", [ DInt id; lp; expr; body ]) ->
       ELet(uint64 id, LetPattern.fromDT lp, fromDT expr, fromDT body)
 
@@ -785,7 +635,6 @@ module Expr =
     | DEnum(_, _, [], "EVariable", [ DInt id; DString varName ]) ->
       EVariable(uint64 id, varName)
 
-    // control flow
     | DEnum(_, _, [], "EIf", [ DInt id; cond; thenExpr; elseExpr ]) ->
       let elseExpr =
         match elseExpr with
@@ -803,32 +652,22 @@ module Expr =
           | DTuple(pattern, expr, _) ->
             [ (MatchPattern.fromDT pattern, fromDT expr) ]
           | _ -> [])
-      EMatch(
-        uint64 id,
-        fromDT arg,
-        NEList.ofListUnsafe
+        |> NEList.ofListUnsafe
           "RT2DT.Expr.fromDT expected at least one case in EMatch"
           []
-          cases
-      )
+      EMatch(uint64 id, fromDT arg, cases)
 
-
-    | DEnum(_, _, [], "ELambda", [ DInt id; DList(_vtTODO, variables); body ]) ->
+    | DEnum(_, _, [], "ELambda", [ DInt id; DList(_vtTODO, args); body ]) ->
       let args =
-        variables
+        args
         |> List.collect (fun arg ->
           match arg with
           | DTuple(DInt argId, DString varName, _) -> [ (uint64 argId, varName) ]
           | _ -> [])
-
-      ELambda(
-        uint64 id,
-        NEList.ofListUnsafe
+        |> NEList.ofListUnsafe
           "RT2DT.Expr.fromDT expected at least one bound variable in ELambda"
           []
-          args,
-        fromDT body
-      )
+      ELambda(uint64 id, args, fromDT body)
 
 
     | DEnum(_,
@@ -883,7 +722,7 @@ module Expr =
 
 
 module RuntimeError =
-  let toDT (e : RuntimeError) : Ply<Dval> =
+  let toDT (e : RuntimeError) : Dval =
     e |> RuntimeTypes.RuntimeError.toDT |> Dval.toDT
 
   let fromDT (d : Dval) : RuntimeError =
@@ -894,61 +733,46 @@ module Dval =
   let valueType = VT.unknownTODO // @Darklang.LanguageTools.RuntimeTypes.Dval.Dval
 
   module KnownType =
-    let toDT (kt : KnownType) : Ply<Dval> =
-      uply {
-        let! (caseName, fields) =
-          uply {
-            match kt with
-            | KTUnit -> return "KTUnit", []
-            | KTBool -> return "KTBool", []
-            | KTInt -> return "KTInt", []
-            | KTFloat -> return "KTFloat", []
-            | KTChar -> return "KTChar", []
-            | KTString -> return "KTString", []
-            | KTUuid -> return "KTUuid", []
-            | KTDateTime -> return "KTDateTime", []
-            | KTBytes -> return "KTBytes", []
+    let toDT (kt : KnownType) : Dval =
+      let vtToDT = ValueType.toDT
 
-            | KTList inner ->
-              let! inner = ValueType.toDT inner
-              return "KTList", [ inner ]
-            | KTTuple(first, second, theRest) ->
-              let! first = ValueType.toDT first
-              let! second = ValueType.toDT second
-              let! theRest =
-                theRest
-                |> Ply.List.mapSequentially ValueType.toDT
-                |> Ply.map (Dval.list ValueType.valueType)
-              return "KTTuple", [ first; second; theRest ]
-            | KTDict inner ->
-              let! inner = ValueType.toDT inner
-              return "KTDict", [ inner ]
+      let (caseName, fields) =
+        match kt with
+        | KTUnit -> "KTUnit", []
+        | KTBool -> "KTBool", []
+        | KTInt -> "KTInt", []
+        | KTFloat -> "KTFloat", []
+        | KTChar -> "KTChar", []
+        | KTString -> "KTString", []
+        | KTUuid -> "KTUuid", []
+        | KTDateTime -> "KTDateTime", []
+        | KTBytes -> "KTBytes", []
 
-            | KTCustomType(typeName, typeArgs) ->
-              let! typeName = TypeName.toDT typeName
-              let! typeArgs =
-                typeArgs
-                |> Ply.List.mapSequentially ValueType.toDT
-                |> Ply.map (Dval.list ValueType.valueType)
-              return "KTCustomType", [ typeName; typeArgs ]
+        | KTList inner -> "KTList", [ ValueType.toDT inner ]
+        | KTTuple(first, second, theRest) ->
+          "KTTuple",
+          [ ValueType.toDT first
+            ValueType.toDT second
+            theRest |> List.map ValueType.toDT |> Dval.list ValueType.valueType ]
+        | KTDict inner -> "KTDict", [ ValueType.toDT inner ]
 
-            | KTFn(args, ret) ->
-              let! args =
-                args
-                |> NEList.toList
-                |> Ply.List.mapSequentially ValueType.toDT
-                |> Ply.map (Dval.list ValueType.valueType)
-              let! ret = ValueType.toDT ret
-              return "KTFn", [ args; ret ]
+        | KTCustomType(typeName, typeArgs) ->
+          "KTCustomType",
+          [ TypeName.toDT typeName
+            typeArgs |> List.map ValueType.toDT |> Dval.list ValueType.valueType ]
 
-            | KTDB d ->
-              let! d = ValueType.toDT d
-              return "KTDB", [ d ]
-          }
+        | KTFn(args, ret) ->
+          let args =
+            args
+            |> NEList.toList
+            |> List.map ValueType.toDT
+            |> Dval.list ValueType.valueType
+          "KTFn", [ args; ValueType.toDT ret ]
 
-        let typeName = rtTyp [] "KnownType" 0
-        return! Dval.enum typeName typeName (Some []) caseName fields
-      }
+        | KTDB d -> "KTDB", [ ValueType.toDT d ]
+
+      let typeName = rtTyp [] "KnownType" 0
+      DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : KnownType =
       match d with
@@ -988,37 +812,30 @@ module Dval =
   module ValueType =
     let valueType = VT.unknownTODO
 
-    let toDT (vt : ValueType) : Ply<Dval> =
-      uply {
-        let! (caseName, fields) =
-          uply {
-            match vt with
-            | ValueType.Unknown -> return "Unknown", []
-            | ValueType.Known kt ->
-              let! kt = KnownType.toDT kt
-              return "Known", [ kt ]
-          }
-
-        let typeName = rtTyp [] "ValueType" 0
-        return! Dval.enum typeName typeName (Some []) caseName fields
-      }
+    let toDT (vt : ValueType) : Dval =
+      let (caseName, fields) =
+        match vt with
+        | ValueType.Unknown -> "Unknown", []
+        | ValueType.Known kt ->
+          let kt = KnownType.toDT kt
+          "Known", [ kt ]
+      let typeName = rtTyp [] "ValueType" 0
+      DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : ValueType =
       match d with
       | DEnum(_, _, [], "Unknown", []) -> ValueType.Unknown
       | DEnum(_, _, [], "Known", [ kt ]) -> ValueType.Known(KnownType.fromDT kt)
-
       | _ -> Exception.raiseInternal "Invalid ValueType" []
 
   module DvalSource =
-    let toDT (s : DvalSource) : Ply<Dval> =
-      let caseName, fields =
+    let toDT (s : DvalSource) : Dval =
+      let (caseName, fields) =
         match s with
         | SourceNone -> "SourceNone", []
         | SourceID(tlid, id) -> "SourceID", [ DInt(int64 tlid); DInt(int64 id) ]
-
       let typeName = rtTyp [] "DvalSource" 0
-      Dval.enum typeName typeName (Some []) caseName fields
+      DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : DvalSource =
       match d with
@@ -1029,76 +846,59 @@ module Dval =
 
 
   module LambdaImpl =
-    let toDT (l : LambdaImpl) : Ply<Dval> =
-      uply {
-        let! tst =
-          l.typeSymbolTable
-          |> Ply.Map.mapSequentially TypeReference.toDT
-          |> Ply.map (Dval.dictFromMap VT.unknownTODO)
-        let! symtable =
-          l.symtable
-          |> Ply.Map.mapSequentially Dval.toDT
-          |> Ply.map (Dval.dictFromMap VT.unknownTODO)
-        let parameters =
-          l.parameters
-          |> NEList.toList
-          |> List.map (fun (id, name) -> DTuple(DInt(int64 id), DString name, []))
-          |> Dval.list VT.unknownTODO
-        let! body = Expr.toDT l.body
-        return!
-          Dval.record
-            (rtTyp [] "LambdaImpl" 0)
-            (Some [])
-            [ "typeSymbolTable", tst
-              "symtable", symtable
-              "parameters", parameters
-              "body", body ]
-      }
+    let toDT (l : LambdaImpl) : Dval =
+      let tst =
+        l.typeSymbolTable
+        |> Map.map TypeReference.toDT
+        |> Dval.dictFromMap VT.unknownTODO
+      let symtable =
+        l.symtable |> Map.map Dval.toDT |> Dval.dictFromMap VT.unknownTODO
+      let parameters =
+        l.parameters
+        |> NEList.toList
+        |> List.map (fun (id, name) -> DTuple(DInt(int64 id), DString name, []))
+        |> Dval.list VT.unknownTODO
+      let body = Expr.toDT l.body
+      let fields =
+        [ "typeSymbolTable", tst
+          "symtable", symtable
+          "parameters", parameters
+          "body", body ]
+
+      let typeName = rtTyp [] "LambdaImpl" 0
+      DRecord(typeName, typeName, [], Map fields)
 
     let fromDT (d : Dval) : LambdaImpl =
       match d with
       | DRecord(_, _, _, fields) ->
-        let typeSymbolTable =
-          fields |> D.mapField "typeSymbolTable" |> Map.map TypeReference.fromDT
+        { typeSymbolTable =
+            fields |> D.mapField "typeSymbolTable" |> Map.map TypeReference.fromDT
 
-        let symtable = fields |> D.mapField "symtable" |> Map.map Dval.fromDT
+          symtable = fields |> D.mapField "symtable" |> Map.map Dval.fromDT
 
-        let parameters =
-          fields
-          |> D.listField "parameters"
-          |> List.map (fun d ->
-            match d with
-            | DTuple(DInt id, DString name, _) -> (uint64 id, name)
-            | _ -> Exception.raiseInternal "Invalid LambdaImpl" [])
-          |> NEList.ofListUnsafe
-            "RT2DT.Dval.fromDT expected at least one parameter in LambdaImpl"
-            []
-        let body = fields |> D.field "body" |> Expr.fromDT
+          parameters =
+            fields
+            |> D.listField "parameters"
+            |> List.map (fun d ->
+              match d with
+              | DTuple(DInt id, DString name, _) -> (uint64 id, name)
+              | _ -> Exception.raiseInternal "Invalid LambdaImpl" [])
+            |> NEList.ofListUnsafe
+              "RT2DT.Dval.fromDT expected at least one parameter in LambdaImpl"
+              []
 
-        { typeSymbolTable = typeSymbolTable
-          symtable = symtable
-          parameters = parameters
-          body = body }
+          body = fields |> D.field "body" |> Expr.fromDT }
 
       | _ -> Exception.raiseInternal "Invalid LambdaImpl" []
 
   module FnValImpl =
-    let toDT (fnValImpl : FnValImpl) : Ply<Dval> =
-      uply {
-        let! (caseName, fields) =
-          uply {
-            match fnValImpl with
-            | Lambda lambda ->
-              let! lambda = LambdaImpl.toDT lambda
-              return "Lambda", [ lambda ]
-            | NamedFn fnName ->
-              let! fnName = FnName.toDT fnName
-              return "NamedFn", [ fnName ]
-          }
-
-        let typeName = rtTyp [] "FnValImpl" 0
-        return! Dval.enum typeName typeName (Some []) caseName fields
-      }
+    let toDT (fnValImpl : FnValImpl) : Dval =
+      let (caseName, fields) =
+        match fnValImpl with
+        | Lambda lambda -> "Lambda", [ LambdaImpl.toDT lambda ]
+        | NamedFn fnName -> "NamedFn", [ FnName.toDT fnName ]
+      let typeName = rtTyp [] "FnValImpl" 0
+      DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : FnValImpl =
       match d with
@@ -1106,85 +906,57 @@ module Dval =
       | DEnum(_, _, [], "NamedFn", [ fnName ]) -> NamedFn(FnName.fromDT fnName)
       | _ -> Exception.raiseInternal "Invalid FnValImpl" []
 
-  let rec toDT (dv : Dval) : Ply<Dval> =
-    uply {
-      let! (caseName, fields) =
-        uply {
-          match dv with
-          | DUnit -> return "DUnit", []
-          | DBool b -> return "DBool", [ DBool b ]
-          | DInt i -> return "DInt", [ DInt i ]
-          | DFloat f -> return "DFloat", [ DFloat f ]
-          | DChar c -> return "DChar", [ DChar c ]
-          | DString s -> return "DString", [ DString s ]
-          | DUuid u -> return "DUuid", [ DUuid u ]
-          | DDateTime d -> return "DDateTime", [ DDateTime d ]
-          | DBytes b -> return "DBytes", [ DBytes b ]
+  let rec toDT (dv : Dval) : Dval =
+    let (caseName, fields) =
+      match dv with
+      | DUnit -> "DUnit", []
+      | DBool b -> "DBool", [ DBool b ]
+      | DInt i -> "DInt", [ DInt i ]
+      | DFloat f -> "DFloat", [ DFloat f ]
+      | DChar c -> "DChar", [ DChar c ]
+      | DString s -> "DString", [ DString s ]
+      | DUuid u -> "DUuid", [ DUuid u ]
+      | DDateTime d -> "DDateTime", [ DDateTime d ]
+      | DBytes b -> "DBytes", [ DBytes b ]
 
+      | DList(vt, items) ->
+        "DList",
+        [ ValueType.toDT vt; items |> List.map toDT |> Dval.list VT.unknownTODO ]
 
-          | DList(vt, items) ->
-            let! vt = ValueType.toDT vt
-            let! items =
-              items
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "DList", [ vt; items ]
+      | DTuple(first, second, theRest) ->
+        "DTuple",
+        [ toDT first
+          toDT second
+          theRest |> List.map toDT |> Dval.list VT.unknownTODO ]
 
-          | DTuple(first, second, theRest) ->
-            let! first = toDT first
-            let! second = toDT second
-            let! theRest =
-              theRest
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return "DTuple", [ first; second; theRest ]
+      | DFnVal fnImpl -> "DFnVal", [ FnValImpl.toDT fnImpl ]
 
-          | DFnVal fnImpl ->
-            let! fnImpl = FnValImpl.toDT fnImpl
-            return "DFnVal", [ fnImpl ]
+      | DDB name -> "DDB", [ DString name ]
 
-          | DDB name -> return "DDB", [ DString name ]
+      | DDict(vt, entries) ->
+        let vt = ValueType.toDT vt
+        let entries = entries |> Map.map toDT |> Dval.dictFromMap VT.unknownTODO
+        "DDict", [ vt; entries ]
 
-          | DDict(vt, entries) ->
-            let! vt = ValueType.toDT vt
-            let! entries =
-              entries
-              |> Ply.Map.mapSequentially toDT
-              |> Ply.map (Dval.dictFromMap VT.unknownTODO)
-            return "DDict", [ vt; entries ]
+      | DRecord(runtimeTypeName, sourceTypeName, typeArgs, fields) ->
+        let runtimeTypeName = TypeName.toDT runtimeTypeName
+        let sourceTypeName = TypeName.toDT sourceTypeName
+        let typeArgs =
+          typeArgs |> List.map ValueType.toDT |> Dval.list ValueType.valueType
+        let fields = fields |> Map.map toDT |> Dval.dictFromMap VT.unknownTODO
+        "DRecord", [ runtimeTypeName; sourceTypeName; typeArgs; fields ]
 
-          | DRecord(runtimeTypeName, sourceTypeName, typeArgs, fields) ->
-            let! runtimeTypeName = TypeName.toDT runtimeTypeName
-            let! sourceTypeName = TypeName.toDT sourceTypeName
-            let! typeArgs =
-              typeArgs
-              |> Ply.List.mapSequentially ValueType.toDT
-              |> Ply.map (Dval.list ValueType.valueType)
-            let! fields =
-              fields
-              |> Ply.Map.mapSequentially toDT
-              |> Ply.map (Dval.dictFromMap VT.unknownTODO)
-            return "DRecord", [ runtimeTypeName; sourceTypeName; typeArgs; fields ]
+      | DEnum(runtimeTypeName, sourceTypeName, typeArgs, caseName, fields) ->
+        let runtimeTypeName = TypeName.toDT runtimeTypeName
+        let sourceTypeName = TypeName.toDT sourceTypeName
+        let typeArgs =
+          typeArgs |> List.map ValueType.toDT |> Dval.list ValueType.valueType
+        let fields = fields |> List.map toDT |> Dval.list VT.unknownTODO
+        "DEnum",
+        [ runtimeTypeName; sourceTypeName; typeArgs; DString caseName; fields ]
 
-          | DEnum(runtimeTypeName, sourceTypeName, typeArgs, caseName, fields) ->
-            let! runtimeTypeName = TypeName.toDT runtimeTypeName
-            let! sourceTypeName = TypeName.toDT sourceTypeName
-            let! typeArgs =
-              typeArgs
-              |> Ply.List.mapSequentially ValueType.toDT
-              |> Ply.map (Dval.list ValueType.valueType)
-            let! fields =
-              fields
-              |> Ply.List.mapSequentially toDT
-              |> Ply.map (Dval.list VT.unknownTODO)
-            return
-              "DEnum",
-              [ runtimeTypeName; sourceTypeName; typeArgs; DString caseName; fields ]
-        }
-
-      let typeName = rtTyp [ "Dval" ] "Dval" 0
-      return! Dval.enum typeName typeName (Some []) caseName fields
-    }
+    let typeName = rtTyp [ "Dval" ] "Dval" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
 
   let fromDT (d : Dval) : Dval =
@@ -1232,7 +1004,6 @@ module Dval =
               DList(_vtTODO1, typeArgs)
               DString caseName
               DList(_vtTODO2, fields) ]) ->
-      // CLEANUP should this be Dval.enum instead?
       DEnum(
         TypeName.fromDT runtimeTypeName,
         TypeName.fromDT sourceTypeName,

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -80,7 +80,7 @@ module Error =
   module RT2DT = RuntimeTypesToDarkTypes
 
   module Location =
-    let toDT (location : Location) : Ply<Dval> =
+    let toDT (location : Location) : Dval =
       let optType = VT.unknownTODO
       match location with
       | None -> Dval.optionNone optType
@@ -97,29 +97,32 @@ module Error =
           uply {
             match context with
             | FunctionCallParameter(fnName, param, paramIndex, location) ->
-              let! fnName = RT2DT.FnName.toDT fnName
-              let! param = RT2DT.Param.toDT param
-              let! location = Location.toDT location
               return
-                "FunctionCallParameter", [ fnName; param; DInt paramIndex; location ]
+                "FunctionCallParameter",
+                [ RT2DT.FnName.toDT fnName
+                  RT2DT.Param.toDT param
+                  DInt paramIndex
+                  Location.toDT location ]
 
             | FunctionCallResult(fnName, returnType, location) ->
-              let! fnName = RT2DT.FnName.toDT fnName
-              let! returnType = RT2DT.TypeReference.toDT returnType
-              let! location = Location.toDT location
-              return "FunctionCallResult", [ fnName; returnType; location ]
+              return
+                "FunctionCallResult",
+                [ RT2DT.FnName.toDT fnName
+                  RT2DT.TypeReference.toDT returnType
+                  Location.toDT location ]
 
             | RecordField(recordTypeName, fieldName, fieldType, location) ->
-              let! typeName = RT2DT.TypeName.toDT recordTypeName
-              let! fieldType = RT2DT.TypeReference.toDT fieldType
-              let! location = Location.toDT location
               return
-                "RecordField", [ typeName; DString fieldName; fieldType; location ]
+                "RecordField",
+                [ RT2DT.TypeName.toDT recordTypeName
+                  DString fieldName
+                  RT2DT.TypeReference.toDT fieldType
+                  Location.toDT location ]
 
             | DictKey(key, typ, location) ->
-              let! typ = RT2DT.TypeReference.toDT typ
-              let! location = Location.toDT location
-              return "DictKey", [ DString key; typ; location ]
+              return
+                "DictKey",
+                [ DString key; RT2DT.TypeReference.toDT typ; Location.toDT location ]
 
             | EnumField(enumTypeName,
                         caseName,
@@ -127,42 +130,44 @@ module Error =
                         fieldCount,
                         fieldType,
                         location) ->
-              let! typeName = RT2DT.TypeName.toDT enumTypeName
-              let! fieldType = RT2DT.TypeReference.toDT fieldType
-              let! location = Location.toDT location
               return
                 "EnumField",
-                [ typeName
+                [ RT2DT.TypeName.toDT enumTypeName
                   DString caseName
                   DInt fieldIndex
                   DInt fieldCount
-                  fieldType
-                  location ]
+                  RT2DT.TypeReference.toDT fieldType
+                  Location.toDT location ]
 
             | DBQueryVariable(varName, expected, location) ->
-              let! expected = RT2DT.TypeReference.toDT expected
-              let! location = Location.toDT location
-              return "DBQueryVariable", [ DString varName; expected; location ]
+              return
+                "DBQueryVariable",
+                [ DString varName
+                  RT2DT.TypeReference.toDT expected
+                  Location.toDT location ]
 
             | DBSchemaType(name, expectedType, location) ->
-              let! expectedType = RT2DT.TypeReference.toDT expectedType
-              let! location = Location.toDT location
-              return "DBSchemaType", [ DString name; expectedType; location ]
+              return
+                "DBSchemaType",
+                [ DString name
+                  RT2DT.TypeReference.toDT expectedType
+                  Location.toDT location ]
 
             | ListIndex(index, listTyp, parent) ->
-              let! listType = RT2DT.TypeReference.toDT listTyp
               let! parent = toDT parent
-              return "ListIndex", [ DInt index; listType; parent ]
+              return
+                "ListIndex", [ DInt index; RT2DT.TypeReference.toDT listTyp; parent ]
 
             | TupleIndex(index, elementType, parent) ->
-              let! elType = RT2DT.TypeReference.toDT elementType
               let! parent = toDT parent
-              return "TupleIndex", [ DInt index; elType; parent ]
+              return
+                "TupleIndex",
+                [ DInt index; RT2DT.TypeReference.toDT elementType; parent ]
 
             | FnValResult(returnType, location) ->
-              let! returnType = RT2DT.TypeReference.toDT returnType
-              let! location = Location.toDT location
-              return "FnValResult", [ returnType; location ]
+              return
+                "FnValResult",
+                [ RT2DT.TypeReference.toDT returnType; Location.toDT location ]
           }
 
         let typeName = RuntimeError.name [ "TypeChecker" ] "Context" 0
@@ -176,15 +181,16 @@ module Error =
         uply {
           match e with
           | ValueNotExpectedType(actualValue, expectedType, context) ->
-            let! actualValue = actualValue |> RT2DT.Dval.toDT
-            let! expectedType = expectedType |> RT2DT.TypeReference.toDT
             let! context = Context.toDT context
-            return "ValueNotExpectedType", [ actualValue; expectedType; context ]
+            return
+              "ValueNotExpectedType",
+              [ actualValue |> RT2DT.Dval.toDT
+                expectedType |> RT2DT.TypeReference.toDT
+                context ]
 
           | TypeDoesntExist(typeName, context) ->
-            let! typeName = RT2DT.TypeName.toDT typeName
             let! context = Context.toDT context
-            return "TypeDoesntExist", [ typeName; context ]
+            return "TypeDoesntExist", [ RT2DT.TypeName.toDT typeName; context ]
         }
 
       let typeName = RuntimeError.name [ "TypeChecker" ] "Error" 0

--- a/backend/src/LibParser/Parser.fs
+++ b/backend/src/LibParser/Parser.fs
@@ -34,7 +34,7 @@ let parseRTExpr
   : Ply<LibExecution.RuntimeTypes.Expr> =
   code
   |> parsePTExpr resolver filename
-  |> Ply.bind LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT
+  |> Ply.map LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT
 
 type Packages =
   List<PT.PackageFn.T> * List<PT.PackageType.T> * List<PT.PackageConstant.T>

--- a/backend/src/LibParser/TestModule.fs
+++ b/backend/src/LibParser/TestModule.fs
@@ -271,9 +271,9 @@ let parseSingleTestFromFile
       |> parseTest
 
     let! actual =
-      wtTest.actual |> WT2PT.Expr.toPT resolver [] |> Ply.bind PT2RT.Expr.toRT
+      wtTest.actual |> WT2PT.Expr.toPT resolver [] |> Ply.map PT2RT.Expr.toRT
     let! expected =
-      wtTest.expected |> WT2PT.Expr.toPT resolver [] |> Ply.bind PT2RT.Expr.toRT
+      wtTest.expected |> WT2PT.Expr.toPT resolver [] |> Ply.map PT2RT.Expr.toRT
     return
       { actual = actual
         expected = expected

--- a/backend/src/LocalExec/Libs/Cli.fs
+++ b/backend/src/LocalExec/Libs/Cli.fs
@@ -37,25 +37,21 @@ let execute
   : Ply<RT.ExecutionResult> =
 
   uply {
-    let! fns =
-      mod'.fns
-      |> Ply.List.mapSequentially (fun fn -> PT2RT.UserFunction.toRT fn)
-      |> Ply.map (Map.fromListBy (fun fn -> fn.name))
-    let! types =
-      mod'.types
-      |> Ply.List.mapSequentially (fun typ -> PT2RT.UserType.toRT typ)
-      |> Ply.map (Map.fromListBy (fun typ -> typ.name))
-    let! constants =
-      mod'.constants
-      |> Ply.List.mapSequentially (fun c -> PT2RT.UserConstant.toRT c)
-      |> Ply.map (Map.fromListBy (fun c -> c.name))
-
     let program : Program =
       { canvasID = System.Guid.NewGuid()
         internalFnsAllowed = true
-        fns = fns
-        types = types
-        constants = constants
+        fns =
+          mod'.fns
+          |> List.map PT2RT.UserFunction.toRT
+          |> Map.fromListBy (fun fn -> fn.name)
+        types =
+          mod'.types
+          |> List.map PT2RT.UserType.toRT
+          |> Map.fromListBy (fun typ -> typ.name)
+        constants =
+          mod'.constants
+          |> List.map PT2RT.UserConstant.toRT
+          |> Map.fromListBy (fun c -> c.name)
         dbs = Map.empty
         secrets = [] }
 
@@ -73,7 +69,7 @@ let execute
         program
 
     if mod'.exprs.Length = 1 then
-      let! expr = PT2RT.Expr.toRT mod'.exprs[0]
+      let expr = PT2RT.Expr.toRT mod'.exprs[0]
       return! Exe.executeExpr state symtable expr
     else if mod'.exprs.Length = 0 then
       return Error(SourceNone, RuntimeError.oldError "No expressions to execute")

--- a/backend/src/LocalExec/Libs/Packages2.fs
+++ b/backend/src/LocalExec/Libs/Packages2.fs
@@ -73,12 +73,9 @@ let fns : List<BuiltInFn> =
             let! (fns, types, constants) =
               LibParser.Parser.parsePackageFile resolver path contents
 
-            let! packagesFns =
-              fns |> Ply.List.mapSequentially (fun fn -> PT2DT.PackageFn.toDT fn)
-            let! packagesTypes =
-              types |> Ply.List.mapSequentially PT2DT.PackageType.toDT
-            let! packagesConstants =
-              constants |> Ply.List.mapSequentially PT2DT.PackageConstant.toDT
+            let packagesFns = fns |> List.map PT2DT.PackageFn.toDT
+            let packagesTypes = types |> List.map PT2DT.PackageType.toDT
+            let packagesConstants = constants |> List.map PT2DT.PackageConstant.toDT
 
             return!
               Dval.record
@@ -87,7 +84,7 @@ let fns : List<BuiltInFn> =
                 [ ("fns", Dval.list VT.unknownTODO packagesFns)
                   ("types", Dval.list VT.unknownTODO packagesTypes)
                   ("constants", Dval.list VT.unknownTODO packagesConstants) ]
-              |> Ply.bind (Dval.resultOk VT.unknownTODO VT.string)
+              |> Ply.map (Dval.resultOk VT.unknownTODO VT.string)
 
           }
         | _ -> incorrectArgs ()

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -77,30 +77,26 @@ let execute
   (symtable : Map<string, RT.Dval>)
   : Ply<RT.ExecutionResult> =
   uply {
-    let! fns =
-      mod'.fns
-      |> Ply.List.mapSequentially PT2RT.UserFunction.toRT
-      |> Ply.map (Map.fromListBy (fun fn -> fn.name))
-    let! types =
-      mod'.types
-      |> Ply.List.mapSequentially PT2RT.UserType.toRT
-      |> Ply.map (Map.fromListBy (fun typ -> typ.name))
-    let! constants =
-      mod'.constants
-      |> Ply.List.mapSequentially PT2RT.UserConstant.toRT
-      |> Ply.map (Map.fromListBy (fun c -> c.name))
-
     let program : RT.Program =
       { canvasID = System.Guid.NewGuid()
         internalFnsAllowed = false
-        fns = fns
-        types = types
-        constants = constants
+        fns =
+          mod'.fns
+          |> List.map PT2RT.UserFunction.toRT
+          |> Map.fromListBy (fun fn -> fn.name)
+        types =
+          mod'.types
+          |> List.map PT2RT.UserType.toRT
+          |> Map.fromListBy (fun typ -> typ.name)
+        constants =
+          mod'.constants
+          |> List.map PT2RT.UserConstant.toRT
+          |> Map.fromListBy (fun c -> c.name)
         dbs = Map.empty
         secrets = [] }
 
     let state = { state () with program = program }
-    let! expr = PT2RT.Expr.toRT mod'.exprs[0]
+    let expr = PT2RT.Expr.toRT mod'.exprs[0]
     return! Exe.executeExpr state symtable expr
   }
 
@@ -236,9 +232,9 @@ module PackageBootstrapping =
 
       let! (inMemPackageManager : RT.PackageManager) =
         uply {
-          let! types = types |> Ply.List.mapSequentially PT2RT.PackageType.toRT
-          let! fns = fns |> Ply.List.mapSequentially PT2RT.PackageFn.toRT
-          let! consts = consts |> Ply.List.mapSequentially PT2RT.PackageConstant.toRT
+          let types = types |> List.map PT2RT.PackageType.toRT
+          let fns = fns |> List.map PT2RT.PackageFn.toRT
+          let consts = consts |> List.map PT2RT.PackageConstant.toRT
 
           let pm : RT.PackageManager =
             { getType =

--- a/backend/src/QueueWorker/QueueWorker.fs
+++ b/backend/src/QueueWorker/QueueWorker.fs
@@ -200,12 +200,11 @@ let processNotification
 
                   // CLEANUP Set a time limit of 3m
                   try
-                    let! handler = PT2RT.Handler.toRT h
                     let! program = Canvas.toProgram c
                     let! (result, traceResults) =
                       CloudExecution.executeHandler
                         LibClientTypesToCloudTypes.Pusher.eventSerializer
-                        handler
+                        (PT2RT.Handler.toRT h)
                         program
                         traceID
                         (Map [ "event", event.value ])

--- a/backend/src/Wasm/Libs/Editor.fs
+++ b/backend/src/Wasm/Libs/Editor.fs
@@ -50,14 +50,12 @@ let fns : List<BuiltInFn> =
         let resultError = Dval.resultError okType VT.string
         (function
         | _, [ _typeParam ], [ DUnit ] ->
-          uply {
-            try
-              let state = editor.CurrentState
-              // TODO: assert that the type matches the given typeParam
-              return! resultOk state
-            with e ->
-              return! $"Error getting state: {e.Message}" |> DString |> resultError
-          }
+          try
+            let state = editor.CurrentState
+            // TODO: assert that the type matches the given typeParam
+            resultOk state |> Ply
+          with e ->
+            $"Error getting state: {e.Message}" |> DString |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
@@ -73,11 +71,9 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, [ _typeParam ], [ v ] ->
-          uply {
-            // TODO: verify that the type matches the given typeParam
-            editor <- { editor with CurrentState = v }
-            return! Dval.resultOk VT.unknownTODO VT.string v
-          }
+          // TODO: verify that the type matches the given typeParam
+          editor <- { editor with CurrentState = v }
+          Dval.resultOk VT.unknownTODO VT.string v |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
@@ -114,17 +110,15 @@ let fns : List<BuiltInFn> =
 
           match args with
           | Ok args ->
-            uply {
-              try
-                do Wasm.WasmHelpers.callJSFunction functionName args
-                return! resultOk DUnit
-              with e ->
-                return!
-                  $"Error calling {functionName} with provided args: {e.Message}"
-                  |> DString
-                  |> resultError
-            }
-          | Error err -> resultError (DString err)
+            try
+              do Wasm.WasmHelpers.callJSFunction functionName args
+              resultOk DUnit |> Ply
+            with e ->
+              $"Error calling {functionName} with provided args: {e.Message}"
+              |> DString
+              |> resultError
+              |> Ply
+          | Error err -> resultError (DString err) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
@@ -168,9 +162,9 @@ let fns : List<BuiltInFn> =
             match result with
             | Error(_source, rte) ->
               // TODO probably need to call `toString` on the RTE, or raise it
-              return! resultError (DString(string rte))
+              return resultError (DString(string rte))
             | Ok result ->
-              return!
+              return
                 LibExecution.DvalReprDeveloper.toRepr result |> DString |> resultOk
           }
         | _ -> incorrectArgs ())

--- a/backend/tests/TestUtils/LibTest.fs
+++ b/backend/tests/TestUtils/LibTest.fs
@@ -110,9 +110,12 @@ let fns : List<BuiltInFn> =
           if Seq.length chars = 1 then
             chars
             |> Seq.toList
-            |> (fun l -> l[0] |> DChar |> Dval.optionSome VT.char)
+            |> (fun l -> l[0])
+            |> DChar
+            |> Dval.optionSome VT.char
+            |> Ply
           else
-            Dval.optionNone VT.char
+            Dval.optionNone VT.char |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/tests/Tests/Execution.Tests.fs
+++ b/backend/tests/Tests/Execution.Tests.fs
@@ -71,10 +71,9 @@ let testExecFunctionTLIDs : Test =
     let! meta = initializeTestCanvas "exec-function-tlids"
     let name = "testFunction"
     let ps = NEList.singleton "param"
-    let! (fn : UserFunction.T) =
+    let (fn : UserFunction.T) =
       testUserFn name [] ps (PT.TVariable "a") (PT.EInt(gid (), 5))
       |> PT2RT.UserFunction.toRT
-      |> Ply.toTask
     let fns = Map.ofList [ (fn.name, fn) ]
     let! state = executionStateFor meta false false Map.empty Map.empty fns Map.empty
 

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -69,45 +69,26 @@ let t
         else
           System.Guid.NewGuid() |> Task.FromResult
 
-      let! rtTypes =
+      let rtTypes =
         types
-        |> Ply.List.mapSequentially (fun typ ->
-          uply {
-            let! typRT = PT2RT.UserType.toRT typ
-            return (PT2RT.TypeName.UserProgram.toRT typ.name, typRT)
-          })
-        |> Ply.map Map.ofList
-        |> Ply.toTask
+        |> List.map (fun typ ->
+          (PT2RT.TypeName.UserProgram.toRT typ.name, PT2RT.UserType.toRT typ))
+        |> Map.ofList
 
-      let! rtDBs =
-        dbs
-        |> Ply.List.mapSequentially (fun db ->
-          uply {
-            let! dbRT = PT2RT.DB.toRT db
-            return (db.name, dbRT)
-          })
-        |> Ply.map Map.ofList
-        |> Ply.toTask
+      let rtDBs =
+        dbs |> List.map (fun db -> (db.name, PT2RT.DB.toRT db)) |> Map.ofList
 
-      let! rtFunctions =
+      let rtFunctions =
         functions
-        |> Ply.List.mapSequentially (fun fn ->
-          uply {
-            let! fn = PT2RT.UserFunction.toRT fn
-            return (fn.name, fn)
-          })
-        |> Ply.map Map.ofList
-        |> Ply.toTask
+        |> List.map (fun fn ->
+          (PT2RT.FnName.UserProgram.toRT fn.name, PT2RT.UserFunction.toRT fn))
+        |> Map.ofList
 
-      let! rtConstants =
+      let rtConstants =
         constants
-        |> Ply.List.mapSequentially (fun c ->
-          uply {
-            let! c = PT2RT.UserConstant.toRT c
-            return (c.name, c)
-          })
-        |> Ply.map Map.ofList
-        |> Ply.toTask
+        |> List.map (fun c ->
+          (PT2RT.ConstantName.UserProgram.toRT c.name, PT2RT.UserConstant.toRT c))
+        |> Map.ofList
 
       let! (state : RT.ExecutionState) =
         executionStateFor
@@ -133,7 +114,7 @@ let t
       let msg =
         $"\n\n{rhsMsg}\n\n{lhsMsg}\n\nTest location: {bold}{underline}{filename}:{lineNumber}{reset}"
 
-      let! expectedExpr = PT2RT.Expr.toRT expectedExpr |> Ply.toTask
+      let expectedExpr = PT2RT.Expr.toRT expectedExpr
       let! expected = Exe.executeExpr state Map.empty expectedExpr
 
       // Initialize
@@ -148,7 +129,7 @@ let t
           state
 
       // Run the actual program (left-hand-side of the =)
-      let! actualExpr = PT2RT.Expr.toRT actualExpr |> Ply.toTask
+      let actualExpr = PT2RT.Expr.toRT actualExpr
       let! actual = Exe.executeExpr state Map.empty actualExpr
 
       if System.Environment.GetEnvironmentVariable "DEBUG" <> null then

--- a/backend/tests/Tests/Parser.Tests.fs
+++ b/backend/tests/Tests/Parser.Tests.fs
@@ -17,7 +17,7 @@ let parserTests =
       let! actual =
         LibParser.Parser.parseRTExpr nameResolver "parser.tests.fs" testStr
         |> Ply.toTask
-      let! expectedExpr = PT2RT.Expr.toRT expectedExpr |> Ply.toTask
+      let expectedExpr = PT2RT.Expr.toRT expectedExpr
       return Expect.equalExprIgnoringIDs actual expectedExpr
     }
   let id = 0UL // since we're ignoring IDs, just use the same one everywhere

--- a/backend/tests/Tests/ProgramTypes.Tests.fs
+++ b/backend/tests/Tests/ProgramTypes.Tests.fs
@@ -53,7 +53,7 @@ let testProgramTypesToRuntimeTypes =
   let u = PT.EUnit(8UL)
   let ru = RT.EUnit(8UL)
 
-  testManyPly
+  testMany
     "program types to runtime types"
     PT2RT.Expr.toRT
     [ PT.EFloat(7UL, Positive, "", "0"), RT.EFloat(7UL, 0.0)

--- a/backend/tests/Tests/Serialization.DarkTypes.Tests.fs
+++ b/backend/tests/Tests/Serialization.DarkTypes.Tests.fs
@@ -36,12 +36,12 @@ module RoundtripTests =
     (testName : string)
     (typeName : RT.TypeName.TypeName)
     (original : 'a)
-    (toDT : 'a -> Ply<RT.Dval>)
+    (toDT : 'a -> RT.Dval)
     (fromDT : RT.Dval -> 'a)
     (customExpect : Option<'a -> 'a -> string -> unit>)
     =
     testTask testName {
-      let! firstDT = original |> toDT |> Ply.toTask
+      let firstDT = original |> toDT
 
       let context =
         LibExecution.TypeChecker.Context.FunctionCallResult(
@@ -86,7 +86,7 @@ module RoundtripTests =
     (testName : string)
     (typeName : RT.TypeName.TypeName)
     (original : List<'a>)
-    (toDT : 'a -> Ply<RT.Dval>)
+    (toDT : 'a -> RT.Dval)
     (fromDT : RT.Dval -> 'a)
     (customExpect : Option<'a -> 'a -> string -> unit>)
     =


### PR DESCRIPTION
PT2DT and RT2DT don't need to go through the Dval. functions - trying to ensure safe construction of dvals _everywhere_ was causing more pain that it's worth. Maybe we'll circle back some day here.

I was intending for this commit to be part of a larger PR, but that work is taking a bit of time, so I'll merge this in the meantime.