### PR TITLE
Finish JSON improvements

### DIFF
--- a/CODING-GUIDE.md
+++ b/CODING-GUIDE.md
@@ -21,7 +21,7 @@
   - String (not Str)
   - Float
   - Bool (not Boolean)
-  - Char (not Character)
+  - Char (not Char)
   - Uuid (not UUID)
   - Dict (not Dictionary)
 

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -277,7 +277,7 @@ let fns : List<BuiltInFn> =
 
                           match! Json.parse types typ str with
                           | Ok v -> return v
-                          | Error e -> return (DString e)
+                          | Error e -> return! (Json.Error.toDT e)
                         })
                       (List.zip expectedTypes stringArgs)
 

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -277,7 +277,7 @@ let fns : List<BuiltInFn> =
 
                           match! Json.parse types typ str with
                           | Ok v -> return v
-                          | Error e -> return! (Json.Error.toDT e)
+                          | Error e -> return! (Json.ParseError.toDT e)
                         })
                       (List.zip expectedTypes stringArgs)
 

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -553,10 +553,7 @@ let parse
 
           | TypeDeclaration.Record fields ->
             if jsonValueKind <> JsonValueKind.Object then
-              // TODO should be user facing
-              Exception.raiseInternal
-                "Expected an object for a record"
-                [ "type", typeName; "value", j ]
+              do! raiseCantMatchWithType typ j pathSoFar
 
             let enumerated = j.EnumerateObject() |> Seq.toList
 

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -182,11 +182,7 @@ let rec serialize
                 "expectedFields", fields ]
 
 
-    | TCustomType(Error errTypeName, _typeArgs), dval ->
-      // TODO should be an RTE
-      Exception.raiseInternal
-        "Couldn't resolve type name"
-        [ "typeName", errTypeName; "dval", dval ]
+    | TCustomType(Error err, _typeArgs), dval -> raiseUntargetedRTE err
 
 
     // Not supported

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -216,7 +216,7 @@ let rec serialize
     | TDict _, _ ->
       // Internal error as this shouldn't get past the typechecker
       Exception.raiseInternal
-        "Can't currently serialize this type/value combination"
+        "Can't serialize this type/value combination"
         [ "value", dv; "type", DString(LibExecution.DvalReprDeveloper.typeName typ) ]
   }
 

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -567,7 +567,7 @@ let fns : List<BuiltInFn> =
   [ { name = fn "serialize" 0
       typeParams = [ "a" ]
       parameters = [ Param.make "arg" (TVariable "a") "" ]
-      returnType = TypeReference.result TString TString
+      returnType = TString
       description = "Serializes a Dark value to a JSON string."
       fn =
         (function
@@ -577,9 +577,6 @@ let fns : List<BuiltInFn> =
             // "'b = Int",
             // so we can Json.serialize<'b>, if 'b is in the surrounding context
 
-            // CLEANUP this should not return a Result
-            // if anything fails due to types, it should result as an InternalException
-            // naturally
             let types = ExecutionState.availableTypes state
             let! response =
               writeJson (fun w -> serialize types w typeToSerializeAs arg)

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -460,9 +460,13 @@ let parse
 
               let! fields =
                 List.zip matchingCase.fields j
-                |> List.map (fun (typ, j) ->
+                |> List.mapWithIndex (fun i (typ, j) ->
+                  let path =
+                    JsonPath.Part.Index i
+                    :: JsonPath.Part.Field caseName
+                    :: pathSoFar
                   let typ = Types.substitute decl.typeParams typeArgs typ
-                  convert typ pathSoFar j) // TODO revisit if we need to do anything with path
+                  convert typ path j)
                 |> Ply.List.flatten
 
               return! Dval.enum typeName typeName VT.typeArgsTODO' caseName fields

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -95,13 +95,12 @@ module RuntimeError =
     | UnsupportedType of TypeReference
   let toRuntimeError (e : Error) : Ply<RuntimeError> =
     uply {
-      let! (caseName, fields) =
-        uply {
-          match e with
-          | UnsupportedType typ ->
-            let! typ = RT2DT.TypeReference.toDT typ
-            return "UnsupportedType", [ typ ]
-        }
+      let (caseName, fields) =
+        match e with
+        | UnsupportedType typ ->
+          let typ = RT2DT.TypeReference.toDT typ
+          "UnsupportedType", [ typ ]
+
       let typeName = RuntimeError.name [ "Json" ] "Error" 0
       return!
         Dval.enum typeName typeName (Some []) caseName fields
@@ -129,7 +128,7 @@ module Error =
           match e with
           | NotJson -> return "NotJson", []
           | CantMatchWithType(typ, json, errorPath) ->
-            let! typ = RT2DT.TypeReference.toDT typ
+            let typ = RT2DT.TypeReference.toDT typ
             let! errorPath = JsonPath.toDT errorPath
             return "CantMatchWithType", [ typ; DString json; errorPath ]
         }

--- a/backend/src/BuiltinExecution/Libs/NoModule.fs
+++ b/backend/src/BuiltinExecution/Libs/NoModule.fs
@@ -345,7 +345,9 @@ let fns : List<BuiltInFn> =
                 |> raiseUntargetedRTE
             | _ -> return raiseUntargetedRTE (RuntimeError.oldError "Invalid Option")
           }
-        | _ -> incorrectArgs ())
+        | _ ->
+          RuntimeError.oldError "Unwrap called with non-Option/non-Result"
+          |> raiseUntargetedRTE)
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -39,7 +39,7 @@ let fns : List<BuiltInFn> =
             [ "character" ] ]
       returnType = TString
       description =
-        "Iterate over each Character (EGC, not byte) in the string, performing the
+        "Iterate over each Char (EGC, not byte) in the string, performing the
          operation in <param fn> on each one."
       fn =
         (function

--- a/backend/src/Cli/prompt.txt
+++ b/backend/src/Cli/prompt.txt
@@ -33,7 +33,7 @@ Here are some functions available in Dark:
 
 These are the available standard library modules:
 - Int
-- Character
+- Char
 - String
 - Float
 - Bool

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -55,14 +55,16 @@ let executeExpr
   : Task<RT.ExecutionResult> =
   task {
     try
-      let symtable = Interpreter.withGlobals state inputVars
-      let typeSymbolTable = Map.empty
-      let! result = Interpreter.eval state typeSymbolTable symtable expr
+      try
+        let symtable = Interpreter.withGlobals state inputVars
+        let typeSymbolTable = Map.empty
+        let! result = Interpreter.eval state typeSymbolTable symtable expr
+        return Ok result
+      with RT.RuntimeErrorException(source, rte) ->
+        return Error(source, rte)
+    finally
       // Does nothing in non-tests
-      state.test.postTestExecutionHook state.test result
-      return Ok result
-    with RT.RuntimeErrorException(source, rte) ->
-      return Error(source, rte)
+      state.test.postTestExecutionHook state.test
   }
 
 
@@ -75,14 +77,16 @@ let executeFunction
   : Task<RT.ExecutionResult> =
   task {
     try
-      let typeSymbolTable = Map.empty
-      let! result =
-        Interpreter.callFn state typeSymbolTable callerID name typeArgs args
+      try
+        let typeSymbolTable = Map.empty
+        let! result =
+          Interpreter.callFn state typeSymbolTable callerID name typeArgs args
+        return Ok result
+      with RT.RuntimeErrorException(source, rte) ->
+        return Error(source, rte)
+    finally
       // Does nothing in non-tests
-      state.test.postTestExecutionHook state.test result
-      return Ok result
-    with RT.RuntimeErrorException(source, rte) ->
-      return Error(source, rte)
+      state.test.postTestExecutionHook state.test
   }
 
 let runtimeErrorToString

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -25,7 +25,7 @@ let noTestContext : RT.TestContext =
 
     exceptionReports = []
     expectedExceptionCount = 0
-    postTestExecutionHook = fun _ _ -> () }
+    postTestExecutionHook = fun _ -> () }
 
 let createState
   (builtIns : RT.BuiltIns)

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -874,7 +874,11 @@ and execFn
                   return! f (state, typeArgs, NEList.toList args)
                 with e ->
                   match e with
-                  | RuntimeErrorException(source, rte) -> return Exception.reraise e
+                  | RuntimeErrorException(SourceNone _, rte) ->
+                    // Add the caller ID to the error if there isn't one already
+                    return raiseRTE sourceID rte
+                  | RuntimeErrorException _ -> return Exception.reraise e
+
                   | e ->
                     let context : Metadata =
                       [ "fn", fnDesc; "args", args; "typeArgs", typeArgs; "id", id ]

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1258,7 +1258,7 @@ and TestContext =
 
     mutable exceptionReports : List<string * string * Metadata>
     mutable expectedExceptionCount : int
-    postTestExecutionHook : TestContext -> Dval -> unit }
+    postTestExecutionHook : TestContext -> unit }
 
 // Functionally written in F# and shipped with the executable
 and BuiltIns =

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -746,6 +746,8 @@ module RuntimeError =
 
   let typeCheckerError field = case "TypeCheckerError" [ field ]
 
+  let jsonError field = case "JsonError" [ field ]
+
   let sqlCompilerRuntimeError (internalError : RuntimeError) =
     case "SqlCompilerRuntimeError" [ toDT internalError ]
 
@@ -770,11 +772,11 @@ module RuntimeError =
 
 exception RuntimeErrorException of DvalSource * RuntimeError
 
-let raiseRTE (source : DvalSource) (rte : RuntimeError) =
+let raiseRTE (source : DvalSource) (rte : RuntimeError) : 'a =
   raise (RuntimeErrorException(source, rte))
 
 // TODO add sources to all RTEs
-let raiseUntargetedRTE (rte : RuntimeError) =
+let raiseUntargetedRTE (rte : RuntimeError) : 'a =
   raise (RuntimeErrorException(SourceNone, rte))
 
 // TODO remove all usages of this in favor of better error cases

--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -711,6 +711,26 @@ module Function =
 
     | _ -> Exception.raiseInternal "Unsupported pattern" [ "pat", pat ]
 
+  let hasArguments (binding : SynBinding) : bool =
+    match binding with
+    | SynBinding(_,
+                 _,
+                 _,
+                 _,
+                 _,
+                 _,
+                 _,
+                 SynPat.LongIdent(_, _, _, argPats, _, _),
+                 _,
+                 _,
+                 _,
+                 _,
+                 _) ->
+      match argPats with
+      | SynArgPats.Pats l -> not (List.isEmpty l)
+      | SynArgPats.NamePatPairs(l, _, _) -> not (List.isEmpty l)
+    | _ -> false
+
 
   let fromSynBinding (binding : SynBinding) : T =
     match binding with

--- a/backend/src/LibParser/Package.fs
+++ b/backend/src/LibParser/Package.fs
@@ -25,19 +25,17 @@ type PTPackageModule =
 let emptyPTModule = { fns = []; types = []; constants = [] }
 
 
-/// Update a CanvasModule by parsing a single F# let binding
-/// Depending on the attribute present, this may add a user function, a handler, or a DB
+/// Update a Package by parsing a single F# let binding
 let parseLetBinding
   (modules : List<string>)
   (letBinding : SynBinding)
   : List<WT.PackageFn.T> * List<WT.PackageConstant.T> =
   match modules with
   | owner :: modules ->
-    try
+    if FS2WT.Function.hasArguments letBinding then
       [ FS2WT.PackageFn.fromSynBinding owner modules letBinding ], []
-    with _ ->
+    else
       [], [ FS2WT.PackageConstant.fromSynBinding owner modules letBinding ]
-
   | _ ->
     Exception.raiseInternal
       "Expected owner, and at least 1 other modules"

--- a/backend/src/LocalExec/local-exec.dark
+++ b/backend/src/LocalExec/local-exec.dark
@@ -77,7 +77,6 @@ let loadPackageFileIntoDarkCanvas
     |> PACKAGE.Darklang.Stdlib.List.map (fun fn ->
       fn
       |> Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>
-      |> Builtin.unwrap
       |> saveItemToCanvas "function")
 
   let typeResults =
@@ -85,7 +84,6 @@ let loadPackageFileIntoDarkCanvas
     |> PACKAGE.Darklang.Stdlib.List.map (fun t ->
       t
       |> Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
-      |> Builtin.unwrap
       |> saveItemToCanvas "type")
 
   let constantResults =
@@ -93,7 +91,6 @@ let loadPackageFileIntoDarkCanvas
     |> PACKAGE.Darklang.Stdlib.List.map (fun c ->
       c
       |> Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>
-      |> Builtin.unwrap
       |> saveItemToCanvas "constant")
 
   // Flatten all the result lists into one list

--- a/backend/src/Prelude/Prelude.fs
+++ b/backend/src/Prelude/Prelude.fs
@@ -379,7 +379,12 @@ let randomSeeded () : System.Random =
 
 let gid () : uint64 =
   try
-    RNG.GetBytes(8) |> System.BitConverter.ToUInt64
+    let rand64 = RNG.GetBytes(8) |> System.BitConverter.ToUInt64
+    // Dark only has 63 bits of positive numbers, so to make it easier to convert IDs
+    // to dark, we keep IDs in that range.
+    let mask =
+      0b0111_1111_1111_1111_1111_1111_1111_1111_0011_1111_1111_1111_1111_1111_1111_1111UL
+    rand64 &&& mask
   with e ->
     Exception.raiseInternal $"gid failed" [ "message", e.Message; "inner", e ]
 

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -425,7 +425,17 @@ module BadTypes =
   // Builtin.Json.parse<'a> "5" = Result.Ok Builtin.Bytes.empty
   // Builtin.Json.serialize<'a> 5 = Result.Error "dunno what happens"
 
-  1 = 1 // just here to avoid parser errors
+  Builtin.Json.parse<Int -> Int> "{}" = Builtin.Test.derrorMessage
+    "Unsupported type in JSON: (Int) -> Int. Some types are not supported in Json serialization, and cannot be used as arguments to Json.parse or Json.serialize
+
+Expected: A supported type (Int, String, etc)
+Actual: (Int) -> Int"
+
+  Builtin.Json.serialize<Int -> Int> (fun i -> 5) = Builtin.Test.derrorMessage
+    "Unsupported type in JSON: (Int) -> Int. Some types are not supported in Json serialization, and cannot be used as arguments to Json.parse or Json.serialize
+
+Expected: A supported type (Int, String, etc)
+Actual: (Int) -> Int"
 
 
 module List =

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -896,6 +896,16 @@ module UserDefinedRecords =
     (Builtin.Json.parse<Person> "[]") |> err = Result.Error
       "Can't parse JSON `[]` as type `Person` at path: `root`"
 
+    // Extra fields are allowed, but missing fields are not
+    (Builtin.Json.parse<Person> "{\"notAField\": 5}") |> err = Result.Error
+      "Can't parse JSON because `Name` field is not provided at path: `root`"
+
+    (Builtin.Json.parse<Person> "{\"Age\": 5, \"Age\": 6, \"Name\": \"\"}") |> err = Result.Error
+      "Can't parse JSON because `Age` is defined more than once at path: `root`"
+
+
+
+
 module UserDefinedAliases =
 
   type MyInt = Int

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -10,21 +10,29 @@ type Person = { Name: String; Age: Int }
 type Result<'ok, 'err> = PACKAGE.Darklang.Stdlib.Result.Result<'ok, 'err>
 type Option<'t> = PACKAGE.Darklang.Stdlib.Option.Option<'t>
 
