### PR TITLE
Build parser before backend

### DIFF
--- a/scripts/build/compile
+++ b/scripts/build/compile
@@ -283,6 +283,10 @@ class Should:
 
 def execute(should):
   success = True
+
+  if should.build_parser:
+    if not build_parser(): success = False
+
   # Fast path: get the important stuff built first
   if should.fsharp_tool_restore:
     if not fsharp_tool_restore(): success = False
@@ -349,9 +353,6 @@ def execute(should):
 
   if should.terraform_validate:
     if not terraform_validate(): success = False
-
-  if should.build_parser:
-    if not build_parser(): success = False
 
   return success
 

--- a/scripts/devcontainer/_vscode-post-start-command
+++ b/scripts/devcontainer/_vscode-post-start-command
@@ -3,14 +3,14 @@
 set -euo pipefail
 
 
-echo "Copying tree-sitter.so to backend/src/LibTreeSitter"
+echo "Copying tree-sitter.so (built in Dockerfile) to backend/src/LibTreeSitter (to P/Invoke against)"
 TREE_SITTER_SOURCE="/home/dark/tree-sitter.so"
 TREE_SITTER_TARGET="/home/dark/app/backend/src/LibTreeSitter/tree-sitter.so"
 if [ -e "$TREE_SITTER_SOURCE" ]; then
-    mv "$TREE_SITTER_SOURCE" "$TREE_SITTER_TARGET"
+  mv "$TREE_SITTER_SOURCE" "$TREE_SITTER_TARGET"
 elif [ ! -e "$TREE_SITTER_TARGET" ]; then
-    echo "Error: Source does not exist and target is missing."
-    exit 1
+  echo "Error: Source does not exist and target is missing."
+  exit 1
 fi
 
 


### PR DESCRIPTION
If we don't do this, the backend build will fail when trying to build the LibTreeSitter.Darklang project, as-is, (only) on the first build after a container rebuild.