### PR TITLE
Provide fake autocomplete ("completions") in our Language Server

### DIFF
--- a/packages/darklang/json-rpc.dark
+++ b/packages/darklang/json-rpc.dark
@@ -152,7 +152,6 @@ module Darklang =
 
           match json with
           | Object o ->
-            Builtin.printLine "here6"
             let idOrError = extractIdFromRequest o
 
             // (this is just convenient for including in some errors)
@@ -251,12 +250,10 @@ module Darklang =
 
     module Response =
       module Ok =
-        let make (requestId: Stdlib.Option.Option<Int64>) (result: Json) : Json =
+        let make (requestId: Stdlib.Option.Option<RequestId>) (result: Json) : Json =
           [ Stdlib.Option.Option.Some(("jsonrpc", Json.String "2.0"))
 
-            (requestId
-             |> Stdlib.Option.map (fun id ->
-               ("id", requestIdToJson (RequestId.Int id))))
+            (requestId |> Stdlib.Option.map (fun id -> ("id", requestIdToJson id)))
 
             Stdlib.Option.Option.Some(("result", result)) ]
 

--- a/packages/darklang/languageServerProtocol/README.md
+++ b/packages/darklang/languageServerProtocol/README.md
@@ -36,13 +36,45 @@ project is quite hard to follow, though, so we've reorganized things here.
 - **notification**: a message sent from one LSP party to another, which does not expect a result
 - **message**: a general term for either a notification, request, or response (error or result)
 
-## Some patterns to follow per-file:
+## Some patterns
 
 - try to keep type names the same as the TypeScript ones in the spec
+- per-file organization
+  - supporting types at the top
+  - types around requests, results, and notifications in the middle
+  - client/server capabilities at the end of the file
+- many types are defined as interfaces with `extends` such as:
 
-- supporting types at the top
-- types around requests, results, and notifications in the middle
-- client/server capabilities at the end of the file
+  ```js
+  export interface CompletionParams extends TextDocumentPositionParams {
+    context?: CompletionContext;
+  }
+  ```
+
+  We could represent this in Darklang by inlining those properties in this type, resulting in something like
+
+  ```fsharp
+  type CompletionParams = {
+    textDocument: TextDocumentIdentifier;
+    position: Position;
+
+    context: CompletionContext;
+  }
+  ```
+
+  or we could add fields per each `extends`:
+
+  ```fsharp
+  type CompletionParams = {
+    textDocumentPosition: TextDocumentPositionParams
+    context: Option<CompletionContext>
+  }
+  ```
+
+  The latter is easier to understand, but won't work out of the box if we end up
+  switching to our usage-ignorant Json parser/serializer. I'm going to use the
+  latter for now, and we can re-evaluate if/when needed. That said, for each case
+  where we do this, we should add a comment roughly of `@extends TextDocumentPositionParams`
 
 ## TODOs:
 

--- a/packages/darklang/languageServerProtocol/common.dark
+++ b/packages/darklang/languageServerProtocol/common.dark
@@ -65,6 +65,32 @@ module Darklang =
           [ ("line", p.line |> Stdlib.UInt64.toFloat Json.Number)
             ("character", p.character |> Stdlib.UInt64.toFloat |> Json.Number) ]
 
