### PR TITLE
Language Server 'glue code' for semantic tokens (for syntax highlighting)

### DIFF
--- a/packages/darklang/json-rpc.dark
+++ b/packages/darklang/json-rpc.dark
@@ -204,7 +204,7 @@ module Darklang =
 
                ("params", v))) ]
 
-          |> Stdlib.List.filterMap (fun x -> x)
+          |> Stdlib.Option.values
 
         (Json.Object fields) |> Stdlib.AltJson.format
 
@@ -257,7 +257,7 @@ module Darklang =
 
             Stdlib.Option.Option.Some(("result", result)) ]
 
-          |> Stdlib.List.filterMap (fun x -> x)
+          |> Stdlib.Option.values
           |> Json.Object
 
       module Error =
@@ -278,12 +278,12 @@ module Darklang =
             [ Some(("code", Json.Number errorCode))
               Some(("message", Json.String errorMessage))
               (errorData |> Stdlib.Option.map (fun data -> ("data", data))) ]
-            |> Stdlib.List.filterMap (fun f -> f)
+            |> Stdlib.Option.values
 
           let fields =
             [ (requestId |> Stdlib.Option.map (fun id -> ("id", requestIdToJson id)))
               Some(("jsonrpc", Json.String "2.0"))
               Some(("error", Json.Object errorDetailFeilds)) ]
-            |> Stdlib.List.filterMap (fun f -> f)
+            |> Stdlib.Option.values
 
           (Json.Object fields) |> Stdlib.AltJson.format

--- a/packages/darklang/languageServerProtocol/README.md
+++ b/packages/darklang/languageServerProtocol/README.md
@@ -71,10 +71,9 @@ project is quite hard to follow, though, so we've reorganized things here.
   }
   ```
 
-  The latter is easier to understand, but won't work out of the box if we end up
-  switching to our usage-ignorant Json parser/serializer. I'm going to use the
-  latter for now, and we can re-evaluate if/when needed. That said, for each case
-  where we do this, we should add a comment roughly of `@extends TextDocumentPositionParams`
+  There are various issues trying with the latter (i.e. redundant definitions when
+  one `@extends` extends another `@extends`), so we've gone with the former. It'll
+  come with some unfortunate redundancy throughout, though.
 
 ## TODOs:
 

--- a/packages/darklang/languageServerProtocol/common.dark
+++ b/packages/darklang/languageServerProtocol/common.dark
@@ -203,6 +203,144 @@ module Darklang =
         | _ -> Stdlib.Result.Result.Error()
 
 
+    module TextDocumentFilterLanguage =
+      /// A document filter where `language` is required field.
+      ///
+      /// @proposed
+      type TextDocumentFilterLanguage =
+        {
+          /// A language id, like `typescript`.
+          language: String
+
+          /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+          scheme: Stdlib.Option.Option<String>
+
+          /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
+          pattern: Stdlib.Option.Option<String>
+        }
+
+      let toJson (l: TextDocumentFilterLanguage) : Json =
+        [ Stdlib.Option.Option.Some(("language", Json.String l.language))
+
+          l.scheme |> Stdlib.Option.map (fun s -> ("scheme", Json.String s))
+
+          l.pattern |> Stdlib.Option.map (fun p -> ("pattern", Json.String p)) ]
+
+        |> Stdlib.Option.values
+        |> Json.Object
+
+
+    module TextDocumentFilterScheme =
+      /// A document filter where `scheme` is required field.
+      ///
+      /// @proposed
+      type TextDocumentFilterScheme =
+        {
+          /// A language id, like `typescript`.
+          language: Stdlib.Option.Option<String>
+
+          /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+          scheme: String
+
+          /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
+          pattern: Stdlib.Option.Option<String>
+        }
+
+      let toJson (s: TextDocumentFilterScheme) : Json =
+        [ s.language |> Stdlib.Option.map (fun l -> ("language", Json.String l))
+
+          Some(("scheme", Json.String s.scheme))
+
+          s.pattern |> Stdlib.Option.map (fun p -> ("pattern", Json.String p)) ]
+
+        |> Stdlib.Option.values
+        |> Json.Object
+
+
+    module TextDocumentFilter =
+      /// A document filter denotes a document by different properties like
+      /// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
+      /// its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
+      ///
+      /// Glob patterns can have the following syntax:
+      /// - `*` to match one or more characters in a path segment
+      /// - `?` to match on one character in a path segment
+      /// - `**` to match any number of path segments, including none
+      /// - `{}` to group sub patterns into an OR expression.
+      ///   (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+      /// - `[]` to declare a range of characters to match in a path segment
+      ///   (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+      /// - `[!...]` to negate a range of characters to match in a path segment
+      ///   (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+      ///
+      /// @sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`
+      /// @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
+      type TextDocumentFilter =
+        | TextDocumentFilterLanguage of
+          TextDocumentFilterLanguage.TextDocumentFilterLanguage
+
+        | TextDocumentFilterScheme of
+          TextDocumentFilterScheme.TextDocumentFilterScheme
+
+      let toJson (f: TextDocumentFilter) : Json =
+        match f with
+        | TextDocumentFilterLanguage l -> TextDocumentFilterLanguage.toJson l
+        | TextDocumentFilterScheme s -> TextDocumentFilterScheme.toJson s
+
+
+    module DocumentFilter =
+      /// A document filter describes a top level text document
+      /// or a notebook cell document.
+      type DocumentFilter = Text of TextDocumentFilter.TextDocumentFilter
+      // TODO: | NotebookCell of NotebookCellTextDocumentFilter;
+
+      let toJson (f: DocumentFilter) : Json =
+        match f with
+        | Text t -> TextDocumentFilter.toJson t
+
+
+    module DocumentSelector =
+      /// A document selector is the combination of one or many document filters.
+      ///
+      /// Sample:
+      /// ```javascript
+      /// let sel:DocumentSelector =
+      ///   [ { language: 'typescript' },
+      ///     { language: 'json', pattern: '**∕tsconfig.json' } ]
+      /// ```;
+      type DocumentSelector = List<DocumentFilter.DocumentFilter>
+
+      let toJson (filters: DocumentSelector) : Json =
+        filters |> Stdlib.List.map (fun f -> DocumentFilter.toJson f) |> Json.Array
+
+
+    module TextDocumentRegistrationOptions =
+      module TextDocumentRegistrationOptionsDocumentSelector =
+        type TextDocumentRegistrationOptionsDocumentSelector =
+          | Null
+          | DocumentSelector of DocumentSelector.DocumentSelector
+
+        let toJson (d: TextDocumentRegistrationOptionsDocumentSelector) : Json =
+          match d with
+          | Null -> Json.Null
+          | DocumentSelector s -> DocumentSelector.toJson s
+
+      /// General text document registration options.
+      type TextDocumentRegistrationOptions =
+        {
+          /// A document selector to identify the scope of the registration.
+          /// If set to null, the document selector provided on the client side will be used.
+          documentSelector:
+            TextDocumentRegistrationOptionsDocumentSelector.TextDocumentRegistrationOptionsDocumentSelector
+        }
+
+      let toJson (o: TextDocumentRegistrationOptions) : Json =
+        [ ("documentSelector",
+           TextDocumentRegistrationOptionsDocumentSelector.toJson o.documentSelector) ]
+        |> Json.Object
+
+
+
     module DiagnosticSeverity =
       type DiagnosticSeverity =
         | Error
