### PR TITLE
Replace our LSP server, written in Node, with one written in Darklang

### DIFF
--- a/backend/src/BuiltinCli/Builtin.fs
+++ b/backend/src/BuiltinCli/Builtin.fs
@@ -19,6 +19,7 @@ let contents =
       Libs.Process.contents
       Libs.Output.contents
       Libs.Stdin.contents
+      Libs.LanguageServerProtocol.contents
       Libs.Time.contents
       Libs.LanguageTools.contents ]
     fnRenames

--- a/backend/src/BuiltinCli/BuiltinCli.fsproj
+++ b/backend/src/BuiltinCli/BuiltinCli.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Libs/Environment.fs" />
     <Compile Include="Libs/File.fs" />
     <Compile Include="Libs/LanguageTools.fs" />
+    <Compile Include="Libs/LanguageServerProtocol.fs" />
     <Compile Include="Libs/Output.fs" />
     <Compile Include="Libs/Process.fs" />
     <Compile Include="Libs/Stdin.fs" />

--- a/backend/src/BuiltinCli/Libs/File.fs
+++ b/backend/src/BuiltinCli/Libs/File.fs
@@ -90,9 +90,9 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "append" 0
+    { name = fn "appendText" 0
       typeParams = []
-      parameters = [ Param.make "path" TString ""; Param.make "content" TBytes "" ]
+      parameters = [ Param.make "path" TString ""; Param.make "content" TString "" ]
       returnType = TypeReference.result TUnit TString
       description =
         "Appends the given <param content> to the file at the specified <param path>. If the file does not exist, a new file is created with the content. Returns a Result type indicating success or failure."
@@ -100,10 +100,10 @@ let fns : List<BuiltInFn> =
         let resultOk = Dval.resultOk KTUnit KTString
         let resultError = Dval.resultError KTUnit KTString
         (function
-        | _, _, [ DBytes content; DString path ] ->
+        | _, _, [ DString path; DString content ] ->
           uply {
             try
-              do! System.IO.File.WriteAllBytesAsync(path, content)
+              do! System.IO.File.AppendAllTextAsync(path, content)
               return resultOk DUnit
             with e ->
               return resultError (DString e.Message)

--- a/backend/src/BuiltinCli/Libs/LanguageServerProtocol.fs
+++ b/backend/src/BuiltinCli/Libs/LanguageServerProtocol.fs
@@ -16,7 +16,7 @@ let constants : List<BuiltInConstant> = []
 // TODO reimplement this in Darklang, without any custom built-in function. I had
 // some difficulties around this - I forget what - but this got the job done for now
 let fns : List<BuiltInFn> =
-  [ { name = fn [ "LanguageServerProtocol" ] "readNextMessage" 0
+  [ { name = fn [ "Danger"; "LanguageServerProtocol" ] "readNextMessage" 0
       typeParams = []
       parameters = [ Param.make "unit" TUnit "" ]
       returnType = TString
@@ -61,6 +61,56 @@ let fns : List<BuiltInFn> =
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated } ]
+
+(*
+  A Darklang draft of replacing this function
+
+
+  let tryReadContentLengthHeader
+    (acc: Stdlib.Option.Option<Int64>)
+    : Stdlib.Result.Result<Int64, Unit> =
+    log "a"
+
+    match Builtin.Stdin.readLine () with
+    | "" ->
+      log "b"
+
+      match acc with
+      | None -> Stdlib.Result.Result.Error()
+      | Some contentLength -> Stdlib.Result.Result.Ok contentLength
+
+    | line ->
+      log $"c: {line}"
+
+      if Stdlib.String.startsWith line "Content-Length: " then
+        log "d"
+
+        let lengthStr =
+          Stdlib.String.dropFirst line (Stdlib.String.length "Content-Length: ")
+
+        log lengthStr
+
+        match Stdlib.Int64.parse lengthStr with
+        | Ok length ->
+          tryReadContentLengthHeader (Stdlib.Option.Option.Some length)
+        | Error _ -> Stdlib.Result.Result.Error()
+
+      else
+        log "e"
+        // ignore other headers
+        tryReadContentLengthHeader acc
+
+
+  let readBody (input : StreamReader) (length : int) =
+      let buffer = Array.create length ' '
+      input.ReadBlock(buffer, 0, length) |> ignore
+      System.String buffer
+
+
+  match tryReadContentLengthHeader Stdlib.Option.Option.None with
+  | Ok contentLength -> "yay"
+  | Error() -> "boo"
+*)
 
 
 let contents : Builtin.Contents = (fns, types, constants)

--- a/backend/src/BuiltinCli/Libs/LanguageServerProtocol.fs
+++ b/backend/src/BuiltinCli/Libs/LanguageServerProtocol.fs
@@ -1,0 +1,66 @@
+module BuiltinCli.Libs.LanguageServerProtocol
+
+open System.IO
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+
+open Prelude
+open LibExecution.RuntimeTypes
+
+module Builtin = LibExecution.Builtin
+open Builtin.Shortcuts
+
+let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
+
+// TODO reimplement this in Darklang, without any custom built-in function. I had
+// some difficulties around this - I forget what - but this got the job done for now
+let fns : List<BuiltInFn> =
+  [ { name = fn [ "LanguageServerProtocol" ] "readNextMessage" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TString
+      description = "Reads a single incoming request from an LSP client, over stdin."
+      fn =
+        (function
+        | _, _, [ DUnit ] ->
+          let tryReadHeader (input : StreamReader) =
+            let mutable contentLength = None
+            let mutable complete = false
+
+            // Continue reading lines until a blank line is encountered
+            while not complete do
+              let line = input.ReadLine()
+
+              if System.String.IsNullOrEmpty line then
+                // End of headers
+                complete <- true
+              else if line.StartsWith("Content-Length: ") then
+                let lengthStr = line.Substring 16 // Get substring after 'Content-Length: '
+                contentLength <- Some(System.Int32.Parse lengthStr)
+            // Note: it's rarely expected for one additional header to be included -
+            // a Content-Type one - but this impl. skips over that header
+
+            contentLength
+
+
+          let readBody (input : StreamReader) (length : int) =
+            let buffer = Array.create length ' '
+            input.ReadBlock(buffer, 0, length) |> ignore<int>
+            System.String buffer
+
+          let reader = new StreamReader(System.Console.OpenStandardInput())
+
+          match tryReadHeader reader with
+          | Some length when length > 0 ->
+            let body = readBody reader length
+            Ply(DString body)
+          | _ -> Exception.raiseInternal "Can't read incoming LSP message" []
+
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated } ]
+
+
+let contents : Builtin.Contents = (fns, types, constants)

--- a/backend/testfiles/execution/stdlib/alt-json.dark
+++ b/backend/testfiles/execution/stdlib/alt-json.dark
@@ -1,9 +1,8 @@
 // aliases and helpers
 
-type JT = PACKAGE.Darklang.Stdlib.AltJson.JsonToken
+type Json = PACKAGE.Darklang.Stdlib.AltJson.Json
 
-type TokenParseError =
-  PACKAGE.Darklang.Stdlib.AltJson.TokenParseError.TokenParseError
+type ParseError = PACKAGE.Darklang.Stdlib.AltJson.ParseError.ParseError
 
 
 
@@ -11,192 +10,190 @@ type TokenParseError =
 
 // TODO: think - should it be impossible for a JNumber to hold anything that isn't alowed by JSON
 // what about huge strings or something? look into the limitations of JSON per the spec
-// I mean, just generally (?print and) read the spec - it's only 21 pages
 
-// TODO: the serializer doesn't _have_ to be a builtin... but the parser kinda does, for now
-// should we bother taking the parser out of Builtin land? enh
+// TODO: `format` doesn't _have_ to be a builtin... but `parse` kinda does, for now
+// should we bother taking the formatter out of Builtin land? enh
 
-module TokenSerialization =
-  // helpers
-  let parseToken
-    (jsonString: String)
-    : PACKAGE.Darklang.Stdlib.Result.Result<JT, TokenParseError> =
-    PACKAGE.Darklang.Stdlib.AltJson.parseToken jsonString
+// <helpers>
+let parse
+  (jsonString: String)
+  : PACKAGE.Darklang.Stdlib.Result.Result<Json, ParseError> =
+  PACKAGE.Darklang.Stdlib.AltJson.parse jsonString
 
-  let serializeToken (token: JT) : String =
-    PACKAGE.Darklang.Stdlib.AltJson.serializeToken token
-
-  let tokenParsedOk
-    (jt: JT)
-    : PACKAGE.Darklang.Stdlib.Result.Result<JT, TokenParseError> =
-    PACKAGE.Darklang.Stdlib.Result.Result.Ok jt
-
-  let tokenParseError
-    (err: TokenParseError)
-    : PACKAGE.Darklang.Stdlib.Result.Result<JT, TokenParseError> =
-    PACKAGE.Darklang.Stdlib.Result.Result.Error err
-
-  // tests
-  module Null =
-    serializeToken JT.Null = "null"
-    parseToken "null" = tokenParsedOk JT.Null
-
-    parseToken "NULL" = tokenParseError TokenParseError.NotJson
-    parseToken "Null" = tokenParseError TokenParseError.NotJson
-    parseToken "unit" = tokenParseError TokenParseError.NotJson
-    parseToken "()" = tokenParseError TokenParseError.NotJson
-    parseToken "" = tokenParseError TokenParseError.NotJson
+let format (json: Json) : String =
+  PACKAGE.Darklang.Stdlib.AltJson.format json
 
 
-  module Bool =
-    serializeToken (JT.Bool true) = "true"
-    serializeToken (JT.Bool false) = "false"
-    parseToken "true" = tokenParsedOk (JT.Bool true)
-    parseToken "false" = tokenParsedOk (JT.Bool false)
+let parsedOk (json: Json) : PACKAGE.Darklang.Stdlib.Result.Result<Json, ParseError> =
+  PACKAGE.Darklang.Stdlib.Result.Result.Ok json
 
-    parseToken "False" = tokenParseError TokenParseError.NotJson
-    parseToken "f" = tokenParseError TokenParseError.NotJson
-    parseToken "True" = tokenParseError TokenParseError.NotJson
-    parseToken "t" = tokenParseError TokenParseError.NotJson
+let parseError
+  (err: ParseError)
+  : PACKAGE.Darklang.Stdlib.Result.Result<Json, ParseError> =
+  PACKAGE.Darklang.Stdlib.Result.Result.Error err
+// </helpers>
+
+// tests
+module Null =
+  format Json.Null = "null"
+  parse "null" = parsedOk Json.Null
+
+  parse "NULL" = parseError ParseError.NotJson
+  parse "Null" = parseError ParseError.NotJson
+  parse "unit" = parseError ParseError.NotJson
+  parse "()" = parseError ParseError.NotJson
+  parse "" = parseError ParseError.NotJson
 
 
-  module Number =
-    // TODO:
-    // - (+/-) infinity
-    // - NaN
-    // - huge numbers (esp at Float's limits)
-    // - other notation
-    serializeToken (JT.Number 0.0) = "0" // TODO: any reason we need to make this `0.0`?
-    parseToken "0" = tokenParsedOk (JT.Number 0.0)
+module Bool =
+  format (Json.Bool true) = "true"
+  format (Json.Bool false) = "false"
+  parse "true" = parsedOk (Json.Bool true)
+  parse "false" = parsedOk (Json.Bool false)
 
-    serializeToken (JT.Number 0.1) = "0.1"
-    parseToken "0.1" = tokenParsedOk (JT.Number 0.1)
+  parse "False" = parseError ParseError.NotJson
+  parse "f" = parseError ParseError.NotJson
+  parse "True" = parseError ParseError.NotJson
+  parse "t" = parseError ParseError.NotJson
 
-    serializeToken (JT.Number -1.0) = "-1"
-    parseToken "-1" = tokenParsedOk (JT.Number -1.0)
 
-    serializeToken (JT.Number -1337.0) = "-1337"
-    parseToken "-1337" = tokenParsedOk (JT.Number -1337.0)
+module Number =
+  // TODO:
+  // - (+/-) infinity
+  // - NaN
+  // - huge numbers (esp at Float's limits)
+  // - other notation
+  format (Json.Number 0.0) = "0" // TODO: any reason we need to make this `0.0`?
+  parse "0" = parsedOk (Json.Number 0.0)
+
+  format (Json.Number 0.1) = "0.1"
+  parse "0.1" = parsedOk (Json.Number 0.1)
+
+  format (Json.Number -1.0) = "-1"
+  parse "-1" = parsedOk (Json.Number -1.0)
+
+  format (Json.Number -1337.0) = "-1337"
+  parse "-1337" = parsedOk (Json.Number -1337.0)
 
 
 
-  module String =
-    // TODO:
-    // - strings with quotes in them
-    // - ' instead of "
-    serializeToken (JT.String "hi") = "\"hi\""
-    parseToken "\"hi\"" = tokenParsedOk (JT.String "hi")
+module String =
+  // TODO:
+  // - strings with quotes in them
+  // - ' instead of "
+  format (Json.String "hi") = "\"hi\""
+  parse "\"hi\"" = parsedOk (Json.String "hi")
 
-    parseToken "hi" = tokenParseError TokenParseError.NotJson
-    parseToken "\'hi\'" = tokenParseError TokenParseError.NotJson
-
-
-  module Array =
-    // TODO:
-    // - huge arrays
-
-    // empty
-    serializeToken (JT.Array []) = "[]"
-    parseToken "[]" = tokenParsedOk (JT.Array [])
-
-    // simple single null
-    serializeToken (JT.Array [ JT.Null ]) = "[null]"
-    parseToken "[ null ]" = tokenParsedOk (JT.Array [ JT.Null ])
-
-    // first fibonnaci numbers
-    serializeToken (
-      JT.Array
-        [ JT.Number 0.0
-          JT.Number 1.0
-          JT.Number 1.0
-          JT.Number 2.0
-          JT.Number 3.0
-          JT.Number 5.0
-          JT.Number 8.0
-          JT.Number 13.0
-          JT.Number 21.0
-          JT.Number 34.0 ]
-    ) = "[0,1,1,2,3,5,8,13,21,34]"
-
-    parseToken "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]" = tokenParsedOk (
-      JT.Array
-        [ JT.Number 0.0
-          JT.Number 1.0
-          JT.Number 1.0
-          JT.Number 2.0
-          JT.Number 3.0
-          JT.Number 5.0
-          JT.Number 8.0
-          JT.Number 13.0
-          JT.Number 21.0
-          JT.Number 34.0 ]
-    )
-
-    // nested arrays
-    parseToken
-      """
-        [ [1, 2, 3],
-          [4, 5, 6],
-          [7, 8, 9] ]""" = tokenParsedOk (
-      JT.Array
-        [ JT.Array [ JT.Number 1.0; JT.Number 2.0; JT.Number 3.0 ]
-          JT.Array [ JT.Number 4.0; JT.Number 5.0; JT.Number 6.0 ]
-          JT.Array [ JT.Number 7.0; JT.Number 8.0; JT.Number 9.0 ] ]
-    )
-
-    serializeToken (
-      JT.Array
-        [ JT.Array [ JT.Number 1.0; JT.Number 2.0; JT.Number 3.0 ]
-          JT.Array [ JT.Number 4.0; JT.Number 5.0; JT.Number 6.0 ]
-          JT.Array [ JT.Number 7.0; JT.Number 8.0; JT.Number 9.0 ] ]
-    ) = "[[1,2,3],[4,5,6],[7,8,9]]"
+  parse "hi" = parseError ParseError.NotJson
+  parse "\'hi\'" = parseError ParseError.NotJson
 
 
-    // mixed types
-    serializeToken (JT.Array [ JT.Null; JT.Number 1.2 ]) = "[null,1.2]"
+module Array =
+  // TODO:
+  // - huge arrays
 
-    parseToken "[ null, 1.2 ]" = tokenParsedOk (JT.Array [ JT.Null; JT.Number 1.2 ])
+  // empty
+  format (Json.Array []) = "[]"
+  parse "[]" = parsedOk (Json.Array [])
+
+  // simple single null
+  format (Json.Array [ Json.Null ]) = "[null]"
+  parse "[ null ]" = parsedOk (Json.Array [ Json.Null ])
+
+  // first fibonnaci numbers
+  format (
+    Json.Array
+      [ Json.Number 0.0
+        Json.Number 1.0
+        Json.Number 1.0
+        Json.Number 2.0
+        Json.Number 3.0
+        Json.Number 5.0
+        Json.Number 8.0
+        Json.Number 13.0
+        Json.Number 21.0
+        Json.Number 34.0 ]
+  ) = "[0,1,1,2,3,5,8,13,21,34]"
+
+  parse "[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]" = parsedOk (
+    Json.Array
+      [ Json.Number 0.0
+        Json.Number 1.0
+        Json.Number 1.0
+        Json.Number 2.0
+        Json.Number 3.0
+        Json.Number 5.0
+        Json.Number 8.0
+        Json.Number 13.0
+        Json.Number 21.0
+        Json.Number 34.0 ]
+  )
+
+  // nested arrays
+  parse
+    """
+      [ [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9] ]""" = parsedOk (
+    Json.Array
+      [ Json.Array [ Json.Number 1.0; Json.Number 2.0; Json.Number 3.0 ]
+        Json.Array [ Json.Number 4.0; Json.Number 5.0; Json.Number 6.0 ]
+        Json.Array [ Json.Number 7.0; Json.Number 8.0; Json.Number 9.0 ] ]
+  )
+
+  format (
+    Json.Array
+      [ Json.Array [ Json.Number 1.0; Json.Number 2.0; Json.Number 3.0 ]
+        Json.Array [ Json.Number 4.0; Json.Number 5.0; Json.Number 6.0 ]
+        Json.Array [ Json.Number 7.0; Json.Number 8.0; Json.Number 9.0 ] ]
+  ) = "[[1,2,3],[4,5,6],[7,8,9]]"
+
+
+  // mixed types
+  format (Json.Array [ Json.Null; Json.Number 1.2 ]) = "[null,1.2]"
+
+  parse "[ null, 1.2 ]" = parsedOk (Json.Array [ Json.Null; Json.Number 1.2 ])
 
 
 
-  module Object =
-    // blank
-    serializeToken (JT.Object []) = """{}"""
-    parseToken """{}""" = tokenParsedOk (JT.Object [])
+module Object =
+  // blank
+  format (Json.Object []) = """{}"""
+  parse """{}""" = parsedOk (Json.Object [])
 
 
-    // single name
-    serializeToken (JT.Object [ ("n", JT.Null) ]) = """{"n":null}"""
+  // single name
+  format (Json.Object [ ("n", Json.Null) ]) = """{"n":null}"""
 
-    parseToken """{ "n": null }""" = tokenParsedOk (JT.Object[("n", JT.Null)])
-
-
-    // dupe name
-    parseToken """{ "n": null, "n": 1 }""" = tokenParsedOk (
-      JT.Object [ ("n", JT.Null); ("n", JT.Number 1.0) ]
-    )
-
-    serializeToken (JT.Object [ ("n", JT.Null); ("n", JT.Number 1.0) ]) = """{"n":null,"n":1}"""
+  parse """{ "n": null }""" = parsedOk (Json.Object[("n", Json.Null)])
 
 
-    // blank name
-    serializeToken (JT.Object [ ("", JT.Null) ]) = """{"":null}"""
+  // dupe name
+  parse """{ "n": null, "n": 1 }""" = parsedOk (
+    Json.Object [ ("n", Json.Null); ("n", Json.Number 1.0) ]
+  )
 
-    parseToken """{ "": null }""" = tokenParsedOk (JT.Object[("", JT.Null)])
+  format (Json.Object [ ("n", Json.Null); ("n", Json.Number 1.0) ]) = """{"n":null,"n":1}"""
 
-    // name with newline
-    // TODO not sure what's right here
-    //serializeToken (JT.Object [ ("a\nb", JT.Null) ]) = "{\"a\nb\": null}"
-    // parseToken  "{\"a\nb\": null}" = tokenParsedOk (JT.Object [ ("a\nb", JT.Null) ])
 
-    module Errors =
-      // names must be strings
-      parseToken """{ 1: 1}""" = tokenParseError TokenParseError.NotJson
+  // blank name
+  format (Json.Object [ ("", Json.Null) ]) = """{"":null}"""
 
-      parseToken """{ null: 1}""" = tokenParseError TokenParseError.NotJson
+  parse """{ "": null }""" = parsedOk (Json.Object[("", Json.Null)])
 
-      // names must be in quotes
-      parseToken """{ invalidName: 1}""" = tokenParseError TokenParseError.NotJson
+  // name with newline
+  // TODO not sure what's right here
+  //format (Json.Object [ ("a\nb", Json.Null) ]) = "{\"a\nb\": null}"
+  // parse  "{\"a\nb\": null}" = parsedOk (Json.Object [ ("a\nb", Json.Null) ])
 
-      // ..._double_ quotes
-      parseToken """{ 'invalidName': 1}""" = tokenParseError TokenParseError.NotJson
+  module Errors =
+    // names must be strings
+    parse """{ 1: 1}""" = parseError ParseError.NotJson
+
+    parse """{ null: 1}""" = parseError ParseError.NotJson
+
+    // names must be in quotes
+    parse """{ invalidName: 1}""" = parseError ParseError.NotJson
+
+    // ..._double_ quotes
+    parse """{ 'invalidName': 1}""" = parseError ParseError.NotJson

--- a/packages/darklang/json-rpc.dark
+++ b/packages/darklang/json-rpc.dark
@@ -1,0 +1,274 @@
+module Darklang =
+  /// https://www.jsonrpc.org/specification
+  ///
+  /// This is for the 2.0 version of the spec.
+  /// TODO consider versioning this module somehow
+  ///
+  /// note: this is currently assuming that the LSP server is prediminantly running as the server
+  /// tehnically, the LSP spec allows for the server to be the client, and the client to be the server
+  module JsonRPC =
+    // <aliases>
+    type Json = Stdlib.AltJson.Json
+    // </aliases>
+
+    let expectedJsonRpcVersion = "2.0"
+
+    type RequestId =
+      | Null
+      | Int of Int64
+      | String of String
+
+    module Request =
+      type RequestParams =
+        | Array of List<Json>
+        | Object of List<String * Json>
+
+      /// A single message from an LSP Client to an LSP Server
+      ///
+      /// Note: when the `id` is `None`, this is referred to as a "notification"
+      type Request =
+        { id: Stdlib.Option.Option<RequestId>
+          method: String
+          ``params``: Stdlib.Option.Option<RequestParams> }
+
+
+      module Parsing =
+        type ParseError =
+          // must be an object `{...}`)
+          | NotObject of Json
+
+          /// must be provided
+          | MissingJsonRpcField
+
+          /// must be `String "2.0"` exactly
+          | InvalidJsonRpcField of actual: Json
+
+          /// can be missing, but otherwise must be null, a String, or a Number
+          | InvalidIdField of actual: Json
+
+          /// must be provided
+          | MissingMethodField of id: Stdlib.Option.Option<RequestId>
+
+          /// must be a string
+          | InvalidMethodField of id: Stdlib.Option.Option<RequestId> * actual: Json
+
+          /// can be missing, but otherwise must be an array or an object
+          | InvalidParamsField of id: Stdlib.Option.Option<RequestId> * actual: Json
+
+
+
+        // all requests, whether sent by themselves or in a batch,
+        // must have a `jsonrpc` field, and its value must be exactly "2.0"
+        let validateJsonRpcVersionField
+          (fields: List<String * Json>)
+          : Stdlib.Result.Result<Unit, ParseError> =
+          match Stdlib.List.findFirst fields (fun (k, v) -> k == "jsonrpc") with
+          | Some((_, String "2.0")) -> Stdlib.Result.Result.Ok()
+
+          | None -> Stdlib.Result.Result.Error(ParseError.MissingJsonRpcField)
+
+          | Some(_, invalidJsonRpc) ->
+            Stdlib.Result.Result.Error(ParseError.InvalidJsonRpcField invalidJsonRpc)
+
+
+        // If `id` is provided, it must be a Json.Null, .String, or .Number
+        // If it's not provided, that's OK -- it's a notification we don't have to respond to!
+        let extractIdFromRequest
+          (fields: List<String * Json>)
+          : Stdlib.Result.Result<Stdlib.Option.Option<RequestId>, ParseError> =
+          match Stdlib.List.findFirst fields (fun (k, v) -> k == "id") with
+
+          // none provided - fine - notification
+          | None -> Stdlib.Result.Result.Ok(Stdlib.Option.Option.None)
+
+          // can be null, a string, or a number
+          | Some((_, Null)) ->
+            RequestId.Null |> Stdlib.Option.Option.Some |> Stdlib.Result.Result.Ok
+          | Some((_, String s)) ->
+            (RequestId.String s)
+            |> Stdlib.Option.Option.Some
+            |> Stdlib.Result.Result.Ok
+          | Some((_, Number n)) ->
+            (Stdlib.Float.floor n)
+            |> RequestId.Int
+            |> Stdlib.Option.Option.Some
+            |> Stdlib.Result.Result.Ok
+
+          // otherwise, invalid
+          | Some((_, invalidId)) ->
+            Stdlib.Result.Result.Error(ParseError.InvalidIdField invalidId)
+
+
+        // for each request, a `method` field must be present, and must be a string
+        let extractMethodFromRequest
+          (requestId: Stdlib.Option.Option<RequestId>)
+          (fields: List<String * Json>)
+          : Stdlib.Result.Result<String, ParseError> =
+          match Stdlib.List.findFirst fields (fun (k, v) -> k == "method") with
+          | Some((_, String method)) -> Stdlib.Result.Result.Ok method
+
+          | Some((_, invalidMethod)) ->
+            Stdlib.Result.Result.Error(
+              ParseError.InvalidMethodField(requestId, invalidMethod)
+            )
+          | None ->
+            Stdlib.Result.Result.Error(ParseError.MissingMethodField requestId)
+
+
+        // can be missing, but if it's present it must be either:
+        // - an Array (with params by index)
+        // - or an Object (with params by name)
+        let extractParamsMaybeFromRequest
+          (requestId: Stdlib.Option.Option<RequestId>)
+          (fields: List<String * Json>)
+          : Stdlib.Result.Result<Stdlib.Option.Option<RequestParams>, ParseError> =
+          match Stdlib.List.findFirst fields (fun (k, v) -> k == "params") with
+          | None -> Stdlib.Option.Option.None |> Stdlib.Result.Result.Ok
+          | Some((_, Array p)) ->
+            (RequestParams.Array p)
+            |> Stdlib.Option.Option.Some
+            |> Stdlib.Result.Result.Ok
+          | Some((_, Object p)) ->
+            (RequestParams.Object p)
+            |> Stdlib.Option.Option.Some
+            |> Stdlib.Result.Result.Ok
+          | Some((_, invalidParams)) ->
+            Stdlib.Result.Result.Error(
+              ParseError.InvalidParamsField(requestId, invalidParams)
+            )
+
+
+        /// Parse a single json-rpc request
+        ///
+        /// e.g. `{ "jsonrpc": "2.0", "method": "$/logTrace", "params": { "message": "hello!" } }`
+        let parse (json: Json) : Stdlib.Result.Result<Request, ParseError> =
+
+          match json with
+          | Object o ->
+            Builtin.printLine "here6"
+            let idOrError = extractIdFromRequest o
+
+            // (this is just convenient for including in some errors)
+            let simplifiedIdMaybe = // : Option<RequestId>
+              match idOrError with
+              | Ok idMaybe -> idMaybe
+              | Error _ -> Stdlib.Option.Option.None
+
+            let method = extractMethodFromRequest simplifiedIdMaybe o
+
+            let ps = extractParamsMaybeFromRequest simplifiedIdMaybe o
+
+            match (validateJsonRpcVersionField o, idOrError, method, ps) with
+            | (Error jsonRpcFieldError, _, _, _) ->
+              Stdlib.Result.Result.Error(jsonRpcFieldError)
+            | (_, Error idError, _, _) -> Stdlib.Result.Result.Error(idError)
+            | (_, _, Error methodError, _) -> Stdlib.Result.Result.Error(methodError)
+            | (_, _, _, Error paramsError) -> Stdlib.Result.Result.Error(paramsError)
+
+            | (Ok(), Ok idMaybe, Ok method, Ok paramsMaybe) ->
+              (Request
+                { id = idMaybe
+                  method = method
+                  ``params`` = paramsMaybe })
+              |> Stdlib.Result.Result.Ok
+
+          | _ -> Stdlib.Result.Result.Error ParseError.NotObject
+
+
+      let makeString
+        (method: String)
+        (id: Stdlib.Option.Option<RequestId>)
+        (params: Stdlib.Option.Option<RequestParams>)
+        : String =
+        let fields =
+          [ Stdlib.Option.Option.Some(
+              ("jsonrpc", Json.String expectedJsonRpcVersion)
+            )
+
+            Stdlib.Option.Option.Some(("method", Json.String method))
+
+            (id
+             |> Stdlib.Option.map (fun id ->
+               let v =
+                 match id with
+                 | Null -> Json.Null
+                 | Int i -> Json.Number i
+                 | String s -> Json.String s
+
+               ("id", v)))
+
+            (params
+             |> Stdlib.Option.map (fun params ->
+               let v =
+                 match params with
+                 | Array a -> Json.Array a
+                 | Object o -> Json.Object o
+
+               ("params", v))) ]
+
+          |> Stdlib.List.filterMap (fun x -> x)
+
+        (Json.Object fields) |> Stdlib.AltJson.format
+
+
+
+      /// Note: a 'notification' is a 'request' where we don't care about the response
+      let makeNotificationString
+        (method: String)
+        (params: Stdlib.Option.Option<RequestParams>)
+        : String =
+        makeString method Stdlib.Option.Option.None params
+
+
+
+    module IncomingMessage =
+      // TODO: SingleResponse, BatchOfResponses
+      // (really rare in our use case, but possible per the spec)
+      type IncomingMessage =
+        | NotJson of String
+        | NotObjectOrArray of Json
+
+        | EmptyBatch
+
+        | SingleRequest of
+          Stdlib.Result.Result<Request.Request, Request.Parsing.ParseError>
+        | BatchOfRequests of
+          List<Stdlib.Result.Result<Request.Request, Request.Parsing.ParseError>>
+
+
+      let parse (jsonString: String) : IncomingMessage =
+        match Stdlib.AltJson.parse jsonString with
+        | Error _ -> IncomingMessage.NotJson jsonString
+        | Ok json ->
+          match json with
+          | Object o -> IncomingMessage.SingleRequest(Request.Parsing.parse json)
+          | Array items ->
+            match items |> Stdlib.List.map (fun r -> Request.Parsing.parse r) with
+            | [] -> IncomingMessage.EmptyBatch
+            | batch -> IncomingMessage.BatchOfRequests batch
+          | other -> IncomingMessage.NotObjectOrArray other
+
+
+
+    module Response =
+      module Ok =
+        let make (requestId: Stdlib.Option.Option<Int64>) (result: Json) : String =
+          (Json.Object
+            [ ("jsonrpc", Json.String "2.0"); ("id", requestId); ("result", result) ])
+          |> Stdlib.AltJson.format
+
+
+      module Error =
+        let make
+          (id: Stdlib.Option.Option<Int64>)
+          (errorCode: Int64)
+          (errorMessage: String)
+          : String =
+          (Json.Object
+            [ ("jsonrpc", Json.String "2.0")
+              ("id", id)
+              ("error",
+               Json.Object
+                 [ ("code", Json.Number(Int64.of_int errorCode))
+                   ("message", Json.String errorMessage) ]) ])
+          |> Stdlib.AltJson.format

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -30,7 +30,7 @@ module Darklang =
       /// TODO just separate the abstractions of 'handle request and send response' apart from 'send request and handle response'
       module JsonRPC =
         // <aliases>
-        type JToken = PACKAGE.Darklang.Stdlib.AltJson.JsonToken
+        type Json = PACKAGE.Darklang.Stdlib.AltJson.Json
         // </aliases>
 
         let expectedJsonRpcVersion = "2.0"
@@ -43,8 +43,8 @@ module Darklang =
 
         module IncomingRequest =
           type RequestParams =
-            | Array of List<JToken>
-            | Object of List<String * JToken>
+            | Array of List<Json>
+            | Object of List<String * Json>
 
         //   type Request =
         //     { jsonrpc: String // should always be "2.0"
@@ -56,25 +56,25 @@ module Darklang =
 
         //   type SingleRequestParseError =
         //     // must be an object `{...}`)
-        //     | NotObject of JToken
+        //     | NotObject of Json
 
         //     /// must be provided
         //     | MissingJsonRpcField
 
         //     /// must be `String "2.0"` exactly
-        //     | InvalidJsonRpcField of actual: JToken
+        //     | InvalidJsonRpcField of actual: Json
 
         //     /// can be missing, but otherwise must be null, a String, or a Number
-        //     | InvalidIdField of actual: JToken
+        //     | InvalidIdField of actual: Json
 
         //     /// must be provided
         //     | MissingMethodField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId>
 
         //     /// must be a string
-        //     | InvalidMethodField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: JToken
+        //     | InvalidMethodField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: Json
 
         //     /// can be missing, but otherwise must be an array or an object
-        //     | InvalidParamsField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: JToken
+        //     | InvalidParamsField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: Json
 
         //   type BatchRequestParseError =
         //     | EmptyArray // generally thse should just be ignored - don't return any response
@@ -96,7 +96,7 @@ module Darklang =
         //     | Batch of Array<Result<Request, SingleRequestParseError>>
 
 
-        // let parseSingleRequest (json: JToken): PACKAGE.Darklang.Stdlib.Result.Result<Request, SingleRequestParseError> =
+        // let parseSingleRequest (json: Json): PACKAGE.Darklang.Stdlib.Result.Result<Request, SingleRequestParseError> =
         //   match json with
         //   | Object o ->
         //     let jsonRpcFieldError =
@@ -127,7 +127,7 @@ module Darklang =
         //   | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None // TODO: invalid request thing
 
         // let parseRequest
-        //   (json: JToken)
+        //   (json: Json)
         //   : PACKAGE.Darklang.Stdlib.Option.Option<Request> =
         //   match json with
         //   | Object o ->
@@ -142,7 +142,7 @@ module Darklang =
         //   type ResponseSuccess =
         //     { jsonrpc: String // should always be "2.0"
         //       id: RequestId
-        //       result: JToken }
+        //       result: Json }
 
         //   type ResponseErrorDetails = { code: Int; message: String }
 
@@ -153,21 +153,21 @@ module Darklang =
 
         //   type Response = Result<ResponseSuccess, ResponseError>
 
-        //   let sendResponse (json: JToken): PACKAGE.Darklang.Stdlib.Result.Result<Response, String> =
+        //   let sendResponse (json: Json): PACKAGE.Darklang.Stdlib.Result.Result<Response, String> =
         //     match json with
         //     | Object o ->
 
 
         // type ServerConfig =
-        //   { handleIncomingRequest: Request -> JToken
-        //     onBatchRequest: Array<Request> -> Array<JToken> }
+        //   { handleIncomingRequest: Request -> Json
+        //     onBatchRequest: Array<Request> -> Array<Json> }
 
         // let runServerCliLoop () : Int =
         //   let incomingRequestRaw = Builtin.Stdin.readLine ()
 
         //   Builtin.printLine $"got request {incomingRequestRaw}"
 
-        //   match Builtin.AltJson.parseToken incomingRequestRaw with
+        //   match Builtin.AltJson.parse incomingRequestRaw with
         //   | Ok incomingRequest ->
         //     // TODO: validate that it's a valid JsonRPC 2.0 request and extract out id, method, params
         //     // TODO: call config.onRequest with the (id, method, params)
@@ -220,7 +220,7 @@ module Darklang =
         // (for requests that require a response, that is -- anything without an `id` can be ignored)
 
         // TODO:
-        // match Builtin.AltJson.parseToken incomingRequestRaw with
+        // match Builtin.AltJson.parse incomingRequestRaw with
         // | Ok incomingRequest ->
         //   // TODO: validate that it's a valid JsonRPC 2.0 request and extract out id, method, params
         //   // TODO: call config.onRequest with the (id, method, params)

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -1,198 +1,16 @@
 module Darklang =
   module LanguageTools =
-    /// This supports the Darklang-specific LSP server
+    /// This supports the Darklang-specific LSP (Language Server Protocol) server,
+    /// per the 3.17 spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification
     ///
-    /// There are 3 layers here:
-    /// - json-rpc support
-    ///   (targeted at 2.0 spec: https://www.jsonrpc.org/specification)
+    /// This LSP server is currently used by our in-progress VS Code Extension.
+    /// Namely, `LspServer.runServerCli` creates a long-running process that reads
+    /// incoming requests from stdin, and writes responses to stdout, following the LSP spec
     ///
-    /// - LSP (Language Server Protocol) support
-    ///   (targeted at 3.17 spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification)
+    /// This depends on json-rpc 2.0 support, currently in the @Darklang.JsonRPC module
     ///
-    /// - Darklang-specific language server (used in our VS Code Extension)
-    ///   - `LspServer.runServerCli` creates a long-running process that reads incoming requests
-    ///    from stdin, and writes responses to stdout, following the LSP spec
-    ///
-    /// TODO: some parts of this (like JsonRPC support, and general LSP support) should be abstracted
-    /// out at some point for general use, but let's see where this ends up before we consider that.
-    ///
-    /// Note: as such, this is meant for internal use only
+    /// TODO: some day, abstract out general LSP support in a separate module
     module LspServer =
-
-      /// https://www.jsonrpc.org/specification
-      ///
-      /// This is for the 2.0 version of the spec.
-      /// TODO consider versioning this module somehow
-      ///
-      /// note: this is currently assuming that the LSP server is prediminantly running as the server
-      /// tehnically, the LSP spec allows for the server to be the client, and the client to be the server
-      ///
-      /// TODO just separate the abstractions of 'handle request and send response' apart from 'send request and handle response'
-      module JsonRPC =
-        // <aliases>
-        type Json = PACKAGE.Darklang.Stdlib.AltJson.Json
-        // </aliases>
-
-        let expectedJsonRpcVersion = "2.0"
-
-        type RequestId =
-          | Null
-          | Int of Int
-          | String of String
-
-
-        module IncomingRequest =
-          type RequestParams =
-            | Array of List<Json>
-            | Object of List<String * Json>
-
-        //   type Request =
-        //     { jsonrpc: String // should always be "2.0"
-        //       id: PACKAGE.Darklang.Stdlib.Option.Option<RequestId>
-        //       method: String
-        //       ``params``: PACKAGE.Darklang.Stdlib.Option.Option<RequestParams> }
-
-
-
-        //   type SingleRequestParseError =
-        //     // must be an object `{...}`)
-        //     | NotObject of Json
-
-        //     /// must be provided
-        //     | MissingJsonRpcField
-
-        //     /// must be `String "2.0"` exactly
-        //     | InvalidJsonRpcField of actual: Json
-
-        //     /// can be missing, but otherwise must be null, a String, or a Number
-        //     | InvalidIdField of actual: Json
-
-        //     /// must be provided
-        //     | MissingMethodField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId>
-
-        //     /// must be a string
-        //     | InvalidMethodField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: Json
-
-        //     /// can be missing, but otherwise must be an array or an object
-        //     | InvalidParamsField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: Json
-
-        //   type BatchRequestParseError =
-        //     | EmptyArray // generally thse should just be ignored - don't return any response
-        //     | InvalidRequest of SingleRequestParseError
-
-        //   type ParseError =
-        //     | SingleRequestParseError of SingleRequestParseError
-        //     | BatchRequestParseError of BatchRequestParseError
-
-        //   type IncomingRequest =
-        //     // return invalid request thing
-        //     | NotJson of String
-
-        //     | SingleRequest of Result<Request, SingleRequestParseError>
-
-        //     // can just be ignored
-        //     | EmptyBatch
-
-        //     | Batch of Array<Result<Request, SingleRequestParseError>>
-
-
-        // let parseSingleRequest (json: Json): PACKAGE.Darklang.Stdlib.Result.Result<Request, SingleRequestParseError> =
-        //   match json with
-        //   | Object o ->
-        //     let jsonRpcFieldError =
-        //       match List.find (fun (k, v) -> k = "jsonrpc") o with
-        //       | Some (_, String "2.0") -> PACKAGE.Darklang.Stdlib.Option.Option.None // great
-        //       | None ->
-        //         PACKAGE.Darklang.Stdlib.Option.Option.Some (SingleRequestParseError.MissingJsonRpcField)
-        //       | Some (_, invalidJsonRpc) ->
-        //         PACKAGE.Darklang.Stdlib.Option.Option.Some (SingleRequestParseError.InvalidJsonRpcField invalidJsonRpc)
-
-        //     // TODO: only one if any
-        //     // TODO extract out value, ensure string or number or null
-        //     let id = List.find (fun (k, v) -> k = "id") o
-
-
-        //     // TODO: only one
-        //     // TODO: extract out value, ensure string
-        //     let method = List.find (fun (k, v) -> k = "method") o
-
-        //     // TODO only one
-        //     // TODO extract out value, ensure array or object
-        //     // TODO; deal with 'params' name being special
-        //     let params = List.find (fun (k, v) -> k = "params") o
-
-        //     // TODO a big `match`,
-        //     // TODO then return either Request (exclude jsonrpc version bit) or error
-
-        //   | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None // TODO: invalid request thing
-
-        // let parseRequest
-        //   (json: Json)
-        //   : PACKAGE.Darklang.Stdlib.Option.Option<Request> =
-        //   match json with
-        //   | Object o ->
-        //     parseSingleRequest json
-        //   | Array l ->
-        //     // TODO deal with batch requests
-        //     None
-        //   | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None // TODO: invalid request thing
-
-
-        // type OutgoingResponse =
-        //   type ResponseSuccess =
-        //     { jsonrpc: String // should always be "2.0"
-        //       id: RequestId
-        //       result: Json }
-
-        //   type ResponseErrorDetails = { code: Int; message: String }
-
-        //   type ResponseError =
-        //     { jsonrpc: String // should always be "2.0"
-        //       id: RequestId
-        //       error: ResponseErrorDetails }
-
-        //   type Response = Result<ResponseSuccess, ResponseError>
-
-        //   let sendResponse (json: Json): PACKAGE.Darklang.Stdlib.Result.Result<Response, String> =
-        //     match json with
-        //     | Object o ->
-
-
-        // type ServerConfig =
-        //   { handleIncomingRequest: Request -> Json
-        //     onBatchRequest: Array<Request> -> Array<Json> }
-
-        // let runServerCliLoop () : Int =
-        //   let incomingRequestRaw = Builtin.Stdin.readLine ()
-
-        //   Builtin.printLine $"got request {incomingRequestRaw}"
-
-        //   match Builtin.AltJson.parse incomingRequestRaw with
-        //   | Ok incomingRequest ->
-        //     // TODO: validate that it's a valid JsonRPC 2.0 request and extract out id, method, params
-        //     // TODO: call config.onRequest with the (id, method, params)
-        //     // TODO: config.onRequest should return a JsonToken
-        //     // TODO: validate that the response is a valid JsonRPC 2.0 response
-        //     // TODO: print the response (-> stdout for consumer)
-
-        //     runServerCliLoop config
-
-        //   | Error err ->
-        //     Builtin.printLine $"Error parsing incoming request: {err}"
-        //     1
-
-
-        // let runServerCli () : Int =
-        //   Builtin.printLine
-        //     "Running Darklang.LanguageTools.LspServer.JsonRPC.runServerCli"
-
-        //   runServerCliLoop ()
-
-        // this exists just to keep the above-commented code indented within its module
-        // (it'll be used soon, but if it's misindented in the meantime it's going to bug me)
-        let foo = "bar"
-
-
       let logFilePath = "/home/dark/app/rundir/logs/lsp-server.log"
 
       let log (input: String) : Unit =
@@ -201,42 +19,136 @@ module Darklang =
 
         ()
 
-      let logRequest (request: String) : Unit = log $"Request: {request}"
+      let logRequest (request: String) : Unit = log $"From client: {request}"
 
 
-      let logAndRespond (response: String) : Unit =
-        log $"Response: {response}"
+      let logAndSendToClient (response: String) : Unit =
+        log $"To client: {response}"
 
-        let contentLength = response |> Stdlib.String.length |> Stdlib.Int.toString
-        Builtin.printLine $"Content-Length: {contentLength}\r\n\r\n{response}"
+        let contentLengthInBytes =
+          response
+          |> Stdlib.String.toBytes_v0
+          |> Stdlib.Bytes.length
+          |> Stdlib.Int64.toString
+
+        Builtin.print $"Content-Length: {contentLengthInBytes}\r\n\r\n{response}"
 
 
-      let runServerCliLoop () : Int =
-        let incomingRequestRaw = Builtin.LanguageServerProtocol.readNextMessage ()
-        log $"Request: {incomingRequestRaw}"
+      // TODO maybe this should return a Result eventually,
+      // and Error if we don't get a proper LSP message
+      let readMessageFromClient () : String =
+        Builtin.Danger.LanguageServerProtocol.readNextMessage ()
 
-        // for now, we're just logging the incoming requests
-        // shortly, we'll need to parse them, and respond to them appropriately
-        // (for requests that require a response, that is -- anything without an `id` can be ignored)
 
-        // TODO:
-        // match Builtin.AltJson.parse incomingRequestRaw with
-        // | Ok incomingRequest ->
-        //   // TODO: validate that it's a valid JsonRPC 2.0 request and extract out id, method, params
-        //   // TODO: call config.onRequest with the (id, method, params)
-        //   // TODO: config.onRequest should return a JsonToken
-        //   // TODO: validate that the response is a valid JsonRPC 2.0 response
-        //   // TODO: print the response (-> stdout for consumer)
+      /// returns `true` if we got a shutdown request
+      ///
+      /// maybe we should instead return some DU here, with "Shutdown" as a case?
+      /// or a list of DUs - like actions, including returning responses?
+      let handleRequest (r: JsonRPC.Request.Request) : Bool =
+        match r.method, r.id with
+        // -- Lifecycle and general support
+        | ("initialized", None) ->
+          log "(ignore)"
+          false
 
-        //   runServerCliLoop config
+        | ("initialize", None) ->
+          log "TODO: fail - we shouldn't be seeing a second one of these"
+          false
 
-        // | Error err ->
-        //   Builtin.printLine $"Error parsing incoming request: {err}"
-        //   1
+        | ("$/setTrace", None) ->
+          log "TODO we should do something with this"
+          false
 
-        runServerCliLoop ()
+        | ("shutdown", None) ->
+          log "shutting down"
+          true
 
-      let runServerCli (u: Unit) : Int =
+
+        // -- textDocument
+        | ("textDocument/didOpen", None) ->
+          log "TODO we should do something with this - like report problems"
+          false
+        | ("textDocument/didSave", None) ->
+          log "TODO we should do something with this - like report problems"
+          false
+
+
+        // -- other
+        | (other, _) ->
+          log $"TODO: we don't yet support this method: {other}"
+          false
+
+
+
+      let runServerCliLoop () : Int64 =
+        log "---"
+
+        let incomingMessageRaw = readMessageFromClient ()
+        logRequest incomingMessageRaw
+
+
+        let shouldShutdown =
+          match JsonRPC.IncomingMessage.parse incomingMessageRaw with
+          // # Things we want/expect
+
+          | SingleRequest(Ok(jsonRpcRequest)) ->
+            log $"Parsed incoming message as single JSON-RPC request"
+            handleRequest jsonRpcRequest
+
+          | BatchOfRequests items ->
+            // TODO: need to reply in a batch as well
+            log "TODO - Got batch request; not yet set to handle these"
+            false
+
+
+          // # Errors
+
+          // was an object {} but not a valid json-rpc 2.0 _request_
+          // (note: could have been a valid _response_ though - we don't yet have good support for that)
+          | SingleRequest(Error(singleRequestParseError)) ->
+            // TODO match on singleRequestParseError, and return proper error-specific responses
+
+            log
+              $"Error parsing incoming message as json-rpc request:\n{incomingMessageRaw}"
+
+            logAndSendToClient
+              """{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"""
+
+            false
+
+
+          | NotJson ->
+            log
+              $"Error parsing incoming message as json:\n{incomingMessageRaw}\nError: {PACKAGE.Darklang.Stdlib.AltJson.ParseError.toString err}"
+
+            logAndSendToClient
+              """{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"""
+
+            false
+
+
+          | NotObjectOrArray ->
+            log $"Error parsing incoming message as json-rpc:\n{incomingMessageRaw}"
+
+            logAndSendToClient
+              """{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null}"""
+
+            false
+
+
+          // The json-rpc spec says to just ignore any incoming messages of `[]`
+          | EmptyBatch ->
+            log "ignoring empty batch"
+            false
+
+
+        // shut down if instructed, or listen for the next message
+        if shouldShutdown then 0L else (runServerCliLoop ())
+
+
+
+      let runServerCli (u: Unit) : Int64 =
+        // clear `lsp.log`
         let _deleted = Builtin.File.delete logFilePath
 
         let nowStr =
@@ -253,11 +165,32 @@ module Darklang =
         // responding with a static set of capabilities of the server
         //
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
-        let incomingRequestRaw = Builtin.LanguageServerProtocol.readNextMessage ()
-        logRequest incomingRequestRaw
+        let incomingMessageRaw = readMessageFromClient ()
+        logRequest incomingMessageRaw
 
-        logAndRespond
+
+        // Let's demonstrate that the server is waking up.
+        // These are (basically) the only things we're allowed to do before
+        // returning the initialize response
+        logAndSendToClient
+          """{ "jsonrpc": "2.0", "method": "$/logTrace", "params": { "message": "hi I'm an early trace" } }"""
+
+        logAndSendToClient
+          """{ "jsonrpc":"2.0", "method":"window/showMessage", "params":{"type":3,"message":"wow cool, a second message from the server came in"}}"""
+
+        logAndSendToClient
+          """{ "jsonrpc":"2.0", "method":"window/logMessage", "params":{"type":1,"message":"just logging a message"}}"""
+
+
+
+        // finally, reply to the initialize request
+        logAndSendToClient
           """{"jsonrpc":"2.0","id":0,"result":{"capabilities":{"completionProvider":{"resolveProvider":true},"textDocumentSync":1}}}"""
+
+
+        // trying to get the `Darklang LSP - Server` output logs to show up...
+        logAndSendToClient
+          """{ "jsonrpc": "2.0", "method": "$/logTrace", "params": { "message": "hi I'm a trace after initialize" } }"""
 
 
         // now that _that_ is out of the way, we can start responding to normal requests

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -1,0 +1,264 @@
+module Darklang =
+  module LanguageTools =
+    /// This supports the Darklang-specific LSP server
+    ///
+    /// There are 3 layers here:
+    /// - json-rpc support
+    ///   (targeted at 2.0 spec: https://www.jsonrpc.org/specification)
+    ///
+    /// - LSP (Language Server Protocol) support
+    ///   (targeted at 3.17 spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification)
+    ///
+    /// - Darklang-specific language server (used in our VS Code Extension)
+    ///   - `LspServer.runServerCli` creates a long-running process that reads incoming requests
+    ///    from stdin, and writes responses to stdout, following the LSP spec
+    ///
+    /// TODO: some parts of this (like JsonRPC support, and general LSP support) should be abstracted
+    /// out at some point for general use, but let's see where this ends up before we consider that.
+    ///
+    /// Note: as such, this is meant for internal use only
+    module LspServer =
+
+      /// https://www.jsonrpc.org/specification
+      ///
+      /// This is for the 2.0 version of the spec.
+      /// TODO consider versioning this module somehow
+      ///
+      /// note: this is currently assuming that the LSP server is prediminantly running as the server
+      /// tehnically, the LSP spec allows for the server to be the client, and the client to be the server
+      ///
+      /// TODO just separate the abstractions of 'handle request and send response' apart from 'send request and handle response'
+      module JsonRPC =
+        // <aliases>
+        type JToken = PACKAGE.Darklang.Stdlib.AltJson.JsonToken
+        // </aliases>
+
+        let expectedJsonRpcVersion = "2.0"
+
+        type RequestId =
+          | Null
+          | Int of Int
+          | String of String
+
+
+        module IncomingRequest =
+          type RequestParams =
+            | Array of Array<JToken>
+            | Object of Array<String * JToken>
+
+        //   type Request =
+        //     { jsonrpc: String // should always be "2.0"
+        //       id: PACKAGE.Darklang.Stdlib.Option.Option<RequestId>
+        //       method: String
+        //       ``params``: PACKAGE.Darklang.Stdlib.Option.Option<RequestParams> }
+
+
+
+        //   type SingleRequestParseError =
+        //     // must be an object `{...}`)
+        //     | NotObject of JToken
+
+        //     /// must be provided
+        //     | MissingJsonRpcField
+
+        //     /// must be `String "2.0"` exactly
+        //     | InvalidJsonRpcField of actual: JToken
+
+        //     /// can be missing, but otherwise must be null, a String, or a Number
+        //     | InvalidIdField of actual: JToken
+
+        //     /// must be provided
+        //     | MissingMethodField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId>
+
+        //     /// must be a string
+        //     | InvalidMethodField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: JToken
+
+        //     /// can be missing, but otherwise must be an array or an object
+        //     | InvalidParamsField of PACKAGE.Darklang.Stdlib.Option.Option<RequestId> * actual: JToken
+
+        //   type BatchRequestParseError =
+        //     | EmptyArray // generally thse should just be ignored - don't return any response
+        //     | InvalidRequest of SingleRequestParseError
+
+        //   type ParseError =
+        //     | SingleRequestParseError of SingleRequestParseError
+        //     | BatchRequestParseError of BatchRequestParseError
+
+        //   type IncomingRequest =
+        //     // return invalid request thing
+        //     | NotJson of String
+
+        //     | SingleRequest of Result<Request, SingleRequestParseError>
+
+        //     // can just be ignored
+        //     | EmptyBatch
+
+        //     | Batch of Array<Result<Request, SingleRequestParseError>>
+
+
+        // let parseSingleRequest (json: JToken): PACKAGE.Darklang.Stdlib.Result.Result<Request, SingleRequestParseError> =
+        //   match json with
+        //   | Object o ->
+        //     let jsonRpcFieldError =
+        //       match List.find (fun (k, v) -> k = "jsonrpc") o with
+        //       | Some (_, String "2.0") -> PACKAGE.Darklang.Stdlib.Option.Option.None // great
+        //       | None ->
+        //         PACKAGE.Darklang.Stdlib.Option.Option.Some (SingleRequestParseError.MissingJsonRpcField)
+        //       | Some (_, invalidJsonRpc) ->
+        //         PACKAGE.Darklang.Stdlib.Option.Option.Some (SingleRequestParseError.InvalidJsonRpcField invalidJsonRpc)
+
+        //     // TODO: only one if any
+        //     // TODO extract out value, ensure string or number or null
+        //     let id = List.find (fun (k, v) -> k = "id") o
+
+
+        //     // TODO: only one
+        //     // TODO: extract out value, ensure string
+        //     let method = List.find (fun (k, v) -> k = "method") o
+
+        //     // TODO only one
+        //     // TODO extract out value, ensure array or object
+        //     // TODO; deal with 'params' name being special
+        //     let params = List.find (fun (k, v) -> k = "params") o
+
+        //     // TODO a big `match`,
+        //     // TODO then return either Request (exclude jsonrpc version bit) or error
+
+        //   | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None // TODO: invalid request thing
+
+        // let parseRequest
+        //   (json: JToken)
+        //   : PACKAGE.Darklang.Stdlib.Option.Option<Request> =
+        //   match json with
+        //   | Object o ->
+        //     parseSingleRequest json
+        //   | Array l ->
+        //     // TODO deal with batch requests
+        //     None
+        //   | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None // TODO: invalid request thing
+
+
+        // type OutgoingResponse =
+        //   type ResponseSuccess =
+        //     { jsonrpc: String // should always be "2.0"
+        //       id: RequestId
+        //       result: JToken }
+
+        //   type ResponseErrorDetails = { code: Int; message: String }
+
+        //   type ResponseError =
+        //     { jsonrpc: String // should always be "2.0"
+        //       id: RequestId
+        //       error: ResponseErrorDetails }
+
+        //   type Response = Result<ResponseSuccess, ResponseError>
+
+        //   let sendResponse (json: JToken): PACKAGE.Darklang.Stdlib.Result.Result<Response, String> =
+        //     match json with
+        //     | Object o ->
+
+
+        // type ServerConfig =
+        //   { handleIncomingRequest: Request -> JToken
+        //     onBatchRequest: Array<Request> -> Array<JToken> }
+
+        // let runServerCliLoop () : Int =
+        //   let incomingRequestRaw = Builtin.Stdin.readLine ()
+
+        //   Builtin.printLine $"got request {incomingRequestRaw}"
+
+        //   match Builtin.AltJson.parseToken incomingRequestRaw with
+        //   | Ok incomingRequest ->
+        //     // TODO: validate that it's a valid JsonRPC 2.0 request and extract out id, method, params
+        //     // TODO: call config.onRequest with the (id, method, params)
+        //     // TODO: config.onRequest should return a JsonToken
+        //     // TODO: validate that the response is a valid JsonRPC 2.0 response
+        //     // TODO: print the response (-> stdout for consumer)
+
+        //     runServerCliLoop config
+
+        //   | Error err ->
+        //     Builtin.printLine $"Error parsing incoming request: {err}"
+        //     1
+
+
+        // let runServerCli () : Int =
+        //   Builtin.printLine
+        //     "Running Darklang.LanguageTools.LspServer.JsonRPC.runServerCli"
+
+        //   runServerCliLoop ()
+
+        // this exists just to keep the above-commented code indented within its module
+        // (it'll be used soon, but if it's misindented in the meantime it's going to bug me)
+        let foo = "bar"
+
+
+      let logFilePath = "/home/dark/app/rundir/logs/lsp-server.log"
+
+      let log (input: String) : Unit =
+        // returns Result -- ignored
+        let _logged = Builtin.File.appendText logFilePath (input ++ "\n")
+
+        ()
+
+      let logRequest (request: String) : Unit = log $"Request: {request}"
+
+
+      let logAndRespond (response: String) : Unit =
+        log $"Response: {response}"
+
+        let contentLength = response |> Stdlib.String.length |> Stdlib.Int.toString
+        Builtin.printLine $"Content-Length: {contentLength}\r\n\r\n{response}"
+
+
+      let runServerCliLoop () : Int =
+        let incomingRequestRaw = Builtin.LanguageServerProtocol.readNextMessage ()
+        log $"Request: {incomingRequestRaw}"
+
+        // for now, we're just logging the incoming requests
+        // shortly, we'll need to parse them, and respond to them appropriately
+        // (for requests that require a response, that is -- anything without an `id` can be ignored)
+
+        // TODO:
+        // match Builtin.AltJson.parseToken incomingRequestRaw with
+        // | Ok incomingRequest ->
+        //   // TODO: validate that it's a valid JsonRPC 2.0 request and extract out id, method, params
+        //   // TODO: call config.onRequest with the (id, method, params)
+        //   // TODO: config.onRequest should return a JsonToken
+        //   // TODO: validate that the response is a valid JsonRPC 2.0 response
+        //   // TODO: print the response (-> stdout for consumer)
+
+        //   runServerCliLoop config
+
+        // | Error err ->
+        //   Builtin.printLine $"Error parsing incoming request: {err}"
+        //   1
+
+        runServerCliLoop ()
+
+      let runServerCli (u: Unit) : Int =
+        let _deleted = Builtin.File.delete logFilePath
+
+        let nowStr =
+          (PACKAGE.Darklang.Stdlib.DateTime.now_v0 ())
+          |> PACKAGE.Darklang.Stdlib.DateTime.toString
+
+        log $"Running Darklang LSP Server {nowStr}"
+
+
+        // The first thing we get is the `"method": "initialize"` request,
+        // which we need to respond to with the capabilities of the server
+        //
+        // At this point we are ignoring the body of this request, and just
+        // responding with a static set of capabilities of the server
+        //
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
+        let incomingRequestRaw = Builtin.LanguageServerProtocol.readNextMessage ()
+        logRequest incomingRequestRaw
+
+        logAndRespond
+          """{"jsonrpc":"2.0","id":0,"result":{"capabilities":{"completionProvider":{"resolveProvider":true},"textDocumentSync":1}}}"""
+
+
+        // now that _that_ is out of the way, we can start responding to normal requests
+        runServerCliLoop ()

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -43,8 +43,8 @@ module Darklang =
 
         module IncomingRequest =
           type RequestParams =
-            | Array of Array<JToken>
-            | Object of Array<String * JToken>
+            | Array of List<JToken>
+            | Object of List<String * JToken>
 
         //   type Request =
         //     { jsonrpc: String // should always be "2.0"

--- a/packages/darklang/languageTools/lsp.dark
+++ b/packages/darklang/languageTools/lsp.dark
@@ -5,6 +5,10 @@ module Darklang =
     //
     // some of these types are somewaht general to the LSP spec,
     // others are specific to our implementation
+    //
+    // Note: this was written as a backend to support a middle-man Node LSP server. This
+    // should all be migrated elsewhere shortly, as we remove that server in favor of
+    // one written in Darklang. TODO
     module LanguageServerProtocol =
       /// A tagging type for string properties that are actually document URIs.
       type DocumentUri = String

--- a/packages/darklang/stdlib/alt-json.dark
+++ b/packages/darklang/stdlib/alt-json.dark
@@ -1,27 +1,24 @@
 module Darklang =
   module Stdlib =
     module AltJson =
-      type JsonToken =
+      type Json =
         | Null
         | Bool of Bool
         | Number of Float
         | String of String
-        | Array of List<JsonToken>
-        | Object of List<String * JsonToken>
+        | Array of List<Json>
+        | Object of List<String * Json>
 
 
-      module TokenParseError =
-        type TokenParseError = | NotJson
+      module ParseError =
+        type ParseError = | NotJson
 
-        let toString (e: TokenParseError) : String =
+        let toString (e: ParseError) : String =
           match e with
           | NotJson -> "Not JSON"
 
 
-      let serializeToken (token: JsonToken) : String =
-        Builtin.AltJson.serializeToken token
+      let format (j: Json) : String = Builtin.AltJson.format j
 
-      let parseToken
-        (jsonString: String)
-        : Result.Result<JsonToken, TokenParseError.TokenParseError> =
-        Builtin.AltJson.parseToken jsonString
+      let parse (jsonString: String) : Result.Result<Json, ParseError.ParseError> =
+        Builtin.AltJson.parse jsonString

--- a/scripts/run-cli
+++ b/scripts/run-cli
@@ -12,6 +12,10 @@ do
   esac
 done
 
+
+LOGS="${DARK_CONFIG_RUNDIR}/logs"
+CLI_LOG="$LOGS/cli.log"
+
 if [[ "$PUBLISHED" == "true" ]]; then
   EXE="backend/Build/out/Cli/Release/net7.0/linux-x64/publish/Cli"
 else
@@ -28,4 +32,4 @@ do
   fi
 done
 
-"${EXE}" "$@"
+"${EXE}" "$@" 2>&1 | tee "${CLI_LOG}"

--- a/user-code/darklang/scripts/language-server.dark
+++ b/user-code/darklang/scripts/language-server.dark
@@ -1,0 +1,1 @@
+PACKAGE.Darklang.LanguageTools.LspServer.runServerCli ()

--- a/vscode-extension/client/src/extension.ts
+++ b/vscode-extension/client/src/extension.ts
@@ -13,7 +13,7 @@ import {
 
 let client: LanguageClient;
 
-const useDarklangServer = false;
+const useDarklangServer = true;
 
 export function activate(context: ExtensionContext) {
   const sharedDarklangServerOptions = {
@@ -23,6 +23,7 @@ export function activate(context: ExtensionContext) {
       "./scripts/run-cli",
       "./user-code/darklang/scripts/language-server.dark",
     ],
+    transport: TransportKind.stdio,
   };
   const darklangServerOptions: ServerOptions = {
     run: sharedDarklangServerOptions,
@@ -62,7 +63,7 @@ export function activate(context: ExtensionContext) {
     serverOptions,
     clientOptions,
   );
-  client.registerFeature(new SemanticTokensFeature(client));
+  //client.registerFeature(new SemanticTokensFeature(client));
   client.trace = Trace.Verbose;
   client.start();
 }

--- a/vscode-extension/client/src/extension.ts
+++ b/vscode-extension/client/src/extension.ts
@@ -13,14 +13,34 @@ import {
 
 let client: LanguageClient;
 
+const useDarklangServer = false;
+
 export function activate(context: ExtensionContext) {
-  const serverModule: string = context.asAbsolutePath(
-    path.join("server", "out", "server.js"),
-  );
-  const serverOptions: ServerOptions = {
-    run: { module: serverModule, transport: TransportKind.ipc },
-    debug: { module: serverModule, transport: TransportKind.ipc },
+  const sharedDarklangServerOptions = {
+    options: { cwd: "/home/dark/app" },
+    command: "bash",
+    args: [
+      "./scripts/run-cli",
+      "./user-code/darklang/scripts/language-server.dark",
+    ],
   };
+  const darklangServerOptions: ServerOptions = {
+    run: sharedDarklangServerOptions,
+    debug: sharedDarklangServerOptions,
+  };
+
+  const sharedNodeServerOptions = {
+    module: context.asAbsolutePath(path.join("server", "out", "server.js")),
+    transport: TransportKind.ipc,
+  };
+  const nodeServerOptions: ServerOptions = {
+    run: sharedNodeServerOptions,
+    debug: sharedNodeServerOptions,
+  };
+
+  const serverOptions = useDarklangServer
+    ? darklangServerOptions
+    : nodeServerOptions;
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "darklang" }],

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "^4.9.4"
       },
       "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.83.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/vscode-extension/server/src/server.ts
+++ b/vscode-extension/server/src/server.ts
@@ -151,6 +151,7 @@ connection.onInitialize(async (params: InitializeParams) => {
     },
   };
 
+  //console.log("initialization result: ", JSON.stringify(result));
   return result;
 });
 


### PR DESCRIPTION
supporting work:
- remove `Builtin.File.append` (broken, ambiguous) with `Builtin.File.appendText` (working, clear)
- update `AltJson` module a bit, mostly removing "token" wording
  - rename `type JsonToken` to just `type Json`
  - rename fn `parseToken` to just `parse`
  - rename fn `serialize` to `format`
- `run-cli` now logs stdout+stderr to `rundir/logs/cli.log` (_so_ helpful)

actual improvements:
- added `Builtin.Danger.LanguageServerProtocol.readNextMessage` to read incoming messages
  - because... I'm not sure why - I had issues trying to replicate this with `Builtin.Stdin.readLine` but I'm sure it's solveable :arrow_down: 
  - TODO added to remove this in favor of a new Builtin fn or two
- add `@Darklang.JsonRPC` module corresponding to the json-rpc 2.0 spec. I really like how this turned out.
- add `@Darklang.LanguageTools.LspServer` module with `.runServerCli` to be run via `run-cli` script to act as our VS Code Extension's LSP Server
  - logs to `rundir/logs/lsp.log` 
- updated `vscode-extension` to point to the new Darklang LSP Server, based on a hardcoded boolean toggle