+let err
+  (v:
+    PACKAGE.Darklang.Stdlib.Result.Result<'a, PACKAGE.Darklang.Stdlib.Json.Error.Error>)
+  : Result<'a, String> =
+  v
+  |> PACKAGE.Darklang.Stdlib.Result.mapError
+    PACKAGE.Darklang.Stdlib.Json.Error.toString
+
 
 module Unit =
   Builtin.Json.serialize<Unit> () = "null"
   Builtin.Json.parse<Unit> "null" = Result.Ok()
 
   module Errors =
-    Builtin.Json.parse<Int> "()" = Result.Error "not JSON"
+    (Builtin.Json.parse<Int> "()") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Unit> "0" = Result.Error
+    (Builtin.Json.parse<Unit> "0") |> err = Result.Error
       "Can't parse JSON `0` as type `Unit` at path: `root`"
 
-    Builtin.Json.parse<Unit> "\"\"" = Result.Error
+    (Builtin.Json.parse<Unit> "\"\"") |> err = Result.Error
       "Can't parse JSON `\"\"` as type `Unit` at path: `root`"
 
-    Builtin.Json.parse<Unit> "\"null\"" = Result.Error
+    (Builtin.Json.parse<Unit> "\"null\"") |> err = Result.Error
       "Can't parse JSON `\"null\"` as type `Unit` at path: `root`"
 
 
@@ -41,25 +49,25 @@ module Bool =
     [ true; true; false; true ]
 
   module Errors =
-    Builtin.Json.parse<Bool> "tru" = Result.Error "not JSON"
+    (Builtin.Json.parse<Bool> "tru") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Bool> "null" = Result.Error
+    (Builtin.Json.parse<Bool> "null") |> err = Result.Error
       "Can't parse JSON `null` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "" = Result.Error "not JSON"
+    (Builtin.Json.parse<Bool> "") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Bool> "\"true\"" = Result.Error
+    (Builtin.Json.parse<Bool> "\"true\"") |> err = Result.Error
       "Can't parse JSON `\"true\"` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "0" = Result.Error
+    (Builtin.Json.parse<Bool> "0") |> err = Result.Error
       "Can't parse JSON `0` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "1" = Result.Error
+    (Builtin.Json.parse<Bool> "1") |> err = Result.Error
       "Can't parse JSON `1` as type `Bool` at path: `root`"
 
-    Builtin.Json.parse<Bool> "False" = Result.Error "not JSON"
+    (Builtin.Json.parse<Bool> "False") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Bool> "tRUE" = Result.Error "not JSON"
+    (Builtin.Json.parse<Bool> "tRUE") |> err = Result.Error "Not JSON"
 
 
 module Int =
@@ -93,14 +101,14 @@ module Int =
     // be certain
 
     // First number that doesn't fit in an int64
-    Builtin.Json.parse<Int> "9223372036854775808" = Result.Error
+    (Builtin.Json.parse<Int> "9223372036854775808") |> err = Result.Error
       "Can't parse JSON `9223372036854775808` as type `Int` at path: `root`"
 
     // This is a float that is a valid int64
     Builtin.Json.parse<Int> "9.2E18" = Result.Ok 9200000000000000000L
 
     // This is a float that is slightly above the int64 max
-    Builtin.Json.parse<Int> "9.3E18" = Result.Error
+    (Builtin.Json.parse<Int> "9.3E18") |> err = Result.Error
       "Can't parse JSON `9.3E18` as type `Int` at path: `root`"
 
     Builtin.Json.serialize<Int> 9223372036854775807L = "9223372036854775807"
@@ -117,33 +125,33 @@ module Int =
     // TODO: review Float.tests for more values to test against
 
     // not ints
-    Builtin.Json.parse<Int> " " = Result.Error "not JSON"
-    Builtin.Json.parse<Int> "4a" = Result.Error "not JSON"
+    (Builtin.Json.parse<Int> " ") |> err = Result.Error "Not JSON"
+    (Builtin.Json.parse<Int> "4a") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Int> "- 42" = Result.Error "not JSON"
+    (Builtin.Json.parse<Int> "- 42") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Int> "null" = Result.Error
+    (Builtin.Json.parse<Int> "null") |> err = Result.Error
       "Can't parse JSON `null` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "true" = Result.Error
+    (Builtin.Json.parse<Int> "true") |> err = Result.Error
       "Can't parse JSON `true` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "false" = Result.Error
+    (Builtin.Json.parse<Int> "false") |> err = Result.Error
       "Can't parse JSON `false` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "\"42\"" = Result.Error
+    (Builtin.Json.parse<Int> "\"42\"") |> err = Result.Error
       "Can't parse JSON `\"42\"` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "[42]" = Result.Error
+    (Builtin.Json.parse<Int> "[42]") |> err = Result.Error
       "Can't parse JSON `[42]` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "{ \"key\": 42 }" = Result.Error
+    (Builtin.Json.parse<Int> "{ \"key\": 42 }") |> err = Result.Error
       "Can't parse JSON `{ \"key\": 42 }` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "42.5" = Result.Error
+    (Builtin.Json.parse<Int> "42.5") |> err = Result.Error
       "Can't parse JSON `42.5` as type `Int` at path: `root`"
 
-    Builtin.Json.parse<Int> "\"42\n\"" = Result.Error "not JSON"
+    (Builtin.Json.parse<Int> "\"42\n\"") |> err = Result.Error "Not JSON"
 
 
 module Float =
@@ -160,7 +168,10 @@ module Float =
   Builtin.Json.serialize<Float> 12345.67890 = "12345.6789"
   Builtin.Json.serialize<Float> -12345.67890 = "-12345.6789"
 
+  // ints as floats
   Builtin.Json.parse<Float> "0.0" = Result.Ok 0.0
+  Builtin.Json.parse<Float> "0" = Result.Ok 0.0
+  Builtin.Json.parse<Float> "123" = Result.Ok 123.0
 
 
   Builtin.Json.parse<Float> "12345.67890" = Result.Ok 12345.67890
@@ -212,53 +223,53 @@ module Float =
 
   module Errors =
 
-    Builtin.Json.parse<Float> "e" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "e") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "pi" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "pi") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> " -42 . 0 " = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> " -42 . 0 ") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "0" = Result.Ok 0.0
+    (Builtin.Json.parse<Float> "0") |> err = Result.Ok 0.0
 
-    Builtin.Json.parse<Float> " " = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> " ") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "4a" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "4a") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "- 42.0" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "- 42.0") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "-141s" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "-141s") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "null" = Result.Error
+    (Builtin.Json.parse<Float> "null") |> err = Result.Error
       "Can't parse JSON `null` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "true" = Result.Error
+    (Builtin.Json.parse<Float> "true") |> err = Result.Error
       "Can't parse JSON `true` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "false" = Result.Error
+    (Builtin.Json.parse<Float> "false") |> err = Result.Error
       "Can't parse JSON `false` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "\"42\"" = Result.Error
+    (Builtin.Json.parse<Float> "\"42\"") |> err = Result.Error
       "Can't parse JSON `\"42\"` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "[42]" = Result.Error
+    (Builtin.Json.parse<Float> "[42]") |> err = Result.Error
       "Can't parse JSON `[42]` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "{ \"key\": 42 }" = Result.Error
+    (Builtin.Json.parse<Float> "{ \"key\": 42 }") |> err = Result.Error
       "Can't parse JSON `{ \"key\": 42 }` as type `Float` at path: `root`"
 
-    Builtin.Json.parse<Float> "\"42\n\"" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "\"42\n\"") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "000000.9" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "000000.9") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "-000000.9" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "-000000.9") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "-00000000.000" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "-00000000.000") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<Float> "00000000.000" = Result.Error "not JSON"
+    (Builtin.Json.parse<Float> "00000000.000") |> err = Result.Error "Not JSON"
 
     // This tests that we get a Result.Error when trying to parse a string, not an
     // internal exception
-    Builtin.Json.parse<Float> "\"65.0\"" = Result.Error
+    (Builtin.Json.parse<Float> "\"65.0\"") |> err = Result.Error
       "Can't parse JSON `\"65.0\"` as type `Float` at path: `root`"
 
 
@@ -292,13 +303,13 @@ module Char =
   Builtin.Json.parse<Char> "\"Ł\"" = Result.Ok 'Ł'
 
   module Errors =
-    Builtin.Json.parse<Char> "\"test\"" = Result.Error
+    (Builtin.Json.parse<Char> "\"test\"") |> err = Result.Error
       "Can't parse JSON `\"test\"` as type `Char` at path: `root`"
 
-    Builtin.Json.parse<Char> "\"\"" = Result.Error
+    (Builtin.Json.parse<Char> "\"\"") |> err = Result.Error
       "Can't parse JSON `\"\"` as type `Char` at path: `root`"
 
-    Builtin.Json.parse<Char> "62" = Result.Error
+    (Builtin.Json.parse<Char> "62") |> err = Result.Error
       "Can't parse JSON `62` as type `Char` at path: `root`"
 
 
@@ -374,13 +385,13 @@ module DateTime =
   )
 
   module Errors =
-    Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36\"" = Result.Error
+    (Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36\"") |> err = Result.Error
       "Can't parse JSON `\"3023-07-28T22:42:36\"` as type `DateTime` at path: `root`"
 
-    Builtin.Json.parse<DateTime> "\"2023-07-28\"" = Result.Error
+    (Builtin.Json.parse<DateTime> "\"2023-07-28\"") |> err = Result.Error
       "Can't parse JSON `\"2023-07-28\"` as type `DateTime` at path: `root`"
 
-    Builtin.Json.parse<DateTime> "1" = Result.Error
+    (Builtin.Json.parse<DateTime> "1") |> err = Result.Error
       "Can't parse JSON `1` as type `DateTime` at path: `root`"
 
 
@@ -391,26 +402,26 @@ module Uuid =
   // empty
   Builtin.Json.serialize<Uuid> (uuid "00000000-0000-0000-0000-000000000000") = "\"00000000-0000-0000-0000-000000000000\""
 
-  Builtin.Json.parse<Uuid> ("\"00000000-0000-0000-0000-000000000000\"") = Result.Ok(
+  Builtin.Json.parse<Uuid> "\"00000000-0000-0000-0000-000000000000\"" = Result.Ok(
     uuid "00000000-0000-0000-0000-000000000000"
   )
 
   // normal
   Builtin.Json.serialize<Uuid> (uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = "\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\""
 
-  Builtin.Json.parse<Uuid> ("\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"") = Result.Ok(
+  Builtin.Json.parse<Uuid> "\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"" = Result.Ok(
     uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
   )
 
   Builtin.Json.serialize<Uuid> (uuid "11111111-2222-3333-4444-555555555555") = "\"11111111-2222-3333-4444-555555555555\""
 
-  Builtin.Json.parse<Uuid> ("\"11111111-2222-3333-4444-555555555555\"") = Result.Ok(
+  Builtin.Json.parse<Uuid> "\"11111111-2222-3333-4444-555555555555\"" = Result.Ok(
     uuid "11111111-2222-3333-4444-555555555555"
   )
 
   module Errors =
     // needs one more 0 at the end
-    Builtin.Json.parse<Uuid> "\"00000000-0000-0000-0000-00000000000\"" = Result.Error
+    (Builtin.Json.parse<Uuid> "\"00000000-0000-0000-0000-00000000000\"") |> err = Result.Error
       "Can't parse JSON `\"00000000-0000-0000-0000-00000000000\"` as type `Uuid` at path: `root`"
 
 
@@ -448,7 +459,7 @@ module List =
 
   Builtin.Json.parse<List<Int>> "[1,2,3]" = Result.Ok [ 1; 2; 3 ]
 
-  Builtin.Json.parse<List<Int>> "[1,2,3,]" = Result.Error "not JSON"
+  (Builtin.Json.parse<List<Int>> "[1,2,3,]") |> err = Result.Error "Not JSON"
 
   Builtin.Json.serialize<List<List<List<Int>>>>
     [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ] = "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]"
@@ -486,18 +497,23 @@ module List =
 
   module Errors =
     Builtin.Json.serialize<List<Int>> [ 1, 2, "three" ] = Builtin.Test.derrorMessage
-      "Json.serialize's 1st argument (`arg`) should be a List<Int>. However, an (Int, Int, String) ((1, 2, \"th...) was passed instead.\n\nExpected: (arg: 'a)\nActual: an (Int, Int, String): (1, 2, \"three\")"
+      "Json.serialize's 1st argument (`arg`) should be a List<Int>. However, an (Int, Int, String) ((1, 2, \"th...) was passed instead.
 
-    Builtin.Json.parse<List<Int>> "[1, 2, \"three\"]" = Result.Error
+Expected: (arg: 'a)
+Actual: an (Int, Int, String): (1, 2, \"three\")"
+
+    (Builtin.Json.parse<List<Int>> "[1, 2, \"three\"]") |> err = Result.Error
       "Can't parse JSON `\"three\"` as type `Int` at path: `root[2]`"
 
-    Builtin.Json.parse<List<Int>> "[1, 2, ]" = Result.Error "not JSON"
+    (Builtin.Json.parse<List<Int>> "[1, 2, ]") |> err = Result.Error "Not JSON"
 
-    Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5.5,6]],[[7,8],[9,0]]]" = Result.Error
+    (Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5.5,6]],[[7,8],[9,0]]]")
+    |> err = Result.Error
       "Can't parse JSON `5.5` as type `Int` at path: `root[0][1][1]`"
 
