### PR TITLE
Move content type HttpClient helpers to consts in module

### DIFF
--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -7,7 +7,7 @@ module NoInternal =
                                                             "application/x-www-form-urlencoded")
 
   PACKAGE.Darklang.Stdlib.HttpClient.ContentType.json_v0 = ("content-type",
-                                                            "application/json; charset=utf-8")
+                                                            "application/json")
 
   PACKAGE.Darklang.Stdlib.HttpClient.ContentType.plainText_v0 = ("content-type",
                                                                  "text/plain; charset=utf-8")

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -3,17 +3,17 @@
 
 // Tests that don't use the internet
 module NoInternal =
-  PACKAGE.Darklang.Stdlib.HttpClient.formContentType_v0 () = ("content-type",
-                                                              "application/x-www-form-urlencoded")
+  PACKAGE.Darklang.Stdlib.HttpClient.ContentType.form_v0 = ("content-type",
+                                                            "application/x-www-form-urlencoded")
 
-  PACKAGE.Darklang.Stdlib.HttpClient.jsonContentType_v0 () = ("content-type",
-                                                              "application/json; charset=utf-8")
+  PACKAGE.Darklang.Stdlib.HttpClient.ContentType.json_v0 = ("content-type",
+                                                            "application/json; charset=utf-8")
 
-  PACKAGE.Darklang.Stdlib.HttpClient.plainTextContentType_v0 () = ("content-type",
-                                                                   "text/plain; charset=utf-8")
+  PACKAGE.Darklang.Stdlib.HttpClient.ContentType.plainText_v0 = ("content-type",
+                                                                 "text/plain; charset=utf-8")
 
-  PACKAGE.Darklang.Stdlib.HttpClient.htmlContentType_v0 () = ("content-type",
-                                                              "text/html; charset=utf-8")
+  PACKAGE.Darklang.Stdlib.HttpClient.ContentType.html_v0 = ("content-type",
+                                                            "text/html; charset=utf-8")
 
   PACKAGE.Darklang.Stdlib.HttpClient.bearerToken "YWxhZGRpbjpvcGVuc2VzYW1l" = (("authorization",
                                                                                 "bearer YWxhZGRpbjpvcGVuc2VzYW1l"))

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-list.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-list.test
@@ -15,7 +15,7 @@ Content-Length: LENGTH
 "Hello back"
 
 [test]
-(let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" { l = [1;2;"a string"; [6]] } HttpClient.jsonContentType_v0) |> Builtin.unwrap
+(let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [HttpClient.ContentType.json_v0] { l = [1;2;"a string"; [6]] }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
   Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-null.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-null.test
@@ -14,7 +14,7 @@ Content-Length: LENGTH
 "Hello back"
 
 [test]
-(let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" { x = null } HttpClient.jsonContentType_v0) |> Builtin.unwrap
+(let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [HttpClient.ContentType.json_v0] { x = null }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-basic.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-basic.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = { value = "some-string" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-key.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = { "😭👨‍👩‍👧‍👦" = "emoji" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-key.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = Dict.set {} "" "empty"
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-value.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = { empty = "" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-values.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-values.test
@@ -17,7 +17,7 @@ Content-Length: LENGTH
 [test]
 // Test what happens with multiple values
 (let query = { empty = ""; notEmpty = "some value" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-key.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = { "[]()`~*&^%$#@!:"<>?,./;'-=_+" = "control" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-value.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = { punctuation = "[]()`~*&^%$#@!:\"<>?,./;'-=_+" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-key.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = { "with spaces" = "x" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-value.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 
 [test]
 (let query = { x = "with spaces" }
- let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query HttpClient.jsonContentType_v0) |> Builtin.unwrap
+ let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
    Builtin.HttpClient.Response

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -42,13 +42,12 @@ module Darklang =
         ("authorization", ("bearer " ++ token))
 
 
-
       module ContentType =
         /// A header <type (String*String))> with {{content-type}} set for HTML form requests or responses
         let form = ("content-type", "application/x-www-form-urlencoded")
 
         /// A header <type (String*String))> with {{content-type}} set for JSON requests or responses
-        let json = ("content-type", "application/json; charset=utf-8")
+        let json = ("content-type", "application/json")
 
         /// A header <type (String*String))> with {{'content-type'}} set for plain text requests or responses
         let plainText = ("content-type", "text/plain; charset=utf-8")

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -42,23 +42,16 @@ module Darklang =
         ("authorization", ("bearer " ++ token))
 
 
-      // TODOs:
-      // - maybe the below should be in another ContentType module,
-      //   accessible by e.g. `HttpClient.ContentType.form`?
-      // - these should likely be Constants (rather than fns)
 
-      /// Returns a header <type (String*String))> with {{content-type}} set for HTML form requests or responses
-      let formContentType () : (String * String) =
-        ("content-type", "application/x-www-form-urlencoded")
+      module ContentType =
+        /// A header <type (String*String))> with {{content-type}} set for HTML form requests or responses
+        let form = ("content-type", "application/x-www-form-urlencoded")
 
-      /// Returns a header <type (String*String))> with {{content-type}} set for JSON requests or responses
-      let jsonContentType () : (String * String) =
-        ("content-type", "application/json; charset=utf-8")
+        /// A header <type (String*String))> with {{content-type}} set for JSON requests or responses
+        let json = ("content-type", "application/json; charset=utf-8")
 
-      /// Returns a header <type (String*String))> with {{'content-type'}} set for plain text requests or responses
-      let plainTextContentType () : (String * String) =
-        ("content-type", "text/plain; charset=utf-8")
+        /// A header <type (String*String))> with {{'content-type'}} set for plain text requests or responses
+        let plainText = ("content-type", "text/plain; charset=utf-8")
 
-      /// Returns a header <type (String*String))> with {{'content-type'}} set for html requests
-      let htmlContentType () : (String * String) =
-        ("content-type", "text/html; charset=utf-8")
+        /// A header <type (String*String))> with {{'content-type'}} set for html requests
+        let html = ("content-type", "text/html; charset=utf-8")


### PR DESCRIPTION
Following up on [this](https://github.com/darklang/dark/pull/4968#discussion_r1259065997).

We had some package functions in `HttpClient` like:
```fsharp
/// Returns a header <type (String*String))> with {{content-type}} set for HTML form requests or responses
let formContentType () : (String * String) =
  ("content-type", "application/x-www-form-urlencoded")
```

This PR updates them all to be Consts, in a new `ContentType` sub-module of `HttpClient`:
```fsharp
module ContentType =
  /// A header <type (String*String))> with {{content-type}} set for HTML form requests or responses
  let form = ("content-type", "application/x-www-form-urlencoded")

  /// A header <type (String*String))> with {{content-type}} set for JSON requests or responses
  let json = ("content-type", "application/json; charset=utf-8")

  /// A header <type (String*String))> with {{'content-type'}} set for plain text requests or responses
  let plainText = ("content-type", "text/plain; charset=utf-8")

  /// A header <type (String*String))> with {{'content-type'}} set for html requests
  let html = ("content-type", "text/html; charset=utf-8")
```