+      let fromJson (json: Json) : Stdlib.Result.Result<Position, Unit> =
+        match json with
+        | Object fields ->
+          let line =
+            match Stdlib.List.findFirst fields (fun (k, _) -> k == "line") with
+            | Some((_, Number l)) ->
+              match Stdlib.UInt64.fromFloat l with
+              | None -> Stdlib.Result.Result.Error()
+              | Some l -> Stdlib.Result.Result.Ok l
+            | _ -> Stdlib.Result.Result.Error()
+
+          let character =
+            match Stdlib.List.findFirst fields (fun (k, _) -> k == "character") with
+            | Some((_, Number c)) ->
+              match Stdlib.UInt64.fromFloat c with
+              | None -> Stdlib.Result.Result.Error()
+              | Some c -> Stdlib.Result.Result.Ok c
+            | _ -> Stdlib.Result.Result.Error()
+
+          match (line, character) with
+          | (Ok line, Ok character) ->
+            Stdlib.Result.Result.Ok(Position { line = line; character = character })
+          | _ -> Stdlib.Result.Result.Error()
+
+        | _ -> Stdlib.Result.Result.Error()
+
     module Range =
       type Range =
         {
@@ -134,6 +160,46 @@ module Darklang =
         match json with
         | Object [ ("uri", String uri) ] ->
           Stdlib.Result.Result.Ok(TextDocumentIdentifier { uri = uri })
+        | _ -> Stdlib.Result.Result.Error()
+
+
+    module TextDocumentPositionParams =
+      /// A parameter literal used in requests to pass a text document and a position inside that document.
+      type TextDocumentPositionParams =
+        {
+          /// The text document.
+          textDocument: TextDocumentIdentifier.TextDocumentIdentifier
+
+          /// The position inside the text document.
+          position: Position.Position
+        }
+
+      let fromJson
+        (json: Json)
+        : Stdlib.Result.Result<TextDocumentPositionParams, Unit> =
+        match json with
+        | Object fields ->
+          let textDocument = // Result<TextDocumentIdentifier, Unit>
+            match
+              Stdlib.List.findFirst fields (fun (k, _) -> k == "textDocument")
+            with
+            | Some((_, textDocument)) -> TextDocumentIdentifier.fromJson textDocument
+            | None -> Stdlib.Result.Result.Error()
+
+          let position = // Result<Position, Unit>
+            match Stdlib.List.findFirst fields (fun (k, _) -> k == "position") with
+            | Some((_, position)) -> Position.fromJson position
+            | None -> Stdlib.Result.Result.Error()
+
+          match (textDocument, position) with
+          | (Ok textDocument, Ok position) ->
+            Stdlib.Result.Result.Ok(
+              TextDocumentPositionParams
+                { textDocument = textDocument
+                  position = position }
+            )
+          | _ -> Stdlib.Result.Result.Error()
+
         | _ -> Stdlib.Result.Result.Error()
 
 
@@ -797,15 +863,7 @@ module Darklang =
 
 
 
-  /// A parameter literal used in requests to pass a text document and a position inside that
-  /// document.
-  export interface TextDocumentPositionParams {
-    /// The text document.
-    textDocument: TextDocumentIdentifier;
 
-    /// The position inside the text document.
-    position: Position;
-  }
 
 
 

--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -1,7 +1,82 @@
 // Supports "completions," generally known as "autocomplete" or "intellisense."
 
-(*
+module Darklang =
+  module LanguageServerProtocol =
+    module Completions =
 
+      /// @proposed
+      module ServerCompletionItemOptions =
+        type ServerCompletionItemOptions =
+          {
+            /// The server has support for completion item label
+            /// details (see also `CompletionItemLabelDetails`) when
+            /// receiving a completion item in a resolve call.
+            labelDetailsSupport: Stdlib.Option.Option<Bool>
+          }
+
+        let toJson (o: ServerCompletionItemOptions) : Json =
+          [ o.labelDetailsSupport
+            |> Stdlib.Option.map (fun b -> ("labelDetailsSupport", Json.Bool b)) ]
+
+          |> Stdlib.List.filterMap (fun self -> self)
+          |> Json.Object
+
+
+      module CompletionOptions =
+        /// Completion options, used for configuration of the completion feature.
+        ///
+        /// TODO: `extends WorkDoneProgressOptions`
+        type CompletionOptions =
+          {
+            /// Most tools trigger completion request automatically without explicitly requesting
+            /// it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user
+            /// starts to type an identifier. For example if the user types `c` in a JavaScript file
+            /// code complete will automatically pop up present `console` besides others as a
+            /// completion item. Characters that make up identifiers don't need to be listed here.
+            /// If code complete should automatically be trigger on characters not being valid inside
+            /// an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
+            triggerCharacters: Stdlib.Option.Option<List<String>>
+
+            /// The list of all possible characters that commit a completion. This field can be used
+            /// if clients don't support individual commit characters per completion item. See
+            /// `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`
+            /// If a server provides both `allCommitCharacters` and commit characters on an individual
+            /// completion item the ones on the completion item win.
+            allCommitCharacters: Stdlib.Option.Option<List<String>>
+
+            /// The server provides support to resolve additional
+            /// information for a completion item.
+            resolveProvider: Stdlib.Option.Option<Bool>
+
+            /// The server supports the following `CompletionItem`-specific capabilities.
+            completionItem:
+              Stdlib.Option.Option<ServerCompletionItemOptions.ServerCompletionItemOptions>
+          }
+
+
+        let toJson (o: CompletionOptions) : Json =
+          [ o.triggerCharacters
+            |> Stdlib.Option.map (fun chars ->
+              ("triggerCharacters",
+               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.List))
+
+            o.allCommitCharacters
+            |> Stdlib.Option.map (fun chars ->
+              ("allCommitCharacters",
+               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.List))
+
+            o.resolveProvider
+            |> Stdlib.Option.map (fun p -> ("resolveProvider", Json.Bool p))
+
+            o.completionItem
+            |> Stdlib.Option.map (fun item ->
+              ("completionItem", ServerCompletionItemOptions.toJson item)) ]
+
+          |> Stdlib.List.filterMap (fun self -> self)
+          |> Json.Object
+
+
+(*
   /// Defines whether the insert text in a completion item should be interpreted as
   /// plain text or a snippet.
   export namespace InsertTextFormat {
@@ -671,43 +746,7 @@
     context?: CompletionContext;
   }
 
-  /// @proposed
-  export interface ServerCompletionItemOptions {
-    /// The server has support for completion item label
-    /// details (see also `CompletionItemLabelDetails`) when
-    /// receiving a completion item in a resolve call.
-    labelDetailsSupport?: boolean;
-  }
 
-  /// Completion options.
-  export interface CompletionOptions
-    extends
-      WorkDoneProgressOptions {
-
-    /// Most tools trigger completion request automatically without explicitly requesting
-    /// it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user
-    /// starts to type an identifier. For example if the user types `c` in a JavaScript file
-    /// code complete will automatically pop up present `console` besides others as a
-    /// completion item. Characters that make up identifiers don't need to be listed here.
-    /// If code complete should automatically be trigger on characters not being valid inside
-    /// an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
-    triggerCharacters?: string[];
-
-    /// The list of all possible characters that commit a completion. This field can be used
-    /// if clients don't support individual commit characters per completion item. See
-    /// `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`
-    /// If a server provides both `allCommitCharacters` and commit characters on an individual
-    /// completion item the ones on the completion item win.
-    allCommitCharacters?: string[];
-
-    /// The server provides support to resolve additional
-    /// information for a completion item.
-    resolveProvider?: boolean;
-
-    /// The server supports the following `CompletionItem` specific
-    /// capabilities.
-    completionItem?: ServerCompletionItemOptions;
-  }
 
   /// Registration options for a {@link CompletionRequest}.
   export interface CompletionRegistrationOptions

--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -3,6 +3,318 @@
 module Darklang =
   module LanguageServerProtocol =
     module Completions =
+      module InsertTextFormat =
+        /// Defines whether the insert text in a completion item should be interpreted as
+        /// plain text or a snippet.
+        type InsertTextFormat =
+          /// The primary text to be inserted is treated as a plain string.
+          | PlainText
+
+          /// The primary text to be inserted is treated as a snippet.
+          ///
+          /// A snippet can define tab stops and placeholders with `$1`, `$2` and `${3:foo}`.
+          /// `$0` defines the final tab stop, it defaults to the end of the snippet.
+          /// Placeholders with equal identifiers are linked, that is typing in one will update others too.
+          ///
+          /// See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax
+          | Snippet
+
+        let toJson (format: InsertTextFormat) : Json =
+          match format with
+          | PlainText -> Json.Number 1.0
+          | Snippet -> Json.Number 2.0
+
+
+      module InsertTextMode =
+        /// How whitespace and indentation is handled during completion item insertion.
+        type InsertTextMode =
+          /// The insertion or replace strings is taken as it is.
+          ///
+          /// If the value is multi-line, the lines below the cursor will be
+          /// inserted using the indentation defined in the string value.
+          /// The client will not apply any kind of adjustments to the string.
+          | AsIs
+
+          /// The editor adjusts leading whitespace of new lines so that
+          /// they match the indentation up to the cursor of the line for
+          /// which the item is accepted.
+          ///
+          /// Consider a line like this: `<2tabs><cursor><3tabs>foo.`
+          ///
+          /// Accepting a multi-line completion item is indented using 2 tabs and all
+          /// following lines inserted will be indented using 2 tabs as well.
+          | AdjustIndentation
+
+        let toJson (mode: InsertTextMode) : Json =
+          match mode with
+          | AsIs -> Json.Number 1.0
+          | AdjustIndentation -> Json.Number 2.0
+
+
+      module CompletionItem =
+        /// A completion item represents a text snippet that is
+        /// proposed to complete text that is being typed.
+        type CompletionItem =
+          {
+            /// The label of this completion item.
+            ///
+            /// The label property is also by default the text that
+            /// is inserted when selecting this completion.
+            ///
+            /// If label details are provided the label itself should
+            /// be an unqualified name of the completion item.
+            label: String
+
+            // /// Additional details for the label
+            // labelDetails?: CompletionItemLabelDetails;
+
+            // /// The kind of this completion item. Based of the kind
+            // /// an icon is chosen by the editor.
+            // kind?: CompletionItemKind;
+
+            // /// Tags for this completion item.
+            // tags?: CompletionItemTag[];
+
+            /// A human-readable string with additional information
+            /// about this item, like type or symbol information.
+            detail: Stdlib.Option.Option<String>
+
+            // /// A human-readable string that represents a doc-comment.
+            // documentation?: string | MarkupContent;
+
+            // /// Select this item when showing.
+            // ///
+            // /// Note that only one completion item can be selected and that the
+            // /// tool / client decides which item that is. The rule is that the *first*
+            // /// item of those that match best is selected.
+            preselect: Stdlib.Option.Option<Bool>
+
+            /// A string that should be used when comparing this item
+            /// with other items. When `falsy` the {@link CompletionItem.label label}
+            /// is used.
+            sortText: Stdlib.Option.Option<String>
+
+            /// A string that should be used when filtering a set of
+            /// completion items. When `falsy` the {@link CompletionItem.label label}
+            /// is used.
+            filterText: Stdlib.Option.Option<String>
+
+            /// A string that should be inserted into a document when selecting
+            /// this completion. When `falsy` the {@link CompletionItem.label label}
+            /// is used.
+            ///
+            /// The `insertText` is subject to interpretation by the client side.
+            /// Some tools might not take the string literally. For example
+            /// VS Code when code complete is requested in this example
+            /// `con<cursor position>` and a completion item with an `insertText` of
+            /// `console` is provided it will only insert `sole`. Therefore it is
+            /// recommended to use `textEdit` instead since it avoids additional client
+            /// side interpretation.
+            insertText: Stdlib.Option.Option<String>
+
+            /// The format of the insert text. The format applies to both the
+            /// `insertText` property and the `newText` property of a provided
+            /// `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
+            ///
+            /// Please note that the insertTextFormat doesn't apply to
+            /// `additionalTextEdits`.
+            insertTextFormat: Stdlib.Option.Option<InsertTextFormat.InsertTextFormat>
+
+            /// How whitespace and indentation is handled during completion
+            /// item insertion. If not provided the clients default value depends on
+            /// the `textDocument.completion.insertTextMode` client capability.
+            insertTextMode: Stdlib.Option.Option<InsertTextMode.InsertTextMode>
+
+            // /// An {@link TextEdit edit} which is applied to a document when selecting
+            // /// this completion. When an edit is provided the value of
+            // /// {@link CompletionItem.insertText insertText} is ignored.
+            // ///
+            // /// Most editors support two different operations when accepting a completion
+            // /// item. One is to insert a completion text and the other is to replace an
+            // /// existing text with a completion text. Since this can usually not be
+            // /// predetermined by a server it can report both ranges. Clients need to
+            // /// signal support for `InsertReplaceEdits` via the
+            // /// `textDocument.completion.insertReplaceSupport` client capability
+            // /// property.
+            // ///
+            // /// *Note 1:* The text edit's range as well as both ranges from an insert
+            // /// replace edit must be a [single line] and they must contain the position
+            // /// at which completion has been requested.
+            // /// *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
+            // /// must be a prefix of the edit's replace range, that means it must be
+            // /// contained and starting at the same position.
+            // textEdit?: TextEdit | InsertReplaceEdit;
+
+            /// The edit text used if the completion item is part of a CompletionList and
+            /// CompletionList defines an item default for the text edit range.
+            ///
+            /// Clients will only honor this property if they opt into completion list
+            /// item defaults using the capability `completionList.itemDefaults`.
+            ///
+            /// If not provided and a list's default range is provided the label
+            /// property is used as a text.
+            textEditText: Stdlib.Option.Option<String>
+
+            // /// An optional array of additional {@link TextEdit text edits} that are applied when
+            // /// selecting this completion. Edits must not overlap (including the same insert position)
+            // /// with the main {@link CompletionItem.textEdit edit} nor with themselves.
+            // ///
+            // /// Additional text edits should be used to change text unrelated to the current cursor position
+            // /// (for example adding an import statement at the top of the file if the completion item will
+            // /// insert an unqualified type).
+            // additionalTextEdits?: TextEdit[];
+
+            /// An optional set of characters that when pressed while this completion is active will accept it first and
+            /// then type that character. Note that all commit characters should have `length=1` and that superfluous
+            /// characters will be ignored.
+            commitCharacters: Stdlib.Option.Option<List<String>>
+
+            // /// An optional {@link Command command} that is executed *after* inserting this completion. Note that
+            // /// additional modifications to the current document should be described with the
+            // /// {@link CompletionItem.additionalTextEdits additionalTextEdits}-property.
+            // command?: Command;
+
+            /// A data entry field that is preserved on a completion item between a
+            /// {@link CompletionRequest} and a {@link CompletionResolveRequest}.
+            data: Stdlib.Option.Option<Json>
+          }
+
+        let toJson (item: CompletionItem) : Json =
+          [ Stdlib.Option.Option.Some(("label", Json.String item.label))
+
+            item.detail |> Stdlib.Option.map (fun d -> ("detail", Json.String d))
+
+            item.preselect |> Stdlib.Option.map (fun p -> ("preselect", Json.Bool p))
+
+            item.sortText |> Stdlib.Option.map (fun t -> ("sortText", Json.String t))
+
+            item.filterText
+            |> Stdlib.Option.map (fun f -> ("filterText", Json.String f))
+
+            item.insertText
+            |> Stdlib.Option.map (fun t -> ("insertText", Json.String t))
+
+            item.insertTextFormat
+            |> Stdlib.Option.map (fun f ->
+              ("insertTextFormat", InsertTextFormat.toJson f))
+
+            item.insertTextMode
+            |> Stdlib.Option.map (fun m ->
+              ("insertTextMode", InsertTextMode.toJson m))
+
+            item.textEditText
+            |> Stdlib.Option.map (fun t -> ("textEditText", Json.String t))
+
+            item.commitCharacters
+            |> Stdlib.Option.map (fun chars ->
+              ("commitCharacters",
+               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.Array))
+
+            item.data |> Stdlib.Option.map (fun d -> ("data", d)) ]
+
+          |> Stdlib.List.filterMap (fun self -> self)
+          |> Json.Object
+
+
+      module CompletionItemDefaults =
+        /// In many cases the items of an actual completion result share the same
+        /// value for properties like `commitCharacters` or the range of a text
+        /// edit. A completion list can therefore define item defaults which will
+        /// be used if a completion item itself doesn't specify the value.
+        ///
+        /// If a completion list specifies a default value and a completion item
+        /// also specifies a corresponding value the one from the item is used.
+        ///
+        /// Servers are only allowed to return default values if the client
+        /// signals support for this via the `completionList.itemDefaults`
+        /// capability.
+        type CompletionItemDefaults =
+          {
+            /// A default commit character set.
+            commitCharacters: Stdlib.Option.Option<List<String>>
+
+            /// A default edit range.
+            editRange: Stdlib.Option.Option<Range.Range>
+
+            /// A default insert text format.
+            insertTextFormat: Stdlib.Option.Option<InsertTextFormat.InsertTextFormat>
+
+            /// A default insert text mode.
+            insertTextMode: Stdlib.Option.Option<InsertTextMode.InsertTextMode>
+
+            /// A default data value.
+            data: Stdlib.Option.Option<Json>
+          }
+
+        let toJson (d: CompletionItemDefaults) : Json =
+          [ d.commitCharacters
+            |> Stdlib.Option.map (fun chars ->
+              ("commitCharacters",
+               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.Array))
+
+            d.editRange |> Stdlib.Option.map (fun r -> ("editRange", Range.toJson r))
+
+            d.insertTextFormat
+            |> Stdlib.Option.map (fun f ->
+              ("insertTextFormat", InsertTextFormat.toJson f))
+
+            d.insertTextMode
+            |> Stdlib.Option.map (fun m ->
+              ("insertTextMode", InsertTextMode.toJson m))
+
+            d.data |> Stdlib.Option.map (fun d -> ("data", d)) ]
+
+          |> Stdlib.List.filterMap (fun self -> self)
+          |> Json.Object
+
+
+
+      module CompletionList =
+        /// Represents a collection of {@link CompletionItem completion items} to be presented
+        /// in the editor.
+        type CompletionList =
+          {
+            /// This list it not complete. Further typing results in recomputing this list.
+            ///
+            /// Recomputed lists have all their items replaced (not appended) in the
+            /// incomplete completion sessions.
+            isIncomplete: Bool
+
+            /// In many cases the items of an actual completion result share the same
+            /// value for properties like `commitCharacters` or the range of a text
+            /// edit. A completion list can therefore define item defaults which will
+            /// be used if a completion item itself doesn't specify the value.
+            ///
+            /// If a completion list specifies a default value and a completion item
+            /// also specifies a corresponding value the one from the item is used.
+            ///
+            /// Servers are only allowed to return default values if the client
+            /// signals support for this via the `completionList.itemDefaults`
+            /// capability.
+            itemDefaults:
+              Stdlib.Option.Option<CompletionItemDefaults.CompletionItemDefaults>
+
+            /// The completion items.
+            items: List<CompletionItem.CompletionItem>
+          }
+
+        let toJson (list: CompletionList) : Json =
+          [ Stdlib.Option.Option.Some(("isIncomplete", Json.Bool list.isIncomplete))
+
+            (list.itemDefaults
+             |> Stdlib.Option.map (fun d ->
+               ("itemDefaults", CompletionItemDefaults.toJson d)))
+
+            Stdlib.Option.Option.Some(
+              ("items",
+               list.items
+               |> Stdlib.List.map (fun item -> CompletionItem.toJson item)
+               |> Json.Array)
+            ) ]
+
+          |> Stdlib.List.filterMap (fun self -> self)
+          |> Json.Object
+
 
       /// @proposed
       module ServerCompletionItemOptions =
@@ -58,12 +370,12 @@ module Darklang =
           [ o.triggerCharacters
             |> Stdlib.Option.map (fun chars ->
               ("triggerCharacters",
-               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.List))
+               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.Array))
 
             o.allCommitCharacters
             |> Stdlib.Option.map (fun chars ->
               ("allCommitCharacters",
-               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.List))
+               chars |> Stdlib.List.map (fun c -> Json.String c) |> Json.Array))
 
             o.resolveProvider
             |> Stdlib.Option.map (fun p -> ("resolveProvider", Json.Bool p))