-    Builtin.Json.parse<List<Dict<Int>>>
-      """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = Result.Error
+    (Builtin.Json.parse<List<Dict<Int>>>
+      """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""")
+    |> err = Result.Error
       "Can't parse JSON `\"Alice\"` as type `Int` at path: `root[0].name`"
 
 
@@ -505,8 +521,8 @@ module Tuples =
   Builtin.Json.serialize<Int * String * Int> (1, "two", 3) = "[1,\"two\",3]"
   Builtin.Json.parse<Int * String * Int> "[1,\"two\",3]" = Result.Ok((1, "two", 3))
 
-  Builtin.Json.parse<Int * String * Int> "[1,3]" = Result.Error
-    "Can't parse JSON `[1,3]` as type `(Int, String, Int)` at path: `root`"
+  (Builtin.Json.parse<Int * String * Int> "[1,3]") |> err = Result.Error
+    "Can't parse JSON `[1,3]` as type `(Int * String * Int)` at path: `root`"
 
 
   Builtin.Json.serialize<List<Int> * List<Person>> (
@@ -586,25 +602,28 @@ module Tuples =
 
 
   module Errors =
-    Builtin.Json.parse<String * String * Int> """[1, "two", 3]""" = Result.Error
+    (Builtin.Json.parse<String * String * Int> """[1, "two", 3]""") |> err = Result.Error
       "Can't parse JSON `1` as type `String` at path: `root[0]`"
 
-    Builtin.Json.parse<String> """[1, "two", 3]""" = Result.Error
+    (Builtin.Json.parse<String> """[1, "two", 3]""") |> err = Result.Error
       "Can't parse JSON `[1, \"two\", 3]` as type `String` at path: `root`"
 
-    Builtin.Json.parse<Int * String> """[1, "two", 3]""" = Result.Error
-      "Can't parse JSON `[1, \"two\", 3]` as type `(Int, String)` at path: `root`"
+    (Builtin.Json.parse<Int * String> """[1, "two", 3]""") |> err = Result.Error
+      "Can't parse JSON `[1, \"two\", 3]` as type `(Int * String)` at path: `root`"
 
-    Builtin.Json.parse<((List<String * String>) * Bytes) * (Person * Dict<String>)>
-      "[[[[2,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":1}]]" = Result.Error
+    (Builtin.Json.parse<((List<String * String>) * Bytes) * (Person * Dict<String>)>
+      "[[[[2,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":1}]]")
+    |> err = Result.Error
       "Can't parse JSON `2` as type `String` at path: `root[0][0][0][0]`"
 
-    Builtin.Json.parse<(List<Int * List<String>>) * String>
-      "[[[1,\"two\"],[3,\"four\"]],\"\"]" = Result.Error
+    (Builtin.Json.parse<(List<Int * List<String>>) * String>
+      "[[[1,\"two\"],[3,\"four\"]],\"\"]")
+    |> err = Result.Error
       "Can't parse JSON `\"two\"` as type `List<String>` at path: `root[0][0][1]`"
 
-    Builtin.Json.parse<Person * Option<Int>>
-      "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]" = Result.Error
+    (Builtin.Json.parse<Person * Option<Int>>
+      "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]")
+    |> err = Result.Error
       "Can't parse JSON `\"one\"` as type `Int` at path: `root[1]`"
 
 
@@ -620,13 +639,13 @@ module Option =
 
   module Errors =
     // TODO: these might make good candidates for more ergonmic parsing
-    Builtin.Json.parse<Option<Int>> "null" = Result.Error
+    (Builtin.Json.parse<Option<Int>> "null") |> err = Result.Error
       "Can't parse JSON `null` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
 
-    Builtin.Json.parse<Option<Int>> "1" = Result.Error
+    (Builtin.Json.parse<Option<Int>> "1") |> err = Result.Error
       "Can't parse JSON `1` as type `PACKAGE.Darklang.Stdlib.Option.Option<Int>` at path: `root`"
 
-    Builtin.Json.parse<Option<List<String>>> "[1,2,3]" = Result.Error
+    (Builtin.Json.parse<Option<List<String>>> "[1,2,3]") |> err = Result.Error
       "Can't parse JSON `[1,2,3]` as type `PACKAGE.Darklang.Stdlib.Option.Option<List<String>>` at path: `root`"
 
 
@@ -696,7 +715,9 @@ module Dict =
     Dict { a = "b"; c = "d" }
   )
 
-  Builtin.Json.parse<Dict<Int>> """{1:"b",2:"d"}""" = Result.Error "not JSON"
+  module Errors =
+    (Builtin.Json.parse<Dict<Int>> """{1:"b",2:"d"}""") |> err = Result.Error
+      "Not JSON"
 
 
 module UserDefinedEnums =
@@ -878,7 +899,7 @@ Actual: an UserDefinedAliases.Person1: UserDefinedAliases.Person1 {\n  Age: 42,\
 
   Builtin.Json.serialize<StringResult<Int>> (Result.Error "err") = "{\"Error\":[\"err\"]}"
 
-// This test current gets by the typechecker, and so we get an internal exception
+// This test currently slips by the typechecker, and so we get an internal exception
 // Builtin.Json.serialize<StringResult<Int>> (Result.Error 1) = Result.Error
 //   "Can't currently serialize this type/value combination"
 

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -12,7 +12,7 @@ type Option<'t> = PACKAGE.Darklang.Stdlib.Option.Option<'t>
 
 
 module Unit =
-  Builtin.Json.serialize<Unit> () = Result.Ok "null"
+  Builtin.Json.serialize<Unit> () = "null"
   Builtin.Json.parse<Unit> "null" = Result.Ok()
 
   module Errors =
@@ -29,8 +29,8 @@ module Unit =
 
 
 module Bool =
-  Builtin.Json.serialize<Bool> true = Result.Ok "true"
-  Builtin.Json.serialize<Bool> false = Result.Ok "false"
+  Builtin.Json.serialize<Bool> true = "true"
+  Builtin.Json.serialize<Bool> false = "false"
 
   Builtin.Json.parse<Bool> "true" = Result.Ok true
   Builtin.Json.parse<Bool> "false" = Result.Ok false
@@ -64,9 +64,9 @@ module Bool =
 
 module Int =
   module Basic =
-    Builtin.Json.serialize<Int> 0 = Result.Ok "0"
-    Builtin.Json.serialize<Int> 12345 = Result.Ok "12345"
-    Builtin.Json.serialize<Int> -12345 = Result.Ok "-12345"
+    Builtin.Json.serialize<Int> 0 = "0"
+    Builtin.Json.serialize<Int> 12345 = "12345"
+    Builtin.Json.serialize<Int> -12345 = "-12345"
     Builtin.Json.parse<Int> "0" = Result.Ok 0
     Builtin.Json.parse<Int> "0.0" = Result.Ok 0
     Builtin.Json.parse<Int> "-0.0" = Result.Ok 0
@@ -77,12 +77,12 @@ module Int =
 
   module Int32Limits =
     // test the limits of int32 (-2147483648 to 2147483647)
-    Builtin.Json.serialize<Int> -2147483648 = Result.Ok "-2147483648"
-    Builtin.Json.serialize<Int> 2147483647 = Result.Ok "2147483647"
+    Builtin.Json.serialize<Int> -2147483648 = "-2147483648"
+    Builtin.Json.serialize<Int> 2147483647 = "2147483647"
     Builtin.Json.parse<Int> "-2147483648" = Result.Ok -2147483648L
     Builtin.Json.parse<Int> "2147483647" = Result.Ok 2147483647
-    Builtin.Json.serialize<Int> -2147483649L = Result.Ok "-2147483649"
-    Builtin.Json.serialize<Int> 2147483648L = Result.Ok "2147483648"
+    Builtin.Json.serialize<Int> -2147483649L = "-2147483649"
+    Builtin.Json.serialize<Int> 2147483648L = "2147483648"
     Builtin.Json.parse<Int> "-2147483649" = Result.Ok(-2147483649L)
     Builtin.Json.parse<Int> "2147483648" = Result.Ok(2147483648L)
 
@@ -103,13 +103,11 @@ module Int =
     Builtin.Json.parse<Int> "9.3E18" = Result.Error
       "Can't parse JSON `9.3E18` as type `Int` at path: `root`"
 
-    Builtin.Json.serialize<Int> 9223372036854775807L = Result.Ok
-      "9223372036854775807"
+    Builtin.Json.serialize<Int> 9223372036854775807L = "9223372036854775807"
 
     Builtin.Json.parse<Int> "9223372036854775807" = Result.Ok 9223372036854775807L
 
-    Builtin.Json.serialize<Int> -9223372036854775808L = Result.Ok
-      "-9223372036854775808"
+    Builtin.Json.serialize<Int> -9223372036854775808L = "-9223372036854775808"
 
     Builtin.Json.parse<Int> "-9223372036854775808" = Result.Ok(-9223372036854775808L)
 
@@ -153,14 +151,14 @@ module Float =
   // TODO: test highly-precise numbers
   // TODO: review Float.tests for more values to test against
 
-  Builtin.Json.serialize<Float> 0.0 = Result.Ok "0.0"
-  Builtin.Json.serialize<Float> 1.0 = Result.Ok "1.0"
-  Builtin.Json.serialize<Float> 0.1 = Result.Ok "0.1"
+  Builtin.Json.serialize<Float> 0.0 = "0.0"
+  Builtin.Json.serialize<Float> 1.0 = "1.0"
+  Builtin.Json.serialize<Float> 0.1 = "0.1"
 
-  Builtin.Json.serialize<Float> (2.0 / 3.0) = Result.Ok "0.6666666666666666"
+  Builtin.Json.serialize<Float> (2.0 / 3.0) = "0.6666666666666666"
 
-  Builtin.Json.serialize<Float> 12345.67890 = Result.Ok "12345.6789"
-  Builtin.Json.serialize<Float> -12345.67890 = Result.Ok "-12345.6789"
+  Builtin.Json.serialize<Float> 12345.67890 = "12345.6789"
+  Builtin.Json.serialize<Float> -12345.67890 = "-12345.6789"
 
   Builtin.Json.parse<Float> "0.0" = Result.Ok 0.0
 
@@ -174,10 +172,9 @@ module Float =
   Builtin.Json.parse<Float> "1e3" = Result.Ok 1000.0
   Builtin.Json.parse<Float> "-1e3" = Result.Ok -1000.0
 
-  Builtin.Json.serialize<Float> 3.14159265358979323846 = Result.Ok
-    "3.141592653589793"
+  Builtin.Json.serialize<Float> 3.14159265358979323846 = "3.141592653589793"
 
-  Builtin.Json.serialize<Float> 1.618033988749895 = Result.Ok "1.618033988749895"
+  Builtin.Json.serialize<Float> 1.618033988749895 = "1.618033988749895"
 
   Builtin.Json.parse<Float> "1.0000001" = Result.Ok 1.0000001
 
@@ -198,17 +195,16 @@ module Float =
   Builtin.Json.parse<Float> "0.7999999999" = Result.Ok 0.7999999999
 
   module Constants =
-    Builtin.Json.serialize<Float> Builtin.Test.negativeInfinity_v0 = Result.Ok
-      "\"-Infinity\""
+    Builtin.Json.serialize<Float> Builtin.Test.negativeInfinity_v0 = "\"-Infinity\""
 
     Builtin.Json.parse<Float> "\"-Infinity\"" = Result.Ok
       Builtin.Test.negativeInfinity_v0
 
-    Builtin.Json.serialize<Float> Builtin.Test.infinity_v0 = Result.Ok "\"Infinity\""
+    Builtin.Json.serialize<Float> Builtin.Test.infinity_v0 = "\"Infinity\""
 
     Builtin.Json.parse<Float> "\"Infinity\"" = Result.Ok Builtin.Test.infinity_v0
 
-    Builtin.Json.serialize<Float> Builtin.Test.nan_v0 = Result.Ok "\"NaN\""
+    Builtin.Json.serialize<Float> Builtin.Test.nan_v0 = "\"NaN\""
 
     Builtin.Json.parse<Float> "\"NaN\"" = Result.Ok Builtin.Test.nan_v0
 
@@ -271,19 +267,17 @@ module Char =
   let charFromString (s: String) : Char =
     (PACKAGE.Darklang.Stdlib.String.head s) |> Builtin.unwrap
 
-  Builtin.Json.serialize<Char> 'a' = Result.Ok "\"a\""
+  Builtin.Json.serialize<Char> 'a' = "\"a\""
   Builtin.Json.parse<Char> "\"a\"" = Result.Ok 'a'
 
   module SimpleEmoji =
-    Builtin.Json.serialize<Char> ("😂" |> charFromString) = Result.Ok
-      "\"\\uD83D\\uDE02\""
+    Builtin.Json.serialize<Char> ("😂" |> charFromString) = "\"\\uD83D\\uDE02\""
 
     Builtin.Json.parse<Char> "\"😂\"" = Result.Ok(charFromString "😂")
     Builtin.Json.parse<Char> "\"\\uD83D\\uDE02\"" = Result.Ok(charFromString "😂")
 
   module ComplexEmoji =
-    Builtin.Json.serialize<Char> (charFromString "👩‍👩‍👧‍👦") = Result.Ok
-      "\"\\uD83D\\uDC69‍\\uD83D\\uDC69‍\\uD83D\\uDC67‍\\uD83D\\uDC66\""
+    Builtin.Json.serialize<Char> (charFromString "👩‍👩‍👧‍👦") = "\"\\uD83D\\uDC69‍\\uD83D\\uDC69‍\\uD83D\\uDC67‍\\uD83D\\uDC66\""
 
     Builtin.Json.parse<Char>
       "\"\\uD83D\\uDC69‍\\uD83D\\uDC69‍\\uD83D\\uDC67‍\\uD83D\\uDC66\"" = Result.Ok(
@@ -294,7 +288,7 @@ module Char =
       "👩‍👩‍👧‍👦" |> charFromString
     )
 
-  Builtin.Json.serialize<Char> (charFromString "Ł") = Result.Ok "\"Ł\""
+  Builtin.Json.serialize<Char> (charFromString "Ł") = "\"Ł\""
   Builtin.Json.parse<Char> "\"Ł\"" = Result.Ok 'Ł'
 
   module Errors =
@@ -309,24 +303,22 @@ module Char =
 
 
 module String =
-  Builtin.Json.serialize<String> "abc" = Result.Ok "\"abc\""
+  Builtin.Json.serialize<String> "abc" = "\"abc\""
   Builtin.Json.parse<String> "\"abc\"" = Result.Ok "abc"
 
-  Builtin.Json.serialize<String> "" = Result.Ok "\"\""
+  Builtin.Json.serialize<String> "" = "\"\""
   Builtin.Json.parse<String> "\"\"" = Result.Ok ""
 
-  Builtin.Json.serialize<String> "żółw" = Result.Ok "\"żółw\""
+  Builtin.Json.serialize<String> "żółw" = "\"żółw\""
   Builtin.Json.parse<String> "\"żółw\"" = Result.Ok "żółw"
 
-  Builtin.Json.serialize<String> "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = Result.Ok
-    "\"\\uD83D\\uDC68‍❤️‍\\uD83D\\uDC8B‍\\uD83D\\uDC68\\uD83D\\uDC69‍\\uD83D\\uDC69‍\\uD83D\\uDC67‍\\uD83D\\uDC66\\uD83C\\uDFF3️‍⚧️‍️\\uD83C\\uDDF5\\uD83C\\uDDF7\""
+  Builtin.Json.serialize<String> "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" = "\"\\uD83D\\uDC68‍❤️‍\\uD83D\\uDC8B‍\\uD83D\\uDC68\\uD83D\\uDC69‍\\uD83D\\uDC69‍\\uD83D\\uDC67‍\\uD83D\\uDC66\\uD83C\\uDFF3️‍⚧️‍️\\uD83C\\uDDF5\\uD83C\\uDDF7\""
 
   Builtin.Json.parse<String> "\"👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷\"" = Result.Ok
     "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷"
 
 
-  Builtin.Json.serialize<String> "👩‍👩‍👧‍👦" = Result.Ok
-    "\"\\uD83D\\uDC69‍\\uD83D\\uDC69‍\\uD83D\\uDC67‍\\uD83D\\uDC66\""
+  Builtin.Json.serialize<String> "👩‍👩‍👧‍👦" = "\"\\uD83D\\uDC69‍\\uD83D\\uDC69‍\\uD83D\\uDC67‍\\uD83D\\uDC66\""
 
   Builtin.Json.parse<String> "\"👩‍👩‍👧‍👦\"" = Result.Ok "👩‍👩‍👧‍👦"
 
@@ -335,16 +327,14 @@ module String =
     "👩‍👩‍👧‍👦"
 
   Builtin.Json.serialize<String>
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." = Result.Ok
-    "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\""
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor." = "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\""
 
   Builtin.Json.parse<String>
     "\"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.\"" = Result.Ok
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor."
 
 
-  Builtin.Json.serialize<String> (PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100) = Result.Ok
-    "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+  Builtin.Json.serialize<String> (PACKAGE.Darklang.Stdlib.String.repeat_v0 "a" 100) = "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
 
   Builtin.Json.parse<String>
     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"" = Result
@@ -356,32 +346,28 @@ module DateTime =
     (PACKAGE.Darklang.Stdlib.DateTime.parse datestr) |> Builtin.unwrap
 
   // now-ish
-  Builtin.Json.serialize<DateTime> (d "2023-07-28T22:42:36Z") = Result.Ok
-    "\"2023-07-28T22:42:36Z\""
+  Builtin.Json.serialize<DateTime> (d "2023-07-28T22:42:36Z") = "\"2023-07-28T22:42:36Z\""
 
   Builtin.Json.parse<DateTime> "\"2023-07-28T22:42:36Z\"" = Result.Ok(
     d "2023-07-28T22:42:36Z"
   )
 
   // epoch
-  Builtin.Json.serialize<DateTime> (d "1969-07-28T22:42:36Z") = Result.Ok
-    "\"1969-07-28T22:42:36Z\""
+  Builtin.Json.serialize<DateTime> (d "1969-07-28T22:42:36Z") = "\"1969-07-28T22:42:36Z\""
 
   Builtin.Json.parse<DateTime> "\"1969-07-28T22:42:36Z\"" = Result.Ok(
     d "1969-07-28T22:42:36Z"
   )
 
   // before epoch
-  Builtin.Json.serialize<DateTime> (d "1402-07-28T22:42:36Z") = Result.Ok
-    "\"1402-07-28T22:42:36Z\""
+  Builtin.Json.serialize<DateTime> (d "1402-07-28T22:42:36Z") = "\"1402-07-28T22:42:36Z\""
 
   Builtin.Json.parse<DateTime> "\"1402-07-28T22:42:36Z\"" = Result.Ok(
     d "1402-07-28T22:42:36Z"
   )
 
   // far in future
-  Builtin.Json.serialize<DateTime> (d "3023-07-28T22:42:36Z") = Result.Ok
-    "\"3023-07-28T22:42:36Z\""
+  Builtin.Json.serialize<DateTime> (d "3023-07-28T22:42:36Z") = "\"3023-07-28T22:42:36Z\""
 
   Builtin.Json.parse<DateTime> "\"3023-07-28T22:42:36Z\"" = Result.Ok(
     d "3023-07-28T22:42:36Z"
@@ -403,23 +389,20 @@ module Uuid =
     (PACKAGE.Darklang.Stdlib.Uuid.parse_v0 s) |> Builtin.unwrap
 
   // empty
-  Builtin.Json.serialize<Uuid> (uuid "00000000-0000-0000-0000-000000000000") = Result.Ok
-    "\"00000000-0000-0000-0000-000000000000\""
+  Builtin.Json.serialize<Uuid> (uuid "00000000-0000-0000-0000-000000000000") = "\"00000000-0000-0000-0000-000000000000\""
 
   Builtin.Json.parse<Uuid> ("\"00000000-0000-0000-0000-000000000000\"") = Result.Ok(
     uuid "00000000-0000-0000-0000-000000000000"
   )
 
   // normal
-  Builtin.Json.serialize<Uuid> (uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = Result.Ok
-    "\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\""
+  Builtin.Json.serialize<Uuid> (uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d") = "\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\""
 
   Builtin.Json.parse<Uuid> ("\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"") = Result.Ok(
     uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
   )
 
-  Builtin.Json.serialize<Uuid> (uuid "11111111-2222-3333-4444-555555555555") = Result.Ok
-    "\"11111111-2222-3333-4444-555555555555\""
+  Builtin.Json.serialize<Uuid> (uuid "11111111-2222-3333-4444-555555555555") = "\"11111111-2222-3333-4444-555555555555\""
 
   Builtin.Json.parse<Uuid> ("\"11111111-2222-3333-4444-555555555555\"") = Result.Ok(
     uuid "11111111-2222-3333-4444-555555555555"
@@ -433,7 +416,7 @@ module Uuid =
 
 module Bytes =
   // TODO check errors
-  Builtin.Json.serialize<Bytes> Builtin.Bytes.empty = Result.Ok "\"\""
+  Builtin.Json.serialize<Bytes> Builtin.Bytes.empty = "\"\""
 
   Builtin.Json.parse<Bytes> "\"\"" = Result.Ok Builtin.Bytes.empty
 
@@ -448,18 +431,17 @@ module BadTypes =
 module List =
   type MyString = String
 
-  Builtin.Json.serialize<List<Int>> [] = Result.Ok "[]"
+  Builtin.Json.serialize<List<Int>> [] = "[]"
   Builtin.Json.parse<List<Int>> "[]" = Result.Ok []
 
-  Builtin.Json.serialize<List<Int>> [ 1; 2; 3 ] = Result.Ok "[1,2,3]"
+  Builtin.Json.serialize<List<Int>> [ 1; 2; 3 ] = "[1,2,3]"
 
   Builtin.Json.parse<List<Int>> "[1,2,3]" = Result.Ok [ 1; 2; 3 ]
 
   Builtin.Json.parse<List<Int>> "[1,2,3,]" = Result.Error "not JSON"
 
   Builtin.Json.serialize<List<List<List<Int>>>>
-    [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ] = Result.Ok
-    "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]"
+    [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ] = "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]"
 
   Builtin.Json.parse<List<List<List<Int>>>> "[[[1,2,3],[4,5,6]],[[7,8],[9,0]]]" = Result.Ok
     [ [ [ 1; 2; 3 ]; [ 4; 5; 6 ] ]; [ [ 7; 8 ]; [ 9; 0 ] ] ]
@@ -473,8 +455,7 @@ module List =
   Builtin.Json.serialize<List<Dict<String>>>
     [ Dict { name = "Alice"; role = "admin" }
       Dict { name = "Bob"; role = "user" }
-      Dict { name = "Charlie"; role = "user" } ] = Result.Ok
-    """[{"name":"Alice","role":"admin"},{"name":"Bob","role":"user"},{"name":"Charlie","role":"user"}]"""
+      Dict { name = "Charlie"; role = "user" } ] = """[{"name":"Alice","role":"admin"},{"name":"Bob","role":"user"},{"name":"Charlie","role":"user"}]"""
 
   Builtin.Json.parse<List<Person>>
     """[{"Name": "Alice", "Age": 42}, {"Name": "Bob", "Age": 27}, {"Name": "Charlie", "Age": 99}]""" = Result.Ok
@@ -485,8 +466,7 @@ module List =
   Builtin.Json.serialize<List<Person>>
     [ Person { Name = "Alice"; Age = 42 }
       Person { Name = "Bob"; Age = 27 }
-      Person { Name = "Charlie"; Age = 99 } ] = Result.Ok
-    """[{"Age":42,"Name":"Alice"},{"Age":27,"Name":"Bob"},{"Age":99,"Name":"Charlie"}]"""
+      Person { Name = "Charlie"; Age = 99 } ] = """[{"Age":42,"Name":"Alice"},{"Age":27,"Name":"Bob"},{"Age":99,"Name":"Charlie"}]"""
 
   Builtin.Json.parse<List<Dict<MyString>>>
     """[{"name": "Alice", "role": "admin"}, {"name": "Bob", "role": "user"}, {"name": "Charlie", "role": "user"}]""" = Result.Ok
@@ -512,43 +492,41 @@ module List =
 
 
 module Tuples =
-  Builtin.Json.serialize<Int * String * Int> (1, "two", 3) = Result.Ok
-    "[1,\"two\",3]"
+  Builtin.Json.serialize<Int * String * Int> (1, "two", 3) = "[1,\"two\",3]"
 
   Builtin.Json.serialize<List<Int> * List<Person>> (
     [ 1; 2; 3 ],
     [ Person { Name = "Alice"; Age = 42 } ]
-  ) = Result.Ok "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
+  ) = "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
 
   Builtin.Json.serialize<(Int * String) * (Person * Dict<String>)> (
     (1, "two"),
     (Person { Name = "Alice"; Age = 42 },
      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
-  ) = Result.Ok "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
+  ) = "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
   Builtin.Json.serialize<(List<Int * String> * Bytes) * (Person * Dict<String>)> (
     ([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
     (Person { Name = "Alice"; Age = 42 },
      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
-  ) = Result.Ok
-    "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
+  ) = "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
   Builtin.Json.serialize<Person * Option<Int>> (
     Person { Name = "Alice"; Age = 42 },
     Option.Some 1
-  ) = Result.Ok "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
+  ) = "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
 
   Builtin.Json.serialize<Option<Int> * Result<Int, String>> (
     Option.Some 1,
     Result.Ok 2
-  ) = Result.Ok "[{\"Some\":[1]},{\"Ok\":[2]}]"
+  ) = "[{\"Some\":[1]},{\"Ok\":[2]}]"
 
-  Builtin.Json.serialize<Char * Bool> ('a', true) = Result.Ok "[\"a\",true]"
+  Builtin.Json.serialize<Char * Bool> ('a', true) = "[\"a\",true]"
 
   Builtin.Json.serialize<DateTime * Uuid> (
     DateTime.d "2023-07-28T22:42:36Z",
     Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
-  ) = Result.Ok "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
+  ) = "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
 
   Builtin.Json.parse<Int * String * Int> "[1,\"two\",3]" = Result.Ok((1, "two", 3))
 
@@ -614,11 +592,11 @@ module Tuples =
 
 module Option =
   // TODO: more...
-  Builtin.Json.serialize<Option<Int>> Option.None = Result.Ok "{\"None\":[]}"
+  Builtin.Json.serialize<Option<Int>> Option.None = "{\"None\":[]}"
 
   Builtin.Json.parse<Option<Int>> "{\"None\":[]}" = Result.Ok Option.None
 
-  Builtin.Json.serialize<Option<Int>> (Option.Some 1) = Result.Ok "{\"Some\":[1]}"
+  Builtin.Json.serialize<Option<Int>> (Option.Some 1) = "{\"Some\":[1]}"
 
   Builtin.Json.parse<Option<Int>> "{\"Some\":[1]}" = Result.Ok(Option.Some 1)
 
@@ -636,13 +614,10 @@ module Option =
 
 
 module Result =
-  Builtin.Json.serialize<Result<Int, String>> (Result.Ok 1) = Result.Ok
-    "{\"Ok\":[1]}"
-
-  Builtin.Json.serialize<Result<Int, String>> (Result.Error "err message") = Result.Ok
-    "{\"Error\":[\"err message\"]}"
-
+  Builtin.Json.serialize<Result<Int, String>> (Result.Ok 1) = "{\"Ok\":[1]}"
   Builtin.Json.parse<Result<Int, String>> "{\"Ok\":[1]}" = Result.Ok(Result.Ok 1)
+
+  Builtin.Json.serialize<Result<Int, String>> (Result.Error "err message") = "{\"Error\":[\"err message\"]}"
 
   Builtin.Json.parse<Result<Int, String>> "{\"Error\":[\"err message\"]}" = Result.Ok(
     Result.Error "err message"
@@ -652,8 +627,7 @@ module Result =
     Result.Ok
       [ (PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b", Option.Some 1)
         (PACKAGE.Darklang.Stdlib.Dict.singleton "c" "d", Option.None) ]
-  ) = Result.Ok
-    "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}"
+  ) = "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}"
 
   Builtin.Json.parse<Result<List<Dict<String> * Option<Int>>, String>>
     "{\"Ok\":[[[{\"a\":\"b\"},{\"Some\":[1]}],[{\"c\":\"d\"},{\"None\":[]}]]]}" = Result
@@ -665,11 +639,11 @@ module Result =
 
   Builtin.Json.serialize<Result<Result<Int, String>, String>> (
     Result.Ok(Result.Ok 1)
-  ) = Result.Ok "{\"Ok\":[{\"Ok\":[1]}]}"
+  ) = "{\"Ok\":[{\"Ok\":[1]}]}"
 
   Builtin.Json.serialize<Result<Result<Int, String>, String>> (
     Result.Ok(Result.Error "err message")
-  ) = Result.Ok "{\"Ok\":[{\"Error\":[\"err message\"]}]}"
+  ) = "{\"Ok\":[{\"Error\":[\"err message\"]}]}"
 
   Builtin.Json.parse<Result<Result<Int, String>, String>> "{\"Ok\":[{\"Ok\":[1]}]}" = Result
     .Ok(Result.Ok(Result.Ok 1))
@@ -681,7 +655,7 @@ module Result =
 
   Builtin.Json.serialize<Result<Result<Option<Result<Int, String>>, String>, String>> (
     Result.Ok(Result.Ok(Option.Some(Result.Ok 1)))
-  ) = Result.Ok "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}"
+  ) = "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}"
 
   Builtin.Json.parse<Result<Result<PACKAGE.Darklang.Stdlib.Option.Option<Result<Int, String>>, String>, String>>
     "{\"Ok\":[{\"Ok\":[{\"Some\":[{\"Ok\":[1]}]}]}]}" = Result.Ok(
@@ -692,14 +666,13 @@ module Dict =
 
   Builtin.Json.serialize<Dict<String>> (
     PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"
-  ) = Result.Ok """{"a":"b"}"""
+  ) = """{"a":"b"}"""
 
   Builtin.Json.parse<Dict<String>> """{"a":"b"}""" = Result.Ok(
     PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"
   )
 
-  Builtin.Json.serialize<Dict<String>> (Dict { a = "b"; c = "d" }) = Result.Ok
-    """{"a":"b","c":"d"}"""
+  Builtin.Json.serialize<Dict<String>> (Dict { a = "b"; c = "d" }) = """{"a":"b","c":"d"}"""
 
   Builtin.Json.parse<Dict<String>> """{"a":"b","c":"d"}""" = Result.Ok(
     Dict { a = "b"; c = "d" }
@@ -719,12 +692,11 @@ module UserDefinedEnums =
     | Yes
     | No
 
-  Builtin.Json.serialize<PrettyLikely> PrettyLikely.Yeah = Result.Ok "{\"Yeah\":[]}"
+  Builtin.Json.serialize<PrettyLikely> PrettyLikely.Yeah = "{\"Yeah\":[]}"
 
   Builtin.Json.parse<PrettyLikely> "{\"Yeah\":[]}" = Result.Ok PrettyLikely.Yeah
 
-  Builtin.Json.serialize<PrettyLikely> (PrettyLikely.Enh("printer broke", 7)) = Result.Ok
-    "{\"Enh\":[\"printer broke\",7]}"
+  Builtin.Json.serialize<PrettyLikely> (PrettyLikely.Enh("printer broke", 7)) = "{\"Enh\":[\"printer broke\",7]}"
 
   Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = Result.Ok(
     PrettyLikely.Enh("printer broke", 7)
@@ -732,7 +704,7 @@ module UserDefinedEnums =
 
   Builtin.Json.serialize<PrettyLikely2> (
     PrettyLikely2.PrettyLikely PrettyLikely.Yeah
-  ) = Result.Ok "{\"PrettyLikely\":[{\"Yeah\":[]}]}"
+  ) = "{\"PrettyLikely\":[{\"Yeah\":[]}]}"
 
   Builtin.Json.parse<PrettyLikely2> "{\"PrettyLikely\":[{\"Yeah\":[]}]}" = Result.Ok(
     PrettyLikely2.PrettyLikely PrettyLikely.Yeah
@@ -740,7 +712,7 @@ module UserDefinedEnums =
 
   Builtin.Json.serialize<PrettyLikely2> (
     PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7))
-  ) = Result.Ok "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}"
+  ) = "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}"
 
   Builtin.Json.parse<PrettyLikely2>
     "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}" = Result.Ok(
@@ -750,8 +722,7 @@ module UserDefinedEnums =
 
 module UserDefinedRecords =
 
-  Builtin.Json.serialize<Person> (Person { Name = "Bob"; Age = 42 }) = Result.Ok
-    """{"Age":42,"Name":"Bob"}"""
+  Builtin.Json.serialize<Person> (Person { Name = "Bob"; Age = 42 }) = """{"Age":42,"Name":"Bob"}"""
 
   Builtin.Json.parse<Person> """{ "Name": "Bob", "Age": 42 }""" = Result.Ok(
     Person { Name = "Bob"; Age = 42 }
@@ -778,8 +749,7 @@ module UserDefinedRecords =
         People =
           [ Person { Name = "George A"; Age = 27 }
             Person { Name = "George B"; Age = 42 } ] }
-  ) = Result.Ok
-    """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}"""
+  ) = """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}"""
 
   Builtin.Json.parse<People>
     """{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]}""" = Result
@@ -806,8 +776,7 @@ module UserDefinedRecords =
                       [ Person { Name = "George A"; Age = 27 }
                         Person { Name = "George B"; Age = 42 } ] }
               e2 = 5 } }
-  ) = Result.Ok
-    """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}"""
+  ) = """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}"""
 
   Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
     """{"e1":{"Age":42,"Name":"Bob"},"e2":{"e1":{"GroupName":"Two Georges","People":[{"Age":27,"Name":"George A"},{"Age":42,"Name":"George B"}]},"e2":5}}""" = Result
@@ -837,7 +806,6 @@ module UserDefinedRecords =
                       Person { Name = "George B"; Age = 42 } ] }
             e2 = 5 } })
   |> Builtin.Json.serialize<Combo<Person, Combo<People, Int>>>
-  |> Builtin.unwrap
   |> Builtin.Json.parse<Combo<Person, Combo<People, Int>>>
   |> Builtin.unwrap = (Combo
     { e1 = Person { Name = "Bob"; Age = 42 }
@@ -855,13 +823,12 @@ module UserDefinedAliases =
 
   type MyInt = Int
 
-  Builtin.Json.serialize<MyInt> 42 = Result.Ok "42"
+  Builtin.Json.serialize<MyInt> 42 = "42"
   Builtin.Json.parse<MyInt> "42" = Result.Ok 42
 
   type MyPerson = Person
 
-  Builtin.Json.serialize<MyPerson> (Person { Name = "Bob"; Age = 42 }) = Result.Ok
-    """{"Age":42,"Name":"Bob"}"""
+  Builtin.Json.serialize<MyPerson> (Person { Name = "Bob"; Age = 42 }) = """{"Age":42,"Name":"Bob"}"""
 
   Builtin.Json.parse<MyPerson> """{ "Name": "Bob", "Age": 42 }""" = Result.Ok(
     Person { Name = "Bob"; Age = 42 }
@@ -871,7 +838,7 @@ module UserDefinedAliases =
 
   Builtin.Json.serialize<MyPrettyLikely> (
     UserDefinedEnums.PrettyLikely.Enh("printer broke", 7)
-  ) = Result.Ok "{\"Enh\":[\"printer broke\",7]}"
+  ) = "{\"Enh\":[\"printer broke\",7]}"
 
   Builtin.Json.parse<MyPrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = Result.Ok(
     UserDefinedEnums.PrettyLikely.Enh("printer broke", 7)
@@ -889,10 +856,9 @@ Actual: an UserDefinedAliases.Person1: UserDefinedAliases.Person1 {\n  Age: 42,\
 
   type StringResult<'a> = Result<'a, String>
 
-  Builtin.Json.serialize<StringResult<Int>> (Result.Ok 1) = Result.Ok "{\"Ok\":[1]}"
+  Builtin.Json.serialize<StringResult<Int>> (Result.Ok 1) = "{\"Ok\":[1]}"
 
-  Builtin.Json.serialize<StringResult<Int>> (Result.Error "err") = Result.Ok
-    "{\"Error\":[\"err\"]}"
+  Builtin.Json.serialize<StringResult<Int>> (Result.Error "err") = "{\"Error\":[\"err\"]}"
 
 // This test current gets by the typechecker, and so we get an internal exception
 // Builtin.Json.serialize<StringResult<Int>> (Result.Error 1) = Result.Error
@@ -900,15 +866,13 @@ Actual: an UserDefinedAliases.Person1: UserDefinedAliases.Person1 {\n  Age: 42,\
 
 
 module Package =
-  Builtin.Json.serialize<Option<Int>> Option.None = Result.Ok "{\"None\":[]}"
+  Builtin.Json.serialize<Option<Int>> Option.None = "{\"None\":[]}"
 
   Builtin.Json.parse<Option<Int>> "{\"None\":[]}" = Result.Ok Option.None
 
-  Builtin.Json.serialize<Result<Int, String>> (Result.Ok 1) = Result.Ok
-    "{\"Ok\":[1]}"
+  Builtin.Json.serialize<Result<Int, String>> (Result.Ok 1) = "{\"Ok\":[1]}"
 
-  Builtin.Json.serialize<Result<Int, String>> (Result.Error "err message") = Result.Ok
-    "{\"Error\":[\"err message\"]}"
+  Builtin.Json.serialize<Result<Int, String>> (Result.Error "err message") = "{\"Error\":[\"err message\"]}"
 
   Builtin.Json.parse<Result<Int, String>> "{\"Ok\":[1]}" = Result.Ok(Result.Ok 1)
 
@@ -916,11 +880,11 @@ module Package =
     Result.Error "err message"
   )
 
-  Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ID> 42 = Result.Ok "42"
+  Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ID> 42 = "42"
   Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.ID> "42" = Result.Ok 42
 
   Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.Sign>
-    PACKAGE.Darklang.LanguageTools.Sign.Positive = Result.Ok "{\"Positive\":[]}"
+    PACKAGE.Darklang.LanguageTools.Sign.Positive = "{\"Positive\":[]}"
 
   Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.Sign> "{\"Positive\":[]}" = Result.Ok
     PACKAGE.Darklang.LanguageTools.Sign.Positive
@@ -928,7 +892,7 @@ module Package =
 
   Builtin.Json.serialize<PACKAGE.OpenAI.Completion.ResponseChoice> (
     PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" }
-  ) = Result.Ok "{\"text\":\"hello\"}"
+  ) = "{\"text\":\"hello\"}"
 
   Builtin.Json.parse<PACKAGE.OpenAI.Completion.ResponseChoice> "{\"text\":\"hello\"}" = Result
     .Ok(PACKAGE.OpenAI.Completion.ResponseChoice { text = "hello" })
@@ -939,8 +903,7 @@ module Package =
         prompt = "test"
         max_tokens = 5
         temperature = 0.7 }
-  ) = Result.Ok
-    "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}"
+  ) = "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}"
 
   Builtin.Json.parse<PACKAGE.OpenAI.Completion.Request>
     "{\"max_tokens\":5,\"model\":\"davinci\",\"prompt\":\"test\",\"temperature\":0.7}" = Result
@@ -953,8 +916,7 @@ module Package =
     )
 
   Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
-    PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName = Result
-    .Ok("{\"InvalidPackageName\":[]}")
+    PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName = "{\"InvalidPackageName\":[]}"
 
   Builtin.Json.parse<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>
     "{\"NotFound\":[]}" = Result.Ok
@@ -964,8 +926,7 @@ module Package =
     [ PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.InvalidPackageName
       (PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.MissingEnumModuleName
         "Ok")
-      PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ] = Result.Ok
-    "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]"
+      PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType.NotFound ] = "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]"
 
   Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.ErrorType>>
     "[{\"InvalidPackageName\":[]},{\"MissingEnumModuleName\":[\"Ok\"]},{\"NotFound\":[]}]" = Result

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -741,10 +741,6 @@ module UserDefinedEnums =
     PrettyLikely.Enh("printer broke", 7)
   )
 
-  (Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",\"not int\"]}")
-  |> err = Result.Error
-    "Can't parse JSON `\"not int\"` as type `Int` at path: `root.Enh[1]`"
-
   Builtin.Json.serialize<PrettyLikely2> (
     PrettyLikely2.PrettyLikely PrettyLikely.Yeah
   ) = "{\"PrettyLikely\":[{\"Yeah\":[]}]}"
@@ -761,6 +757,20 @@ module UserDefinedEnums =
     "{\"PrettyLikely\":[{\"Enh\":[\"printer broke\",7]}]}" = Result.Ok(
     PrettyLikely2.PrettyLikely(PrettyLikely.Enh("printer broke", 7))
   )
+
+  module Errors =
+    (Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",\"not int\"]}")
+    |> err = Result.Error
+      "Can't parse JSON `\"not int\"` as type `Int` at path: `root.Enh[1]`"
+
+    (Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\"]}") |> err = Result.Error
+      "Can't parse JSON because argument 1 (`Int`) is missing at path: `root.Enh`"
+
+    (Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\", 1, 2.0]}")
+    |> err = Result.Error
+      "Can't parse JSON due to an extra argument `2.0` at path: `root.Enh[2]`"
+
+
 
 
 module UserDefinedRecords =
@@ -1026,4 +1036,5 @@ module Package =
 //Builtin.Json.parse<TODO> "({\"id\" : 555, \"edition\" : \"First\", \"author\" : \"Dennis Ritchie\"})" = Result.Error "'(' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 0."
 
 // ## Nested types (lists, tuples, records, etc.)
+// Builtin.Json.serialize<List<List<Int * List<MyType<String>> * Dict<MyType<List<Int>>>>>> = Ok "test"
 // Builtin.Json.serialize<List<List<Int * List<MyType<String>> * Dict<MyType<List<Int>>>>>> = Ok "test"

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -12,11 +12,11 @@ type Option<'t> = PACKAGE.Darklang.Stdlib.Option.Option<'t>
 
 let err
   (v:
-    PACKAGE.Darklang.Stdlib.Result.Result<'a, PACKAGE.Darklang.Stdlib.Json.Error.Error>)
+    PACKAGE.Darklang.Stdlib.Result.Result<'a, PACKAGE.Darklang.Stdlib.Json.ParseError.ParseError>)
   : Result<'a, String> =
   v
   |> PACKAGE.Darklang.Stdlib.Result.mapError
-    PACKAGE.Darklang.Stdlib.Json.Error.toString
+    PACKAGE.Darklang.Stdlib.Json.ParseError.toString
 
 
 module Unit =

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -493,11 +493,22 @@ module List =
 
 module Tuples =
   Builtin.Json.serialize<Int * String * Int> (1, "two", 3) = "[1,\"two\",3]"
+  Builtin.Json.parse<Int * String * Int> "[1,\"two\",3]" = Result.Ok((1, "two", 3))
+
+  Builtin.Json.parse<Int * String * Int> "[1,3]" = Result.Error
+    "Can't parse JSON `[1,3]` as type `(Int, String, Int)` at path: `root`"
+
 
   Builtin.Json.serialize<List<Int> * List<Person>> (
     [ 1; 2; 3 ],
     [ Person { Name = "Alice"; Age = 42 } ]
   ) = "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]"
+
+  Builtin.Json.parse<List<Int> * List<Person>>
+    "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]" = Result.Ok(
+    ([ 1; 2; 3 ], [ Person { Name = "Alice"; Age = 42 } ])
+  )
+
 
   Builtin.Json.serialize<(Int * String) * (Person * Dict<String>)> (
     (1, "two"),
@@ -505,42 +516,19 @@ module Tuples =
      PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
   ) = "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
-  Builtin.Json.serialize<(List<Int * String> * Bytes) * (Person * Dict<String>)> (
-    ([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
-    (Person { Name = "Alice"; Age = 42 },
-     PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
-  ) = "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
-
-  Builtin.Json.serialize<Person * Option<Int>> (
-    Person { Name = "Alice"; Age = 42 },
-    Option.Some 1
-  ) = "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
-
-  Builtin.Json.serialize<Option<Int> * Result<Int, String>> (
-    Option.Some 1,
-    Result.Ok 2
-  ) = "[{\"Some\":[1]},{\"Ok\":[2]}]"
-
-  Builtin.Json.serialize<Char * Bool> ('a', true) = "[\"a\",true]"
-
-  Builtin.Json.serialize<DateTime * Uuid> (
-    DateTime.d "2023-07-28T22:42:36Z",
-    Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
-  ) = "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
-
-  Builtin.Json.parse<Int * String * Int> "[1,\"two\",3]" = Result.Ok((1, "two", 3))
-
-  Builtin.Json.parse<List<Int> * List<Person>>
-    "[[1,2,3],[{\"Age\":42,\"Name\":\"Alice\"}]]" = Result.Ok(
-    ([ 1; 2; 3 ], [ Person { Name = "Alice"; Age = 42 } ])
-  )
-
   Builtin.Json.parse<(Int * String) * (Person * Dict<String>)>
     "[[1,\"two\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = Result.Ok(
     ((1, "two"),
      (Person { Name = "Alice"; Age = 42 },
       PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
   )
+
+
+  Builtin.Json.serialize<(List<Int * String> * Bytes) * (Person * Dict<String>)> (
+    ([ (1, "two"); (3, "four") ], Builtin.Bytes.empty),
+    (Person { Name = "Alice"; Age = 42 },
+     PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b")
+  ) = "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]"
 
   Builtin.Json.parse<(List<Int * String> * Bytes) * (Person * Dict<String>)>
     "[[[[1,\"two\"],[3,\"four\"]],\"\"],[{\"Age\":42,\"Name\":\"Alice\"},{\"a\":\"b\"}]]" = Result
@@ -550,15 +538,35 @@ module Tuples =
         PACKAGE.Darklang.Stdlib.Dict.singleton "a" "b"))
     )
 
+
+  Builtin.Json.serialize<Person * Option<Int>> (
+    Person { Name = "Alice"; Age = 42 },
+    Option.Some 1
+  ) = "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]"
+
   Builtin.Json.parse<Person * Option<Int>>
     "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[1]}]" = Result.Ok(
     (Person { Name = "Alice"; Age = 42 }, Option.Some 1)
   )
 
+
+  Builtin.Json.serialize<Option<Int> * Result<Int, String>> (
+    Option.Some 1,
+    Result.Ok 2
+  ) = "[{\"Some\":[1]},{\"Ok\":[2]}]"
+
   Builtin.Json.parse<Option<Int> * Result<Int, String>>
     "[{\"Some\":[1]},{\"Ok\":[2]}]" = Result.Ok((Option.Some 1, Result.Ok 2))
 
+
+  Builtin.Json.serialize<Char * Bool> ('a', true) = "[\"a\",true]"
   Builtin.Json.parse<Char * Bool> "[\"a\",true]" = Result.Ok(('a', true))
+
+
+  Builtin.Json.serialize<DateTime * Uuid> (
+    DateTime.d "2023-07-28T22:42:36Z",
+    Uuid.uuid "3700adbc-7a46-4ff4-81d3-45afb03f6e2d"
+  ) = "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]"
 
   Builtin.Json.parse<DateTime * Uuid>
     "[\"2023-07-28T22:42:36Z\",\"3700adbc-7a46-4ff4-81d3-45afb03f6e2d\"]" = Result.Ok(

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -763,12 +763,29 @@ module UserDefinedEnums =
     |> err = Result.Error
       "Can't parse JSON `\"not int\"` as type `Int` at path: `root.Enh[1]`"
 
+    // EnumMissingField
     (Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\"]}") |> err = Result.Error
       "Can't parse JSON because argument 1 (`Int`) is missing at path: `root.Enh`"
 
+    // EnumExtraField
     (Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\", 1, 2.0]}")
     |> err = Result.Error
       "Can't parse JSON due to an extra argument `2.0` at path: `root.Enh[2]`"
+
+    // CantMatchWithType
+    (Builtin.Json.parse<PrettyLikely> "{}") |> err = Result.Error
+      "Can't parse JSON `{}` as type `UserDefinedEnums.PrettyLikely` at path: `root`"
+
+    // EnumInvalidCasename
+    (Builtin.Json.parse<PrettyLikely> "{\"Wrong\":[\"printer broke\", 1, 2.0]}")
+    |> err = Result.Error
+      "Can't parse JSON as `Wrong` is not a known case of type `UserDefinedEnums.PrettyLikely` at path: `root`"
+
+    // EnumTooManyCases
+    (Builtin.Json.parse<PrettyLikely>
+      "{\"Enh\":[\"printer broke\", 1], \"Extra\": \"field\"}")
+    |> err = Result.Error
+      "Can't parse JSON with multiple fields (`Enh`, `Extra`) as type `UserDefinedEnums.PrettyLikely` at path: `root`"
 
 
 

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -624,7 +624,7 @@ module Tuples =
     (Builtin.Json.parse<Person * Option<Int>>
       "[{\"Age\":42,\"Name\":\"Alice\"},{\"Some\":[\"one\"]}]")
     |> err = Result.Error
-      "Can't parse JSON `\"one\"` as type `Int` at path: `root[1]`"
+      "Can't parse JSON `\"one\"` as type `Int` at path: `root[1].Some[0]`"
 
 
 module Option =
@@ -740,6 +740,10 @@ module UserDefinedEnums =
   Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",7]}" = Result.Ok(
     PrettyLikely.Enh("printer broke", 7)
   )
+
+  (Builtin.Json.parse<PrettyLikely> "{\"Enh\":[\"printer broke\",\"not int\"]}")
+  |> err = Result.Error
+    "Can't parse JSON `\"not int\"` as type `Int` at path: `root.Enh[1]`"
 
   Builtin.Json.serialize<PrettyLikely2> (
     PrettyLikely2.PrettyLikely PrettyLikely.Yeah

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -776,6 +776,9 @@ module UserDefinedEnums =
     (Builtin.Json.parse<PrettyLikely> "{}") |> err = Result.Error
       "Can't parse JSON `{}` as type `UserDefinedEnums.PrettyLikely` at path: `root`"
 
+    (Builtin.Json.parse<PrettyLikely> "[]") |> err = Result.Error
+      "Can't parse JSON `[]` as type `UserDefinedEnums.PrettyLikely` at path: `root`"
+
     // EnumInvalidCasename
     (Builtin.Json.parse<PrettyLikely> "{\"Wrong\":[\"printer broke\", 1, 2.0]}")
     |> err = Result.Error
@@ -888,6 +891,10 @@ module UserDefinedRecords =
                     [ Person { Name = "George A"; Age = 27 }
                       Person { Name = "George B"; Age = 42 } ] }
             e2 = 5 } })
+
+  module Errors =
+    (Builtin.Json.parse<Person> "[]") |> err = Result.Error
+      "Can't parse JSON `[]` as type `Person` at path: `root`"
 
 module UserDefinedAliases =
 

--- a/backend/testfiles/execution/stdlib/string.dark
+++ b/backend/testfiles/execution/stdlib/string.dark
@@ -202,9 +202,9 @@ module Map =
 
   PACKAGE.Darklang.Stdlib.String.map "👨‍❤️‍💋‍👨👩‍👩‍👧‍👦🏳️‍⚧️‍️🇵🇷" (fun x ->
     5) = Builtin.Test.derrorMessage
-    """Function return value should be a Character. However, an Int (5) was returned instead.
+    """Function return value should be a Char. However, an Int (5) was returned instead.
 
-Expected: Character
+Expected: Char
 Actual: an Int: 5"""
 
   // Check that map executes the right number of times