@@ -316,6 +454,21 @@ module Darklang =
         let fields = [] // TODO
         Json.Object fields
 
+
+    module StaticRegistrationOptions =
+      /// Static registration options to be returned in the initialize request.
+      type StaticRegistrationOptions =
+        {
+          /// The id used to register the request.
+          /// The id can be used to deregister the request again. See also Registration#id.
+          id: Stdlib.Option.Option<String>
+        }
+
+      let toJson (o: StaticRegistrationOptions) : Json =
+        [ o.id |> Stdlib.Option.map (fun i -> ("id", Json.String i)) ]
+        |> Stdlib.Option.values
+        |> Json.Object
+
 (* LSP Error Codes
   export namespace LSPErrorCodes {
     * This is the start range of LSP reserved error codes.
@@ -388,10 +541,6 @@ module Darklang =
   /// interval notations (e.g. [0, 1] denotes all decimals d with
   /// 0 <= d <= 1.
   export type decimal = number;
-
-
-
-
 
 
 
@@ -700,11 +849,6 @@ module Darklang =
 
 
 
-
-
-
-
-
   /// The definition of a symbol represented as one or many {@link Location locations}.
   /// For most programming languages there is only one location at which a symbol is
   /// defined.
@@ -737,8 +881,6 @@ module Darklang =
     /// Include the declaration of the current symbol.
     includeDeclaration: boolean;
   }
-
-
 
 
 
@@ -823,9 +965,6 @@ module Darklang =
 
 
 
-
-
-
   /// A workspace folder inside a client.
   export interface WorkspaceFolder {
     /// The associated URI for this workspace folder.
@@ -835,8 +974,6 @@ module Darklang =
     /// workspace folder in the user interface.
     name: string;
   }
-
-
 
 
 
@@ -858,84 +995,6 @@ module Darklang =
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  /// Static registration options to be returned in the initialize request.
-  export interface StaticRegistrationOptions {
-    /// The id used to register the request. The id can be used to deregister
-    /// the request again. See also Registration#id.
-    id?: string;
-  }
-
-
-
-
-
-
-
-
-
-
-
-  /// A document filter where `language` is required field.
-  ///
-  /// @proposed
-  export interface TextDocumentFilterLanguage {
-    /// A language id, like `typescript`.
-    language: string;
-
-    /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
-    scheme?: string;
-
-    /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
-    pattern?: string;
-  }
-
-  /// A document filter where `scheme` is required field.
-  ///
-  /// @proposed
-  export interface TextDocumentFilterScheme {
-    /// A language id, like `typescript`.
-    language?: string;
-
-    /// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
-    scheme: string;
-
-    /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
-    pattern?: string;
-  }
-
-
-  /// A document filter denotes a document by different properties like
-  /// the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
-  /// its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
-  ///
-  /// Glob patterns can have the following syntax:
-  /// - `*` to match one or more characters in a path segment
-  /// - `?` to match on one character in a path segment
-  /// - `**` to match any number of path segments, including none
-  /// - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
-  /// - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
-  /// - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
-  ///
-  /// @sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`
-  /// @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
-  export type TextDocumentFilter = TextDocumentFilterLanguage | TextDocumentFilterScheme;
 
 
 
@@ -991,19 +1050,4 @@ module Darklang =
   };
 
 
-  /// A document filter describes a top level text document or
-  /// a notebook cell document.
-  export type DocumentFilter = TextDocumentFilter | NotebookCellTextDocumentFilter;
-
-  /// A document selector is the combination of one or many document filters.
-  ///
-  /// @sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;
-  export type DocumentSelector = (DocumentFilter)[];
-
-  /// General text document registration options.
-  export interface TextDocumentRegistrationOptions {
-    /// A document selector to identify the scope of the registration. If set to null
-    /// the document selector provided on the client side will be used.
-    documentSelector: DocumentSelector | null;
-  }
 *)

--- a/packages/darklang/languageServerProtocol/documentSync/textDocument.dark
+++ b/packages/darklang/languageServerProtocol/documentSync/textDocument.dark
@@ -220,7 +220,7 @@ module Darklang =
               options.save
               |> Stdlib.Option.map (fun s -> ("save", SaveOptionsOrBool.toJson s)) ]
 
-            |> Stdlib.List.filterMap (fun x -> x)
+            |> Stdlib.Option.values
             |> Json.Object
 
 

--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -489,10 +489,12 @@ module Darklang =
               /// to send this using the client capability `textDocument.completion.contextSupport === true`
               context: Stdlib.Option.Option<CompletionContext.CompletionContext>
 
-              // in TypeScript, was inlined via `@extends TextDocumentPositionParams`
-              // TODO: inline it here too
-              textDocumentPosition:
-                TextDocumentPositionParams.TextDocumentPositionParams
+              // <extends TextDocumentPositionParams>
+              /// The text document.
+              textDocument: TextDocumentIdentifier.TextDocumentIdentifier
+
+              /// The position inside the text document.
+              position: Position.Position
             }
 
           let fromJson (json: Json) : Stdlib.Result.Result<CompletionParams, Unit> =