@@ -166,7 +478,6 @@ module Darklang =
 
 
         module CompletionParams =
-
           /// Completion parameters
           ///
           /// TODO:
@@ -215,24 +526,23 @@ module Darklang =
 
             | _ -> Stdlib.Result.Result.Error()
 
-(*
-  /// Defines whether the insert text in a completion item should be interpreted as
-  /// plain text or a snippet.
-  export namespace InsertTextFormat {
-    /// The primary text to be inserted is treated as a plain string.
-    export const PlainText: 1 = 1;
 
-    /// The primary text to be inserted is treated as a snippet.
-    ///
-    /// A snippet can define tab stops and placeholders with `$1`, `$2`
-    /// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
-    /// the end of the snippet. Placeholders with equal identifiers are linked,
-    /// that is typing in one will update others too.
-    ///
-    /// See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax
-    export const Snippet: 2 = 2;
-  }
-  export type InsertTextFormat = 1 | 2;
+        module CompletionResult =
+          type CompletionResult =
+            | Null
+            | SimpleList of List<CompletionItem.CompletionItem>
+            | CompletionList of CompletionList.CompletionList
+
+          let toJson (result: CompletionResult) : Json =
+            match result with
+            | Null -> Json.Null
+            | SimpleList items ->
+              items
+              |> Stdlib.List.map (fun item -> CompletionItem.toJson item)
+              |> Json.Array
+            | CompletionList list -> CompletionList.toJson list
+(*
+
 
 
   /// Completion item tags are extra annotations that tweak the rendering of a completion item.
@@ -256,26 +566,10 @@ module Darklang =
   }
 
 
-  /// How whitespace and indentation is handled during completion
-  /// item insertion.
-  export namespace InsertTextMode {
-    /// The insertion or replace strings is taken as it is. If the
-    /// value is multi line the lines below the cursor will be
-    /// inserted using the indentation defined in the string value.
-    /// The client will not apply any kind of adjustments to the
-    /// string.
-    export const asIs: 1 = 1;
 
-    /// The editor adjusts leading whitespace of new lines so that
-    /// they match the indentation up to the cursor of the line for
-    /// which the item is accepted.
-    ///
-    /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
-    /// multi line completion item is indented using 2 tabs and all
-    /// following lines inserted will be indented using 2 tabs as well.
-    export const adjustIndentation: 2 = 2;
-  }
-  export type InsertTextMode = 1 | 2;
+
+
+
 
 
 
@@ -322,415 +616,12 @@ module Darklang =
   export type CompletionItemKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25;
 
 
-  /// A completion item represents a text snippet that is
-  /// proposed to complete text that is being typed.
-  export interface CompletionItem {
-    /// The label of this completion item.
-    ///
-    /// The label property is also by default the text that
-    /// is inserted when selecting this completion.
-    ///
-    /// If label details are provided the label itself should
-    /// be an unqualified name of the completion item.
-    label: string;
-
-    /// Additional details for the label
-    labelDetails?: CompletionItemLabelDetails;
-
-    /// The kind of this completion item. Based of the kind
-    /// an icon is chosen by the editor.
-    kind?: CompletionItemKind;
-
-    /// Tags for this completion item.
-    tags?: CompletionItemTag[];
-
-    /// A human-readable string with additional information
-    /// about this item, like type or symbol information.
-    detail?: string;
-
-    /// A human-readable string that represents a doc-comment.
-    documentation?: string | MarkupContent;
-
-    /// Select this item when showing.
-    ///
-    /// Note that only one completion item can be selected and that the
-    /// tool / client decides which item that is. The rule is that the *first*
-    /// item of those that match best is selected.
-    preselect?: boolean;
-
-    /// A string that should be used when comparing this item
-    /// with other items. When `falsy` the {@link CompletionItem.label label}
-    /// is used.
-    sortText?: string;
-
-    /// A string that should be used when filtering a set of
-    /// completion items. When `falsy` the {@link CompletionItem.label label}
-    /// is used.
-    filterText?: string;
-
-    /// A string that should be inserted into a document when selecting
-    /// this completion. When `falsy` the {@link CompletionItem.label label}
-    /// is used.
-    ///
-    /// The `insertText` is subject to interpretation by the client side.
-    /// Some tools might not take the string literally. For example
-    /// VS Code when code complete is requested in this example
-    /// `con<cursor position>` and a completion item with an `insertText` of
-    /// `console` is provided it will only insert `sole`. Therefore it is
-    /// recommended to use `textEdit` instead since it avoids additional client
-    /// side interpretation.
-    insertText?: string;
-
-    /// The format of the insert text. The format applies to both the
-    /// `insertText` property and the `newText` property of a provided
-    /// `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
-    ///
-    /// Please note that the insertTextFormat doesn't apply to
-    /// `additionalTextEdits`.
-    insertTextFormat?: InsertTextFormat;
-
-    /// How whitespace and indentation is handled during completion
-    /// item insertion. If not provided the clients default value depends on
-    /// the `textDocument.completion.insertTextMode` client capability.
-    insertTextMode?: InsertTextMode;
-
-    /// An {@link TextEdit edit} which is applied to a document when selecting
-    /// this completion. When an edit is provided the value of
-    /// {@link CompletionItem.insertText insertText} is ignored.
-    ///
-    /// Most editors support two different operations when accepting a completion
-    /// item. One is to insert a completion text and the other is to replace an
-    /// existing text with a completion text. Since this can usually not be
-    /// predetermined by a server it can report both ranges. Clients need to
-    /// signal support for `InsertReplaceEdits` via the
-    /// `textDocument.completion.insertReplaceSupport` client capability
-    /// property.
-    ///
-    /// *Note 1:* The text edit's range as well as both ranges from an insert
-    /// replace edit must be a [single line] and they must contain the position
-    /// at which completion has been requested.
-    /// *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
-    /// must be a prefix of the edit's replace range, that means it must be
-    /// contained and starting at the same position.
-    textEdit?: TextEdit | InsertReplaceEdit;
-
-    /// The edit text used if the completion item is part of a CompletionList and
-    /// CompletionList defines an item default for the text edit range.
-    ///
-    /// Clients will only honor this property if they opt into completion list
-    /// item defaults using the capability `completionList.itemDefaults`.
-    ///
-    /// If not provided and a list's default range is provided the label
-    /// property is used as a text.
-    textEditText?: string;
-
-    /// An optional array of additional {@link TextEdit text edits} that are applied when
-    /// selecting this completion. Edits must not overlap (including the same insert position)
-    /// with the main {@link CompletionItem.textEdit edit} nor with themselves.
-    ///
-    /// Additional text edits should be used to change text unrelated to the current cursor position
-    /// (for example adding an import statement at the top of the file if the completion item will
-    /// insert an unqualified type).
-    additionalTextEdits?: TextEdit[];
-
-    /// An optional set of characters that when pressed while this completion is active will accept it first and
-    /// then type that character. Note that all commit characters should have `length=1` and that superfluous
-    /// characters will be ignored.
-    commitCharacters?: string[];
-
-    /// An optional {@link Command command} that is executed *after* inserting this completion. Note that
-    /// additional modifications to the current document should be described with the
-    /// {@link CompletionItem.additionalTextEdits additionalTextEdits}-property.
-    command?: Command;
-
-    /// A data entry field that is preserved on a completion item between a
-    /// {@link CompletionRequest} and a {@link CompletionResolveRequest}.
-    data?: LSPAny;
-  }
 
 
 
 
-  /// In many cases the items of an actual completion result share the same
-  /// value for properties like `commitCharacters` or the range of a text
-  /// edit. A completion list can therefore define item defaults which will
-  /// be used if a completion item itself doesn't specify the value.
-  ///
-  /// If a completion list specifies a default value and a completion item
-  /// also specifies a corresponding value the one from the item is used.
-  ///
-  /// Servers are only allowed to return default values if the client
-  /// signals support for this via the `completionList.itemDefaults`
-  /// capability.
-  export interface CompletionItemDefaults {
-    /// A default commit character set.
-    commitCharacters?: string[];
-
-    /// A default edit range.
-    editRange?: Range;
-
-    /// A default insert text format.
-    insertTextFormat?: InsertTextFormat;
-
-    /// A default insert text mode.
-    insertTextMode?: InsertTextMode;
-
-    /// A default data value.
-    data?: LSPAny;
-  }
-
-  /// Represents a collection of {@link CompletionItem completion items} to be presented
-  /// in the editor.
-  export interface CompletionList {
-    /// This list it not complete. Further typing results in recomputing this list.
-    ///
-    /// Recomputed lists have all their items replaced (not appended) in the
-    /// incomplete completion sessions.
-    isIncomplete: boolean;
-
-    /// In many cases the items of an actual completion result share the same
-    /// value for properties like `commitCharacters` or the range of a text
-    /// edit. A completion list can therefore define item defaults which will
-    /// be used if a completion item itself doesn't specify the value.
-    ///
-    /// If a completion list specifies a default value and a completion item
-    /// also specifies a corresponding value the one from the item is used.
-    ///
-    /// Servers are only allowed to return default values if the client
-    /// signals support for this via the `completionList.itemDefaults`
-    /// capability.
-    itemDefaults?: CompletionItemDefaults;
-
-    /// The completion items.
-    items: CompletionItem[];
-  }
 
 
-  /// Additional details for a completion item label.
-  export interface CompletionItemLabelDetails {
-    /// An optional string which is rendered less prominently directly after {@link CompletionItem.label label},
-    /// without any spacing. Should be used for function signatures and type annotations.
-    detail?: string;
-
-    /// An optional string which is rendered less prominently after {@link CompletionItem.detail}. Should be used
-    /// for fully qualified names and file paths.
-    description?: string;
-  }
-
-
-  /// The kind of a completion entry.
-  export namespace CompletionItemKind {
-    export const Text: 1 = 1;
-    export const Method: 2 = 2;
-    export const Function: 3 = 3;
-    export const Constructor: 4 = 4;
-    export const Field: 5 = 5;
-    export const Variable: 6 = 6;
-    export const Class: 7 = 7;
-    export const Interface: 8 = 8;
-    export const Module: 9 = 9;
-    export const Property: 10 = 10;
-    export const Unit: 11 = 11;
-    export const Value: 12 = 12;
-    export const Enum: 13 = 13;
-    export const Keyword: 14 = 14;
-    export const Snippet: 15 = 15;
-    export const Color: 16 = 16;
-    export const File: 17 = 17;
-    export const Reference: 18 = 18;
-    export const Folder: 19 = 19;
-    export const EnumMember: 20 = 20;
-    export const Constant: 21 = 21;
-    export const Struct: 22 = 22;
-    export const Event: 23 = 23;
-    export const Operator: 24 = 24;
-    export const TypeParameter: 25 = 25;
-  }
-  export type CompletionItemKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25;
-
-
-  /// A completion item represents a text snippet that is
-  /// proposed to complete text that is being typed.
-  export interface CompletionItem {
-    /// The label of this completion item.
-    ///
-    /// The label property is also by default the text that
-    /// is inserted when selecting this completion.
-    ///
-    /// If label details are provided the label itself should
-    /// be an unqualified name of the completion item.
-    label: string;
-
-    /// Additional details for the label
-    labelDetails?: CompletionItemLabelDetails;
-
-    /// The kind of this completion item. Based of the kind
-    /// an icon is chosen by the editor.
-    kind?: CompletionItemKind;
-
-    /// Tags for this completion item.
-    tags?: CompletionItemTag[];
-
-    /// A human-readable string with additional information
-    /// about this item, like type or symbol information.
-    detail?: string;
-
-    /// A human-readable string that represents a doc-comment.
-    documentation?: string | MarkupContent;
-
-    /// Select this item when showing.
-    ///
-    /// Note that only one completion item can be selected and that the
-    /// tool / client decides which item that is. The rule is that the *first*
-    /// item of those that match best is selected.
-    preselect?: boolean;
-
-    /// A string that should be used when comparing this item
-    /// with other items. When `falsy` the {@link CompletionItem.label label}
-    /// is used.
-    sortText?: string;
-
-    /// A string that should be used when filtering a set of
-    /// completion items. When `falsy` the {@link CompletionItem.label label}
-    /// is used.
-    filterText?: string;
-
-    /// A string that should be inserted into a document when selecting
-    /// this completion. When `falsy` the {@link CompletionItem.label label}
-    /// is used.
-    ///
-    /// The `insertText` is subject to interpretation by the client side.
-    /// Some tools might not take the string literally. For example
-    /// VS Code when code complete is requested in this example
-    /// `con<cursor position>` and a completion item with an `insertText` of
-    /// `console` is provided it will only insert `sole`. Therefore it is
-    /// recommended to use `textEdit` instead since it avoids additional client
-    /// side interpretation.
-    insertText?: string;
-
-    /// The format of the insert text. The format applies to both the
-    /// `insertText` property and the `newText` property of a provided
-    /// `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
-    ///
-    /// Please note that the insertTextFormat doesn't apply to
-    /// `additionalTextEdits`.
-    insertTextFormat?: InsertTextFormat;
-
-    /// How whitespace and indentation is handled during completion
-    /// item insertion. If not provided the clients default value depends on
-    /// the `textDocument.completion.insertTextMode` client capability.
-    insertTextMode?: InsertTextMode;
-
-    /// An {@link TextEdit edit} which is applied to a document when selecting
-    /// this completion. When an edit is provided the value of
-    /// {@link CompletionItem.insertText insertText} is ignored.
-    ///
-    /// Most editors support two different operations when accepting a completion
-    /// item. One is to insert a completion text and the other is to replace an
-    /// existing text with a completion text. Since this can usually not be
-    /// predetermined by a server it can report both ranges. Clients need to
-    /// signal support for `InsertReplaceEdits` via the
-    /// `textDocument.completion.insertReplaceSupport` client capability
-    /// property.
-    ///
-    /// *Note 1:* The text edit's range as well as both ranges from an insert
-    /// replace edit must be a [single line] and they must contain the position
-    /// at which completion has been requested.
-    /// *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
-    /// must be a prefix of the edit's replace range, that means it must be
-    /// contained and starting at the same position.
-    textEdit?: TextEdit | InsertReplaceEdit;
-
-    /// The edit text used if the completion item is part of a CompletionList and
-    /// CompletionList defines an item default for the text edit range.
-    ///
-    /// Clients will only honor this property if they opt into completion list
-    /// item defaults using the capability `completionList.itemDefaults`.
-    ///
-    /// If not provided and a list's default range is provided the label
-    /// property is used as a text.
-    textEditText?: string;
-
-    /// An optional array of additional {@link TextEdit text edits} that are applied when
-    /// selecting this completion. Edits must not overlap (including the same insert position)
-    /// with the main {@link CompletionItem.textEdit edit} nor with themselves.
-    ///
-    /// Additional text edits should be used to change text unrelated to the current cursor position
-    /// (for example adding an import statement at the top of the file if the completion item will
-    /// insert an unqualified type).
-    additionalTextEdits?: TextEdit[];
-
-    /// An optional set of characters that when pressed while this completion is active will accept it first and
-    /// then type that character. Note that all commit characters should have `length=1` and that superfluous
-    /// characters will be ignored.
-    commitCharacters?: string[];
-
-    /// An optional {@link Command command} that is executed *after* inserting this completion. Note that
-    /// additional modifications to the current document should be described with the
-    /// {@link CompletionItem.additionalTextEdits additionalTextEdits}-property.
-    command?: Command;
-
-    /// A data entry field that is preserved on a completion item between a
-    /// {@link CompletionRequest} and a {@link CompletionResolveRequest}.
-    data?: LSPAny;
-  }
-
-
-
-
-  /// In many cases the items of an actual completion result share the same
-  /// value for properties like `commitCharacters` or the range of a text
-  /// edit. A completion list can therefore define item defaults which will
-  /// be used if a completion item itself doesn't specify the value.
-  ///
-  /// If a completion list specifies a default value and a completion item
-  /// also specifies a corresponding value the one from the item is used.
-  ///
-  /// Servers are only allowed to return default values if the client
-  /// signals support for this via the `completionList.itemDefaults`
-  /// capability.
-  export interface CompletionItemDefaults {
-    /// A default commit character set.
-    commitCharacters?: string[];
-
-    /// A default edit range.
-    editRange?: Range;
-
-    /// A default insert text format.
-    insertTextFormat?: InsertTextFormat;
-
-    /// A default insert text mode.
-    insertTextMode?: InsertTextMode;
-
-    /// A default data value.
-    data?: LSPAny;
-  }
-
-  /// Represents a collection of {@link CompletionItem completion items} to be presented
-  /// in the editor.
-  export interface CompletionList {
-    /// This list it not complete. Further typing results in recomputing this list.
-    ///
-    /// Recomputed lists have all their items replaced (not appended) in the
-    /// incomplete completion sessions.
-    isIncomplete: boolean;
-
-    /// In many cases the items of an actual completion result share the same
-    /// value for properties like `commitCharacters` or the range of a text
-    /// edit. A completion list can therefore define item defaults which will
-    /// be used if a completion item itself doesn't specify the value.
-    ///
-    /// If a completion list specifies a default value and a completion item
-    /// also specifies a corresponding value the one from the item is used.
-    ///
-    /// Servers are only allowed to return default values if the client
-    /// signals support for this via the `completionList.itemDefaults`
-    /// capability.
-    itemDefaults?: CompletionItemDefaults;
-
-    /// The completion items.
-    items: CompletionItem[];
-  }
 
 
   /// The client supports the following `CompletionList` specific capabilities.

--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -76,6 +76,145 @@ module Darklang =
           |> Json.Object
 
 
+      /// Request to request completion at a given text document position.
+      ///
+      /// The request's parameter is of type {@link TextDocumentPosition}.
+      ///
+      /// The response may be of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
+      /// or a Thenable that resolves to such.
+      ///
+      /// The request can delay the computation of the {@link CompletionItem.detail `detail`}
+      /// and {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`
+      /// request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
+      /// `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
+      module CompletionRequest =
+        let method = "textDocument/completion"
+        // let messageDirection = MessageDirection.ClientToServer
+        // params: CompletionParams
+        // result: CompletionItem[] | CompletionList | null
+        // registrationOptions: CompletionRegistrationOptions
+
+
+        module CompletionTriggerKind =
+          /// How a completion was triggered
+          type CompletionTriggerKind =
+            /// Completion was triggered by:
+            /// - typing an identifier (24x7 code complete)
+            /// - manual invocation (e.g Ctrl+Space)
+            /// - , or via API. (TODO: not sure what this means)
+            | Invoked
+
+            /// Completion was triggered by a trigger character specified by
+            /// the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+            | TriggerCharacter
+
+            /// Completion was re-triggered as current completion list is incomplete
+            | TriggerForIncompleteCompletions
+
+          let fromJson
+            (json: Json)
+            : Stdlib.Result.Result<CompletionTriggerKind, Unit> =
+            match json with
+            | Number 1.0 -> Stdlib.Result.Result.Ok CompletionTriggerKind.Invoked
+            | Number 2.0 ->
+              Stdlib.Result.Result.Ok CompletionTriggerKind.TriggerCharacter
+            | Number 3.0 ->
+              Stdlib.Result.Result.Ok
+                CompletionTriggerKind.TriggerForIncompleteCompletions
+            | _ -> Stdlib.Result.Result.Error()
+
+
+        /// Contains additional information about the context in which a completion request is triggered.
+        module CompletionContext =
+          type CompletionContext =
+            {
+              /// How the completion was triggered.
+              triggerKind: CompletionTriggerKind.CompletionTriggerKind
+
+              /// The trigger character (a single character) that has trigger code complete.
+              /// Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+              triggerCharacter: Stdlib.Option.Option<String>
+            }
+
+          let fromJson (json: Json) : Stdlib.Result.Result<CompletionContext, Unit> =
+            match json with
+            | Object fields ->
+              let triggerKind = // Result<CompletionTriggerKind, Unit>
+                match
+                  Stdlib.List.findFirst fields (fun (key, _) -> key == "triggerKind")
+                with
+                | Some((_, tk)) -> CompletionTriggerKind.fromJson tk
+                | _ -> Stdlib.Result.Result.Error()
+
+              let triggerCharacter = // Option<String>
+                match
+                  Stdlib.List.findFirst fields (fun (key, _) ->
+                    key == "triggerCharacter")
+                with
+                | Some((_, String triggerCharacter)) ->
+                  Stdlib.Option.Option.Some triggerCharacter
+                | _ -> Stdlib.Option.Option.None
+
+              match (triggerKind, triggerCharacter) with
+              | (Ok triggerKind, triggerCharacter) ->
+                (CompletionContext
+                  { triggerKind = triggerKind
+                    triggerCharacter = triggerCharacter })
+                |> Stdlib.Result.Result.Ok
+
+            | _ -> Stdlib.Result.Result.Error()
+
+
+        module CompletionParams =
+
+          /// Completion parameters
+          ///
+          /// TODO:
+          /// - extends WorkDoneProgressParams
+          /// - extends PartialResultParams
+          type CompletionParams =
+            {
+              // in TypeScript, was inlined via `@extends TextDocumentPositionParams`
+              textDocumentPosition:
+                TextDocumentPositionParams.TextDocumentPositionParams
+
+              /// The completion context. This is only available it the client specifies
+              /// to send this using the client capability `textDocument.completion.contextSupport === true`
+              context: Stdlib.Option.Option<CompletionContext.CompletionContext>
+            }
+
+          let fromJson (json: Json) : Stdlib.Result.Result<CompletionParams, Unit> =
+            match json with
+            | Object fields ->
+              let textDocumentPosition = // Result<TextDocumentPositionParams, Unit>
+                TextDocumentPositionParams.fromJson json
+
+              let context = // Option<Result<CompletionContext, Unit>>
+                match
+                  Stdlib.List.findFirst fields (fun (key, _) -> key == "context")
+                with
+                | None -> Stdlib.Option.Option.None
+                | Some((_, context)) ->
+                  (CompletionContext.fromJson context) |> Stdlib.Option.Option.Some
+                | _ -> Stdlib.Result.Result.Error()
+
+              match textDocumentPosition, context with
+              | Ok(textDocumentPosition), None ->
+                (CompletionParams
+                  { textDocumentPosition = textDocumentPosition
+                    context = Stdlib.Option.Option.None })
+                |> Stdlib.Result.Result.Ok
+
+              | Ok(textDocumentPosition), Some(Ok context) ->
+                (CompletionParams
+                  { textDocumentPosition = textDocumentPosition
+                    context = Stdlib.Option.Option.Some context })
+                |> Stdlib.Result.Result.Ok
+
+              | _ -> Stdlib.Result.Result.Error()
+
+            | _ -> Stdlib.Result.Result.Error()
+
 (*
   /// Defines whether the insert text in a completion item should be interpreted as
   /// plain text or a snippet.
@@ -707,44 +846,11 @@ module Darklang =
     completionList?: CompletionListCapabilities;
   }
 
-  /// How a completion was triggered
-  export namespace CompletionTriggerKind {
-    /// Completion was triggered by typing an identifier (24x7 code
-    /// complete), manual invocation (e.g Ctrl+Space) or via API.
-    export const Invoked: 1 = 1;
-
-    /// Completion was triggered by a trigger character specified by
-    /// the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
-    export const TriggerCharacter: 2 = 2;
-
-    /// Completion was re-triggered as current completion list is incomplete
-    export const TriggerForIncompleteCompletions: 3 = 3;
-  }
-
-  export type CompletionTriggerKind = 1 | 2 | 3;
 
 
-  /// Contains additional information about the context in which a completion request is triggered.
-  export interface CompletionContext {
-    /// How the completion was triggered.
-    triggerKind: CompletionTriggerKind;
 
-    /// The trigger character (a single character) that has trigger code complete.
-    /// Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
-    triggerCharacter?: string;
-  }
 
-  /// Completion parameters
-  export interface CompletionParams
-    extends
-      TextDocumentPositionParams,
-      WorkDoneProgressParams,
-      PartialResultParams {
 
-    /// The completion context. This is only available it the client specifies
-    /// to send this using the client capability `textDocument.completion.contextSupport === true`
-    context?: CompletionContext;
-  }
 
 
 
@@ -755,20 +861,7 @@ module Darklang =
       CompletionOptions {
   }
 
-  /// Request to request completion at a given text document position. The request's
-  /// parameter is of type {@link TextDocumentPosition} the response
-  /// is of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
-  /// or a Thenable that resolves to such.
-  ///
-  /// The request can delay the computation of the {@link CompletionItem.detail `detail`}
-  /// and {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`
-  /// request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
-  /// `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
-  export namespace CompletionRequest {
-    export const method: 'textDocument/completion' = 'textDocument/completion';
-    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
-    export const type = new ProtocolRequestType<CompletionParams, CompletionItem[] | CompletionList | null, CompletionItem[], void, CompletionRegistrationOptions>(method);
-  }
+
 
   /// Request to resolve additional information for a given completion item.The request's
   /// parameter is of type {@link CompletionItem} the response

--- a/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
@@ -450,11 +450,12 @@ module Darklang =
               textDocumentSync:
                 Stdlib.Option.Option<TextDocumentSyncServerCapabilities.TextDocumentSyncServerCapabilities>
 
-            // /// Defines how notebook documents are synced.
-            // notebookDocumentSync?: NotebookDocumentSyncOptions | NotebookDocumentSyncRegistrationOptions;
+              // /// Defines how notebook documents are synced.
+              // notebookDocumentSync?: NotebookDocumentSyncOptions | NotebookDocumentSyncRegistrationOptions;
 
-            // /// The server provides completion support.
-            // completionProvider?: CompletionOptions;
+              /// The server provides completion support.
+              completionProvider:
+                Stdlib.Option.Option<Completions.CompletionOptions.CompletionOptions>
 
             // /// The server provides hover support.
             // hoverProvider?: boolean | HoverOptions;
@@ -562,7 +563,12 @@ module Darklang =
           let toJson (capabilities: ServerCapabilities) : Json =
             [ capabilities.textDocumentSync
               |> Stdlib.Option.map (fun sync ->
-                ("textDocumentSync", TextDocumentSyncServerCapabilities.toJson sync)) ]
+                ("textDocumentSync", TextDocumentSyncServerCapabilities.toJson sync))
+
+              (capabilities.completionProvider
+               |> Stdlib.Option.map (fun provider ->
+                 ("completionProvider",
+                  Completions.CompletionOptions.toJson provider))) ]
 
             |> Stdlib.List.filterMap (fun self -> self)
             |> Json.Object

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -146,7 +146,7 @@ module Darklang =
 
 
         // -- autocomplete