@@ -517,9 +517,9 @@ module FromList =
     [ c "👩‍👩‍👧‍👦"; c "🏳️‍⚧️‍️"; c "👱🏾"; c "Z̤͔ͧ̑̓" ] = "👩‍👩‍👧‍👦🏳️‍⚧️‍️👱🏾Z̤͔ͧ̑̓"
 
   PACKAGE.Darklang.Stdlib.String.fromList [ "a" ] = Builtin.Test.derrorMessage
-    "PACKAGE.Darklang.Stdlib.String.fromList's 1st argument (`lst`) should be a List<Character>. However, a List<String> ([  \"a\"]) was passed instead.
+    "PACKAGE.Darklang.Stdlib.String.fromList's 1st argument (`lst`) should be a List<Char>. However, a List<String> ([  \"a\"]) was passed instead.
 
-Expected: (lst: List<Character>)
+Expected: (lst: List<Char>)
 Actual: a List<String>: [\n  \"a\"\n]"
 
 

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -185,12 +185,7 @@ let executionStateFor
         exceptionReports = []
         expectedExceptionCount = 0
         postTestExecutionHook =
-          fun tc _ ->
-            // In an effort to find errors in the test suite, we track exceptions
-            // that we report in the runtime and check for them after the test
-            // completes. There are a lot of places where exceptions are allowed,
-            // possibly too many to annotate, so we assume that errors are intended
-            // to be reported anytime the result is a RTE.
+          fun tc ->
             let exceptionCountMatches =
               tc.exceptionReports.Length = tc.expectedExceptionCount
 

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -61,8 +61,8 @@ let t
   : Test =
   testTask $"line{lineNumber}" {
     try
+      // Little optimization to skip the DB sometimes
       let! canvasID =
-        // Little optimization to skip the DB sometimes
         let initializeCanvas = internalFnsAllowed || dbs <> [] || workers <> []
         if initializeCanvas then
           initializeTestCanvas canvasName

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -197,11 +197,14 @@ let t
                   (NEList.ofList actual [])
 
               match result with
-              | Error _ ->
+              | Error(_, result) ->
+                let result = RT.RuntimeError.toDT result
+                print $"{state.test.exceptionReports}"
                 return
                   Exception.raiseInternal
                     ("We received an RTE, and when trying to stringify it, there was another RTE error. There is probably a bug in Darklang.LanguageTools.RuntimeErrors.Error.toString")
-                    [ "originalError", actual; "stringifyError", result ]
+                    [ "originalError", LibExecution.DvalReprDeveloper.toRepr actual
+                      "stringified", LibExecution.DvalReprDeveloper.toRepr result ]
               | Ok(RT.DEnum(_, _, [], "ErrorString", [ RT.DString _ ])) ->
                 return result
               | Ok _ ->

--- a/canvases/builtin/prompt.txt
+++ b/canvases/builtin/prompt.txt
@@ -49,7 +49,7 @@ some examples:
       Param.makeWithArgs "fn" (TFn([ TChar ], TChar)) "" [ "character" ] ]
   returnType = TStr
   description =
-    "Iterate over each Character (EGC, not byte) in the string, performing the
+    "Iterate over each Char (EGC, not byte) in the string, performing the
       operation in <param fn> on each one."
   fn =
     (function

--- a/canvases/dark-cli-demo/main.dark
+++ b/canvases/dark-cli-demo/main.dark
@@ -1,13 +1,9 @@
 [<HttpHandler("GET", "/")>]
 let _indexHandler _req =
-  let files =
+  let respBody =
     Builtin.Directory.pwd
     |> Builtin.Directory.ls
     |> Builtin.Json.serialize<List<String>>
-
-  let respBody =
-    match files with
-    | Ok files -> PACKAGE.Darklang.Stdlib.String.toBytes files
-    | Error _ -> "failed :("
+    |> PACKAGE.Darklang.Stdlib.String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response respBody 200

--- a/canvases/dark-editor/client.dark
+++ b/canvases/dark-editor/client.dark
@@ -44,34 +44,32 @@ let openAIcompletion
         messages =
           [ OpenAIChatCompletionRequestMessage { role = "user"; content = prompt } ] }
 
-  match Builtin.Json.serialize<OpenAIChatCompletionRequest> openAIRequest with
-  | Ok reqBody ->
-    let headers =
-      [ ("authorization", "Bearer " ++ apiKey)
-        ("content-type", "application/json") ]
+  let reqBody = Builtin.Json.serialize<OpenAIChatCompletionRequest> openAIRequest
 
-    let openAIResponse =
-      PACKAGE.Darklang.Stdlib.HttpClient.request
-        "POST"
-        "https://api.openai.com/v1/chat/completions"
-        headers
-        (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+  let headers =
+    [ ("authorization", "Bearer " ++ apiKey); ("content-type", "application/json") ]
 
-    match openAIResponse with
+  let openAIResponse =
+    PACKAGE.Darklang.Stdlib.HttpClient.request
+      "POST"
+      "https://api.openai.com/v1/chat/completions"
+      headers
+      (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+
+  match openAIResponse with
+  | Ok r ->
+    match
+      Builtin.Json.parse<OpenAIChatCompletionResponse> (
+        PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
+      )
+    with
     | Ok r ->
-      match
-        Builtin.Json.parse<OpenAIChatCompletionResponse> (
-          PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
-        )
-      with
-      | Ok r ->
-        match PACKAGE.Darklang.Stdlib.List.head r.choices with
-        | Some c -> Ok c.message.content
+      match PACKAGE.Darklang.Stdlib.List.head r.choices with
+      | Some c -> Ok c.message.content
 
-        | None -> Error("No choices returned")
-      | Error err -> Error("Couldn't parse open ai completino response - " ++ err)
-    | Error e -> Error("OpenAI API request failed\n" ++ e)
-  | Error e -> Error("Couldn't serialize request" ++ e)
+      | None -> Error("No choices returned")
+    | Error err -> Error("Couldn't parse open ai completino response - " ++ err)
+  | Error e -> Error("OpenAI API request failed\n" ++ e)
 
 
 let parseAndSerializeProgram
@@ -379,15 +377,9 @@ let update (model: Model) (msg: Msg) : Model =
 let updateStateInJS
   (newState: Model)
   : PACKAGE.Darklang.Stdlib.Result.Result<Unit, String> =
-  match Builtin.Json.serialize<Model> newState with
-  | Ok serialized ->
-    let _ = WASM.Editor.callJSFunction "self.receiveEvalResult" [ serialized ]
-    Ok()
-  | Error err ->
-    let _ =
-      WASM.Editor.callJSFunction "console.warn" [ "Couldn't serialize - " ++ err ]
-
-    Error "Couldn't serialize updated state"
+  let serialized = Builtin.Json.serialize<Model> newState
+  let _ = WASM.Editor.callJSFunction "self.receiveEvalResult" [ serialized ]
+  Ok()
 
 
 /// Single point of communication from JS host

--- a/canvases/dark-editor/system-prompt-cli.txt
+++ b/canvases/dark-editor/system-prompt-cli.txt
@@ -68,7 +68,7 @@ Here are some functions available in Dark:
 
 These are the available standard library modules:
 - Int
-- Character
+- Char
 - String
 - Float
 - Bool

--- a/canvases/dark-editor/system-prompt-older.txt
+++ b/canvases/dark-editor/system-prompt-older.txt
@@ -67,7 +67,7 @@ Here are some functions available in Dark:
 
 These are the available standard library modules:
 - Int
-- Character
+- Char
 - String
 - Float
 - Bool

--- a/canvases/dark-editor/system-prompt-without-tasks.txt
+++ b/canvases/dark-editor/system-prompt-without-tasks.txt
@@ -79,7 +79,7 @@ Here are some functions available in Dark:
 
 These are the available standard library modules:
 - Int
-- Character
+- Char
 - String
 - Float
 - Bool

--- a/canvases/dark-editor/system-prompt.txt
+++ b/canvases/dark-editor/system-prompt.txt
@@ -64,7 +64,7 @@ Here are some functions available in Dark:
 
 These are the available standard library modules:
 - Int
-- Character
+- Char
 - String
 - Float
 - Bool

--- a/canvases/dark-packages/main.dark
+++ b/canvases/dark-packages/main.dark
@@ -188,7 +188,7 @@ let fetchByName
         Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>
           typ
 
-    let respBody = json |> Builtin.unwrap |> PACKAGE.Darklang.Stdlib.String.toBytes
+    let respBody = json |> PACKAGE.Darklang.Stdlib.String.toBytes
 
     PACKAGE.Darklang.Stdlib.Http.response respBody 200
 
@@ -261,7 +261,6 @@ let _handler _req =
         fns = fns
         constants = constants })
     |> Builtin.Json.serialize<PACKAGE.Darklang.Stdlib.Packages>
-    |> Builtin.unwrap
     |> PACKAGE.Darklang.Stdlib.String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response respBody 200

--- a/canvases/dark-single-file-canvas/main.dark
+++ b/canvases/dark-single-file-canvas/main.dark
@@ -50,11 +50,7 @@ let _handler _req =
   let allRecords = Builtin.DB.getAll TestDB
   let respBody = allRecords |> Builtin.Json.serialize<List<Test>>
 
-  let respBody =
-    match respBody with
-    | Ok v -> v |> PACKAGE.Darklang.Stdlib.String.toBytes
-    | Err e -> "fail"
-
+  let respBody = respBody |> PACKAGE.Darklang.Stdlib.String.toBytes
 
   PACKAGE.Darklang.Stdlib.Http.response respBody 200
 

--- a/canvases/dark-tree-sitter-demo/main.dark
+++ b/canvases/dark-tree-sitter-demo/main.dark
@@ -342,19 +342,13 @@ let _handler _req =
       match root.children with
       | [ userFunction ] -> parseUserFunction userFunction
 
-    match Builtin.Json.serialize<PTUserFunction> userFn with
-    | Ok serialized ->
-      let respHeaders = [ ("content-type", "application/json") ]
+    let serialized = Builtin.Json.serialize<PTUserFunction> userFn
+    let respHeaders = [ ("content-type", "application/json") ]
 
-      PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
-        (PACKAGE.Darklang.Stdlib.String.toBytes serialized)
-        respHeaders
-        200
-
-    | Error e ->
-      PACKAGE.Darklang.Stdlib.Http.response
-        (PACKAGE.Darklang.Stdlib.String.toBytes_v0 e)
-        500
+    PACKAGE.Darklang.Stdlib.Http.responseWithHeaders
+      (PACKAGE.Darklang.Stdlib.String.toBytes serialized)
+      respHeaders
+      200
 
   | Error e ->
     PACKAGE.Darklang.Stdlib.Http.response

--- a/packages/darklang/languageTools/runtimeErrors/json.dark
+++ b/packages/darklang/languageTools/runtimeErrors/json.dark
@@ -1,0 +1,44 @@
+module Darklang =
+  module LanguageTools =
+    module RuntimeErrors =
+      module Json =
+        type Error = UnsupportedType of RuntimeTypes.TypeReference
+
+        let toSegments (e: Error) : ErrorOutput =
+          match e with
+          | UnsupportedType typ ->
+            let summary =
+              [ ErrorSegment.ErrorSegment.String "Unsupported type in JSON: "
+                ErrorSegment.ErrorSegment.TypeReference typ ]
+
+            let extraExplanation =
+              let parse =
+                RuntimeTypes.FnName.FnName.BuiltIn(
+                  RuntimeTypes.FnName.BuiltIn
+                    { modules = [ "Json" ]
+                      name = RuntimeTypes.FnName.Name.FnName "parse"
+                      version = 0 }
+                )
+
+              let serialize =
+                RuntimeTypes.FnName.FnName.BuiltIn(
+                  RuntimeTypes.FnName.BuiltIn
+                    { modules = [ "Json" ]
+                      name = RuntimeTypes.FnName.Name.FnName "serialize"
+                      version = 0 }
+                )
+
+
+              [ ErrorSegment.ErrorSegment.String
+                  ". Some types are not supported in Json serialization, and cannot be used as arguments to "
+                ErrorSegment.ErrorSegment.FunctionName parse
+                ErrorSegment.ErrorSegment.String " or "
+                ErrorSegment.ErrorSegment.FunctionName serialize ]
+
+            ErrorOutput
+              { summary = summary
+                extraExplanation = extraExplanation
+                actual = [ ErrorSegment.ErrorSegment.TypeReference typ ]
+                expected =
+                  [ ErrorSegment.ErrorSegment.String
+                      "A supported type (Int, String, etc)" ] }

--- a/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
+++ b/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
@@ -104,38 +104,11 @@ module Darklang =
                   | FullValue dv ->
                     PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.dval dv
                   | segment ->
-                    $"(RTETODO toString parts {(Builtin.Json.serialize<ErrorSegment> segment) |> Builtin.unwrap})"
+                    $"(RTETODO toString parts {(Builtin.Json.serialize<ErrorSegment> segment)})"
 
                 PACKAGE.Darklang.Stdlib.List.push prevSegments newSegment)
 
           PACKAGE.Darklang.Stdlib.String.join parts ""