@@ -505,26 +507,38 @@ module Darklang =
                 | None -> Stdlib.Option.Option.None
                 | Some((_, context)) ->
                   (CompletionContext.fromJson context) |> Stdlib.Option.Option.Some
-                | _ -> Stdlib.Result.Result.Error()
 
-              let textDocumentPosition = // Result<TextDocumentPositionParams, Unit>
-                TextDocumentPositionParams.fromJson json
+              let textDocument = // Result<TextDocumentIdentifier, Unit>
+                match
+                  Stdlib.List.findFirst fields (fun (k, _) -> k == "textDocument")
+                with
+                | Some((_, textDocument)) ->
+                  TextDocumentIdentifier.fromJson textDocument
+                | None -> Stdlib.Result.Result.Error()
 
-              match textDocumentPosition, context with
-              | Ok(textDocumentPosition), None ->
+              let position = // Result<Position, Unit>
+                match
+                  Stdlib.List.findFirst fields (fun (k, _) -> k == "position")
+                with
+                | Some((_, position)) -> Position.fromJson position
+                | None -> Stdlib.Result.Result.Error()
+
+              match context, textDocument, position with
+              | None, Ok textDocument, Ok position ->
                 (CompletionParams
                   { context = Stdlib.Option.Option.None
-                    textDocumentPosition = textDocumentPosition })
+                    textDocument = textDocument
+                    position = position })
                 |> Stdlib.Result.Result.Ok
 
-              | Ok(textDocumentPosition), Some(Ok context) ->
+              | Some(Ok context), Ok textDocument, Ok position ->
                 (CompletionParams
                   { context = Stdlib.Option.Option.Some context
-                    textDocumentPosition = textDocumentPosition })
+                    textDocument = textDocument
+                    position = position })
                 |> Stdlib.Result.Result.Ok
 
               | _ -> Stdlib.Result.Result.Error()
-
             | _ -> Stdlib.Result.Result.Error()
 
 

--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -212,7 +212,7 @@ module Darklang =
 
             item.data |> Stdlib.Option.map (fun d -> ("data", d)) ]
 
-          |> Stdlib.List.filterMap (fun self -> self)
+          |> Stdlib.Option.values
           |> Json.Object
 
 
@@ -264,7 +264,7 @@ module Darklang =
 
             d.data |> Stdlib.Option.map (fun d -> ("data", d)) ]
 
-          |> Stdlib.List.filterMap (fun self -> self)
+          |> Stdlib.Option.values
           |> Json.Object
 
 
@@ -312,7 +312,7 @@ module Darklang =
                |> Json.Array)
             ) ]
 
-          |> Stdlib.List.filterMap (fun self -> self)
+          |> Stdlib.Option.values
           |> Json.Object
 
 
@@ -330,7 +330,7 @@ module Darklang =
           [ o.labelDetailsSupport
             |> Stdlib.Option.map (fun b -> ("labelDetailsSupport", Json.Bool b)) ]
 
-          |> Stdlib.List.filterMap (fun self -> self)
+          |> Stdlib.Option.values
           |> Json.Object
 
 
@@ -384,7 +384,7 @@ module Darklang =
             |> Stdlib.Option.map (fun item ->
               ("completionItem", ServerCompletionItemOptions.toJson item)) ]
 
-          |> Stdlib.List.filterMap (fun self -> self)
+          |> Stdlib.Option.values
           |> Json.Object
 
 
@@ -485,21 +485,19 @@ module Darklang =
           /// - extends PartialResultParams
           type CompletionParams =
             {
-              // in TypeScript, was inlined via `@extends TextDocumentPositionParams`
-              textDocumentPosition:
-                TextDocumentPositionParams.TextDocumentPositionParams
-
               /// The completion context. This is only available it the client specifies
               /// to send this using the client capability `textDocument.completion.contextSupport === true`
               context: Stdlib.Option.Option<CompletionContext.CompletionContext>
+
+              // in TypeScript, was inlined via `@extends TextDocumentPositionParams`
+              // TODO: inline it here too
+              textDocumentPosition:
+                TextDocumentPositionParams.TextDocumentPositionParams
             }
 
           let fromJson (json: Json) : Stdlib.Result.Result<CompletionParams, Unit> =
             match json with
             | Object fields ->
-              let textDocumentPosition = // Result<TextDocumentPositionParams, Unit>
-                TextDocumentPositionParams.fromJson json
-
               let context = // Option<Result<CompletionContext, Unit>>
                 match
                   Stdlib.List.findFirst fields (fun (key, _) -> key == "context")
@@ -509,17 +507,20 @@ module Darklang =
                   (CompletionContext.fromJson context) |> Stdlib.Option.Option.Some
                 | _ -> Stdlib.Result.Result.Error()
 
+              let textDocumentPosition = // Result<TextDocumentPositionParams, Unit>
+                TextDocumentPositionParams.fromJson json
+
               match textDocumentPosition, context with
               | Ok(textDocumentPosition), None ->
                 (CompletionParams
-                  { textDocumentPosition = textDocumentPosition
-                    context = Stdlib.Option.Option.None })
+                  { context = Stdlib.Option.Option.None
+                    textDocumentPosition = textDocumentPosition })
                 |> Stdlib.Result.Result.Ok
 
               | Ok(textDocumentPosition), Some(Ok context) ->
                 (CompletionParams
-                  { textDocumentPosition = textDocumentPosition
-                    context = Stdlib.Option.Option.Some context })
+                  { context = Stdlib.Option.Option.Some context
+                    textDocumentPosition = textDocumentPosition })
                 |> Stdlib.Result.Result.Ok
 
               | _ -> Stdlib.Result.Result.Error()

--- a/packages/darklang/languageServerProtocol/language/diagnostics.dark
+++ b/packages/darklang/languageServerProtocol/language/diagnostics.dark
@@ -47,7 +47,7 @@ module Darklang =
                      Stdlib.List.map p.diagnostics (fun d -> Diagnostic.toJson d)
                    ))
                 ) ]
-              |> Stdlib.List.filterMap (fun f -> f)
+              |> Stdlib.Option.values
 
             Json.Object fields
 