-        | ("textDocument/completion", Some id, Some(Object requestParams)) ->
+        | ("textDocument/completion", Some requestId, Some(Object requestParams)) ->
           let parsed =
             (Stdlib.AltJson.Json.Object requestParams)
             |> LanguageServerProtocol.Completions.CompletionRequest.CompletionParams.fromJson
@@ -156,7 +156,41 @@ module Darklang =
             log
               $"got completion request for {parsed.textDocumentPosition.textDocument.uri}"
 
-            log "TODO: return a response with some completions"
+
+            let includeBogusCompletion = true
+
+            let bogusCompletions =
+              [ LanguageServerProtocol.Completions.CompletionItem.CompletionItem
+                  { label =
+                      "bogus completion response | a b c d e f g h i j k l m n o p q r s t u v w x y z"
+                    detail = Stdlib.Option.Option.None
+                    preselect = Stdlib.Option.Option.Some true
+                    sortText = Stdlib.Option.Option.None
+                    filterText = Stdlib.Option.Option.None
+                    insertText = Stdlib.Option.Option.None
+                    insertTextFormat = Stdlib.Option.Option.None
+                    insertTextMode = Stdlib.Option.Option.None
+                    textEditText = Stdlib.Option.Option.None
+                    commitCharacters = Stdlib.Option.Option.None
+                    data = Stdlib.Option.Option.None } ]
+
+            let bogusResponse =
+              LanguageServerProtocol
+                .Completions
+                .CompletionRequest
+                .CompletionResult
+                .CompletionResult
+                .SimpleList(if includeBogusCompletion then bogusCompletions else [])
+
+            let bogusResponseJson =
+              bogusResponse
+              |> LanguageServerProtocol.Completions.CompletionRequest.CompletionResult.toJson
+              |> (fun r ->
+                JsonRPC.Response.Ok.make (Stdlib.Option.Option.Some requestId) r)
+              |> Stdlib.AltJson.format
+
+            logAndSendToClient bogusResponseJson
+
           | Error() -> log "couldn't parse params of completion request"
 
           state
