### PR TITLE
Add warnings

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -16,5 +16,7 @@
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <!-- Run some parts of compilation in parallel: https://blog.nojaf.com/2023/08/22/unleashing-parallel-processing-in-your-fsharp-compiler/ -->
     <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen</OtherFlags>
+    <!-- warnings - https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-options#opt-in-warnings -->
+    <OtherFlags>$(OtherFlags) --warnaserror --warnon:1182,3387,3366</OtherFlags>
   </PropertyGroup>
 </Project>

--- a/backend/experiments/BwdDangerServer/BwdDangerServer.fsproj
+++ b/backend/experiments/BwdDangerServer/BwdDangerServer.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>

--- a/backend/experiments/CanvasHack/CanvasHack.fsproj
+++ b/backend/experiments/CanvasHack/CanvasHack.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>

--- a/backend/src/BuiltinCli/BuiltinCli.fsproj
+++ b/backend/src/BuiltinCli/BuiltinCli.fsproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/BuiltinCli/Libs/File.fs
+++ b/backend/src/BuiltinCli/Libs/File.fs
@@ -125,7 +125,7 @@ let fns : List<BuiltInFn> =
               let attrs = System.IO.File.GetAttributes(path)
               let isDir = attrs.HasFlag(System.IO.FileAttributes.Directory)
               return DBool isDir
-            with e ->
+            with _ ->
               return DBool false
           }
         | _ -> incorrectArgs ())
@@ -150,7 +150,7 @@ let fns : List<BuiltInFn> =
               let exists =
                 System.IO.File.Exists(path) || System.IO.Directory.Exists(path)
               return DBool(exists && not isDir)
-            with e ->
+            with _ ->
               return DBool false
           }
         | _ -> incorrectArgs ())

--- a/backend/src/BuiltinCliHost/BuiltinCliHost.fsproj
+++ b/backend/src/BuiltinCliHost/BuiltinCliHost.fsproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -230,8 +230,8 @@ let fns : List<BuiltInFn> =
                   []
                   (WT.Unresolved name)
 
-              match fnName, args with
-              | Ok fnName, firstArg :: additionalArgs ->
+              match fnName with
+              | Ok fnName ->
 
                 let desc = fnName |> PT2RT.FnName.toRT
                 let! fn =
@@ -241,7 +241,6 @@ let fns : List<BuiltInFn> =
                       let! fn = state.packageManager.getFn pkg
                       return Option.map packageFnToFn fn
                     }
-
                   | _ ->
                     Exception.raiseInternal
                       "Error constructing package function name"

--- a/backend/src/BuiltinCloudExecution/BuiltinCloudExecution.fsproj
+++ b/backend/src/BuiltinCloudExecution/BuiltinCloudExecution.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/BuiltinDarkInternal/BuiltinDarkInternal.fsproj
+++ b/backend/src/BuiltinDarkInternal/BuiltinDarkInternal.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/BuiltinDarkInternal/Libs/Workers.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Workers.fs
@@ -20,7 +20,8 @@ let modifySchedule (fn : CanvasID -> string -> Task<unit>) =
   | _, _, [ DUuid canvasID; DString handlerName ] ->
     uply {
       do! fn canvasID handlerName
-      let! s = SchedulingRules.getWorkerSchedules canvasID
+      // TODO reenable
+      let! _s = SchedulingRules.getWorkerSchedules canvasID
       // Pusher.push
       //   LibClientTypesToCloudTypes.Pusher.eventSerializer
       //   canvasID

--- a/backend/src/BuiltinExecution/BuiltinExecution.fsproj
+++ b/backend/src/BuiltinExecution/BuiltinExecution.fsproj
@@ -3,8 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <!-- Publishing configuration -->
+<!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>

--- a/backend/src/BuiltinExecution/Libs/Char.fs
+++ b/backend/src/BuiltinExecution/Libs/Char.fs
@@ -57,7 +57,7 @@ let fns : List<BuiltInFn> =
       fn =
         function
         | _, _, [ DChar c ] ->
-          let charValue = int c.[0]
+          let charValue = int c[0]
           if charValue >= 0 && charValue < 256 then
             Dval.optionSome VT.int (DInt charValue) |> Ply
           else

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -236,7 +236,7 @@ let rec serialize
                 "expectedFields", fields ]
 
 