--- a/packages/darklang/languageServerProtocol/language/semanticToken.dark
+++ b/packages/darklang/languageServerProtocol/language/semanticToken.dark
@@ -1,41 +1,258 @@
+// Supports "semantic tokens," which are a way to provide syntax highlighting, among other things.
+
+module Darklang =
+  module LanguageServerProtocol =
+    module SemanticTokens =
+
+      module SemanticTokensLegend =
+        type SemanticTokensLegend =
+          {
+            /// The token types a server uses.
+            tokenTypes: List<String>
+
+            /// The token modifiers a server uses.
+            tokenModifiers: List<String>
+          }
+
+        let toJson (l: SemanticTokensLegend) : Json =
+          [ ("tokenTypes",
+             l.tokenTypes |> Stdlib.List.map (fun t -> Json.String t) |> Json.Array)
+
+            ("tokenModifiers",
+             l.tokenModifiers
+             |> Stdlib.List.map (fun m -> Json.String m)
+             |> Json.Array) ]
+
+          |> Json.Object
+
+
+      module SemanticTokens =
+        type SemanticTokens =
+          {
+            /// An optional result id. If provided and clients support delta updating
+            /// the client will include the result id in the next semantic token request.
+            /// A server can then instead of computing all semantic tokens again simply
+            /// send a delta.
+            resultId: Stdlib.Option.Option<String>
+
+            /// The actual tokens.
+            ///
+            /// TODO describe the data format
+            data: List<UInt64>
+          }
+
+        let toJson (t: SemanticTokens) : Json =
+          [ t.resultId |> Stdlib.Option.map (fun id -> ("resultId", Json.String id))
+
+            Stdlib.Option.Option.Some(
+              ("data",
+               t.data
+               |> Stdlib.List.map (fun d -> Json.Number(Stdlib.UInt64.toFloat d))
+               |> Json.Array)
+            ) ]
+
+          |> Stdlib.Option.values
+          |> Json.Object
+
+
+
+
+      module SemanticTokensRequest =
+        let method = "textDocument/semanticTokens/full"
+        // let messageDirection = MessageDirection.clientToServer;
+        // registration: SemanticTokensRegistrationType.method;
+
+        module SemanticTokensParams =
+          /// TODO: extends WorkDoneProgressParams
+          /// TODO: extends PartialResultParams
+          type SemanticTokensParams =
+            {
+              /// The text document.
+              textDocument: TextDocumentIdentifier.TextDocumentIdentifier
+            }
+
+          let fromJson
+            (json: Json)
+            : Stdlib.Result.Result<SemanticTokensParams, Unit> =
+            match json with
+            | Object fields ->
+              let textDocument = // Result<TextDocumentIdentifier, Unit>
+                match
+                  Stdlib.List.findFirst fields (fun (k, _) -> k == "textDocument")
+                with
+                | Some((_, d)) -> TextDocumentIdentifier.fromJson d
+                | _ -> Stdlib.Result.Result.Error()
+
+              match textDocument with
+              | Ok d ->
+                (SemanticTokensParams { textDocument = d })
+                |> Stdlib.Result.Result.Ok
+              | _ -> Stdlib.Result.Result.Error()
+
+            | _ -> Stdlib.Result.Result.Error()
+
+
+        module SemanticTokensResult =
+          type SemanticTokensResult =
+            | Null
+            | SemanticTokens of SemanticTokens.SemanticTokens
+
+          let toJson (r: SemanticTokensResult) : Json =
+            match r with
+            | Null -> Json.Null
+            | SemanticTokens t -> SemanticTokens.toJson t
+
+
+
+      // <server options>
+
+      module SemanticTokensOptions =
+        // Note: not a type in the spec, but used in SemanticTokensOptions as a union
+        module SemanticTokensOptionsRange =
+          type SemanticTokensOptionsRange =
+            | Bool of Bool
+            | EmptyObject
+
+          let toJson (r: SemanticTokensOptionsRange) : Json =
+            match r with
+            | Bool b -> Json.Bool b
+            | EmptyObject -> Json.Object []
+
+        module SemanticTokensFullDelta =
+          /// Semantic tokens options to support deltas for full documents
+          ///
+          /// @proposed
+          type SemanticTokensFullDelta =
+            {
+              /// The server supports deltas for full documents.
+              delta: Stdlib.Option.Option<Bool>
+            }
+
+          let toJson (d: SemanticTokensFullDelta) : Json =
+            [ d.delta |> Stdlib.Option.map (fun b -> ("delta", Json.Bool b)) ]
+
+            |> Stdlib.Option.values
+            |> Json.Object
+
+        // Note: not a type in the spec, but used in SemanticTokensOptions as a union
+        module SemanticTokensOptionsFull =
+          type SemanticTokensOptionsFull =
+            | Bool of Bool
+            | SemanticTokensFullDelta of
+              SemanticTokensFullDelta.SemanticTokensFullDelta
+
+          let toJson (f: SemanticTokensOptionsFull) : Json =
+            match f with
+            | Bool b -> Json.Bool b
+            | SemanticTokensFullDelta d -> SemanticTokensFullDelta.toJson d
+
+        type SemanticTokensOptions =
+          {
+            /// The legend used by the server
+            legend: SemanticTokensLegend.SemanticTokensLegend
+
+            /// Server supports providing semantic tokens for a specific range of a document.
+            range:
+              Stdlib.Option.Option<SemanticTokensOptionsRange.SemanticTokensOptionsRange>
+
+            /// Server supports providing semantic tokens for a full document.
+            full:
+              Stdlib.Option.Option<SemanticTokensOptionsFull.SemanticTokensOptionsFull>
+
+          // TODO: extends WorkDoneProgressOptions {
+          }
+
+        let toJson (o: SemanticTokensOptions) : Json =
+          [ Stdlib.Option.Option.Some(
+              ("legend", SemanticTokensLegend.toJson o.legend)
+            )
+
+            o.range
+            |> Stdlib.Option.map (fun r ->
+              ("range", SemanticTokensOptionsRange.toJson r))
+
+            o.full
+            |> Stdlib.Option.map (fun f ->
+              ("full", SemanticTokensOptionsFull.toJson f)) ]
+
+          |> Stdlib.Option.values
+          |> Json.Object
+
+
+      // module SemanticTokensRegistrationOptions =
+      //   type SemanticTokensRegistrationOptions =
+      //     {
+      //       // <extends TextDocumentRegistrationOptions>
+      //       documentSelector:
+      //         TextDocumentRegistrationOptions.TextDocumentRegistrationOptionsDocumentSelector.TextDocumentRegistrationOptionsDocumentSelector
+
+
+      //       // <extends SemanticTokensOptions>
+      //       /// The legend used by the server
+      //       legend: SemanticTokensLegend.SemanticTokensLegend
+
+      //       /// Server supports providing semantic tokens for a specific range of a document.
+      //       range:
+      //         Stdlib.Option.Option<SemanticTokensOptions.SemanticTokensOptionsRange.SemanticTokensOptionsRange>
+
+      //       /// Server supports providing semantic tokens for a full document.
+      //       full:
+      //         Stdlib.Option.Option<SemanticTokensOptions.SemanticTokensOptionsFull.SemanticTokensOptionsFull>
+
+
+      //       // <extends StaticRegistrationOptions>
+      //       /// The id used to register the request.
+      //       /// The id can be used to deregister the request again. See also Registration#id.
+      //       id: Stdlib.Option.Option<String>
+      //     }
+
+      //   let toJson (o: SemanticTokensRegistrationOptions) : Json =
+      //     [ Some(
+      //         ("documentSelector",
+      //          TextDocumentRegistrationOptions.TextDocumentRegistrationOptionsDocumentSelector.toJson
+      //            o.documentSelector)
+      //       )
+
+      //       Some(("legend", SemanticTokensLegend.toJson o.legend))
+
+      //       o.range
+      //       |> Stdlib.Option.map (fun r ->
+      //         ("range", SemanticTokensOptions.SemanticTokensOptionsRange.toJson r))
+
+      //       o.full
+      //       |> Stdlib.Option.map (fun f ->
+      //         ("full", SemanticTokensOptions.SemanticTokensOptionsFull.toJson f))
+
+      //       o.id |> Stdlib.Option.map (fun id -> ("id", Json.String id)) ]
+
+      //     |> Stdlib.Option.values
+      //     |> Json.Object
+
+
+      /// What server capabilities the server declares it supports,
+      /// during the `initialize` handshake.
+      module SemanticTokenProviderOptions =
+        type SemanticTokenProviderOptions =
+          // | SemanticTokensRegistrationOptions of
+          //   SemanticTokensRegistrationOptions.SemanticTokensRegistrationOptions
+
+          | SemanticTokensOptions of SemanticTokensOptions.SemanticTokensOptions
+
+        let toJson (o: SemanticTokenProviderOptions) : Json =
+          match o with
+          // | SemanticTokensRegistrationOptions o ->
+          //   SemanticTokensRegistrationOptions.toJson o
+
+          | SemanticTokensOptions o -> SemanticTokensOptions.toJson o
+
+
+
+
 (*
-  export interface SemanticTokens {
-    /// An optional result id. If provided and clients support delta updating
-    /// the client will include the result id in the next semantic token request.
-    /// A server can then instead of computing all semantic tokens again simply
-    /// send a delta.
-    resultId?: string;
-
-    /// The actual tokens.
-    data: uinteger[];
-  }
-
-  //------- 'textDocument/semanticTokens/full' -----
-
-  export interface SemanticTokensParams
-    extends
-      WorkDoneProgressParams,
-      PartialResultParams {
-
-    /// The text document.
-    textDocument: TextDocumentIdentifier;
-  }
-
-  export namespace SemanticTokensRequest {
-    export const method: 'textDocument/semanticTokens/full' = 'textDocument/semanticTokens/full';
-    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
-    export const type = new ProtocolRequestType<SemanticTokensParams, SemanticTokens | null, SemanticTokensPartialResult, void, SemanticTokensRegistrationOptions>(method);
-    export const registrationMethod: typeof SemanticTokensRegistrationType.method  = SemanticTokensRegistrationType.method;
-    export type HandlerSignature = RequestHandler<SemanticTokensDeltaParams, SemanticTokens | null, void>;
-  }
-*)
-
-
-
-
-(*
-  /// A set of predefined token types. This set is not fixed and clients can specify
-  /// additional token types via the corresponding client capabilities.
+  /// A set of predefined token types.
+  ///
+  /// This set is not fixed and clients can specify additional token types
+  /// via the corresponding client capabilities.
   export enum SemanticTokenTypes {
     namespace = 'namespace',
     /// Represents a generic type. Acts as a fallback for types which can't be mapped to
@@ -64,8 +281,9 @@
     decorator = 'decorator'
   }
 
-  /// A set of predefined token modifiers. This set is not fixed
-  /// an clients can specify additional token types via the
+  /// A set of predefined token modifiers.
+  ///
+  /// This set is not fixed, and clients can specify additional token types via the
   /// corresponding client capabilities.
   export enum SemanticTokenModifiers {
     declaration = 'declaration',
@@ -80,13 +298,7 @@
     defaultLibrary = 'defaultLibrary'
   }
 
-  export interface SemanticTokensLegend {
-    /// The token types a server uses.
-    tokenTypes: string[];
 
-    /// The token modifiers a server uses.
-    tokenModifiers: string[];
-  }
 
 
 
@@ -195,35 +407,10 @@
   }
 
 