@@ -322,7 +356,10 @@ module Darklang =
         let initializeResponse =
           initializeResult
           |> LanguageServerProtocol.Lifecycle.InitializeRequest.InitializeResult.toJson
-          |> (fun r -> JsonRPC.Response.Ok.make (Stdlib.Option.Option.Some 0L) r)
+          |> (fun r ->
+            JsonRPC.Response.Ok.make
+              (Stdlib.Option.Option.Some(JsonRPC.RequestId.Int 0L))
+              r)
           |> Stdlib.AltJson.format
 
         logAndSendToClient initializeResponse

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -333,6 +333,15 @@ module Darklang =
                                       )
                                   ) }
                           )
+                      )
+
+                    completionProvider =
+                      Stdlib.Option.Option.Some(
+                        LanguageServerProtocol.Completions.CompletionOptions.CompletionOptions
+                          { triggerCharacters = Stdlib.Option.Option.None
+                            allCommitCharacters = Stdlib.Option.Option.None
+                            resolveProvider = Stdlib.Option.Option.Some false // just return all info at once
+                            completionItem = Stdlib.Option.Option.None }
                       ) }
               serverInfo = Stdlib.Option.Option.None }
 

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -80,13 +80,11 @@ module Darklang =
 
 
         // -- textDocument synchronization