-
-
-
-      // /// The result of Exception.raiseInternal
-      // module ExceptionThrown =
-      //   type ExceptionThrown =
-      //     { message: String
-      //       stackTrace: String
-      //       metadata: List<String * String> }
-
-      //   let toSegments (e: ExceptionThrown) : ErrorOutput =
-      //     let summary =
-      //       [ ErrorSegment.ErrorSegment.String "An internal error occurred" ]
-
-      //     let extraExplanation =
-      //       [ ErrorSegment.ErrorSegment.String "The error was: "
-      //         ErrorSegment.ErrorSegment.String e.message
-
-      //         ErrorSegment.ErrorSegment.String "\n"
-      //         ErrorSegment.ErrorSegment.String "The stack trace was: "
-      //         ErrorSegment.ErrorSegment.String e.stackTrace ]
-
-      //     ErrorOutput
-      //       { summary = summary
-      //         extraExplanation = extraExplanation
-      //         actual = []
-      //         expected = [] }
 
 
       type ErrorOutput =
@@ -158,8 +131,9 @@ module Darklang =
         | SqlCompilerRuntimeError of Error
         | ExecutionError of
           PACKAGE.Darklang.LanguageTools.RuntimeErrors.Execution.Error
+        | JsonError of PACKAGE.Darklang.LanguageTools.RuntimeErrors.Json.Error
+
         | OldStringErrorTODO of String