-  /// Semantic tokens options to support deltas for full documents
-  ///
-  /// @proposed
-  export interface SemanticTokensFullDelta {
-    /// The server supports deltas for full documents.
-    delta?: boolean;
-  }
 
-  export interface SemanticTokensOptions
-    extends
-      WorkDoneProgressOptions {
 
-    /// The legend used by the server
-    legend: SemanticTokensLegend;
 
-    /// Server supports providing semantic tokens for a specific range
-    /// of a document.
-    range?: boolean | {};
 
-    /// Server supports providing semantic tokens for a full document.
-    full?: boolean | SemanticTokensFullDelta;
-  }
-
-  export interface SemanticTokensRegistrationOptions
-    extends
-      TextDocumentRegistrationOptions,
-      SemanticTokensOptions,
-      StaticRegistrationOptions {
-  }
 
   export namespace SemanticTokensRegistrationType {
     export const method: 'textDocument/semanticTokens' = 'textDocument/semanticTokens';

--- a/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
+++ b/packages/darklang/languageServerProtocol/lifecycle/initialize.dark
@@ -433,6 +433,8 @@ module Darklang =
             | TextDocumentSyncKind kind -> TextDocumentSyncKind.toJson kind
 
 
+
+
         module ServerCapabilities =
           /// Defines the capabilities provided by a language server.
           type ServerCapabilities =
@@ -457,81 +459,82 @@ module Darklang =
               completionProvider:
                 Stdlib.Option.Option<Completions.CompletionOptions.CompletionOptions>
 
-            // /// The server provides hover support.
-            // hoverProvider?: boolean | HoverOptions;
+              // /// The server provides hover support.
+              // hoverProvider?: boolean | HoverOptions;
 
-            // /// The server provides signature help support.
-            // signatureHelpProvider?: SignatureHelpOptions;
+              // /// The server provides signature help support.
+              // signatureHelpProvider?: SignatureHelpOptions;
 
-            // /// The server provides Goto Declaration support.
-            // declarationProvider?: boolean | DeclarationOptions | DeclarationRegistrationOptions;
+              // /// The server provides Goto Declaration support.
+              // declarationProvider?: boolean | DeclarationOptions | DeclarationRegistrationOptions;
 
-            // /// The server provides goto definition support.
-            // definitionProvider?: boolean | DefinitionOptions;
+              // /// The server provides goto definition support.
+              // definitionProvider?: boolean | DefinitionOptions;
 
-            // /// The server provides Goto Type Definition support.
-            // typeDefinitionProvider?: boolean | TypeDefinitionOptions | TypeDefinitionRegistrationOptions;
+              // /// The server provides Goto Type Definition support.
+              // typeDefinitionProvider?: boolean | TypeDefinitionOptions | TypeDefinitionRegistrationOptions;
 
-            // /// The server provides Goto Implementation support.
-            // implementationProvider?: boolean | ImplementationOptions | ImplementationRegistrationOptions;
+              // /// The server provides Goto Implementation support.
+              // implementationProvider?: boolean | ImplementationOptions | ImplementationRegistrationOptions;
 
-            // /// The server provides find references support.
-            // referencesProvider?: boolean | ReferenceOptions;
+              // /// The server provides find references support.
+              // referencesProvider?: boolean | ReferenceOptions;
 
-            // /// The server provides document highlight support.
-            // documentHighlightProvider?: boolean | DocumentHighlightOptions;
+              // /// The server provides document highlight support.
+              // documentHighlightProvider?: boolean | DocumentHighlightOptions;
 
-            // /// The server provides document symbol support.
-            // documentSymbolProvider?: boolean | DocumentSymbolOptions;
+              // /// The server provides document symbol support.
+              // documentSymbolProvider?: boolean | DocumentSymbolOptions;
 
-            // /// The server provides code actions. CodeActionOptions may only be
-            // /// specified if the client states that it supports
-            // /// `codeActionLiteralSupport` in its initial `initialize` request.
-            // codeActionProvider?: boolean | CodeActionOptions;
+              // /// The server provides code actions. CodeActionOptions may only be
+              // /// specified if the client states that it supports
+              // /// `codeActionLiteralSupport` in its initial `initialize` request.
+              // codeActionProvider?: boolean | CodeActionOptions;
 
-            // /// The server provides code lens.
-            // codeLensProvider?: CodeLensOptions;
+              // /// The server provides code lens.
+              // codeLensProvider?: CodeLensOptions;
 
-            // /// The server provides document link support.
-            // documentLinkProvider?: DocumentLinkOptions;
+              // /// The server provides document link support.
+              // documentLinkProvider?: DocumentLinkOptions;
 
-            // /// The server provides color provider support.
-            // colorProvider?: boolean | DocumentColorOptions | DocumentColorRegistrationOptions;
+              // /// The server provides color provider support.
+              // colorProvider?: boolean | DocumentColorOptions | DocumentColorRegistrationOptions;
 
-            // /// The server provides workspace symbol support.
-            // workspaceSymbolProvider?: boolean | WorkspaceSymbolOptions;
+              // /// The server provides workspace symbol support.
+              // workspaceSymbolProvider?: boolean | WorkspaceSymbolOptions;
 
-            // /// The server provides document formatting.
-            // documentFormattingProvider?: boolean | DocumentFormattingOptions;
+              // /// The server provides document formatting.
+              // documentFormattingProvider?: boolean | DocumentFormattingOptions;
 
-            // /// The server provides document range formatting.
-            // documentRangeFormattingProvider?: boolean | DocumentRangeFormattingOptions;
+              // /// The server provides document range formatting.
+              // documentRangeFormattingProvider?: boolean | DocumentRangeFormattingOptions;
 
-            // /// The server provides document formatting on typing.
-            // documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions;
+              // /// The server provides document formatting on typing.
+              // documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions;
 
-            // /// The server provides rename support. RenameOptions may only be
-            // /// specified if the client states that it supports
-            // /// `prepareSupport` in its initial `initialize` request.
-            // renameProvider?: boolean | RenameOptions;
+              // /// The server provides rename support. RenameOptions may only be
+              // /// specified if the client states that it supports
+              // /// `prepareSupport` in its initial `initialize` request.
+              // renameProvider?: boolean | RenameOptions;
 
-            // /// The server provides folding provider support.
-            // foldingRangeProvider?: boolean | FoldingRangeOptions | FoldingRangeRegistrationOptions;
+              // /// The server provides folding provider support.
+              // foldingRangeProvider?: boolean | FoldingRangeOptions | FoldingRangeRegistrationOptions;
 
-            // /// The server provides selection range support.
-            // selectionRangeProvider?: boolean | SelectionRangeOptions | SelectionRangeRegistrationOptions;
+              // /// The server provides selection range support.
+              // selectionRangeProvider?: boolean | SelectionRangeOptions | SelectionRangeRegistrationOptions;
 
-            // /// The server provides execute command support.
-            // executeCommandProvider?: ExecuteCommandOptions;
+              // /// The server provides execute command support.
+              // executeCommandProvider?: ExecuteCommandOptions;
 
-            // /// The server provides call hierarchy support.
-            // callHierarchyProvider?: boolean | CallHierarchyOptions | CallHierarchyRegistrationOptions;
+              // /// The server provides call hierarchy support.
+              // callHierarchyProvider?: boolean | CallHierarchyOptions | CallHierarchyRegistrationOptions;
 
-            // /// The server provides linked editing range support.
-            // linkedEditingRangeProvider?: boolean | LinkedEditingRangeOptions | LinkedEditingRangeRegistrationOptions;
+              // /// The server provides linked editing range support.
+              // linkedEditingRangeProvider?: boolean | LinkedEditingRangeOptions | LinkedEditingRangeRegistrationOptions;
 
-            // /// The server provides semantic tokens support.
-            // semanticTokensProvider?: SemanticTokensOptions | SemanticTokensRegistrationOptions;
+              /// The server provides semantic tokens support.
+              semanticTokensProvider:
+                Stdlib.Option.Option<SemanticTokens.SemanticTokenProviderOptions.SemanticTokenProviderOptions>
 
             // /// The server provides moniker support.
             // monikerProvider?: boolean | MonikerOptions | MonikerRegistrationOptions;
@@ -565,12 +568,16 @@ module Darklang =
               |> Stdlib.Option.map (fun sync ->
                 ("textDocumentSync", TextDocumentSyncServerCapabilities.toJson sync))
 
-              (capabilities.completionProvider
-               |> Stdlib.Option.map (fun provider ->
-                 ("completionProvider",
-                  Completions.CompletionOptions.toJson provider))) ]
+              capabilities.completionProvider
+              |> Stdlib.Option.map (fun p ->
+                ("completionProvider", Completions.CompletionOptions.toJson p))
 