-        | ("textDocument/didOpen", None, Some(Object fields)) ->
-          // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidOpenTextDocumentNotification.method` above
-          let reconstructedJson = Stdlib.AltJson.Json.Object fields
-
+        // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidOpenTextDocumentNotification.method` below
+        | ("textDocument/didOpen", None, Some(Object requestParams)) ->
           let parsed =
-            LanguageServerProtocol.DocumentSync.TextDocument.DidOpenTextDocumentNotification.DidOpenTextDocumentParams.fromJson
-              reconstructedJson
+            (Stdlib.AltJson.Json.Object requestParams)
+            |> LanguageServerProtocol.DocumentSync.TextDocument.DidOpenTextDocumentNotification.DidOpenTextDocumentParams.fromJson
 
           match parsed with
           | Ok parsed ->
@@ -103,13 +101,11 @@ module Darklang =
             state
 
 
-        | ("textDocument/didSave", None, Some(Object fields)) ->
-          // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidSaveTextDocumentNotification.method` above
-          let reconstructedJson = Stdlib.AltJson.Json.Object fields
-
+        // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidSaveTextDocumentNotification.method` below
+        | ("textDocument/didSave", None, Some(Object requestParams)) ->
           let parsed =
-            LanguageServerProtocol.DocumentSync.TextDocument.DidSaveTextDocumentNotification.DidSaveTextDocumentParams.fromJson
-              reconstructedJson
+            (Stdlib.AltJson.Json.Object requestParams)
+            |> LanguageServerProtocol.DocumentSync.TextDocument.DidSaveTextDocumentNotification.DidSaveTextDocumentParams.fromJson
 
           match parsed with
           | Ok parsed ->
