### PR TITLE
Update copy of built tree-sitter.so in devcontainer start-up

### DIFF
--- a/scripts/devcontainer/_vscode-post-start-command
+++ b/scripts/devcontainer/_vscode-post-start-command
@@ -4,7 +4,14 @@ set -euo pipefail
 
 
 echo "Copying tree-sitter.so to backend/src/LibTreeSitter"
-mv /home/dark/tree-sitter.so /home/dark/app/backend/src/LibTreeSitter/tree-sitter.so
+TREE_SITTER_SOURCE="/home/dark/tree-sitter.so"
+TREE_SITTER_TARGET="/home/dark/app/backend/src/LibTreeSitter/tree-sitter.so"
+if [ -e "$TREE_SITTER_SOURCE" ]; then
+    mv "$TREE_SITTER_SOURCE" "$TREE_SITTER_TARGET"
+elif [ ! -e "$TREE_SITTER_TARGET" ]; then
+    echo "Error: Source does not exist and target is missing."
+    exit 1
+fi
 
 
 echo "Starting build server"


### PR DESCRIPTION
I noticed that devcontainer start-up was failing after the first build, since the `mv`'s _source_ doesn't exist unless the container was _just_ built