-            |> Stdlib.List.filterMap (fun self -> self)
+              capabilities.semanticTokensProvider
+              |> Stdlib.Option.map (fun p ->
+                ("semanticTokensProvider",
+                 SemanticTokens.SemanticTokenProviderOptions.toJson p)) ]
+
+            |> Stdlib.Option.values
             |> Json.Object
 
 
@@ -592,7 +599,7 @@ module Darklang =
 
                 (serverInfo.version
                  |> Stdlib.Option.map (fun v -> ("version", Json.String v))) ]
-              |> Stdlib.List.filterMap (fun self -> self)
+              |> Stdlib.Option.values
 
             Json.Object fields
 
@@ -620,7 +627,7 @@ module Darklang =
                |> Stdlib.Option.map (fun info ->
                  ("serverInfo", ServerInfo.toJson info))) ]
 
-            |> Stdlib.List.filterMap (fun self -> self)
+            |> Stdlib.Option.values
             |> Json.Object
 
 

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -196,6 +196,57 @@ module Darklang =
           state
 
 
+        // -- semantic tokens (which provides syntax highlighting)
+        | ("textDocument/semanticTokens/full",
+           Some requestId,
+           Some(Object requestParams)) ->
+          let parsed =
+            (Stdlib.AltJson.Json.Object requestParams)
+            |> LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensParams.fromJson
+
+          match parsed with
+          | Ok parsed ->
+            log $"got semanticTokens request for {parsed.textDocument.uri}"
+
+            let bogusResponse =
+              LanguageServerProtocol
+                .SemanticTokens
+                .SemanticTokensRequest
+                .SemanticTokensResult
+                .SemanticTokensResult
+                .SemanticTokens(
+                  LanguageServerProtocol.SemanticTokens.SemanticTokens.SemanticTokens
+                    { resultId = Stdlib.Option.Option.None
+                      data =
+                        [
+                          // Reported tokens are all in a big list of UInts -- five #s per reported token.
+                          // The following translates to:
+
+                          //                    the first token, ...
+                          0UL // (deltaLine)      starts 0 lines after the previous token
+                          0UL // (deltaStart)     starts 0 characters after the previous token
+                          3UL // (length)         is 3 characters long
+                          0UL // (tokenType)      is a keyword (in the `initialize` handshake, "keyword" is the 0th token type we declared)
+                          0UL // (tokenModifiers) has no modifiers
+                          //                      ^ _would_ be a bit-wise representation of the modifiers, but we have none
+
+                          // (the .dark file that I've been testing against starts with the word `let` so this works out well)
+                          ] }
+                )
+
+            let bogusResponseJson =
+              bogusResponse
+              |> LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensResult.toJson
+              |> (fun r ->
+                JsonRPC.Response.Ok.make (Stdlib.Option.Option.Some requestId) r)
+              |> Stdlib.AltJson.format
+
+            logAndSendToClient bogusResponseJson
+
+          | Error() -> log "couldn't parse params of semanticTokens request"
+
+          state
+
         // -- other
         | (other, _, _) ->
           log $"TODO: we don't yet support this method: {other}"