-    | TCustomType(Error err, _typeArgs), dval -> raiseUntargetedRTE err
+    | TCustomType(Error err, _typeArgs), _dval -> raiseUntargetedRTE err
 
 
     // Not supported

--- a/backend/src/BuiltinExecution/Libs/List.fs
+++ b/backend/src/BuiltinExecution/Libs/List.fs
@@ -97,7 +97,7 @@ module DvalComparator =
       else
         c
 
-  and compareExprs (e1 : Expr) (e2 : Expr) : int = 0 // CLEANUP
+  and compareExprs (_e1 : Expr) (_e2 : Expr) : int = 0 // CLEANUP
 
 
 
@@ -270,7 +270,7 @@ let fns : List<BuiltInFn> =
       description = "Returns the number of values in <param list>"
       fn =
         (function
-        | _, _, [ DList(vt, l) ] -> Ply(Dval.int (l.Length))
+        | _, _, [ DList(_, l) ] -> Ply(Dval.int (l.Length))
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
@@ -428,7 +428,7 @@ let fns : List<BuiltInFn> =
          preserving the order."
       fn =
         (function
-        | _, _, [ DList(vt1, l1); DList(vt2, l2) ] ->
+        | _, _, [ DList(vt1, l1); DList(_vt2, l2) ] ->
           // VTTODO should fail here in the case of vt1 conflicting with vt2?
           // (or is this handled by the interpreter?)
           Ply(Dval.list vt1 (List.append l1 l2))

--- a/backend/src/BuiltinExecution/Libs/NoModule.fs
+++ b/backend/src/BuiltinExecution/Libs/NoModule.fs
@@ -278,7 +278,7 @@ let fns : List<BuiltInFn> =
       description = "Returns true if the two value are equal"
       fn =
         (function
-        | state, _, [ a; b ] -> equals a b |> DBool |> Ply
+        | _, _, [ a; b ] -> equals a b |> DBool |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "="
       previewable = Pure
@@ -292,7 +292,7 @@ let fns : List<BuiltInFn> =
       description = "Returns true if the two value are not equal"
       fn =
         (function
-        | state, _, [ a; b ] -> equals a b |> not |> DBool |> Ply
+        | _, _, [ a; b ] -> equals a b |> not |> DBool |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<>"
       previewable = Pure

--- a/backend/src/BwdServer/BwdServer.fsproj
+++ b/backend/src/BwdServer/BwdServer.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>

--- a/backend/src/Cli/Cli.fsproj
+++ b/backend/src/Cli/Cli.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!-- We publish these for lots of different runtimes, so leave these empty and

--- a/backend/src/CronChecker/CronChecker.fsproj
+++ b/backend/src/CronChecker/CronChecker.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>

--- a/backend/src/LibBinarySerialization/LibBinarySerialization.fsproj
+++ b/backend/src/LibBinarySerialization/LibBinarySerialization.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/LibCliExecution/LibCliExecution.fsproj
+++ b/backend/src/LibCliExecution/LibCliExecution.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/LibCliExecution/PackageManager.fs
+++ b/backend/src/LibCliExecution/PackageManager.fs
@@ -724,7 +724,7 @@ let packageManager : RT.PackageManager =
         fetch "function" name.owner name.modules fnName name.version conversionFn)
 
     getFnByTLID =
-      withCache (fun tlid ->
+      withCache (fun _tlid ->
         uply { return Exception.raiseInternal "TODO getFnByTLID" [] })
 
     getConstant =

--- a/backend/src/LibClientTypes/LibClientTypes.fsproj
+++ b/backend/src/LibClientTypes/LibClientTypes.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/LibClientTypesToCloudTypes/LibClientTypesToCloudTypes.fsproj
+++ b/backend/src/LibClientTypesToCloudTypes/LibClientTypesToCloudTypes.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/LibCloud/LibCloud.fsproj
+++ b/backend/src/LibCloud/LibCloud.fsproj
@@ -4,8 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <!-- Publishing configuration -->
+<!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>

--- a/backend/src/LibCloud/SqlCompiler.fs
+++ b/backend/src/LibCloud/SqlCompiler.fs
@@ -259,7 +259,6 @@ let rec inline'
       | EApply(_, EFnName(_, (fnName)), [], args) ->
         uply {
           let arguments = args |> NEList.toList
-          let nameStr = FnName.toString fnName
           match fnName with
           | FQName.Package p ->
             match! fns.package p with
@@ -770,7 +769,7 @@ let rec lambdaToSql
 
             return (sql, [], dbFieldType)
 
-          | TCustomType(Ok(t), []) ->
+          | TCustomType(Ok(_t), []) ->
             let jsonAccessPath =
               fieldAccessPath
               |> NEList.toList

--- a/backend/src/LibCloudExecution/LibCloudExecution.fsproj
+++ b/backend/src/LibCloudExecution/LibCloudExecution.fsproj
@@ -5,7 +5,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/LibExecution/Builtin.fs
+++ b/backend/src/LibExecution/Builtin.fs
@@ -66,7 +66,7 @@ let renameTypes
     |> Map.values
   existing @ newTypes
 
-let checkFn (fn : BuiltInFn) : unit =
+let checkFn (_fn : BuiltInFn) : unit =
   // We can't do this until constants (eg Math.pi) are no longer implemented as functions
   // if fn.parameters = [] then
   //   Exception.raiseInternal $"function {fn.name} has no parameters" [ "fn", fn.name ]

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -87,7 +87,7 @@ let rec evalConst (source : Source) (c : Const) : Dval =
   | CEnum(Ok typeName, caseName, fields) ->
     // TYPESTODO: this uses the original type name, so if it's an alias, it won't be equal to the
     DEnum(typeName, typeName, VT.typeArgsTODO, caseName, List.map r fields)
-  | CEnum(Error msg, caseName, fields) ->
+  | CEnum(Error msg, _caseName, _fields) ->
     raiseRTE source (RuntimeError.oldError $"Invalid const name: {msg}")
   | CList items -> DList(ValueType.Unknown, (List.map r items))
   | CDict items ->
@@ -279,7 +279,7 @@ let rec eval
         | Some constant -> return evalConst source constant.body
 
 
-    | ELet(id, pattern, rhs, body) ->
+    | ELet(_id, pattern, rhs, body) ->
       /// Does the dval 'match' the given pattern?
       ///
       /// Returns:
@@ -288,7 +288,7 @@ let rec eval
       let rec checkPattern (dv : Dval) (pattern : LetPattern) : List<string * Dval> =
         match pattern with
 
-        | LPVariable(id, varName) -> [ (varName, dv) ]
+        | LPVariable(_id, varName) -> [ (varName, dv) ]
 
         | LPUnit id ->
           if dv <> DUnit then errStr id "Unit pattern does not match" else []
@@ -532,7 +532,7 @@ let rec eval
               return!
                 raiseExeRTE id (ExecutionError.MatchExprPatternWrongType("Unit", dv))
 
-          | MPVariable(id, varName) -> return true, [ (varName, dv) ]
+          | MPVariable(_id, varName) -> return true, [ (varName, dv) ]
 
 
           | MPEnum(id, caseName, fieldPats) ->

--- a/backend/src/LibExecution/LibExecution.fsproj
+++ b/backend/src/LibExecution/LibExecution.fsproj
@@ -3,8 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <!-- Publishing configuration -->
+<!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>
     <SelfContained>true</SelfContained>

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -279,7 +279,7 @@ module Expr =
       RT.EOr(id, toRT left, toRT right)
 
     | PT.ELambda(id, vars, body) ->
-      let vars = vars |> NEList.filter (fun (name, v) -> v <> "")
+      let vars = vars |> NEList.filter (fun (_, v) -> v <> "")
       match vars with
       | [] ->
         RT.EError(

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -499,7 +499,7 @@ and TypeReference =
 
   member this.isConcrete() : bool =
     let rec isConcrete (t : TypeReference) : bool =
-      match this with
+      match t with
       | TVariable _ -> false
       | TList t -> isConcrete t
       | TTuple(t1, t2, ts) ->
@@ -907,7 +907,7 @@ module Dval =
     | DFnVal(Lambda l), TFn(parameters, _) ->
       NEList.length parameters = NEList.length l.parameters
 
-    | DRecord(typeName, _, _typeArgsTODO, fields),
+    | DRecord(typeName, _, _typeArgsTODO, _fields),
       TCustomType(Ok typeName', _typeArgs) ->
       // TYPESCLEANUP: should load type by name
       // TYPESCLEANUP: are we handling type arguments here?
@@ -1396,7 +1396,7 @@ let rec getTypeReferenceFromAlias
   | TCustomType(Ok outerTypeName, outerTypeArgs) ->
     uply {
       match! Types.find outerTypeName types with
-      | Some { definition = TypeDeclaration.Alias typ; typeParams = typeParams } as decl ->
+      | Some { definition = TypeDeclaration.Alias typ; typeParams = typeParams } ->
         let typ = Types.substitute typeParams outerTypeArgs typ
         return! getTypeReferenceFromAlias types typ
       | _ -> return Ok typ

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -734,7 +734,6 @@ module Dval =
 
   module KnownType =
     let toDT (kt : KnownType) : Dval =
-      let vtToDT = ValueType.toDT
 
       let (caseName, fields) =
         match kt with

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -280,7 +280,7 @@ let rec valueTypeUnifies
       //return! rMult typeArgsT typeArgsV
       return true
 
-    | TFn(argTypes, returnType), ValueType.Known(KTFn(vArgs, vRet)) ->
+    | TFn(_argTypes, _returnType), ValueType.Known(KTFn(_vArgs, _vRet)) ->
       // TODO: follow up here when type args are properly passed around and handled
 
       // let expected = returnType :: (NEList.toList argTypes)
@@ -354,7 +354,7 @@ let rec unify
         // | true -> return! Ply()
         return Ok()
 
-      | TFn(argTypes, returnType), DFnVal fnVal -> return Ok() // TYPESTODO check lambdas and fnVals
+      | TFn(_argTypes, _returnType), DFnVal _fnVal -> return Ok() // TYPESTODO check lambdas and fnVals
       | TTuple(t1, t2, tRest), DTuple(v1, v2, vRest) ->
         let ts = t1 :: t2 :: tRest
         let vs = v1 :: v2 :: vRest
@@ -410,7 +410,7 @@ let rec unify
                 getTypeReferenceFromAlias types (TCustomType(Ok tn, []))
               match aliasedType with
               | Ok(TCustomType(Error rte, _)) -> return Error rte
-              | Ok(TCustomType(Ok concreteTn, typeArgs)) ->
+              | Ok(TCustomType(Ok concreteTn, _typeArgs)) ->
                 if concreteTn <> typeName then
                   return!
                     ValueNotExpectedType(value, expected, context)

--- a/backend/src/LibHttpMiddleware/LibHttpMiddleware.fsproj
+++ b/backend/src/LibHttpMiddleware/LibHttpMiddleware.fsproj
@@ -4,8 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <IsPublishable>false</IsPublishable>
+        <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>
     <None Include="paket.references" />

--- a/backend/src/LibParser/Canvas.fs
+++ b/backend/src/LibParser/Canvas.fs
@@ -102,21 +102,21 @@ let parseLetBinding (m : WTCanvasModule) (letBinding : SynBinding) : WTCanvasMod
         let newHttpHanlder = WT.Handler.Spec.HTTP(route, method)
         { m with handlers = (newHttpHanlder, expr) :: m.handlers }
 
-      | SimpleAttribute("REPL", [ name ]) ->
+      | SimpleAttribute("REPL", [ _name ]) ->
         //let newHandler = PT.Handler.Spec.REPL(name, randomIds ())
         //{ m with handlers = (newHandler, expr) :: m.handlers }
         Exception.raiseInternal
           $"Not currently supporting REPLs, as we can't test them well yet"
           [ "attr", attr ]
 
-      | SimpleAttribute("Worker", [ name ]) ->
+      | SimpleAttribute("Worker", [ _name ]) ->
         //let newWorker = PT.Handler.Spec.Worker(name, randomIds ())
         //{ m with handlers = (newWorker, expr) :: m.handlers }
         Exception.raiseInternal
           $"Not currently supporting Workers, as we can't test them well yet"
           [ "attr", attr ]
 
-      | SimpleAttribute("Cron", [ name; interval ]) ->
+      | SimpleAttribute("Cron", [ _name; _interval ]) ->
         //let newCron = PT.Handler.Spec.Cron(name, interval, randomIds ())
         //{ m with handlers = (newCron, expr) :: m.handlers }
         Exception.raiseInternal

--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -103,7 +103,7 @@ module TypeReference =
     // - built-in F# types like `bool`
     // - Stdlib-defined types
     // - User-defined types
-    | SynType.App(name, _, typeArgs, _, _, _, range) ->
+    | SynType.App(name, _, typeArgs, _, _, _, _) ->
       let name = parseTypeName name
       fromNamesAndTypeArgs name typeArgs
 
@@ -125,8 +125,6 @@ module SimpleTypeArgs =
         | [] ->
           decls
           |> List.map (fun decl ->
-            let SynTyparDecl (_, decl) = decl
-
             match decl with
             | SynTyparDecl(_, SynTypar(name, TyparStaticReq.None, _)) -> name.idText
             | _ ->
@@ -527,7 +525,7 @@ module Expr =
         WT.EPipe(id, arg1, [ synToPipeExpr arg ])
       | WT.EPipe(id, arg1, rest) -> WT.EPipe(id, arg1, rest @ [ synToPipeExpr arg ])
       // Exception.raiseInternal $"Pipe: {nestedPipes},\n\n{arg},\n\n{pipe}\n\n, {c arg})"
-      | other ->
+      | _ ->
         Exception.raiseInternal
           $"Pipe: {nestedPipes},\n\n{arg},\n\n{pipe}\n\n, {c arg})"
           [ "arg", arg ]
@@ -545,7 +543,7 @@ module Expr =
     // e.g. MyMod.MyRecord
     | SynExpr.App(_,
                   _,
-                  SynExpr.TypeApp(name, _, typeArgs, _, _, _, _),
+                  SynExpr.TypeApp(_, _, typeArgs, _, _, _, _),
                   (SynExpr.Record _ as expr),
                   _) ->
       if List.length typeArgs <> 0 then
@@ -562,9 +560,6 @@ module Expr =
       NEList.forall (fun n -> String.isCapitalized n) (parseExprName name)
       ->
       let names = parseExprName name
-      let typename = NEList.last names
-      let modules = NEList.initial names
-
       let fields =
         fields
         |> List.map (fun field ->

--- a/backend/src/LibParser/LibParser.fsproj
+++ b/backend/src/LibParser/LibParser.fsproj
@@ -4,8 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <IsPublishable>false</IsPublishable>
+        <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>

--- a/backend/src/LibParser/TestModule.fs
+++ b/backend/src/LibParser/TestModule.fs
@@ -115,7 +115,7 @@ let parseFile (parsedAsFSharp : ParsedImplFileInput) : List<WTModule> =
     (binding : SynBinding)
     : List<WT.UserFunction.T> * List<WT.UserConstant.T> =
     match binding with
-    | SynBinding(_, _, _, _, _, _, _, signature, _, expr, _, _, _) ->
+    | SynBinding(_, _, _, _, _, _, _, signature, _, _, _, _, _) ->
       match signature with
       | SynPat.LongIdent(SynLongIdent _, _, _, _, _, _) ->
         [ FS2WT.UserFunction.fromSynBinding moduleName binding ], []

--- a/backend/src/LibService/LibService.fsproj
+++ b/backend/src/LibService/LibService.fsproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/LibService/Telemetry.fs
+++ b/backend/src/LibService/Telemetry.fs
@@ -264,7 +264,7 @@ let configureAspNetCore
     =
     let ipAddress =
       try
-        httpRequest.Headers.["x-forwarded-for"].[0]
+        httpRequest.Headers["x-forwarded-for"][0]
         |> String.split ","
         |> List.head
         |> Option.unwrap (string httpRequest.HttpContext.Connection.RemoteIpAddress)
@@ -272,7 +272,7 @@ let configureAspNetCore
         ""
     let proto =
       try
-        httpRequest.Headers.["x-forwarded-proto"].[0]
+        httpRequest.Headers["x-forwarded-proto"][0]
       with _ ->
         ""
 

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -43,7 +43,7 @@ let state () =
       dbs = Map.empty
       secrets = [] }
 
-  let extraMetadata (state : RT.ExecutionState) : Metadata = []
+  let extraMetadata (_state : RT.ExecutionState) : Metadata = []
 
   let notify (state : RT.ExecutionState) (msg : string) (metadata : Metadata) =
     let metadata = extraMetadata state @ metadata

--- a/backend/src/LocalExec/LocalExec.fsproj
+++ b/backend/src/LocalExec/LocalExec.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>

--- a/backend/src/Prelude/Json.fs
+++ b/backend/src/Prelude/Json.fs
@@ -73,7 +73,7 @@ module Vanilla =
     override this.Read
       (
         reader : byref<Utf8JsonReader>,
-        typeToConvert : System.Type,
+        _typeToConvert : System.Type,
         options : JsonSerializerOptions
       ) =
       let list =
@@ -115,7 +115,7 @@ module Vanilla =
   type LocalDateTimeConverter() =
     inherit JsonConverter<NodaTime.LocalDateTime>()
 
-    override _.Read(reader : byref<Utf8JsonReader>, tipe, options) =
+    override _.Read(reader : byref<Utf8JsonReader>, _typ, _options) =
       let rawToken = reader.GetString()
       (NodaTime.Instant.ofIsoString rawToken).toUtcLocalTimeZone ()
 

--- a/backend/src/Prelude/Prelude.fsproj
+++ b/backend/src/Prelude/Prelude.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>

--- a/backend/src/Prelude/String.fs
+++ b/backend/src/Prelude/String.fs
@@ -45,7 +45,7 @@ let isCapitalized (s : string) : bool =
   if s.Length = 0 then
     false
   else
-    let firstChar = s.[0]
+    let firstChar = s[0]
     firstChar >= 'A' && firstChar <= 'Z'
 
 let toLowercase (s : string) : string = s.ToLower()

--- a/backend/src/ProdExec/ProdExec.fsproj
+++ b/backend/src/ProdExec/ProdExec.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>

--- a/backend/src/QueueWorker/QueueWorker.fsproj
+++ b/backend/src/QueueWorker/QueueWorker.fsproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
     <!-- Publishing configuration -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>

--- a/backend/src/Wasm/Wasm.fsproj
+++ b/backend/src/Wasm/Wasm.fsproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <PublishTrimmed>true</PublishTrimmed>
+        <PublishTrimmed>true</PublishTrimmed>
     <!-- Things that were uncommented in classic-dark -->
     <!-- <RunAOTCompilation>true</RunAOTCompilation> -->
     <!-- <BlazorEnableCompression>false</BlazorEnableCompression> -->

--- a/backend/src/Wasm/WasmHelpers.fs
+++ b/backend/src/Wasm/WasmHelpers.fs
@@ -33,5 +33,5 @@ let getJsRuntimeThis () : IJSInProcessRuntime =
 let callJSFunction (functionToCall : string) (args : List<string>) : unit =
   let jsRuntimeThis = getJsRuntimeThis ()
   let args = args |> List.toArray |> Array.map box
-  let response = jsRuntimeThis.Invoke(functionToCall, args)
+  let _response : obj = jsRuntimeThis.Invoke(functionToCall, args)
   ()

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -56,7 +56,7 @@ let initializeTestCanvas' (name : string) : Task<CanvasID * string> =
 
 let initializeTestCanvas (name : string) : Task<CanvasID> =
   task {
-    let! (canvasID, domain) = initializeTestCanvas' name
+    let! (canvasID, _domain) = initializeTestCanvas' name
     return canvasID
   }
 
@@ -596,7 +596,7 @@ module Expect =
       letPatternEqualityBaseFn checkIDs path pat pat' errorFn
       eq ("rhs" :: path) rhs rhs'
       eq ("body" :: path) body body'
-    | EIf(id, con, thn, els), EIf(_, con', thn', els') ->
+    | EIf(_, con, thn, els), EIf(_, con', thn', els') ->
       eq ("cond" :: path) con con'
       eq ("then" :: path) thn thn'
       match els, els' with
@@ -881,12 +881,7 @@ module Expect =
     matchPatternEqualityBaseFn false [] actual expected (fun path a e ->
       Expect.equal a e (formatMsg "" path actual))
 
-  let rec equalExpr
-    (types : Types)
-    (actual : Expr)
-    (expected : Expr)
-    (msg : string)
-    : unit =
+  let rec equalExpr (actual : Expr) (expected : Expr) (msg : string) : unit =
     exprEqualityBaseFn true [] actual expected (fun path a e ->
       Expect.equal a e (formatMsg msg path actual))
 

--- a/backend/tests/TestUtils/TestUtils.fsproj
+++ b/backend/tests/TestUtils/TestUtils.fsproj
@@ -3,8 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <IsPublishable>false</IsPublishable>
+        <IsPublishable>false</IsPublishable>
     <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>

--- a/backend/tests/Tests/Execution.Tests.fs
+++ b/backend/tests/Tests/Execution.Tests.fs
@@ -24,7 +24,6 @@ module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 type Dictionary<'k, 'v> = System.Collections.Generic.Dictionary<'k, 'v>
 
 let executionStateForPreview
-  (name : string)
   (dbs : Map<string, DB.T>)
   (types : Map<TypeName.UserProgram, UserType.T>)
   (fns : Map<FnName.UserProgram, UserFunction.T>)
@@ -40,7 +39,6 @@ let executionStateForPreview
   }
 
 let execSaveDvals
-  (canvasName : string)
   (dbs : List<DB.T>)
   (userTypes : List<UserType.T>)
   (userFns : List<UserFunction.T>)
@@ -54,8 +52,7 @@ let execSaveDvals
     let dbs = dbs |> List.map (fun db -> db.name, db) |> Map.ofList
     let constants = userConstants |> List.map (fun c -> c.name, c) |> Map.ofList
 
-    let! (results, state) =
-      executionStateForPreview canvasName dbs types fns constants
+    let! (results, state) = executionStateForPreview dbs types fns constants
 
     let inputVars = Map.empty
     let! _result = Exe.executeExpr state tlid inputVars ast

--- a/backend/tests/Tests/HttpClient.Tests.fs
+++ b/backend/tests/Tests/HttpClient.Tests.fs
@@ -208,14 +208,14 @@ let runTestHandler (ctx : HttpContext) : Task<HttpContext> =
       let versionName, testName =
         let segments = System.Uri(ctx.Request.Path.Value).Segments
 
-        let versionName = segments.[1]
+        let versionName = segments[1]
         let versionName =
           if String.endsWith "/" versionName then
             String.dropRight 1 versionName
           else
             versionName
 
-        let testName = segments.[2]
+        let testName = segments[2]
         let testName =
           if String.endsWith "/" testName then
             String.dropRight 1 testName

--- a/backend/tests/Tests/Serialization.TestValues.fs
+++ b/backend/tests/Tests/Serialization.TestValues.fs
@@ -241,14 +241,14 @@ module RuntimeTypes =
 
   let dvals : List<RT.Dval> =
     // TODO: is this exhaustive? I haven't checked.
-    sampleDvals |> List.map (fun (name, (dv, t)) -> dv)
+    sampleDvals |> List.map (fun (_, (dv, _)) -> dv)
 
   let dval : RT.Dval =
     let typeName =
       RT.FQName.UserProgram
         { modules = []; name = RT.TypeName.TypeName "MyType"; version = 0 }
     sampleDvals
-    |> List.map (fun (name, (dv, t)) -> name, dv)
+    |> List.map (fun (name, (dv, _)) -> name, dv)
     |> fun fields -> RT.DRecord(typeName, typeName, [], Map fields)
 
 

--- a/backend/tests/Tests/Tests.fsproj
+++ b/backend/tests/Tests/Tests.fsproj
@@ -3,8 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>7.0</LangVersion>
-    <OtherFlags>--warnaserror</OtherFlags>
-    <!-- We make this publishable so that we can run tests on the published version -->
+        <!-- We make this publishable so that we can run tests on the published version -->
     <PublishReadyToRun>true</PublishReadyToRun>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>


### PR DESCRIPTION
Enable unused variable warning. Caught a few things (nothing broken in practice).

Also, it seems like the build parallelization thing I added before was being overwritten in each fsproj (and thus didnt work), so this moves OtherFlags to being set in one place (Directory.Build.props) instead of each fsproj (might be something to expand on later).