@@ -131,13 +127,11 @@ module Darklang =
             log "couldn't parse params of didSave"
             state
 
-        | ("textDocument/didClose", None, Some(Object fields)) ->
-          // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidCloseTextDocumentNotification.method` above
-          let reconstructedJson = Stdlib.AltJson.Json.Object fields
-
+        // TODO: use `LanguageServerProtocol.DocumentSync.TextDocument.DidCloseTextDocumentNotification.method` below
+        | ("textDocument/didClose", None, Some(Object requestParams)) ->
           let parsed =
-            LanguageServerProtocol.DocumentSync.TextDocument.DidCloseTextDocumentNotification.DidCloseTextDocumentParams.fromJson
-              reconstructedJson
+            (Stdlib.AltJson.Json.Object requestParams)
+            |> LanguageServerProtocol.DocumentSync.TextDocument.DidCloseTextDocumentNotification.DidCloseTextDocumentParams.fromJson
 
           match parsed with
           | Ok parsed ->
@@ -152,39 +146,19 @@ module Darklang =
 
 
         // -- autocomplete
-        | ("textDocument/completion", Some id, Some p) ->
-          match p with
-          | Array p ->
-            let p = (Json.Array p) |> Stdlib.AltJson.format
-            log $"Some Array-based params: {p}"
-          | Object p ->
-            let p = (Json.Object p) |> Stdlib.AltJson.format
-            log $"Some Object-based params: {p}"
+        | ("textDocument/completion", Some id, Some(Object requestParams)) ->
+          let parsed =
+            (Stdlib.AltJson.Json.Object requestParams)
+            |> LanguageServerProtocol.Completions.CompletionRequest.CompletionParams.fromJson
 