-      //| ExceptionThrown of ExceptionThrown.ExceptionThrown
 
       let sqlErrorTemplate =
         "You're using our new experimental Datastore query compiler. It compiles your lambdas into optimized (and partially indexed) Datastore queries, which should be reasonably fast.\n\nUnfortunately, we hit a snag while compiling your lambda. We only support a subset of Darklang's functionality, but will be expanding it in the future.\n\nSome Darklang code is not supported in DB::query lambdas for now, and some of it won't be supported because it's an odd thing to do in a datastore query. If you think your operation should be supported, let us know in #general in Discord.\n\n  Error: "
@@ -194,19 +168,8 @@ module Darklang =
                     [ (ErrorSegment.ErrorSegment.String sqlErrorTemplate) ]
                     innerOutput.summary }
 
-          //| ExceptionThrown err -> ExceptionThrown.toSegments err
+          | JsonError err -> Json.toSegments err
 
-          | _ ->
-            ErrorOutput
-              { summary =
-                  [ ErrorSegment.ErrorSegment.String "RTETODO Error.toSegments" ]
-                extraExplanation =
-                  [ e
-                    |> Builtin.Json.serialize<Error>
-                    |> Builtin.unwrap
-                    |> ErrorSegment.ErrorSegment.String ]
-                actual = []
-                expected = [] }
 
         let toString (e: Error) : String =
           let s = toSegments e

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -332,7 +332,7 @@ module Darklang =
         | TBool -> "Bool"
         | TInt -> "Int"
         | TFloat -> "Float"
