### PR TITLE
Solidify Darklang LSP Support; handle document sync

### DIFF
--- a/packages/darklang/json-rpc.dark
+++ b/packages/darklang/json-rpc.dark
@@ -21,7 +21,7 @@ module Darklang =
     let requestIdToJson (id: RequestId) : Json =
       match id with
       | Null -> Json.Null
-      | Int i -> Json.Number i
+      | Int i -> Json.Number(Stdlib.Int64.toFloat i)
       | String s -> Json.String s
 
 
@@ -251,10 +251,17 @@ module Darklang =
 
     module Response =
       module Ok =
-        let make (requestId: Stdlib.Option.Option<Int64>) (result: Json) : String =
-          (Json.Object
-            [ ("jsonrpc", Json.String "2.0"); ("id", requestId); ("result", result) ])
-          |> Stdlib.AltJson.format
+        let make (requestId: Stdlib.Option.Option<Int64>) (result: Json) : Json =
+          [ Stdlib.Option.Option.Some(("jsonrpc", Json.String "2.0"))
+
+            (requestId
+             |> Stdlib.Option.map (fun id ->
+               ("id", requestIdToJson (RequestId.Int id))))
+
+            Stdlib.Option.Option.Some(("result", result)) ]
+
+          |> Stdlib.List.filterMap (fun x -> x)
+          |> Json.Object
 
       module Error =
         module KnownErrorCodes =

