### PR TITLE
DvalSource/Caller/tlid updates

### DIFF
--- a/backend/experiments/BwdDangerServer/DangerExecution.fs
+++ b/backend/experiments/BwdDangerServer/DangerExecution.fs
@@ -234,7 +234,8 @@ let reexecuteFunction
     // the rootTLID of the trace.
     let tracing = Tracing.create program.canvasID rootTLID traceID
     let! state = createState traceID callerTLID program tracing.executionTracing
-    let! result = Exe.executeFunction state callerID name typeArgs args
+    let! result =
+      Exe.executeFunction state (Some(callerTLID, callerID)) name typeArgs args
     tracing.storeTraceResults ()
     return result, tracing.results
   }

--- a/backend/experiments/BwdDangerServer/DangerExecution.fs
+++ b/backend/experiments/BwdDangerServer/DangerExecution.fs
@@ -42,7 +42,11 @@ let createState
   : Task<RT.ExecutionState> =
   task {
     let extraMetadata (state : RT.ExecutionState) : Metadata =
-      [ "tlid", state.tlid; "trace_id", traceID; "canvasID", program.canvasID ]
+      let tlid, id = Option.defaultValue (0UL, 0UL) state.caller
+      [ "callerTLID", tlid
+        "id", id
+        "trace_id", traceID
+        "canvasID", program.canvasID ]
 
     let notify (state : RT.ExecutionState) (msg : string) (metadata : Metadata) =
       let metadata = extraMetadata state @ metadata
@@ -92,7 +96,7 @@ let executeHandler
 
     let! state = createState traceID h.tlid program tracing.executionTracing
     HashSet.add h.tlid tracing.results.tlids
-    let! result = Exe.executeExpr state inputVars h.ast
+    let! result = Exe.executeExpr state h.tlid inputVars h.ast
 
     let findUserBody (tlid : tlid) : Option<string * RT.Expr> =
       program.fns

--- a/backend/experiments/BwdDangerServer/DangerExecution.fs
+++ b/backend/experiments/BwdDangerServer/DangerExecution.fs
@@ -136,10 +136,10 @@ let executeHandler
         return $"fn {fnName}\nexpr:\n{expr}\n"
       }
 
-    let sourceString (source : RT.DvalSource) : Ply<string> =
+    let sourceString (source : RT.Source) : Ply<string> =
       match source with
-      | RT.SourceNone -> Ply "No source"
-      | RT.SourceID(tlid, id) -> sourceOf tlid id
+      | None -> Ply "No source"
+      | Some(tlid, id) -> sourceOf tlid id
 
     let error (msg : string) =
       let typeName =
@@ -228,7 +228,7 @@ let reexecuteFunction
   (name : RT.FnName.FnName)
   (typeArgs : List<RT.TypeReference>)
   (args : NEList<RT.Dval>)