-          (*[
-            { label: "TypeScript", kind: CompletionItemKind.Text, data: 1 },
-            { label: "JavaScript", kind: CompletionItemKind.Text, data: 2 },
-          ]*)
+          match parsed with
+          | Ok parsed ->
+            log
+              $"got completion request for {parsed.textDocumentPosition.textDocument.uri}"
 
-          log "TODO: return a response with some completions"
-          state
+            log "TODO: return a response with some completions"
+          | Error() -> log "couldn't parse params of completion request"
 
-        | ("completionItem/resolve", Some id) ->
-          (*
-            // once you hover over some completion, this fills in some details (I think)
-            connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
-              if (item.data === 1) {
-                item.detail = "TypeScript details";
-                item.documentation = "TypeScript documentation";
-              } else if (item.data === 2) {
-                item.detail = "JavaScript details";
-                item.documentation = "JavaScript documentation";
-              }
-              return item;
-            });
-          *)
-          // TODO: use r.params
-          log "TODO: deal with completion item resolution"
           state
 
 

--- a/packages/darklang/stdlib/uint64.dark
+++ b/packages/darklang/stdlib/uint64.dark
@@ -67,6 +67,10 @@ module Darklang =
       /// Converts an <type UInt64> to a <type Float>
       let toFloat (a: UInt64) : Float = Builtin.UInt64.toFloat a
 
+      /// Converts a <type Float> to an <type UInt64>
+      let fromFloat (a: Float) : Stdlib.Option.Option<UInt64> =
+        a |> Float.round |> fromInt64
+
 
       /// Returns the sum of all the ints in the list
       let sum (lst: List<UInt64>) : UInt64 =

--- a/user-code/darklang/scripts/sample-for-testing-extension.dark
+++ b/user-code/darklang/scripts/sample-for-testing-extension.dark
@@ -1,0 +1,1 @@
+let double (i: Int) : Int = i + i


### PR DESCRIPTION
- in `initialize` handshake, announce that we support 'completions'
  `"completionProvider":{"resolveProvider":false}`
- handle `textDocument/completion` requests, and respond to them with a single fake autocomplete

https://github.com/darklang/dark/assets/906686/20261594-8371-410b-a5ab-794ad5c895f0