@@ -350,6 +401,38 @@ module Darklang =
                             allCommitCharacters = Stdlib.Option.Option.None
                             resolveProvider = Stdlib.Option.Option.Some false // just return all info at once
                             completionItem = Stdlib.Option.Option.None }
+                      )
+
+                    semanticTokensProvider =
+                      Stdlib.Option.Option.Some(
+                        LanguageServerProtocol
+                          .SemanticTokens
+                          .SemanticTokenProviderOptions
+                          .SemanticTokenProviderOptions
+                          .SemanticTokensOptions(
+                            LanguageServerProtocol.SemanticTokens.SemanticTokensOptions.SemanticTokensOptions
+                              { legend =
+                                  LanguageServerProtocol.SemanticTokens.SemanticTokensLegend.SemanticTokensLegend
+                                    { tokenTypes =
+                                        [ "keyword"
+                                          "function"
+                                          "parameter"
+                                          "type"
+                                          "string"
+                                          "operator"
+                                          "variable" ]
+                                      tokenModifiers = [] }
+                                range =
+                                  Stdlib.Option.Option.Some(
+                                    LanguageServerProtocol.SemanticTokens.SemanticTokensOptions.SemanticTokensOptionsRange.SemanticTokensOptionsRange.Bool
+                                      false
+                                  )
+                                full =
+                                  Stdlib.Option.Option.Some(
+                                    LanguageServerProtocol.SemanticTokens.SemanticTokensOptions.SemanticTokensOptionsFull.SemanticTokensOptionsFull.Bool
+                                      true
+                                  ) }
+                          )
                       ) }
               serverInfo = Stdlib.Option.Option.None }
 