-        | TChar -> "Character"
+        | TChar -> "Char"
         | TString -> "String"
         | TDateTime -> "DateTime"
         | TUuid -> "Uuid"

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -386,12 +386,8 @@ module Darklang =
           $"{argPart} -> {PACKAGE.Darklang.PrettyPrinter.ProgramTypes.typeReference ret}"
         | _ ->
           let s =
-            match
-              Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference>
-                t
-            with
-            | Ok s -> s
-            | Error e -> "Err" ++ e
+            Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeReference>
+              t
 
           $"({s})"
 
@@ -902,9 +898,8 @@ module Darklang =
         // CLEANUP: remove this case before shipping to users
         | expr ->
           let s =
-            (Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
-              expr)
-            |> Builtin.unwrap
+            Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.ProgramTypes.Expr>
+              expr
 
           $"{s}"
 

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -259,7 +259,7 @@ module Darklang =
             | [] -> ""
             | args ->
               args
-              |> PACKAGE.Darklang.Stdlib.List.map (fun t -> valueTypeName t)
+              |> PACKAGE.Darklang.Stdlib.List.map (fun t -> valueType t)
               |> PACKAGE.Darklang.Stdlib.String.join ", "
               |> fun betweenBrackets -> "<" + betweenBrackets + ">"
 

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -181,7 +181,7 @@ module Darklang =
         | TBool -> "Bool"
         | TInt -> "Int"
         | TFloat -> "Float"
-        | TChar -> "Character"
+        | TChar -> "Char"
         | TString -> "String"
         | TUuid -> "Uuid"
         | TBytes -> "Bytes"

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -249,9 +249,9 @@ module Darklang =
           |> fun s -> $"({s})"
 
         | KTFn(argTypes, retType) ->
-          (Stdlib.List.push retType argTypes)
+          (Stdlib.List.push argTypes retType)
           |> PACKAGE.Darklang.Stdlib.List.map (fun vt -> valueType vt)
-          |> PACKAGE.Darklang.Stdlib.String.join parts " -> "
+          |> PACKAGE.Darklang.Stdlib.String.join " -> "
 
         | KTCustomType(name, typeArgs) ->
           let typeArgsPortion =
@@ -424,18 +424,23 @@ module Darklang =
               $"{typeStr}{typeArgsPart}.{caseName}{fieldStr}"
 
 
-          // | DFnVal _ ->
-          //   // TODO: we should Builtin.print this, as this use case is safe
-          //   // See docs/dblock-serialization.md
-          //   justType
+          | DFnVal(NamedFn fnName) ->
+            PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.FnName.fnName fnName
+
+          | DFnVal(Lambda impl) ->
+            // Note: this use case is safe (RE docs/dblock-serialization.md)
+            let ps =
+              impl.parameters
+              |> Stdlib.List.map Stdlib.Tuple2.second
+              |> Stdlib.String.join ", "
+
+            // TODO
+            // let body = impl.body |> RuntimeTypes.Expr.toString
+            $"\\ {ps} {{ ... }}"
+
 
           | DDB name -> $"<{valueTypeName}: {name}>"
 
-          // | DError(_, msg) -> $"<error: {msg}>"
-
-          | _ ->
-            $"(PP.RT.Dval TODO {(Builtin.Json.serialize<PACKAGE.Darklang.LanguageTools.RuntimeTypes.Dval.Dval> dv)
-                                |> Builtin.unwrap})"
 
 
       let dval (dv: PACKAGE.Darklang.LanguageTools.RuntimeTypes.Dval.Dval) : String =

--- a/packages/darklang/stdlib/json.dark
+++ b/packages/darklang/stdlib/json.dark
@@ -27,10 +27,18 @@ module Darklang =
             PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
             String *
             JsonPath.JsonPath
-          | EnumExtraField of String * JsonPath.JsonPath
+          | EnumExtraField of rawJson: String * JsonPath.JsonPath
           | EnumMissingField of
             PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
-            Int *
+            index: Int *
+            JsonPath.JsonPath
+          | EnumInvalidCasename of
+            PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
+            caseName: String *
+            JsonPath.JsonPath
+          | EnumTooManyCases of
+            PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
+            cases: List<String> *
             JsonPath.JsonPath
           | NotJson
 
@@ -62,4 +70,26 @@ module Darklang =
             ++ "`) is missing at path: `"
             ++ JsonPath.toString path
             ++ "`"
+
+          // Can't parse JSON as `Wrong` is not a known case of type `PrettyLikely` at path: `root`
+          | EnumInvalidCasename(typ, caseName, path) ->
+            "Can't parse JSON as `"
+            ++ caseName
+            ++ "` is not a known case of type `"
+            ++ PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.typeReference typ
+            ++ "` at path: `"
+            ++ JsonPath.toString path
+            ++ "`"
+
+          // Can't parse JSON with multiple fields (`Enh` and `Extra`) as type `PrettyLikely` at path: `root`
+          | EnumTooManyCases(typ, cases, path) ->
+            let cases = cases |> List.map (fun c -> $"`{c}`") |> String.join ", "
+
+            $"Can't parse JSON with multiple fields ({cases}) as type `"
+            ++ PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.typeReference typ
+            ++ "` at path: `"
+            ++ JsonPath.toString path
+            ++ "`"
+
+
           | NotJson -> "Not JSON"

--- a/packages/darklang/stdlib/json.dark
+++ b/packages/darklang/stdlib/json.dark
@@ -1,7 +1,7 @@
 module Darklang =
   module Stdlib =
     module Json =
-      module Error =
+      module ParseError =
         module JsonPath =
           module Part =
             type Part =
@@ -21,7 +21,7 @@ module Darklang =
             path |> List.reverse |> List.map Part.toString |> String.join ""
 
 
-        type Error =
+        type ParseError =
           /// The json string can't be parsed as the given type.
           | CantMatchWithType of
             PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
@@ -44,7 +44,7 @@ module Darklang =
           | RecordMissingField of fieldName: String * JsonPath.JsonPath
           | NotJson
 
-        let toString (e: Error) : String =
+        let toString (e: ParseError) : String =
           match e with
           | CantMatchWithType(typ, json, path) ->
             "Can't parse JSON `"

--- a/packages/darklang/stdlib/json.dark
+++ b/packages/darklang/stdlib/json.dark
@@ -27,8 +27,8 @@ module Darklang =
             PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
             String *
             JsonPath.JsonPath
-          | ExtraEnumField of String * JsonPath.JsonPath
-          | MissingEnumField of
+          | EnumExtraField of String * JsonPath.JsonPath
+          | EnumMissingField of
             PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
             Int *
             JsonPath.JsonPath
@@ -46,7 +46,7 @@ module Darklang =
             ++ "`"
 
           // Can't parse JSON due to an extra argument `2.0` at path: `root.Enh[2]`
-          | ExtraEnumField(rawJson, path) ->
+          | EnumExtraField(rawJson, path) ->
             "Can't parse JSON due to an extra argument `"
             ++ rawJson
             ++ "` at path: `"
@@ -54,7 +54,7 @@ module Darklang =
             ++ "`"
 
           // Can't parse JSON because argument 4 (`Int`) is missing at path: `root.Enh`
-          | MissingEnumField(typ, index, path) ->
+          | EnumMissingField(typ, index, path) ->
             "Can't parse JSON because argument "
             ++ Int.toString index
             ++ " (`"

--- a/packages/darklang/stdlib/json.dark
+++ b/packages/darklang/stdlib/json.dark
@@ -1,0 +1,42 @@
+module Darklang =
+  module Stdlib =
+    module Json =
+      module Error =
+        module JsonPath =
+          module Part =
+            type Part =
+              | Root
+              | Index of Int
+              | Field of String
+
+            let toString (part: Part) : String =
+              match part with
+              | Root -> "root"
+              | Field(name) -> "." ++ name
+              | Index(index) -> "[" ++ Int.toString index ++ "]"
+
+          type JsonPath = List<Part.Part>
+
+          let toString (path: JsonPath) : String =
+            path |> List.reverse |> List.map Part.toString |> String.join ""
+
+
+        type Error =
+          /// The json string can't be parsed as the given type.
+          | CantMatchWithType of
+            PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
+            String *
+            JsonPath.JsonPath
+          | NotJson
+
+        let toString (e: Error) : String =
+          match e with
+          | CantMatchWithType(typ, json, path) ->
+            "Can't parse JSON `"
+            ++ json
+            ++ "` as type `"
+            ++ PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.typeReference typ
+            ++ "` at path: `"
+            ++ JsonPath.toString path
+            ++ "`"
+          | NotJson -> "Not JSON"

--- a/packages/darklang/stdlib/json.dark
+++ b/packages/darklang/stdlib/json.dark
@@ -27,6 +27,11 @@ module Darklang =
             PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
             String *
             JsonPath.JsonPath
+          | ExtraEnumField of String * JsonPath.JsonPath
+          | MissingEnumField of
+            PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
+            Int *
+            JsonPath.JsonPath
           | NotJson
 
         let toString (e: Error) : String =
@@ -37,6 +42,24 @@ module Darklang =
             ++ "` as type `"
             ++ PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.typeReference typ
             ++ "` at path: `"