--- a/packages/darklang/languageServerProtocol/README.md
+++ b/packages/darklang/languageServerProtocol/README.md
@@ -1,0 +1,52 @@
+# Language Server Protocol support
+
+The `@Darklang.LanguageServerProtocol` module contains many types (and functions?)
+towards supporting the Language Server Protocol. This was written per the 3.17.0
+spec, found here: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification
+and is largely organized similarly to the spec.
+
+Base types are found in the `common.dark` file, most the rest of the files are
+organized by the LSP spec sections, and `io.dark` is the main entry point for handling
+incoming messages and dispatching responses and notifications to the client.
+(TODO nothing is actually in io.dark - it's a place for future abstraction)
+
+Note: this is framed largely as an LSP _Server_ specifically, although the spec
+notes that both parties may act as both client and server - we're ignoring that, as
+it's not really ever done in reality.
+
+Many types were borrowed from the most 'official' sample LSP server:
+https://github.com/microsoft/vscode-languageserver-node. The organization of that
+project is quite hard to follow, though, so we've reorganized things here.
+
+## Some terms
+
+- **client**: the editor that is using the LSP server
+- **server**: the LSP server
+- **client capabilities**: the capabilities that the client has, which the server
+  can use to determine what features to support (i.e. what messages to send).
+  These are sent by the client during the `initialize` handshake.
+- **server capabilities**: the capabilities that the server has, which the client
+  can use to determine what features to use (i.e. what messages to send).
+  These are sent by the server during the `initialize` handshake.
+- **document**: a file that is open in the client
+- **workspace**: the set of documents that are open in the client
+- **request**: a message sent from one LSP party to another, which expects a result (i.e. contains an `id`)
+- **result**: a message sent from one LSP party to another, in response to a request
+  (i.e. contains an `id` corresponding to an earlier request)
+- **notification**: a message sent from one LSP party to another, which does not expect a result
+- **message**: a general term for either a notification, request, or response (error or result)
+
+## Some patterns to follow per-file:
+
+- try to keep type names the same as the TypeScript ones in the spec
+
+- supporting types at the top
+- types around requests, results, and notifications in the middle
+- client/server capabilities at the end of the file
+
+## TODOs:
+
+- deal with @proposed
+- deal with @deprecated
+- any more @since?
+- deal with io.dark

--- a/packages/darklang/languageServerProtocol/common.dark
+++ b/packages/darklang/languageServerProtocol/common.dark
@@ -17,7 +17,75 @@ module Darklang =
     // TODO: maybe better constraints here
     type URI = String
 
+    let knownEOLs = [ "\n"; "\r\n"; "\r" ]
 
+
+    module Position =
+      /// Position in a text document expressed as zero-based line and character
+      /// offset. Clients and servers can agree on a different string encoding
+      /// representation (e.g. UTF-8). The client announces it's supported encoding
+      /// via the client capability [`general.positionEncodings`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#clientCapabilities).
+      /// The value is an array of position encodings the client supports, with
+      /// decreasing preference (e.g. the encoding at index `0` is the most preferred
+      /// one). To stay backwards compatible the only mandatory encoding is UTF-16
+      /// represented via the string `utf-16`. The server can pick one of the
+      /// encodings offered by the client and signals that encoding back to the
+      /// client via the initialize result's property
+      /// [`capabilities.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverCapabilities). If the string value
+      /// `utf-16` is missing from the client's capability `general.positionEncodings`
+      /// servers can safely assume that the client supports UTF-16. If the server
+      /// omits the position encoding in its initialize result the encoding defaults
+      /// to the string value `utf-16`. Implementation considerations: since the
+      /// conversion from one encoding into another requires the content of the
+      /// file / line the conversion is best done where the file is read which is
+      /// usually on the server side.
+      ///
+      /// Positions are line end character agnostic. So you can not specify a position
+      /// that denotes `\r|\n` or `\n|` where `|` represents the character offset.
+      type Position =
+        {
+          /// Line position in a document (zero-based).
+          ///
+          /// If a line number is greater than the number of lines in a document,
+          /// it defaults back to the number of lines in the document.
+          ///
+          /// If a line number is negative, it defaults to 0.
+          line: UInt64
+
+          /// Character offset on a line in a document (zero-based). The meaning of this
+          /// offset is determined by the negotiated `PositionEncodingKind`.
+          ///
+          /// If the character value is greater than the line length it defaults back
+          /// to the line length.
+          character: UInt64
+        }
+
+      let toJson (p: Position) : Json =
+        Json.Object
+          [ ("line", p.line |> Stdlib.UInt64.toFloat Json.Number)
+            ("character", p.character |> Stdlib.UInt64.toFloat |> Json.Number) ]
+
+    module Range =
+      type Range =
+        {
+          /// The range's start position.
+          start: Position.Position
+
+          /// The range's end position.
+          ``end``: Position.Position
+        }
+
+      let toJson (r: Range) : Json =
+        Json.Object
+          [ ("start", Position.toJson p.start); ("end", Position.toJson p.``end``) ]
+
+
+
+    module Location =
+      /// Represents a location inside a resource, such as a line
+      /// inside a text file.
+      type Location =
+        { uri: DocumentUri; range: Range.Range }
 
     module TextDocumentItem =
       /// An item to transfer a text document from the client to the server.
@@ -68,3 +136,816 @@ module Darklang =
           Stdlib.Result.Result.Ok(TextDocumentIdentifier { uri = uri })
         | _ -> Stdlib.Result.Result.Error()
 
+
+    module DiagnosticSeverity =
+      type DiagnosticSeverity =
+        | Error
+        | Warning
+        | Information
+        | Hint
+
+      let toJson (s: DiagnosticSeverity) : Json =
+        match s with
+        | Error -> Json.Number 1
+        | Warning -> Json.Number 2
+        | Information -> Json.Number 3
+        | Hint -> Json.Number 4
+
+      let fromJson (json: Json) : Stdlib.Result.Result<DiagnosticSeverity, Unit> =
+        match json with
+        | Number 1 -> DiagnosticSeverity.Error |> Stdlib.Result.Result.Ok
+        | Number 2 -> DiagnosticSeverity.Warning |> Stdlib.Result.Result.Ok
+        | Number 3 -> DiagnosticSeverity.Information |> Stdlib.Result.Result.Ok
+        | Number 4 -> DiagnosticSeverity.Hint |> Stdlib.Result.Result.Ok
+        | _ -> Stdlib.Result.Result.Error()
+
+    module DiagnosticTag =
+      type DiagnosticTag =
+
+        /// Unused or unnecessary code.
+        ///
+        /// Clients are allowed to render diagnostics with this tag faded out
+        /// instead of having an error squiggle.
+        | Unnecessary
+
+        /// Deprecated or obsolete code.
+        ///
+        /// Clients are allowed to rendered diagnostics with this tag strike through.
+        | Deprecated
+
+      let toJson (t: DiagnosticTag) : Json =
+        match t with
+        | Unnecessary -> Json.Number 1
+        | Deprecated -> Json.Number 2
+
+      let fromJson (json: Json) : Stdlib.Result.Result<DiagnosticTag, Unit> =
+        match json with
+        | Number 1 -> DiagnosticTag.Unnecessary |> Stdlib.Result.Result.Ok
+        | Number 2 -> DiagnosticTag.Deprecated |> Stdlib.Result.Result.Ok
+        | _ -> Stdlib.Result.Result.Error()
+
+    module DiagnosticRelatedInformation =
+      /// Represents a related message and source code location for a diagnostic. This should be
+      /// used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+      /// a symbol in a scope.
+      type DiagnosticRelatedInformation =
+        {
+          /// The location of this related diagnostic information.
+          location: Location.Location
+
+          /// The message of this related diagnostic information.
+          message: String
+        }
+
+    module CodeDescription =
+      /// Structure to capture a description for an error code.
+      type CodeDescription =
+        {
+          /// An URI to open with more information about the diagnostic error.
+          href: URI
+        }
+
+    module DiagnosticCode =
+      type DiagnosticCode =
+        | Number of Int64
+        | String of String
+
+    module Diagnostic =
+      type Diagnostic =
+        {
+          /// The range at which the message applies.
+          range: Range.Range
+
+          /// The diagnostic's severity. Can be omitted. If omitted it is up to the
+          /// client to interpret diagnostics as error, warning, info or hint.
+          severity: Stdlib.Option.Option<DiagnosticSeverity.DiagnosticSeverity>
+
+          /// The diagnostic's code, which might appear in the user interface.
+          code: Stdlib.Option.Option<DiagnosticCode.DiagnosticCode>
+
+          /// An optional property to describe the error code.
+          codeDescription: Stdlib.Option.Option<CodeDescription.CodeDescription>
+
+          /// A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.
+          source: Stdlib.Option.Option<String>
+
+          /// The diagnostic's message.
+          message: String
+
+          /// Additional metadata about the diagnostic.
+          tags: Stdlib.Option.Option<List<DiagnosticTag.DiagnosticTag>>
+
+          /// An array of related diagnostic information, e.g. when symbol-names within
+          /// a scope collide all definitions can be marked via this property.
+          relatedInformation:
+            Stdlib.Option.Option<List<DiagnosticRelatedInformation.DiagnosticRelatedInformation>>
+
+          /// A data entry field that is preserved between a
+          /// `textDocument/publishDiagnostics` notification and
+          /// `textDocument/codeAction` request.
+          data: Stdlib.Option.Option<Json>
+        }
+
+      let toJson (d: Diagnostic) : Json =
+        let fields = [] // TODO
+        Json.Object fields
+
+(* LSP Error Codes
+  export namespace LSPErrorCodes {
+    * This is the start range of LSP reserved error codes.
+    * It doesn't denote a real error code.
+    export const lspReservedErrorRangeStart: integer = -32899;
+
+    /// A request failed but it was syntactically correct, e.g the
+    /// method name was known and the parameters were valid. The error
+    /// message should contain human readable information about why
+    /// the request failed.
+    export const RequestFailed: integer = -32803;
+
+    /// The server cancelled the request. This error code should
+    /// only be used for requests that explicitly support being
+    /// server cancellable.
+    export const ServerCancelled: integer = -32802;
+
+    /// The server detected that the content of a document got
+    /// modified outside normal conditions. A server should
+    /// NOT send this error code if it detects a content change
+    /// in it unprocessed messages. The result even computed
+    /// on an older state might still be useful for the client.
+    ///
+    /// If a client decides that a result is not of any use anymore
+    /// the client should cancel the request.
+    export const ContentModified: integer = -32801;
+
+    /// The client has canceled a request and a server as detected
+    /// the cancel.
+    export const RequestCancelled: integer = -32800;
+
+    * This is the end range of LSP reserved error codes.
+    * It doesn't denote a real error code.
+    export const lspReservedErrorRangeEnd: integer = -32800;
+  }
+  export type LSPErrorCodes = integer;
+*)
+
+
+(*
+  These types are defined as part of the Microsoft/vscode-languageserver-node
+  repo, which is the canonical implementation of the LSP server. I've copied
+  them here, and tidied the cruft, to slowly port into our solution as-needed.
+
+  The original source does a good job of documenting which properties are and
+  are not necesarry, and we should use this information as we port the types in,
+  to decide how we define our corresponding Json mappers.
+
+
+
+  /// Defines an integer in the range of -2^31 to 2^31 - 1.
+  export type integer = number;
+
+  export namespace integer {
+    export const MIN_VALUE = -2147483648;
+    export const MAX_VALUE = 2147483647;
+  }
+
+  /// Defines an unsigned integer in the range of 0 to 2^31 - 1.
+  export type uinteger = number;
+
+  export namespace uinteger {
+    export const MIN_VALUE = 0;
+    export const MAX_VALUE = 2147483647;
+  }
+
+  /// Defines a decimal number. Since decimal numbers are very
+  /// rare in the language server specification we denote the
+  /// exact range with every decimal using the mathematics
+  /// interval notations (e.g. [0, 1] denotes all decimals d with
+  /// 0 <= d <= 1.
+  export type decimal = number;
+
+
+
+
+
+
+
+
+
+  /// Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},
+  /// including an origin range.
+  export interface LocationLink {
+    /// Span of the origin of this link.
+    ///
+    /// Used as the underlined span for mouse interaction. Defaults to the word range at
+    /// the definition position.
+    originSelectionRange?: Range;
+
+    /// The target resource identifier of this link.
+    targetUri: DocumentUri;
+
+    /// The full target range of this link. If the target for example is a symbol then target range is the
+    /// range enclosing this symbol not including leading/trailing whitespace but everything else
+    /// like comments. This information is typically used to highlight the range in the editor.
+    targetRange: Range;
+
+    /// The range that should be selected and revealed when this link is being followed, e.g the name of a function.
+    /// Must be contained by the `targetRange`. See also `DocumentSymbol#range`
+    targetSelectionRange: Range;
+  }
+
+
+
+
+
+
+
+  /// Represents a reference to a command. Provides a title which
+  /// will be used to represent a command in the UI and, optionally,
+  /// an array of arguments which will be passed to the command handler
+  /// function when invoked.
+  export interface Command {
+    /// Title of the command, like `save`.
+    title: string;
+
+    /// The identifier of the actual command handler.
+    command: string;
+
+    /// Arguments that the command handler should be
+    /// invoked with.
+    arguments?: LSPAny[];
+  }
+
+
+  /// A text edit applicable to a text document.
+  export interface TextEdit {
+    /// The range of the text document to be manipulated. To insert
+    /// text into a document create a range where start === end.
+    range: Range;
+
+    /// The string to be inserted. For delete operations use an empty string.
+    newText: string;
+  }
+
+
+  /// Additional information that describes document changes.
+  export interface ChangeAnnotation {
+    /// A human-readable string describing the actual change. The string
+    /// is rendered prominent in the user interface.
+    label: string;
+
+    /// A flag which indicates that user confirmation is needed before applying the change.
+    needsConfirmation?: boolean;
+
+    /// A human-readable string which is rendered less prominent in
+    /// the user interface.
+    description?: string;
+  }
+
+
+
+  /// An identifier to refer to a change annotation stored with a workspace edit.
+  export type ChangeAnnotationIdentifier = string;
+
+  /// A special text edit with an additional change annotation.
+  export interface AnnotatedTextEdit
+    extends
+      TextEdit {
+
+    /// The actual identifier of the change annotation
+    annotationId: ChangeAnnotationIdentifier;
+  }
+
+
+  /// Describes textual changes on a text document. A TextDocumentEdit describes all changes
+  /// on a document version Si and after they are applied move the document to version Si+1.
+  /// So the creator of a TextDocumentEdit doesn't need to sort the array of edits or do any
+  /// kind of ordering. However the edits must be non overlapping.
+  export interface TextDocumentEdit {
+    /// The text document to change.
+    textDocument: OptionalVersionedTextDocumentIdentifier;
+
+    /// The edits to be applied.
+    edits: (TextEdit | AnnotatedTextEdit)[];
+  }
+
+
+  /// A generic resource operation.
+  interface ResourceOperation {
+    /// The resource operation kind.
+    kind: string;
+
+    /// An optional annotation identifier describing the operation.
+    annotationId?: ChangeAnnotationIdentifier;
+  }
+
+  /// Options to create a file.
+  export interface CreateFileOptions {
+    /// Overwrite existing file. Overwrite wins over `ignoreIfExists`
+    overwrite?: boolean;
+
+    /// Ignore if exists.
+    ignoreIfExists?: boolean;
+  }
+
+  /// Create file operation.
+  export interface CreateFile
+    extends
+      ResourceOperation {
+
+    kind: 'create';
+
+    /// The resource to create.
+    uri: DocumentUri;
+
+    /// Additional options
+    options?: CreateFileOptions;
+  }
+
+
+  /// Rename file options
+  export interface RenameFileOptions {
+    /// Overwrite target if existing. Overwrite wins over `ignoreIfExists`
+    overwrite?: boolean;
+
+    /// Ignores if target exists.
+    ignoreIfExists?: boolean;
+  }
+
+  /// Rename file operation
+  export interface RenameFile
+    extends
+      ResourceOperation {
+
+    kind: 'rename';
+
+    /// The old (existing) location.
+    oldUri: DocumentUri;
+
+    /// The new location.
+    newUri: DocumentUri;
+
+    /// Rename options.
+    options?: RenameFileOptions;
+  }
+
+  /// Delete file options
+  export interface DeleteFileOptions {
+    /// Delete the content recursively if a folder is denoted.
+    recursive?: boolean;
+
+    /// Ignore the operation if the file doesn't exist.
+    ignoreIfNotExists?: boolean;
+  }
+
+  /// Delete file operation
+  export interface DeleteFile
+    extends
+      ResourceOperation {
+
+    /// A delete
+    kind: 'delete';
+
+    /// The file to delete.
+    uri: DocumentUri;
+
+    /// Delete options.
+    options?: DeleteFileOptions;
+  }
+
+  /// A workspace edit represents changes to many resources managed in the workspace. The edit
+  /// should either provide `changes` or `documentChanges`. If documentChanges are present
+  /// they are preferred over `changes` if the client can handle versioned document edits.
+  ///
+  /// Since version 3.13.0 a workspace edit can contain resource operations as well. If resource
+  /// operations are present clients need to execute the operations in the order in which they
+  /// are provided. So a workspace edit for example can consist of the following two changes:
+  /// (1) a create file a.txt and (2) a text document edit which insert text into file a.txt.
+  ///
+  /// An invalid sequence (e.g. (1) delete file a.txt and (2) insert text into file a.txt) will
+  /// cause failure of the operation. How the client recovers from the failure is described by
+  /// the client capability: `workspace.workspaceEdit.failureHandling`
+  export interface WorkspaceEdit {
+    /// Holds changes to existing resources.
+    changes?: { [uri: DocumentUri]: TextEdit[] };
+
+    /// Depending on the client capability `workspace.workspaceEdit.resourceOperations` document changes
+    /// are either an array of `TextDocumentEdit`s to express changes to n different text documents
+    /// where each text document edit addresses a specific version of a text document. Or it can contain
+    /// above `TextDocumentEdit`s mixed with create, rename and delete file / folder operations.
+    ///
+    /// Whether a client supports versioned document edits is expressed via
+    /// `workspace.workspaceEdit.documentChanges` client capability.
+    ///
+    /// If a client neither supports `documentChanges` nor `workspace.workspaceEdit.resourceOperations` then
+    /// only plain `TextEdit`s using the `changes` property are supported.
+    documentChanges?: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[];
+
+    /// A map of change annotations that can be referenced in `AnnotatedTextEdit`s or create, rename and
+    /// delete file / folder operations.
+    ///
+    /// Whether clients honor this property depends on the client capability `workspace.changeAnnotationSupport`.
+    changeAnnotations?: {
+      [id: ChangeAnnotationIdentifier]: ChangeAnnotation;
+    };
+  }
+
+
+
+  /// A literal to identify a text document in the client.
+  export interface TextDocumentIdentifier {
+    /// The text document's uri.
+    uri: DocumentUri;
+  }
+
+  /// A text document identifier to denote a specific version of a text document.
+  export interface VersionedTextDocumentIdentifier
+    extends
+      TextDocumentIdentifier {
+
+    /// The version number of this document.
+    version: integer;
+  }
+
+
+  /// A text document identifier to optionally denote a specific version of a text document.
+  export interface OptionalVersionedTextDocumentIdentifier
+    extends
+      TextDocumentIdentifier {
+
+    /// The version number of this document. If a versioned text document identifier
+    /// is sent from the server to the client and the file is not open in the editor
+    /// (the server has not received an open notification before) the server can send
+    /// `null` to indicate that the version is unknown and the content on disk is the
+    /// truth (as specified with document content ownership).
+    version: integer | null;
+  }
+
+
+
+
+
+  /// Describes the content type that a client supports in various
+  /// result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+  ///
+  /// Please note that `MarkupKinds` must not start with a `$`. This kinds
+  /// are reserved for internal usage.
+  export namespace MarkupKind {
+    /// Plain text is supported as a content format
+    export const PlainText: 'plaintext' = 'plaintext';
+
+    /// Markdown is supported as a content format
+    export const Markdown: 'markdown' = 'markdown';
+  }
+  export type MarkupKind = 'plaintext' | 'markdown';
+
+  /// A `MarkupContent` literal represents a string value which content is interpreted base on its
+  /// kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
+  ///
+  /// If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
+  /// See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+  ///
+  /// Here is an example how such a string can be constructed using JavaScript / TypeScript:
+  /// ```ts
+  /// let markdown: MarkdownContent = {
+  ///  kind: MarkupKind.Markdown,
+  ///  value: [
+  ///    '# Header',
+  ///    'Some text',
+  ///    '```typescript',
+  ///    'someCode();',
+  ///    '```'
+  ///  ].join('\n')
+  /// };
+  /// ```
+  ///
+  /// *Please Note* that clients might sanitize the return markdown. A client could decide to
+  /// remove HTML from the markdown to avoid script execution.
+  export interface MarkupContent {
+    /// The type of the Markup
+    kind: MarkupKind;
+
+    /// The content itself
+    value: string;
+  }
+
+
+
+
+
+
+
+
+
+
+
+
+  /// The definition of a symbol represented as one or many {@link Location locations}.
+  /// For most programming languages there is only one location at which a symbol is
+  /// defined.
+  ///
+  /// Servers should prefer returning `DefinitionLink` over `Definition` if supported
+  /// by the client.
+  export type Definition = Location | Location[];
+
+  /// Information about where a symbol is defined.
+  ///
+  /// Provides additional metadata over normal {@link Location location} definitions, including the range of
+  /// the defining symbol
+  export type DefinitionLink = LocationLink;
+
+  /// The declaration of a symbol representation as one or many {@link Location locations}.
+  export type Declaration = Location | Location[];
+
+  /// Information about where a symbol is declared.
+  ///
+  /// Provides additional metadata over normal {@link Location location} declarations, including the range of
+  /// the declaring symbol.
+  ///
+  /// Servers should prefer returning `DeclarationLink` over `Declaration` if supported
+  /// by the client.
+  export type DeclarationLink = LocationLink;
+
+  /// Value-object that contains additional information when
+  /// requesting references.
+  export interface ReferenceContext {
+    /// Include the declaration of the current symbol.
+    includeDeclaration: boolean;
+  }
+
+
+
+
+
+
+  /// A symbol kind.
+  export namespace SymbolKind {
+    export const File: 1 = 1;
+    export const Module: 2 = 2;
+    export const Namespace: 3 = 3;
+    export const Package: 4 = 4;
+    export const Class: 5 = 5;
+    export const Method: 6 = 6;
+    export const Property: 7 = 7;
+    export const Field: 8 = 8;
+    export const Constructor: 9 = 9;
+    export const Enum: 10 = 10;
+    export const Interface: 11 = 11;
+    export const Function: 12 = 12;
+    export const Variable: 13 = 13;
+    export const Constant: 14 = 14;
+    export const String: 15 = 15;
+    export const Number: 16 = 16;
+    export const Boolean: 17 = 17;
+    export const Array: 18 = 18;
+    export const Object: 19 = 19;
+    export const Key: 20 = 20;
+    export const Null: 21 = 21;
+    export const EnumMember: 22 = 22;
+    export const Struct: 23 = 23;
+    export const Event: 24 = 24;
+    export const Operator: 25 = 25;
+    export const TypeParameter: 26 = 26;
+  }
+  export type SymbolKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26;
+
+  /// Symbol tags are extra annotations that tweak the rendering of a symbol.
+  export namespace SymbolTag {
+    /// Render a symbol as obsolete, usually using a strike-out.
+    export const Deprecated: 1 = 1;
+  }
+  export type SymbolTag = 1;
+
+
+  /// A base for all symbol information.
+  export interface BaseSymbolInformation {
+    /// The name of this symbol.
+    name: string;
+
+    /// The kind of this symbol.
+    kind: SymbolKind;
+
+    /// Tags for this symbol.
+    tags?: SymbolTag[];
+
+    /// The name of the symbol containing this symbol. This information is for
+    /// user interface purposes (e.g. to render a qualifier in the user interface
+    /// if necessary). It can't be used to re-infer a hierarchy for the document
+    /// symbols.
+    containerName?: string;
+  }
+
+  /// Represents information about programming constructs like variables, classes,
+  /// interfaces etc.
+  export interface SymbolInformation
+    extends
+      BaseSymbolInformation {
+
+    /// The location of this symbol. The location's range is used by a tool
+    /// to reveal the location in the editor. If the symbol is selected in the
+    /// tool the range's start information is used to position the cursor. So
+    /// the range usually spans more than the actual symbol's name and does
+    /// normally include things like visibility modifiers.
+    ///
+    /// The range doesn't have to denote a node range in the sense of an abstract
+    /// syntax tree. It can therefore not be used to re-construct a hierarchy of
+    /// the symbols.
+    location: Location;
+  }
+
+
+
+
+
+
+
+
+
+  /// A workspace folder inside a client.
+  export interface WorkspaceFolder {
+    /// The associated URI for this workspace folder.
+    uri: URI;
+
+    /// The name of the workspace folder. Used to refer to this
+    /// workspace folder in the user interface.
+    name: string;
+  }
+
+
+
+
+
+
+  export interface WorkDoneProgressParams {
+    /// An optional token that a server can use to report work done progress.
+    workDoneToken?: ProgressToken;
+  }
+  export interface WorkDoneProgressOptions {
+    workDoneProgress?: boolean;
+  }
+
+  export interface PartialResultParams {
+    /// An optional token that a server can use to report partial results (e.g. streaming) to
+    /// the client.
+    partialResultToken?: ProgressToken;
+  }
+
+
+
+
+
+
+
+
+
+  /// A parameter literal used in requests to pass a text document and a position inside that
+  /// document.
+  export interface TextDocumentPositionParams {
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The position inside the text document.
+    position: Position;
+  }
+
+
+
+
+
+
+
+
+
+
+
+  /// Static registration options to be returned in the initialize request.
+  export interface StaticRegistrationOptions {
+    /// The id used to register the request. The id can be used to deregister
+    /// the request again. See also Registration#id.
+    id?: string;
+  }
+
+
+
+
+
+
+
+
+
+
+
+  /// A document filter where `language` is required field.
+  ///
+  /// @proposed
+  export interface TextDocumentFilterLanguage {
+    /// A language id, like `typescript`.
+    language: string;
+
+    /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+    scheme?: string;
+
+    /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
+    pattern?: string;
+  }
+
+  /// A document filter where `scheme` is required field.
+  ///
+  /// @proposed
+  export interface TextDocumentFilterScheme {
+    /// A language id, like `typescript`.
+    language?: string;
+
+    /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+    scheme: string;
+
+    /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
+    pattern?: string;
+  }
+
+
+  /// A document filter denotes a document by different properties like
+  /// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
+  /// its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
+  ///
+  /// Glob patterns can have the following syntax:
+  /// - `*` to match one or more characters in a path segment
+  /// - `?` to match on one character in a path segment
+  /// - `**` to match any number of path segments, including none
+  /// - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+  /// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+  /// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+  ///
+  /// @sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`
+  /// @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
+  export type TextDocumentFilter = TextDocumentFilterLanguage | TextDocumentFilterScheme;
+
+
+
+
+
+  /// A notebook document filter where `scheme` is required field.
+  ///
+  /// @proposed
+  export interface NotebookDocumentFilterScheme {
+    /// The type of the enclosing notebook.
+    notebookType?: string;
+
+    /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+    scheme: string;
+
+    /// A glob pattern.
+    pattern?: string;
+  }
+
+  /// A notebook document filter where `pattern` is required field.
+  ///
+  /// @proposed
+  export interface NotebookDocumentFilterPattern {
+    /// The type of the enclosing notebook.
+    notebookType?: string;
+
+    /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+    scheme?: string;
+
+    /// A glob pattern.
+    pattern: string;
+  }
+
+  /// A notebook document filter denotes a notebook document by
+  /// different properties. The properties will be match
+  /// against the notebook's URI (same as with documents)
+  export type NotebookDocumentFilter = NotebookDocumentFilterScheme | NotebookDocumentFilterPattern;
+
+
+  /// A notebook cell text document filter denotes a cell text
+  /// document by different properties.
+  export type NotebookCellTextDocumentFilter = {
+    /// A filter that matches against the notebook
+    /// containing the notebook cell. If a string
+    /// value is provided it matches against the
+    /// notebook type. '*' matches every notebook.
+    notebook: string | NotebookDocumentFilter;
+
+    /// A language id like `python`.
+    /// Will be matched against the language id of the
+    /// notebook cell document. '*' matches every language.
+    language?: string;
+  };
+
+
+  /// A document filter describes a top level text document or
+  /// a notebook cell document.
+  export type DocumentFilter = TextDocumentFilter | NotebookCellTextDocumentFilter;
+
+  /// A document selector is the combination of one or many document filters.
+  ///
+  /// @sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;
+  export type DocumentSelector = (DocumentFilter)[];
+
+  /// General text document registration options.
+  export interface TextDocumentRegistrationOptions {
+    /// A document selector to identify the scope of the registration. If set to null
+    /// the document selector provided on the client side will be used.
+    documentSelector: DocumentSelector | null;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/common.dark
+++ b/packages/darklang/languageServerProtocol/common.dark
@@ -1,0 +1,70 @@
+// All of the base / common types shared between the LSP client and server
+// explicitly does not include any messages, requests, or responses
+
+module Darklang =
+  /// Supporting types and functionality corresponding to the LSP 3.17.0 specification,
+  /// built as-needed for _our_ LSP Server implementation
+  module LanguageServerProtocol =
+    // <aliases>
+    type Json = Stdlib.AltJson.Json
+    // </aliases>
+
+
+    // TODO: maybe better constraints here
+    type DocumentUri = String
+
+    /// A tagging type for string properties that are actually URIs
+    // TODO: maybe better constraints here
+    type URI = String
+
+
+
+    module TextDocumentItem =
+      /// An item to transfer a text document from the client to the server.
+      type TextDocumentItem =
+        {
+          /// The text document's URI.
+          uri: DocumentUri
+
+          /// The text document's language identifier.
+          languageId: String
+
+          /// The version number of this document
+          /// (it will increase after each change, including undo/redo).
+          version: Int64
+
+          /// The content of the opened text document.
+          text: String
+        }
+
+      let toJson (i: TextDocumentItem) : Json =
+        [ ("uri", Json.String i.uri)
+          ("languageId", Json.String i.languageId)
+          ("version", Json.Number(Stdlib.Int64.toFloat i.version))
+          ("text", Json.String i.text) ]
+        |> Json.Object
+
+      let fromJson (json: Json) : Stdlib.Result.Result<TextDocumentItem, Unit> =
+        match Builtin.Json.parse<TextDocumentItem> json with
+        | Ok item -> Stdlib.Result.Result.Ok item
+        | Error _ -> Stdlib.Result.Result.Error()
+
+
+    module TextDocumentIdentifier =
+      type TextDocumentIdentifier =
+        {
+          /// The text document's URI.
+          uri: DocumentUri
+        }
+
+      let toJson (i: TextDocumentIdentifier) : Json =
+        Json.Object [ ("uri", Json.String i.uri) ]
+
+      let fromJson
+        (json: Json)
+        : Stdlib.Result.Result<TextDocumentIdentifier, Unit> =
+        match json with
+        | Object [ ("uri", String uri) ] ->
+          Stdlib.Result.Result.Ok(TextDocumentIdentifier { uri = uri })
+        | _ -> Stdlib.Result.Result.Error()
+

--- a/packages/darklang/languageServerProtocol/documentSync/README.md
+++ b/packages/darklang/languageServerProtocol/documentSync/README.md
@@ -1,0 +1,6 @@
+Note: there's a clear line drawn in the spec between:
+
+- text documents (what you normally work with)
+- notebooks (those interactive things like "IPython notebooks")
+
+There's overlap between the two, but they're generally different things here.

--- a/packages/darklang/languageServerProtocol/documentSync/common.dark
+++ b/packages/darklang/languageServerProtocol/documentSync/common.dark
@@ -1,0 +1,16 @@
+// types and such common between notebook sync and doc sync
+
+(*
+  /// An event describing a change to a text document. If range and rangeLength are omitted
+  /// the new text is considered to be the full content of the document.
+  type TextDocumentContentChangeEvent = {
+    /// The range of the document that changed.
+    range: Range;
+
+    /// The new text for the provided range.
+    text: string;
+  } | {
+    /// The new text of the whole document.
+    text: string;
+  };
+*)

--- a/packages/darklang/languageServerProtocol/documentSync/notebook.dark
+++ b/packages/darklang/languageServerProtocol/documentSync/notebook.dark
@@ -1,0 +1,296 @@
+(*
+
+  /// Notebook specific client capabilities.
+  export type NotebookDocumentSyncClientCapabilities = {
+    /// Whether implementation supports dynamic registration. If this is
+    /// set to `true` the client supports the new
+    /// `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+
+    /// The client supports sending execution summary data per cell.
+    executionSummarySupport?: boolean;
+  };
+
+  /// A notebook cell kind.
+  export namespace NotebookCellKind {
+    /// A markup-cell is formatted source that is used for display.
+    export const Markup: 1 = 1;
+
+    /// A code-cell is source code.
+    export const Code: 2 = 2;
+  }
+  export type NotebookCellKind = 1 | 2;
+
+  export type ExecutionSummary = {
+    /// A strict monotonically increasing value
+    /// indicating the execution order of a cell
+    /// inside a notebook.
+    executionOrder: uinteger;
+
+    /// Whether the execution was successful or not if known by the client.
+    success?: boolean;
+  };
+
+  /// A notebook cell.
+  ///
+  /// A cell's document URI must be unique across ALL notebook
+  /// cells and can therefore be used to uniquely identify a
+  /// notebook cell or the cell's text document.
+  export type NotebookCell = {
+    /// The cell's kind
+    kind: NotebookCellKind;
+
+    /// The URI of the cell's text document
+    /// content.
+    document: DocumentUri;
+
+    /// Additional metadata stored with the cell.
+    ///
+    /// Note: should always be an object literal (e.g. LSPObject)
+    metadata?: LSPObject;
+
+    /// Additional execution summary information if supported by the client.
+    executionSummary?: ExecutionSummary;
+  };
+
+
+  /// A notebook document.
+  export type NotebookDocument = {
+    /// The notebook document's uri.
+    uri: URI;
+
+    /// The type of the notebook.
+    notebookType: string;
+
+    /// The version number of this document (it will increase after each
+    /// change, including undo/redo).
+    version: integer;
+
+    /// Additional metadata stored with the notebook
+    /// document.
+    ///
+    /// Note: should always be an object literal (e.g. LSPObject)
+    metadata?: LSPObject;
+
+    /// The cells of a notebook.
+    cells: NotebookCell[];
+  };
+
+
+  /// A literal to identify a notebook document in the client.
+  export type NotebookDocumentIdentifier = {
+    /// The notebook document's uri.
+    uri: URI;
+  };
+
+  /// A versioned notebook document identifier.
+  export type VersionedNotebookDocumentIdentifier = {
+    /// The version number of this notebook document.
+    version: integer;
+
+    /// The notebook document's uri.
+    uri: URI;
+  };
+
+  /// @proposed
+  export interface NotebookCellLanguage {
+    language: string;
+  }
+
+  /// @proposed
+  export interface NotebookDocumentFilterWithNotebook {
+    /// The notebook to be synced If a string
+    /// value is provided it matches against the
+    /// notebook type. '*' matches every notebook.
+    notebook: string | NotebookDocumentFilter;
+
+    /// The cells of the matching notebook to be synced.
+    cells?: NotebookCellLanguage[];
+  }
+
+
+  /// @proposed
+  export interface NotebookDocumentFilterWithCells {
+    /// The notebook to be synced If a string
+    /// value is provided it matches against the
+    /// notebook type. '*' matches every notebook.
+    notebook?: string | NotebookDocumentFilter;
+
+    /// The cells of the matching notebook to be synced.
+    cells: NotebookCellLanguage[];
+  }
+
+  /// Options specific to a notebook plus its cells
+  /// to be synced to the server.
+  ///
+  /// If a selector provides a notebook document
+  /// filter but no cell selector all cells of a
+  /// matching notebook document will be synced.
+  ///
+  /// If a selector provides no notebook document
+  /// filter but only a cell selector all notebook
+  /// document that contain at least one matching
+  /// cell will be synced.
+  export type NotebookDocumentSyncOptions = {
+    /// The notebooks to be synced
+    notebookSelector: (NotebookDocumentFilterWithNotebook | NotebookDocumentFilterWithCells)[];
+
+    /// Whether save notification should be forwarded to
+    /// the server. Will only be honored if mode === `notebook`.
+    save?: boolean;
+  };
+
+  /// Registration options specific to a notebook.
+  export type NotebookDocumentSyncRegistrationOptions = NotebookDocumentSyncOptions & StaticRegistrationOptions;
+
+  export namespace NotebookDocumentSyncRegistrationType {
+    export const method: 'notebookDocument/sync' = 'notebookDocument/sync';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new RegistrationType<NotebookDocumentSyncRegistrationOptions>(method);
+  }
+
+  /// The params sent in an open notebook document notification.
+  export type DidOpenNotebookDocumentParams = {
+    /// The notebook document that got opened.
+    notebookDocument: NotebookDocument;
+
+    /// The text documents that represent the content
+    /// of a notebook cell.
+    cellTextDocuments: TextDocumentItem[];
+  };
+
+  /// A notification sent when a notebook opens.
+  export namespace DidOpenNotebookDocumentNotification {
+    export const method: 'notebookDocument/didOpen' = 'notebookDocument/didOpen';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DidOpenNotebookDocumentParams, void>(method);
+    export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
+  }
+
+  /// A change describing how to move a `NotebookCell`
+  /// array from state S to S'.
+  export type NotebookCellArrayChange = {
+    /// The start oftest of the cell that changed.
+    start: uinteger;
+
+    /// The deleted cells
+    deleteCount: uinteger;
+
+    /// The new cells, if any
+    cells?: NotebookCell[];
+  };
+
+
+
+  /// Structural changes to cells in a notebook document.
+  ///
+  /// @proposed
+  export interface NotebookDocumentCellChangeStructure {
+    /// The change to the cell array.
+    array: NotebookCellArrayChange;
+
+    /// Additional opened cell text documents.
+    didOpen?: TextDocumentItem[];
+
+    /// Additional closed cell text documents.
+    didClose?: TextDocumentIdentifier[];
+  }
+
+  /// Content changes to a cell in a notebook document.
+  ///
+  /// @proposed
+  export interface NotebookDocumentCellContentChanges {
+    document: VersionedTextDocumentIdentifier;
+    changes: TextDocumentContentChangeEvent[];
+  }
+
+  /// Cell changes to a notebook document.
+  ///
+  /// @proposed
+  export interface NotebookDocumentCellChanges {
+    /// Changes to the cell structure to add or remove cells.
+    structure?: NotebookDocumentCellChangeStructure;
+
+    /// Changes to notebook cells properties like its
+    /// kind, execution summary or metadata.
+    data?: NotebookCell[];
+
+    /// Changes to the text content of notebook cells.
+    textContent?: NotebookDocumentCellContentChanges[];
+  }
+
+  /// A change event for a notebook document.
+  export type NotebookDocumentChangeEvent = {
+    /// The changed meta data if any.
+    ///
+    /// Note: should always be an object literal (e.g. LSPObject)
+    metadata?: LSPObject;
+
+    /// Changes to cells
+    cells?: NotebookDocumentCellChanges;
+  };
+
+  /// The params sent in a change notebook document notification.
+  export type DidChangeNotebookDocumentParams = {
+    /// The notebook document that did change. The version number points
+    /// to the version after all provided changes have been applied. If
+    /// only the text document content of a cell changes the notebook version
+    /// doesn't necessarily have to change.
+    notebookDocument: VersionedNotebookDocumentIdentifier;
+
+    /// The actual changes to the notebook document.
+    ///
+    /// The changes describe single state changes to the notebook document.
+    /// So if there are two changes c1 (at array index 0) and c2 (at array
+    /// index 1) for a notebook in state S then c1 moves the notebook from
+    /// S to S' and c2 from S' to S''. So c1 is computed on the state S and
+    /// c2 is computed on the state S'.
+    ///
+    /// To mirror the content of a notebook using change events use the following approach:
+    /// - start with the same initial content
+    /// - apply the 'notebookDocument/didChange' notifications in the order you receive them.
+    /// - apply the `NotebookChangeEvent`s in a single notification in the order
+    ///   you receive them.
+    change: NotebookDocumentChangeEvent;
+  };
+
+  export namespace DidChangeNotebookDocumentNotification {
+    export const method: 'notebookDocument/didChange' = 'notebookDocument/didChange';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DidChangeNotebookDocumentParams, void>(method);
+    export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
+  }
+
+  /// The params sent in a save notebook document notification.
+  export type DidSaveNotebookDocumentParams = {
+    /// The notebook document that got saved.
+    notebookDocument: NotebookDocumentIdentifier;
+  };
+
+  /// A notification sent when a notebook document is saved.
+  export namespace DidSaveNotebookDocumentNotification {
+    export const method: 'notebookDocument/didSave' = 'notebookDocument/didSave';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DidSaveNotebookDocumentParams, void>(method);
+    export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
+  }
+
+  /// The params sent in a close notebook document notification.
+  export type DidCloseNotebookDocumentParams = {
+    /// The notebook document that got closed.
+    notebookDocument: NotebookDocumentIdentifier;
+
+    /// The text documents that represent the content
+    /// of a notebook cell that got closed.
+    cellTextDocuments: TextDocumentIdentifier[];
+  };
+
+  /// A notification sent when a notebook closes.
+  export namespace DidCloseNotebookDocumentNotification {
+    export const method: 'notebookDocument/didClose' = 'notebookDocument/didClose';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DidCloseNotebookDocumentParams, void>(method);
+    export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/documentSync/textDocument.dark
+++ b/packages/darklang/languageServerProtocol/documentSync/textDocument.dark
@@ -223,3 +223,165 @@ module Darklang =
             |> Stdlib.List.filterMap (fun x -> x)
             |> Json.Object
 
+
+
+// /// The document change notification is sent from the client to the server to signal
+// /// changes to a text document.
+// module DidChangeTextDocumentNotification =
+//   let method = "textDocument/didChange"
+//   //let messageDirection = MessageDirection.clientToServer;
+//   // registration options: TextDocumentChangeRegistrationOptions
+
+//   module DidChangeTextDocumentParams =
+//     type DidChangeTextDocumentParams =
+//     /// The change text document notification's parameters.
+//     type DidChangeTextDocumentParams {
+//       /// The document that did change. The version number points
+//       /// to the version after all provided content changes have
+//       /// been applied.
+//       textDocument: VersionedTextDocumentIdentifier
+
+//       /// The actual content changes. The content changes describe single state changes
+//       /// to the document. So if there are two content changes c1 (at array index 0) and
+//       /// c2 (at array index 1) for a document in state S then c1 moves the document from
+//       /// S to S' and c2 from S' to S''. So c1 is computed on the state S and c2 is computed
+//       /// on the state S'.
+//       /// To mirror the content of a document using change events use the following approach:
+//       /// - start with the same initial content
+//       /// - apply the 'textDocument/didChange' notifications in the order you receive them.
+//       /// - apply the `TextDocumentContentChangeEvent`s in a single notification in the order
+//       ///   you receive them.
+//       contentChanges: TextDocumentContentChangeEvent[];
+//     }
+
+(*
+
+  export interface TextDocumentSyncClientCapabilities {
+    /// Whether text document synchronization supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// The client supports sending will save notifications.
+    willSave?: boolean;
+
+    /// The client supports sending a will save request and
+    /// waits for a response providing text edits which will
+    /// be applied to the document before it is saved.
+    willSaveWaitUntil?: boolean;
+
+    /// The client supports did save notifications.
+    didSave?: boolean;
+  }
+
+
+
+
+
+  /// @proposed
+  export interface TextDocumentContentChangeWholeDocument {
+    /// The new text of the whole document.
+    text: string;
+  }
+
+  /// @proposed
+  export interface TextDocumentContentChangePartial {
+    /// The range of the document that changed.
+    range: Range;
+
+    /// The optional length of the range that got replaced.
+    /// @deprecated use range instead.
+    rangeLength?: uinteger;
+
+    /// The new text for the provided range.
+    text: string;
+  }
+
+  /// An event describing a change to a text document. If only a text is provided
+  /// it is considered to be the full content of the document.
+  export type TextDocumentContentChangeEvent = TextDocumentContentChangePartial | TextDocumentContentChangeWholeDocument;
+
+
+
+  /// The change text document notification's parameters.
+  export interface DidChangeTextDocumentParams {
+    /// The document that did change. The version number points
+    /// to the version after all provided content changes have
+    /// been applied.
+    textDocument: VersionedTextDocumentIdentifier;
+
+    /// The actual content changes. The content changes describe single state changes
+    /// to the document. So if there are two content changes c1 (at array index 0) and
+    /// c2 (at array index 1) for a document in state S then c1 moves the document from
+    /// S to S' and c2 from S' to S''. So c1 is computed on the state S and c2 is computed
+    /// on the state S'.
+    /// To mirror the content of a document using change events use the following approach:
+    /// - start with the same initial content
+    /// - apply the 'textDocument/didChange' notifications in the order you receive them.
+    /// - apply the `TextDocumentContentChangeEvent`s in a single notification in the order
+    ///   you receive them.
+    contentChanges: TextDocumentContentChangeEvent[];
+  }
+
+  /// Describe options to be used when registered for text document change events.
+  export interface TextDocumentChangeRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions {
+
+    /// How documents are synced to the server.
+    syncKind: TextDocumentSyncKind;
+  }
+
+
+
+
+
+
+  /// Save registration options.
+  export interface TextDocumentSaveRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      SaveOptions {
+  }
+
+  /// Represents reasons why a text document is saved.
+  export namespace TextDocumentSaveReason {
+    /// Manually triggered, e.g. by the user pressing save, by starting debugging,
+    /// or by an API call.
+    export const Manual: 1 = 1;
+
+    /// Automatic after a delay.
+    export const AfterDelay: 2 = 2;
+
+    /// When the editor lost focus.
+    export const FocusOut: 3 = 3;
+  }
+  export type TextDocumentSaveReason = 1 | 2 | 3;
+
+  /// The parameters sent in a will save text document notification.
+  export interface WillSaveTextDocumentParams {
+    /// The document that will be saved.
+    textDocument: TextDocumentIdentifier;
+
+    /// The 'TextDocumentSaveReason'.
+    reason: TextDocumentSaveReason;
+  }
+
+  /// A document will save notification is sent from the client to the server before
+  /// the document is actually saved.
+  export namespace WillSaveTextDocumentNotification {
+    export const method: 'textDocument/willSave' = 'textDocument/willSave';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<WillSaveTextDocumentParams, TextDocumentRegistrationOptions>(method);
+  }
+
+  /// A "document will save" request is sent from the client to the server before
+  /// the document is actually saved. The request can return an array of TextEdits
+  /// which will be applied to the text document before it is saved. Please note that
+  /// clients might drop results if computing the text edits took too long or if a
+  /// server constantly fails on this request. This is done to keep the save fast and
+  /// reliable.
+  export namespace WillSaveTextDocumentWaitUntilRequest {
+    export const method: 'textDocument/willSaveWaitUntil' = 'textDocument/willSaveWaitUntil';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<WillSaveTextDocumentParams, TextEdit[] | null, never, void, TextDocumentRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/documentSync/textDocument.dark
+++ b/packages/darklang/languageServerProtocol/documentSync/textDocument.dark
@@ -1,0 +1,225 @@
+module Darklang =
+  module LanguageServerProtocol =
+    module DocumentSync =
+      module TextDocument =
+        // <aliases>
+        type Json = Stdlib.AltJson.Json
+        // </aliases>
+
+        module TextDocumentSyncKind =
+          type TextDocumentSyncKind =
+            /// Documents should not be synced at all.
+            | None
+
+            /// Documents are synced by always sending the full content of the document.
+            | Full
+
+            /// Documents are synced by sending the full content on open.
+            /// After that only incremental updates to the document are send.
+            | Incremental
+
+          let toJson (kind: TextDocumentSyncKind) : Json =
+            match kind with
+            | None -> Json.Number 0.0
+            | Full -> Json.Number 1.0
+            | Incremental -> Json.Number 2.0
+
+          let fromJson
+            (json: Json)
+            : Stdlib.Result.Result<TextDocumentSyncKind, Unit> =
+            match json with
+            | Number 0.0 -> Stdlib.Result.Result.Ok TextDocumentSyncKind.None
+            | Number 1.0 -> Stdlib.Result.Result.Ok TextDocumentSyncKind.Full
+            | Number 2.0 -> Stdlib.Result.Result.Ok TextDocumentSyncKind.Incremental
+            | _ -> Stdlib.Result.Result.Error()
+
+
+        /// The document open notification is sent from the client to the server to signal
+        /// newly opened text documents. The document's truth is now managed by the client
+        /// and the server must not try to read the document's truth using the document's
+        /// uri. Open in this sense means it is managed by the client. It doesn't necessarily
+        /// mean that its content is presented in an editor. An open notification must not
+        /// be sent more than once without a corresponding close notification send before.
+        /// This means open and close notification must be balanced and the max open count
+        /// is one. DidOpenTextDocumentNotification
+        module DidOpenTextDocumentNotification =
+          let method = "textDocument/didOpen"
+          // params: DidOpenTextDocumentParams (from client)
+          // registrationOptions: TextDocumentRegistrationOptions -- not sure what this is used for
+          // messageDirection = MessageDirection.clientToServer
+          // response: N/A
+
+
+          /// The parameters sent in an open text document notification
+          module DidOpenTextDocumentParams =
+            type DidOpenTextDocumentParams =
+              {
+                /// The document that was opened.
+                textDocument: TextDocumentItem.TextDocumentItem
+              }
+
+            let fromJson
+              (json: Json)
+              : Stdlib.Result.Result<DidOpenTextDocumentParams, Unit> =
+              let jsonAsText = Stdlib.AltJson.format json // TODO: manually parse the JSON so we have better control
+
+              match Builtin.Json.parse<DidOpenTextDocumentParams> jsonAsText with
+              | Ok params -> Stdlib.Result.Result.Ok params
+              | Error _ -> Stdlib.Result.Result.Error()
+
+
+        /// The document close notification is sent from the client to the server when
+        /// the document got closed in the client. The document's truth now exists where
+        /// the document's uri points to (e.g. if the document's uri is a file uri the
+        /// truth now exists on disk). As with the open notification the close notification
+        /// is about managing the document's content. Receiving a close notification
+        /// doesn't mean that the document was open in an editor before. A close
+        /// notification requires a previous open notification to be sent.
+        module DidCloseTextDocumentNotification =
+          let method = "textDocument/didClose"
+          //let messageDirection = MessageDirection.clientToServer
+          // registration options: `TextDocumentRegistrationOptions`
+
+          module DidCloseTextDocumentParams =
+            /// The parameters sent in a close text document notification
+            type DidCloseTextDocumentParams =
+              {
+                /// The document that was closed.
+                textDocument: TextDocumentIdentifier.TextDocumentIdentifier
+              }
+
+            let fromJson
+              (json: Json)
+              : Stdlib.Result.Result<DidCloseTextDocumentParams, Unit> =
+              let jsonAsText = Stdlib.AltJson.format json // TODO: manually parse the JSON so we have better control
+
+              match Builtin.Json.parse<DidCloseTextDocumentParams> jsonAsText with
+              | Ok params -> Stdlib.Result.Result.Ok params
+              | Error _ -> Stdlib.Result.Result.Error()
+
+
+        /// The document save notification is sent from the client to the server when
+        /// the document got saved in the client.
+        module DidSaveTextDocumentNotification =
+          let method = "textDocument/didSave"
+          //let messageDirection = MessageDirection.clientToServer;
+          // registration options: `TextDocumentSaveRegistrationOptions`
+
+          /// The parameters sent in a "save text document" notification
+          module DidSaveTextDocumentParams =
+            type DidSaveTextDocumentParams =
+              {
+                /// The document that was saved.
+                textDocument: TextDocumentIdentifier.TextDocumentIdentifier
+
+                /// Optional the content when saved. Depends on the includeText value
+                /// when the save notification was requested.
+                text: Stdlib.Option.Option<String>
+              }
+
+            let fromJson
+              (json: Json)
+              : Stdlib.Result.Result<DidSaveTextDocumentParams, Unit> =
+
+              match json with
+              | Object fields ->
+                let textDocument = // Result<TextDocumentIdentifier, Unit>
+                  match
+                    Stdlib.List.findFirst fields (fun (k, _) -> k == "textDocument")
+                  with
+                  | None -> Stdlib.Result.Result.Error()
+                  | Some((_key, textDocument)) ->
+                    TextDocumentIdentifier.fromJson textDocument
+
+                let textMaybe = // Option<String>
+                  match Stdlib.List.findFirst fields (fun (k, _) -> k == "text") with
+                  | Some((_key, String textJson)) ->
+                    Stdlib.Option.Option.Some textJson
+                  | _ -> Stdlib.Option.Option.None
+
+                match textDocument, textMaybe with
+                | Ok textDocument, textMaybe ->
+                  Stdlib.Result.Result.Ok(
+                    DidSaveTextDocumentParams
+                      { textDocument = textDocument
+                        text = textMaybe }
+                  )
+                | _ -> Stdlib.Result.Result.Error()
+              | _ -> Stdlib.Result.Result.Error()
+
+
+        /// Save options.
+        module SaveOptions =
+          type SaveOptions =
+            {
+              /// The client is supposed to include the content on save.
+              includeText: Stdlib.Option.Option<Bool>
+            }
+
+          let toJson (saveOptions: SaveOptions.SaveOptions) : Json =
+            match saveOptions.includeText with
+            | Some b -> Json.Object [ ("includeText", Json.Bool b) ]
+            | None -> Json.Object []
+
+
+        module TextDocumentSyncOptions =
+          /// The `save` property of the `TextDocumentSyncOptions` type can be
+          /// either a `Bool` or a `SaveOptions` type, and this type is used to
+          /// represent that. It's important to note that this type itself should
+          /// have no artifact in the resultant Json.
+          ///
+          /// TODO: better name
+          module SaveOptionsOrBool =
+            type SaveOptionsOrBool =
+              | Bool of Bool
+              | SaveOptions of SaveOptions.SaveOptions
+
+            let toJson (s: SaveOptionsOrBool.SaveOptionsOrBool) : Json =
+              match s with
+              | Bool b -> Json.Bool b
+              | SaveOptions saveOptions -> SaveOptions.toJson saveOptions
+
+          type TextDocumentSyncOptions =
+            {
+              /// Open and close notifications are sent to the server.
+              /// If omitted open close notification should not be sent.
+              openClose: Stdlib.Option.Option<Bool>
+
+              /// Change notifications are sent to the server.
+              /// See
+              /// - TextDocumentSyncKind.None
+              /// - TextDocumentSyncKind.Full
+              /// - TextDocumentSyncKind.Incremental.
+              ///
+              /// If omitted it defaults to TextDocumentSyncKind.None.
+              change: Stdlib.Option.Option<TextDocumentSyncKind.TextDocumentSyncKind>
+
+              // /// If present will save notifications are sent to the server.
+              // /// If omitted the notification should not be sent.
+              // willSave?: boolean;
+
+              // /// If present will save wait until requests are sent to the server.
+              // /// If omitted the request should not be sent.
+              // willSaveWaitUntil?: boolean;
+
+              /// If present save notifications are sent to the server.
+              /// If omitted the notification should not be sent.
+              save: Stdlib.Option.Option<SaveOptionsOrBool.SaveOptionsOrBool>
+            }
+
+          let toJson
+            (options: TextDocumentSyncOptions.TextDocumentSyncOptions)
+            : Json =
+            [ options.openClose
+              |> Stdlib.Option.map (fun b -> ("openClose", Json.Bool b))
+
+              options.change
+              |> Stdlib.Option.map (fun c ->
+                ("change", TextDocumentSyncKind.toJson c))
+
+              options.save
+              |> Stdlib.Option.map (fun s -> ("save", SaveOptionsOrBool.toJson s)) ]
+
+            |> Stdlib.List.filterMap (fun x -> x)
+            |> Json.Object
+

--- a/packages/darklang/languageServerProtocol/io.dark
+++ b/packages/darklang/languageServerProtocol/io.dark
@@ -1,0 +1,1 @@
+// Actually communicating with the client.

--- a/packages/darklang/languageServerProtocol/language/callHierarchy.dark
+++ b/packages/darklang/languageServerProtocol/language/callHierarchy.dark
@@ -1,0 +1,127 @@
+// Used to find and display incoming and outgoing calls of whatever was selected in the editor
+// (probably/only a function)
+
+(*
+  /// Represents programming constructs like functions or constructors in the context
+  /// of call hierarchy.
+  export interface CallHierarchyItem {
+    /// The name of this item.
+    name: string;
+
+    /// The kind of this item.
+    kind: SymbolKind;
+
+    /// Tags for this item.
+    tags?: SymbolTag[];
+
+    /// More detail for this item, e.g. the signature of a function.
+    detail?: string;
+
+    /// The resource identifier of this item.
+    uri: DocumentUri;
+
+    /// The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code.
+    range: Range;
+
+    /// The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.
+    /// Must be contained by the {@link CallHierarchyItem.range `range`}.
+    selectionRange: Range;
+
+    /// A data entry field that is preserved between a call hierarchy prepare and
+    /// incoming calls or outgoing calls requests.
+    data?: LSPAny;
+  }
+
+  /// Represents an incoming call, e.g. a caller of a method or constructor.
+  export interface CallHierarchyIncomingCall {
+    /// The item that makes the call.
+    from: CallHierarchyItem;
+
+    /// The ranges at which the calls appear. This is relative to the caller
+    /// denoted by {@link CallHierarchyIncomingCall.from `this.from`}.
+    fromRanges: Range[];
+  }
+
+  /// Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
+  export interface CallHierarchyOutgoingCall {
+    /// The item that is called.
+    to: CallHierarchyItem;
+
+    /// The range at which this item is called. This is the range relative to the caller, e.g the item
+    /// passed to {@link CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls `provideCallHierarchyOutgoingCalls`}
+    /// and not {@link CallHierarchyOutgoingCall.to `this.to`}.
+    fromRanges: Range[];
+  }
+
+  export interface CallHierarchyClientCapabilities {
+    /// Whether implementation supports dynamic registration. If this is set to `true`
+    /// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+  }
+
+
+  /// Call hierarchy options used during static registration.
+  export interface CallHierarchyOptions
+    extends
+      WorkDoneProgressOptions { }
+
+  /// Call hierarchy options used during static or dynamic registration.
+  export interface CallHierarchyRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      CallHierarchyOptions,
+      StaticRegistrationOptions {
+  }
+
+  /// The parameter of a `textDocument/prepareCallHierarchy` request.
+  export interface CallHierarchyPrepareParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams { }
+
+  /// A request to result a `CallHierarchyItem` in a document at a given position.
+  /// Can be used as an input to an incoming or outgoing call hierarchy.
+  export namespace CallHierarchyPrepareRequest {
+    export const method: 'textDocument/prepareCallHierarchy' = 'textDocument/prepareCallHierarchy';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CallHierarchyPrepareParams, CallHierarchyItem[] | null, never, void, CallHierarchyRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<CallHierarchyPrepareParams, CallHierarchyItem[] | null, void>;
+  }
+
+
+  /// The parameter of a `callHierarchy/incomingCalls` request.
+  export interface CallHierarchyIncomingCallsParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    item: CallHierarchyItem;
+  }
+
+  /// A request to resolve the incoming calls for a given `CallHierarchyItem`.
+  export namespace CallHierarchyIncomingCallsRequest {
+    export const method: 'callHierarchy/incomingCalls' = 'callHierarchy/incomingCalls';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CallHierarchyIncomingCallsParams, CallHierarchyIncomingCall[] | null, CallHierarchyIncomingCall[], void, void>(method);
+    export type HandlerSignature = RequestHandler<CallHierarchyIncomingCallsParams, CallHierarchyIncomingCall[] | null, void>;
+  }
+
+
+  /// The parameter of a `callHierarchy/outgoingCalls` request.
+  export interface CallHierarchyOutgoingCallsParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    item: CallHierarchyItem;
+  }
+
+  /// A request to resolve the outgoing calls for a given `CallHierarchyItem`.
+  export namespace CallHierarchyOutgoingCallsRequest {
+    export const method: 'callHierarchy/outgoingCalls' = 'callHierarchy/outgoingCalls';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CallHierarchyOutgoingCallsParams, CallHierarchyOutgoingCall[] | null, CallHierarchyOutgoingCall[], void, void>(method);
+    export type HandlerSignature = RequestHandler<CallHierarchyOutgoingCallsParams, CallHierarchyOutgoingCall[] | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/codeAction.dark
+++ b/packages/darklang/languageServerProtocol/language/codeAction.dark
@@ -1,0 +1,254 @@
+// see: https://code.visualstudio.com/docs/editor/refactoring#_code-actions-quick-fixes-and-refactorings
+
+(*
+  /// The kind of a code action.
+  ///
+  /// Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`.
+  ///
+  /// The set of kinds is open and client needs to announce the kinds it supports to the server during
+  /// initialization.
+  export type CodeActionKind = string;
+
+  /// A set of predefined code action kinds
+  export namespace CodeActionKind {
+    /// Empty kind.
+    export const Empty: '' = '';
+
+    /// Base kind for quickfix actions: 'quickfix'
+    export const QuickFix: 'quickfix' = 'quickfix';
+
+    /// Base kind for refactoring actions: 'refactor'
+    export const Refactor: 'refactor' = 'refactor';
+
+    /// Base kind for refactoring extraction actions: 'refactor.extract'
+    ///
+    /// Example extract actions:
+    ///
+    /// - Extract method
+    /// - Extract function
+    /// - Extract variable
+    /// - Extract interface from class
+    /// - ...
+    export const RefactorExtract: 'refactor.extract' = 'refactor.extract';
+
+    /// Base kind for refactoring inline actions: 'refactor.inline'
+    ///
+    /// Example inline actions:
+    ///
+    /// - Inline function
+    /// - Inline variable
+    /// - Inline constant
+    /// - ...
+    export const RefactorInline: 'refactor.inline' = 'refactor.inline';
+
+    /// Base kind for refactoring rewrite actions: 'refactor.rewrite'
+    ///
+    /// Example rewrite actions:
+    ///
+    /// - Convert JavaScript function to class
+    /// - Add or remove parameter
+    /// - Encapsulate field
+    /// - Make method static
+    /// - Move method to base class
+    /// - ...
+    export const RefactorRewrite: 'refactor.rewrite' = 'refactor.rewrite';
+
+    /// Base kind for source actions: `source`
+    ///
+    /// Source code actions apply to the entire file.
+    export const Source: 'source' = 'source';
+
+    /// Base kind for an organize imports source action: `source.organizeImports`
+    export const SourceOrganizeImports: 'source.organizeImports' = 'source.organizeImports';
+
+    /// Base kind for auto-fix source actions: `source.fixAll`.
+    ///
+    /// Fix all actions automatically fix errors that have a clear fix that do not require user input.
+    /// They should not suppress errors or perform unsafe fixes such as generating new types or classes.
+    export const SourceFixAll: 'source.fixAll' = 'source.fixAll';
+  }
+
+  /// The reason why code actions were requested.
+  export namespace CodeActionTriggerKind {
+    /// Code actions were explicitly requested by the user or by an extension.
+    export const Invoked: 1 = 1;
+
+    /// Code actions were requested automatically.
+    ///
+    /// This typically happens when current selection in a file changes, but can
+    /// also be triggered when file content changes.
+    export const Automatic: 2 = 2;
+  }
+  export type CodeActionTriggerKind = 1 | 2;
+
+
+  /// Contains additional diagnostic information about the context in which
+  /// a {@link CodeActionProvider.provideCodeActions code action} is run.
+  export interface CodeActionContext {
+    /// An array of diagnostics known on the client side overlapping the range provided to the
+    /// `textDocument/codeAction` request. They are provided so that the server knows which
+    /// errors are currently presented to the user for the given range. There is no guarantee
+    /// that these accurately reflect the error state of the resource. The primary parameter
+    /// to compute code actions is the provided range.
+    diagnostics: Diagnostic[];
+
+    /// Requested kind of actions to return.
+    ///
+    /// Actions not of this kind are filtered out by the client before being shown. So servers
+    /// can omit computing them.
+    only?: CodeActionKind[];
+
+    /// The reason why code actions were requested.
+    triggerKind?: CodeActionTriggerKind;
+  }
+
+
+
+
+  /// A code action represents a change that can be performed in code, e.g. to fix a problem or
+  /// to refactor code.
+  ///
+  /// A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
+  export interface CodeAction {
+    /// A short, human-readable, title for this code action.
+    title: string;
+
+    /// The kind of the code action.
+    ///
+    /// Used to filter code actions.
+    kind?: CodeActionKind;
+
+    /// The diagnostics that this code action resolves.
+    diagnostics?: Diagnostic[];
+
+    /// Marks this as a preferred action. Preferred actions are used by the `auto fix` command and can be targeted
+    /// by keybindings.
+    ///
+    /// A quick fix should be marked preferred if it properly addresses the underlying error.
+    /// A refactoring should be marked preferred if it is the most reasonable choice of actions to take.
+    isPreferred?: boolean;
+
+
+    /// The workspace edit this code action performs.
+    edit?: WorkspaceEdit;
+
+    /// A command this code action executes. If a code action
+    /// provides an edit and a command, first the edit is
+    /// executed and then the command.
+    command?: Command;
+
+    /// A data entry field that is preserved on a code action between
+    /// a `textDocument/codeAction` and a `codeAction/resolve` request.
+    data?: LSPAny;
+  }
+
+  /// @proposed
+  export interface ClientCodeActionKindOptions {
+    /// The code action kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    valueSet: CodeActionKind[]
+  }
+  /// @proposed
+  export interface ClientCodeActionLiteralOptions {
+    /// The code action kind is support with the following value set.
+    codeActionKind: ClientCodeActionKindOptions
+  }
+
+  /// @proposed
+  export interface ClientCodeActionResolveOptions {
+    /// The properties that a client can resolve lazily.
+    properties: string[]
+  }
+
+  /// The Client Capabilities of a {@link CodeActionRequest}.
+  export interface CodeActionClientCapabilities {
+    /// Whether code action supports dynamic registration.
+    dynamicRegistration?: boolean
+
+    /// The client support code action literals of type `CodeAction` as a valid
+    /// response of the `textDocument/codeAction` request. If the property is not
+    /// set the request can only return `Command` literals.
+    codeActionLiteralSupport?: ClientCodeActionLiteralOptions
+
+    /// Whether code action supports the `isPreferred` property.
+    isPreferredSupport?: boolean
+
+    /// Whether code action supports the `disabled` property.
+    disabledSupport?: boolean
+
+    /// Whether code action supports the `data` property which is
+    /// preserved between a `textDocument/codeAction` and a
+    /// `codeAction/resolve` request.
+    dataSupport?: boolean
+
+    /// Whether the client supports resolving additional code action
+    /// properties via a separate `codeAction/resolve` request.
+    resolveSupport?: ClientCodeActionResolveOptions
+
+    /// Whether the client honors the change annotations in
+    /// text edits and resource operations returned via the
+    /// `CodeAction#edit` property by for example presenting
+    /// the workspace edit in the user interface and asking
+    /// for confirmation.
+    honorsChangeAnnotations?: boolean
+  }
+
+
+
+  /// The parameters of a {@link CodeActionRequest}.
+  export interface CodeActionParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The document in which the command was invoked.
+    textDocument: TextDocumentIdentifier
+
+    /// The range for which the command was invoked.
+    range: Range
+
+    /// Context carrying additional information.
+    context: CodeActionContext
+  }
+
+  /// Provider options for a {@link CodeActionRequest}.
+  export interface CodeActionOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// CodeActionKinds that this server may return.
+    /// The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the server
+    /// may list out every specific kind they provide.
+    codeActionKinds?: CodeActionKind[]
+
+    /// The server provides support to resolve additional
+    /// information for a code action.
+    resolveProvider?: boolean
+  }
+
+  /// Registration options for a {@link CodeActionRequest}.
+  export interface CodeActionRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      CodeActionOptions {
+  }
+
+  /// A request to provide commands for the given text document and range.
+  export namespace CodeActionRequest {
+    export const method: 'textDocument/codeAction' = 'textDocument/codeAction'
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer
+    export const type = new ProtocolRequestType<CodeActionParams, (Command | CodeAction)[] | null, (Command | CodeAction)[], void, CodeActionRegistrationOptions>(method)
+  }
+
+
+  /// Request to resolve additional information for a given code action.
+  /// The request's parameter is of type {@link CodeAction} the response
+  /// is of type {@link CodeAction} or a Thenable that resolves to such.
+  export namespace CodeActionResolveRequest {
+    export const method: 'codeAction/resolve' = 'codeAction/resolve'
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer
+    export const type = new ProtocolRequestType<CodeAction, CodeAction, never, void, void>(method)
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/codeLens.dark
+++ b/packages/darklang/languageServerProtocol/language/codeLens.dark
@@ -1,0 +1,87 @@
+// see: https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup
+
+(*  /// A code lens represents a {@link Command command} that should be shown along with
+  /// source text, like the number of references, a way to run tests, etc.
+  ///
+  /// A code lens is _unresolved_ when no command is associated to it. For performance
+  /// reasons the creation of a code lens and resolving should be done in two stages.
+  export interface CodeLens {
+    /// The range in which this code lens is valid. Should only span a single line.
+    range: Range;
+
+    /// The command this code lens represents.
+    command?: Command;
+
+    /// A data entry field that is preserved on a code lens item between
+    /// a {@link CodeLensRequest} and a {@link CodeLensResolveRequest}
+    data?: LSPAny;
+  }
+
+
+
+  /// The client capabilities of a {@link CodeLensRequest}.
+  export interface CodeLensClientCapabilities {
+    /// Whether code lens supports dynamic registration.
+    dynamicRegistration?: boolean;
+  }
+
+  export interface CodeLensWorkspaceClientCapabilities {
+    /// Whether the client implementation supports a refresh request sent from the
+    /// server to the client.
+    /// Note that this event is global and will force the client to refresh all
+    /// code lenses currently shown. It should be used with absolute care and is
+    /// useful for situations where a server for example detects a project-wide
+    /// change that requires such a calculation.
+    refreshSupport?: boolean;
+  }
+
+  /// The parameters of a {@link CodeLensRequest}.
+  export interface CodeLensParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The document to request code lens for.
+    textDocument: TextDocumentIdentifier;
+  }
+
+  /// Code Lens provider options of a {@link CodeLensRequest}.
+  export interface CodeLensOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// Code lens has a resolve provider as well.
+    resolveProvider?: boolean;
+  }
+
+  /// Registration options for a {@link CodeLensRequest}.
+  export interface CodeLensRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      CodeLensOptions {
+  }
+
+
+  /// A request to provide code lens for the given text document.
+  export namespace CodeLensRequest {
+    export const method: 'textDocument/codeLens' = 'textDocument/codeLens';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CodeLensParams, CodeLens[] | null, CodeLens[], void, CodeLensRegistrationOptions>(method);
+  }
+
+
+  /// A request to resolve a command for a given code lens.
+  export namespace CodeLensResolveRequest {
+    export const method: 'codeLens/resolve' = 'codeLens/resolve';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CodeLens, CodeLens, never, void, void>(method);
+  }
+
+
+  /// A request to refresh all code actions
+  export namespace CodeLensRefreshRequest {
+    export const method: `workspace/codeLens/refresh` = `workspace/codeLens/refresh`;
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType0<void, void, void, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/colorProvider.dark
+++ b/packages/darklang/languageServerProtocol/language/colorProvider.dark
@@ -1,0 +1,119 @@
+(* see: https://github.com/microsoft/language-server-protocol/issues/300
+
+
+
+  /// Represents a color in RGBA space.
+  export interface Color {
+    /// The red component of this color in the range [0-1].
+    readonly red: decimal;
+
+    /// The green component of this color in the range [0-1].
+    readonly green: decimal;
+
+    /// The blue component of this color in the range [0-1].
+    readonly blue: decimal;
+
+    /// The alpha component of this color in the range [0-1].
+    readonly alpha: decimal;
+  }
+
+
+  /// Represents a color range from a document.
+  export interface ColorInformation {
+    /// The range in the document where this color appears.
+    range: Range;
+
+    /// The actual color value for this color range.
+    color: Color;
+  }
+
+  export interface ColorPresentation {
+    /// The label of this color presentation. It will be shown on the color
+    /// picker header. By default this is also the text that is inserted when selecting
+    /// this color presentation.
+    label: string;
+
+    /// An {@link TextEdit edit} which is applied to a document when selecting
+    /// this presentation for the color.  When `falsy` the {@link ColorPresentation.label label}
+    /// is used.
+    textEdit?: TextEdit;
+
+    /// An optional array of additional {@link TextEdit text edits} that are applied when
+    /// selecting this color presentation. Edits must not overlap with the main {@link ColorPresentation.textEdit edit} nor with themselves.
+    additionalTextEdits?: TextEdit[];
+  }
+
+
+  export interface DocumentColorClientCapabilities {
+    /// Whether implementation supports dynamic registration. If this is set to `true`
+    /// the client supports the new `DocumentColorRegistrationOptions` return value
+    /// for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+  }
+
+
+
+
+
+  export interface DocumentColorOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface DocumentColorRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      StaticRegistrationOptions,
+      DocumentColorOptions {
+  }
+
+  /// Parameters for a {@link DocumentColorRequest}.
+  export interface DocumentColorParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+  }
+
+  /// A request to list all color symbols found in a given text document. The request's
+  /// parameter is of type {@link DocumentColorParams} the
+  /// response is of type {@link ColorInformation ColorInformation[]} or a Thenable
+  /// that resolves to such.
+  export namespace DocumentColorRequest {
+    export const method: 'textDocument/documentColor' = 'textDocument/documentColor';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentColorParams, ColorInformation[], ColorInformation[], void, DocumentColorRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<DocumentColorParams, ColorInformation[], void>;
+  }
+
+
+
+  /// Parameters for a {@link ColorPresentationRequest}.
+  export interface ColorPresentationParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The color to request presentations for.
+    color: Color;
+
+    /// The range where the color would be inserted. Serves as a context.
+    range: Range;
+  }
+
+  /// A request to list all presentation for a color. The request's
+  /// parameter is of type {@link ColorPresentationParams} the
+  /// response is of type {@link ColorInformation ColorInformation[]} or a Thenable
+  /// that resolves to such.
+  export namespace ColorPresentationRequest {
+    export const method: 'textDocument/colorPresentation' = 'textDocument/colorPresentation';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<ColorPresentationParams, ColorPresentation[], ColorPresentation[], void, WorkDoneProgressOptions & TextDocumentRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<ColorPresentationParams, ColorPresentation[], void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -1,0 +1,742 @@
+// Supports "completions," generally known as "autocomplete" or "intellisense."
+
+(*
+
+  /// Defines whether the insert text in a completion item should be interpreted as
+  /// plain text or a snippet.
+  export namespace InsertTextFormat {
+    /// The primary text to be inserted is treated as a plain string.
+    export const PlainText: 1 = 1;
+
+    /// The primary text to be inserted is treated as a snippet.
+    ///
+    /// A snippet can define tab stops and placeholders with `$1`, `$2`
+    /// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+    /// the end of the snippet. Placeholders with equal identifiers are linked,
+    /// that is typing in one will update others too.
+    ///
+    /// See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax
+    export const Snippet: 2 = 2;
+  }
+  export type InsertTextFormat = 1 | 2;
+
+
+  /// Completion item tags are extra annotations that tweak the rendering of a completion item.
+  export namespace CompletionItemTag {
+    /// Render a completion as obsolete, usually using a strike-out.
+    export const Deprecated = 1;
+  }
+  export type CompletionItemTag = 1;
+
+
+  /// A special text edit to provide an insert and a replace operation.
+  export interface InsertReplaceEdit {
+    /// The string to be inserted.
+    newText: string;
+
+    /// The range if the insert is requested
+    insert: Range;
+
+    /// The range if the replace is requested.
+    replace: Range;
+  }
+
+
+  /// How whitespace and indentation is handled during completion
+  /// item insertion.
+  export namespace InsertTextMode {
+    /// The insertion or replace strings is taken as it is. If the
+    /// value is multi line the lines below the cursor will be
+    /// inserted using the indentation defined in the string value.
+    /// The client will not apply any kind of adjustments to the
+    /// string.
+    export const asIs: 1 = 1;
+
+    /// The editor adjusts leading whitespace of new lines so that
+    /// they match the indentation up to the cursor of the line for
+    /// which the item is accepted.
+    ///
+    /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
+    /// multi line completion item is indented using 2 tabs and all
+    /// following lines inserted will be indented using 2 tabs as well.
+    export const adjustIndentation: 2 = 2;
+  }
+  export type InsertTextMode = 1 | 2;
+
+
+
+  /// Additional details for a completion item label.
+  export interface CompletionItemLabelDetails {
+    /// An optional string which is rendered less prominently directly after {@link CompletionItem.label label},
+    /// without any spacing. Should be used for function signatures and type annotations.
+    detail?: string;
+
+    /// An optional string which is rendered less prominently after {@link CompletionItem.detail}. Should be used
+    /// for fully qualified names and file paths.
+    description?: string;
+  }
+
+
+  /// The kind of a completion entry.
+  export namespace CompletionItemKind {
+    export const Text: 1 = 1;
+    export const Method: 2 = 2;
+    export const Function: 3 = 3;
+    export const Constructor: 4 = 4;
+    export const Field: 5 = 5;
+    export const Variable: 6 = 6;
+    export const Class: 7 = 7;
+    export const Interface: 8 = 8;
+    export const Module: 9 = 9;
+    export const Property: 10 = 10;
+    export const Unit: 11 = 11;
+    export const Value: 12 = 12;
+    export const Enum: 13 = 13;
+    export const Keyword: 14 = 14;
+    export const Snippet: 15 = 15;
+    export const Color: 16 = 16;
+    export const File: 17 = 17;
+    export const Reference: 18 = 18;
+    export const Folder: 19 = 19;
+    export const EnumMember: 20 = 20;
+    export const Constant: 21 = 21;
+    export const Struct: 22 = 22;
+    export const Event: 23 = 23;
+    export const Operator: 24 = 24;
+    export const TypeParameter: 25 = 25;
+  }
+  export type CompletionItemKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25;
+
+
+  /// A completion item represents a text snippet that is
+  /// proposed to complete text that is being typed.
+  export interface CompletionItem {
+    /// The label of this completion item.
+    ///
+    /// The label property is also by default the text that
+    /// is inserted when selecting this completion.
+    ///
+    /// If label details are provided the label itself should
+    /// be an unqualified name of the completion item.
+    label: string;
+
+    /// Additional details for the label
+    labelDetails?: CompletionItemLabelDetails;
+
+    /// The kind of this completion item. Based of the kind
+    /// an icon is chosen by the editor.
+    kind?: CompletionItemKind;
+
+    /// Tags for this completion item.
+    tags?: CompletionItemTag[];
+
+    /// A human-readable string with additional information
+    /// about this item, like type or symbol information.
+    detail?: string;
+
+    /// A human-readable string that represents a doc-comment.
+    documentation?: string | MarkupContent;
+
+    /// Select this item when showing.
+    ///
+    /// Note that only one completion item can be selected and that the
+    /// tool / client decides which item that is. The rule is that the *first*
+    /// item of those that match best is selected.
+    preselect?: boolean;
+
+    /// A string that should be used when comparing this item
+    /// with other items. When `falsy` the {@link CompletionItem.label label}
+    /// is used.
+    sortText?: string;
+
+    /// A string that should be used when filtering a set of
+    /// completion items. When `falsy` the {@link CompletionItem.label label}
+    /// is used.
+    filterText?: string;
+
+    /// A string that should be inserted into a document when selecting
+    /// this completion. When `falsy` the {@link CompletionItem.label label}
+    /// is used.
+    ///
+    /// The `insertText` is subject to interpretation by the client side.
+    /// Some tools might not take the string literally. For example
+    /// VS Code when code complete is requested in this example
+    /// `con<cursor position>` and a completion item with an `insertText` of
+    /// `console` is provided it will only insert `sole`. Therefore it is
+    /// recommended to use `textEdit` instead since it avoids additional client
+    /// side interpretation.
+    insertText?: string;
+
+    /// The format of the insert text. The format applies to both the
+    /// `insertText` property and the `newText` property of a provided
+    /// `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
+    ///
+    /// Please note that the insertTextFormat doesn't apply to
+    /// `additionalTextEdits`.
+    insertTextFormat?: InsertTextFormat;
+
+    /// How whitespace and indentation is handled during completion
+    /// item insertion. If not provided the clients default value depends on
+    /// the `textDocument.completion.insertTextMode` client capability.
+    insertTextMode?: InsertTextMode;
+
+    /// An {@link TextEdit edit} which is applied to a document when selecting
+    /// this completion. When an edit is provided the value of
+    /// {@link CompletionItem.insertText insertText} is ignored.
+    ///
+    /// Most editors support two different operations when accepting a completion
+    /// item. One is to insert a completion text and the other is to replace an
+    /// existing text with a completion text. Since this can usually not be
+    /// predetermined by a server it can report both ranges. Clients need to
+    /// signal support for `InsertReplaceEdits` via the
+    /// `textDocument.completion.insertReplaceSupport` client capability
+    /// property.
+    ///
+    /// *Note 1:* The text edit's range as well as both ranges from an insert
+    /// replace edit must be a [single line] and they must contain the position
+    /// at which completion has been requested.
+    /// *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
+    /// must be a prefix of the edit's replace range, that means it must be
+    /// contained and starting at the same position.
+    textEdit?: TextEdit | InsertReplaceEdit;
+
+    /// The edit text used if the completion item is part of a CompletionList and
+    /// CompletionList defines an item default for the text edit range.
+    ///
+    /// Clients will only honor this property if they opt into completion list
+    /// item defaults using the capability `completionList.itemDefaults`.
+    ///
+    /// If not provided and a list's default range is provided the label
+    /// property is used as a text.
+    textEditText?: string;
+
+    /// An optional array of additional {@link TextEdit text edits} that are applied when
+    /// selecting this completion. Edits must not overlap (including the same insert position)
+    /// with the main {@link CompletionItem.textEdit edit} nor with themselves.
+    ///
+    /// Additional text edits should be used to change text unrelated to the current cursor position
+    /// (for example adding an import statement at the top of the file if the completion item will
+    /// insert an unqualified type).
+    additionalTextEdits?: TextEdit[];
+
+    /// An optional set of characters that when pressed while this completion is active will accept it first and
+    /// then type that character. Note that all commit characters should have `length=1` and that superfluous
+    /// characters will be ignored.
+    commitCharacters?: string[];
+
+    /// An optional {@link Command command} that is executed *after* inserting this completion. Note that
+    /// additional modifications to the current document should be described with the
+    /// {@link CompletionItem.additionalTextEdits additionalTextEdits}-property.
+    command?: Command;
+
+    /// A data entry field that is preserved on a completion item between a
+    /// {@link CompletionRequest} and a {@link CompletionResolveRequest}.
+    data?: LSPAny;
+  }
+
+
+
+
+  /// In many cases the items of an actual completion result share the same
+  /// value for properties like `commitCharacters` or the range of a text
+  /// edit. A completion list can therefore define item defaults which will
+  /// be used if a completion item itself doesn't specify the value.
+  ///
+  /// If a completion list specifies a default value and a completion item
+  /// also specifies a corresponding value the one from the item is used.
+  ///
+  /// Servers are only allowed to return default values if the client
+  /// signals support for this via the `completionList.itemDefaults`
+  /// capability.
+  export interface CompletionItemDefaults {
+    /// A default commit character set.
+    commitCharacters?: string[];
+
+    /// A default edit range.
+    editRange?: Range;
+
+    /// A default insert text format.
+    insertTextFormat?: InsertTextFormat;
+
+    /// A default insert text mode.
+    insertTextMode?: InsertTextMode;
+
+    /// A default data value.
+    data?: LSPAny;
+  }
+
+  /// Represents a collection of {@link CompletionItem completion items} to be presented
+  /// in the editor.
+  export interface CompletionList {
+    /// This list it not complete. Further typing results in recomputing this list.
+    ///
+    /// Recomputed lists have all their items replaced (not appended) in the
+    /// incomplete completion sessions.
+    isIncomplete: boolean;
+
+    /// In many cases the items of an actual completion result share the same
+    /// value for properties like `commitCharacters` or the range of a text
+    /// edit. A completion list can therefore define item defaults which will
+    /// be used if a completion item itself doesn't specify the value.
+    ///
+    /// If a completion list specifies a default value and a completion item
+    /// also specifies a corresponding value the one from the item is used.
+    ///
+    /// Servers are only allowed to return default values if the client
+    /// signals support for this via the `completionList.itemDefaults`
+    /// capability.
+    itemDefaults?: CompletionItemDefaults;
+
+    /// The completion items.
+    items: CompletionItem[];
+  }
+
+
+  /// Additional details for a completion item label.
+  export interface CompletionItemLabelDetails {
+    /// An optional string which is rendered less prominently directly after {@link CompletionItem.label label},
+    /// without any spacing. Should be used for function signatures and type annotations.
+    detail?: string;
+
+    /// An optional string which is rendered less prominently after {@link CompletionItem.detail}. Should be used
+    /// for fully qualified names and file paths.
+    description?: string;
+  }
+
+
+  /// The kind of a completion entry.
+  export namespace CompletionItemKind {
+    export const Text: 1 = 1;
+    export const Method: 2 = 2;
+    export const Function: 3 = 3;
+    export const Constructor: 4 = 4;
+    export const Field: 5 = 5;
+    export const Variable: 6 = 6;
+    export const Class: 7 = 7;
+    export const Interface: 8 = 8;
+    export const Module: 9 = 9;
+    export const Property: 10 = 10;
+    export const Unit: 11 = 11;
+    export const Value: 12 = 12;
+    export const Enum: 13 = 13;
+    export const Keyword: 14 = 14;
+    export const Snippet: 15 = 15;
+    export const Color: 16 = 16;
+    export const File: 17 = 17;
+    export const Reference: 18 = 18;
+    export const Folder: 19 = 19;
+    export const EnumMember: 20 = 20;
+    export const Constant: 21 = 21;
+    export const Struct: 22 = 22;
+    export const Event: 23 = 23;
+    export const Operator: 24 = 24;
+    export const TypeParameter: 25 = 25;
+  }
+  export type CompletionItemKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25;
+
+
+  /// A completion item represents a text snippet that is
+  /// proposed to complete text that is being typed.
+  export interface CompletionItem {
+    /// The label of this completion item.
+    ///
+    /// The label property is also by default the text that
+    /// is inserted when selecting this completion.
+    ///
+    /// If label details are provided the label itself should
+    /// be an unqualified name of the completion item.
+    label: string;
+
+    /// Additional details for the label
+    labelDetails?: CompletionItemLabelDetails;
+
+    /// The kind of this completion item. Based of the kind
+    /// an icon is chosen by the editor.
+    kind?: CompletionItemKind;
+
+    /// Tags for this completion item.
+    tags?: CompletionItemTag[];
+
+    /// A human-readable string with additional information
+    /// about this item, like type or symbol information.
+    detail?: string;
+
+    /// A human-readable string that represents a doc-comment.
+    documentation?: string | MarkupContent;
+
+    /// Select this item when showing.
+    ///
+    /// Note that only one completion item can be selected and that the
+    /// tool / client decides which item that is. The rule is that the *first*
+    /// item of those that match best is selected.
+    preselect?: boolean;
+
+    /// A string that should be used when comparing this item
+    /// with other items. When `falsy` the {@link CompletionItem.label label}
+    /// is used.
+    sortText?: string;
+
+    /// A string that should be used when filtering a set of
+    /// completion items. When `falsy` the {@link CompletionItem.label label}
+    /// is used.
+    filterText?: string;
+
+    /// A string that should be inserted into a document when selecting
+    /// this completion. When `falsy` the {@link CompletionItem.label label}
+    /// is used.
+    ///
+    /// The `insertText` is subject to interpretation by the client side.
+    /// Some tools might not take the string literally. For example
+    /// VS Code when code complete is requested in this example
+    /// `con<cursor position>` and a completion item with an `insertText` of
+    /// `console` is provided it will only insert `sole`. Therefore it is
+    /// recommended to use `textEdit` instead since it avoids additional client
+    /// side interpretation.
+    insertText?: string;
+
+    /// The format of the insert text. The format applies to both the
+    /// `insertText` property and the `newText` property of a provided
+    /// `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
+    ///
+    /// Please note that the insertTextFormat doesn't apply to
+    /// `additionalTextEdits`.
+    insertTextFormat?: InsertTextFormat;
+
+    /// How whitespace and indentation is handled during completion
+    /// item insertion. If not provided the clients default value depends on
+    /// the `textDocument.completion.insertTextMode` client capability.
+    insertTextMode?: InsertTextMode;
+
+    /// An {@link TextEdit edit} which is applied to a document when selecting
+    /// this completion. When an edit is provided the value of
+    /// {@link CompletionItem.insertText insertText} is ignored.
+    ///
+    /// Most editors support two different operations when accepting a completion
+    /// item. One is to insert a completion text and the other is to replace an
+    /// existing text with a completion text. Since this can usually not be
+    /// predetermined by a server it can report both ranges. Clients need to
+    /// signal support for `InsertReplaceEdits` via the
+    /// `textDocument.completion.insertReplaceSupport` client capability
+    /// property.
+    ///
+    /// *Note 1:* The text edit's range as well as both ranges from an insert
+    /// replace edit must be a [single line] and they must contain the position
+    /// at which completion has been requested.
+    /// *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
+    /// must be a prefix of the edit's replace range, that means it must be
+    /// contained and starting at the same position.
+    textEdit?: TextEdit | InsertReplaceEdit;
+
+    /// The edit text used if the completion item is part of a CompletionList and
+    /// CompletionList defines an item default for the text edit range.
+    ///
+    /// Clients will only honor this property if they opt into completion list
+    /// item defaults using the capability `completionList.itemDefaults`.
+    ///
+    /// If not provided and a list's default range is provided the label
+    /// property is used as a text.
+    textEditText?: string;
+
+    /// An optional array of additional {@link TextEdit text edits} that are applied when
+    /// selecting this completion. Edits must not overlap (including the same insert position)
+    /// with the main {@link CompletionItem.textEdit edit} nor with themselves.
+    ///
+    /// Additional text edits should be used to change text unrelated to the current cursor position
+    /// (for example adding an import statement at the top of the file if the completion item will
+    /// insert an unqualified type).
+    additionalTextEdits?: TextEdit[];
+
+    /// An optional set of characters that when pressed while this completion is active will accept it first and
+    /// then type that character. Note that all commit characters should have `length=1` and that superfluous
+    /// characters will be ignored.
+    commitCharacters?: string[];
+
+    /// An optional {@link Command command} that is executed *after* inserting this completion. Note that
+    /// additional modifications to the current document should be described with the
+    /// {@link CompletionItem.additionalTextEdits additionalTextEdits}-property.
+    command?: Command;
+
+    /// A data entry field that is preserved on a completion item between a
+    /// {@link CompletionRequest} and a {@link CompletionResolveRequest}.
+    data?: LSPAny;
+  }
+
+
+
+
+  /// In many cases the items of an actual completion result share the same
+  /// value for properties like `commitCharacters` or the range of a text
+  /// edit. A completion list can therefore define item defaults which will
+  /// be used if a completion item itself doesn't specify the value.
+  ///
+  /// If a completion list specifies a default value and a completion item
+  /// also specifies a corresponding value the one from the item is used.
+  ///
+  /// Servers are only allowed to return default values if the client
+  /// signals support for this via the `completionList.itemDefaults`
+  /// capability.
+  export interface CompletionItemDefaults {
+    /// A default commit character set.
+    commitCharacters?: string[];
+
+    /// A default edit range.
+    editRange?: Range;
+
+    /// A default insert text format.
+    insertTextFormat?: InsertTextFormat;
+
+    /// A default insert text mode.
+    insertTextMode?: InsertTextMode;
+
+    /// A default data value.
+    data?: LSPAny;
+  }
+
+  /// Represents a collection of {@link CompletionItem completion items} to be presented
+  /// in the editor.
+  export interface CompletionList {
+    /// This list it not complete. Further typing results in recomputing this list.
+    ///
+    /// Recomputed lists have all their items replaced (not appended) in the
+    /// incomplete completion sessions.
+    isIncomplete: boolean;
+
+    /// In many cases the items of an actual completion result share the same
+    /// value for properties like `commitCharacters` or the range of a text
+    /// edit. A completion list can therefore define item defaults which will
+    /// be used if a completion item itself doesn't specify the value.
+    ///
+    /// If a completion list specifies a default value and a completion item
+    /// also specifies a corresponding value the one from the item is used.
+    ///
+    /// Servers are only allowed to return default values if the client
+    /// signals support for this via the `completionList.itemDefaults`
+    /// capability.
+    itemDefaults?: CompletionItemDefaults;
+
+    /// The completion items.
+    items: CompletionItem[];
+  }
+
+
+  /// The client supports the following `CompletionList` specific capabilities.
+  export interface CompletionListCapabilities {
+    /// The client supports the following itemDefaults on a completion list.
+    ///
+    /// The value lists the supported property names of the
+    /// `CompletionList.itemDefaults` object.
+    ///
+    /// If omitted, no properties are supported.
+    itemDefaults?: string[];
+  }
+
+
+  /// @proposed
+  export interface CompletionItemTagOptions {
+    /// The tags supported by the client.
+    valueSet: CompletionItemTag[];
+  }
+
+  /// @proposed
+  export interface ClientCompletionItemResolveOptions {
+    /// The properties that a client can resolve lazily.
+    properties: string[];
+  }
+
+  /// @proposed
+  export interface ClientCompletionItemInsertTextModeOptions {
+    valueSet: InsertTextMode[];
+  }
+
+  /// @proposed
+  export interface ClientCompletionItemOptions {
+    /// Client supports snippets as insert text.
+    /// A snippet can define tab stops and placeholders with `$1`, `$2`
+    /// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+    /// the end of the snippet. Placeholders with equal identifiers are linked,
+    /// that is typing in one will update others too.
+    snippetSupport?: boolean;
+
+    /// Client supports commit characters on a completion item.
+    commitCharactersSupport?: boolean;
+
+    /// Client supports the following content formats for the documentation
+    /// property. The order describes the preferred format of the client.
+    documentationFormat?: MarkupKind[];
+
+    /// Client supports the deprecated property on a completion item.
+    deprecatedSupport?: boolean;
+
+    /// Client supports the preselect property on a completion item.
+    preselectSupport?: boolean;
+
+    /// Client supports the tag property on a completion item. Clients supporting
+    /// tags have to handle unknown tags gracefully. Clients especially need to
+    /// preserve unknown tags when sending a completion item back to the server in
+    /// a resolve call.
+    tagSupport?: CompletionItemTagOptions;
+
+    /// Client support insert replace edit to control different behavior if a
+    /// completion item is inserted in the text or should replace text.
+    insertReplaceSupport?: boolean;
+
+    /// Indicates which properties a client can resolve lazily on a completion
+    /// item. Before version 3.16.0 only the predefined properties `documentation`
+    /// and `details` could be resolved lazily.
+    resolveSupport?: ClientCompletionItemResolveOptions;
+
+    /// The client supports the `insertTextMode` property on
+    /// a completion item to override the whitespace handling mode
+    /// as defined by the client (see `insertTextMode`).
+    insertTextModeSupport?: ClientCompletionItemInsertTextModeOptions;
+
+    /// The client has support for completion item label
+    /// details (see also `CompletionItemLabelDetails`).
+    labelDetailsSupport?: boolean;
+  }
+
+  /// @proposed
+  export interface ClientCompletionItemOptionsKind {
+    /// The completion item kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    /// If this property is not present the client only supports
+    /// the completion items kinds from `Text` to `Reference` as defined in
+    /// the initial version of the protocol.
+    valueSet?: CompletionItemKind[];
+  }
+
+  /// Completion client capabilities
+  export interface CompletionClientCapabilities {
+    /// Whether completion supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// The client supports the following `CompletionItem` specific
+    /// capabilities.
+    completionItem?: ClientCompletionItemOptions;
+
+    completionItemKind?: ClientCompletionItemOptionsKind;
+
+    /// Defines how the client handles whitespace and indentation
+    /// when accepting a completion item that uses multi line
+    /// text in either `insertText` or `textEdit`.
+    insertTextMode?: InsertTextMode;
+
+    /// The client supports to send additional context information for a
+    /// `textDocument/completion` request.
+    contextSupport?: boolean;
+
+    /// The client supports the following `CompletionList` specific
+    /// capabilities.
+    completionList?: CompletionListCapabilities;
+  }
+
+  /// How a completion was triggered
+  export namespace CompletionTriggerKind {
+    /// Completion was triggered by typing an identifier (24x7 code
+    /// complete), manual invocation (e.g Ctrl+Space) or via API.
+    export const Invoked: 1 = 1;
+
+    /// Completion was triggered by a trigger character specified by
+    /// the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+    export const TriggerCharacter: 2 = 2;
+
+    /// Completion was re-triggered as current completion list is incomplete
+    export const TriggerForIncompleteCompletions: 3 = 3;
+  }
+
+  export type CompletionTriggerKind = 1 | 2 | 3;
+
+
+  /// Contains additional information about the context in which a completion request is triggered.
+  export interface CompletionContext {
+    /// How the completion was triggered.
+    triggerKind: CompletionTriggerKind;
+
+    /// The trigger character (a single character) that has trigger code complete.
+    /// Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+    triggerCharacter?: string;
+  }
+
+  /// Completion parameters
+  export interface CompletionParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The completion context. This is only available it the client specifies
+    /// to send this using the client capability `textDocument.completion.contextSupport === true`
+    context?: CompletionContext;
+  }
+
+  /// @proposed
+  export interface ServerCompletionItemOptions {
+    /// The server has support for completion item label
+    /// details (see also `CompletionItemLabelDetails`) when
+    /// receiving a completion item in a resolve call.
+    labelDetailsSupport?: boolean;
+  }
+
+  /// Completion options.
+  export interface CompletionOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// Most tools trigger completion request automatically without explicitly requesting
+    /// it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user
+    /// starts to type an identifier. For example if the user types `c` in a JavaScript file
+    /// code complete will automatically pop up present `console` besides others as a
+    /// completion item. Characters that make up identifiers don't need to be listed here.
+    /// If code complete should automatically be trigger on characters not being valid inside
+    /// an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
+    triggerCharacters?: string[];
+
+    /// The list of all possible characters that commit a completion. This field can be used
+    /// if clients don't support individual commit characters per completion item. See
+    /// `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`
+    /// If a server provides both `allCommitCharacters` and commit characters on an individual
+    /// completion item the ones on the completion item win.
+    allCommitCharacters?: string[];
+
+    /// The server provides support to resolve additional
+    /// information for a completion item.
+    resolveProvider?: boolean;
+
+    /// The server supports the following `CompletionItem` specific
+    /// capabilities.
+    completionItem?: ServerCompletionItemOptions;
+  }
+
+  /// Registration options for a {@link CompletionRequest}.
+  export interface CompletionRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      CompletionOptions {
+  }
+
+  /// Request to request completion at a given text document position. The request's
+  /// parameter is of type {@link TextDocumentPosition} the response
+  /// is of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
+  /// or a Thenable that resolves to such.
+  ///
+  /// The request can delay the computation of the {@link CompletionItem.detail `detail`}
+  /// and {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`
+  /// request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
+  /// `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
+  export namespace CompletionRequest {
+    export const method: 'textDocument/completion' = 'textDocument/completion';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CompletionParams, CompletionItem[] | CompletionList | null, CompletionItem[], void, CompletionRegistrationOptions>(method);
+  }
+
+  /// Request to resolve additional information for a given completion item.The request's
+  /// parameter is of type {@link CompletionItem} the response
+  /// is of type {@link CompletionItem} or a Thenable that resolves to such.
+  export namespace CompletionResolveRequest {
+    export const method: 'completionItem/resolve' = 'completionItem/resolve';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CompletionItem, CompletionItem, never, void, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/diagnostics.dark
+++ b/packages/darklang/languageServerProtocol/language/diagnostics.dark
@@ -1,0 +1,315 @@
+// Supports the reporting of diagnostics against code (i.e. "problems" -- errors and warnings)
+//
+// _Usually_, diagnostics are reported by the server to the client without an explicit prompt from the client,
+// usually after the server learns about some file being changed. In this case, the server will send a
+// `textDocument/publishDiagnostics` notification to the client.
+//
+// However, the client can also request diagnostics from the server for a given file, using the
+// `textDocument/publishDiagnostics` request. This is useful for clients that want to show diagnostics
+// for a file that has not been opened yet, or for clients that want to show diagnostics for a file
+// that has been opened but not changed recently.
+//
+// The client can also request diagnostics for a given file _and_ all files that depend on it, using the
+// `workspace/publishDiagnostics` request. This is useful for clients that want to show diagnostics
+// for a file that has not been opened yet, or for clients that want to show diagnostics for a file
+// that has been opened but not changed recently.
+
+
+module Darklang =
+  module LanguageServerProtocol =
+    module Messages =
+      /// server -> client `textDocument/publishDiagnostics` notification
+      module PublishDiagnostics =
+        let method = "textDocument/publishDiagnostics"
+
+        module PublishDiagnosticsParams =
+          type PublishDiagnosticsParams =
+            {
+              /// The URI for which diagnostic information is reported.
+              uri: DocumentUri
+
+              /// Optionally, the version number of the document the diagnostics are published for.
+              version: Stdlib.Option.Option<Int64>
+
+              /// An array of diagnostic information items.
+              diagnostics: List<Diagnostic.Diagnostic>
+            }
+
+          let toJson (p: PublishDiagnosticsParams) : Json =
+            let fields =
+              [ Some(("uri", Json.String p.uri))
+
+                (p.version |> Stdlib.Option.map (fun v -> ("version", Json.String v)))
+
+                Some(
+                  ("diagnostics",
+                   Json.Array(
+                     Stdlib.List.map p.diagnostics (fun d -> Diagnostic.toJson d)
+                   ))
+                ) ]
+              |> Stdlib.List.filterMap (fun f -> f)
+
+            Json.Object fields
+
+
+(*
+  /// @proposed
+  export interface ClientDiagnosticsTagOptions {
+    /// The tags supported by the client.
+    valueSet: DiagnosticTag[];
+  }
+
+  /// The publish diagnostic client capabilities.
+  export interface PublishDiagnosticsClientCapabilities {
+    /// Whether the clients accepts diagnostics with related information.
+    relatedInformation?: boolean;
+
+    /// Client supports the tag property to provide meta data about a diagnostic.
+    /// Clients supporting tags have to handle unknown tags gracefully.
+    tagSupport?: ClientDiagnosticsTagOptions;
+
+    /// Whether the client interprets the version property of the
+    /// `textDocument/publishDiagnostics` notification's parameter.
+    versionSupport?: boolean;
+
+    /// Client supports a codeDescription property
+    codeDescriptionSupport?: boolean;
+
+    /// Whether code action supports the `data` property which is
+    /// preserved between a `textDocument/publishDiagnostics` and
+    /// `textDocument/codeAction` request.
+    dataSupport?: boolean;
+  }
+
+
+  /// Diagnostics notification are sent from the server to the client to signal
+  /// results of validation runs.
+  export namespace PublishDiagnosticsNotification {
+    export const method: 'textDocument/publishDiagnostics' = 'textDocument/publishDiagnostics';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolNotificationType<PublishDiagnosticsParams, void>(method);
+  }
+*)
+
+
+
+(*
+  /// Client capabilities specific to diagnostic pull requests.
+  export type DiagnosticClientCapabilities = {
+    /// Whether implementation supports dynamic registration. If this is set to `true`
+    /// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+
+    /// Whether the clients supports related documents for document diagnostic pulls.
+    relatedDocumentSupport?: boolean;
+  };
+
+  /// Workspace client capabilities specific to diagnostic pull requests.
+  export type DiagnosticWorkspaceClientCapabilities = {
+    /// Whether the client implementation supports a refresh request sent from
+    /// the server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// pulled diagnostics currently shown. It should be used with absolute care and
+    /// is useful for situation where a server for example detects a project wide
+    /// change that requires such a calculation.
+    refreshSupport?: boolean;
+  };
+
+  /// Diagnostic options.
+  export type DiagnosticOptions = WorkDoneProgressOptions & {
+    /// An optional identifier under which the diagnostics are
+    /// managed by the client.
+    identifier?: string;
+
+    /// Whether the language has inter file dependencies meaning that
+    /// editing code in one file can result in a different diagnostic
+    /// set in another file. Inter file dependencies are common for
+    /// most programming languages and typically uncommon for linters.
+    interFileDependencies: boolean;
+
+    /// The server provides support for workspace diagnostics as well.
+    workspaceDiagnostics: boolean;
+  };
+
+  /// Diagnostic registration options.
+  export type DiagnosticRegistrationOptions = TextDocumentRegistrationOptions & DiagnosticOptions & StaticRegistrationOptions;
+
+  export type $DiagnosticServerCapabilities = {
+    diagnosticProvider?: DiagnosticOptions;
+  };
+
+  /// Cancellation data returned from a diagnostic request.
+  export type DiagnosticServerCancellationData = {
+    retriggerRequest: boolean;
+  };
+
+
+  /// Parameters of the document diagnostic request.
+  export type DocumentDiagnosticParams = WorkDoneProgressParams & PartialResultParams & {
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The additional identifier  provided during registration.
+    identifier?: string;
+
+    /// The result id of a previous response if provided.
+    previousResultId?: string;
+  };
+
+  /// The document diagnostic report kinds.
+  export namespace DocumentDiagnosticReportKind {
+    /// A diagnostic report with a full set of problems.
+    export const Full = 'full';
+
+    /// A report indicating that the last returned report is still accurate.
+    export const Unchanged = 'unchanged';
+  }
+
+  export type DocumentDiagnosticReportKind = 'full' | 'unchanged';
+
+  /// A diagnostic report with a full set of problems.
+  export type FullDocumentDiagnosticReport = {
+    /// A full document diagnostic report.
+    kind: typeof DocumentDiagnosticReportKind.Full;
+
+    /// An optional result id. If provided it will
+    /// be sent on the next diagnostic request for the
+    /// same document.
+    resultId?: string;
+
+    /// The actual items.
+    items: Diagnostic[];
+  };
+
+  /// A full diagnostic report with a set of related documents.
+  export type RelatedFullDocumentDiagnosticReport = FullDocumentDiagnosticReport & {
+    /// Diagnostics of related documents. This information is useful
+    /// in programming languages where code in a file A can generate
+    /// diagnostics in a file B which A depends on. An example of
+    /// such a language is C/C++ where marco definitions in a file
+    /// a.cpp and result in errors in a header file b.hpp.
+    relatedDocuments?: {
+      [uri: DocumentUri]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport;
+    };
+  };
+
+  /// A diagnostic report indicating that the last returned
+  /// report is still accurate.
+  export type UnchangedDocumentDiagnosticReport = {
+    /// A document diagnostic report indicating
+    /// no changes to the last result. A server can
+    /// only return `unchanged` if result ids are
+    /// provided.
+    kind: typeof DocumentDiagnosticReportKind.Unchanged;
+
+    /// A result id which will be sent on the next
+    /// diagnostic request for the same document.
+    resultId: string;
+  };
+
+  /// An unchanged diagnostic report with a set of related documents.
+  export type RelatedUnchangedDocumentDiagnosticReport = UnchangedDocumentDiagnosticReport & {
+    /// Diagnostics of related documents. This information is useful
+    /// in programming languages where code in a file A can generate
+    /// diagnostics in a file B which A depends on. An example of
+    /// such a language is C/C++ where marco definitions in a file
+    /// a.cpp and result in errors in a header file b.hpp.
+    relatedDocuments?: {
+      [uri: DocumentUri]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport;
+    };
+  };
+
+  /// The result of a document diagnostic pull request. A report can
+  /// either be a full report containing all diagnostics for the
+  /// requested document or an unchanged report indicating that nothing
+  /// has changed in terms of diagnostics in comparison to the last
+  /// pull request.
+  export type DocumentDiagnosticReport = RelatedFullDocumentDiagnosticReport | RelatedUnchangedDocumentDiagnosticReport;
+
+  /// A partial result for a document diagnostic report.
+  export type DocumentDiagnosticReportPartialResult = {
+    relatedDocuments: {
+      [uri: DocumentUri]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport;
+    };
+  };
+
+  /// The document diagnostic request definition.
+  export namespace DocumentDiagnosticRequest {
+    export const method: 'textDocument/diagnostic' = 'textDocument/diagnostic';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportPartialResult, DiagnosticServerCancellationData, DiagnosticRegistrationOptions>(method);
+    export const partialResult = new ProgressType<DocumentDiagnosticReportPartialResult>();
+    export type HandlerSignature = RequestHandler<DocumentDiagnosticParams, DocumentDiagnosticReport, void>;
+  }
+
+  /// A previous result id in a workspace pull request.
+  export type PreviousResultId = {
+    /// The URI for which the client knowns a result id.
+    uri: DocumentUri;
+
+    /// The value of the previous result id.
+    value: string;
+  };
+
+  /// Parameters of the workspace diagnostic request.
+  export type WorkspaceDiagnosticParams = WorkDoneProgressParams & PartialResultParams & {
+    /// The additional identifier provided during registration.
+    identifier?: string;
+
+    /// The currently known diagnostic reports with their previous result ids.
+    previousResultIds: PreviousResultId[];
+  };
+
+  /// A full document diagnostic report for a workspace diagnostic result.
+  export type WorkspaceFullDocumentDiagnosticReport = FullDocumentDiagnosticReport & {
+    /// The URI for which diagnostic information is reported.
+    uri: DocumentUri;
+
+    /// The version number for which the diagnostics are reported.
+    /// If the document is not marked as open `null` can be provided.
+    version: integer | null;
+  };
+
+  /// An unchanged document diagnostic report for a workspace diagnostic result.
+  export type WorkspaceUnchangedDocumentDiagnosticReport = UnchangedDocumentDiagnosticReport & {
+    /// The URI for which diagnostic information is reported.
+    uri: DocumentUri;
+
+    /// The version number for which the diagnostics are reported.
+    /// If the document is not marked as open `null` can be provided.
+    version: integer | null;
+  };
+
+  /// A workspace diagnostic document report.
+  export type WorkspaceDocumentDiagnosticReport = WorkspaceFullDocumentDiagnosticReport | WorkspaceUnchangedDocumentDiagnosticReport;
+
+
+  /// A workspace diagnostic report.
+  export type WorkspaceDiagnosticReport = {
+    items: WorkspaceDocumentDiagnosticReport[];
+  };
+
+  /// A partial result for a workspace diagnostic report.
+  export type WorkspaceDiagnosticReportPartialResult = {
+    items: WorkspaceDocumentDiagnosticReport[];
+  };
+
+  /// The workspace diagnostic request definition.
+  export namespace WorkspaceDiagnosticRequest {
+    export const method: 'workspace/diagnostic' = 'workspace/diagnostic';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult, DiagnosticServerCancellationData, void>(method);
+    export const partialResult = new ProgressType<WorkspaceDiagnosticReportPartialResult>();
+    export type HandlerSignature = RequestHandler<WorkspaceDiagnosticParams, WorkspaceDiagnosticReport | null, void>;
+  }
+
+  /// The diagnostic refresh request definition.
+  export namespace DiagnosticRefreshRequest {
+    export const method: `workspace/diagnostic/refresh` = `workspace/diagnostic/refresh`;
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType0<void, void, void, void>(method);
+    export type HandlerSignature = RequestHandler0<void, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/documentHighlight.dark
+++ b/packages/darklang/languageServerProtocol/language/documentHighlight.dark
@@ -1,0 +1,68 @@
+// A document highlight is a range inside a text document which deserves
+// special attention. Usually a document highlight is visualized by changing
+// the background color of its range.
+
+(*
+  /// A document highlight kind.
+  export namespace DocumentHighlightKind {
+    /// A textual occurrence.
+    export const Text: 1 = 1;
+
+    /// Read-access of a symbol, like reading a variable.
+    export const Read: 2 = 2;
+
+    /// Write-access of a symbol, like writing to a variable.
+    export const Write: 3 = 3;
+  }
+  export type DocumentHighlightKind = 1 | 2 | 3;
+
+
+  /// A document highlight is a range inside a text document which deserves
+  /// special attention. Usually a document highlight is visualized by changing
+  /// the background color of its range.
+  export interface DocumentHighlight {
+    /// The range this highlight applies to.
+    range: Range;
+
+    /// The highlight kind, default is {@link DocumentHighlightKind.Text text}.
+    kind?: DocumentHighlightKind;
+  }
+
+
+  /// Client Capabilities for a {@link DocumentHighlightRequest}.
+  export interface DocumentHighlightClientCapabilities {
+    /// Whether document highlight supports dynamic registration.
+    dynamicRegistration?: boolean;
+  }
+
+  /// Parameters for a {@link DocumentHighlightRequest}.
+  export interface DocumentHighlightParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+  }
+
+  /// Provider options for a {@link DocumentHighlightRequest}.
+  export interface DocumentHighlightOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  /// Registration options for a {@link DocumentHighlightRequest}.
+  export interface DocumentHighlightRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      DocumentHighlightOptions {
+  }
+
+  /// Request to resolve a {@link DocumentHighlight} for a given
+  /// text document position. The request's parameter is of type {@link TextDocumentPosition}
+  /// the request response is an array of type {@link DocumentHighlight}
+  /// or a Thenable that resolves to such.
+  export namespace DocumentHighlightRequest {
+    export const method: 'textDocument/documentHighlight' = 'textDocument/documentHighlight';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentHighlightParams, DocumentHighlight[] | null, DocumentHighlight[], void, DocumentHighlightRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/documentSymbols.dark
+++ b/packages/darklang/languageServerProtocol/language/documentSymbols.dark
@@ -1,0 +1,91 @@
+(*
+  /// Represents programming constructs like variables, classes, interfaces etc.
+  /// that appear in a document. Document symbols can be hierarchical and they
+  /// have two ranges: one that encloses its definition and one that points to
+  /// its most interesting range, e.g. the range of an identifier.
+  export interface DocumentSymbol {
+    /// The name of this symbol. Will be displayed in the user interface and therefore must not be
+    /// an empty string or a string only consisting of white spaces.
+    name: string;
+
+    /// More detail for this symbol, e.g the signature of a function.
+    detail?: string;
+
+    /// The kind of this symbol.
+    kind: SymbolKind;
+
+    /// Tags for this document symbol.
+    tags?: SymbolTag[];
+
+    /// The range enclosing this symbol not including leading/trailing whitespace but everything else
+    /// like comments. This information is typically used to determine if the clients cursor is
+    /// inside the symbol to reveal in the symbol in the UI.
+    range: Range;
+
+    /// The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+    /// Must be contained by the `range`.
+    selectionRange: Range;
+
+    /// Children of this symbol, e.g. properties of a class.
+    children?: DocumentSymbol[];
+  }
+
+
+  export interface DocumentSymbolClientCapabilities {
+    /// Whether document symbol supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// Specific capabilities for the `SymbolKind` in the
+    /// `textDocument/documentSymbol` request.
+    symbolKind?: ClientSymbolKindOptions;
+
+    /// The client supports hierarchical document symbols.
+    hierarchicalDocumentSymbolSupport?: boolean;
+
+    /// The client supports tags on `SymbolInformation`. Tags are supported on
+    /// `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+    /// Clients supporting tags have to handle unknown tags gracefully.
+    tagSupport?: ClientSymbolTagOptions;
+
+    /// The client supports an additional label presented in the UI when
+    /// registering a document symbol provider.
+    labelSupport?: boolean;
+  }
+
+
+  /// Parameters for a {@link DocumentSymbolRequest}.
+  export interface DocumentSymbolParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+  }
+
+  /// Provider options for a {@link DocumentSymbolRequest}.
+  export interface DocumentSymbolOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// A human-readable string that is shown when multiple outlines trees
+    /// are shown for the same document.
+    label?: string;
+  }
+
+  /// Registration options for a {@link DocumentSymbolRequest}.
+  export interface DocumentSymbolRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      DocumentSymbolOptions {
+  }
+
+  /// A request to list all symbols found in a given text document. The request's
+  /// parameter is of type {@link TextDocumentIdentifier} the
+  /// response is of type {@link SymbolInformation SymbolInformation[]} or a Thenable
+  /// that resolves to such.
+  export namespace DocumentSymbolRequest {
+    export const method: 'textDocument/documentSymbol' = 'textDocument/documentSymbol';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentSymbolParams, SymbolInformation[] | DocumentSymbol[] | null, SymbolInformation[] | DocumentSymbol[], void, DocumentSymbolRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/findReferences.dark
+++ b/packages/darklang/languageServerProtocol/language/findReferences.dark
@@ -1,0 +1,40 @@
+(* supports a client's ability to "find all references" for something in focus
+
+  /// Client Capabilities for a {@link ReferencesRequest}.
+  export interface ReferenceClientCapabilities {
+    * Whether references supports dynamic registration.
+    dynamicRegistration?: boolean;
+  }
+
+  /// Parameters for a {@link ReferencesRequest}.
+  export interface ReferenceParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    context: ReferenceContext;
+  }
+
+  export interface ReferenceOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  /// Registration options for a {@link ReferencesRequest}.
+  export interface ReferenceRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      ReferenceOptions {
+  }
+
+  /// A request to resolve project-wide references for the symbol denoted
+  /// by the given text document position. The request's parameter is of
+  /// type {@link ReferenceParams} the response is of type
+  /// {@link Location Location[]} or a Thenable that resolves to such.
+  export namespace ReferencesRequest {
+    export const method: 'textDocument/references' = 'textDocument/references';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<ReferenceParams, Location[] | null, Location[], void, ReferenceRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/foldingRange.dark
+++ b/packages/darklang/languageServerProtocol/language/foldingRange.dark
@@ -1,0 +1,148 @@
+(*
+  /// A set of predefined range kinds.
+  export namespace FoldingRangeKind {
+    /// Folding range for a comment
+    export const Comment = 'comment';
+
+    /// Folding range for an import or include
+    export const Imports = 'imports';
+
+    /// Folding range for a region (e.g. `#region`)
+    export const Region = 'region';
+  }
+
+  /// A predefined folding range kind.
+  ///
+  /// The type is a string since the value set is extensible
+  export type FoldingRangeKind = string;
+
+
+
+  /// Represents a folding range. To be valid, start and end line must be bigger than zero and smaller
+  /// than the number of lines in the document. Clients are free to ignore invalid ranges.
+  export interface FoldingRange {
+    /// The zero-based start line of the range to fold. The folded area starts after the line's last character.
+    /// To be valid, the end must be zero or larger and smaller than the number of lines in the document.
+    startLine: uinteger;
+
+    /// The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+    startCharacter?: uinteger;
+
+    /// The zero-based end line of the range to fold. The folded area ends with the line's last character.
+    /// To be valid, the end must be zero or larger and smaller than the number of lines in the document.
+    endLine: uinteger;
+
+    /// The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+    endCharacter?: uinteger;
+
+    /// Describes the kind of the folding range such as `comment' or 'region'. The kind
+    /// is used to categorize folding ranges and used by commands like 'Fold all comments'.
+    /// See {@link FoldingRangeKind} for an enumeration of standardized kinds.
+    kind?: FoldingRangeKind;
+
+    /// The text that the client should show when the specified range is
+    /// collapsed. If not defined or not supported by the client, a default
+    /// will be chosen by the client.
+    collapsedText?: string;
+  }
+
+
+  /// @proposed
+  export interface ClientFoldingRangeKindOptions {
+    /// The folding range kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    valueSet?: FoldingRangeKind[];
+  }
+
+  /// @proposed
+  export interface ClientFoldingRangeOptions {
+    /// If set, the client signals that it supports setting collapsedText on
+    /// folding ranges to display custom labels instead of the default text.
+    collapsedText?: boolean;
+  }
+
+  export interface FoldingRangeClientCapabilities {
+    /// Whether implementation supports dynamic registration for folding range
+    /// providers. If this is set to `true` the client supports the new
+    /// `FoldingRangeRegistrationOptions` return value for the corresponding
+    /// server capability as well.
+    dynamicRegistration?: boolean;
+
+    /// The maximum number of folding ranges that the client prefers to receive
+    /// per document. The value serves as a hint, servers are free to follow the
+    /// limit.
+    rangeLimit?: uinteger;
+
+    /// If set, the client signals that it only supports folding complete lines.
+    /// If set, client will ignore specified `startCharacter` and `endCharacter`
+    /// properties in a FoldingRange.
+    lineFoldingOnly?: boolean;
+
+    /// Specific options for the folding range kind.
+    foldingRangeKind?: ClientFoldingRangeKindOptions;
+
+    /// Specific options for the folding range.
+    foldingRange?: ClientFoldingRangeOptions;
+  }
+
+  /// Client workspace capabilities specific to folding ranges
+  ///
+  /// @proposed
+  export interface FoldingRangeWorkspaceClientCapabilities {
+    /// Whether the client implementation supports a refresh request sent from the
+    /// server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// folding ranges currently shown. It should be used with absolute care and is
+    /// useful for situation where a server for example detects a project wide
+    /// change that requires such a calculation.
+    ///
+    /// @proposed
+    refreshSupport?: boolean;
+  }
+
+
+
+  export interface FoldingRangeOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface FoldingRangeRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      FoldingRangeOptions,
+      StaticRegistrationOptions {
+  }
+
+  /// Parameters for a {@link FoldingRangeRequest}.
+  export interface FoldingRangeParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+  }
+
+  /// A request to provide folding ranges in a document. The request's
+  /// parameter is of type {@link FoldingRangeParams}, the
+  /// response is of type {@link FoldingRangeList} or a Thenable
+  /// that resolves to such.
+  export namespace FoldingRangeRequest {
+    export const method: 'textDocument/foldingRange' = 'textDocument/foldingRange';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<FoldingRangeParams, FoldingRange[] | null, FoldingRange[], void, FoldingRangeRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<FoldingRangeParams, FoldingRange[] | null, void>;
+  }
+
+  /// @proposed
+  export namespace FoldingRangeRefreshRequest {
+    export const method: `workspace/foldingRange/refresh` = `workspace/foldingRange/refresh`;
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType0<void, void, void, void>(method);
+    export type HandlerSignature = RequestHandler0<void, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/formatting.dark
+++ b/packages/darklang/languageServerProtocol/language/formatting.dark
@@ -1,0 +1,187 @@
+(* Supports formatting code: a whole document, a range, multiple ranges, and (seemingly?) _as_ you type
+
+  /// Value-object describing what options formatting should use.
+  export interface FormattingOptions {
+    /// Size of a tab in spaces.
+    tabSize: uinteger;
+
+    /// Prefer spaces over tabs.
+    insertSpaces: boolean;
+
+    /// Trim trailing whitespace on a line.
+    trimTrailingWhitespace?: boolean;
+
+    /// Insert a newline character at the end of the file if one does not exist.
+    insertFinalNewline?: boolean;
+
+    /// Trim all newlines after the final newline at the end of the file.
+    trimFinalNewlines?: boolean;
+
+    /// Signature for further properties.
+    [key: string]: boolean | integer | string | undefined;
+  }
+
+
+
+  /// Client capabilities of a {@link DocumentFormattingRequest}.
+  export interface DocumentFormattingClientCapabilities {
+    /// Whether formatting supports dynamic registration.
+    dynamicRegistration?: boolean;
+  }
+
+  /// The parameters of a {@link DocumentFormattingRequest}.
+  export interface DocumentFormattingParams
+    extends
+      WorkDoneProgressParams {
+
+    /// The document to format.
+    textDocument: TextDocumentIdentifier;
+
+    /// The format options.
+    options: FormattingOptions;
+  }
+
+  /// Provider options for a {@link DocumentFormattingRequest}.
+  export interface DocumentFormattingOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  /// Registration options for a {@link DocumentFormattingRequest}.
+  export interface DocumentFormattingRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      DocumentFormattingOptions {
+  }
+
+  /// A request to format a whole document.
+  export namespace DocumentFormattingRequest {
+    export const method: 'textDocument/formatting' = 'textDocument/formatting';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentFormattingParams, TextEdit[] | null, never, void, DocumentFormattingRegistrationOptions>(method);
+  }
+
+  /// Client capabilities of a {@link DocumentRangeFormattingRequest}.
+  export interface DocumentRangeFormattingClientCapabilities {
+    /// Whether range formatting supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// Whether the client supports formatting multiple ranges at once.
+    /// @proposed
+    rangesSupport?: boolean;
+  }
+
+  /// The parameters of a {@link DocumentRangeFormattingRequest}.
+  export interface DocumentRangeFormattingParams
+    extends
+      WorkDoneProgressParams {
+
+    /// The document to format.
+    textDocument: TextDocumentIdentifier;
+
+    /// The range to format
+    range: Range;
+
+    /// The format options
+    options: FormattingOptions;
+  }
+
+  /// The parameters of a {@link DocumentRangesFormattingRequest}.
+  ///
+  /// @proposed
+  export interface DocumentRangesFormattingParams
+    extends
+      WorkDoneProgressParams {
+
+    /// The document to format.
+    textDocument: TextDocumentIdentifier;
+
+    /// The ranges to format
+    ranges: Range[];
+
+    /// The format options
+    options: FormattingOptions;
+  }
+
+  /// Provider options for a {@link DocumentRangeFormattingRequest}.
+  export interface DocumentRangeFormattingOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// Whether the server supports formatting multiple ranges at once.
+    rangesSupport?: boolean;
+  }
+
+  /// Registration options for a {@link DocumentRangeFormattingRequest}.
+  export interface DocumentRangeFormattingRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      DocumentRangeFormattingOptions {
+  }
+
+  /// A request to format a range in a document.
+  export namespace DocumentRangeFormattingRequest {
+    export const method: 'textDocument/rangeFormatting' = 'textDocument/rangeFormatting';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentRangeFormattingParams, TextEdit[] | null, never, void, DocumentRangeFormattingRegistrationOptions>(method);
+  }
+
+  /// A request to format ranges in a document.
+  ///
+  /// @proposed
+  export namespace DocumentRangesFormattingRequest {
+    export const method: 'textDocument/rangesFormatting' = 'textDocument/rangesFormatting';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentRangesFormattingParams, TextEdit[] | null, never, void, DocumentRangeFormattingRegistrationOptions>(method);
+  }
+
+  /// Client capabilities of a {@link DocumentOnTypeFormattingRequest}.
+  export interface DocumentOnTypeFormattingClientCapabilities {
+    /// Whether on type formatting supports dynamic registration.
+    dynamicRegistration?: boolean;
+  }
+
+  /// The parameters of a {@link DocumentOnTypeFormattingRequest}.
+  export interface DocumentOnTypeFormattingParams {
+
+    /// The document to format.
+    textDocument: TextDocumentIdentifier;
+
+    /// The position around which the on type formatting should happen.
+    /// This is not necessarily the exact position where the character denoted
+    /// by the property `ch` got typed.
+    position: Position;
+
+    /// The character that has been typed that triggered the formatting
+    /// on type request. That is not necessarily the last character that
+    /// got inserted into the document since the client could auto insert
+    /// characters as well (e.g. like automatic brace completion).
+    ch: string;
+
+    /// The formatting options.
+    options: FormattingOptions;
+  }
+
+  /// Provider options for a {@link DocumentOnTypeFormattingRequest}.
+  export interface DocumentOnTypeFormattingOptions {
+    /// A character on which formatting should be triggered, like `{`.
+    firstTriggerCharacter: string;
+
+    /// More trigger characters.
+    moreTriggerCharacter?: string[];
+  }
+
+  /// Registration options for a {@link DocumentOnTypeFormattingRequest}.
+  export interface DocumentOnTypeFormattingRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      DocumentOnTypeFormattingOptions {
+  }
+
+  /// A request to format a document on type.
+  export namespace DocumentOnTypeFormattingRequest {
+    export const method: 'textDocument/onTypeFormatting' = 'textDocument/onTypeFormatting';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentOnTypeFormattingParams, TextEdit[] | null, never, void, DocumentOnTypeFormattingRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/getDocumentLinks.dark
+++ b/packages/darklang/languageServerProtocol/language/getDocumentLinks.dark
@@ -1,0 +1,77 @@
+// Seemingly, provides some way for the client to ask the server where all the 'links' are in a document. (by position)
+// Not totally sure what this is useful for
+
+(*
+  /// A document link is a range in a text document that links to an internal or external resource, like another
+  /// text document or a web site.
+  export interface DocumentLink {
+    /// The range this link applies to.
+    range: Range;
+
+    /// The uri this link points to. If missing a resolve request is sent later.
+    target?: URI;
+
+    /// The tooltip text when you hover over this link.
+    ///
+    /// If a tooltip is provided, is will be displayed in a string that includes instructions on how to
+    /// trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary depending on OS,
+    /// user settings, and localization.
+    tooltip?: string;
+
+    /// A data entry field that is preserved on a document link between a
+    /// DocumentLinkRequest and a DocumentLinkResolveRequest.
+    data?: LSPAny;
+  }
+
+
+  /// The client capabilities of a {@link DocumentLinkRequest}.
+  export interface DocumentLinkClientCapabilities {
+    /// Whether document link supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// Whether the client supports the `tooltip` property on `DocumentLink`.
+    tooltipSupport?: boolean;
+  }
+
+  /// The parameters of a {@link DocumentLinkRequest}.
+  export interface DocumentLinkParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The document to provide document links for.
+    textDocument: TextDocumentIdentifier;
+  }
+
+  /// Provider options for a {@link DocumentLinkRequest}.
+  export interface DocumentLinkOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// Document links have a resolve provider as well.
+    resolveProvider?: boolean;
+  }
+
+  /// Registration options for a {@link DocumentLinkRequest}.
+  export interface DocumentLinkRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      DocumentLinkOptions {
+  }
+
+  /// A request to provide document links
+  export namespace DocumentLinkRequest {
+    export const method: 'textDocument/documentLink' = 'textDocument/documentLink';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentLinkParams, DocumentLink[] | null, DocumentLink[], void, DocumentLinkRegistrationOptions>(method);
+  }
+
+  /// Request to resolve additional information for a given document link. The request's
+  /// parameter is of type {@link DocumentLink} the response
+  /// is of type {@link DocumentLink} or a Thenable that resolves to such.
+  export namespace DocumentLinkResolveRequest {
+    export const method: 'documentLink/resolve' = 'documentLink/resolve';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DocumentLink, DocumentLink, never, void, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/goToDeclaration.dark
+++ b/packages/darklang/languageServerProtocol/language/goToDeclaration.dark
@@ -1,0 +1,43 @@
+// supports 'go to declaration'
+
+(*
+  export interface DeclarationClientCapabilities {
+    /// Whether declaration supports dynamic registration. If this is set to `true`
+    /// the client supports the new `DeclarationRegistrationOptions` return value
+    /// for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+
+    /// The client supports additional metadata in the form of declaration links.
+    linkSupport?: boolean;
+  }
+
+  export interface DeclarationOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface DeclarationRegistrationOptions
+    extends
+      DeclarationOptions,
+      TextDocumentRegistrationOptions,
+      StaticRegistrationOptions  {
+  }
+
+  export interface DeclarationParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+  }
+
+  /// A request to resolve the type definition locations of a symbol at a given text
+  /// document position. The request's parameter is of type {@link TextDocumentPositionParams}
+  /// the response is of type {@link Declaration} or a typed array of {@link DeclarationLink}
+  /// or a Thenable that resolves to such.
+  export namespace DeclarationRequest {
+    export const method: 'textDocument/declaration' = 'textDocument/declaration';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DeclarationParams, Declaration | DeclarationLink[] | null, Location[] | DeclarationLink[], void, DeclarationRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<DeclarationParams, Declaration | DeclarationLink[] | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/goToDefinition.dark
+++ b/packages/darklang/languageServerProtocol/language/goToDefinition.dark
@@ -1,0 +1,41 @@
+(*
+  /// Client Capabilities for a {@link DefinitionRequest}.
+  export interface DefinitionClientCapabilities {
+    /// Whether definition supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// The client supports additional metadata in the form of definition links.
+    linkSupport?: boolean;
+  }
+
+  /// Server Capabilities for a {@link DefinitionRequest}.
+  export interface DefinitionOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  /// Parameters for a {@link DefinitionRequest}.
+  export interface DefinitionParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+  }
+
+  /// Registration options for a {@link DefinitionRequest}.
+  export interface DefinitionRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      DefinitionOptions {
+  }
+
+  /// A request to resolve the definition location of a symbol at a given text
+  /// document position. The request's parameter is of type {@link TextDocumentPosition}
+  /// the response is of either type {@link Definition} or a typed array of
+  /// {@link DefinitionLink} or a Thenable that resolves to such.
+  export namespace DefinitionRequest {
+    export const method: 'textDocument/definition' = 'textDocument/definition';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DefinitionParams, Definition | DefinitionLink[] | null, Location[] | DefinitionLink[], void, DefinitionRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/goToImplementation.dark
+++ b/packages/darklang/languageServerProtocol/language/goToImplementation.dark
@@ -1,0 +1,42 @@
+// supports 'go to implementation'
+
+(*
+  export interface ImplementationClientCapabilities {
+    /// Whether implementation supports dynamic registration. If this is set to `true`
+    /// the client supports the new `ImplementationRegistrationOptions` return value
+    /// for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+
+    /// The client supports additional metadata in the form of definition links.
+    linkSupport?: boolean;
+  }
+
+  export interface ImplementationOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface ImplementationRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      ImplementationOptions,
+      StaticRegistrationOptions {
+  }
+
+  export interface ImplementationParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+  }
+
+  /// A request to resolve the implementation locations of a symbol at a given text
+  /// document position. The request's parameter is of type {@link TextDocumentPositionParams}
+  /// the response is of type {@link Definition} or a Thenable that resolves to such.
+  export namespace ImplementationRequest {
+    export const method: 'textDocument/implementation' = 'textDocument/implementation';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<ImplementationParams, Definition | DefinitionLink[] | null, Location[] | DefinitionLink[], void, ImplementationRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<ImplementationParams, Definition | DefinitionLink[] | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/handleRename.dark
+++ b/packages/darklang/languageServerProtocol/language/handleRename.dark
@@ -1,0 +1,96 @@
+// Supports rename-handling of variables, functions, types, etc.
+
+(*
+  export namespace PrepareSupportDefaultBehavior {
+    /// The client's default behavior is to select the identifier
+    /// according the to language's syntax rule.
+    export const Identifier: 1 = 1;
+  }
+
+  export type PrepareSupportDefaultBehavior = 1;
+
+  export interface RenameClientCapabilities {
+    /// Whether rename supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// Client supports testing for validity of rename operations
+    /// before execution.
+    prepareSupport?: boolean;
+
+    /// Client supports the default behavior result.
+    /// The value indicates the default behavior used by the
+    /// client.
+    prepareSupportDefaultBehavior?: PrepareSupportDefaultBehavior;
+
+    /// Whether the client honors the change annotations in
+    /// text edits and resource operations returned via the
+    /// rename request's workspace edit by for example presenting
+    /// the workspace edit in the user interface and asking
+    /// for confirmation.
+    honorsChangeAnnotations?: boolean;
+  }
+
+  /// The parameters of a {@link RenameRequest}.
+  export interface RenameParams
+    extends
+      WorkDoneProgressParams {
+    /// The document to rename.
+    textDocument: TextDocumentIdentifier;
+
+    /// The position at which this request was sent.
+    position: Position;
+
+    /// The new name of the symbol. If the given name is not valid the
+    /// request must return a {@link ResponseError} with an
+    /// appropriate message set.
+    newName: string;
+  }
+
+  /// Provider options for a {@link RenameRequest}.
+  export interface RenameOptions
+    extends
+      WorkDoneProgressOptions {
+    /// Renames should be checked and tested before being executed.
+    prepareProvider?: boolean;
+  }
+
+  /// Registration options for a {@link RenameRequest}.
+  export interface RenameRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      RenameOptions {
+  }
+
+  /// A request to rename a symbol.
+  export namespace RenameRequest {
+    export const method: 'textDocument/rename' = 'textDocument/rename';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<RenameParams, WorkspaceEdit | null, never, void, RenameRegistrationOptions>(method);
+  }
+
+  export interface PrepareRenameParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams {
+  }
+
+  /// @proposed
+  export interface PrepareRenamePlaceholder {
+    range: Range;
+    placeholder: string;
+  }
+
+  /// @proposed
+  export interface PrepareRenameDefaultBehavior {
+    defaultBehavior: boolean;
+  }
+
+  export type PrepareRenameResult = Range | PrepareRenamePlaceholder | PrepareRenameDefaultBehavior;
+
+  /// A request to test and perform the setup necessary for a rename.
+  export namespace PrepareRenameRequest {
+    export const method: 'textDocument/prepareRename' = 'textDocument/prepareRename';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<PrepareRenameParams, PrepareRenameResult | null, never, void, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/inlayHint.dark
+++ b/packages/darklang/languageServerProtocol/language/inlayHint.dark
@@ -1,0 +1,164 @@
+(*
+  /// Inlay hint kinds.
+  export namespace InlayHintKind {
+
+    /// An inlay hint that for a type annotation.
+    export const Type = 1;
+
+    /// An inlay hint that is for a parameter.
+    export const Parameter = 2;
+  }
+  export type InlayHintKind = 1 | 2;
+
+  /// An inlay hint label part allows for interactive and composite labels of inlay hints.
+  export type InlayHintLabelPart = {
+    /// The value of this label part.
+    value: string;
+
+    /// The tooltip text when you hover over this label part. Depending on
+    /// the client capability `inlayHint.resolveSupport` clients might resolve
+    /// this property late using the resolve request.
+    tooltip?: string | MarkupContent;
+
+    /// An optional source code location that represents this
+    /// label part.
+    ///
+    /// The editor will use this location for the hover and for code navigation
+    /// features: This part will become a clickable link that resolves to the
+    /// definition of the symbol at the given location (not necessarily the
+    /// location itself), it shows the hover that shows at the given location,
+    /// and it shows a context menu with further code navigation commands.
+    ///
+    /// Depending on the client capability `inlayHint.resolveSupport` clients
+    /// might resolve this property late using the resolve request.
+    location?: Location;
+
+    /// An optional command for this label part.
+    ///
+    /// Depending on the client capability `inlayHint.resolveSupport` clients
+    /// might resolve this property late using the resolve request.
+    command?: Command;
+  };
+
+
+
+  /// Inlay hint information.
+  export type InlayHint = {
+    /// The position of this hint.
+    position: Position;
+
+    /// The label of this hint. A human readable string or an array of
+    /// InlayHintLabelPart label parts.
+    ///
+    /// Note that neither the string nor the label part can be empty.
+    label: string | InlayHintLabelPart[];
+
+    /// The kind of this hint. Can be omitted in which case the client
+    /// should fall back to a reasonable default.
+    kind?: InlayHintKind;
+
+    /// Optional text edits that are performed when accepting this inlay hint.
+    ///
+    /// Note that edits are expected to change the document so that the inlay
+    /// hint (or its nearest variant) is now part of the document and the inlay
+    /// hint itself is now obsolete.
+    textEdits?: TextEdit[];
+
+    /// The tooltip text when you hover over this item.
+    tooltip?: string | MarkupContent;
+
+    /// Render padding before the hint.
+    ///
+    /// Note: Padding should use the editor's background color, not the
+    /// background color of the hint itself. That means padding can be used
+    /// to visually align/separate an inlay hint.
+    paddingLeft?: boolean;
+
+    /// Render padding after the hint.
+    ///
+    /// Note: Padding should use the editor's background color, not the
+    /// background color of the hint itself. That means padding can be used
+    /// to visually align/separate an inlay hint.
+    paddingRight?: boolean;
+
+    /// A data entry field that is preserved on an inlay hint between
+    /// a `textDocument/inlayHint` and a `inlayHint/resolve` request.
+    data?: LSPAny;
+  };
+
+
+
+  /// @proposed
+  export interface ClientInlayHintResolveOptions {
+    /// The properties that a client can resolve lazily.
+    properties: string[];
+  }
+
+  /// Inlay hint client capabilities.
+  export type InlayHintClientCapabilities = {
+    /// Whether inlay hints support dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// Indicates which properties a client can resolve lazily on an inlay hint.
+    resolveSupport?: ClientInlayHintResolveOptions;
+  };
+
+  /// Client workspace capabilities specific to inlay hints.
+  export type InlayHintWorkspaceClientCapabilities = {
+    /// Whether the client implementation supports a refresh request sent from
+    /// the server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// inlay hints currently shown. It should be used with absolute care and
+    /// is useful for situation where a server for example detects a project wide
+    /// change that requires such a calculation.
+    refreshSupport?: boolean;
+  };
+
+
+  /// Inlay hint options used during static registration.
+  export type InlayHintOptions = WorkDoneProgressOptions & {
+    /// The server provides support to resolve additional
+    /// information for an inlay hint item.
+    resolveProvider?: boolean;
+  };
+
+  /// Inlay hint options used during static or dynamic registration.
+  export type InlayHintRegistrationOptions = InlayHintOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions;
+
+  /// A parameter literal used in inlay hint requests.
+  export type InlayHintParams = WorkDoneProgressParams & {
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The document range for which inlay hints should be computed.
+    range: Range;
+  };
+
+  /// A request to provide inlay hints in a document. The request's parameter is of
+  /// type {@link InlayHintsParams}, the response is of type
+  /// {@link InlayHint InlayHint[]} or a Thenable that resolves to such.
+  export namespace InlayHintRequest {
+    export const method: 'textDocument/inlayHint' = 'textDocument/inlayHint';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<InlayHintParams, InlayHint[] | null, InlayHint[], void, InlayHintRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<InlayHintParams, InlayHint[] | null, void>;
+  }
+
+  /// A request to resolve additional properties for an inlay hint.
+  /// The request's parameter is of type {@link InlayHint}, the response is
+  /// of type {@link InlayHint} or a Thenable that resolves to such.
+  export namespace InlayHintResolveRequest {
+    export const method: 'inlayHint/resolve' = 'inlayHint/resolve';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<InlayHint, InlayHint, never, void, void>(method);
+    export type HandlerSignature = RequestHandler<InlayHint, InlayHint, void>;
+  }
+
+  export namespace InlayHintRefreshRequest {
+    export const method: `workspace/inlayHint/refresh` = `workspace/inlayHint/refresh`;
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType0<void, void, void, void>(method);
+    export type HandlerSignature = RequestHandler0<void, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/inlineCompletion.dark
+++ b/packages/darklang/languageServerProtocol/language/inlineCompletion.dark
@@ -1,0 +1,40 @@
+(*
+  /// Client capabilities specific to inline completions.
+  ///
+  /// @proposed
+  export type InlineCompletionClientCapabilities = {
+    * Whether implementation supports dynamic registration for inline completion providers.
+    dynamicRegistration?: boolean;
+  };
+
+  /// Inline completion options used during static registration.
+  ///
+  /// @proposed
+  export type InlineCompletionOptions = WorkDoneProgressOptions;
+
+  /// Inline completion options used during static or dynamic registration.
+  ///
+  /// @proposed
+  export type InlineCompletionRegistrationOptions = InlineCompletionOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions;
+
+  /// A parameter literal used in inline completion requests.
+  ///
+  /// @proposed
+  export type InlineCompletionParams = WorkDoneProgressParams & TextDocumentPositionParams & {
+    * Additional information about the context in which inline completions were
+    * requested.
+    context: InlineCompletionContext;
+  };
+
+  /// A request to provide inline completions in a document. The request's parameter is of
+  /// type {@link InlineCompletionParams}, the response is of type
+  /// {@link InlineCompletion InlineCompletion[]} or a Thenable that resolves to such.
+  ///
+  /// @proposed
+  export namespace InlineCompletionRequest {
+    export const method: 'textDocument/inlineCompletion' = 'textDocument/inlineCompletion';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<InlineCompletionParams, InlineCompletionList | InlineCompletionItem[] | null, InlineCompletionItem[], void, InlineCompletionRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<InlineCompletionParams, InlineCompletionList | InlineCompletionItem[] | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/inlineValue.dark
+++ b/packages/darklang/languageServerProtocol/language/inlineValue.dark
@@ -1,0 +1,117 @@
+// Allows for the display of variable values directly in line with the code, without having to hover or open a separate tool or pane.
+// It's a way to provide developers with immediate information about the state of a program while they are coding.
+
+(*
+
+  /// Provide inline value as text.
+  export type InlineValueText = {
+    /// The document range for which the inline value applies.
+    range: Range;
+
+    /// The text of the inline value.
+    text: string;
+  };
+
+
+  /// Provide inline value through a variable lookup.
+  /// If only a range is specified, the variable name will be extracted from the underlying document.
+  /// An optional variable name can be used to override the extracted name.
+  export type InlineValueVariableLookup = {
+    /// The document range for which the inline value applies.
+    /// The range is used to extract the variable name from the underlying document.
+    range: Range;
+
+    /// If specified the name of the variable to look up.
+    variableName?: string;
+
+    /// How to perform the lookup.
+    caseSensitiveLookup: boolean;
+  };
+
+
+  /// Provide an inline value through an expression evaluation.
+  /// If only a range is specified, the expression will be extracted from the underlying document.
+  /// An optional expression can be used to override the extracted expression.
+  export type InlineValueEvaluatableExpression = {
+    /// The document range for which the inline value applies.
+    /// The range is used to extract the evaluatable expression from the underlying document.
+    range: Range;
+
+    /// If specified the expression overrides the extracted expression.
+    expression?: string;
+  };
+
+
+  /// Inline value information can be provided by different means:
+  /// - directly as a text value (class InlineValueText).
+  /// - as a name to use for a variable lookup (class InlineValueVariableLookup)
+  /// - as an evaluatable expression (class InlineValueEvaluatableExpression)
+  /// The InlineValue types combines all inline value types into one type.
+  export type InlineValue = InlineValueText | InlineValueVariableLookup | InlineValueEvaluatableExpression;
+
+  export type InlineValueContext = {
+    /// The stack frame (as a DAP Id) where the execution has stopped.
+    frameId: integer;
+
+    /// The document range where execution has stopped.
+    /// Typically the end position of the range denotes the line where the inline values are shown.
+    stoppedLocation: Range;
+  };
+
+
+
+
+  /// Client capabilities specific to inline values.
+  export type InlineValueClientCapabilities = {
+    /// Whether implementation supports dynamic registration for inline value providers.
+    dynamicRegistration?: boolean;
+  };
+
+  /// Client workspace capabilities specific to inline values.
+  export type InlineValueWorkspaceClientCapabilities = {
+    /// Whether the client implementation supports a refresh request sent from the
+    /// server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// inline values currently shown. It should be used with absolute care and is
+    /// useful for situation where a server for example detects a project wide
+    /// change that requires such a calculation.
+    refreshSupport?: boolean;
+  };
+
+  /// Inline value options used during static registration.
+  export type InlineValueOptions = WorkDoneProgressOptions;
+
+  /// Inline value options used during static or dynamic registration.
+  export type InlineValueRegistrationOptions = InlineValueOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions;
+
+  /// A parameter literal used in inline value requests.
+  export type InlineValueParams = WorkDoneProgressParams & {
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The document range for which inline values should be computed.
+    range: Range;
+
+    /// Additional information about the context in which inline values were requested.
+    context: InlineValueContext;
+  };
+
+  /// A request to provide inline values in a document. The request's parameter is of
+  /// type {@link InlineValueParams}, the response is of type
+  /// {@link InlineValue InlineValue[]} or a Thenable that resolves to such.
+  export namespace InlineValueRequest {
+    export const method: 'textDocument/inlineValue' = 'textDocument/inlineValue';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<InlineValueParams, InlineValue[] | null, InlineValue[], void, InlineValueRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<InlineValueParams, InlineValue[] | null, void>;
+  }
+
+  /// @since 3.17.0
+  export namespace InlineValueRefreshRequest {
+    export const method: `workspace/inlineValue/refresh` = `workspace/inlineValue/refresh`;
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType0<void, void, void, void>(method);
+    export type HandlerSignature = RequestHandler0<void, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/linkedEditingRange.dark
+++ b/packages/darklang/languageServerProtocol/language/linkedEditingRange.dark
@@ -1,0 +1,47 @@
+(*
+  /// Client capabilities for the linked editing range request.
+  export interface LinkedEditingRangeClientCapabilities {
+    /// Whether implementation supports dynamic registration. If this is set to `true`
+    /// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+  }
+
+  export interface LinkedEditingRangeParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams {
+  }
+
+  export interface LinkedEditingRangeOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface LinkedEditingRangeRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      LinkedEditingRangeOptions,
+      StaticRegistrationOptions {
+  }
+
+  /// The result of a linked editing range request.
+  export interface LinkedEditingRanges {
+    /// A list of ranges that can be edited together. The ranges must have
+    /// identical length and contain identical text content. The ranges cannot overlap.
+    ranges: Range[];
+
+    /// An optional word pattern (regular expression) that describes valid contents for
+    /// the given ranges. If no pattern is provided, the client configuration's word
+    /// pattern will be used.
+    wordPattern?: string;
+  }
+
+  /// A request to provide ranges that can be edited together.
+  export namespace LinkedEditingRangeRequest {
+    export const method: 'textDocument/linkedEditingRange' = 'textDocument/linkedEditingRange';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<LinkedEditingRangeParams, LinkedEditingRanges | null, void, void, LinkedEditingRangeRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<LinkedEditingRangeParams, LinkedEditingRanges | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/monikor.dark
+++ b/packages/darklang/languageServerProtocol/language/monikor.dark
@@ -1,0 +1,92 @@
+(*
+  /// Moniker uniqueness level to define scope of the moniker.
+  export namespace UniquenessLevel {
+    /// The moniker is only unique inside a document
+    export const document = 'document';
+
+    /// The moniker is unique inside a project for which a dump got created
+    export const project = 'project';
+
+    /// The moniker is unique inside the group to which a project belongs
+    export const group = 'group';
+
+    /// The moniker is unique inside the moniker scheme.
+    export const scheme = 'scheme';
+
+    /// The moniker is globally unique
+    export const global = 'global';
+  }
+  export type UniquenessLevel = 'document' | 'project' | 'group' | 'scheme' | 'global';
+
+
+  /// The moniker kind.
+  export namespace MonikerKind {
+    /// The moniker represent a symbol that is imported into a project
+    export const $import = 'import';
+
+    /// The moniker represents a symbol that is exported from a project
+    export const $export = 'export';
+
+    /// The moniker represents a symbol that is local to a project (e.g. a local
+    /// variable of a function, a class not visible outside the project, ...)
+    export const local = 'local';
+  }
+  export type MonikerKind = 'import' | 'export' | 'local';
+
+
+  /// Moniker definition to match LSIF 0.5 moniker definition.
+  export interface Moniker {
+    /// The scheme of the moniker. For example tsc or .Net
+    scheme: string;
+
+    /// The identifier of the moniker. The value is opaque in LSIF however
+    /// schema owners are allowed to define the structure if they want.
+    identifier: string;
+
+    /// The scope in which the moniker is unique
+    unique: UniquenessLevel;
+
+    /// The moniker kind if known.
+    kind?: MonikerKind;
+  }
+
+
+  /// Client capabilities specific to the moniker request.
+  export interface MonikerClientCapabilities {
+    /// Whether moniker supports dynamic registration. If this is set to `true`
+    /// the client supports the new `MonikerRegistrationOptions` return value
+    /// for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+  }
+
+  export interface MonikerServerCapabilities {
+  }
+
+
+  export interface MonikerOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface MonikerRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      MonikerOptions {
+  }
+
+  export interface MonikerParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+  }
+
+  /// A request to get the moniker of a symbol at a given text document position.
+  /// The request parameter is of type {@link TextDocumentPositionParams}.
+  /// The response is of type {@link Moniker Moniker[]} or `null`.
+  export namespace MonikerRequest {
+    export const method: 'textDocument/moniker' = 'textDocument/moniker';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<MonikerParams, Moniker[] | null, Moniker[], void, MonikerRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/onHover.dark
+++ b/packages/darklang/languageServerProtocol/language/onHover.dark
@@ -1,0 +1,52 @@
+// What happens when you 'hover' on something in the editor?
+
+(*
+  /// The result of a hover request.
+  export interface Hover {
+    /// The hover's content
+    contents: MarkupContent;
+
+    /// An optional range inside the text document that is used to
+    /// visualize the hover, e.g. by changing the background color.
+    range?: Range;
+  }
+
+
+  export interface HoverClientCapabilities {
+    /// Whether hover supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// Client supports the following content formats for the content
+    /// property. The order describes the preferred format of the client.
+    contentFormat?: MarkupKind[];
+  }
+
+  /// Hover options.
+  export interface HoverOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  /// Parameters for a {@link HoverRequest}.
+  export interface HoverParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams {
+  }
+
+  /// Registration options for a {@link HoverRequest}.
+  export interface HoverRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      HoverOptions {
+  }
+
+  /// Request to request hover information at a given text document position. The request's
+  /// parameter is of type {@link TextDocumentPosition} the response is of
+  /// type {@link Hover} or a Thenable that resolves to such.
+  export namespace HoverRequest {
+    export const method: 'textDocument/hover' = 'textDocument/hover';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<HoverParams, Hover | null, never, void, HoverRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/selectionRange.dark
+++ b/packages/darklang/languageServerProtocol/language/selectionRange.dark
@@ -1,0 +1,57 @@
+(*
+
+  /// A selection range represents a part of a selection hierarchy. A selection range
+  /// may have a parent selection range that contains it.
+  export interface SelectionRange {
+    /// The {@link Range range} of this selection range.
+    range: Range;
+
+    /// The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
+    parent?: SelectionRange;
+  }
+
+
+
+  export interface SelectionRangeClientCapabilities {
+    /// Whether implementation supports dynamic registration for selection range providers. If this is set to `true`
+    /// the client supports the new `SelectionRangeRegistrationOptions` return value for the corresponding server
+    /// capability as well.
+    dynamicRegistration?: boolean;
+  }
+
+  export interface SelectionRangeOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface SelectionRangeRegistrationOptions
+    extends
+      SelectionRangeOptions,
+      TextDocumentRegistrationOptions,
+      StaticRegistrationOptions {
+  }
+
+  /// A parameter literal used in selection range requests.
+  export interface SelectionRangeParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The positions inside the text document.
+    positions: Position[];
+  }
+
+  /// A request to provide selection ranges in a document. The request's
+  /// parameter is of type {@link SelectionRangeParams}, the
+  /// response is of type {@link SelectionRange SelectionRange[]} or a Thenable
+  /// that resolves to such.
+  export namespace SelectionRangeRequest {
+    export const method: 'textDocument/selectionRange' = 'textDocument/selectionRange';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<SelectionRangeParams, SelectionRange[] | null, SelectionRange[], void, SelectionRangeRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<SelectionRangeParams, SelectionRange[] | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/semanticToken.dark
+++ b/packages/darklang/languageServerProtocol/language/semanticToken.dark
@@ -1,0 +1,305 @@
+(*
+  export interface SemanticTokens {
+    /// An optional result id. If provided and clients support delta updating
+    /// the client will include the result id in the next semantic token request.
+    /// A server can then instead of computing all semantic tokens again simply
+    /// send a delta.
+    resultId?: string;
+
+    /// The actual tokens.
+    data: uinteger[];
+  }
+
+  //------- 'textDocument/semanticTokens/full' -----
+
+  export interface SemanticTokensParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+  }
+
+  export namespace SemanticTokensRequest {
+    export const method: 'textDocument/semanticTokens/full' = 'textDocument/semanticTokens/full';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<SemanticTokensParams, SemanticTokens | null, SemanticTokensPartialResult, void, SemanticTokensRegistrationOptions>(method);
+    export const registrationMethod: typeof SemanticTokensRegistrationType.method  = SemanticTokensRegistrationType.method;
+    export type HandlerSignature = RequestHandler<SemanticTokensDeltaParams, SemanticTokens | null, void>;
+  }
+*)
+
+
+
+
+(*
+  /// A set of predefined token types. This set is not fixed and clients can specify
+  /// additional token types via the corresponding client capabilities.
+  export enum SemanticTokenTypes {
+    namespace = 'namespace',
+    /// Represents a generic type. Acts as a fallback for types which can't be mapped to
+    /// a specific type like class or enum.
+    type = 'type',
+    class = 'class',
+    enum = 'enum',
+    interface = 'interface',
+    struct = 'struct',
+    typeParameter = 'typeParameter',
+    parameter = 'parameter',
+    variable = 'variable',
+    property = 'property',
+    enumMember = 'enumMember',
+    event = 'event',
+    function = 'function',
+    method = 'method',
+    macro = 'macro',
+    keyword = 'keyword',
+    modifier = 'modifier',
+    comment = 'comment',
+    string = 'string',
+    number = 'number',
+    regexp = 'regexp',
+    operator = 'operator',
+    decorator = 'decorator'
+  }
+
+  /// A set of predefined token modifiers. This set is not fixed
+  /// an clients can specify additional token types via the
+  /// corresponding client capabilities.
+  export enum SemanticTokenModifiers {
+    declaration = 'declaration',
+    definition = 'definition',
+    readonly = 'readonly',
+    static = 'static',
+    deprecated = 'deprecated',
+    abstract = 'abstract',
+    async = 'async',
+    modification = 'modification',
+    documentation = 'documentation',
+    defaultLibrary = 'defaultLibrary'
+  }
+
+  export interface SemanticTokensLegend {
+    /// The token types a server uses.
+    tokenTypes: string[];
+
+    /// The token modifiers a server uses.
+    tokenModifiers: string[];
+  }
+
+
+
+  export interface SemanticTokensEdit {
+    /// The start offset of the edit.
+    start: uinteger;
+
+    /// The count of elements to remove.
+    deleteCount: uinteger;
+
+    /// The elements to insert.
+    data?: uinteger[];
+  }
+
+  export interface SemanticTokensDelta {
+    readonly resultId?: string;
+    /// The semantic token edits to transform a previous result into a new result.
+    edits: SemanticTokensEdit[];
+  }
+
+
+
+  export interface SemanticTokensPartialResult {
+    data: uinteger[];
+  }
+
+  export interface SemanticTokensDeltaPartialResult {
+    edits: SemanticTokensEdit[];
+  }
+
+
+
+  //------- 'textDocument/semanticTokens' -----
+
+  export namespace TokenFormat {
+    export const Relative: 'relative' = 'relative';
+  }
+
+  export type TokenFormat = 'relative';
+
+
+  /// @proposed
+  export interface ClientSemanticTokensRequestFullDelta {
+    /// The client will send the `textDocument/semanticTokens/full/delta` request if
+    /// the server provides a corresponding handler.
+    delta?: boolean;
+  }
+
+  /// @proposed
+  export interface ClientSemanticTokensRequestOptions  {
+    /// The client will send the `textDocument/semanticTokens/range` request if
+    /// the server provides a corresponding handler.
+    range?: boolean | {};
+
+    /// The client will send the `textDocument/semanticTokens/full` request if
+    /// the server provides a corresponding handler.
+    full?: boolean | ClientSemanticTokensRequestFullDelta;
+  }
+
+  export interface SemanticTokensClientCapabilities {
+    /// Whether implementation supports dynamic registration. If this is set to `true`
+    /// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+
+    /// Which requests the client supports and might send to the server
+    /// depending on the server's capability. Please note that clients might not
+    /// show semantic tokens or degrade some of the user experience if a range
+    /// or full request is advertised by the client but not provided by the
+    /// server. If for example the client capability `requests.full` and
+    /// `request.range` are both set to true but the server only provides a
+    /// range provider the client might not render a minimap correctly or might
+    /// even decide to not show any semantic tokens at all.
+    requests: ClientSemanticTokensRequestOptions;
+
+    /// The token types that the client supports.
+    tokenTypes: string[];
+
+    /// The token modifiers that the client supports.
+    tokenModifiers: string[];
+
+    /// The token formats the clients supports.
+    formats: TokenFormat[];
+
+    /// Whether the client supports tokens that can overlap each other.
+    overlappingTokenSupport?: boolean;
+
+    /// Whether the client supports tokens that can span multiple lines.
+    multilineTokenSupport?: boolean;
+
+    /// Whether the client allows the server to actively cancel a
+    /// semantic token request, e.g. supports returning
+    /// LSPErrorCodes.ServerCancelled. If a server does the client
+    /// needs to retrigger the request.
+    serverCancelSupport?: boolean;
+
+    /// Whether the client uses semantic tokens to augment existing
+    /// syntax tokens. If set to `true` client side created syntax
+    /// tokens and semantic tokens are both used for colorization. If
+    /// set to `false` the client only uses the returned semantic tokens
+    /// for colorization.
+    ///
+    /// If the value is `undefined` then the client behavior is not
+    /// specified.
+    augmentsSyntaxTokens?: boolean;
+  }
+
+
+  /// Semantic tokens options to support deltas for full documents
+  ///
+  /// @proposed
+  export interface SemanticTokensFullDelta {
+    /// The server supports deltas for full documents.
+    delta?: boolean;
+  }
+
+  export interface SemanticTokensOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// The legend used by the server
+    legend: SemanticTokensLegend;
+
+    /// Server supports providing semantic tokens for a specific range
+    /// of a document.
+    range?: boolean | {};
+
+    /// Server supports providing semantic tokens for a full document.
+    full?: boolean | SemanticTokensFullDelta;
+  }
+
+  export interface SemanticTokensRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      SemanticTokensOptions,
+      StaticRegistrationOptions {
+  }
+
+  export namespace SemanticTokensRegistrationType {
+    export const method: 'textDocument/semanticTokens' = 'textDocument/semanticTokens';
+    export const type = new RegistrationType<SemanticTokensRegistrationOptions>(method);
+  }
+
+
+
+
+
+  //------- 'textDocument/semanticTokens/edits' -----
+
+  export interface SemanticTokensDeltaParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The result id of a previous response. The result Id can either point to a full response
+    /// or a delta response depending on what was received last.
+    previousResultId: string;
+  }
+
+  export namespace SemanticTokensDeltaRequest {
+    export const method: 'textDocument/semanticTokens/full/delta' = 'textDocument/semanticTokens/full/delta';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<SemanticTokensDeltaParams, SemanticTokens | SemanticTokensDelta | null, SemanticTokensPartialResult | SemanticTokensDeltaPartialResult, void, SemanticTokensRegistrationOptions>(method);
+    export const registrationMethod: typeof SemanticTokensRegistrationType.method  = SemanticTokensRegistrationType.method;
+    export type HandlerSignature = RequestHandler<SemanticTokensDeltaParams, SemanticTokens | SemanticTokensDelta | null, void>;
+  }
+
+
+
+  //------- 'textDocument/semanticTokens/range' -----
+
+  export interface SemanticTokensRangeParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// The text document.
+    textDocument: TextDocumentIdentifier;
+
+    /// The range the semantic tokens are requested for.
+    range: Range;
+  }
+
+  export namespace SemanticTokensRangeRequest {
+    export const method: 'textDocument/semanticTokens/range' = 'textDocument/semanticTokens/range';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<SemanticTokensRangeParams, SemanticTokens | null, SemanticTokensPartialResult, void, void>(method);
+    export const registrationMethod: typeof SemanticTokensRegistrationType.method  = SemanticTokensRegistrationType.method;
+    export type HandlerSignature = RequestHandler<SemanticTokensRangeParams, SemanticTokens | null, void>;
+  }
+
+
+
+  //------- 'workspace/semanticTokens/refresh' -----
+
+  export interface SemanticTokensWorkspaceClientCapabilities {
+    /// Whether the client implementation supports a refresh request sent from
+    /// the server to the client.
+    ///
+    /// Note that this event is global and will force the client to refresh all
+    /// semantic tokens currently shown. It should be used with absolute care
+    /// and is useful for situation where a server for example detects a project
+    /// wide change that requires such a calculation.
+    refreshSupport?: boolean;
+  }
+
+  export namespace SemanticTokensRefreshRequest {
+    export const method: `workspace/semanticTokens/refresh` = `workspace/semanticTokens/refresh`;
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType0<void, void, void, void>(method);
+    export type HandlerSignature = RequestHandler0<void, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/signatureHelp.dark
+++ b/packages/darklang/languageServerProtocol/language/signatureHelp.dark
@@ -1,0 +1,183 @@
+// see: https://code.visualstudio.com/docs/languages/javascript#_signature-help for what this is about
+
+(*
+
+  /// Represents a parameter of a callable-signature. A parameter can
+  /// have a label and a doc-comment.
+  export interface ParameterInformation {
+    /// The label of this parameter information.
+    ///
+    /// Either a string or an inclusive start and exclusive end offsets within its containing
+    /// signature label. (see SignatureInformation.label). The offsets are based on a UTF-16
+    /// string representation as `Position` and `Range` does.
+    ///
+    /// Note: a label of type string should be a substring of its containing signature label.
+    /// Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
+    label: string | [uinteger, uinteger];
+
+    /// The human-readable doc-comment of this parameter. Will be shown
+    /// in the UI but can be omitted.
+    documentation?: string | MarkupContent;
+  }
+
+
+  /// Represents the signature of something callable. A signature
+  /// can have a label, like a function-name, a doc-comment, and
+  /// a set of parameters.
+  export interface SignatureInformation {
+    /// The label of this signature. Will be shown in
+    /// the UI.
+    label: string;
+
+    /// The human-readable doc-comment of this signature. Will be shown
+    /// in the UI but can be omitted.
+    documentation?: string | MarkupContent;
+
+    /// The parameters of this signature.
+    parameters?: ParameterInformation[];
+
+    /// The index of the active parameter.
+    ///
+    /// If provided, this is used in place of `SignatureHelp.activeParameter`.
+    activeParameter?: uinteger;
+  }
+
+
+  /// Signature help represents the signature of something
+  /// callable. There can be multiple signature but only one
+  /// active and only one active parameter.
+  export interface SignatureHelp {
+    /// One or more signatures.
+    signatures: SignatureInformation[];
+
+    /// The active signature. If omitted or the value lies outside the
+    /// range of `signatures` the value defaults to zero or is ignored if
+    /// the `SignatureHelp` has no signatures.
+    ///
+    /// Whenever possible implementors should make an active decision about
+    /// the active signature and shouldn't rely on a default value.
+    ///
+    /// In future version of the protocol this property might become
+    /// mandatory to better express this.
+    activeSignature?: uinteger;
+
+    /// The active parameter of the active signature. If omitted or the value
+    /// lies outside the range of `signatures[activeSignature].parameters`
+    /// defaults to 0 if the active signature has parameters. If
+    /// the active signature has no parameters it is ignored.
+    /// In future version of the protocol this property might become
+    /// mandatory to better express the active parameter if the
+    /// active signature does have any.
+    activeParameter?: uinteger;
+  }
+
+
+  /// @proposed
+  export interface ClientSignatureParameterInformationOptions {
+    /// The client supports processing label offsets instead of a
+    /// simple label string.
+    labelOffsetSupport?: boolean;
+  }
+
+  /// @proposed
+  export interface ClientSignatureInformationOptions {
+    /// Client supports the following content formats for the documentation
+    /// property. The order describes the preferred format of the client.
+    documentationFormat?: MarkupKind[];
+
+    /// Client capabilities specific to parameter information.
+    parameterInformation?: ClientSignatureParameterInformationOptions;
+
+    /// The client supports the `activeParameter` property on `SignatureInformation`
+    /// literal.
+    activeParameterSupport?: boolean;
+  }
+
+  /// Client Capabilities for a {@link SignatureHelpRequest}.
+  export interface SignatureHelpClientCapabilities {
+    /// Whether signature help supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// The client supports the following `SignatureInformation`
+    /// specific properties.
+    signatureInformation?: ClientSignatureInformationOptions;
+
+    /// The client supports to send additional context information for a
+    /// `textDocument/signatureHelp` request. A client that opts into
+    /// contextSupport will also support the `retriggerCharacters` on
+    /// `SignatureHelpOptions`.
+    contextSupport?: boolean;
+  }
+
+  /// Server Capabilities for a {@link SignatureHelpRequest}.
+  export interface SignatureHelpOptions
+    extends
+      WorkDoneProgressOptions
+
+
+    /// List of characters that trigger signature help automatically.
+    triggerCharacters?: string[];
+
+    /// List of characters that re-trigger signature help.
+    /// These trigger characters are only active when signature help is already showing. All trigger characters
+    /// are also counted as re-trigger characters.
+    retriggerCharacters?: string[];
+  }
+
+  /// How a signature help was triggered.
+  ///
+  export namespace SignatureHelpTriggerKind {
+    /// Signature help was invoked manually by the user or by a command.
+    export const Invoked: 1 = 1;
+    /// Signature help was triggered by a trigger character.
+    export const TriggerCharacter: 2 = 2;
+    /// Signature help was triggered by the cursor moving or by the document content changing.
+    export const ContentChange: 3 = 3;
+  }
+  export type SignatureHelpTriggerKind = 1 | 2 | 3;
+
+  /// Additional information about the context in which a signature help request was triggered.
+  ///
+  export interface SignatureHelpContext {
+    /// Action that caused signature help to be triggered.
+    triggerKind: SignatureHelpTriggerKind;
+
+    /// Character that caused signature help to be triggered.
+    /// This is undefined when `triggerKind !== SignatureHelpTriggerKind.TriggerCharacter`
+    triggerCharacter?: string;
+
+    /// `true` if signature help was already showing when it was triggered.
+    /// Retriggers occurs when the signature help is already active and can be caused by actions such as
+    /// typing a trigger character, a cursor move, or document content changes.
+    isRetrigger: boolean;
+
+    /// The currently active `SignatureHelp`.
+    /// The `activeSignatureHelp` has its `SignatureHelp.activeSignature` field updated based on
+    /// the user navigating through available signatures.
+    activeSignatureHelp?: SignatureHelp;
+  }
+
+  /// Parameters for a {@link SignatureHelpRequest}.
+  export interface SignatureHelpParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams {
+
+    /// The signature help context. This is only available if the client specifies
+    /// to send this using the client capability `textDocument.signatureHelp.contextSupport === true`
+    context?: SignatureHelpContext;
+  }
+
+  /// Registration options for a {@link SignatureHelpRequest}.
+  export interface SignatureHelpRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      SignatureHelpOptions {
+  }
+
+  export namespace SignatureHelpRequest {
+    export const method: 'textDocument/signatureHelp' = 'textDocument/signatureHelp';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<SignatureHelpParams, SignatureHelp | null, never, void, SignatureHelpRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/typeDefinition.dark
+++ b/packages/darklang/languageServerProtocol/language/typeDefinition.dark
@@ -1,0 +1,42 @@
+// supports "go to type definition"
+
+(*
+  export interface TypeDefinitionClientCapabilities {
+    * Whether implementation supports dynamic registration. If this is set to `true`
+    * the client supports the new `TypeDefinitionRegistrationOptions` return value
+    * for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+
+    * The client supports additional metadata in the form of definition links.
+    linkSupport?: boolean;
+  }
+
+  export interface TypeDefinitionOptions
+    extends
+      WorkDoneProgressOptions {
+  }
+
+  export interface TypeDefinitionRegistrationOptions
+    extends
+      TextDocumentRegistrationOptions,
+      TypeDefinitionOptions,
+      StaticRegistrationOptions {
+  }
+
+  export interface TypeDefinitionParams
+    extends
+      TextDocumentPositionParams,
+      WorkDoneProgressParams,
+      PartialResultParams {
+  }
+
+  * A request to resolve the type definition locations of a symbol at a given text
+  * document position. The request's parameter is of type {@link TextDocumentPositionParams}
+  * the response is of type {@link Definition} or a Thenable that resolves to such.
+  export namespace TypeDefinitionRequest {
+    export const method: 'textDocument/typeDefinition' = 'textDocument/typeDefinition';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<TypeDefinitionParams, Definition | DefinitionLink[] | null, Location[] | DefinitionLink[], void, TypeDefinitionRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<TypeDefinitionParams, Definition | DefinitionLink[] | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/language/typeHierarchy.dark
+++ b/packages/darklang/languageServerProtocol/language/typeHierarchy.dark
@@ -1,0 +1,92 @@
+// given a function, show outgoing and incoming calls
+// given a type, show usages of that type and types it uses (I think?)
+// maybe others
+
+(*
+
+  export type TypeHierarchyItem = {
+    /// The name of this item.
+    name: string;
+
+    /// The kind of this item.
+    kind: SymbolKind;
+
+    /// Tags for this item.
+    tags?: SymbolTag[];
+
+    /// More detail for this item, e.g. the signature of a function.
+    detail?: string;
+
+    /// The resource identifier of this item.
+    uri: DocumentUri;
+
+    /// The range enclosing this symbol not including leading/trailing whitespace
+    /// but everything else, e.g. comments and code.
+    range: Range;
+
+    /**
+    /// The range that should be selected and revealed when this symbol is being
+    /// picked, e.g. the name of a function. Must be contained by the
+    /// {@link TypeHierarchyItem.range `range`}.
+    ////
+    selectionRange: Range;
+
+    /// A data entry field that is preserved between a type hierarchy prepare and
+    /// supertypes or subtypes requests. It could also be used to identify the
+    /// type hierarchy in the server, helping improve the performance on
+    /// resolving supertypes and subtypes.
+    data?: LSPAny;
+  };
+
+
+  export type TypeHierarchyClientCapabilities = {
+    /// Whether implementation supports dynamic registration. If this is set to `true`
+    /// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+    /// return value for the corresponding server capability as well.
+    dynamicRegistration?: boolean;
+  };
+
+  /// Type hierarchy options used during static registration.
+  export type TypeHierarchyOptions = WorkDoneProgressOptions;
+
+  /// Type hierarchy options used during static or dynamic registration.
+  export type TypeHierarchyRegistrationOptions = TextDocumentRegistrationOptions & TypeHierarchyOptions & StaticRegistrationOptions;
+
+  /// The parameter of a `textDocument/prepareTypeHierarchy` request.
+  export type TypeHierarchyPrepareParams = TextDocumentPositionParams & WorkDoneProgressParams;
+
+  /// A request to result a `TypeHierarchyItem` in a document at a given position.
+  /// Can be used as an input to a subtypes or supertypes type hierarchy.
+  export namespace TypeHierarchyPrepareRequest {
+    export const method: 'textDocument/prepareTypeHierarchy' = 'textDocument/prepareTypeHierarchy';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<TypeHierarchyPrepareParams, TypeHierarchyItem[] | null, never, void, TypeHierarchyRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<TypeHierarchyPrepareParams, TypeHierarchyItem[] | null, void>;
+  }
+
+  /// The parameter of a `typeHierarchy/supertypes` request.
+  export type TypeHierarchySupertypesParams = WorkDoneProgressParams & PartialResultParams & {
+    item: TypeHierarchyItem;
+  };
+
+  /// A request to resolve the supertypes for a given `TypeHierarchyItem`.
+  export namespace TypeHierarchySupertypesRequest {
+    export const method: 'typeHierarchy/supertypes' = 'typeHierarchy/supertypes';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<TypeHierarchySupertypesParams, TypeHierarchyItem[] | null, TypeHierarchyItem[], void, void>(method);
+    export type HandlerSignature = RequestHandler<TypeHierarchySupertypesParams, TypeHierarchyItem[] | null, void>;
+  }
+
+  /// The parameter of a `typeHierarchy/subtypes` request.
+  export type TypeHierarchySubtypesParams = WorkDoneProgressParams & PartialResultParams & {
+    item: TypeHierarchyItem;
+  };
+
+  /// A request to resolve the subtypes for a given `TypeHierarchyItem`.
+  export namespace TypeHierarchySubtypesRequest {
+    export const method: 'typeHierarchy/subtypes' = 'typeHierarchy/subtypes';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<TypeHierarchySubtypesParams, TypeHierarchyItem[] | null, TypeHierarchyItem[], void, void>(method);
+    export type HandlerSignature = RequestHandler<TypeHierarchySubtypesParams, TypeHierarchyItem[] | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/lifecycle/capabilityRegistration.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/capabilityRegistration.dark
@@ -1,0 +1,55 @@
+// for registering and unregistering capabilities _after_ the initialize handshake
+
+(*
+  /// General parameters to register for a notification or to register a provider.
+  export interface Registration {
+    /// The id used to register the request. The id can be used to deregister
+    /// the request again.
+    id: string;
+
+    /// The method / capability to register for.
+    method: string;
+
+    /// Options necessary for the registration.
+    registerOptions?: LSPAny;
+  }
+
+  export interface RegistrationParams {
+    registrations: Registration[];
+  }
+
+  /// The `client/registerCapability` request is sent from the server to the client to register a new capability
+  /// handler on the client side.
+  export namespace RegistrationRequest {
+    export const method: 'client/registerCapability' = 'client/registerCapability';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType<RegistrationParams, void, never, void, void>(method);
+    export type HandlerSignature = RequestHandler<RegistrationParams, void, void>;
+  }
+
+  /// General parameters to unregister a request or notification.
+  export interface Unregistration {
+    /// The id used to unregister the request or notification. Usually an id
+    /// provided during the register request.
+    id: string;
+
+    /// The method to unregister for.
+    method: string;
+  }
+
+  export interface UnregistrationParams {
+    // Should correctly be named `unregistrations`. However
+    // this is a breaking change which has to wait for
+    // protocol version 4.0.
+    unregisterations: Unregistration[];
+  }
+
+  /// The `client/unregisterCapability` request is sent from the server to the client to unregister a previously registered capability
+  /// handler on the client side.
+  export namespace UnregistrationRequest {
+    export const method: 'client/unregisterCapability' = 'client/unregisterCapability';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType<UnregistrationParams, void, never, void, void>(method);
+    export type HandlerSignature = RequestHandler<UnregistrationParams, void, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/lifecycle/exit.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/exit.dark
@@ -1,0 +1,9 @@
+(*
+  /// The exit event is sent from the client to the server to
+  /// ask the server to exit its process.
+  export namespace ExitNotification {
+    export const method: 'exit' = 'exit';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType0<void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
@@ -6,6 +6,404 @@ module Darklang =
       module InitializeRequest =
         let method = "initialize"
 
+        module ClientInfo =
+          /// Information about the client, provided by the client
+          type ClientInfo =
+            {
+              /// The name of the client as defined by the client.
+              name: String
+
+              /// The client's version as defined by the client.
+              version: Stdlib.Option.Option<String>
+            }
+
+          let fromJson (json: Json) : Stdlib.Result.Result<ClientInfo, Unit> =
+            match json with
+            | Object fields ->
+              let name = // Result<String, Unit>
+                match
+                  Stdlib.List.findFirst (fun (key, _) -> key = "name") fields
+                with
+                | Some(_, String name) -> Stdlib.Result.Result.Ok name
+                | _ -> Stdlib.Result.Result.Error()
+
+              let version = // Result<Option<String>, Unit>
+                match
+                  Stdlib.List.findFirst (fun (key, _) -> key = "version") fields
+                with
+                | Some(_, String version) -> Stdlib.Result.Result.Ok(Some version)
+                | _ -> Stdlib.Result.Result.Error()
+
+              match (name, version) with
+              | (Ok name, Ok version) ->
+                (ClientInfo { name = name, version = version })
+                |> Stdlib.Result.Result.Ok
+              | _ -> Stdlib.Result.Result.Error()
+            | _ -> Stdlib.Result.Result.Error()
+
+
+
+        module WindowClientCapabilities =
+          type WindowClientCapabilities =
+            {
+              // /// It indicates whether the client supports server initiated
+              // /// progress using the `window/workDoneProgress/create` request.
+              // /// The capability also controls Whether client supports handling
+              // /// of progress notifications. If set servers are allowed to report a
+              // /// `workDoneProgress` property in the request specific server
+              // /// capabilities.
+              // workDoneProgress?: boolean;
+
+              /// Capabilities specific to the showMessage request.
+              showMessage:
+                Stdlib.Option.Option<Window.ShowMessageRequest.ShowMessageRequestClientCapabilities>
+
+            // /// Capabilities specific to the showDocument request.
+            // showDocument?: ShowDocumentClientCapabilities;
+            }
+
+        // /// Client capabilities specific to regular expressions.
+        // export interface RegularExpressionsClientCapabilities {
+        //   /// The engine's name.
+        //   engine: string;
+
+        //   /// The engine's version.
+        //   version?: string;
+        // }
+
+
+        // /// Capabilities specific to the notebook document support.
+        // export interface NotebookDocumentClientCapabilities {
+        //   /// Capabilities specific to notebook document synchronization
+        //   synchronization: NotebookDocumentSyncClientCapabilities;
+        // }
+
+
+        // /// A set of predefined position encoding kinds.
+        // export namespace PositionEncodingKind {
+        //   /// Character offsets count UTF-8 code units (e.g. bytes).
+        //   export const UTF8: PositionEncodingKind = 'utf-8';
+
+        //   /// Character offsets count UTF-16 code units.
+        //   /// This is the default and must always be supported by servers
+        //   export const UTF16: PositionEncodingKind = 'utf-16';
+
+        //   /// Character offsets count UTF-32 code units.
+        //   /// Implementation note: these are the same as Unicode codepoints,
+        //   /// so this `PositionEncodingKind` may also be used for an
+        //   /// encoding-agnostic representation of character offsets.
+        //   export const UTF32: PositionEncodingKind = 'utf-32';
+        // }
+        // /// A type indicating how positions are encoded,
+        // /// specifically what column offsets mean.
+        // export type PositionEncodingKind = string;
+
+
+
+        // /// @proposed
+        // export interface StaleRequestSupportOptions {
+        //   /// The client will actively cancel the request.
+        //   cancel: boolean;
+
+        //   /// The list of requests for which the client
+        //   /// will retry the request if it receives a
+        //   /// response with error code `ContentModified`
+        //   retryOnContentModified: string[];
+        // }
+
+
+        // /// General client capabilities.
+        // export interface GeneralClientCapabilities {
+        //   /// Client capability that signals how the client handles stale requests
+        //   /// (e.g. a request for which the client will not process the response
+        //   /// anymore since the information is outdated).
+        //   staleRequestSupport?: StaleRequestSupportOptions;
+
+        //   /// Client capabilities specific to regular expressions.
+        //   regularExpressions?: RegularExpressionsClientCapabilities;
+
+        //   /// Client capabilities specific to the client's markdown parser.
+        //   markdown?: MarkdownClientCapabilities;
+
+        //   /// The position encodings supported by the client. Client and server have to
+        //   /// agree on the same position encoding to ensure that offsets (e.g. character
+        //   /// position in a line) are interpreted the same on both sides.
+        //   ///
+        //   /// To keep the protocol backwards-compatible the following applies:
+        //   /// if the value 'utf-16' is missing from the array of position encodings
+        //   /// servers can assume that the client supports UTF-16. UTF-16 is therefore a
+        //   /// mandatory encoding.
+        //   ///
+        //   /// If omitted it defaults to ['utf-16'].
+        //   ///
+        //   /// Implementation considerations: since the conversion from one encoding into
+        //   /// another requires the content of the file / line the conversion is best done
+        //   /// where the file is read which is usually on the server side.
+        //   positionEncodings?: PositionEncodingKind[];
+        // }
+
+
+
+        // /// Workspace specific client capabilities.
+        // export interface WorkspaceClientCapabilities {
+        //   /// The client supports applying batch edits
+        //   /// to the workspace by supporting the request
+        //   /// 'workspace/applyEdit'
+        //   applyEdit?: boolean;
+
+        //   /// Capabilities specific to `WorkspaceEdit`s.
+        //   workspaceEdit?: WorkspaceEditClientCapabilities;
+
+        //   /// Capabilities specific to the `workspace/didChangeConfiguration` notification.
+        //   didChangeConfiguration?: DidChangeConfigurationClientCapabilities;
+
+        //   /// Capabilities specific to the `workspace/didChangeWatchedFiles` notification.
+        //   didChangeWatchedFiles?: DidChangeWatchedFilesClientCapabilities;
+
+        //   /// Capabilities specific to the `workspace/symbol` request.
+        //   symbol?: WorkspaceSymbolClientCapabilities;
+
+        //   /// Capabilities specific to the `workspace/executeCommand` request.
+        //   executeCommand?: ExecuteCommandClientCapabilities;
+
+        //   /// The client has support for workspace folders.
+        //   workspaceFolders?: boolean;
+
+        //   /// The client supports `workspace/configuration` requests.
+        //   configuration?: boolean;
+
+        //   /// Capabilities specific to the semantic token requests scoped to the
+        //   /// workspace.
+        //   semanticTokens?: SemanticTokensWorkspaceClientCapabilities;
+
+        //   /// Capabilities specific to the code lens requests scoped to the
+        //   /// workspace.
+        //   codeLens?: CodeLensWorkspaceClientCapabilities;
+
+        //   /// The client has support for file notifications/requests for user operations on files.
+        //   fileOperations?: FileOperationClientCapabilities;
+
+        //   /// Capabilities specific to the inline values requests scoped to the
+        //   /// workspace.
+        //   inlineValue?: InlineValueWorkspaceClientCapabilities;
+
+        //   /// Capabilities specific to the inlay hint requests scoped to the
+        //   /// workspace.
+        //   inlayHint?: InlayHintWorkspaceClientCapabilities;
+
+        //   /// Capabilities specific to the diagnostic requests scoped to the
+        //   /// workspace.
+        //   diagnostics?: DiagnosticWorkspaceClientCapabilities;
+
+        //   /// Capabilities specific to the folding range requests scoped to the workspace.
+        //   /// @proposed
+        //   foldingRange?: FoldingRangeWorkspaceClientCapabilities;
+        // }
+
+
+        // /// Client capabilities specific to the used markdown parser.
+        // export interface MarkdownClientCapabilities {
+        //   /// The name of the parser.
+        //   parser: string;
+
+        //   /// The version of the parser.
+        //   version?: string;
+
+        //   /// A list of HTML tags that the client allows / supports in
+        //   /// Markdown.
+        //   allowedTags?: string[];
+        // }
+
+
+        // /// Text document specific client capabilities.
+        // export interface TextDocumentClientCapabilities {
+        //   /// Defines which synchronization capabilities the client supports.
+        //   synchronization?: TextDocumentSyncClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/completion` request.
+        //   completion?: CompletionClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/hover` request.
+        //   hover?: HoverClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/signatureHelp` request.
+        //   signatureHelp?: SignatureHelpClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/declaration` request.
+        //   declaration?: DeclarationClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/definition` request.
+        //   definition?: DefinitionClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/typeDefinition` request.
+        //   typeDefinition?: TypeDefinitionClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/implementation` request.
+        //   implementation?: ImplementationClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/references` request.
+        //   references?: ReferenceClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/documentHighlight` request.
+        //   documentHighlight?: DocumentHighlightClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/documentSymbol` request.
+        //   documentSymbol?: DocumentSymbolClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/codeAction` request.
+        //   codeAction?: CodeActionClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/codeLens` request.
+        //   codeLens?: CodeLensClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/documentLink` request.
+        //   documentLink?: DocumentLinkClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/documentColor` and the
+        //   /// `textDocument/colorPresentation` request.
+        //   colorProvider?: DocumentColorClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/formatting` request.
+        //   formatting?: DocumentFormattingClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/rangeFormatting` request.
+        //   rangeFormatting?: DocumentRangeFormattingClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/onTypeFormatting` request.
+        //   onTypeFormatting?: DocumentOnTypeFormattingClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/rename` request.
+        //   rename?: RenameClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/foldingRange` request.
+        //   foldingRange?: FoldingRangeClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/selectionRange` request.
+        //   selectionRange?: SelectionRangeClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/publishDiagnostics` notification.
+        //   publishDiagnostics?: PublishDiagnosticsClientCapabilities;
+
+        //   /// Capabilities specific to the various call hierarchy requests.
+        //   callHierarchy?: CallHierarchyClientCapabilities;
+
+        //   /// Capabilities specific to the various semantic token request.
+        //   semanticTokens?: SemanticTokensClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/linkedEditingRange` request.
+        //   linkedEditingRange?: LinkedEditingRangeClientCapabilities;
+
+        //   /// Client capabilities specific to the `textDocument/moniker` request.
+        //   moniker?: MonikerClientCapabilities;
+
+        //   /// Capabilities specific to the various type hierarchy requests.
+        //   typeHierarchy?: TypeHierarchyClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/inlineValue` request.
+        //   inlineValue?: InlineValueClientCapabilities;
+
+        //   /// Capabilities specific to the `textDocument/inlayHint` request.
+        //   inlayHint?: InlayHintClientCapabilities;
+
+        //   /// Capabilities specific to the diagnostic pull model.
+        //   diagnostic?: DiagnosticClientCapabilities;
+
+        //   /// Client capabilities specific to inline completions.
+        //   ///
+        //   * @proposed
+        //   inlineCompletion?: InlineCompletionClientCapabilities;
+        // }
+
+
+
+        /// Defines the capabilities provided by the client.
+        type ClientCapabilities =
+          {
+            // /// Workspace specific client capabilities.
+            // workspace?: WorkspaceClientCapabilities;
+
+            // /// Text document specific client capabilities.
+            // textDocument?: TextDocumentClientCapabilities;
+
+            // /// Capabilities specific to the notebook document support.
+            // notebookDocument?: NotebookDocumentClientCapabilities;
+
+            // /// Window specific client capabilities.
+            // window?: WindowClientCapabilities;
+
+            // /// General client capabilities.
+            // general?: GeneralClientCapabilities;
+
+            /// Experimental client capabilities.
+            experimental: Stdlib.Option.Option<Json>
+          }
+
+
+        module InitializeParams =
+          /// The initialize parameters
+          ///
+          /// TODO: extends
+          /// - WorkDoneProgressParams
+          type InitializeParams =
+            {
+              // /// The process Id of the parent process that started the server.
+              // /// Is `null` if the process has not been started by another process.
+              // /// If the parent process is not alive then the server should exit.
+              // processId: integer | null;
+
+              /// Information about the client
+              clientInfo: Stdlib.Option.Option<ClientInfo.ClientInfo>
+
+            // /// The locale the client is currently showing the user interface in.
+            // /// This must not necessarily be the locale of the operating system.
+            // /// Uses IETF language tags as the value's syntax
+            // /// (See https://en.wikipedia.org/wiki/IETF_language_tag)
+            // locale?: string;
+
+            // /// The rootUri of the workspace.Is null if no folder is open.
+            // /// If both `rootPath` and `rootUri` are set, `rootUri` wins.
+            // /// @deprecated in favour of workspaceFolders.
+            // rootUri: DocumentUri | null;
+
+            // /// The capabilities provided by the client (editor or tool)
+            // capabilities: ClientCapabilities;
+
+            // /// User-provided initialization options.
+            // initializationOptions?: LSPAny;
+
+            // /// The initial trace setting. If omitted trace is disabled ('off').
+            // trace?: TraceValues;
+
+            // /// The workspace folders configured in the client when the server starts.
+            // ///
+            // /// This property is only available if the client supports workspace folders.
+            // /// It can be `null` if the client supports workspace folders but none are
+            // /// configured.
+            // workspaceFolders?: WorkspaceFolder[] | null;
+            }
+
+          let fromJson (json: Json) : Stdlib.Result.Result<InitializeParams, Unit> =
+            match json with
+            | Object fields ->
+              let clientInfo = // Result<Option<ClientInfo>, Unit>
+                match Json.Object.get fields "clientInfo" with
+                | Some clientInfo -> ClientInfo.fromJson clientInfo
+                | None -> Stdlib.Result.Result.Ok
+
+              match clientInfo with
+              | Ok clientInfo ->
+                (InitializeParams { clientInfo = clientInfo })
+                |> Stdlib.Result.Result.Ok
+              | Error _ -> Stdlib.Result.Result.Error()
+            | _ -> Stdlib.Result.Result.Error()
+
+
+        // --- </`initialize` request params from client>
+
+
+
+        // --- <`initialize` request result from server>
+
         // /// Defines workspace specific capabilities of the server.
         // ///
         // /// @proposed

--- a/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
@@ -1,0 +1,235 @@
+module Darklang =
+  module LanguageServerProtocol =
+    module Lifecycle =
+      /// The initialize request is the first request of a client-server relationship.
+      /// It is sent once, from the client to the server.
+      module InitializeRequest =
+        let method = "initialize"
+
+        // /// Defines workspace specific capabilities of the server.
+        // ///
+        // /// @proposed
+        // export interface WorkspaceOptions {
+        //   /// The server supports workspace folder.
+        //   workspaceFolders?: WorkspaceFoldersServerCapabilities;
+
+        //   * The server is interested in notifications/requests for operations on files.
+        //   fileOperations?: FileOperationOptions;
+        // }
+
+
+        // note: this doesn't directly map to a single type in the spec
+        module TextDocumentSyncServerCapabilities =
+          type TextDocumentSyncServerCapabilities =
+            | TextDocumentSyncOptions of
+              DocumentSync.TextDocument.TextDocumentSyncOptions.TextDocumentSyncOptions
+            | TextDocumentSyncKind of
+              DocumentSync.TextDocument.TextDocumentSyncKind.TextDocumentSyncKind
+
+          // Note: we intentionally don't include any extra json representing this wrapper union type
+          // (i.e. we don't indicate the 'case' of the union)
+          let toJson (capabilities: TextDocumentSyncServerCapabilities) : Json =
+            match capabilities with
+            | TextDocumentSyncOptions o ->
+              DocumentSync.TextDocument.TextDocumentSyncOptions.toJson o
+            | TextDocumentSyncKind kind -> TextDocumentSyncKind.toJson kind
+
+
+        module ServerCapabilities =
+          /// Defines the capabilities provided by a language server.
+          type ServerCapabilities =
+            {
+              // /// The position encoding the server picked from the encodings offered
+              // /// by the client via the client capability `general.positionEncodings`.
+              // /// If the client didn't provide any position encodings the only valid
+              // /// value that a server can return is 'utf-16'.
+              // /// If omitted it defaults to 'utf-16'.
+              // positionEncoding?: PositionEncodingKind;
+
+              /// Defines how text documents are synced. Is either a detailed structure
+              /// defining each notification or for backwards compatibility the
+              /// TextDocumentSyncKind number.
+              textDocumentSync:
+                Stdlib.Option.Option<TextDocumentSyncServerCapabilities.TextDocumentSyncServerCapabilities>
+
+            // /// Defines how notebook documents are synced.
+            // notebookDocumentSync?: NotebookDocumentSyncOptions | NotebookDocumentSyncRegistrationOptions;
+
+            // /// The server provides completion support.
+            // completionProvider?: CompletionOptions;
+
+            // /// The server provides hover support.
+            // hoverProvider?: boolean | HoverOptions;
+
+            // /// The server provides signature help support.
+            // signatureHelpProvider?: SignatureHelpOptions;
+
+            // /// The server provides Goto Declaration support.
+            // declarationProvider?: boolean | DeclarationOptions | DeclarationRegistrationOptions;
+
+            // /// The server provides goto definition support.
+            // definitionProvider?: boolean | DefinitionOptions;
+
+            // /// The server provides Goto Type Definition support.
+            // typeDefinitionProvider?: boolean | TypeDefinitionOptions | TypeDefinitionRegistrationOptions;
+
+            // /// The server provides Goto Implementation support.
+            // implementationProvider?: boolean | ImplementationOptions | ImplementationRegistrationOptions;
+
+            // /// The server provides find references support.
+            // referencesProvider?: boolean | ReferenceOptions;
+
+            // /// The server provides document highlight support.
+            // documentHighlightProvider?: boolean | DocumentHighlightOptions;
+
+            // /// The server provides document symbol support.
+            // documentSymbolProvider?: boolean | DocumentSymbolOptions;
+
+            // /// The server provides code actions. CodeActionOptions may only be
+            // /// specified if the client states that it supports
+            // /// `codeActionLiteralSupport` in its initial `initialize` request.
+            // codeActionProvider?: boolean | CodeActionOptions;
+
+            // /// The server provides code lens.
+            // codeLensProvider?: CodeLensOptions;
+
+            // /// The server provides document link support.
+            // documentLinkProvider?: DocumentLinkOptions;
+
+            // /// The server provides color provider support.
+            // colorProvider?: boolean | DocumentColorOptions | DocumentColorRegistrationOptions;
+
+            // /// The server provides workspace symbol support.
+            // workspaceSymbolProvider?: boolean | WorkspaceSymbolOptions;
+
+            // /// The server provides document formatting.
+            // documentFormattingProvider?: boolean | DocumentFormattingOptions;
+
+            // /// The server provides document range formatting.
+            // documentRangeFormattingProvider?: boolean | DocumentRangeFormattingOptions;
+
+            // /// The server provides document formatting on typing.
+            // documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions;
+
+            // /// The server provides rename support. RenameOptions may only be
+            // /// specified if the client states that it supports
+            // /// `prepareSupport` in its initial `initialize` request.
+            // renameProvider?: boolean | RenameOptions;
+
+            // /// The server provides folding provider support.
+            // foldingRangeProvider?: boolean | FoldingRangeOptions | FoldingRangeRegistrationOptions;
+
+            // /// The server provides selection range support.
+            // selectionRangeProvider?: boolean | SelectionRangeOptions | SelectionRangeRegistrationOptions;
+
+            // /// The server provides execute command support.
+            // executeCommandProvider?: ExecuteCommandOptions;
+
+            // /// The server provides call hierarchy support.
+            // callHierarchyProvider?: boolean | CallHierarchyOptions | CallHierarchyRegistrationOptions;
+
+            // /// The server provides linked editing range support.
+            // linkedEditingRangeProvider?: boolean | LinkedEditingRangeOptions | LinkedEditingRangeRegistrationOptions;
+
+            // /// The server provides semantic tokens support.
+            // semanticTokensProvider?: SemanticTokensOptions | SemanticTokensRegistrationOptions;
+
+            // /// The server provides moniker support.
+            // monikerProvider?: boolean | MonikerOptions | MonikerRegistrationOptions;
+
+            // /// The server provides type hierarchy support.
+            // typeHierarchyProvider?: boolean | TypeHierarchyOptions | TypeHierarchyRegistrationOptions;
+
+            // /// The server provides inline values.
+            // inlineValueProvider?: boolean | InlineValueOptions | InlineValueRegistrationOptions;
+
+            // /// The server provides inlay hints.
+            // inlayHintProvider?: boolean | InlayHintOptions | InlayHintRegistrationOptions;
+
+            // /// The server has support for pull model diagnostics.
+            // diagnosticProvider?: DiagnosticOptions | DiagnosticRegistrationOptions;
+
+            // /// Inline completion options used during static registration.
+            // ///
+            // /// @proposed
+            // inlineCompletionProvider?: boolean | InlineCompletionOptions;
+
+            // /// Workspace specific server capabilities.
+            // workspace?: WorkspaceOptions;
+
+            // /// Experimental server capabilities.
+            // experimental: Stdlib.Option.Option<Json>
+            }
+
+          let toJson (capabilities: ServerCapabilities) : Json =
+            [ capabilities.textDocumentSync
+              |> Stdlib.Option.map (fun sync ->
+                ("textDocumentSync", TextDocumentSyncServerCapabilities.toJson sync)) ]
+
+            |> Stdlib.List.filterMap (fun self -> self)
+            |> Json.Object
+
+
+        /// Information about the server
+        module ServerInfo =
+          /// Information about the server
+          type ServerInfo =
+            {
+              /// The name of the server as defined by the server.
+              name: String
+
+              /// The server's version as defined by the server.
+              version: Stdlib.Option.Option<String>
+            }
+
+          let toJson (serverInfo: ServerInfo) : Json =
+            let fields =
+              [ Some(("name", Json.String serverInfo.name))
+
+                (serverInfo.version
+                 |> Stdlib.Option.map (fun v -> ("version", Json.String v))) ]
+              |> Stdlib.List.filterMap (fun self -> self)
+
+            Json.Object fields
+
+
+        module InitializeResult =
+          /// The result returned from an `initialize` request.
+          type InitializeResult =
+            {
+              /// The capabilities the language server provides.
+              capabilities: ServerCapabilities.ServerCapabilities
+
+              /// Information about the server.
+              serverInfo: Stdlib.Option.Option<ServerInfo.ServerInfo>
+
+            // /// Custom initialization results.
+            // [custom: string]: LSPAny | ServerCapabilities<T> | undefined; /** undefined is needed since serverInfo is optional */
+            }
+
+          let toJson (result: InitializeResult) : Json =
+            [ Stdlib.Option.Option.Some(
+                ("capabilities", ServerCapabilities.toJson result.capabilities)
+              )
+
+              (result.serverInfo
+               |> Stdlib.Option.map (fun info ->
+                 ("serverInfo", ServerInfo.toJson info))) ]
+
+            |> Stdlib.List.filterMap (fun self -> self)
+            |> Json.Object
+
+
+        module InitializeError =
+          /// The data type of the ResponseError if the initialize request fails.
+          type InitializeError =
+            {
+              /// Indicates whether the client execute the following retry logic:
+              /// (1) show the message provided by the ResponseError to the user
+              /// (2) user selects retry or cancel
+              /// (3) if user selected retry the initialize method is sent again.
+              retry: Bool
+            }
+
+          let toJson (error: InitializeError) : Json =
+            Json.Object [ ("retry", Json.Bool error.retry) ]

--- a/packages/darklang/languageServerProtocol/lifecycle/initialized.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/initialized.dark
@@ -1,0 +1,12 @@
+(*
+  export interface InitializedParams {}
+
+  /// The initialized notification is sent from the client to the
+  /// server after the client is fully initialized and the server
+  /// is allowed to send requests from the server to the client.
+  export namespace InitializedNotification {
+    export const method: 'initialized' = 'initialized';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<InitializedParams, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/lifecycle/shutdown.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/shutdown.dark
@@ -1,0 +1,11 @@
+(*
+  /// A shutdown request is sent from the client to the server.
+  /// It is sent once when the client decides to shutdown the
+  /// server. The only notification that is sent after a shutdown request
+  /// is the exit event.
+  export namespace ShutdownRequest {
+    export const method: 'shutdown' = 'shutdown';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType0<void, never, void, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/tracing.dark
+++ b/packages/darklang/languageServerProtocol/tracing.dark
@@ -1,0 +1,17 @@
+// Supports:
+// - the client setting a trace level
+// - the server logging a trace
+
+(*
+  namespace SetTraceNotification {
+    export const method: '$/setTrace' = '$/setTrace';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<SetTraceParams, void>(method);
+  }
+
+  namespace LogTraceNotification {
+    export const method: '$/logTrace' = '$/logTrace';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolNotificationType<LogTraceParams, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/window/logMessage.dark
+++ b/packages/darklang/languageServerProtocol/window/logMessage.dark
@@ -1,0 +1,20 @@
+// Server->Client notification to log a message (to console or something)
+
+(*
+  /// The log message notification is sent from the server to the client to ask
+  /// the client to log a particular message.
+  export namespace LogMessageNotification {
+    export const method: 'window/logMessage' = 'window/logMessage';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolNotificationType<LogMessageParams, void>(method);
+  }
+
+  /// The log message parameters.
+  export interface LogMessageParams {
+    /// The message type. See {@link MessageType}
+    type: MessageType;
+
+    /// The actual message.
+    message: string;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/window/showDocument.dark
+++ b/packages/darklang/languageServerProtocol/window/showDocument.dark
@@ -1,0 +1,40 @@
+// Server->Client request to show a document (by URI)
+
+(*
+  /// Client capabilities for the showDocument request.
+  export interface ShowDocumentClientCapabilities {
+    /// The client has support for the showDocument request.
+    support: boolean;
+  }
+
+  /// Params to show a resource in the UI.
+  export interface ShowDocumentParams {
+    uri: URI;
+
+    /// Indicates to show the resource in an external program (i.e. web browser)
+    external?: boolean;
+
+    /// An optional property to indicate whether the editor showing the document should take focus or not.
+    /// Clients might ignore this property if an external program is started.
+    takeFocus?: boolean;
+
+    /// An optional selection range if the document is a text document.
+    /// Clients might ignore the property if an external program is started or the file is not a text file.
+    selection?: Range;
+  }
+
+  /// The result of a showDocument request.
+  export interface ShowDocumentResult {
+    /// A boolean indicating if the show was successful.
+    success: boolean;
+  }
+
+  /// A request to show a document in the UI
+  export namespace ShowDocumentRequest {
+    export const method: 'window/showDocument' = 'window/showDocument';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType<ShowDocumentParams, ShowDocumentResult, void, void, void>(method);
+    export type HandlerSignature = RequestHandler<ShowDocumentParams, ShowDocumentResult, void>;
+    export type MiddlewareSignature = (params: ShowDocumentParams, next: HandlerSignature) => HandlerResult<ShowDocumentResult, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/window/showMessage.dark
+++ b/packages/darklang/languageServerProtocol/window/showMessage.dark
@@ -1,0 +1,32 @@
+// Server->Client notification to show a message (as a little popup) in the UI
+
+(*
+  /// The message type
+  export namespace MessageType {
+    export const Error = 1;
+    export const Warning = 2;
+    export const Info = 3;
+    export const Log = 4;
+
+    /// @proposed
+    export const Debug = 5;
+  }
+  export type MessageType = 1 | 2 | 3 | 4 | 5;
+
+  /// The parameters of a notification message.
+  export interface ShowMessageParams {
+    /// The message type. See {@link MessageType}
+    type: MessageType;
+
+    /// The actual message.
+    message: string;
+  }
+
+  /// The show message notification is sent from a server to a client to ask
+  /// the client to display a particular message in the user interface.
+  export namespace ShowMessageNotification {
+    export const method: 'window/showMessage' = 'window/showMessage';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolNotificationType<ShowMessageParams, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/window/showMessageRequest.dark
+++ b/packages/darklang/languageServerProtocol/window/showMessageRequest.dark
@@ -1,0 +1,54 @@
+// Server->Client request to show a message (as a little popup) in the UI,
+// along with a number of options to choose from, as a prompt for the user.
+
+module Darklang =
+  module LanguageServerProtocol =
+    module Window =
+      module ShowMessageRequest =
+        /// @proposed
+        type ClientShowMessageActionItemOptions =
+          {
+            /// Whether the client supports additional attributes which are
+            /// preserved and send back to the server in the request's response.
+            additionalPropertiesSupport: Stdlib.Option.Option<Bool>
+          }
+
+        /// Show message request client capabilities
+        type ShowMessageRequestClientCapabilities =
+          {
+            /// Capabilities specific to the `MessageActionItem` type.
+            messageActionItem:
+              Stdlib.Option.Option<ClientShowMessageActionItemOptions>
+          }
+
+(*
+
+  export interface MessageActionItem {
+    /// A short title like 'Retry', 'Open Log' etc.
+    title: string;
+
+    /// Additional attributes that the client preserves and
+    /// sends back to the server. This depends on the client
+    /// capability window.messageActionItem.additionalPropertiesSupport
+    [key: string]: string | boolean | integer | object;
+  }
+
+  export interface ShowMessageRequestParams {
+    /// The message type. See {@link MessageType}
+    type: MessageType;
+
+    /// The actual message.
+    message: string;
+
+    /// The message action items to present.
+    actions?: MessageActionItem[];
+  }
+
+  /// The show message request is sent from the server to the client to show a message
+  /// and a set of options actions to the user.
+  export namespace ShowMessageRequest {
+    export const method: 'window/showMessageRequest' = 'window/showMessageRequest';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType<ShowMessageRequestParams, MessageActionItem | null, never, void, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/window/telemetry.dark
+++ b/packages/darklang/languageServerProtocol/window/telemetry.dark
@@ -1,0 +1,11 @@
+// Server->Client notification to log telemetry data
+
+(*
+  /// The telemetry event notification is sent from the server to the client to ask
+  /// the client to log telemetry data.
+  export namespace TelemetryEventNotification {
+    export const method: 'telemetry/event' = 'telemetry/event';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolNotificationType<LSPAny, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/workInProgress.dark
+++ b/packages/darklang/languageServerProtocol/workInProgress.dark
@@ -1,0 +1,131 @@
+(*
+  No, this is not a .dark file that is a "work in progress".
+  Rather, this supports the LSP's "work in progress" feature.
+
+  Various requests and notifications that support the ability to report intermediate work -
+  that something has begun, made progress, or finished.
+
+  Although
+
+
+  export interface WorkDoneProgressBegin {
+    kind: 'begin';
+
+    /// Mandatory title of the progress operation.
+    /// Used to briefly inform about the kind of operation being performed.
+    ///
+    /// Examples: "Indexing" or "Linking dependencies".
+    title: string;
+
+    /// Controls if a cancel button should show to allow the user to cancel the
+    /// long running operation. Clients that don't support cancellation are allowed
+    /// to ignore the setting.
+    cancellable?: boolean;
+
+    /// Optional, more detailed associated progress message.
+    /// Contains complementary information to the `title`.
+    ///
+    /// Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".
+    /// If unset, the previous progress message (if any) is still valid.
+    message?: string;
+
+    /// Optional progress percentage to display (value 100 is considered 100%).
+    /// If not provided infinite progress is assumed and clients are allowed
+    /// to ignore the `percentage` value in subsequent in report notifications.
+    ///
+    /// The value should be steadily rising. Clients are free to ignore values
+    /// that are not following this rule. The value range is [0, 100].
+    percentage?: uinteger;
+  }
+
+  export interface WorkDoneProgressReport {
+    kind: 'report';
+
+    /// Controls enablement state of a cancel button.
+    ///
+    /// Clients that don't support cancellation or don't support controlling the button's
+    /// enablement state are allowed to ignore the property.
+    cancellable?: boolean;
+
+    /// Optional, more detailed associated progress message. Contains
+    /// complementary information to the `title`.
+    ///
+    /// Examples: "3/25 files", "project/src/module2", "node_modules/some_dep".
+    /// If unset, the previous progress message (if any) is still valid.
+    message?: string;
+
+    /// Optional progress percentage to display (value 100 is considered 100%).
+    /// If not provided infinite progress is assumed and clients are allowed
+    /// to ignore the `percentage` value in subsequent in report notifications.
+    ///
+    /// The value should be steadily rising. Clients are free to ignore values
+    /// that are not following this rule. The value range is [0, 100]
+    percentage?: uinteger;
+  }
+
+  export interface WorkDoneProgressEnd {
+    kind: 'end';
+
+    /// Optional, a final message indicating to for example indicate the outcome
+    /// of the operation.
+    message?: string;
+  }
+
+  export namespace WorkDoneProgress {
+    export const type = new ProgressType<WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd>();
+  }
+
+  export interface WorkDoneProgressCreateParams  {
+    /// The token to be used to report progress.
+    token: ProgressToken;
+  }
+
+  /// The `window/workDoneProgress/create` request is sent from the server to the client to initiate progress
+  /// reporting from the server.
+  export namespace WorkDoneProgressCreateRequest {
+    export const method: 'window/workDoneProgress/create' = 'window/workDoneProgress/create';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType<WorkDoneProgressCreateParams, void, never, void, void>(method);
+    export type HandlerSignature = RequestHandler<WorkDoneProgressCreateParams, void, void>;
+  }
+
+  export interface WorkDoneProgressCancelParams {
+    /// The token to be used to report progress.
+    token: ProgressToken;
+  }
+
+  /// The `window/workDoneProgress/cancel` notification is sent from the client to the server to cancel a progress
+  /// initiated on the server side.
+  export namespace WorkDoneProgressCancelNotification {
+    export const method: 'window/workDoneProgress/cancel' = 'window/workDoneProgress/cancel';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<WorkDoneProgressCancelParams, void>(method);
+    export type HandlerSignature = NotificationHandler<WorkDoneProgressCancelParams>;
+  }
+
+
+  interface CancelParams {
+    /// The request id to cancel.
+    id: number | string;
+  }
+
+  namespace CancelNotification {
+    export const method: '$/cancelRequest' = '$/cancelRequest';
+    export const messageDirection: MessageDirection = MessageDirection.both;
+    export const type = new ProtocolNotificationType<CancelParams, void>(method);
+  }
+
+  interface ProgressParams {
+    /// The progress token provided by the client or server.
+    token: ProgressToken;
+
+    /// The progress data.
+    value: LSPAny;
+  }
+
+  namespace ProgressNotification {
+    export const method: '$/progress' = '$/progress';
+    export const messageDirection: MessageDirection = MessageDirection.both;
+    export const type = new ProtocolNotificationType<ProgressParams, void>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/workspace/configuration.dark
+++ b/packages/darklang/languageServerProtocol/workspace/configuration.dark
@@ -1,0 +1,60 @@
+// Supports workspace-wide configuration for a specific LSP server
+
+(*
+  export interface ConfigurationItem {
+    /// The scope to get the configuration section for.
+    scopeUri?: URI;
+
+    /// The configuration section asked for.
+    section?: string;
+  }
+
+  /// The parameters of a configuration request.
+  export interface ConfigurationParams {
+    items: ConfigurationItem[];
+  }
+
+  /// The 'workspace/configuration' request is sent from the server to the client to fetch a certain
+  /// configuration setting.
+  ///
+  /// This pull model replaces the old push model were the client signaled configuration change via an
+  /// event. If the server still needs to react to configuration changes (since the server caches the
+  /// result of `workspace/configuration` requests) the server should register for an empty configuration
+  /// change event and empty the cache if such an event is received.
+  export namespace ConfigurationRequest {
+    export const method: 'workspace/configuration' = 'workspace/configuration';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType<ConfigurationParams, LSPAny[], never, void, void>(method);
+    export type HandlerSignature = RequestHandler<ConfigurationParams, LSPAny[], void>;
+    export type MiddlewareSignature = (params: ConfigurationParams, token: CancellationToken, next: HandlerSignature) => HandlerResult<LSPAny[], void>;
+  }
+
+
+
+
+  //---- Configuration notification ----
+
+  export interface DidChangeConfigurationClientCapabilities {
+    /// Did change configuration notification supports dynamic registration.
+    dynamicRegistration?: boolean;
+  }
+
+  /// The configuration change notification is sent from the client to the server
+  /// when the client's configuration has changed. The notification contains
+  /// the changed configuration as defined by the language client.
+  export namespace DidChangeConfigurationNotification {
+    export const method: 'workspace/didChangeConfiguration' = 'workspace/didChangeConfiguration';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions>(method);
+  }
+
+  export interface DidChangeConfigurationRegistrationOptions {
+    section?: string | string[];
+  }
+
+  /// The parameters of a change configuration notification.
+  export interface DidChangeConfigurationParams {
+    /// The actual changed settings
+    settings: LSPAny;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/workspace/executeCommand.dark
+++ b/packages/darklang/languageServerProtocol/workspace/executeCommand.dark
@@ -1,0 +1,45 @@
+// Provides the ability for the client to request a "command" to be executed on the server.
+
+(*
+  /// The client capabilities of a {@link ExecuteCommandRequest}.
+  export interface ExecuteCommandClientCapabilities {
+    /// Execute command supports dynamic registration.
+    dynamicRegistration?: boolean;
+  }
+
+  /// The parameters of a {@link ExecuteCommandRequest}.
+  export interface ExecuteCommandParams
+    extends
+      WorkDoneProgressParams {
+
+    /// The identifier of the actual command handler.
+    command: string;
+
+    /// Arguments that the command should be invoked with.
+    arguments?: LSPAny[];
+  }
+
+  /// The server capabilities of a {@link ExecuteCommandRequest}.
+  export interface ExecuteCommandOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// The commands to be executed on the server
+    commands: string[];
+  }
+
+  /// Registration options for a {@link ExecuteCommandRequest}.
+  export interface ExecuteCommandRegistrationOptions
+    extends
+      ExecuteCommandOptions {
+
+  }
+
+  /// A request send from the client to the server to execute a command. The request might return
+  /// a workspace edit which the client will apply to the workspace.
+  export namespace ExecuteCommandRequest {
+    export const method: 'workspace/executeCommand' = 'workspace/executeCommand';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<ExecuteCommandParams, LSPAny | null, never, void, ExecuteCommandRegistrationOptions>(method);
+  }
+*)

--- a/packages/darklang/languageServerProtocol/workspace/fileOperations.dark
+++ b/packages/darklang/languageServerProtocol/workspace/fileOperations.dark
@@ -1,0 +1,205 @@
+(*
+  /// Options for notifications/requests for user operations on files.
+  export interface FileOperationOptions {
+    /// The server is interested in receiving didCreateFiles notifications.
+    didCreate?: FileOperationRegistrationOptions;
+
+    /// The server is interested in receiving willCreateFiles requests.
+    willCreate?: FileOperationRegistrationOptions;
+
+    /// The server is interested in receiving didRenameFiles notifications.
+    didRename?: FileOperationRegistrationOptions;
+
+    /// The server is interested in receiving willRenameFiles requests.
+    willRename?: FileOperationRegistrationOptions;
+
+    /// The server is interested in receiving didDeleteFiles file notifications.
+    didDelete?: FileOperationRegistrationOptions;
+
+    /// The server is interested in receiving willDeleteFiles file requests.
+    willDelete?: FileOperationRegistrationOptions;
+  }
+
+  /// The options to register for file operations.
+  export interface FileOperationRegistrationOptions {
+    /// The actual filters.
+    filters: FileOperationFilter[];
+  }
+
+  /// A pattern kind describing if a glob pattern matches a file a folder or
+  /// both.
+  export namespace FileOperationPatternKind {
+    /// The pattern matches a file only.
+    export const file: 'file' = 'file';
+
+    /// The pattern matches a folder only.
+    export const folder: 'folder' = 'folder';
+  }
+  export type FileOperationPatternKind = 'file' | 'folder';
+
+
+  /// Matching options for the file operation pattern.
+  export interface FileOperationPatternOptions {
+    /// The pattern should be matched ignoring casing.
+    ignoreCase?: boolean;
+  }
+
+  /// A pattern to describe in which file operation requests or notifications
+  /// the server is interested in receiving.
+  interface FileOperationPattern {
+    /// The glob pattern to match. Glob patterns can have the following syntax:
+    /// - `*` to match one or more characters in a path segment
+    /// - `?` to match on one character in a path segment
+    /// - `**` to match any number of path segments, including none
+    /// - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+    /// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+    /// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+    glob: string;
+
+    /// Whether to match files or folders with this pattern.
+    ///
+    /// Matches both if undefined.
+    matches?: FileOperationPatternKind;
+
+    /// Additional options used during matching.
+    options?: FileOperationPatternOptions;
+  }
+
+  /// A filter to describe in which file operation requests or notifications
+  /// the server is interested in receiving.
+  export interface FileOperationFilter {
+    /// A Uri scheme like `file` or `untitled`.
+    scheme?: string;
+
+    /// The actual file operation pattern.
+    pattern: FileOperationPattern;
+  }
+
+  /// Capabilities relating to events from file operations by the user in the client.
+  ///
+  /// These events do not come from the file system, they come from user operations
+  /// like renaming a file in the UI.
+  export interface FileOperationClientCapabilities {
+    /// Whether the client supports dynamic registration for file requests/notifications.
+    dynamicRegistration?: boolean;
+
+    /// The client has support for sending didCreateFiles notifications.
+    didCreate?: boolean;
+
+    /// The client has support for sending willCreateFiles requests.
+    willCreate?: boolean;
+
+    /// The client has support for sending didRenameFiles notifications.
+    didRename?: boolean;
+
+    /// The client has support for sending willRenameFiles requests.
+    willRename?: boolean;
+
+    /// The client has support for sending didDeleteFiles notifications.
+    didDelete?: boolean;
+
+    /// The client has support for sending willDeleteFiles requests.
+    willDelete?: boolean;
+  }
+
+  /// The parameters sent in notifications/requests for user-initiated creation of files.
+  export interface CreateFilesParams {
+    /// An array of all files/folders created in this operation.
+    files: FileCreate[];
+  }
+
+  /// Represents information on a file/folder create.
+  export interface FileCreate {
+    /// A file:// URI for the location of the file/folder being created.
+    uri: string;
+  }
+
+  /// The parameters sent in notifications/requests for user-initiated renames of
+  /// files.
+  export interface RenameFilesParams {
+    /// An array of all files/folders renamed in this operation. When a folder is renamed, only
+    /// the folder will be included, and not its children.
+    files: FileRename[];
+  }
+
+  /// Represents information on a file/folder rename.
+  export interface FileRename {
+    /// A file:// URI for the original location of the file/folder being renamed.
+    oldUri: string;
+
+    /// A file:// URI for the new location of the file/folder being renamed.
+    newUri: string;
+  }
+
+  /// The parameters sent in notifications/requests for user-initiated deletes of
+  /// files.
+  export interface DeleteFilesParams {
+    /// An array of all files/folders deleted in this operation.
+    files: FileDelete[];
+  }
+
+  /// Represents information on a file/folder delete.
+  export interface FileDelete {
+    /// A file:// URI for the location of the file/folder being deleted.
+    uri: string;
+  }
+
+
+  /// The will create files request is sent from the client to the server before files are actually
+  /// created as long as the creation is triggered from within the client.
+  ///
+  /// The request can return a `WorkspaceEdit` which will be applied to workspace before the
+  /// files are created. Hence the `WorkspaceEdit` can not manipulate the content of the file
+  /// to be created.
+  export namespace WillCreateFilesRequest {
+    export const method: 'workspace/willCreateFiles' = 'workspace/willCreateFiles';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<CreateFilesParams, WorkspaceEdit | null, never, void, FileOperationRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<CreateFilesParams, WorkspaceEdit | undefined | null, void>;
+  }
+
+  /// The did create files notification is sent from the client to the server when
+  /// files were created from within the client.
+  export namespace DidCreateFilesNotification {
+    export const method: 'workspace/didCreateFiles' = 'workspace/didCreateFiles';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<CreateFilesParams, FileOperationRegistrationOptions>(method);
+    export type HandlerSignature = NotificationHandler<CreateFilesParams>;
+  }
+
+  /// The will rename files request is sent from the client to the server before files are actually
+  /// renamed as long as the rename is triggered from within the client.
+  export namespace WillRenameFilesRequest {
+    export const method: 'workspace/willRenameFiles' = 'workspace/willRenameFiles';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<RenameFilesParams, WorkspaceEdit | null, never, void, FileOperationRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<RenameFilesParams, WorkspaceEdit | undefined | null, void>;
+  }
+
+  /// The did rename files notification is sent from the client to the server when
+  /// files were renamed from within the client.
+  export namespace DidRenameFilesNotification {
+    export const method: 'workspace/didRenameFiles' = 'workspace/didRenameFiles';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<RenameFilesParams, FileOperationRegistrationOptions>(method);
+    export type HandlerSignature = NotificationHandler<RenameFilesParams>;
+  }
+
+  /// The will delete files request is sent from the client to the server before files are actually
+  /// deleted as long as the deletion is triggered from within the client.
+  export namespace DidDeleteFilesNotification {
+    export const method: 'workspace/didDeleteFiles' = 'workspace/didDeleteFiles';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DeleteFilesParams, FileOperationRegistrationOptions>(method);
+    export type HandlerSignature = NotificationHandler<DeleteFilesParams>;
+  }
+
+  /// The did delete files notification is sent from the client to the server when
+  /// files were deleted from within the client.
+  export namespace WillDeleteFilesRequest {
+    export const method: 'workspace/willDeleteFiles' = 'workspace/willDeleteFiles';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<DeleteFilesParams, WorkspaceEdit | null, never, void, FileOperationRegistrationOptions>(method);
+    export type HandlerSignature = RequestHandler<DeleteFilesParams, WorkspaceEdit | undefined | null, void>;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/workspace/onDidChangeWatchedFiles.dark
+++ b/packages/darklang/languageServerProtocol/workspace/onDidChangeWatchedFiles.dark
@@ -1,0 +1,98 @@
+(*
+  /// The file event type
+  export namespace FileChangeType {
+    export const Created = 1;
+    export const Changed = 2;
+    export const Deleted = 3;
+  }
+  export type FileChangeType = 1 | 2 | 3;
+
+
+  /// An event describing a file change.
+  export interface FileEvent {
+    /// The file's uri.
+    uri: DocumentUri;
+
+    /// The change type.
+    type: FileChangeType;
+  }
+
+  /// The watched files change notification's parameters.
+  export interface DidChangeWatchedFilesParams {
+    /// The actual file events.
+    changes: FileEvent[];
+  }
+
+
+
+
+
+  /// The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:
+  /// - `*` to match one or more characters in a path segment
+  /// - `?` to match on one character in a path segment
+  /// - `**` to match any number of path segments, including none
+  /// - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+  /// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+  /// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+  export type Pattern = string;
+
+  /// A relative pattern is a helper to construct glob patterns that are matched
+  /// relatively to a base URI. The common value for a `baseUri` is a workspace
+  /// folder root, but it can be another absolute URI as well.
+  export interface RelativePattern {
+    /// A workspace folder or a base URI to which this pattern will be matched
+    /// against relatively.
+    baseUri: WorkspaceFolder | URI;
+
+    /// The actual glob pattern;
+    pattern: Pattern;
+  }
+
+  /// The glob pattern. Either a string pattern or a relative pattern.
+  export type GlobPattern = Pattern | RelativePattern;
+
+  export namespace WatchKind {
+    export const Create: 1 = 1;
+    export const Change: 2 = 2;
+    export const Delete: 4 = 4;
+  }
+  export type WatchKind = uinteger;
+
+  export interface FileSystemWatcher {
+    /// The glob pattern to watch. See {@link GlobPattern glob pattern} for more detail.
+    globPattern: GlobPattern;
+
+    /// The kind of events of interest. If omitted it defaults
+    /// to `WatchKind.Create | WatchKind.Change | WatchKind.Delete`
+    /// which is 7.
+    kind?: WatchKind;
+  }
+
+  /// Describe options to be used when registered for text document change events.
+  export interface DidChangeWatchedFilesRegistrationOptions {
+    /// The watchers to register.
+    watchers: FileSystemWatcher[];
+  }
+
+
+
+  /// The watched files notification is sent from the client to the server when
+  /// the client detects changes to file watched by the language client.
+  export namespace DidChangeWatchedFilesNotification {
+    export const method: 'workspace/didChangeWatchedFiles' = 'workspace/didChangeWatchedFiles';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions>(method);
+  }
+
+
+  export interface DidChangeWatchedFilesClientCapabilities {
+    /// Did change watched files notification supports dynamic registration. Please note
+    /// that the current protocol doesn't support static configuration for file changes
+    /// from the server side.
+    dynamicRegistration?: boolean;
+
+    /// Whether the client has support for {@link  RelativePattern relative pattern}
+    /// or not.
+    relativePatternSupport?: boolean;
+  }
+*)

--- a/packages/darklang/languageServerProtocol/workspace/workspaceEdit.dark
+++ b/packages/darklang/languageServerProtocol/workspace/workspaceEdit.dark
@@ -1,0 +1,107 @@
+// Server->Client request to edit something in the workspace.
+//
+// currently supports file renames, whole-file deletions, and whole-file creations
+
+(*
+  /// @proposed
+  export interface ChangeAnnotationsSupportOptions {
+    /// Whether the client groups edits with equal labels into tree nodes,
+    /// for instance all edits labelled with "Changes in Strings" would
+    /// be a tree node.
+    groupsOnLabel?: boolean;
+  }
+
+  /// The kind of resource operations supported by the client.
+  export type ResourceOperationKind = 'create' | 'rename' | 'delete';
+
+  export namespace ResourceOperationKind {
+    /// Supports creating new files and folders.
+    export const Create: ResourceOperationKind = 'create';
+
+    /// Supports renaming existing files and folders.
+    export const Rename: ResourceOperationKind = 'rename';
+
+    /// Supports deleting existing files and folders.
+    export const Delete: ResourceOperationKind = 'delete';
+  }
+
+  export interface WorkspaceEditClientCapabilities {
+    /// The client supports versioned document changes in `WorkspaceEdit`s
+    documentChanges?: boolean;
+
+    /// The resource operations the client supports. Clients should at least
+    /// support 'create', 'rename' and 'delete' files and folders.
+    resourceOperations?: ResourceOperationKind[];
+
+    /// The failure handling strategy of a client if applying the workspace edit
+    /// fails.
+    failureHandling?: FailureHandlingKind;
+
+    /// Whether the client normalizes line endings to the client specific setting.
+    /// If set to `true` the client will normalize line ending characters
+    /// in a workspace edit to the client-specified new line
+    /// character.
+    normalizesLineEndings?: boolean;
+
+    /// Whether the client in general supports change annotations on text edits,
+    /// create file, rename file and delete file changes.
+    changeAnnotationSupport?: ChangeAnnotationsSupportOptions;
+  }
+
+  /// The parameters passed via an apply workspace edit request.
+  export interface ApplyWorkspaceEditParams {
+    /// An optional label of the workspace edit. This label is
+    /// presented in the user interface for example on an undo
+    /// stack to undo the workspace edit.
+    label?: string;
+
+    /// The edits to apply.
+    edit: WorkspaceEdit;
+  }
+
+  /// The result returned from the apply workspace edit request.
+  export interface ApplyWorkspaceEditResult {
+    /// Indicates whether the edit was applied or not.
+    applied: boolean;
+
+    /// An optional textual description for why the edit was not applied.
+    /// This may be used by the server for diagnostic logging or to provide
+    /// a suitable error for a request that triggered the edit.
+    failureReason?: string;
+
+    /// Depending on the client's failure handling strategy `failedChange` might
+    /// contain the index of the change that failed. This property is only available
+    /// if the client signals a `failureHandlingStrategy` in its client capabilities.
+    failedChange?: uinteger;
+  }
+
+  /// A request sent from the server to the client to modified certain resources.
+  export namespace ApplyWorkspaceEditRequest {
+    export const method: 'workspace/applyEdit' = 'workspace/applyEdit';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType<ApplyWorkspaceEditParams, ApplyWorkspaceEditResult, never, void, void>('workspace/applyEdit');
+    export type HandlerSignature = RequestHandler<ApplyWorkspaceEditParams, ApplyWorkspaceEditResult, void>;
+  }
+
+
+
+  export namespace FailureHandlingKind {
+    /// Applying the workspace change is simply aborted if one of the changes provided
+    /// fails. All operations executed before the failing operation stay executed.
+    export const Abort: FailureHandlingKind = 'abort';
+
+    /// All operations are executed transactional. That means they either all
+    /// succeed or no changes at all are applied to the workspace.
+    export const Transactional: FailureHandlingKind = 'transactional';
+
+    /// If the workspace edit contains only textual file changes they are executed transactional.
+    /// If resource changes (create, rename or delete file) are part of the change the failure
+    /// handling strategy is abort.
+    export const TextOnlyTransactional: FailureHandlingKind = 'textOnlyTransactional';
+
+    /// The client tries to undo the operations already executed. But there is no
+    /// guarantee that this is succeeding.
+    export const Undo: FailureHandlingKind = 'undo';
+  }
+  export type FailureHandlingKind = 'abort' | 'transactional' | 'undo' | 'textOnlyTransactional';
+*)

--- a/packages/darklang/languageServerProtocol/workspace/workspaceFolder.dark
+++ b/packages/darklang/languageServerProtocol/workspace/workspaceFolder.dark
@@ -1,0 +1,53 @@
+(*
+
+
+  export interface WorkspaceFoldersServerCapabilities {
+    /// The server has support for workspace folders
+    supported?: boolean;
+
+    /// Whether the server wants to receive workspace folder
+    /// change notifications.
+    ///
+    /// If a string is provided the string is treated as an ID
+    /// under which the notification is registered on the client
+    /// side. The ID can be used to unregister for these events
+    /// using the `client/unregisterCapability` request.
+    changeNotifications?: string | boolean;
+  }
+
+  /// The `workspace/workspaceFolders` is sent from the server to the client to fetch the open workspace folders.
+  export namespace WorkspaceFoldersRequest {
+    export const method: 'workspace/workspaceFolders' = 'workspace/workspaceFolders';
+    export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+    export const type = new ProtocolRequestType0<WorkspaceFolder[] | null, never, void, void>(method);
+    export type HandlerSignature = RequestHandler0<WorkspaceFolder[] | null, void>;
+    export type MiddlewareSignature = (token: CancellationToken, next: HandlerSignature) => HandlerResult<WorkspaceFolder[] | null, void>;
+  }
+
+
+
+  /// The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server when the workspace
+  /// folder configuration changes.
+  export namespace DidChangeWorkspaceFoldersNotification {
+    export const method: 'workspace/didChangeWorkspaceFolders' = 'workspace/didChangeWorkspaceFolders';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolNotificationType<DidChangeWorkspaceFoldersParams, void>(method);
+    export type HandlerSignature = NotificationHandler<DidChangeWorkspaceFoldersParams>;
+    export type MiddlewareSignature = (params: DidChangeWorkspaceFoldersParams, next: HandlerSignature) => void;
+  }
+
+  /// The parameters of a `workspace/didChangeWorkspaceFolders` notification.
+  export interface DidChangeWorkspaceFoldersParams {
+    /// The actual workspace folder change event.
+    event: WorkspaceFoldersChangeEvent;
+  }
+
+  /// The workspace folder change event.
+  export interface WorkspaceFoldersChangeEvent {
+    /// The array of added workspace folders
+    added: WorkspaceFolder[];
+
+    /// The array of the removed workspace folders
+    removed: WorkspaceFolder[];
+  }
+*)

--- a/packages/darklang/languageServerProtocol/workspace/workspaceSymbols.dark
+++ b/packages/darklang/languageServerProtocol/workspace/workspaceSymbols.dark
@@ -1,0 +1,116 @@
+//
+
+(*
+  /// A special workspace symbol that supports locations without a range.
+  ///
+  /// See also SymbolInformation.
+  export interface WorkspaceSymbol
+    extends
+      BaseSymbolInformation {
+
+    /// The location of the symbol. Whether a server is allowed to
+    /// return a location without a range depends on the client
+    /// capability `workspace.symbol.resolveSupport`.
+    ///
+    /// See SymbolInformation#location for more details.
+    location: Location;
+
+    /// A data entry field that is preserved on a workspace symbol between a
+    /// workspace symbol request and a workspace symbol resolve request.
+    data?: LSPAny;
+  }
+
+
+
+  /// @proposed
+  export interface ClientSymbolKindOptions {
+    /// The symbol kind values the client supports. When this
+    /// property exists the client also guarantees that it will
+    /// handle values outside its set gracefully and falls back
+    /// to a default value when unknown.
+    /// If this property is not present the client only supports
+    /// the symbol kinds from `File` to `Array` as defined in
+    /// the initial version of the protocol.
+    valueSet?: SymbolKind[];
+  }
+
+  /// @proposed
+  export interface ClientSymbolTagOptions {
+    /// The tags supported by the client.
+    valueSet: SymbolTag[];
+  }
+
+  /// @proposed
+  export interface ClientSymbolResolveOptions {
+    /// The properties that a client can resolve lazily. Usually
+    /// `location.range`
+    properties: string[];
+  }
+
+  /// Client capabilities for a {@link WorkspaceSymbolRequest}.
+  export interface WorkspaceSymbolClientCapabilities {
+    /// Symbol request supports dynamic registration.
+    dynamicRegistration?: boolean;
+
+    /// Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
+    symbolKind?: ClientSymbolKindOptions;
+
+    /// The client supports tags on `SymbolInformation`.
+    /// Clients supporting tags have to handle unknown tags gracefully.
+    tagSupport?: ClientSymbolTagOptions;
+
+    /// The client support partial workspace symbols. The client will send the
+    /// request `workspaceSymbol/resolve` to the server to resolve additional
+    /// properties.
+    resolveSupport?: ClientSymbolResolveOptions;
+  }
+
+  /// The parameters of a {@link WorkspaceSymbolRequest}.
+  export interface WorkspaceSymbolParams
+    extends
+      WorkDoneProgressParams,
+      PartialResultParams {
+
+    /// A query string to filter symbols by. Clients may send an empty
+    /// string here to request all symbols.
+    query: string;
+  }
+
+  /// Server capabilities for a {@link WorkspaceSymbolRequest}.
+  export interface WorkspaceSymbolOptions
+    extends
+      WorkDoneProgressOptions {
+
+    /// The server provides support to resolve additional
+    /// information for a workspace symbol.
+    resolveProvider?: boolean;
+  }
+
+
+  /// Registration options for a {@link WorkspaceSymbolRequest}.
+  export interface WorkspaceSymbolRegistrationOptions
+    extends
+      WorkspaceSymbolOptions {
+
+  }
+
+  /// A request to list project-wide symbols matching the query string given
+  /// by the {@link WorkspaceSymbolParams}. The response is
+  /// of type {@link SymbolInformation SymbolInformation[]} or a Thenable that
+  /// resolves to such.
+  ///
+  /// need to advertise support for WorkspaceSymbols via the client capability
+  /// `workspace.symbol.resolveSupport`.
+  export namespace WorkspaceSymbolRequest {
+    export const method: 'workspace/symbol' = 'workspace/symbol';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<WorkspaceSymbolParams, SymbolInformation[] | WorkspaceSymbol[] | null, SymbolInformation[] | WorkspaceSymbol[], void, WorkspaceSymbolRegistrationOptions>(method);
+  }
+
+  /// A request to resolve the range inside the workspace symbol's location.
+  export namespace WorkspaceSymbolResolveRequest {
+    export const method: 'workspaceSymbol/resolve' = 'workspaceSymbol/resolve';
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new ProtocolRequestType<WorkspaceSymbol, WorkspaceSymbol, never, void, void>(method);
+  }
+*)

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -149,13 +149,43 @@ module Darklang =
           | Error() ->
             log "couldn't parse params of didSave"
             state
-        // -- textDocument
-        | ("textDocument/didOpen", None) ->
-          log "TODO we should do something with this - like report problems"
-          false
-        | ("textDocument/didSave", None) ->
-          log "TODO we should do something with this - like report problems"
-          false
+
+
+        // -- autocomplete
+        | ("textDocument/completion", Some id, Some p) ->
+          match p with
+          | Array p ->
+            let p = (Json.Array p) |> Stdlib.AltJson.format
+            log $"Some Array-based params: {p}"
+          | Object p ->
+            let p = (Json.Object p) |> Stdlib.AltJson.format
+            log $"Some Object-based params: {p}"
+
+          (*[
+            { label: "TypeScript", kind: CompletionItemKind.Text, data: 1 },
+            { label: "JavaScript", kind: CompletionItemKind.Text, data: 2 },
+          ]*)
+
+          log "TODO: return a response with some completions"
+          state
+
+        | ("completionItem/resolve", Some id) ->
+          (*
+            // once you hover over some completion, this fills in some details (I think)
+            connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
+              if (item.data === 1) {
+                item.detail = "TypeScript details";
+                item.documentation = "TypeScript documentation";
+              } else if (item.data === 2) {
+                item.detail = "JavaScript details";
+                item.documentation = "JavaScript documentation";
+              }
+              return item;
+            });
+          *)
+          // TODO: use r.params
+          log "TODO: deal with completion item resolution"
+          state
 
 
         // -- other
@@ -408,39 +438,7 @@ documents.onDidChangeContent(change => {
 
 
 
-(* Future: completions (autocomplete)
 
-include this in 'capabilities' configuration:
-
-      completionProvider: {
-        resolveProvider: true,
-      },
-
-
-// (how) should we autocomplete?
-// (currently this just provides 2 bogus autocompletes)
-connection.onCompletion(
-  (_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
-    return [
-      { label: "TypeScript", kind: CompletionItemKind.Text, data: 1 },
-      { label: "JavaScript", kind: CompletionItemKind.Text, data: 2 },
-    ];
-  },
-);
-
-// once you hover over some completion, this fills in some details (I think)
-connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
-  if (item.data === 1) {
-    item.detail = "TypeScript details";
-    item.documentation = "TypeScript documentation";
-  } else if (item.data === 2) {
-    item.detail = "JavaScript details";
-    item.documentation = "JavaScript documentation";
-  }
-  return item;
-});
-
-*)
 
 
 

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -11,6 +11,25 @@ module Darklang =
     ///
     /// TODO: some day, abstract out general LSP support in a separate module
     module LspServer =
+      // <aliases>
+      type Json = Stdlib.AltJson.Json
+      // </aliases>
+
+
+      type DocumentInScope = { uri: String; text: String }
+
+      type State =
+        {
+          initialized: Bool
+
+          shouldShutdown: Bool
+
+          /// Documents that are currently open in the editor
+          /// (i.e. have been `textDocument/didOpen`ed, and not yet `textDocument/didClose`d)
+          /// note: the string key here is the URI
+          documentsInScope: Dict<DocumentInScope>
+        }
+
       let logFilePath = "/home/dark/app/rundir/logs/lsp-server.log"
 
       let log (input: String) : Unit =
@@ -40,30 +59,96 @@ module Darklang =
         Builtin.Danger.LanguageServerProtocol.readNextMessage ()
 
 
-      /// returns `true` if we got a shutdown request
-      ///
-      /// maybe we should instead return some DU here, with "Shutdown" as a case?
-      /// or a list of DUs - like actions, including returning responses?
-      let handleRequest (r: JsonRPC.Request.Request) : Bool =
-        match r.method, r.id with
+      let handleRequest (state: State) (r: JsonRPC.Request.Request) : State =
+        match (r.method, r.id, r.params) with
         // -- Lifecycle and general support
-        | ("initialized", None) ->
-          log "(ignore)"
-          false
-
-        | ("initialize", None) ->
+        | ("initialize", None, _) ->
           log "TODO: fail - we shouldn't be seeing a second one of these"
-          false
+          { state with initialized = true }
 
-        | ("$/setTrace", None) ->
+        | ("initialized", None, Some(Object [])) ->
+          log "(ignore)"
+          state
+
+        | ("$/setTrace", None, _) ->
           log "TODO we should do something with this"
-          false
+          state
 
-        | ("shutdown", None) ->
+        | ("shutdown", None, _) ->
           log "shutting down"
-          true
+          { state with shouldShutdown = true }
 
 
+        // -- textDocument synchronization
+        | ("textDocument/didOpen", None, Some(Object fields)) ->
+          // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidOpenTextDocumentNotification.method` above
+          let reconstructedJson = Stdlib.AltJson.Json.Object fields
+
+          let parsed =
+            LanguageServerProtocol.DocumentSync.TextDocument.DidOpenTextDocumentNotification.DidOpenTextDocumentParams.fromJson
+              reconstructedJson
+
+          match parsed with
+          | Ok parsed ->
+            log $"adding/setting document {parsed.textDocument.uri}"
+
+            { state with
+                documentsInScope =
+                  Stdlib.Dict.set
+                    state.documentsInScope
+                    parsed.textDocument.uri
+                    parsed.textDocument.text }
+          | Error() ->
+            log "couldn't parse params of didOpen"
+            state
+
+
+        | ("textDocument/didSave", None, Some(Object fields)) ->
+          // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidSaveTextDocumentNotification.method` above
+          let reconstructedJson = Stdlib.AltJson.Json.Object fields
+
+          let parsed =
+            LanguageServerProtocol.DocumentSync.TextDocument.DidSaveTextDocumentNotification.DidSaveTextDocumentParams.fromJson
+              reconstructedJson
+
+          match parsed with
+          | Ok parsed ->
+            match parsed.text with
+            | None ->
+              log "WARNING: no text in didSave"
+              state
+
+            | Some text ->
+              log $"updating document {parsed.textDocument.uri}"
+
+              { state with
+                  documentsInScope =
+                    Stdlib.Dict.set
+                      state.documentsInScope
+                      parsed.textDocument.uri
+                      text }
+          | Error() ->
+            log "couldn't parse params of didSave"
+            state
+
+        | ("textDocument/didClose", None, Some(Object fields)) ->
+          // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidCloseTextDocumentNotification.method` above
+          let reconstructedJson = Stdlib.AltJson.Json.Object fields
+
+          let parsed =
+            LanguageServerProtocol.DocumentSync.TextDocument.DidCloseTextDocumentNotification.DidCloseTextDocumentParams.fromJson
+              reconstructedJson
+
+          match parsed with
+          | Ok parsed ->
+            log $"removing document from documentsInScope"
+
+            { state with
+                documentsInScope =
+                  Stdlib.Dict.remove state.documentsInScope parsed.textDocument.uri }
+          | Error() ->
+            log "couldn't parse params of didSave"
+            state
         // -- textDocument
         | ("textDocument/didOpen", None) ->
           log "TODO we should do something with this - like report problems"
@@ -74,31 +159,30 @@ module Darklang =
 
 
         // -- other
-        | (other, _) ->
+        | (other, _, _) ->
           log $"TODO: we don't yet support this method: {other}"
-          false
+          state
 
 
-
-      let runServerCliLoop () : Int64 =
+      let runServerCliLoop (state: State) : Int64 =
         log "---"
 
         let incomingMessageRaw = readMessageFromClient ()
         logRequest incomingMessageRaw
 
 
-        let shouldShutdown =
+        let updatedState =
           match JsonRPC.IncomingMessage.parse incomingMessageRaw with
           // # Things we want/expect
 
           | SingleRequest(Ok(jsonRpcRequest)) ->
             log $"Parsed incoming message as single JSON-RPC request"
-            handleRequest jsonRpcRequest
+            handleRequest state jsonRpcRequest
 
           | BatchOfRequests items ->
             // TODO: need to reply in a batch as well
             log "TODO - Got batch request; not yet set to handle these"
-            false
+            state
 
 
           // # Errors
@@ -114,7 +198,7 @@ module Darklang =
             logAndSendToClient
               """{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"""
 
-            false
+            state
 
 
           | NotJson ->
@@ -124,7 +208,7 @@ module Darklang =
             logAndSendToClient
               """{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"""
 
-            false
+            state
 
 
           | NotObjectOrArray ->
@@ -133,17 +217,20 @@ module Darklang =
             logAndSendToClient
               """{"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null}"""
 
-            false
+            state
 
 
           // The json-rpc spec says to just ignore any incoming messages of `[]`
           | EmptyBatch ->
             log "ignoring empty batch"
-            false
+            state
 
 
         // shut down if instructed, or listen for the next message
-        if shouldShutdown then 0L else (runServerCliLoop ())
+        if updatedState.shouldShutdown then
+          0L
+        else
+          runServerCliLoop updatedState
 
 
 
@@ -166,7 +253,7 @@ module Darklang =
         //
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
         let incomingMessageRaw = readMessageFromClient ()
-        logRequest incomingMessageRaw
+        logRequest incomingMessageRaw // otherwise ignored...
 
 
         // Let's demonstrate that the server is waking up.
@@ -184,18 +271,58 @@ module Darklang =
 
 
         // finally, reply to the initialize request
-        logAndSendToClient
-          """{"jsonrpc":"2.0","id":0,"result":{"capabilities":{"completionProvider":{"resolveProvider":true},"textDocumentSync":1}}}"""
+        let initializeResult =
+          LanguageServerProtocol.Lifecycle.InitializeRequest.InitializeResult.InitializeResult
+            { capabilities =
+                LanguageServerProtocol.Lifecycle.InitializeRequest.ServerCapabilities.ServerCapabilities
+                  { textDocumentSync =
+                      Stdlib.Option.Option.Some(
+                        LanguageServerProtocol
+                          .Lifecycle
+                          .InitializeRequest
+                          .TextDocumentSyncServerCapabilities
+                          .TextDocumentSyncServerCapabilities
+                          .TextDocumentSyncOptions(
+                            LanguageServerProtocol.DocumentSync.TextDocument.TextDocumentSyncOptions.TextDocumentSyncOptions
+                              { openClose = Stdlib.Option.Option.Some true
+                                change =
+                                  Stdlib.Option.Option.Some
+                                    LanguageServerProtocol.DocumentSync.TextDocument.TextDocumentSyncKind.TextDocumentSyncKind.Full
+                                save =
+                                  Stdlib.Option.Option.Some(
+                                    LanguageServerProtocol
+                                      .DocumentSync
+                                      .TextDocument
+                                      .TextDocumentSyncOptions
+                                      .SaveOptionsOrBool
+                                      .SaveOptionsOrBool
+                                      .SaveOptions(
+                                        LanguageServerProtocol.DocumentSync.TextDocument.SaveOptions.SaveOptions
+                                          { includeText =
+                                              Stdlib.Option.Option.Some true }
+                                      )
+                                  ) }
+                          )
+                      ) }
+              serverInfo = Stdlib.Option.Option.None }
+
+        let initializeResponse =
+          initializeResult
+          |> LanguageServerProtocol.Lifecycle.InitializeRequest.InitializeResult.toJson
+          |> (fun r -> JsonRPC.Response.Ok.make (Stdlib.Option.Option.Some 0L) r)
+          |> Stdlib.AltJson.format
+
+        logAndSendToClient initializeResponse
 
 
-        // trying to get the `Darklang LSP - Server` output logs to show up...
-        logAndSendToClient
-          """{ "jsonrpc": "2.0", "method": "$/logTrace", "params": { "message": "hi I'm a trace after initialize" } }"""
-
+        let initialState =
+          State
+            { initialized = true
+              shouldShutdown = false
+              documentsInScope = Dict { } }
 
         // now that _that_ is out of the way, we can start responding to normal requests
-        runServerCliLoop ()
-
+        runServerCliLoop initialState
 
 
 


### PR DESCRIPTION
- minor fixes to `json-rpc` support
- from the [LSP Spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) and the [de facto Node LSP server](https://github.com/microsoft/vscode-languageserver-node) that demonstrates the spec, ports many many types we'll need to build out our language server. _most_ of these are still commented out and left in their equivalent TypeScript interface form, but the up-front organization here should help us out a lot. Ones necessary (and a few more) have been fully ported and paired with `toJson`/`fromJson` functions
- specifically, port types needed in the `initialize` request, as well as the`didOpen`, `didClose`, and `didSave` notifications
- reduces our server's advertised capabilities to _only_ include document sync, and add that support to our server
  - involves maintaining a `state` between `runServerCliLoop` iterations