--- a/packages/darklang/languageTools/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server.dark
@@ -153,9 +153,7 @@ module Darklang =
 
           match parsed with
           | Ok parsed ->
-            log
-              $"got completion request for {parsed.textDocumentPosition.textDocument.uri}"
-
+            log $"got completion request for {parsed.textDocument.uri}"
 
             let includeBogusCompletion = true
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "darklang",
+  "name": "darklang-vs-code-extension",
   "description": "darklang VS Code Extension",
   "author": "darklang",
   "version": "0.0.1",
@@ -38,47 +38,17 @@
       "type": "object",
       "title": "Darklang Extension Config",
       "properties": {
-        "darklangLsp.maxNumberOfProblems": {
-          "scope": "resource",
-          "type": "number",
-          "default": 100,
-          "description": "Controls the maximum number of problems produced by the server."
-        },
-        "darklangLsp.trace.server": {
-          "TODO": "not sure what this is used for",
-          "scope": "window",
-          "type": "string",
-          "enum": [ "off", "messages", "verbose" ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the language server."
-        }
       }
     },
-    "_semanticTokenProvider": {
-        "legend": {
-            "tokenTypes": ["keyword", "function", "parameter", "type", "string", "operator", "variable"],
-            "tokenModifiers": []
-        },
-        "languages": ["darklang", "dark"]
-    },
     "semanticTokenTypes": [
-      {"id": "keyword","description": "Language keywords like 'let' and 'in'"},
-      {"id": "function","description": "Function names or identifiers"},
-      {"id": "parameter","description": "Function parameter identifiers"},
-      {"id": "type","description": "Type names like Int, Bool, etc."},
-      {"id": "string","description": "String literals"},
-      {"id": "operator","description": "Operators like +, -"},
-      {"id": "variable","description": "General variable identifiers"}
-    ],
-    "semanticTokenColors": {
-      "keyword": "#FF4500",
-      "function": "#4CAF50",
-      "parameter": "#FFD700",
-      "type": "#00CED1",
-      "string": "#DAA520",
-      "operator": "#FF6347",
-      "variable": "#20B2AA"
-    }
+      {"id": "keyword", "description": "Language keywords like 'let' and 'in'"},
+      {"id": "function", "description": "Function names or identifiers"},
+      {"id": "parameter", "description": "Function parameter identifiers"},
+      {"id": "type", "description": "Type names like Int, Bool, etc."},
+      {"id": "string", "description": "String literals"},
+      {"id": "operator", "description": "Operators like +, -"},
+      {"id": "variable", "description": "General variable identifiers"}
+    ]
   },
 
   "scripts": {


### PR DESCRIPTION
behold, the `let` of color.

![image](https://github.com/darklang/dark/assets/906686/f84f9388-27b9-4208-8087-a531e11ae2b8)

---

This:
- updates the server's response in the `initialize` handshake to advertise that we support semantic tokens
  ```fsharp
  let initializeResult =
    LanguageServerProtocol.Lifecycle.InitializeRequest.InitializeResult.InitializeResult
      { capabilities =
          LanguageServerProtocol.Lifecycle.InitializeRequest.ServerCapabilities.ServerCapabilities
            { textDocumentSync = ...

              completionProvider = ...

              semanticTokensProvider =
                Stdlib.Option.Option.Some(
                  LanguageServerProtocol.SemanticTokens.SemanticTokenProviderOptions.SemanticTokenProviderOptions.SemanticTokensOptions(
                      LanguageServerProtocol.SemanticTokens.SemanticTokensOptions.SemanticTokensOptions
                        { legend =
                            LanguageServerProtocol.SemanticTokens.SemanticTokensLegend.SemanticTokensLegend
                              { tokenTypes = [ "keyword"; "function"; "parameter"; "type"; "string"; "operator"; "variable" ]
                                tokenModifiers = [] }
                          range =
                            Stdlib.Option.Option.Some(
                              LanguageServerProtocol.SemanticTokens.SemanticTokensOptions.SemanticTokensOptionsRange.SemanticTokensOptionsRange.Bool
                                false
                            )
                          full =
                            Stdlib.Option.Option.Some(
                              LanguageServerProtocol.SemanticTokens.SemanticTokensOptions.SemanticTokensOptionsFull.SemanticTokensOptionsFull.Bool
                                true
                            ) }
                    )
                ) }
        serverInfo = Stdlib.Option.Option.None }
  ```
- accepts and responds to incoming `textDocument/semanticTokens/full` requests with a bogus response declaring that the first 3 characters are a "keyword", which VS Code highlights based on your theme
  ```fsharp
  // -- semantic tokens (which provides syntax highlighting)
  | ("textDocument/semanticTokens/full",
     Some requestId,
     Some(Object requestParams)) ->
    let parsed =
      (Stdlib.AltJson.Json.Object requestParams)
      |> LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensParams.fromJson

    match parsed with
    | Ok parsed ->
      log $"got semanticTokens request for {parsed.textDocument.uri}"

      let bogusResponse =
        LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensResult.SemanticTokensResult.SemanticTokens(
            LanguageServerProtocol.SemanticTokens.SemanticTokens.SemanticTokens
              { resultId = Stdlib.Option.Option.None
                data =
                  [
                    // Reported tokens are all in a big list of UInts -- five #s per reported token.
                    // The following translates to:

                    //                    the first token, ...
                    0UL // (deltaLine)      starts 0 lines after the previous token
                    0UL // (deltaStart)     starts 0 characters after the previous token
                    3UL // (length)         is 3 characters long
                    0UL // (tokenType)      is a keyword (in the `initialize` handshake, "keyword" is the 0th token type we declared)
                    0UL // (tokenModifiers) has no modifiers
                    //                      ^ _would_ be a bit-wise representation of the modifiers, but we have none

                    // (the .dark file that I've been testing against starts with the word `let` so this works out well)
                    ] }
          )

      let bogusResponseJson =
        bogusResponse
        |> LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensResult.toJson
        |> (fun r -> JsonRPC.Response.Ok.make (Stdlib.Option.Option.Some requestId) r)
        |> Stdlib.AltJson.format

      logAndSendToClient bogusResponseJson

    | Error() -> log "couldn't parse params of semanticTokens request"

    state
  ```

Most of the work here was setting up types, toJson, and fromJson functions.