+            ++ JsonPath.toString path
+            ++ "`"
+
+          // Can't parse JSON due to an extra argument `2.0` at path: `root.Enh[2]`
+          | ExtraEnumField(rawJson, path) ->
+            "Can't parse JSON due to an extra argument `"
+            ++ rawJson
+            ++ "` at path: `"
+            ++ JsonPath.toString path
+            ++ "`"
+
+          // Can't parse JSON because argument 4 (`Int`) is missing at path: `root.Enh`
+          | MissingEnumField(typ, index, path) ->
+            "Can't parse JSON because argument "
+            ++ Int.toString index
+            ++ " (`"
+            ++ PACKAGE.Darklang.PrettyPrinter.RuntimeTypes.typeReference typ
+            ++ "`) is missing at path: `"
             ++ JsonPath.toString path
             ++ "`"
           | NotJson -> "Not JSON"

--- a/packages/darklang/stdlib/json.dark
+++ b/packages/darklang/stdlib/json.dark
@@ -40,6 +40,8 @@ module Darklang =
             PACKAGE.Darklang.LanguageTools.RuntimeTypes.TypeReference *
             cases: List<String> *
             JsonPath.JsonPath
+          | RecordDuplicateField of fieldName: String * JsonPath.JsonPath
+          | RecordMissingField of fieldName: String * JsonPath.JsonPath
           | NotJson
 
         let toString (e: Error) : String =
@@ -91,5 +93,21 @@ module Darklang =
             ++ JsonPath.toString path
             ++ "`"
 
+          // Can't parse JSON because `Name` field is not provided at path: `root`
+          | RecordMissingField(fieldName, path) ->
+            "Can't parse JSON because `"
+            ++ fieldName
+            ++ "` field is not provided at path: `"
+            ++ JsonPath.toString path
+            ++ "`"
+
+
+          // Can't parse JSON because `Age` is defined more than once at path: `root`
+          | RecordDuplicateField(fieldName, path) ->
+            "Can't parse JSON because `"
+            ++ fieldName
+            ++ "` is defined more than once at path: `"
+            ++ JsonPath.toString path
+            ++ "`"
 
           | NotJson -> "Not JSON"

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -40,7 +40,7 @@ module Darklang =
       let isEmpty (s: String) : Bool = s == ""
 
 
-      /// Iterate over each Character (EGC, not byte) in the string, performing the
+      /// Iterate over each Char (EGC, not byte) in the string, performing the
       /// operation in <param fn> on each one.
       let map (s: String) (fn: Char -> Char) : String = Builtin.String.map s fn
 

--- a/packages/openai.dark
+++ b/packages/openai.dark
@@ -181,6 +181,7 @@ module OpenAI =
 
       let reqBody =
         Builtin.Json.serialize<PACKAGE.OpenAI.ChatCompletion.Request> openAIRequest
+
       let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
       let openAIResponse =
@@ -231,6 +232,7 @@ module OpenAI =
 
       let reqBody =
         Builtin.Json.serialize<PACKAGE.OpenAI.ImageGeneration.Request> openAIRequest
+
       let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
       let openAIResponse =

--- a/packages/openai.dark
+++ b/packages/openai.dark
@@ -35,45 +35,35 @@ module OpenAI =
             max_tokens = 700
             temperature = 0.7 }
 
-      match
+      let reqBody =
         Builtin.Json.serialize<PACKAGE.OpenAI.Completion.Request> openAIRequest
-      with
-      | Ok reqBody ->
-        let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
-        let openAIResponse =
-          PACKAGE.Darklang.Stdlib.HttpClient.request
-            "POST"
-            "https://api.openai.com/v1/completions"
-            headers
-            (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+      let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
-        match openAIResponse with
+      let openAIResponse =
+        PACKAGE.Darklang.Stdlib.HttpClient.request
+          "POST"
+          "https://api.openai.com/v1/completions"
+          headers
+          (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+
+      match openAIResponse with
+      | Ok r ->
+        match
+          Builtin.Json.parse<PACKAGE.OpenAI.Completion.Response> (
+            PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
+          )
+        with
         | Ok r ->
-          match
-            Builtin.Json.parse<PACKAGE.OpenAI.Completion.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
-            )
-          with
-          | Ok r ->
-            match PACKAGE.Darklang.Stdlib.List.head r.choices with
-            | Some c -> PACKAGE.Darklang.Stdlib.Result.Result.Ok c.text
+          match PACKAGE.Darklang.Stdlib.List.head r.choices with
+          | Some c -> PACKAGE.Darklang.Stdlib.Result.Result.Ok c.text
 
-            | None ->
-              PACKAGE.Darklang.Stdlib.Result.Result.Error("No choices returned")
-        | Error err ->
-          PACKAGE.Darklang.Stdlib.Result.Result.Error(
-            "Couldn't parse OpenAI completion response - " ++ err
-          )
-        | Error e ->
-          PACKAGE.Darklang.Stdlib.Result.Result.Error(
-            "OpenAI API request failed\n" ++ e
-          )
-      | Error e ->
+          | None ->
+            PACKAGE.Darklang.Stdlib.Result.Result.Error("No choices returned")
+      | Error err ->
         PACKAGE.Darklang.Stdlib.Result.Result.Error(
-          "Couldn't serialize request" ++ e
+          "Couldn't parse OpenAI completion response - " ++ err
         )
-
 
 
   module ChatCompletion =
@@ -139,44 +129,39 @@ module OpenAI =
 
       let openAIRequest = options
 
-      match
+      let reqBody =
         Builtin.Json.serialize<PACKAGE.OpenAI.ChatCompletion.CompletionOptions>
           openAIRequest
-      with
-      | Ok reqBody ->
-        let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
-        let openAIResponse =
-          PACKAGE.Darklang.Stdlib.HttpClient.request
-            "POST"
-            "https://api.openai.com/v1/chat/completions"
-            headers
-            (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+      let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
-        match openAIResponse with
+      let openAIResponse =
+        PACKAGE.Darklang.Stdlib.HttpClient.request
+          "POST"
+          "https://api.openai.com/v1/chat/completions"
+          headers
+          (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+
+      match openAIResponse with
+      | Ok r ->
+        match
+          Builtin.Json.parse<PACKAGE.OpenAI.ChatCompletion.Response> (
+            PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
+          )
+        with
         | Ok r ->
-          match
-            Builtin.Json.parse<PACKAGE.OpenAI.ChatCompletion.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
-            )
-          with
-          | Ok r ->
-            match PACKAGE.Darklang.Stdlib.List.head r.choices with
-            | Some c -> PACKAGE.Darklang.Stdlib.Result.Result.Ok c.message.content
+          match PACKAGE.Darklang.Stdlib.List.head r.choices with
+          | Some c -> PACKAGE.Darklang.Stdlib.Result.Result.Ok c.message.content
 
-            | None ->
-              PACKAGE.Darklang.Stdlib.Result.Result.Error("No choices returned")
-          | Error err ->
-            PACKAGE.Darklang.Stdlib.Result.Result.Error(
-              "Couldn't parse OpenAI completion response - " ++ err
-            )
-        | Error e ->
+          | None ->
+            PACKAGE.Darklang.Stdlib.Result.Result.Error("No choices returned")
+        | Error err ->
           PACKAGE.Darklang.Stdlib.Result.Result.Error(
-            "OpenAI API request failed\n" ++ e
+            "Couldn't parse OpenAI completion response - " ++ err
           )
       | Error e ->
         PACKAGE.Darklang.Stdlib.Result.Result.Error(
-          "Couldn't serialize request" ++ e
+          "OpenAI API request failed\n" ++ e
         )
 
 
@@ -194,43 +179,37 @@ module OpenAI =
               [ PACKAGE.OpenAI.ChatCompletion.RequestMessage
                   { role = "user"; content = prompt } ] }
 
-      match
+      let reqBody =
         Builtin.Json.serialize<PACKAGE.OpenAI.ChatCompletion.Request> openAIRequest
-      with
-      | Ok reqBody ->
-        let headers = PACKAGE.OpenAI.Config.getHeaders ()
+      let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
-        let openAIResponse =
-          PACKAGE.Darklang.Stdlib.HttpClient.request
-            "POST"
-            "https://api.openai.com/v1/chat/completions"
-            headers
-            (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+      let openAIResponse =
+        PACKAGE.Darklang.Stdlib.HttpClient.request
+          "POST"
+          "https://api.openai.com/v1/chat/completions"
+          headers
+          (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
 
-        match openAIResponse with
+      match openAIResponse with
+      | Ok r ->
+        match
+          Builtin.Json.parse<PACKAGE.OpenAI.ChatCompletion.Response> (
+            PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
+          )
+        with
         | Ok r ->
-          match
-            Builtin.Json.parse<PACKAGE.OpenAI.ChatCompletion.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
-            )
-          with
-          | Ok r ->
-            match PACKAGE.Darklang.Stdlib.List.head r.choices with
-            | Some c -> PACKAGE.Darklang.Stdlib.Result.Result.Ok c.message.content
+          match PACKAGE.Darklang.Stdlib.List.head r.choices with
+          | Some c -> PACKAGE.Darklang.Stdlib.Result.Result.Ok c.message.content
 
-            | None ->
-              PACKAGE.Darklang.Stdlib.Result.Result.Error("No choices returned")
-          | Error err ->
-            PACKAGE.Darklang.Stdlib.Result.Result.Error(
-              "Couldn't parse OpenAI completion response - " ++ err
-            )
-        | Error e ->
+          | None ->
+            PACKAGE.Darklang.Stdlib.Result.Result.Error("No choices returned")
+        | Error err ->
           PACKAGE.Darklang.Stdlib.Result.Result.Error(
-            "OpenAI API request failed\n" ++ e
+            "Couldn't parse OpenAI completion response - " ++ err
           )
       | Error e ->
         PACKAGE.Darklang.Stdlib.Result.Result.Error(
-          "Couldn't serialize request" ++ e
+          "OpenAI API request failed\n" ++ e
         )
 
 
@@ -250,41 +229,35 @@ module OpenAI =
       let openAIRequest =
         PACKAGE.OpenAI.ImageGeneration.Request { prompt = prompt; size = "256x256" }
 
-      match
+      let reqBody =
         Builtin.Json.serialize<PACKAGE.OpenAI.ImageGeneration.Request> openAIRequest
-      with
-      | Ok reqBody ->
-        let headers = PACKAGE.OpenAI.Config.getHeaders ()
+      let headers = PACKAGE.OpenAI.Config.getHeaders ()
 
-        let openAIResponse =
-          PACKAGE.Darklang.Stdlib.HttpClient.request
-            "POST"
-            "https://api.openai.com/v1/images/generations"
-            headers
-            (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
+      let openAIResponse =
+        PACKAGE.Darklang.Stdlib.HttpClient.request
+          "POST"
+          "https://api.openai.com/v1/images/generations"
+          headers
+          (PACKAGE.Darklang.Stdlib.String.toBytes reqBody)
 
-        match openAIResponse with
+      match openAIResponse with
+      | Ok r ->
+        match
+          Builtin.Json.parse<PACKAGE.OpenAI.ImageGeneration.Response> (
+            PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
+          )
+        with
         | Ok r ->
-          match
-            Builtin.Json.parse<PACKAGE.OpenAI.ImageGeneration.Response> (
-              PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement r.body
-            )
-          with
-          | Ok r ->
-            match PACKAGE.Darklang.Stdlib.List.head r.data with
-            | Some d -> PACKAGE.Darklang.Stdlib.Result.Result.Ok d.url
-            | None -> PACKAGE.Darklang.Stdlib.Result.Result.Error("No data returned")
+          match PACKAGE.Darklang.Stdlib.List.head r.data with
+          | Some d -> PACKAGE.Darklang.Stdlib.Result.Result.Ok d.url
+          | None -> PACKAGE.Darklang.Stdlib.Result.Result.Error("No data returned")
         | Error err ->
           PACKAGE.Darklang.Stdlib.Result.Result.Error(
             "Couldn't parse open ai image generation response - " ++ err
           )
-        | Error e ->
-          PACKAGE.Darklang.Stdlib.Result.Result.Error(
-            "OpenAI API request failed\n" ++ e
-          )
       | Error e ->
         PACKAGE.Darklang.Stdlib.Result.Result.Error(
-          "Couldn't serialize request" ++ e
+          "OpenAI API request failed\n" ++ e
         )
 
 

--- a/scripts/deployment/buildcontainers.dark
+++ b/scripts/deployment/buildcontainers.dark
@@ -30,7 +30,7 @@ let main () : Int =
       DockerImageID { imageID = parsedResponse.id })
 
   let jsonImageIds =
-    (Builtin.Json.serialize<List<DockerImageId>> imageIds) |> Builtin.unwrap
+    Builtin.Json.serialize<List<DockerImageId>> imageIds
 
   let _ =
     Builtin.File.write

--- a/scripts/deployment/buildcontainers.dark
+++ b/scripts/deployment/buildcontainers.dark
@@ -29,8 +29,7 @@ let main () : Int =
       let parsedResponse = Builtin.Json.parse<DockerBuildResponse> (response)
       DockerImageID { imageID = parsedResponse.id })
 
-  let jsonImageIds =
-    Builtin.Json.serialize<List<DockerImageId>> imageIds
+  let jsonImageIds = Builtin.Json.serialize<List<DockerImageId>> imageIds
 
   let _ =
     Builtin.File.write

--- a/scripts/deployment/sync-packages-and-canvases.dark
+++ b/scripts/deployment/sync-packages-and-canvases.dark
@@ -52,7 +52,7 @@ let export (unit: Unit) : Result<Unit, String> =
 
   Builtin.print "serializing data to export"
 
-  let json = (Builtin.Json.serialize<DataExport> data) |> Builtin.unwrap
+  let json = Builtin.Json.serialize<DataExport> data
 
   Builtin.print "exporting data to `dark-ai-backup`"
 

--- a/scripts/run-canvas-hack
+++ b/scripts/run-canvas-hack
@@ -33,8 +33,6 @@ do
   fi
 done
 
-set -x
-
 echo "Clearing canvas before loading from disk"
 ./scripts/clear-canvas.sh "${CANVAS}"
 


### PR DESCRIPTION
This does the remainder of JSON error handling improvements, esp adding a Json.ParserError type that is returned for errors instead of strings. I believe this handlers all broken things in the Stdlib.Json module.

One open question I have is whether putting a TypeReference in the type is a good idea. This isn't a RuntimeError that will be handled by the runtime, it's a user facing error. So I'm not quite sure what to do with this.

As part of this:
- anything that the typechecker should have caught is now an InternalException
- anything that the user could trigger during parsing is now a parseError
- `serialize` doesn't error (but there is still a typechecker error if the type and data don't match, or if you use an unsupported type)

Unrelated fixes:
- add a special error message for incorrect types to `unwrap` 
- don't default to trying to parse a package constant if package function parsing failed (lost the error message)
- stringify error messages with toRepr to be more readable
- switch to 63 bits for IDs
- Call all Chars "Char"
- if we call a function and it threw a runtimeError with no DvalSource, use the caller's DvalSource
- make sure we always catch testing exceptions using postTestExecutionHook