### PR TITLE
Add a new IntRuntimeError and replace some string errors

### DIFF
--- a/backend/src/BuiltinExecution/Libs/Float.fs
+++ b/backend/src/BuiltinExecution/Libs/Float.fs
@@ -14,6 +14,18 @@ let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Float" ]
 
+module FloatParseError =
+  type FloatParseError = | BadFormat
+
+  let toDT (e : FloatParseError) : Dval =
+    let (caseName, fields) =
+      match e with
+      | BadFormat -> "BadFormat", []
+
+    let typeName =
+      TypeName.fqPackage "Darklang" [ "Stdlib"; "Float" ] "FloatParseError" 0
+    DEnum(typeName, typeName, [], caseName, fields)
+
 let fns : List<BuiltInFn> =
   [ { name = fn "ceiling" 0
       typeParams = []
@@ -269,20 +281,31 @@ let fns : List<BuiltInFn> =
     { name = fn "parse" 0
       typeParams = []
       parameters = [ Param.make "s" TString "" ]
-      returnType = TypeReference.result TFloat TString
+      returnType =
+        TypeReference.result
+          TFloat
+          (TCustomType(
+            Ok(
+              FQName.Package
+                { owner = "Darklang"
+                  modules = [ "Stdlib"; "Int" ]
+                  name = TypeName.TypeName "IntParseError"
+                  version = 0 }
+            ),
+            []
+          ))
       description =
         "Returns the <type Float> value wrapped in a {{Result}} of the <type String>"
       fn =
         let resultOk r = Dval.resultOk KTFloat KTString r |> Ply
-        let resultError r = Dval.resultError KTFloat KTString r |> Ply
+        let typeName = RuntimeError.name [ "Float" ] "FloatParseError" 0
+        let resultError = Dval.resultError KTFloat (KTCustomType(typeName, []))
         (function
         | _, _, [ DString s ] ->
           try
             float (s) |> DFloat |> resultOk
-          with e ->
-            "Expected a String representation of an IEEE float"
-            |> DString
-            |> resultError
+          with :? System.FormatException ->
+            FloatParseError.BadFormat |> FloatParseError.toDT |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Float.fs
+++ b/backend/src/BuiltinExecution/Libs/Float.fs
@@ -14,16 +14,15 @@ let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Float" ]
 
-module FloatParseError =
-  type FloatParseError = | BadFormat
+module ParseError =
+  type ParseError = | BadFormat
 
-  let toDT (e : FloatParseError) : Dval =
+  let toDT (e : ParseError) : Dval =
     let (caseName, fields) =
       match e with
       | BadFormat -> "BadFormat", []
 
-    let typeName =
-      TypeName.fqPackage "Darklang" [ "Stdlib"; "Float" ] "FloatParseError" 0
+    let typeName = TypeName.fqPackage "Darklang" [ "Stdlib"; "Float" ] "ParseError" 0
     DEnum(typeName, typeName, [], caseName, fields)
 
 let fns : List<BuiltInFn> =
@@ -289,7 +288,7 @@ let fns : List<BuiltInFn> =
               FQName.Package
                 { owner = "Darklang"
                   modules = [ "Stdlib"; "Int" ]
-                  name = TypeName.TypeName "IntParseError"
+                  name = TypeName.TypeName "ParseError"
                   version = 0 }
             ),
             []
@@ -298,14 +297,14 @@ let fns : List<BuiltInFn> =
         "Returns the <type Float> value wrapped in a {{Result}} of the <type String>"
       fn =
         let resultOk r = Dval.resultOk KTFloat KTString r |> Ply
-        let typeName = RuntimeError.name [ "Float" ] "FloatParseError" 0
+        let typeName = RuntimeError.name [ "Float" ] "ParseError" 0
         let resultError = Dval.resultError KTFloat (KTCustomType(typeName, []))
         (function
         | _, _, [ DString s ] ->
           try
             float (s) |> DFloat |> resultOk
           with :? System.FormatException ->
-            FloatParseError.BadFormat |> FloatParseError.toDT |> resultError |> Ply
+            ParseError.BadFormat |> ParseError.toDT |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -26,9 +26,9 @@ module IntParseError =
     | BadFormat
     | OutOfRange
 
-  let toDT (pe : IntParseError) : Dval =
+  let toDT (e : IntParseError) : Dval =
     let (caseName, fields) =
-      match pe with
+      match e with
       | BadFormat -> "BadFormat", []
       | OutOfRange -> "OutOfRange", []
 
@@ -372,7 +372,8 @@ let fns : List<BuiltInFn> =
       description = "Returns the <type Int> value of a <type String>"
       fn =
         let resultOk = Dval.resultOk KTInt KTString
-        let resultError = Dval.resultError KTInt KTString
+        let typeName = RuntimeError.name [ "Int" ] "IntParseError" 0
+        let resultError = Dval.resultError KTInt (KTCustomType(typeName, []))
         (function
         | _, _, [ DString s ] ->
           try

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -375,21 +375,13 @@ let fns : List<BuiltInFn> =
         let resultError = Dval.resultError KTInt KTString
         (function
         | _, _, [ DString s ] ->
-          let trimmedString = s.Trim()
-          if
-            not (
-              System.Text.RegularExpressions.Regex.IsMatch(
-                trimmedString,
-                @"^[+-]?\d+$"
-              )
-            )
-          then
+          try
+            s |> System.Convert.ToInt64 |> DInt |> resultOk |> Ply
+          with
+          | :? System.FormatException ->
             IntParseError.BadFormat |> IntParseError.toDT |> resultError |> Ply
-          else
-            match System.Int64.TryParse(s) with
-            | true, value -> value |> DInt |> resultOk |> Ply
-            | false, _ ->
-              IntParseError.OutOfRange |> IntParseError.toDT |> resultError |> Ply
+          | :? System.OverflowException ->
+            IntParseError.OutOfRange |> IntParseError.toDT |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -221,9 +221,8 @@ let fns : List<BuiltInFn> =
         | _, _, [ DInt number; DInt exp ] ->
           (try
             (bigint number) ** (int exp) |> int64 |> DInt |> resultOk |> Ply
-           with
-           | :? System.OverflowException ->
-              IntPowerError.OutOfRange |> IntPowerError.toDT |> resultError |> Ply)
+           with :? System.OverflowException ->
+             IntPowerError.OutOfRange |> IntPowerError.toDT |> resultError |> Ply)
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "^"
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -220,7 +220,9 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, _, [ DInt a; DInt b ] ->
-          if b = 0L then Ply(raiseString "Division by zero") else Ply(DInt(a / b))
+          if b = 0L then
+            RuntimeError.DivideByZeroError |> raiseUntargetedRTE |> Ply
+          else Ply(DInt(a / b))
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "/"
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -44,19 +44,18 @@ module IntRuntimeError =
       DEnum(typeName, typeName, [], caseName, fields) |> RuntimeError.intError
 
 
-module IntParseError =
-  type IntParseError =
+module ParseError =
+  type ParseError =
     | BadFormat
     | OutOfRange
 
-  let toDT (e : IntParseError) : Dval =
+  let toDT (e : ParseError) : Dval =
     let (caseName, fields) =
       match e with
       | BadFormat -> "BadFormat", []
       | OutOfRange -> "OutOfRange", []
 
-    let typeName =
-      TypeName.fqPackage "Darklang" [ "Stdlib"; "Int" ] "IntParseError" 0
+    let typeName = TypeName.fqPackage "Darklang" [ "Stdlib"; "Int" ] "ParseError" 0
     DEnum(typeName, typeName, [], caseName, fields)
 
 
@@ -397,7 +396,7 @@ let fns : List<BuiltInFn> =
               FQName.Package
                 { owner = "Darklang"
                   modules = [ "Stdlib"; "Int" ]
-                  name = TypeName.TypeName "IntParseError"
+                  name = TypeName.TypeName "ParseError"
                   version = 0 }
             ),
             []
@@ -405,7 +404,7 @@ let fns : List<BuiltInFn> =
       description = "Returns the <type Int> value of a <type String>"
       fn =
         let resultOk = Dval.resultOk KTInt KTString
-        let typeName = RuntimeError.name [ "Int" ] "IntParseError" 0
+        let typeName = RuntimeError.name [ "Int" ] "ParseError" 0
         let resultError = Dval.resultError KTInt (KTCustomType(typeName, []))
         (function
         | _, _, [ DString s ] ->
@@ -413,9 +412,9 @@ let fns : List<BuiltInFn> =
             s |> System.Convert.ToInt64 |> DInt |> resultOk |> Ply
           with
           | :? System.FormatException ->
-            IntParseError.BadFormat |> IntParseError.toDT |> resultError |> Ply
+            ParseError.BadFormat |> ParseError.toDT |> resultError |> Ply
           | :? System.OverflowException ->
-            IntParseError.OutOfRange |> IntParseError.toDT |> resultError |> Ply
+            ParseError.OutOfRange |> ParseError.toDT |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -32,8 +32,9 @@ module IntParseError =
       | BadFormat -> "BadFormat", []
       | OutOfRange -> "OutOfRange", []
 
-    let typeName = TypeName.fqPackage "Darklang" ["Stdlib"; "Int"] "IntParseError" 0
-    DEnum (typeName, typeName, [], caseName, fields)
+    let typeName =
+      TypeName.fqPackage "Darklang" [ "Stdlib"; "Int" ] "IntParseError" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
 let fn = fn [ "Int" ]
 
@@ -222,7 +223,8 @@ let fns : List<BuiltInFn> =
         | _, _, [ DInt a; DInt b ] ->
           if b = 0L then
             RuntimeError.DivideByZeroError |> raiseUntargetedRTE |> Ply
-          else Ply(DInt(a / b))
+          else
+            Ply(DInt(a / b))
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "/"
       previewable = Pure
@@ -374,12 +376,20 @@ let fns : List<BuiltInFn> =
         (function
         | _, _, [ DString s ] ->
           let trimmedString = s.Trim()
-          if not (System.Text.RegularExpressions.Regex.IsMatch(trimmedString, @"^[+-]?\d+$")) then
+          if
+            not (
+              System.Text.RegularExpressions.Regex.IsMatch(
+                trimmedString,
+                @"^[+-]?\d+$"
+              )
+            )
+          then
             IntParseError.BadFormat |> IntParseError.toDT |> resultError |> Ply
           else
             match System.Int64.TryParse(s) with
             | true, value -> value |> DInt |> resultOk |> Ply
-            | false, _ -> IntParseError.OutOfRange |> IntParseError.toDT |> resultError |> Ply
+            | false, _ ->
+              IntParseError.OutOfRange |> IntParseError.toDT |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Uuid.fs
+++ b/backend/src/BuiltinExecution/Libs/Uuid.fs
@@ -15,16 +15,15 @@ let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Uuid" ]
 
-module UuidParseError =
-  type UuidParseError = | BadFormat
+module ParseError =
+  type ParseError = | BadFormat
 
-  let toDT (e : UuidParseError) : Dval =
+  let toDT (e : ParseError) : Dval =
     let (caseName, fields) =
       match e with
       | BadFormat -> "BadFormat", []
 
-    let typeName =
-      TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "UuidParseError" 0
+    let typeName = TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "ParseError" 0
     DEnum(typeName, typeName, [], caseName, fields)
 
 
@@ -56,7 +55,7 @@ let fns : List<BuiltInFn> =
               FQName.Package
                 { owner = "Darklang"
                   modules = [ "Stdlib"; "Uuid" ]
-                  name = TypeName.TypeName "UuidParseError"
+                  name = TypeName.TypeName "ParseError"
                   version = 0 }
             ),
             []
@@ -66,14 +65,13 @@ let fns : List<BuiltInFn> =
       fn =
         let resultOk = Dval.resultOk KTUuid KTString
         let typeName =
-          TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "UuidParseError" 0
+          TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "ParseError" 0
         let resultError = Dval.resultError KTUuid (KTCustomType(typeName, []))
         (function
         | _, _, [ DString s ] ->
           match System.Guid.TryParse s with
           | true, x -> x |> DUuid |> resultOk |> Ply
-          | _ ->
-            UuidParseError.BadFormat |> UuidParseError.toDT |> resultError |> Ply
+          | _ -> ParseError.BadFormat |> ParseError.toDT |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Uuid.fs
+++ b/backend/src/BuiltinExecution/Libs/Uuid.fs
@@ -16,16 +16,16 @@ let constants : List<BuiltInConstant> = []
 let fn = fn [ "Uuid" ]
 
 module UuidParseError =
-  type UuidParseError =
-    | BadFormat
+  type UuidParseError = | BadFormat
 
   let toDT (e : UuidParseError) : Dval =
     let (caseName, fields) =
       match e with
       | BadFormat -> "BadFormat", []
 
-    let typeName = TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "UuidParseError" 0
-    DEnum (typeName, typeName, [], caseName, fields)
+    let typeName =
+      TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "UuidParseError" 0
+    DEnum(typeName, typeName, [], caseName, fields)
 
 
 let fns : List<BuiltInFn> =
@@ -65,13 +65,15 @@ let fns : List<BuiltInFn> =
         "Parse a <type Uuid> of form {{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}}"
       fn =
         let resultOk = Dval.resultOk KTUuid KTString
-        let typeName = TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "UuidParseError" 0
+        let typeName =
+          TypeName.fqPackage "Darklang" [ "Stdlib"; "Uuid" ] "UuidParseError" 0
         let resultError = Dval.resultError KTUuid (KTCustomType(typeName, []))
         (function
         | _, _, [ DString s ] ->
           match System.Guid.TryParse s with
           | true, x -> x |> DUuid |> resultOk |> Ply
-          | _ -> UuidParseError.BadFormat |> UuidParseError.toDT |> resultError |> Ply
+          | _ ->
+            UuidParseError.BadFormat |> UuidParseError.toDT |> resultError |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -807,6 +807,8 @@ module RuntimeError =
 
   let executionError field = case "ExecutionError" [ field ]
 
+  let DivideByZeroError = case "DivideByZeroError" []
+
 
   // let exceptionThrown (ex : System.Exception) : RuntimeError =
   //   case

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -807,7 +807,7 @@ module RuntimeError =
 
   let executionError field = case "ExecutionError" [ field ]
 
-  let DivideByZeroError = case "DivideByZeroError" []
+  let intError field = case "IntError" [ field ]
 
 
   // let exceptionThrown (ex : System.Exception) : RuntimeError =

--- a/backend/testfiles/execution/stdlib/float.dark
+++ b/backend/testfiles/execution/stdlib/float.dark
@@ -166,14 +166,20 @@ PACKAGE.Darklang.Stdlib.Float.parse_v0 "-55555555555555555555555555555.5" = PACK
   -55555555555555555555555555555.5
 
 PACKAGE.Darklang.Stdlib.Float.parse_v0 "-141s" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected a String representation of an IEEE float"
+  PACKAGE.Darklang.Stdlib.Float.FloatParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Float.parse_v0 "" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected a String representation of an IEEE float"
+  PACKAGE.Darklang.Stdlib.Float.FloatParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Float.parse "-5.55555555556e+28" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
   -55555555555555555555555555555.5
 //PACKAGE.Darklang.Stdlib.Float.parse_v0 "0xffffffffffffffff" = PACKAGE.Darklang.Stdlib.Result.Result.Ok 1.844674407e+19
+
+PACKAGE.Darklang.Stdlib.Float.parse_v0 "-1.8E+308" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Test.negativeInfinity_v0
+
+PACKAGE.Darklang.Stdlib.Float.parse_v0 "1.8E+308" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  Builtin.Test.infinity_v0
 
 PACKAGE.Darklang.Stdlib.Float.power_v0 4.0 -0.5 = 0.5
 PACKAGE.Darklang.Stdlib.Float.power_v0 4.0 0.5 = 2.0

--- a/backend/testfiles/execution/stdlib/float.dark
+++ b/backend/testfiles/execution/stdlib/float.dark
@@ -166,10 +166,10 @@ PACKAGE.Darklang.Stdlib.Float.parse_v0 "-55555555555555555555555555555.5" = PACK
   -55555555555555555555555555555.5
 
 PACKAGE.Darklang.Stdlib.Float.parse_v0 "-141s" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Float.FloatParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Float.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Float.parse_v0 "" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Float.FloatParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Float.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Float.parse "-5.55555555556e+28" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
   -55555555555555555555555555555.5

--- a/backend/testfiles/execution/stdlib/float.dark
+++ b/backend/testfiles/execution/stdlib/float.dark
@@ -95,6 +95,8 @@ PACKAGE.Darklang.Stdlib.Float.clamp_v0 3.0 0.0 2.0 = PACKAGE.Darklang.Stdlib.Res
   2.0
 
 PACKAGE.Darklang.Stdlib.Float.divide_v0 9.0 2.0 = 4.5
+PACKAGE.Darklang.Stdlib.Float.divide_v0 9.0 0.0 = Builtin.Test.infinity_v0
+PACKAGE.Darklang.Stdlib.Float.divide_v0 9.0 -0.0 = Builtin.Test.negativeInfinity_v0
 
 9.0 / 2.0 = 4.5
 17.0 / 3.3 = 5.151515152

--- a/backend/testfiles/execution/stdlib/int.dark
+++ b/backend/testfiles/execution/stdlib/int.dark
@@ -110,53 +110,44 @@ PACKAGE.Darklang.Stdlib.Int.mod_v0 (-1) 2 = 1
 PACKAGE.Darklang.Stdlib.Int.mod_v0 (-754) 53 = 41
 PACKAGE.Darklang.Stdlib.Int.mod_v0 9999999999998L 3 = 2
 
-PACKAGE.Darklang.Stdlib.Int.mod_v0 5 0 = Builtin.Test.derrorMessage
-  "Expected `b` to be positive, but it was `0`"
+PACKAGE.Darklang.Stdlib.Int.mod_v0 5 0 = Builtin.Test.derrorMessage "Zero modulus"
 
 PACKAGE.Darklang.Stdlib.Int.mod_v0 5 (-5) = Builtin.Test.derrorMessage
-  "Expected `b` to be positive, but it was `-5`"
+  "Negative modulus"
 
 // PACKAGE.Darklang.Stdlib.List.map_v0 (PACKAGE.Darklang.Stdlib.List.range_v0 (-5) 5) (fun v ->
 //  PACKAGE.Darklang.Stdlib.Int.mod_v0 v 4) = [ 3 0 1 2 3 0 1 2 3 0 1 ]
 
 15 % 5 = 0
-5 % 0 = Builtin.Test.derrorMessage "Expected `b` to be positive, but it was `0`"
-5 % (-5) = Builtin.Test.derrorMessage "Expected `b` to be positive, but it was `-5`"
+5 % 0 = Builtin.Test.derrorMessage "Zero modulus"
+5 % (-5) = Builtin.Test.derrorMessage "Negative modulus"
 
 PACKAGE.Darklang.Stdlib.List.map_v0
   (PACKAGE.Darklang.Stdlib.List.range_v0 -5 5)
   (fun v -> v % 4) = [ 3; 0; 1; 2; 3; 0; 1; 2; 3; 0; 1 ]
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 8 5 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  32768
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 0 1 = PACKAGE.Darklang.Stdlib.Result.Result.Ok 0
-PACKAGE.Darklang.Stdlib.Int.power_v0 1 0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+PACKAGE.Darklang.Stdlib.Int.power_v0 8 5 = 32768
+PACKAGE.Darklang.Stdlib.Int.power_v0 0 1 = 0
+PACKAGE.Darklang.Stdlib.Int.power_v0 1 0 = 1
+PACKAGE.Darklang.Stdlib.Int.power_v0 1000 0 = 1
+PACKAGE.Darklang.Stdlib.Int.power_v0 -8 5 = -32768
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 1000 0 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  1
+PACKAGE.Darklang.Stdlib.Int.power_v0 200 20 = Builtin.Test.derrorMessage
+  "Out of range"
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 -8 5 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  -32768
+PACKAGE.Darklang.Stdlib.Int.power_v0 200 7 = 12800000000000000L
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 200 20 = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntPowerError.OutOfRange
+PACKAGE.Darklang.Stdlib.Int.power_v0 1 2147483649L = 1
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 200 7 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  12800000000000000L
+PACKAGE.Darklang.Stdlib.Int.power_v0 -1 2147483649L = -1
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 1 2147483649L = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  1
+PACKAGE.Darklang.Stdlib.Int.power_v0 2 -3 = Builtin.Test.derrorMessage
+  "Negative exponent"
 
-PACKAGE.Darklang.Stdlib.Int.power_v0 -1 2147483649L = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  -1
-
-PACKAGE.Darklang.Stdlib.Int.power_v0 2 -3 = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntPowerError.NegativeExponent
-
-5 ^ 2 = PACKAGE.Darklang.Stdlib.Result.Result.Ok 25
--8 ^ 5 = PACKAGE.Darklang.Stdlib.Result.Result.Ok -32768
-50 ^ 2 = PACKAGE.Darklang.Stdlib.Result.Result.Ok 2500
+5 ^ 2 = 25
+-8 ^ 5 = -32768
+50 ^ 2 = 2500
 
 PACKAGE.Darklang.Stdlib.Int.greaterThan_v0 20 1 = true
 20 > 1 = true

--- a/backend/testfiles/execution/stdlib/int.dark
+++ b/backend/testfiles/execution/stdlib/int.dark
@@ -330,7 +330,7 @@ PACKAGE.Darklang.Stdlib.Int.parse_v0 "-9223372036854775808" = PACKAGE.Darklang.S
   -9223372036854775808L // .NET lower limit
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "-9223372036854775809" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.OutOfRange
+  PACKAGE.Darklang.Stdlib.Int.ParseError.OutOfRange
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "4611686018427387903" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
   4611686018427387903L // int63 upper limit
@@ -342,49 +342,49 @@ PACKAGE.Darklang.Stdlib.Int.parse_v0 "9223372036854775807" = PACKAGE.Darklang.St
   9223372036854775807L // .NET upper limit
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.OutOfRange
+  PACKAGE.Darklang.Stdlib.Int.ParseError.OutOfRange
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "1 2 3" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "+ 1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "- 1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "0xA" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "0x123" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "0b0100" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "pi" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "PACKAGE.Darklang.Stdlib.Math.pi" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "1.23E+04" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.OutOfRange
+  PACKAGE.Darklang.Stdlib.Int.ParseError.OutOfRange
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "1I" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "one" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "XIV" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Int.ParseError.BadFormat
 
 
 PACKAGE.Darklang.Stdlib.Int.toString 0 = "0"

--- a/backend/testfiles/execution/stdlib/int.dark
+++ b/backend/testfiles/execution/stdlib/int.dark
@@ -50,8 +50,8 @@ PACKAGE.Darklang.Stdlib.Int.remainder_v0 -20 -8 = PACKAGE.Darklang.Stdlib.Result
 PACKAGE.Darklang.Stdlib.Int.remainder_v0 -15 6 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
   -3
 
-PACKAGE.Darklang.Stdlib.Int.remainder_v0 5 0 = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "`divisor` must be non-zero"
+PACKAGE.Darklang.Stdlib.Int.remainder_v0 5 0 = Builtin.Test.derrorMessage
+  "Division by zero"
 
 PACKAGE.Darklang.Stdlib.List.map_v0
   (PACKAGE.Darklang.Stdlib.List.range_v0 -5 5)
@@ -140,7 +140,7 @@ PACKAGE.Darklang.Stdlib.Int.power_v0 -8 5 = PACKAGE.Darklang.Stdlib.Result.Resul
   -32768
 
 PACKAGE.Darklang.Stdlib.Int.power_v0 200 20 = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Error raising to exponent"
+  PACKAGE.Darklang.Stdlib.Int.IntPowerError.OutOfRange
 
 PACKAGE.Darklang.Stdlib.Int.power_v0 200 7 = PACKAGE.Darklang.Stdlib.Result.Result.Ok
   12800000000000000L
@@ -152,7 +152,7 @@ PACKAGE.Darklang.Stdlib.Int.power_v0 -1 2147483649L = PACKAGE.Darklang.Stdlib.Re
   -1
 
 PACKAGE.Darklang.Stdlib.Int.power_v0 2 -3 = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected `exponent` to be positive, but it was `-3`"
+  PACKAGE.Darklang.Stdlib.Int.IntPowerError.NegativeExponent
 
 5 ^ 2 = PACKAGE.Darklang.Stdlib.Result.Result.Ok 25
 -8 ^ 5 = PACKAGE.Darklang.Stdlib.Result.Result.Ok -32768

--- a/backend/testfiles/execution/stdlib/int.dark
+++ b/backend/testfiles/execution/stdlib/int.dark
@@ -339,7 +339,7 @@ PACKAGE.Darklang.Stdlib.Int.parse_v0 "-9223372036854775808" = PACKAGE.Darklang.S
   -9223372036854775808L // .NET lower limit
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "-9223372036854775809" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"-9223372036854775809\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.OutOfRange
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "4611686018427387903" = PACKAGE.Darklang.Stdlib.Result.Result.Ok
   4611686018427387903L // int63 upper limit
@@ -351,49 +351,49 @@ PACKAGE.Darklang.Stdlib.Int.parse_v0 "9223372036854775807" = PACKAGE.Darklang.St
   9223372036854775807L // .NET upper limit
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"9223372036854775808\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.OutOfRange
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "1 2 3" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"1 2 3\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "+ 1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"+ 1\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "- 1" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"- 1\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "0xA" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"0xA\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "0x123" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"0x123\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "0b0100" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"0b0100\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "pi" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"pi\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "PACKAGE.Darklang.Stdlib.Math.pi" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"PACKAGE.Darklang.Stdlib.Math.pi\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "1.23E+04" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"1.23E+04\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "9223372036854775808" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"9223372036854775808\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.OutOfRange
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "1I" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"1I\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "one" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"one\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Int.parse_v0 "XIV" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected to parse String with only numbers, instead got \"XIV\""
+  PACKAGE.Darklang.Stdlib.Int.IntParseError.BadFormat
 
 
 PACKAGE.Darklang.Stdlib.Int.toString 0 = "0"

--- a/backend/testfiles/execution/stdlib/uuid.dark
+++ b/backend/testfiles/execution/stdlib/uuid.dark
@@ -1,20 +1,20 @@
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "👱🏼" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "1111111🍇-2222-3333-4444-555555555555" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "psp-soslsls==" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "123456" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "d388ff30-667f-11eb-ae93" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "d388ff30-667f-11eb-ae93-0242ac13000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "`uuid` parameter was not of form XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
 
 (PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
 |> Builtin.unwrap

--- a/backend/testfiles/execution/stdlib/uuid.dark
+++ b/backend/testfiles/execution/stdlib/uuid.dark
@@ -1,20 +1,20 @@
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "👱🏼" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Uuid.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "1111111🍇-2222-3333-4444-555555555555" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Uuid.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "psp-soslsls==" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Uuid.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "123456" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Uuid.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "d388ff30-667f-11eb-ae93" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Uuid.ParseError.BadFormat
 
 PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "d388ff30-667f-11eb-ae93-0242ac13000" = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  PACKAGE.Darklang.Stdlib.Uuid.UuidParseError.BadFormat
+  PACKAGE.Darklang.Stdlib.Uuid.ParseError.BadFormat
 
 (PACKAGE.Darklang.Stdlib.Uuid.parse_v0 "3700adbc-7a46-4ff4-81d3-45afb03f6e2d")
 |> Builtin.unwrap

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -757,7 +757,14 @@ module Expect =
         System.Double.IsNegativeInfinity l && System.Double.IsNegativeInfinity r
       then
         ()
-      else if System.Double.IsNaN l || System.Double.IsNaN r || System.Double.IsPositiveInfinity l || System.Double.IsPositiveInfinity r || System.Double.IsNegativeInfinity l || System.Double.IsNegativeInfinity r then
+      else if
+        System.Double.IsNaN l
+        || System.Double.IsNaN r
+        || System.Double.IsPositiveInfinity l
+        || System.Double.IsPositiveInfinity r
+        || System.Double.IsNegativeInfinity l
+        || System.Double.IsNegativeInfinity r
+      then
         error path
       else if not (Accuracy.areClose Accuracy.veryHigh l r) then
         error path

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -757,6 +757,8 @@ module Expect =
         System.Double.IsNegativeInfinity l && System.Double.IsNegativeInfinity r
       then
         ()
+      else if System.Double.IsNaN l || System.Double.IsNaN r || System.Double.IsPositiveInfinity l || System.Double.IsPositiveInfinity r || System.Double.IsNegativeInfinity l || System.Double.IsNegativeInfinity r then
+        error path
       else if not (Accuracy.areClose Accuracy.veryHigh l r) then
         error path
     | DDateTime l, DDateTime r ->

--- a/packages/darklang/languageTools/runtimeErrors/int.dark
+++ b/packages/darklang/languageTools/runtimeErrors/int.dark
@@ -1,0 +1,47 @@
+module Darklang =
+  module LanguageTools =
+    module RuntimeErrors =
+      module Int =
+        type Error =
+          | DivideByZeroError
+          | OutOfRange
+          | NegativeExponent
+          | NegativeModulus
+          | ZeroModulus
+
+        let toSegments (e: Error) : ErrorOutput =
+          match e with
+          | DivideByZeroError ->
+            ErrorOutput
+              { summary = [ ErrorSegment.ErrorSegment.String "Division by zero" ]
+                extraExplanation = []
+                actual = []
+                expected = [] }
+
+          | OutOfRange ->
+            ErrorOutput
+              { summary = [ ErrorSegment.ErrorSegment.String "Out of range" ]
+                extraExplanation = []
+                actual = []
+                expected = [] }
+
+          | NegativeExponent ->
+            ErrorOutput
+              { summary = [ ErrorSegment.ErrorSegment.String "Negative exponent" ]
+                extraExplanation = []
+                actual = []
+                expected = [] }
+
+          | NegativeModulus ->
+            ErrorOutput
+              { summary = [ ErrorSegment.ErrorSegment.String "Negative modulus" ]
+                extraExplanation = []
+                actual = []
+                expected = [] }
+
+          | ZeroModulus ->
+            ErrorOutput
+              { summary = [ ErrorSegment.ErrorSegment.String "Zero modulus" ]
+                extraExplanation = []
+                actual = []
+                expected = [] }

--- a/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
+++ b/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
@@ -132,7 +132,7 @@ module Darklang =
         | ExecutionError of
           PACKAGE.Darklang.LanguageTools.RuntimeErrors.Execution.Error
         | JsonError of PACKAGE.Darklang.LanguageTools.RuntimeErrors.Json.Error
-        | DivideByZeroError
+        | IntError of PACKAGE.Darklang.LanguageTools.RuntimeErrors.Int.Error
 
         | OldStringErrorTODO of String
 
@@ -171,13 +171,7 @@ module Darklang =
 
           | JsonError err -> Json.toSegments err
 
-          | DivideByZeroError ->
-            ErrorOutput
-              { summary = [ ErrorSegment.ErrorSegment.String "Division by zero" ]
-                extraExplanation = []
-                actual = []
-                expected = [] }
-
+          | IntError err -> Int.toSegments err
 
         let toString (e: Error) : String =
           let s = toSegments e

--- a/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
+++ b/packages/darklang/languageTools/runtimeErrors/runtimeErrors.dark
@@ -132,6 +132,7 @@ module Darklang =
         | ExecutionError of
           PACKAGE.Darklang.LanguageTools.RuntimeErrors.Execution.Error
         | JsonError of PACKAGE.Darklang.LanguageTools.RuntimeErrors.Json.Error
+        | DivideByZeroError
 
         | OldStringErrorTODO of String
 
@@ -169,6 +170,13 @@ module Darklang =
                     innerOutput.summary }
 
           | JsonError err -> Json.toSegments err
+
+          | DivideByZeroError ->
+            ErrorOutput
+              { summary = [ ErrorSegment.ErrorSegment.String "Division by zero" ]
+                extraExplanation = []
+                actual = []
+                expected = [] }
 
 
         let toString (e: Error) : String =

--- a/packages/darklang/stdlib/float.dark
+++ b/packages/darklang/stdlib/float.dark
@@ -1,6 +1,9 @@
 module Darklang =
   module Stdlib =
     module Float =
+
+      type FloatParseError = | BadFormat
+
       /// Round up to an integer value
       let ceiling (a: Float) : Int = Builtin.Float.ceiling a
 

--- a/packages/darklang/stdlib/float.dark
+++ b/packages/darklang/stdlib/float.dark
@@ -2,7 +2,7 @@ module Darklang =
   module Stdlib =
     module Float =
 
-      type FloatParseError = | BadFormat
+      type ParseError = | BadFormat
 
       /// Round up to an integer value
       let ceiling (a: Float) : Int = Builtin.Float.ceiling a

--- a/packages/darklang/stdlib/int.dark
+++ b/packages/darklang/stdlib/int.dark
@@ -6,9 +6,6 @@ module Darklang =
         | BadFormat
         | OutOfRange
 
-      type IntPowerError =
-        | OutOfRange
-        | NegativeExponent
 
       /// Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
       /// The modulus <param b> must be 0 or negative.
@@ -49,27 +46,16 @@ module Darklang =
       /// Raise <param base> to the power of <param exponent>.
       /// <param exponent> must to be positive.
       /// Return value wrapped in a {{Result}}
-      let power
-        (``base``: Int)
-        (exponent: Int)
-        : PACKAGE.Darklang.Stdlib.Result.Result<Int, PACKAGE.Darklang.Stdlib.Int.IntPowerError> =
-        if exponent < 0 then
-          PACKAGE.Darklang.Stdlib.Result.Result.Error
-            PACKAGE.Darklang.Stdlib.Int.IntPowerError.NegativeExponent
+      let power (``base``: Int) (exponent: Int) : Int =
         // Handle some edge cases around 1. We want to make this match
         // OCaml, so we have to support an exponent above int32, but
         // below int63. This only matters for 1 or -1, and otherwise a
         // number raised to an int63 exponent wouldn't fit in an int63
-        else if ``base`` == 0 then
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok 0
-        else if ``base`` == 1 then
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-        else if ``base`` == -1 && exponent % 2 == 0 then
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
-        else if ``base`` == -1 then
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok -1
-        else
-          ``base`` ^ exponent
+        if ``base`` == 0 then 0
+        else if ``base`` == 1 then 1
+        else if ``base`` == -1 && exponent % 2 == 0 then 1
+        else if ``base`` == -1 then -1
+        else ``base`` ^ exponent
 
 
       /// Returns the absolute value of <param a> (turning negative inputs into positive outputs)

--- a/packages/darklang/stdlib/int.dark
+++ b/packages/darklang/stdlib/int.dark
@@ -135,7 +135,9 @@ module Darklang =
 
 
       /// Returns the <type Int> value of a <type String>
-      let parse (s: String) : PACKAGE.Darklang.Stdlib.Result.Result<Int, PACKAGE.Darklang.Stdlib.Int.IntParseError> =
+      let parse
+        (s: String)
+        : PACKAGE.Darklang.Stdlib.Result.Result<Int, PACKAGE.Darklang.Stdlib.Int.IntParseError> =
         Builtin.Int.parse s
 
 

--- a/packages/darklang/stdlib/int.dark
+++ b/packages/darklang/stdlib/int.dark
@@ -6,6 +6,10 @@ module Darklang =
         | BadFormat
         | OutOfRange
 
+      type IntPowerError =
+        | OutOfRange
+        | NegativeExponent
+
       /// Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
       /// The modulus <param b> must be 0 or negative.
       /// Use <fn Int.remainder> if you want the remainder after division, which has
@@ -48,8 +52,24 @@ module Darklang =
       let power
         (``base``: Int)
         (exponent: Int)
-        : PACKAGE.Darklang.Stdlib.Result.Result<Int, String> =
-        ``base`` ^ exponent
+        : PACKAGE.Darklang.Stdlib.Result.Result<Int, PACKAGE.Darklang.Stdlib.Int.IntPowerError> =
+        if exponent < 0 then
+          PACKAGE.Darklang.Stdlib.Result.Result.Error
+            PACKAGE.Darklang.Stdlib.Int.IntPowerError.NegativeExponent
+        // Handle some edge cases around 1. We want to make this match
+        // OCaml, so we have to support an exponent above int32, but
+        // below int63. This only matters for 1 or -1, and otherwise a
+        // number raised to an int63 exponent wouldn't fit in an int63
+        else if ``base`` == 0 then
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok 0
+        else if ``base`` == 1 then
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+        else if ``base`` == -1 && exponent % 2 == 0 then
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok 1
+        else if ``base`` == -1 then
+          PACKAGE.Darklang.Stdlib.Result.Result.Ok -1
+        else
+          ``base`` ^ exponent
 
 
       /// Returns the absolute value of <param a> (turning negative inputs into positive outputs)
@@ -115,7 +135,7 @@ module Darklang =
 
 
       /// Returns the <type Int> value of a <type String>
-      let parse (s: String) : PACKAGE.Darklang.Stdlib.Result.Result<Int, String> =
+      let parse (s: String) : PACKAGE.Darklang.Stdlib.Result.Result<Int, PACKAGE.Darklang.Stdlib.Int.IntParseError> =
         Builtin.Int.parse s
 
 

--- a/packages/darklang/stdlib/int.dark
+++ b/packages/darklang/stdlib/int.dark
@@ -2,6 +2,10 @@ module Darklang =
   module Stdlib =
     module Int =
 
+      type IntParseError =
+        | BadFormat
+        | OutOfRange
+
       /// Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
       /// The modulus <param b> must be 0 or negative.
       /// Use <fn Int.remainder> if you want the remainder after division, which has

--- a/packages/darklang/stdlib/int.dark
+++ b/packages/darklang/stdlib/int.dark
@@ -2,7 +2,7 @@ module Darklang =
   module Stdlib =
     module Int =
 
-      type IntParseError =
+      type ParseError =
         | BadFormat
         | OutOfRange
 
@@ -123,7 +123,7 @@ module Darklang =
       /// Returns the <type Int> value of a <type String>
       let parse
         (s: String)
-        : PACKAGE.Darklang.Stdlib.Result.Result<Int, PACKAGE.Darklang.Stdlib.Int.IntParseError> =
+        : PACKAGE.Darklang.Stdlib.Result.Result<Int, PACKAGE.Darklang.Stdlib.Int.ParseError> =
         Builtin.Int.parse s
 
 

--- a/packages/darklang/stdlib/uuid.dark
+++ b/packages/darklang/stdlib/uuid.dark
@@ -1,6 +1,10 @@
 module Darklang =
   module Stdlib =
     module Uuid =
+
+      type UuidParseError =
+        | BadFormat
+
       /// Generate a new <type Uuid> v4 according to RFC 4122
       let generate () : Uuid = Builtin.Uuid.generate ()
 
@@ -8,7 +12,7 @@ module Darklang =
       /// Parse a <type Uuid> of form {{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}}
       let parse
         (uuid: String)
-        : PACKAGE.Darklang.Stdlib.Result.Result<Uuid, String> =
+        : PACKAGE.Darklang.Stdlib.Result.Result<Uuid, PACKAGE.Darklang.Stdlib.Uuid.UuidParseError> =
         Builtin.Uuid.parse uuid
 
 

--- a/packages/darklang/stdlib/uuid.dark
+++ b/packages/darklang/stdlib/uuid.dark
@@ -2,7 +2,7 @@ module Darklang =
   module Stdlib =
     module Uuid =
 
-      type UuidParseError = | BadFormat
+      type ParseError = | BadFormat
 
       /// Generate a new <type Uuid> v4 according to RFC 4122
       let generate () : Uuid = Builtin.Uuid.generate ()
@@ -11,7 +11,7 @@ module Darklang =
       /// Parse a <type Uuid> of form {{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}}
       let parse
         (uuid: String)
-        : PACKAGE.Darklang.Stdlib.Result.Result<Uuid, PACKAGE.Darklang.Stdlib.Uuid.UuidParseError> =
+        : PACKAGE.Darklang.Stdlib.Result.Result<Uuid, PACKAGE.Darklang.Stdlib.Uuid.ParseError> =
         Builtin.Uuid.parse uuid
 
 

--- a/packages/darklang/stdlib/uuid.dark
+++ b/packages/darklang/stdlib/uuid.dark
@@ -2,8 +2,7 @@ module Darklang =
   module Stdlib =
     module Uuid =
 
-      type UuidParseError =
-        | BadFormat
+      type UuidParseError = | BadFormat
 
       /// Generate a new <type Uuid> v4 according to RFC 4122
       let generate () : Uuid = Builtin.Uuid.generate ()


### PR DESCRIPTION


No changelog

This PR:
- Introduces a new IntRuntimeError and uses it for Int.mod, Int.power, and Int.divide
  ```
    type Error =
      | DivideByZeroError
      | OutOfRange
      | NegativeExponent
      | NegativeModulus
      | ZeroModulus
  ```
- Replaces Float.parse string error with a custom IntParseError
- Replaces Int.parse string error with a custom IntParseError
- Updates Int.power to return an `Int` instead of `Result`
- Replaces Uuid.parse string error with a custom UuidParseError