-  : Task<(Result<RT.Dval, RT.DvalSource * RT.RuntimeError> * Tracing.TraceResults.T)> =
+  : Task<(Result<RT.Dval, RT.Source * RT.RuntimeError> * Tracing.TraceResults.T)> =
   task {
     // FIX - the TLID here is the tlid of the toplevel in which the call exists, not
     // the rootTLID of the trace.

--- a/backend/serialization/vanilla_LibExecution-AnalysisTypes-TraceData_testTraceData.json
+++ b/backend/serialization/vanilla_LibExecution-AnalysisTypes-TraceData_testTraceData.json
@@ -544,6 +544,7 @@
                   "Lambda": [
                     {
                       "typeSymbolTable": {},
+                      "tlid": 77777723098234,
                       "symtable": {},
                       "parameters": [
                         [
@@ -567,6 +568,7 @@
                   "Lambda": [
                     {
                       "typeSymbolTable": {},
+                      "tlid": 7777772349823445,
                       "symtable": {},
                       "parameters": [
                         [
@@ -4885,6 +4887,7 @@
                   "Lambda": [
                     {
                       "typeSymbolTable": {},
+                      "tlid": 77777723098234,
                       "symtable": {},
                       "parameters": [
                         [
@@ -4908,6 +4911,7 @@
                   "Lambda": [
                     {
                       "typeSymbolTable": {},
+                      "tlid": 7777772349823445,
                       "symtable": {},
                       "parameters": [
                         [

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -81,7 +81,7 @@ let execute
   (parentState : RT.ExecutionState)
   (mod' : LibParser.Canvas.PTCanvasModule)
   (symtable : Map<string, RT.Dval>)
-  : Ply<Result<RT.Dval, DvalSource * RuntimeError>> =
+  : Ply<Result<RT.Dval, Source * RuntimeError>> =
 
   uply {
     let (program : Program) =
@@ -120,12 +120,12 @@ let execute
     else if mod'.exprs.Length = 0 then
       let! rte =
         CliRuntimeError.NoExpressionsToExecute |> CliRuntimeError.RTE.toRuntimeError
-      return Error((SourceNone, rte))
+      return Error((None, rte))
     else // mod'.exprs.Length > 1
       let! rte =
         CliRuntimeError.MultipleExpressionsToExecute(mod'.exprs |> List.map string)
         |> CliRuntimeError.RTE.toRuntimeError
-      return Error((SourceNone, rte))
+      return Error((None, rte))
   }
 
 let types : List<BuiltInType> = []

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -111,7 +111,6 @@ let execute
         Exe.noTracing
         sendException
         notify
-        7777778402656UL
         program
 
     if mod'.exprs.Length = 1 then

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -283,8 +283,8 @@ let fns : List<BuiltInFn> =
                   let! result =
                     Exe.executeFunction
                       state
-                      (gid ())
-                      (f.name)
+                      None
+                      f.name
                       []
                       (NEList.ofList args.Head args.Tail)
 

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -116,7 +116,7 @@ let execute
 
     if mod'.exprs.Length = 1 then
       let expr = PT2RT.Expr.toRT mod'.exprs[0]
-      return! Exe.executeExpr state symtable expr
+      return! Exe.executeExpr state 7777779489234UL symtable expr
     else if mod'.exprs.Length = 0 then
       let! rte =
         CliRuntimeError.NoExpressionsToExecute |> CliRuntimeError.RTE.toRuntimeError

--- a/backend/src/BuiltinCloudExecution/Libs/DB.fs
+++ b/backend/src/BuiltinCloudExecution/Libs/DB.fs
@@ -61,7 +61,7 @@ let fns : List<BuiltInFn> =
 
             match id with
             | Ok _id -> return value
-            | Error rte -> return raiseRTE SourceNone rte
+            | Error rte -> return raiseRTE None rte
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -266,7 +266,7 @@ let fns : List<BuiltInFn> =
                   | dv ->
                     return!
                       TypeChecker.raiseFnValResultNotExpectedType
-                        SourceNone
+                        state.caller
                         dv
                         TUnit
                 })
@@ -303,7 +303,7 @@ let fns : List<BuiltInFn> =
                 | DBool v -> return v
                 | v ->
                   return!
-                    TypeChecker.raiseFnValResultNotExpectedType SourceNone v TBool
+                    TypeChecker.raiseFnValResultNotExpectedType state.caller v TBool
               }
             let! result = Ply.Map.filterSequentially f o
             return Dval.dictFromMap VT.unknownTODO result
@@ -359,7 +359,7 @@ let fns : List<BuiltInFn> =
                   let expectedType = TypeReference.option varB
                   return!
                     TypeChecker.raiseFnValResultNotExpectedType
-                      SourceNone
+                      state.caller
                       v
                       expectedType
               }

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -229,7 +229,7 @@ let fns : List<BuiltInFn> =
               Ply.Map.mapSequentially
                 (fun (key, dv) ->
                   let args = NEList.ofList (DString key) [ dv ]
-                  Interpreter.applyFnVal state 0UL b [] args)
+                  Interpreter.applyFnVal state state.caller b [] args)
                 mapped
 
             return Dval.dict VT.unknownTODO (Map.toList result)
@@ -261,7 +261,7 @@ let fns : List<BuiltInFn> =
               |> Ply.List.iterSequentially (fun (key, dv) ->
                 uply {
                   let args = NEList.ofList (DString key) [ dv ]
-                  match! Interpreter.applyFnVal state 0UL b [] args with
+                  match! Interpreter.applyFnVal state state.caller b [] args with
                   | DUnit -> return ()
                   | dv ->
                     return!
@@ -299,7 +299,7 @@ let fns : List<BuiltInFn> =
             let f (key : string) (data : Dval) : Ply<bool> =
               uply {
                 let args = NEList.ofList (DString key) [ data ]
-                match! Interpreter.applyFnVal state 0UL b [] args with
+                match! Interpreter.applyFnVal state state.caller b [] args with
                 | DBool v -> return v
                 | v ->
                   return!
@@ -336,7 +336,7 @@ let fns : List<BuiltInFn> =
             let f (key : string) (data : Dval) : Ply<Option<Dval>> =
               uply {
                 let args = NEList.ofList (DString key) [ data ]
-                let! result = Interpreter.applyFnVal state 0UL b [] args
+                let! result = Interpreter.applyFnVal state state.caller b [] args
 
                 match result with
                 | DEnum(FQName.Package { owner = "Darklang"

--- a/backend/src/BuiltinExecution/Libs/HttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/HttpClient.fs
@@ -432,7 +432,6 @@ let fns (config : Configuration) : List<BuiltInFn> =
                   |> Dval.record typ (Some [])
                   |> Ply.map resultOk
 
-              // TODO: include a DvalSource rather than SourceNone
               | Error(BadUrl details) -> return resultErrorStr $"Bad URL: {details}"
               | Error(Timeout) -> return resultErrorStr $"Request timed out"
               | Error(NetworkError) -> return resultErrorStr $"Network error"

--- a/backend/src/BuiltinExecution/Libs/List.fs
+++ b/backend/src/BuiltinExecution/Libs/List.fs
@@ -243,7 +243,7 @@ let fns : List<BuiltInFn> =
                 (fun dv ->
                   uply {
                     let args = NEList.singleton dv
-                    let! key = Interpreter.applyFnVal state 0UL b [] args
+                    let! key = Interpreter.applyFnVal state state.caller b [] args
 
                     // TODO: type check to ensure `varB` is "comparable"
                     return (dv, key)
@@ -340,7 +340,7 @@ let fns : List<BuiltInFn> =
           uply {
             let fn dv =
               let args = NEList.singleton dv
-              Interpreter.applyFnVal state 0UL b [] args
+              Interpreter.applyFnVal state state.caller b [] args
             let! withKeys =
               list
               |> Ply.List.mapSequentially (fun v ->
@@ -392,7 +392,7 @@ let fns : List<BuiltInFn> =
           let fn (dv1 : Dval) (dv2 : Dval) : Ply<int> =
             uply {
               let args = NEList.doubleton dv1 dv2
-              let! result = Interpreter.applyFnVal state 0UL f [] args
+              let! result = Interpreter.applyFnVal state state.caller f [] args
 
               match result with
               | DInt i when i = 1L || i = 0L || i = -1L -> return int i
@@ -457,7 +457,7 @@ let fns : List<BuiltInFn> =
             let f (dv : Dval) : Ply<bool> =
               uply {
                 let args = NEList.singleton dv
-                let! result = Interpreter.applyFnVal state 0UL fn [] args
+                let! result = Interpreter.applyFnVal state state.caller fn [] args
 
                 match result with
                 | DBool b -> return b
@@ -503,7 +503,7 @@ let fns : List<BuiltInFn> =
             let f (dv : Dval) : Ply<Option<Dval>> =
               uply {
                 let args = NEList.singleton dv
-                let! result = Interpreter.applyFnVal state 0UL b [] args
+                let! result = Interpreter.applyFnVal state state.caller b [] args
 
                 match result with
                 | DEnum(FQName.Package { owner = "Darklang"
@@ -564,7 +564,7 @@ let fns : List<BuiltInFn> =
               Ply.List.mapSequentially
                 (fun ((i, dv) : int * Dval) ->
                   let args = NEList.doubleton (DInt(int64 i)) dv
-                  Interpreter.applyFnVal state 0UL b [] args)
+                  Interpreter.applyFnVal state state.caller b [] args)
                 list
 
             return Dval.list VT.unknownTODO result
@@ -611,7 +611,7 @@ let fns : List<BuiltInFn> =
               Ply.List.mapSequentially
                 (fun ((dv1, dv2) : Dval * Dval) ->
                   let args = NEList.doubleton dv1 dv2
-                  Interpreter.applyFnVal state 0UL b [] args)
+                  Interpreter.applyFnVal state state.caller b [] args)
                 list
 
             return Dval.list VT.unknownTODO result
@@ -659,7 +659,7 @@ let fns : List<BuiltInFn> =
                 Ply.List.mapSequentially
                   (fun ((dv1, dv2) : Dval * Dval) ->
                     let args = NEList.doubleton dv1 dv2
-                    Interpreter.applyFnVal state 0UL b [] args)
+                    Interpreter.applyFnVal state state.caller b [] args)
                   list
 
               return Dval.optionSome optType (Dval.list VT.unknownTODO result)
@@ -715,7 +715,7 @@ let fns : List<BuiltInFn> =
           uply {
             let applyFn (dval : Dval) : DvalTask =
               let args = NEList.singleton dval
-              Interpreter.applyFnVal state 0UL fn [] args
+              Interpreter.applyFnVal state state.caller fn [] args
 
             // apply the function to each element in the list
             let! result =

--- a/backend/src/BuiltinExecution/Libs/List.fs
+++ b/backend/src/BuiltinExecution/Libs/List.fs
@@ -398,7 +398,8 @@ let fns : List<BuiltInFn> =
               | DInt i when i = 1L || i = 0L || i = -1L -> return int i
               | DInt i -> return raise (Sort.InvalidSortComparatorInt i)
               | v ->
-                return! TypeChecker.raiseFnValResultNotExpectedType SourceNone v TInt
+                return!
+                  TypeChecker.raiseFnValResultNotExpectedType state.caller v TInt
             }
 
           uply {
@@ -462,7 +463,7 @@ let fns : List<BuiltInFn> =
                 | DBool b -> return b
                 | v ->
                   return!
-                    TypeChecker.raiseFnValResultNotExpectedType SourceNone v TBool
+                    TypeChecker.raiseFnValResultNotExpectedType state.caller v TBool
               }
 
             let! result = Ply.List.filterSequentially f l
@@ -524,7 +525,7 @@ let fns : List<BuiltInFn> =
                 | v ->
                   return!
                     TypeChecker.raiseFnValResultNotExpectedType
-                      SourceNone
+                      state.caller
                       v
                       (TypeReference.option varB)
               }

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -54,7 +54,7 @@ let fns : List<BuiltInFn> =
              |> Ply.List.mapSequentially (function
                | DChar c -> Ply c
                | dv ->
-                 TypeChecker.raiseFnValResultNotExpectedType SourceNone dv TChar)
+                 TypeChecker.raiseFnValResultNotExpectedType state.caller dv TChar)
              |> Ply.map (fun parts ->
                parts |> String.concat "" |> String.normalize |> DString)))
         | _ -> incorrectArgs ())

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -48,7 +48,7 @@ let fns : List<BuiltInFn> =
            |> Seq.toList
            |> Ply.List.mapSequentially (fun te ->
              let args = NEList.singleton (DChar te)
-             Interpreter.applyFnVal state 0UL b [] args)
+             Interpreter.applyFnVal state state.caller b [] args)
            |> Ply.bind (fun dvals ->
              dvals
              |> Ply.List.mapSequentially (function

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -90,7 +90,7 @@ let state () =
 
 let execute
   (args : List<string>)
-  : Task<Result<RT.Dval, RT.DvalSource * RT.RuntimeError>> =
+  : Task<Result<RT.Dval, RT.Source * RT.RuntimeError>> =
   task {
     let state = state ()
     let fnName = RT.FnName.fqPackage "Darklang" [ "Cli" ] "executeCliCommand" 0
@@ -127,8 +127,8 @@ let main (args : string[]) =
       let state = state ()
       let source =
         match source with
-        | RT.SourceID(tlid, id) -> $"(source: {tlid}, {id})"
-        | RT.SourceNone -> "(source unknown)"
+        | Some(tlid, id) -> $"(source: {tlid}, {id})"
+        | None -> "(source unknown)"
       match (LibExecution.Execution.runtimeErrorToString state rte).Result with
       | Ok(RT.DString s) -> System.Console.WriteLine $"Error {source}:\n  {s}"
       | Ok otherVal ->

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -76,14 +76,7 @@ let state () =
   let sendException (_ : RT.ExecutionState) (metadata : Metadata) (exn : exn) =
     printException "Internal error" metadata exn
 
-  Exe.createState
-    builtIns
-    packageManager
-    tracing
-    sendException
-    notify
-    979275UL
-    program
+  Exe.createState builtIns packageManager tracing sendException notify program
 
 
 

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -99,7 +99,7 @@ let execute
       |> List.map RT.DString
       |> Dval.list (RT.ValueType.Known RT.KTString)
       |> NEList.singleton
-    return! Exe.executeFunction state 7UL fnName [] args
+    return! Exe.executeFunction state None fnName [] args
   }
 
 let initSerializers () =

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -44,6 +44,7 @@ let rec canonicalize (expr : Expr) : Expr = expr
 // Returns a typeReference since we don't always know what type it should have (eg is
 // a polymorphic function is being called)
 let rec dvalToSql
+  (source : Source)
   (types : Types)
   (expectedType : TypeReference)
   (dval : Dval)
@@ -61,13 +62,13 @@ let rec dvalToSql
     | TVariable _, DRecord(typeName, _, [], _)
     | TVariable _, DEnum(typeName, _, [], _, _) ->
       let! jsonString =
-        DvalReprInternalQueryable.toJsonStringV0 types expectedType dval
+        DvalReprInternalQueryable.toJsonStringV0 source types expectedType dval
       return Sql.jsonb jsonString, TCustomType(Ok typeName, [])
 
     | TCustomType(_, []), DEnum _
     | TCustomType(_, []), DRecord _ ->
       let! jsonString =
-        DvalReprInternalQueryable.toJsonStringV0 types expectedType dval
+        DvalReprInternalQueryable.toJsonStringV0 source types expectedType dval
       return Sql.jsonb jsonString, expectedType
 
     | TVariable _, DDateTime date
@@ -343,6 +344,7 @@ let rec lambdaToSql
   (paramName : string)
   (dbTypeRef : TypeReference)
   (expectedType : TypeReference)
+  (tlid : tlid)
   (expr : Expr)
   : Ply<CompiledSqlQuery> =
   uply {
@@ -356,12 +358,14 @@ let rec lambdaToSql
         paramName
         dbTypeRef
         expectedType
+        tlid
         expr
 
     let! (sql, vars, actualType) =
       uply {
         match expr with
-        | EConstant(_, (constantName)) ->
+        | EConstant(id, (constantName)) ->
+          let source = Some(tlid, id)
           let nameStr = ConstantName.toString constantName
 
           let! constant =
@@ -374,15 +378,14 @@ let rec lambdaToSql
               | FQName.Package p ->
                 match! constants.package p with
                 | None -> return error $"No package constant {nameStr} found"
-                | Some c ->
-                  return LibExecution.Interpreter.evalConst SourceNone c.body
+                | Some c -> return LibExecution.Interpreter.evalConst source c.body
               | FQName.UserProgram _ ->
                 return error $"User constants are not yet supported"
             }
           do! typecheckDval nameStr types constant expectedType
           let random = randomString 8
           let newname = $"{nameStr}_{random}"
-          let! (sqlValue, actualType) = dvalToSql types expectedType constant
+          let! (sqlValue, actualType) = dvalToSql source types expectedType constant
           return ($"(@{newname})", [ newname, sqlValue ], actualType)
 
         | EApply(_, EFnName(_, fnName), [], args) ->
@@ -506,7 +509,8 @@ let rec lambdaToSql
 
         // TYPESCLEANUP - this could be the paramName, now that we support more than
         // records here.
-        | EVariable(_, varname) ->
+        | EVariable(id, varname) ->
+          let source = Some(tlid, id)
           match Map.get varname symtable with
           | Some dval ->
             do! typecheckDval varname types dval expectedType
@@ -514,7 +518,7 @@ let rec lambdaToSql
             let newname = $"{varname}_{random}"
             // Fetch the actualType here as well as we might be passing in an abstract
             // type.
-            let! (sqlValue, actualType) = dvalToSql types expectedType dval
+            let! (sqlValue, actualType) = dvalToSql source types expectedType dval
             return $"(@{newname})", [ newname, sqlValue ], actualType
           | None -> return error $"This variable is not defined: {varname}"
 
@@ -593,12 +597,13 @@ let rec lambdaToSql
             return (sql, vars, TList actualType)
           | _ -> return error "Expected a List"
 
-        | EEnum(_, typeName, caseName, []) ->
+        | EEnum(id, typeName, caseName, []) ->
+          let source = Some(tlid, id)
           let! dv =
             LibExecution.Dval.enum typeName typeName VT.typeArgsTODO' caseName []
           let typ = (TCustomType(Ok typeName, []))
           typecheck $"Enum '{dv}'" typ expectedType
-          let! v = DvalReprInternalQueryable.toJsonStringV0 types typ dv
+          let! v = DvalReprInternalQueryable.toJsonStringV0 source types typ dv
           let name = randomString 10
           return $"(@{name})", [ name, Sql.jsonb v ], typ
 
@@ -1059,7 +1064,17 @@ let compileLambda
       match dbType with
       | Ok dbType ->
         let! compiled =
-          lambdaToSql fns types constants tst symtable paramName dbType TBool body
+          lambdaToSql
+            fns
+            types
+            constants
+            tst
+            symtable
+            paramName
+            dbType
+            TBool
+            state.tlid
+            body
 
         return Ok { sql = compiled.sql; vars = compiled.vars }
       | Error err -> return Error err

--- a/backend/src/LibCloud/Tracing.fs
+++ b/backend/src/LibCloud/Tracing.fs
@@ -134,7 +134,8 @@ let createCloudStorageTracer
     executionTracing =
       { Exe.noTracing with
           storeFnResult =
-            (fun (tlid, name, id) args result ->
+            (fun (source, name) args result ->
+              let tlid, id = Option.defaultValue (0UL, 0UL) source
               let hash =
                 args
                 |> DvalReprInternalHash.hash DvalReprInternalHash.currentHashVersion
@@ -169,8 +170,9 @@ let createTelemetryTracer
       executionTracing =
         { standardTracing with
             storeFnResult =
-              (fun (tlid, name, id) args result ->
+              (fun (source, name) args result ->
                 let stringifiedName = LibExecution.RuntimeTypes.FnName.toString name
+                let tlid, id = Option.defaultValue (0UL, 0UL) source
                 let hash =
                   args
                   |> DvalReprInternalHash.hash
@@ -184,7 +186,7 @@ let createTelemetryTracer
                     "hash", hash
                     "resultType",
                     LibExecution.DvalReprDeveloper.toTypeName result :> obj ]
-                standardTracing.storeFnResult (tlid, name, id) args result)
+                standardTracing.storeFnResult (source, name) args result)
             traceTLID =
               fun tlid ->
                 Telemetry.addEvent $"called {tlid}" [ "tlid", tlid ]

--- a/backend/src/LibCloud/UserDB.fs
+++ b/backend/src/LibCloud/UserDB.fs
@@ -233,6 +233,7 @@ let doQuery
     let! compiled =
       SqlCompiler.compileLambda
         state
+        b.tlid
         b.typeSymbolTable
         b.symtable
         paramName

--- a/backend/src/LibCloud/UserDB.fs
+++ b/backend/src/LibCloud/UserDB.fs
@@ -39,8 +39,13 @@ let rec dbToDval
   : Ply<RT.Dval> =
   DvalReprInternalQueryable.parseJsonV0 types db.typ dbValue
 
-let rec dvalToDB (types : RT.Types) (db : RT.DB.T) (dv : RT.Dval) : Ply<string> =
-  DvalReprInternalQueryable.toJsonStringV0 types db.typ dv
+let dvalToDB
+  (source : RT.Source)
+  (types : RT.Types)
+  (db : RT.DB.T)
+  (dv : RT.Dval)
+  : Ply<string> =
+  DvalReprInternalQueryable.toJsonStringV0 source types db.typ dv
 
 let rec set
   (state : RT.ExecutionState)
@@ -67,7 +72,7 @@ let rec set
         else
           ""
 
-      let! data = dvalToDB types db dv
+      let! data = dvalToDB state.caller types db dv
 
       do!
         Sql.query

--- a/backend/src/LibCloudExecution/CloudExecution.fs
+++ b/backend/src/LibCloudExecution/CloudExecution.fs
@@ -232,7 +232,8 @@ let reexecuteFunction
     // the rootTLID of the trace.
     let tracing = Tracing.create canvasID rootTLID traceID
     let! state = createState traceID callerTLID program tracing.executionTracing
-    let! result = Exe.executeFunction state callerID name typeArgs args
+    let source = Some(callerTLID, callerID)
+    let! result = Exe.executeFunction state source name typeArgs args
     tracing.storeTraceResults ()
     return result, tracing.results
   }

--- a/backend/src/LibCloudExecution/CloudExecution.fs
+++ b/backend/src/LibCloudExecution/CloudExecution.fs
@@ -135,10 +135,10 @@ let executeHandler
         return $"fn {fnName}\nexpr:\n{expr}\n"
       }
 
-    let sourceString (source : RT.DvalSource) : Ply<string> =
+    let sourceString (source : RT.Source) : Ply<string> =
       match source with
-      | RT.SourceNone -> Ply "No source"
-      | RT.SourceID(tlid, id) -> sourceOf tlid id
+      | None -> Ply "No source"
+      | Some(tlid, id) -> sourceOf tlid id
 
     let error (msg : string) : Ply<RT.Dval> =
       let typeName =

--- a/backend/src/LibCloudExecution/CloudExecution.fs
+++ b/backend/src/LibCloudExecution/CloudExecution.fs
@@ -91,7 +91,7 @@ let executeHandler
 
     let! state = createState traceID h.tlid program tracing.executionTracing
     HashSet.add h.tlid tracing.results.tlids
-    let! result = Exe.executeExpr state inputVars h.ast
+    let! result = Exe.executeExpr state h.tlid inputVars h.ast
 
     let findUserBody (tlid : tlid) : Option<string * RT.Expr> =
       program.fns

--- a/backend/src/LibExecution/Dval.fs
+++ b/backend/src/LibExecution/Dval.fs
@@ -139,11 +139,7 @@ let rec toValueType (dv : Dval) : ValueType =
 
 
 
-let mergeFailureRte
-  (sourceId : DvalSource)
-  (vt1 : ValueType)
-  (vt2 : ValueType)
-  : 'a =
+let mergeFailureRte (sourceId : Source) (vt1 : ValueType) (vt2 : ValueType) : 'a =
   RuntimeError.oldError
     $"Could not merge types {ValueType.toString vt1} and {ValueType.toString vt2}"
   |> fun e -> raiseRTE sourceId e
@@ -162,7 +158,7 @@ let private listPush
   | Ok newType -> newType, dv :: list
   | Error() ->
     mergeFailureRte
-      SourceNone
+      None
       (ValueType.Known(KTList listType))
       (ValueType.Known(KTList dvalType))
 
@@ -301,7 +297,7 @@ let optionSome (innerType : ValueType) (dv : Dval) : Dval =
     DEnum(optionType, optionType, ignoreAndUseEmpty [ typ ], "Some", [ dv ])
   | Error() ->
     mergeFailureRte
-      SourceNone
+      None
       (ValueType.Known(KTCustomType(optionType, [ innerType ])))
       (ValueType.Known(KTCustomType(optionType, [ dvalType ])))
 
@@ -330,7 +326,7 @@ let resultOk (okType : ValueType) (errorType : ValueType) (dvOk : Dval) : Dval =
     )
   | Error() ->
     mergeFailureRte
-      SourceNone
+      None
       (ValueType.Known(KTCustomType(resultType, [ okType; errorType ])))
       (ValueType.Known(KTCustomType(resultType, [ dvalType; errorType ])))
 
@@ -351,7 +347,7 @@ let resultError
     )
   | Error() ->
     mergeFailureRte
-      SourceNone
+      None
       (ValueType.Known(KTCustomType(resultType, [ okType; errorType ])))
       (ValueType.Known(KTCustomType(resultType, [ okType; dvalType ])))
 

--- a/backend/src/LibExecution/DvalReprInternalQueryable.fs
+++ b/backend/src/LibExecution/DvalReprInternalQueryable.fs
@@ -76,12 +76,13 @@ type Utf8JsonWriter with
 
 let rec private toJsonV0
   (w : Utf8JsonWriter)
+  (source : Source)
   (types : Types)
   (typ : TypeReference)
   (dv : Dval)
   : Ply<unit> =
   uply {
-    let writeDval = toJsonV0 w types
+    let writeDval = toJsonV0 w source types
 
     match typ, dv with
     // basic types
@@ -187,7 +188,7 @@ let rec private toJsonV0
             "Value to be stored does not match a declared type"
             [ "value", dv; "type", typ; "typeName", typeName ]
 
-    | TCustomType(Error err, _), _ -> raiseRTE SourceNone err
+    | TCustomType(Error err, _), _ -> raiseRTE source err
 
     // Not supported
     | TVariable _, _
@@ -220,11 +221,12 @@ let rec private toJsonV0
 
 
 let toJsonStringV0
+  (source : Source)
   (types : Types)
   (typ : TypeReference)
   (dval : Dval)
   : Ply<string> =
-  writeJson (fun w -> toJsonV0 w types typ dval)
+  writeJson (fun w -> toJsonV0 w source types typ dval)
 
 
 let parseJsonV0 (types : Types) (typ : TypeReference) (str : string) : Ply<Dval> =

--- a/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
+++ b/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
@@ -269,6 +269,7 @@ module FormatV0 =
       RT.DFnVal(
         RT.Lambda
           { typeSymbolTable = Map []
+            tlid = 0UL
             symtable = Map []
             parameters = NEList.singleton (gid (), "var")
             body = RT.Expr.EUnit 0UL }

--- a/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
+++ b/backend/src/LibExecution/DvalReprInternalRoundtrippable.fs
@@ -225,11 +225,9 @@ module FormatV0 =
 
 
   type DvalMap = Map<string, Dval>
-  and DvalSource =
-    | SourceNone
-    | SourceID of tlid * id
+  and Source = Option<tlid * id>
 
-  and RuntimeError = RuntimeError of DvalSource * Dval
+  and RuntimeError = RuntimeError of Source * Dval
 
   and Dval =
     | DInt of int64

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -42,11 +42,11 @@ let createState
     test = noTestContext
     reportException = reportException
     notify = notify
-    tlid = tlid
     caller = None }
 
 let executeExpr
   (state : RT.ExecutionState)
+  (tlid : tlid)
   (inputVars : RT.Symtable)
   (expr : RT.Expr)
   : Task<RT.ExecutionResult> =
@@ -55,7 +55,7 @@ let executeExpr
       try
         let symtable = Interpreter.withGlobals state inputVars
         let typeSymbolTable = Map.empty
-        let! result = Interpreter.eval state typeSymbolTable symtable expr
+        let! result = Interpreter.eval state tlid typeSymbolTable symtable expr
         return Ok result
       with RT.RuntimeErrorException(source, rte) ->
         return Error(source, rte)

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -67,7 +67,7 @@ let executeExpr
 
 let executeFunction
   (state : RT.ExecutionState)
-  (callerID : id)
+  (caller : RT.Source)
   (name : RT.FnName.FnName)
   (typeArgs : List<RT.TypeReference>)
   (args : NEList<RT.Dval>)
@@ -77,7 +77,7 @@ let executeFunction
       try
         let typeSymbolTable = Map.empty
         let! result =
-          Interpreter.callFn state typeSymbolTable callerID name typeArgs args
+          Interpreter.callFn state typeSymbolTable caller name typeArgs args
         return Ok result
       with RT.RuntimeErrorException(source, rte) ->
         return Error(source, rte)
@@ -98,7 +98,7 @@ let runtimeErrorToString
         "toString"
         0
     let args = NEList.singleton (RT.RuntimeError.toDT rte)
-    return! executeFunction state 8UL fnName [] args
+    return! executeFunction state None fnName [] args
   }
 
 /// Return a function to trace TLIDs (add it to state via

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -32,7 +32,6 @@ let createState
   (tracing : RT.Tracing)
   (reportException : RT.ExceptionReporter)
   (notify : RT.Notifier)
-  (tlid : tlid)
   (program : RT.Program)
   : RT.ExecutionState =
   { builtIns = builtIns

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -42,7 +42,8 @@ let createState
     test = noTestContext
     reportException = reportException
     notify = notify
-    tlid = tlid }
+    tlid = tlid
+    caller = None }
 
 let executeExpr
   (state : RT.ExecutionState)
@@ -88,7 +89,7 @@ let executeFunction
 let runtimeErrorToString
   (state : RT.ExecutionState)
   (rte : RT.RuntimeError)
-  : Task<Result<RT.Dval, RT.DvalSource * RT.RuntimeError>> =
+  : Task<Result<RT.Dval, RT.Source * RT.RuntimeError>> =
   task {
     let fnName =
       RT.FnName.fqPackage

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -584,6 +584,7 @@ and DvalMap = Map<string, Dval>
 
 and LambdaImpl =
   { typeSymbolTable : TypeSymbolTable
+    tlid : tlid // The TLID of the expression where this was defined
     symtable : Symtable
     parameters : NEList<id * string>
     body : Expr }
@@ -1289,17 +1290,8 @@ and ExecutionState =
     // users are doing, etc.
     notify : Notifier
 
-    // TLID of the source of the _currently_ executing expression (when initially
-    // created this is the TLID of either the handler or the function, or if there
-    // are neither of these, then the caller is expected to create a TLID for itself
-    // -- use a custom TLID starting with 777777 for each call-site so it's easier to
-    // notice and find the source by searching).
-    //
-    // During execution this is updated when a new function is entered.
-    tlid : tlid
-
-    // tlid/id of the caller. The tlid comes from state.tlid at that point, and id is
-    // the caller's ID (usually the ID of the EApply)
+    // tlid/id of the caller - used to find the source of an error. It's not the end
+    // of the world if this is wrong or missing, but it will give worse errors.
     caller : Source }
 
 and Functions =

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1209,7 +1209,7 @@ and FnImpl =
   | PackageFunction of tlid * Expr
 
 
-and FunctionRecord = tlid * FnName.FnName * id
+and FunctionRecord = Source * FnName.FnName
 
 and TraceDval = id -> Dval -> unit
 

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -828,22 +828,6 @@ module Dval =
       | DEnum(_, _, [], "Known", [ kt ]) -> ValueType.Known(KnownType.fromDT kt)
       | _ -> Exception.raiseInternal "Invalid ValueType" []
 
-  module DvalSource =
-    let toDT (s : DvalSource) : Dval =
-      let (caseName, fields) =
-        match s with
-        | SourceNone -> "SourceNone", []
-        | SourceID(tlid, id) -> "SourceID", [ DInt(int64 tlid); DInt(int64 id) ]
-      let typeName = rtTyp [] "DvalSource" 0
-      DEnum(typeName, typeName, [], caseName, fields)
-
-    let fromDT (d : Dval) : DvalSource =
-      match d with
-      | DEnum(_, _, [], "SourceNone", []) -> SourceNone
-      | DEnum(_, _, [], "SourceID", [ DInt tlid; DInt id ]) ->
-        SourceID(uint64 tlid, uint64 id)
-      | _ -> Exception.raiseInternal "Invalid DvalSource" []
-
 
   module LambdaImpl =
     let toDT (l : LambdaImpl) : Dval =

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -860,6 +860,8 @@ module Dval =
 
           symtable = fields |> D.mapField "symtable" |> Map.map Dval.fromDT
 
+          tlid = 0UL
+
           parameters =
             fields
             |> D.listField "parameters"

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -200,7 +200,7 @@ module Error =
     }
 
 let raiseValueNotExpectedType
-  (source : DvalSource)
+  (source : Source)
   (dv : Dval)
   (typ : TypeReference)
   (context : Context)
@@ -210,15 +210,11 @@ let raiseValueNotExpectedType
   |> Ply.map (raiseRTE source)
 
 let raiseFnValResultNotExpectedType
-  (source : DvalSource)
+  (source : Source)
   (dv : Dval)
   (typ : TypeReference)
   : Ply<'a> =
-  let location =
-    match source with
-    | SourceNone -> None
-    | SourceID(tlid, id) -> Some(tlid, id)
-  let context = FnValResult(typ, location)
+  let context = FnValResult(typ, source)
   ValueNotExpectedType(dv, typ, context)
   |> Error.toRuntimeError
   |> Ply.map (raiseRTE source)

--- a/backend/src/LocalExec/Libs/Cli.fs
+++ b/backend/src/LocalExec/Libs/Cli.fs
@@ -69,7 +69,7 @@ let execute
 
     if mod'.exprs.Length = 1 then
       let expr = PT2RT.Expr.toRT mod'.exprs[0]
-      return! Exe.executeExpr state symtable expr
+      return! Exe.executeExpr state 7777772347523UL symtable expr
     else if mod'.exprs.Length = 0 then
       return Error(None, RuntimeError.oldError "No expressions to execute")
     else // mod'.exprs.Length > 1

--- a/backend/src/LocalExec/Libs/Cli.fs
+++ b/backend/src/LocalExec/Libs/Cli.fs
@@ -64,7 +64,6 @@ let execute
         Exe.noTracing
         sendException
         notify
-        7UL
         program
 
     if mod'.exprs.Length = 1 then

--- a/backend/src/LocalExec/Libs/Cli.fs
+++ b/backend/src/LocalExec/Libs/Cli.fs
@@ -71,10 +71,9 @@ let execute
       let expr = PT2RT.Expr.toRT mod'.exprs[0]
       return! Exe.executeExpr state symtable expr
     else if mod'.exprs.Length = 0 then
-      return Error(SourceNone, RuntimeError.oldError "No expressions to execute")
+      return Error(None, RuntimeError.oldError "No expressions to execute")
     else // mod'.exprs.Length > 1
-      return
-        Error(SourceNone, RuntimeError.oldError "Multiple expressions to execute")
+      return Error(None, RuntimeError.oldError "Multiple expressions to execute")
   }
 
 let constants : List<BuiltInConstant> = []

--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -47,7 +47,7 @@ let fns : List<BuiltInFn> =
                     let context = TypeChecker.Context.FnValResult(TUnit, None)
                     return!
                       TypeChecker.raiseValueNotExpectedType
-                        SourceNone
+                        state.caller
                         v
                         TUnit
                         context

--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -41,7 +41,7 @@ let fns : List<BuiltInFn> =
               |> Ply.List.iterSequentially (fun e ->
                 uply {
                   let args = NEList.singleton e
-                  match! Interpreter.applyFnVal state 0UL b [] args with
+                  match! Interpreter.applyFnVal state state.caller b [] args with
                   | DUnit -> return ()
                   | v ->
                     let context = TypeChecker.Context.FnValResult(TUnit, None)

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -94,7 +94,7 @@ let execute
 
     let state = { state () with program = program }
     let expr = PT2RT.Expr.toRT mod'.exprs[0]
-    return! Exe.executeExpr state symtable expr
+    return! Exe.executeExpr state 77777723478932UL symtable expr
   }
 
 

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -64,7 +64,6 @@ let state () =
     Exe.noTracing
     reportException
     notify
-    defaultTLID
     program
 
 

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -297,8 +297,8 @@ let runLocalExecScript (args : string[]) : Ply<int> =
       let state = state ()
       let source =
         match source with
-        | RT.SourceID(tlid, id) -> sourceOf mainFile tlid id modul
-        | RT.SourceNone -> "unknown"
+        | Some(tlid, id) -> sourceOf mainFile tlid id modul
+        | None -> "unknown"
       match! LibExecution.Execution.runtimeErrorToString state rte with
       | Ok(RT.DString s) ->
         System.Console.WriteLine $"Error: {s}"

--- a/backend/src/Wasm/DarkEditor.fs
+++ b/backend/src/Wasm/DarkEditor.fs
@@ -70,7 +70,7 @@ let LoadClient (canvasName : string) : Task<string> =
           clientSource.constants
       LibExecution.Execution.executeFunction
         state
-        (gid ())
+        None
         (FnName.fqUserProgram [] "init" 0)
         []
         (NEList.singleton DUnit)
@@ -108,7 +108,7 @@ let HandleEvent (serializedEvent : string) : Task<string> =
     let! result =
       LibExecution.Execution.executeFunction
         state
-        (gid ())
+        None
         (FnName.fqUserProgram [] "handleEvent" 0)
         []
         (NEList.singleton (DString serializedEvent))

--- a/backend/src/Wasm/EvalHelpers.fs
+++ b/backend/src/Wasm/EvalHelpers.fs
@@ -37,7 +37,8 @@ let getStateForEval
     test = LibExecution.Execution.noTestContext
     reportException = consoleReporter
     notify = consoleNotifier
-    tlid = 777777937265453UL }
+    tlid = 777777937265453UL
+    caller = None }
 
 /// Any 'loose' exprs in the source are mapped without context of previous/later exprs
 /// so, a binding set in one 'let' will be unavailable in the next expr if evaluated one by one.

--- a/backend/src/Wasm/EvalHelpers.fs
+++ b/backend/src/Wasm/EvalHelpers.fs
@@ -37,7 +37,6 @@ let getStateForEval
     test = LibExecution.Execution.noTestContext
     reportException = consoleReporter
     notify = consoleNotifier
-    tlid = 777777937265453UL
     caller = None }
 
 /// Any 'loose' exprs in the source are mapped without context of previous/later exprs

--- a/backend/src/Wasm/Libs/Editor.fs
+++ b/backend/src/Wasm/Libs/Editor.fs
@@ -137,6 +137,7 @@ let fns : List<BuiltInFn> =
         | _, _, [ DString sourceJson ] ->
           uply {
             let source = Json.Vanilla.deserialize<UserProgramSource> sourceJson
+            let tlid = 77777723978322UL
 
             let httpConfig : BuiltinExecution.Libs.HttpClient.Configuration =
               { BuiltinExecution.Libs.HttpClient.defaultConfig with
@@ -157,7 +158,7 @@ let fns : List<BuiltInFn> =
               let state =
                 getStateForEval builtin source.types source.fns source.constants
               let inputVars = Map.empty
-              LibExecution.Execution.executeExpr state inputVars expr
+              LibExecution.Execution.executeExpr state tlid inputVars expr
 
             match result with
             | Error(_source, rte) ->

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -227,7 +227,6 @@ let executionStateFor
         Exe.noTracing
         exceptionReporter
         notifier
-        (id 7)
         program
     let state = { state with test = testContext }
     return state

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -1078,6 +1078,7 @@ let interestingDvals : List<string * RT.Dval * RT.TypeReference> =
      DFnVal(
        Lambda
          { body = RT.EUnit(id 1234)
+           tlid = 77777723098234UL
            typeSymbolTable = Map.empty
            symtable = Map.empty
            parameters = NEList.singleton (id 5678, "a") }
@@ -1134,6 +1135,7 @@ let interestingDvals : List<string * RT.Dval * RT.TypeReference> =
                  )
                )
              )
+           tlid = 7777772349823445UL
            symtable = Map.empty
            typeSymbolTable = Map.empty
            parameters = NEList.singleton ((id 5678, "a")) }

--- a/backend/tests/Tests/DvalRepr.Tests.fs
+++ b/backend/tests/Tests/DvalRepr.Tests.fs
@@ -56,7 +56,7 @@ let queryableRoundtripsSuccessfullyInRecord
 
     let! roundtripped =
       record
-      |> DvalReprInternalQueryable.toJsonStringV0 types typeRef
+      |> DvalReprInternalQueryable.toJsonStringV0 None types typeRef
       |> Ply.bind (DvalReprInternalQueryable.parseJsonV0 types typeRef)
 
     return Expect.dvalEquality record roundtripped
@@ -69,7 +69,7 @@ let queryableRoundtripsSuccessfully
   ) : Task<bool> =
   task {
     let! serialized =
-      DvalReprInternalQueryable.toJsonStringV0 (defaultTypes ()) typ dv
+      DvalReprInternalQueryable.toJsonStringV0 None (defaultTypes ()) typ dv
     let! roundtripped =
       DvalReprInternalQueryable.parseJsonV0 (defaultTypes ()) typ serialized
     return Expect.dvalEquality dv roundtripped

--- a/backend/tests/Tests/Execution.Tests.fs
+++ b/backend/tests/Tests/Execution.Tests.fs
@@ -48,6 +48,7 @@ let execSaveDvals
   (ast : Expr)
   : Task<AT.AnalysisResults> =
   task {
+    let tlid = 777777827493UL
     let types = userTypes |> List.map (fun typ -> typ.name, typ) |> Map.ofList
     let fns = userFns |> List.map (fun fn -> fn.name, fn) |> Map.ofList
     let dbs = dbs |> List.map (fun db -> db.name, db) |> Map.ofList
@@ -57,7 +58,7 @@ let execSaveDvals
       executionStateForPreview canvasName dbs types fns constants
 
     let inputVars = Map.empty
-    let! _result = Exe.executeExpr state inputVars ast
+    let! _result = Exe.executeExpr state tlid inputVars ast
 
     return results
   }

--- a/backend/tests/Tests/Execution.Tests.fs
+++ b/backend/tests/Tests/Execution.Tests.fs
@@ -81,7 +81,7 @@ let testExecFunctionTLIDs : Test =
     let! value =
       Exe.executeFunction
         state
-        (gid ())
+        None
         (FQName.UserProgram fn.name)
         []
         (NEList.singleton DUnit)

--- a/backend/tests/Tests/HttpClient.Tests.fs
+++ b/backend/tests/Tests/HttpClient.Tests.fs
@@ -144,6 +144,7 @@ let makeTest versionName filename =
     else
       // Set up the canvas
       let canvasID = System.Guid.NewGuid()
+      let tlid = 7777772398743UL
       let! state =
         executionStateFor canvasID false true Map.empty Map.empty Map.empty Map.empty
 
@@ -162,7 +163,7 @@ let makeTest versionName filename =
       // Run the handler (call the HTTP client)
       // Note: this will update the corresponding value in `testCases` with the
       // actual request received
-      let! actual = Exe.executeExpr state Map.empty test.actual
+      let! actual = Exe.executeExpr state tlid Map.empty test.actual
 
       // First check: expected HTTP request matches actual HTTP request
       let tc = testCases[dictKey]
@@ -177,7 +178,7 @@ let makeTest versionName filename =
       // Second check: expected result (Dval) matches actual result (Dval)
       let actual = Result.map normalizeDvalResult actual
 
-      let! expected = Exe.executeExpr state Map.empty test.expected
+      let! expected = Exe.executeExpr state tlid Map.empty test.expected
       match actual, expected with
       | Ok actual, Ok expected ->
         return Expect.equalDval actual expected $"Responses don't match"

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -191,7 +191,7 @@ let t
               let! result =
                 LibExecution.Execution.executeFunction
                   state
-                  0UL
+                  None
                   errorMessageFn
                   []
                   (NEList.ofList actual [])
@@ -218,7 +218,7 @@ let t
               return!
                 LibExecution.Execution.executeFunction
                   state
-                  0UL
+                  None
                   errorMessageFn
                   []
                   (NEList.ofList (RT.RuntimeError.toDT e) [])

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -69,6 +69,8 @@ let t
         else
           System.Guid.NewGuid() |> Task.FromResult
 
+      let tlid = 777777297845223UL
+
       let rtTypes =
         types
         |> List.map (fun typ ->
@@ -115,7 +117,7 @@ let t
         $"\n\n{rhsMsg}\n\n{lhsMsg}\n\nTest location: {bold}{underline}{filename}:{lineNumber}{reset}"
 
       let expectedExpr = PT2RT.Expr.toRT expectedExpr
-      let! expected = Exe.executeExpr state Map.empty expectedExpr
+      let! expected = Exe.executeExpr state tlid Map.empty expectedExpr
 
       // Initialize
       if workers <> [] then do! setupWorkers canvasID workers
@@ -130,7 +132,7 @@ let t
 
       // Run the actual program (left-hand-side of the =)
       let actualExpr = PT2RT.Expr.toRT actualExpr
-      let! actual = Exe.executeExpr state Map.empty actualExpr
+      let! actual = Exe.executeExpr state tlid Map.empty actualExpr
 
       if System.Environment.GetEnvironmentVariable "DEBUG" <> null then
         debuGList "results" (Dictionary.toList results |> List.sortBy fst)

--- a/backend/tests/Tests/Serialization.TestValues.fs
+++ b/backend/tests/Tests/Serialization.TestValues.fs
@@ -239,9 +239,6 @@ module RuntimeTypes =
       )
       known (RT.KnownType.KTDict ktUnit) ]
 
-  let dvalSources : List<RT.DvalSource> =
-    [ RT.SourceNone; RT.SourceID(123UL, 91293UL) ]
-
   let dvals : List<RT.Dval> =
     // TODO: is this exhaustive? I haven't checked.
     sampleDvals |> List.map (fun (name, (dv, t)) -> dv)


### PR DESCRIPTION
DvalSource has been broken for a while (perhaps a few years). This attempts to untangle it and restore it to its original purpose: a way to identify the Darklang code that was the source of the "problem", and to propagate it appropriately.

As such, I got rid of `state.tlid` and added `state.caller` - those things represent what we're really interested in. It also fixes the signatures of a lot of the interpreter to allow us to consistently get this right.