### PR TITLE
Add source ranges to dark writtentypes

### DIFF
--- a/backend/testfiles/execution/language/elet.dark
+++ b/backend/testfiles/execution/language/elet.dark
@@ -33,6 +33,16 @@ module Tuples =
   (let ((a, ((b, (c, d)), e)), f) = ((1L, ((2L, (3L, 4L)), 5L)), 6L) in c) = 3L
   (let ((a, ((b, cd), e)), f) = ((1L, ((2L, (3L, 4L)), 5L)), 6L) in cd) = (3L, 4L)
 
+
+module Nesting =
+  (let x =
+    let y = 1L
+    let z = 2L
+    y + z
+
+   x) = 3L
+
+
 module Shadowing =
   (let x = 5L
    let x = 6L

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -11,410 +11,511 @@ let range (s: Int64 * Int64) (e: Int64 * Int64) : Range =
     { start = Point { row = startRow; column = startColumn }
       end_ = Point { row = endRow; column = endColumn } }
 
+module ParseToSimplifiedTree =
+  // super basic test just to make sure we don't throw an exception
+  (let parsed =
+    Builtin.Parser.parseToSimplifiedTree
+      "let add (a: Int) (b: Int): Int =\n  let sum = a + b\n  sum"
 
-// super basic test just to make sure we don't throw an exception
-(let parsed =
-  Builtin.Parser.parseToSimplifiedTree
-    "let add (a: Int) (b: Int): Int =\n  let sum = a + b\n  sum"
-
- parsed.typ) = "source_file"
-
-
-// successful parse
-(Builtin.Parser.parseToSimplifiedTree "let self (i: Int): Int =\n  i") = ParsedNode
-  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-    typ = "source_file"
-    text = "let self (i: Int): Int =\n  i"
-    sourceRange = range (0L, 0L) (1L, 3L)
-    children =
-      [ ParsedNode
-          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-            typ = "fn_def"
-            sourceRange = range (0L, 0L) (1L, 3L)
-            text = "let self (i: Int): Int =\n  i"
-            children =
-              [ ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = "let"
-                    text = "let"
-                    sourceRange = range (0L, 0L) (0L, 3L)
-                    children = [] }
-
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "name"
-                    typ = "identifier"
-                    text = "self"
-                    sourceRange = range (0L, 4L) (0L, 8L)
-                    children = [] }
-
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "params"
-                    typ = "fn_params_def"
-                    text = "(i: Int)"
-                    sourceRange = range (0L, 9L) (0L, 17L)
-                    children =
-                      [ ParsedNode
-                          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                            typ = "fn_param_def"
-                            text = "(i: Int)"
-                            sourceRange = range (0L, 9L) (0L, 17L)
-                            children =
-                              [ ParsedNode
-                                  { children = []
-                                    fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.None
-                                    text = "("
-                                    sourceRange = range (0L, 9L) (0L, 10L)
-                                    typ = "(" }
-
-                                ParsedNode
-                                  { fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.Some
-                                        "identifier"
-                                    typ = "identifier"
-                                    text = "i"
-                                    sourceRange = range (0L, 10L) (0L, 11L)
-                                    children = [] }
-
-                                ParsedNode
-                                  { fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.None
-                                    typ = ":"
-                                    text = ":"
-                                    sourceRange = range (0L, 11L) (0L, 12L)
-                                    children = [] }
-
-                                ParsedNode
-                                  { typ = "type"
-                                    sourceRange = range (0L, 13L) (0L, 16L)
-                                    fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.Some
-                                        "typ"
-                                    text = "Int"
-                                    children = [] }
-
-                                ParsedNode
-                                  { children = []
-                                    fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.None
-                                    text = ")"
-                                    sourceRange = range (0L, 16L) (0L, 17L)
-                                    typ = ")" } ] } ] }
-
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = ":"
-                    text = ":"
-                    sourceRange = range (0L, 17L) (0L, 18L)
-                    children = [] }
-
-                ParsedNode
-                  { fieldName =
-                      PACKAGE.Darklang.Stdlib.Option.Option.Some "return_type"
-                    typ = "type"
-                    text = "Int"
-                    sourceRange = range (0L, 19L) (0L, 22L)
-                    children = [] }
-
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = "="
-                    text = "="
-                    sourceRange = range (0L, 23L) (0L, 24L)
-                    children = [] }
-
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "body"
-                    typ = "expression"
-                    text = "i"
-                    sourceRange = range (1L, 2L) (1L, 3L)
-                    children =
-                      [ ParsedNode
-                          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                            typ = "identifier"
-                            text = "i"
-                            sourceRange = range (1L, 2L) (1L, 3L)
-                            children = [] } ] } ] } ] }
+   parsed.typ) = "source_file"
 
 
-// failing parse
-// an ERROR exists here because the grammar doesn't support raw ints (`1`) yet
-(Builtin.Parser.parseToSimplifiedTree "let increment (i: Int): Int =\n  i + 1") = ParsedNode
-  { typ = "source_file"
-    fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-    text = "let increment (i: Int): Int =\n  i + 1"
-    sourceRange = range (0L, 0L) (1L, 7L)
-    children =
-      [ ParsedNode
-          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-            typ = "fn_def"
-            sourceRange = range (0L, 0L) (1L, 3L)
-            text = "let increment (i: Int): Int =\n  i"
-            children =
-              [ ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = "let"
-                    text = "let"
-                    sourceRange = range (0L, 0L) (0L, 3L)
-                    children = [] }
+  // successful parse
+  (Builtin.Parser.parseToSimplifiedTree "let self (i: Int): Int =\n  i") = ParsedNode
+    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+      typ = "source_file"
+      text = "let self (i: Int): Int =\n  i"
+      sourceRange = range (0L, 0L) (1L, 3L)
+      children =
+        [ ParsedNode
+            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+              typ = "fn_def"
+              sourceRange = range (0L, 0L) (1L, 3L)
+              text = "let self (i: Int): Int =\n  i"
+              children =
+                [ ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = "let"
+                      text = "let"
+                      sourceRange = range (0L, 0L) (0L, 3L)
+                      children = [] }
 
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "name"
-                    typ = "identifier"
-                    text = "increment"
-                    sourceRange = range (0L, 4L) (0L, 13L)
-                    children = [] }
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "name"
+                      typ = "identifier"
+                      text = "self"
+                      sourceRange = range (0L, 4L) (0L, 8L)
+                      children = [] }
 
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "params"
-                    typ = "fn_params_def"
-                    text = "(i: Int)"
-                    sourceRange = range (0L, 14L) (0L, 22L)
-                    children =
-                      [ ParsedNode
-                          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                            typ = "fn_param_def"
-                            text = "(i: Int)"
-                            sourceRange = range (0L, 14L) (0L, 22L)
-                            children =
-                              [ ParsedNode
-                                  { children = []
-                                    fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.None
-                                    text = "("
-                                    sourceRange = range (0L, 14L) (0L, 15L)
-                                    typ = "(" }
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "params"
+                      typ = "fn_params_def"
+                      text = "(i: Int)"
+                      sourceRange = range (0L, 9L) (0L, 17L)
+                      children =
+                        [ ParsedNode
+                            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                              typ = "fn_param_def"
+                              text = "(i: Int)"
+                              sourceRange = range (0L, 9L) (0L, 17L)
+                              children =
+                                [ ParsedNode
+                                    { children = []
+                                      fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.None
+                                      text = "("
+                                      sourceRange = range (0L, 9L) (0L, 10L)
+                                      typ = "(" }
 
-                                ParsedNode
-                                  { fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.Some
-                                        "identifier"
-                                    typ = "identifier"
-                                    text = "i"
-                                    sourceRange = range (0L, 15L) (0L, 16L)
-                                    children = [] }
+                                  ParsedNode
+                                    { fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.Some
+                                          "identifier"
+                                      typ = "identifier"
+                                      text = "i"
+                                      sourceRange = range (0L, 10L) (0L, 11L)
+                                      children = [] }
 
-                                ParsedNode
-                                  { fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.None
-                                    typ = ":"
-                                    text = ":"
-                                    sourceRange = range (0L, 16L) (0L, 17L)
-                                    children = [] }
+                                  ParsedNode
+                                    { fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.None
+                                      typ = ":"
+                                      text = ":"
+                                      sourceRange = range (0L, 11L) (0L, 12L)
+                                      children = [] }
 
-                                ParsedNode
-                                  { typ = "type"
-                                    sourceRange = range (0L, 18L) (0L, 21L)
-                                    fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.Some
-                                        "typ"
-                                    text = "Int"
-                                    children = [] }
+                                  ParsedNode
+                                    { typ = "type"
+                                      sourceRange = range (0L, 13L) (0L, 16L)
+                                      fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.Some
+                                          "typ"
+                                      text = "Int"
+                                      children = [] }
 
-                                ParsedNode
-                                  { children = []
-                                    fieldName =
-                                      PACKAGE.Darklang.Stdlib.Option.Option.None
-                                    text = ")"
-                                    sourceRange = range (0L, 21L) (0L, 22L)
-                                    typ = ")" } ] } ] }
+                                  ParsedNode
+                                    { children = []
+                                      fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.None
+                                      text = ")"
+                                      sourceRange = range (0L, 16L) (0L, 17L)
+                                      typ = ")" } ] } ] }
 
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = ":"
-                    text = ":"
-                    sourceRange = range (0L, 22L) (0L, 23L)
-                    children = [] }
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = ":"
+                      text = ":"
+                      sourceRange = range (0L, 17L) (0L, 18L)
+                      children = [] }
 
-                ParsedNode
-                  { fieldName =
-                      PACKAGE.Darklang.Stdlib.Option.Option.Some "return_type"
-                    typ = "type"
-                    text = "Int"
-                    sourceRange = range (0L, 24L) (0L, 27L)
-                    children = [] }
+                  ParsedNode
+                    { fieldName =
+                        PACKAGE.Darklang.Stdlib.Option.Option.Some "return_type"
+                      typ = "type"
+                      text = "Int"
+                      sourceRange = range (0L, 19L) (0L, 22L)
+                      children = [] }
 
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = "="
-                    text = "="
-                    sourceRange = range (0L, 28L) (0L, 29L)
-                    children = [] }
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = "="
+                      text = "="
+                      sourceRange = range (0L, 23L) (0L, 24L)
+                      children = [] }
 
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "body"
-                    typ = "expression"
-                    text = "i"
-                    sourceRange = range (1L, 2L) (1L, 3L)
-                    children =
-                      [ ParsedNode
-                          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                            typ = "identifier"
-                            text = "i"
-                            sourceRange = range (1L, 2L) (1L, 3L)
-                            children = [] } ] } ] }
-
-        ParsedNode
-          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-            typ = "ERROR"
-            text = "+ 1"
-            sourceRange = range (1L, 4L) (1L, 7L)
-            children =
-              [ ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = "infix_operator"
-                    text = "+"
-                    sourceRange = range (1L, 4L) (1L, 5L)
-                    children =
-                      [ ParsedNode
-                          { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                            typ = "+"
-                            text = "+"
-                            sourceRange = range (1L, 4L) (1L, 5L)
-                            children = [] } ] }
-
-                ParsedNode
-                  { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
-                    typ = "ERROR"
-                    text = "1"
-                    sourceRange = range (1L, 6L) (1L, 7L)
-                    children = [] } ] } ] }
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "body"
+                      typ = "expression"
+                      text = "i"
+                      sourceRange = range (1L, 2L) (1L, 3L)
+                      children =
+                        [ ParsedNode
+                            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                              typ = "identifier"
+                              text = "i"
+                              sourceRange = range (1L, 2L) (1L, 3L)
+                              children = [] } ] } ] } ] }
 
 
+  // failing parse
+  // an ERROR exists here because the grammar doesn't support raw ints (`1`) yet
+  (Builtin.Parser.parseToSimplifiedTree "let increment (i: Int): Int =\n  i + 1") = ParsedNode
+    { typ = "source_file"
+      fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+      text = "let increment (i: Int): Int =\n  i + 1"
+      sourceRange = range (0L, 0L) (1L, 7L)
+      children =
+        [ ParsedNode
+            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+              typ = "fn_def"
+              sourceRange = range (0L, 0L) (1L, 3L)
+              text = "let increment (i: Int): Int =\n  i"
+              children =
+                [ ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = "let"
+                      text = "let"
+                      sourceRange = range (0L, 0L) (0L, 3L)
+                      children = [] }
 
-// test parseNodeToWT
-(let parsed = Builtin.Parser.parseToSimplifiedTree "let self (i: Int64): Int64 = i"
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "name"
+                      typ = "identifier"
+                      text = "increment"
+                      sourceRange = range (0L, 4L) (0L, 13L)
+                      children = [] }
 
- PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWT parsed) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-      { name =
-          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package
-            { owner = "TODO"
-              modules = [ "TODO" ]
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "params"
+                      typ = "fn_params_def"
+                      text = "(i: Int)"
+                      sourceRange = range (0L, 14L) (0L, 22L)
+                      children =
+                        [ ParsedNode
+                            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                              typ = "fn_param_def"
+                              text = "(i: Int)"
+                              sourceRange = range (0L, 14L) (0L, 22L)
+                              children =
+                                [ ParsedNode
+                                    { children = []
+                                      fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.None
+                                      text = "("
+                                      sourceRange = range (0L, 14L) (0L, 15L)
+                                      typ = "(" }
+
+                                  ParsedNode
+                                    { fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.Some
+                                          "identifier"
+                                      typ = "identifier"
+                                      text = "i"
+                                      sourceRange = range (0L, 15L) (0L, 16L)
+                                      children = [] }
+
+                                  ParsedNode
+                                    { fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.None
+                                      typ = ":"
+                                      text = ":"
+                                      sourceRange = range (0L, 16L) (0L, 17L)
+                                      children = [] }
+
+                                  ParsedNode
+                                    { typ = "type"
+                                      sourceRange = range (0L, 18L) (0L, 21L)
+                                      fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.Some
+                                          "typ"
+                                      text = "Int"
+                                      children = [] }
+
+                                  ParsedNode
+                                    { children = []
+                                      fieldName =
+                                        PACKAGE.Darklang.Stdlib.Option.Option.None
+                                      text = ")"
+                                      sourceRange = range (0L, 21L) (0L, 22L)
+                                      typ = ")" } ] } ] }
+
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = ":"
+                      text = ":"
+                      sourceRange = range (0L, 22L) (0L, 23L)
+                      children = [] }
+
+                  ParsedNode
+                    { fieldName =
+                        PACKAGE.Darklang.Stdlib.Option.Option.Some "return_type"
+                      typ = "type"
+                      text = "Int"
+                      sourceRange = range (0L, 24L) (0L, 27L)
+                      children = [] }
+
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = "="
+                      text = "="
+                      sourceRange = range (0L, 28L) (0L, 29L)
+                      children = [] }
+
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.Some "body"
+                      typ = "expression"
+                      text = "i"
+                      sourceRange = range (1L, 2L) (1L, 3L)
+                      children =
+                        [ ParsedNode
+                            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                              typ = "identifier"
+                              text = "i"
+                              sourceRange = range (1L, 2L) (1L, 3L)
+                              children = [] } ] } ] }
+
+          ParsedNode
+            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+              typ = "ERROR"
+              text = "+ 1"
+              sourceRange = range (1L, 4L) (1L, 7L)
+              children =
+                [ ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = "infix_operator"
+                      text = "+"
+                      sourceRange = range (1L, 4L) (1L, 5L)
+                      children =
+                        [ ParsedNode
+                            { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                              typ = "+"
+                              text = "+"
+                              sourceRange = range (1L, 4L) (1L, 5L)
+                              children = [] } ] }
+
+                  ParsedNode
+                    { fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+                      typ = "ERROR"
+                      text = "1"
+                      sourceRange = range (1L, 6L) (1L, 7L)
+                      children = [] } ] } ] }
+
+
+
+
+module ParseNodeToWrittenTypes =
+
+  ("let self (i: Int64): Int64 = i"
+   |> Builtin.Parser.parseToSimplifiedTree
+   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
+        range (0L, 0L) (0L, 30L),
+        [ (PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+            { sourceRange = range (0L, 0L) (0L, 30L)
               name =
-                PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name.FnName "self"
-              version = 0L }
-        body = PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "i")
-        typeParams = []
-        parameters =
-          [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-              { name = "i"
-                typ =
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-                description = "" } ]
-        returnType = PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-        description = "" } ]
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                  range (0L, 4L) (0L, 8L),
+                  [ "self" ]
+                )
+              parameters =
+                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                    { sourceRange = range (0L, 9L) (0L, 19L) // TODO: is this needed? we don't need to highlight for anything... but I'm getting the idea we should just have a source range for EVERYTHING in WT..
+                      name = "i" // TODO: should include range?
+                      typ =
+                        PACKAGE
+                          .Darklang
+                          .LanguageTools
+                          .WrittenTypes
+                          .TypeReference
+                          .TInt64(range (0L, 13L) (0L, 16L)) } ]
+              returnType =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                  range (0L, 21L) (0L, 24L)
+                )
+              body =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                  (range (0L, 29L) (0L, 30L)),
+                  "i"
+                ) }) ]
+      )
+    )
 
-(let parsed =
-  Builtin.Parser.parseToSimplifiedTree "let double1 (i: Int64): Int64 = i + i"
 
- PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWT parsed) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-      { name =
-          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package
-            { owner = "TODO"
-              modules = [ "TODO" ]
+  ("let double1 (i: Int): Int = i + i"
+   |> Builtin.Parser.parseToSimplifiedTree
+   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
+        range (0L, 0L) (0L, 33L),
+        [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+            { sourceRange = range (0L, 0L) (0L, 33L)
               name =
-                PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name.FnName
-                  "double1"
-              version = 0L }
-        body =
-          PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
-            0L,
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
-            ),
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "i"),
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "i")
-          )
-        typeParams = []
-        parameters =
-          [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-              { name = "i"
-                typ =
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-                description = "" } ]
-        returnType = PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-        description = "" } ]
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                  range (0L, 4L) (0L, 11L),
+                  [ "double1" ]
+                )
 
-(let parsed =
-  Builtin.Parser.parseToSimplifiedTree "let add (a: Int64) (b: Int64): Int64 = a + b"
+              parameters =
+                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                    { sourceRange = range (0L, 12L) (0L, 20L)
+                      name = "i"
+                      typ =
+                        PACKAGE
+                          .Darklang
+                          .LanguageTools
+                          .WrittenTypes
+                          .TypeReference
+                          .TInt64(range (0L, 16L) (0L, 19L)) } ]
 
- PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWT parsed) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-      { name =
-          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package
-            { owner = "TODO"
-              modules = [ "TODO" ]
+              returnType =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                  range (0L, 22L) (0L, 25L)
+                )
+
+              body =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
+                  range (0L, 28L) (0L, 33L),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
+                    PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
+                  ),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                    range (0L, 28L) (0L, 29L),
+                    "i"
+                  ),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                    range (0L, 32L) (0L, 33L),
+                    "i"
+                  )
+                ) } ]
+      )
+    )
+
+
+  ("let add (a: Int) (b: Int): Int = a + b"
+   |> Builtin.Parser.parseToSimplifiedTree
+   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
+        range (0L, 0L) (0L, 38L),
+        [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+            { sourceRange = range (0L, 0L) (0L, 38L)
               name =
-                PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name.FnName "add"
-              version = 0L }
-        body =
-          PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
-            0L,
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
-            ),
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "a"),
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "b")
-          )
-        typeParams = []
-        parameters =
-          [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-              { name = "a"
-                typ =
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-                description = "" }
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-              { name = "b"
-                typ =
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-                description = "" } ]
-        returnType = PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-        description = "" } ]
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                  range (0L, 4L) (0L, 7L),
+                  [ "add" ]
+                )
+
+              parameters =
+                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                    { sourceRange = range (0L, 8L) (0L, 16L)
+                      name = "a" // TODO: 9-10
+                      typ =
+                        PACKAGE
+                          .Darklang
+                          .LanguageTools
+                          .WrittenTypes
+                          .TypeReference
+                          .TInt64(range (0L, 12L) (0L, 15L)) }
+
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                    { sourceRange = range (0L, 17L) (0L, 25L)
+                      name = "b" // TODO: 18-19
+                      typ =
+                        PACKAGE
+                          .Darklang
+                          .LanguageTools
+                          .WrittenTypes
+                          .TypeReference
+                          .TInt64(range (0L, 21L) (0L, 24L)) } ]
+
+              returnType =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                  range (0L, 27L) (0L, 30L)
+                )
+
+              body =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
+                  range (0L, 33L) (0L, 38L),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
+                    PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
+                  ),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                    range (0L, 33L) (0L, 34L),
+                    "a"
+                  ),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                    range (0L, 37L) (0L, 38L),
+                    "b"
+                  )
+                ) } ]
+      )
+    )
 
 
-(let parsed =
-  Builtin.Parser.parseToSimplifiedTree
-    "let add (a: Int64) (b: Int64): Int64 =\n  let sum = a + b\n  sum"
-
- PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWT parsed) = PACKAGE.Darklang.Stdlib.Result.Result.Ok
-  [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-      { name =
-          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package
-            { owner = "TODO"
-              modules = [ "TODO" ]
+  ("let add (a: Int) (b: Int): Int =\n  let sum = a + b\n  sum"
+   |> Builtin.Parser.parseToSimplifiedTree
+   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Ok(
+      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
+        range (0L, 0L) (2L, 5L),
+        [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+            { sourceRange = range (0L, 0L) (2L, 5L)
               name =
-                PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name.FnName "add"
-              version = 0L }
-        body =
-          PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.ELet(
-            0L,
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.LetPattern.LPVariable(
-              0L,
-              "sum"
-            ),
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
-              0L,
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
-              ),
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "a"),
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "b")
-            ),
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(0L, "sum")
-          )
-        typeParams = []
-        parameters =
-          [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-              { name = "a"
-                typ =
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-                description = "" }
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-              { name = "b"
-                typ =
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-                description = "" } ]
-        returnType = PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-        description = "" } ]
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                  range (0L, 4L) (0L, 7L),
+                  [ "add" ]
+                )
+
+              parameters =
+                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                    { sourceRange = range (0L, 8L) (0L, 16L)
+                      name = "a" // TODO: 9-10
+                      typ =
+                        PACKAGE
+                          .Darklang
+                          .LanguageTools
+                          .WrittenTypes
+                          .TypeReference
+                          .TInt64(range (0L, 12L) (0L, 15L)) }
+
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                    { sourceRange = range (0L, 17L) (0L, 25L)
+                      name = "b" // TODO: 18-19
+                      typ =
+                        PACKAGE
+                          .Darklang
+                          .LanguageTools
+                          .WrittenTypes
+                          .TypeReference
+                          .TInt64(range (0L, 21L) (0L, 24L)) } ]
+
+              returnType =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                  range (0L, 27L) (0L, 30L)
+                )
+
+              body =
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.ELet(
+                  range (1L, 2L) (2L, 5L),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.LetPattern.LPVariable(
+                    range (1L, 6L) (1L, 9L),
+                    "sum"
+                  ),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
+                    range (1L, 12L) (1L, 17L),
+                    PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
+                      PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
+                    ),
+                    PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                      range (1L, 12L) (1L, 13L),
+                      "a"
+                    ),
+                    PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                      range (1L, 16L) (1L, 17L),
+                      "b"
+                    )
+                  ),
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                    range (2L, 2L) (2L, 5L),
+                    "sum"
+                  )
+                ) } ]
+      )
+    )

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -11,6 +11,7 @@ let range (s: Int64 * Int64) (e: Int64 * Int64) : Range =
     { start = Point { row = startRow; column = startColumn }
       end_ = Point { row = endRow; column = endColumn } }
 
+
 module ParseToSimplifiedTree =
   // super basic test just to make sure we don't throw an exception
   (let parsed =
@@ -284,238 +285,228 @@ module ParseToSimplifiedTree =
 
 
 module ParseNodeToWrittenTypes =
+  let p (source: String) : PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile =
+    source
+    |> Builtin.Parser.parseToSimplifiedTree
+    |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile
+    |> Builtin.unwrap
 
-  ("let self (i: Int64): Int64 = i"
-   |> Builtin.Parser.parseToSimplifiedTree
-   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
+
+  (p "let self (i: Int64): Int64 = i") = PACKAGE
     .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
-        range (0L, 0L) (0L, 30L),
-        [ (PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-            { sourceRange = range (0L, 0L) (0L, 30L)
-              name =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
-                  range (0L, 4L) (0L, 8L),
-                  [ "self" ]
-                )
-              parameters =
-                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-                    { sourceRange = range (0L, 9L) (0L, 19L) // TODO: is this needed? we don't need to highlight for anything... but I'm getting the idea we should just have a source range for EVERYTHING in WT..
-                      name = "i" // TODO: should include range?
-                      typ =
-                        PACKAGE
-                          .Darklang
-                          .LanguageTools
-                          .WrittenTypes
-                          .TypeReference
-                          .TInt64(range (0L, 13L) (0L, 16L)) } ]
-              returnType =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
-                  range (0L, 21L) (0L, 24L)
-                )
-              body =
+    .LanguageTools
+    .WrittenTypes
+    .ParsedFile
+    .PackageFunctions(
+      range (0L, 0L) (0L, 30L),
+      [ (PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+          { sourceRange = range (0L, 0L) (0L, 30L)
+            name =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                range (0L, 4L) (0L, 8L),
+                [ "self" ]
+              )
+            parameters =
+              [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                  { sourceRange = range (0L, 9L) (0L, 19L) // TODO: is this needed? we don't need to highlight for anything... but I'm getting the idea we should just have a source range for EVERYTHING in WT..
+                    name = "i" // TODO: should include range?
+                    typ =
+                      PACKAGE
+                        .Darklang
+                        .LanguageTools
+                        .WrittenTypes
+                        .TypeReference
+                        .TInt64(range (0L, 13L) (0L, 16L)) } ]
+            returnType =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                range (0L, 21L) (0L, 24L)
+              )
+            body =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                (range (0L, 29L) (0L, 30L)),
+                "i"
+              ) }) ]
+    )
+
+
+  (p "let double1 (i: Int): Int = i + i") = PACKAGE
+    .Darklang
+    .LanguageTools
+    .WrittenTypes
+    .ParsedFile
+    .PackageFunctions(
+      range (0L, 0L) (0L, 33L),
+      [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+          { sourceRange = range (0L, 0L) (0L, 33L)
+            name =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                range (0L, 4L) (0L, 11L),
+                [ "double1" ]
+              )
+
+            parameters =
+              [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                  { sourceRange = range (0L, 12L) (0L, 20L)
+                    name = "i"
+                    typ =
+                      PACKAGE
+                        .Darklang
+                        .LanguageTools
+                        .WrittenTypes
+                        .TypeReference
+                        .TInt64(range (0L, 16L) (0L, 19L)) } ]
+
+            returnType =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                range (0L, 22L) (0L, 25L)
+              )
+
+            body =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
+                range (0L, 28L) (0L, 33L),
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
+                ),
                 PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                  (range (0L, 29L) (0L, 30L)),
+                  range (0L, 28L) (0L, 29L),
                   "i"
-                ) }) ]
-      )
+                ),
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                  range (0L, 32L) (0L, 33L),
+                  "i"
+                )
+              ) } ]
     )
 
 
-  ("let double1 (i: Int): Int = i + i"
-   |> Builtin.Parser.parseToSimplifiedTree
-   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
+  (p "let add (a: Int) (b: Int): Int = a + b") = PACKAGE
     .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
-        range (0L, 0L) (0L, 33L),
-        [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-            { sourceRange = range (0L, 0L) (0L, 33L)
-              name =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
-                  range (0L, 4L) (0L, 11L),
-                  [ "double1" ]
+    .LanguageTools
+    .WrittenTypes
+    .ParsedFile
+    .PackageFunctions(
+      range (0L, 0L) (0L, 38L),
+      [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+          { sourceRange = range (0L, 0L) (0L, 38L)
+            name =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                range (0L, 4L) (0L, 7L),
+                [ "add" ]
+              )
+
+            parameters =
+              [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                  { sourceRange = range (0L, 8L) (0L, 16L)
+                    name = "a" // TODO: 9-10
+                    typ =
+                      PACKAGE
+                        .Darklang
+                        .LanguageTools
+                        .WrittenTypes
+                        .TypeReference
+                        .TInt64(range (0L, 12L) (0L, 15L)) }
+
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                  { sourceRange = range (0L, 17L) (0L, 25L)
+                    name = "b" // TODO: 18-19
+                    typ =
+                      PACKAGE
+                        .Darklang
+                        .LanguageTools
+                        .WrittenTypes
+                        .TypeReference
+                        .TInt64(range (0L, 21L) (0L, 24L)) } ]
+
+            returnType =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                range (0L, 27L) (0L, 30L)
+              )
+
+            body =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
+                range (0L, 33L) (0L, 38L),
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
+                  PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
+                ),
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                  range (0L, 33L) (0L, 34L),
+                  "a"
+                ),
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                  range (0L, 37L) (0L, 38L),
+                  "b"
                 )
+              ) } ]
+    )
 
-              parameters =
-                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-                    { sourceRange = range (0L, 12L) (0L, 20L)
-                      name = "i"
-                      typ =
-                        PACKAGE
-                          .Darklang
-                          .LanguageTools
-                          .WrittenTypes
-                          .TypeReference
-                          .TInt64(range (0L, 16L) (0L, 19L)) } ]
 
-              returnType =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
-                  range (0L, 22L) (0L, 25L)
-                )
+  (p "let add (a: Int) (b: Int): Int =\n  let sum = a + b\n  sum") = PACKAGE
+    .Darklang
+    .LanguageTools
+    .WrittenTypes
+    .ParsedFile
+    .PackageFunctions(
+      range (0L, 0L) (2L, 5L),
+      [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+          { sourceRange = range (0L, 0L) (2L, 5L)
+            name =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
+                range (0L, 4L) (0L, 7L),
+                [ "add" ]
+              )
 
-              body =
+            parameters =
+              [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                  { sourceRange = range (0L, 8L) (0L, 16L)
+                    name = "a" // TODO: 9-10
+                    typ =
+                      PACKAGE
+                        .Darklang
+                        .LanguageTools
+                        .WrittenTypes
+                        .TypeReference
+                        .TInt64(range (0L, 12L) (0L, 15L)) }
+
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+                  { sourceRange = range (0L, 17L) (0L, 25L)
+                    name = "b" // TODO: 18-19
+                    typ =
+                      PACKAGE
+                        .Darklang
+                        .LanguageTools
+                        .WrittenTypes
+                        .TypeReference
+                        .TInt64(range (0L, 21L) (0L, 24L)) } ]
+
+            returnType =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
+                range (0L, 27L) (0L, 30L)
+              )
+
+            body =
+              PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.ELet(
+                range (1L, 2L) (2L, 5L),
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.LetPattern.LPVariable(
+                  range (1L, 6L) (1L, 9L),
+                  "sum"
+                ),
                 PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
-                  range (0L, 28L) (0L, 33L),
+                  range (1L, 12L) (1L, 17L),
                   PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
                     PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
                   ),
                   PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                    range (0L, 28L) (0L, 29L),
-                    "i"
-                  ),
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                    range (0L, 32L) (0L, 33L),
-                    "i"
-                  )
-                ) } ]
-      )
-    )
-
-
-  ("let add (a: Int) (b: Int): Int = a + b"
-   |> Builtin.Parser.parseToSimplifiedTree
-   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
-        range (0L, 0L) (0L, 38L),
-        [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-            { sourceRange = range (0L, 0L) (0L, 38L)
-              name =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
-                  range (0L, 4L) (0L, 7L),
-                  [ "add" ]
-                )
-
-              parameters =
-                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-                    { sourceRange = range (0L, 8L) (0L, 16L)
-                      name = "a" // TODO: 9-10
-                      typ =
-                        PACKAGE
-                          .Darklang
-                          .LanguageTools
-                          .WrittenTypes
-                          .TypeReference
-                          .TInt64(range (0L, 12L) (0L, 15L)) }
-
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-                    { sourceRange = range (0L, 17L) (0L, 25L)
-                      name = "b" // TODO: 18-19
-                      typ =
-                        PACKAGE
-                          .Darklang
-                          .LanguageTools
-                          .WrittenTypes
-                          .TypeReference
-                          .TInt64(range (0L, 21L) (0L, 24L)) } ]
-
-              returnType =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
-                  range (0L, 27L) (0L, 30L)
-                )
-
-              body =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
-                  range (0L, 33L) (0L, 38L),
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
-                    PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
-                  ),
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                    range (0L, 33L) (0L, 34L),
+                    range (1L, 12L) (1L, 13L),
                     "a"
                   ),
                   PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                    range (0L, 37L) (0L, 38L),
+                    range (1L, 16L) (1L, 17L),
                     "b"
                   )
-                ) } ]
-      )
-    )
-
-
-  ("let add (a: Int) (b: Int): Int =\n  let sum = a + b\n  sum"
-   |> Builtin.Parser.parseToSimplifiedTree
-   |> PACKAGE.Darklang.LanguageTools.Parser.parseNodeToWrittenTypesSourceFile) = PACKAGE
-    .Darklang
-    .Stdlib
-    .Result
-    .Result
-    .Ok(
-      PACKAGE.Darklang.LanguageTools.WrittenTypes.ParsedFile.PackageFunctions(
-        range (0L, 0L) (2L, 5L),
-        [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
-            { sourceRange = range (0L, 0L) (2L, 5L)
-              name =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
-                  range (0L, 4L) (0L, 7L),
-                  [ "add" ]
+                ),
+                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
+                  range (2L, 2L) (2L, 5L),
+                  "sum"
                 )
-
-              parameters =
-                [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-                    { sourceRange = range (0L, 8L) (0L, 16L)
-                      name = "a" // TODO: 9-10
-                      typ =
-                        PACKAGE
-                          .Darklang
-                          .LanguageTools
-                          .WrittenTypes
-                          .TypeReference
-                          .TInt64(range (0L, 12L) (0L, 15L)) }
-
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
-                    { sourceRange = range (0L, 17L) (0L, 25L)
-                      name = "b" // TODO: 18-19
-                      typ =
-                        PACKAGE
-                          .Darklang
-                          .LanguageTools
-                          .WrittenTypes
-                          .TypeReference
-                          .TInt64(range (0L, 21L) (0L, 24L)) } ]
-
-              returnType =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64(
-                  range (0L, 27L) (0L, 30L)
-                )
-
-              body =
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.ELet(
-                  range (1L, 2L) (2L, 5L),
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.LetPattern.LPVariable(
-                    range (1L, 6L) (1L, 9L),
-                    "sum"
-                  ),
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
-                    range (1L, 12L) (1L, 17L),
-                    PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
-                      PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
-                    ),
-                    PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                      range (1L, 12L) (1L, 13L),
-                      "a"
-                    ),
-                    PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                      range (1L, 16L) (1L, 17L),
-                      "b"
-                    )
-                  ),
-                  PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-                    range (2L, 2L) (2L, 5L),
-                    "sum"
-                  )
-                ) } ]
-      )
+              ) } ]
     )

--- a/packages/darklang/languageTools/parser.dark
+++ b/packages/darklang/languageTools/parser.dark
@@ -36,27 +36,25 @@ module Darklang =
       let findNodeByFieldName
         (node: ParsedNode)
         (fieldName: String)
-        : PACKAGE.Darklang.Stdlib.Option.Option<ParsedNode> =
+        : Stdlib.Option.Option<ParsedNode> =
         let children = node.children
 
         let filteredChildren =
           children
-          |> PACKAGE.Darklang.Stdlib.List.filter (fun c ->
+          |> Stdlib.List.filter (fun c ->
             match c.fieldName with
             | Some fName -> fName == fieldName
             | None -> false)
 
         match filteredChildren with
-        | [ c ] -> PACKAGE.Darklang.Stdlib.Option.Option.Some c
-        | [] -> PACKAGE.Darklang.Stdlib.Option.Option.None
-        | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None // TODO: this should error, there are multiple matches
+        | [ c ] -> Stdlib.Option.Option.Some c
+        | [] -> Stdlib.Option.Option.None
+        | _ -> Stdlib.Option.Option.None // TODO: this should error, there are multiple matches
 
-      let stringToPackage
-        (str: String)
-        : PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package =
-        let name = PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name.FnName str
+      let stringToPackage (str: String) : ProgramTypes.FQName.Package =
+        let name = ProgramTypes.FnName.Name.FnName str
 
-        PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package
+        ProgramTypes.FQName.Package
           { owner = "TODO"
             modules = [ "TODO" ]
             name = name
@@ -75,40 +73,27 @@ module Darklang =
 
       let parseTypeReference
         (node: ParsedNode)
-        : PACKAGE.Darklang.Stdlib.Option.Option<WTTypeReference> =
+        : Stdlib.Option.Option<WTTypeReference> =
         // TODO: support more types
         let typ = node.typ
 
         if typ == "type" then
           match (getText node) with
-          | "Int" ->
-            PACKAGE.Darklang.Stdlib.Option.Option.Some
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-          | "Int64" ->
-            PACKAGE.Darklang.Stdlib.Option.Option.Some
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TInt64
-          | "Bool" ->
-            PACKAGE.Darklang.Stdlib.Option.Option.Some
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TBool
-          | "String" ->
-            PACKAGE.Darklang.Stdlib.Option.Option.Some
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeReference.TString
-          | _ -> PACKAGE.Darklang.Stdlib.Option.Option.None
+          | "Int" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TInt64
+          | "Int64" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TInt64
+          | "Bool" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TBool
+          | "String" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TString
+          | _ -> Stdlib.Option.Option.None
         else
-          PACKAGE.Darklang.Stdlib.Option.Option.None // this should return and error?
+          Stdlib.Option.Option.None // this should return and error?
 
 
       let parseExprCase
         (parsed: ParsedNode)
-        : PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr, String> =
+        : Stdlib.Result.Result<WrittenTypes.Expr, String> =
         match parsed.typ with
         | "identifier" ->
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EVariable(
-              0L,
-              getText parsed
-            )
-          )
+          Stdlib.Result.Result.Ok(WrittenTypes.Expr.EVariable(0L, getText parsed))
         | "infix_operation" ->
           let left =
             (findNodeByFieldName parsed "left")
@@ -130,24 +115,15 @@ module Darklang =
           let operator =
             match operatorText with
             | "+" ->
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticPlus
-              )
+              WrittenTypes.Infix.InfixFnCall(WrittenTypes.InfixFnName.ArithmeticPlus)
             | "-" ->
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.Infix.InfixFnCall(
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.InfixFnName.ArithmeticMinus
+              WrittenTypes.Infix.InfixFnCall(
+                WrittenTypes.InfixFnName.ArithmeticMinus
               )
-            | _ ->
-              PACKAGE.Darklang.Stdlib.Result.Result.Error
-                "TODO : operator not implemented"
+            | _ -> Stdlib.Result.Result.Error "TODO : operator not implemented"
 
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EInfix(
-              0L,
-              operator,
-              left,
-              right
-            )
+          Stdlib.Result.Result.Ok(
+            WrittenTypes.Expr.EInfix(0L, operator, left, right)
           )
 
         | "let_expression" ->
@@ -166,13 +142,10 @@ module Darklang =
             |> parseExpr
             |> Builtin.unwrap
 
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.ELet(
+          Stdlib.Result.Result.Ok(
+            WrittenTypes.Expr.ELet(
               0L,
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.LetPattern.LPVariable(
-                0L,
-                identifier
-              ),
+              WrittenTypes.LetPattern.LPVariable(0L, identifier),
               expr,
               body
             )
@@ -185,60 +158,53 @@ module Darklang =
           let args =
             (findNodeByFieldName parsed "args")
             |> Builtin.unwrap
-            |> PACKAGE.Darklang.Stdlib.List.map (
-              fun arg -> (parseExpr arg)
-              |> Builtin.unwrap
-            )
+            |> Stdlib.List.map (fun arg -> (parseExpr arg) |> Builtin.unwrap)
 
           let fnCallExpr =
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EApply(
+            WrittenTypes.Expr.EApply(
               0L,
-              PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr.EFnName(
+              WrittenTypes.Expr.EFnName(
                 0L,
-                PACKAGE.Darklang.LanguageTools.WrittenTypes.Name.Unresolved
-                  [ "Darklang"; "Stdlib"; "Int"; fnName ]
+                WrittenTypes.Name.Unresolved [ "Darklang"; "Stdlib"; "Int"; fnName ]
               ),
               [],
               args
             )
 
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok(fnCallExpr)
-        | _ ->
-          PACKAGE.Darklang.Stdlib.Result.Result.Error
-            "TODO : parseExprCase not implemented"
+          Stdlib.Result.Result.Ok(fnCallExpr)
+        | _ -> Stdlib.Result.Result.Error "TODO : parseExprCase not implemented"
 
 
       let parseExpr
         (parsed: ParsedNode)
-        : PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.LanguageTools.WrittenTypes.Expr, String> =
+        : Stdlib.Result.Result<WrittenTypes.Expr, String> =
         if parsed.typ == "expression" then
           match parsed.children with
           | [ single ] -> parseExprCase single
-          | _ ->
-            PACKAGE.Darklang.Stdlib.Result.Result.Error "Not a single expression"
+          | _ -> Stdlib.Result.Result.Error "Not a single expression"
         else
-          PACKAGE.Darklang.Stdlib.Result.Result.Error "Not an expression"
+          Stdlib.Result.Result.Error "Not an expression"
 
 
       let parseNodeToWT
         (parsed: ParsedNode)
-        : PACKAGE.Darklang.Stdlib.Result.Result<List<PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn>, String> =
+        : Stdlib.Result.Result<List<WrittenTypes.PackageFn.PackageFn>, String> =
         if parsed.typ == "source_file" then
           match parsed.children with
           | [ fnDef ] -> parsePackageFn fnDef
-          | _ -> PACKAGE.Darklang.Stdlib.Result.Result.Error "Not a single fn_def"
+          | _ -> Stdlib.Result.Result.Error "Not a single fn_def"
         else
-          PACKAGE.Darklang.Stdlib.Result.Result.Error "Not a source_file"
+          Stdlib.Result.Result.Error "Not a source_file"
 
 
       let parsePackageFn
         (parsed: ParsedNode)
-        : PACKAGE.Darklang.Stdlib.Result.Result<List<PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn>, String> =
+        : Stdlib.Result.Result<List<WrittenTypes.PackageFn.PackageFn>, String> =
         if parsed.typ == "fn_def" then
           let parameters =
             match (findNodeByFieldName parsed "params") with
             | Some p -> (parseFnParams p) |> Builtin.unwrap
-            | None -> PACKAGE.Darklang.Stdlib.Result.Result.Error "No params"
+            | None -> Stdlib.Result.Result.Error "No params"
 
           let body =
             (findNodeByFieldName parsed "body")
@@ -256,8 +222,8 @@ module Darklang =
             ((findNodeByFieldName parsed "name") |> Builtin.unwrap |> getText)
             |> stringToPackage
 
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok
-            [ PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.PackageFn
+          Stdlib.Result.Result.Ok
+            [ WrittenTypes.PackageFn.PackageFn
                 { name = name
                   body = body
                   typeParams = []
@@ -265,29 +231,28 @@ module Darklang =
                   returnType = returnType
                   description = "" } ]
         else
-          PACKAGE.Darklang.Stdlib.Result.Result.Error parsed
+          Stdlib.Result.Result.Error parsed
 
 
       let parseFnParams
         (parsed: ParsedNode)
-        : PACKAGE.Darklang.Stdlib.Result.Result<List<PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter>, String> =
+        : Stdlib.Result.Result<List<WrittenTypes.PackageFn.Parameter>, String> =
         if parsed.typ == "fn_params_def" then
           let parameters =
             parsed.children
-            |> PACKAGE.Darklang.Stdlib.List.map (fun p ->
-              (parseFnParam p) |> Builtin.unwrap)
+            |> Stdlib.List.map (fun p -> (parseFnParam p) |> Builtin.unwrap)
 
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok parameters
+          Stdlib.Result.Result.Ok parameters
         else
-          PACKAGE.Darklang.Stdlib.Result.Result.Error "Not a fn_params_def"
+          Stdlib.Result.Result.Error "Not a fn_params_def"
 
 
       let parseFnParam
         (parsed: ParsedNode)
-        : PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter, String> =
+        : Stdlib.Result.Result<WrittenTypes.PackageFn.Parameter, String> =
         if parsed.typ == "fn_param_def" then
-          PACKAGE.Darklang.Stdlib.Result.Result.Ok(
-            PACKAGE.Darklang.LanguageTools.WrittenTypes.PackageFn.Parameter
+          Stdlib.Result.Result.Ok(
+            WrittenTypes.PackageFn.Parameter
               { name =
                   (findNodeByFieldName parsed "identifier")
                   |> Builtin.unwrap
@@ -300,4 +265,4 @@ module Darklang =
                 description = "" }
           )
         else
-          PACKAGE.Darklang.Stdlib.Result.Result.Error "Not a fn_param_def"
+          Stdlib.Result.Result.Error "Not a fn_param_def"

--- a/packages/darklang/languageTools/parser.dark
+++ b/packages/darklang/languageTools/parser.dark
@@ -27,6 +27,13 @@ module Darklang =
       let parse (text: String) : ParsedNode =
         Builtins.LanguageTools.Parser.parse text
 
+
+      // TODO: maybe re-frame this into expected/actual or something
+      type ParseError =
+        { sourceRange: Range
+          sourceText: String
+          message: String }
+
       // --------------------
       // Helper functions
       // --------------------
@@ -37,10 +44,8 @@ module Darklang =
         (node: ParsedNode)
         (fieldName: String)
         : Stdlib.Option.Option<ParsedNode> =
-        let children = node.children
-
         let filteredChildren =
-          children
+          node.children
           |> Stdlib.List.filter (fun c ->
             match c.fieldName with
             | Some fName -> fName == fieldName
@@ -48,70 +53,77 @@ module Darklang =
 
         match filteredChildren with
         | [ c ] -> Stdlib.Option.Option.Some c
+
         | [] -> Stdlib.Option.Option.None
         | _ -> Stdlib.Option.Option.None // TODO: this should error, there are multiple matches
 
-      let stringToPackage (str: String) : ProgramTypes.FQName.Package =
-        let name = ProgramTypes.FnName.Name.FnName str
-
-        ProgramTypes.FQName.Package
-          { owner = "TODO"
-            modules = [ "TODO" ]
-            name = name
-            version = 0L }
 
 
       // --------------------
       // Parsing to WrittenTypes
       // --------------------
 
-      // TODO: support more types
-      type WTTypeReference =
-        | TInt64
-        | TBool
-        | TString
-
       let parseTypeReference
         (node: ParsedNode)
-        : Stdlib.Option.Option<WTTypeReference> =
-        // TODO: support more types
-        let typ = node.typ
-
-        if typ == "type" then
+        : Stdlib.Option.Option<WrittenTypes.TypeReference> =
+        if node.typ == "type" then
           match (getText node) with
-          | "Int" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TInt64
-          | "Int64" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TInt64
-          | "Bool" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TBool
-          | "String" -> Stdlib.Option.Option.Some WrittenTypes.TypeReference.TString
-          | _ -> Stdlib.Option.Option.None
+          | "Unit" ->
+            (WrittenTypes.TypeReference.TInt64(node.sourceRange))
+            |> Stdlib.Option.Option.Some
+
+          | "Int" ->
+            (WrittenTypes.TypeReference.TInt64(node.sourceRange))
+            |> Stdlib.Option.Option.Some
+
+          | "Bool" ->
+            (WrittenTypes.TypeReference.TBool(node.sourceRange))
+            |> Stdlib.Option.Option.Some
+
+          | "Float" ->
+            (WrittenTypes.TypeReference.TFloat(node.sourceRange))
+            |> Stdlib.Option.Option.Some
+
+          | "String" ->
+            (WrittenTypes.TypeReference.TString(node.sourceRange))
+            |> Stdlib.Option.Option.Some
+
+          | "Char" ->
+            (WrittenTypes.TypeReference.TChar(node.sourceRange))
+            |> Stdlib.Option.Option.Some
+
+          | _ -> Stdlib.Option.Option.None // TODO: error?
         else
-          Stdlib.Option.Option.None // this should return and error?
+          Stdlib.Option.Option.None // TODO: error?
 
 
+      /// this parses one of the Expr cases
       let parseExprCase
         (parsed: ParsedNode)
         : Stdlib.Result.Result<WrittenTypes.Expr, String> =
         match parsed.typ with
         | "identifier" ->
-          Stdlib.Result.Result.Ok(WrittenTypes.Expr.EVariable(0L, getText parsed))
+          (WrittenTypes.Expr.EVariable(parsed.sourceRange, getText parsed))
+          |> Stdlib.Result.Result.Ok
+
+
         | "infix_operation" ->
-          let left =
+          let leftArg =
             (findNodeByFieldName parsed "left")
             |> Builtin.unwrap
             |> parseExpr
             |> Builtin.unwrap
 
-          let right =
+          let operatorText =
+            (findNodeByFieldName parsed "operator") |> Builtin.unwrap |> getText
+
+          let rightArg =
             (findNodeByFieldName parsed "right")
             |> Builtin.unwrap
             |> parseExpr
             |> Builtin.unwrap
 
-          let operatorNode =
-            (findNodeByFieldName parsed "operator") |> Builtin.unwrap
-
-          let operatorText = getText operatorNode
-
+          // TODO: revisit error-handling
           let operator =
             match operatorText with
             | "+" ->
@@ -122,13 +134,13 @@ module Darklang =
               )
             | _ -> Stdlib.Result.Result.Error "TODO : operator not implemented"
 
-          Stdlib.Result.Result.Ok(
-            WrittenTypes.Expr.EInfix(0L, operator, left, right)
-          )
+          (WrittenTypes.Expr.EInfix(parsed.sourceRange, operator, leftArg, rightArg))
+          |> Stdlib.Result.Result.Ok
+
 
         | "let_expression" ->
-          let identifier =
-            (findNodeByFieldName parsed "identifier") |> Builtin.unwrap |> getText
+          let identifierNode =
+            (findNodeByFieldName parsed "identifier") |> Builtin.unwrap
 
           let expr =
             (findNodeByFieldName parsed "expr")
@@ -142,39 +154,49 @@ module Darklang =
             |> parseExpr
             |> Builtin.unwrap
 
-          Stdlib.Result.Result.Ok(
-            WrittenTypes.Expr.ELet(
-              0L,
-              WrittenTypes.LetPattern.LPVariable(0L, identifier),
-              expr,
-              body
-            )
-          )
+          (WrittenTypes.Expr.ELet(
+            parsed.sourceRange,
+            WrittenTypes.LetPattern.LPVariable(
+              identifierNode.sourceRange,
+              identifierNode.text
+            ),
+            expr,
+            body
+          ))
+          |> Stdlib.Result.Result.Ok
+
 
         // TODO: This is not tested yet
         | "function_call" ->
-          let fnName = (findNodeByFieldName parsed "fn") |> Builtin.unwrap |> getText
+          let fnNameNode = (findNodeByFieldName parsed "fn") |> Builtin.unwrap
 
           let args =
             (findNodeByFieldName parsed "args")
             |> Builtin.unwrap
+            |> fun argsNode -> argsNode.children
             |> Stdlib.List.map (fun arg -> (parseExpr arg) |> Builtin.unwrap)
 
-          let fnCallExpr =
-            WrittenTypes.Expr.EApply(
-              0L,
-              WrittenTypes.Expr.EFnName(
-                0L,
-                WrittenTypes.Name.Unresolved [ "Darklang"; "Stdlib"; "Int"; fnName ]
-              ),
-              [],
-              args
-            )
+          (WrittenTypes.Expr.EApply(
+            parsed.sourceRange,
+            WrittenTypes.Expr.EFnName(
+              WrittenTypes.Name.Unresolved(
+                fnNameNode.sourceRange,
+                [ "Darklang"; "Stdlib"; "Int"; getText fnNameNode ]
+              )
 
-          Stdlib.Result.Result.Ok(fnCallExpr)
-        | _ -> Stdlib.Result.Result.Error "TODO : parseExprCase not implemented"
+            ),
+            [],
+            args
+          ))
+          |> Stdlib.Result.Result.Ok
 
 
+        | uncaughtType ->
+          Stdlib.Result.Result.Error
+            $"TODO : parseExprCase {uncaughtType} not implemented"
+
+
+      /// this parses the 'container' of an expression
       let parseExpr
         (parsed: ParsedNode)
         : Stdlib.Result.Result<WrittenTypes.Expr, String> =
@@ -186,30 +208,82 @@ module Darklang =
           Stdlib.Result.Result.Error "Not an expression"
 
 
-      let parseNodeToWT
+
+      /// Parses a package function definiti;on parameter
+      ///
+      /// i.e. in `fn foo(x: Int)`, this parses `x: Int`
+      let parseFnDefParam
         (parsed: ParsedNode)
-        : Stdlib.Result.Result<List<WrittenTypes.PackageFn.PackageFn>, String> =
-        if parsed.typ == "source_file" then
-          match parsed.children with
-          | [ fnDef ] -> parsePackageFn fnDef
-          | _ -> Stdlib.Result.Result.Error "Not a single fn_def"
+        : Stdlib.Result.Result<WrittenTypes.PackageFn.Parameter, String> =
+        if parsed.typ == "fn_param_def" then
+          let name =
+            (findNodeByFieldName parsed "identifier") |> Builtin.unwrap |> getText
+
+          let typ =
+            (findNodeByFieldName parsed "typ")
+            |> Builtin.unwrap
+            |> parseTypeReference
+            |> Builtin.unwrap
+
+          (WrittenTypes.PackageFn.Parameter
+            { sourceRange = parsed.sourceRange
+              name = name
+              typ = typ
+            //description = ""
+            })
+          |> Stdlib.Result.Result.Ok
+
         else
-          Stdlib.Result.Result.Error "Not a source_file"
+          Stdlib.Result.Result.Error "Not a fn_param_def"
 
 
-      let parsePackageFn
+      /// Parses a package function definition's parameters
+      ///
+      /// i.e. in `fn add(x: Int, y: Int)`, this parses `x: Int, y: Int`
+      let parseFnDefParams
+        (parsed: ParsedNode)
+        : Stdlib.Result.Result<List<WrittenTypes.PackageFn.Parameter>, String> =
+        if parsed.typ == "fn_params_def" then
+          let defs =
+            Stdlib.List.fold
+              parsed.children
+              (Stdlib.Result.Result.Ok [])
+              (fun defs param ->
+                match defs with
+                | Error e -> Stdlib.Result.Result.Error e
+
+                | Ok defs ->
+                  match parseFnDefParam param with
+                  | Error e -> Stdlib.Result.Result.Error e
+
+                  | Ok parsed ->
+                    Stdlib.Result.Result.Ok(Stdlib.List.push defs parsed))
+
+          match defs with
+          | Error _e -> defs
+          | Ok defs -> Stdlib.Result.Result.Ok(Stdlib.List.reverse defs)
+        else
+          Stdlib.Result.Result.Error "Not a fn_params_def"
+
+
+      /// Parses a package function definition
+      ///
+      /// i.e. `let add (x: Int) (y: Int) = x + y`,
+      ///
+      /// - `add` is the function name
+      /// - `x: Int` and `y: Int` are the parameters
+      /// - `x + y` is the body
+      /// - `Int` is the return type
+      let parsePackageFnDef
         (parsed: ParsedNode)
         : Stdlib.Result.Result<List<WrittenTypes.PackageFn.PackageFn>, String> =
         if parsed.typ == "fn_def" then
-          let parameters =
-            match (findNodeByFieldName parsed "params") with
-            | Some p -> (parseFnParams p) |> Builtin.unwrap
-            | None -> Stdlib.Result.Result.Error "No params"
+          let nameNode = parsed |> findNodeByFieldName "name" |> Builtin.unwrap
 
-          let body =
-            (findNodeByFieldName parsed "body")
+          let parameters =
+            (findNodeByFieldName parsed "params")
             |> Builtin.unwrap
-            |> parseExpr
+            |> parseFnDefParams
             |> Builtin.unwrap
 
           let returnType =
@@ -218,51 +292,57 @@ module Darklang =
             |> parseTypeReference
             |> Builtin.unwrap
 
-          let name =
-            ((findNodeByFieldName parsed "name") |> Builtin.unwrap |> getText)
-            |> stringToPackage
+          let body =
+            (findNodeByFieldName parsed "body")
+            |> Builtin.unwrap
+            |> parseExpr
+            |> Builtin.unwrap
 
-          Stdlib.Result.Result.Ok
-            [ WrittenTypes.PackageFn.PackageFn
-                { name = name
-                  body = body
-                  typeParams = []
-                  parameters = parameters
-                  returnType = returnType
-                  description = "" } ]
+          (WrittenTypes.PackageFn.PackageFn
+            { sourceRange = parsed.sourceRange
+              name =
+                WrittenTypes.Name.Unresolved(nameNode.sourceRange, [ nameNode.text ])
+              //typeParams = []
+              parameters = parameters
+              returnType = returnType
+              body = body
+            //description = ""
+            })
+          |> Stdlib.Result.Result.Ok
         else
           Stdlib.Result.Result.Error parsed
 
 
-      let parseFnParams
+      /// Currently, all "source files"
+      /// are just a list of package function definitions
+      ///
+      /// TODO^
+      let parseNodeToWrittenTypesSourceFile
         (parsed: ParsedNode)
-        : Stdlib.Result.Result<List<WrittenTypes.PackageFn.Parameter>, String> =
-        if parsed.typ == "fn_params_def" then
-          let parameters =
-            parsed.children
-            |> Stdlib.List.map (fun p -> (parseFnParam p) |> Builtin.unwrap)
+        : Stdlib.Result.Result<WrittenTypes.ParsedFile, String> =
+        if parsed.typ == "source_file" then
+          let packageFnDefs =
+            Stdlib.List.fold
+              parsed.children
+              (Stdlib.Result.Result.Ok [])
+              (fun defs packageFnDef ->
+                match defs with
+                | Error e -> Stdlib.Result.Result.Error e
 
-          Stdlib.Result.Result.Ok parameters
+                | Ok defs ->
+                  match parsePackageFnDef packageFnDef with
+                  | Error e -> Stdlib.Result.Result.Error e
+                  | Ok parsed ->
+                    Stdlib.Result.Result.Ok(Stdlib.List.push defs parsed))
+
+          match packageFnDefs with
+          | Error e -> Stdlib.Result.Result.Error e
+          | Ok packageFnDefs ->
+            (WrittenTypes.ParsedFile.PackageFunctions(
+              parsed.sourceRange,
+              Stdlib.List.reverse packageFnDefs
+            ))
+            |> Stdlib.Result.Result.Ok
+
         else
-          Stdlib.Result.Result.Error "Not a fn_params_def"
-
-
-      let parseFnParam
-        (parsed: ParsedNode)
-        : Stdlib.Result.Result<WrittenTypes.PackageFn.Parameter, String> =
-        if parsed.typ == "fn_param_def" then
-          Stdlib.Result.Result.Ok(
-            WrittenTypes.PackageFn.Parameter
-              { name =
-                  (findNodeByFieldName parsed "identifier")
-                  |> Builtin.unwrap
-                  |> getText
-                typ =
-                  (findNodeByFieldName parsed "typ")
-                  |> Builtin.unwrap
-                  |> parseTypeReference
-                  |> Builtin.unwrap
-                description = "" }
-          )
-        else
-          Stdlib.Result.Result.Error "Not a fn_param_def"
+          Stdlib.Result.Result.Error "Not a source_file"

--- a/packages/darklang/languageTools/programTypes.dark
+++ b/packages/darklang/languageTools/programTypes.dark
@@ -46,9 +46,7 @@ module Darklang =
 
         type BuiltIn = FQName.BuiltIn<Name>
         type UserProgram = FQName.UserProgram<Name>
-
-        type Package =
-          PACKAGE.Darklang.LanguageTools.ProgramTypes.FQName.Package<Name>
+        type Package = FQName.Package<Name>
 
       module ConstantName =
         type Name = ConstantName of String
@@ -59,7 +57,7 @@ module Darklang =
         type Package = FQName.Package<Name>
 
       type NameResolution<'a> =
-        PACKAGE.Darklang.Stdlib.Result.Result<'a, PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.Error>
+        Stdlib.Result.Result<'a, PACKAGE.Darklang.LanguageTools.RuntimeErrors.NameResolution.Error>
 
 
       /// Darklang's available types (int, List<T>, user-defined types, etc.)

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -1,290 +1,241 @@
 module Darklang =
   module LanguageTools =
     module WrittenTypes =
+      // <aliases>
+      type SourceRange = Parser.Range
+      // <aliases>
 
-      type Name =
-        | KnownBuiltin of List<String> * String * Int64
-        | Unresolved of List<String>
+      type Name = Unresolved of SourceRange * parts: List<String>
 
-      type UnresolvedEnumTypeName = List<String>
+      //type UnresolvedEnumTypeName = List<String>
 
       type LetPattern =
-        | LPUnit of ID
-        | LPVariable of ID * name: String
-        | LPTuple of
-          ID *
-          first: LetPattern *
-          second: LetPattern *
-          theRest: List<LetPattern>
+        // | LPUnit
+        | LPVariable of SourceRange * name: String
+      // | LPTuple of
+      //   first: LetPattern *
+      //   second: LetPattern *
+      //   theRest: List<LetPattern>
 
-      type MatchPattern =
-        | MPUnit of ID
-        | MPBool of ID * Bool
-        | MPInt64 of ID * Int64
-        | MPUInt64 of ID * UInt64
-        | MPInt8 of ID * Int8
-        | MPUInt8 of ID * UInt8
-        | MPInt16 of ID * Int16
-        | MPUInt16 of ID * UInt16
-        | MPInt32 of ID * Int32
-        | MPUInt32 of ID * UInt32
-        | MPInt128 of ID * Int128
-        | MPUInt128 of ID * UInt128
-        | MPFloat of ID * Sign * String * String
-        | MPChar of ID * String
-        | MPString of ID * String
+      // type MatchPattern =
+      //   | MPUnit
+      //   | MPBool of Bool
+      //   | MPInt64 of Int64
+      //   | MPUInt64 of UInt64
+      //   | MPInt8 of Int8
+      //   | MPUInt8 of UInt8
+      //   | MPInt16 of Int16
+      //   | MPUInt16 of UInt16
+      //   | MPInt32 of Int32
+      //   | MPUInt32 of UInt32
+      //   | MPInt128 of Int128
+      //   | MPUInt128 of UInt128
+      //   | MPFloat of Sign * String * String
+      //   | MPChar of String
+      //   | MPString of String
 
-        | MPList of ID * List<MatchPattern>
-        | MPListCons of ID * head: MatchPattern * tail: MatchPattern
-        | MPTuple of ID * MatchPattern * MatchPattern * List<MatchPattern>
+      //   | MPList of List<MatchPattern>
+      //   | MPListCons of head: MatchPattern * tail: MatchPattern
+      //   | MPTuple of MatchPattern * MatchPattern * List<MatchPattern>
 
-        | MPVariable of ID * String
+      //   | MPVariable of String
 
-        | MPEnum of ID * caseName: String * fieldPats: List<MatchPattern>
+      //   | MPEnum of caseName: String * fieldPats: List<MatchPattern>
 
-      type BinaryOperation =
-        | BinOpAnd
-        | BinOpOr
+      // type BinaryOperation =
+      //   | BinOpAnd
+      //   | BinOpOr
 
       type InfixFnName =
         | ArithmeticPlus
         | ArithmeticMinus
-        | ArithmeticMultiply
-        | ArithmeticDivide
-        | ArithmeticModulo
-        | ArithmeticPower
-        | ComparisonGreaterThan
-        | ComparisonGreaterThanOrEqual
-        | ComparisonLessThan
-        | ComparisonLessThanOrEqual
-        | ComparisonEquals
-        | ComparisonNotEquals
-        | StringConcat
+      // | ArithmeticMultiply
+      // | ArithmeticDivide
+      // | ArithmeticModulo
+      // | ArithmeticPower
+      // | ComparisonGreaterThan
+      // | ComparisonGreaterThanOrEqual
+      // | ComparisonLessThan
+      // | ComparisonLessThanOrEqual
+      // | ComparisonEquals
+      // | ComparisonNotEquals
+      // | StringConcat
 
-      type Infix =
-        | InfixFnCall of InfixFnName
-        | BinOp of BinaryOperation
+      type Infix = InfixFnCall of InfixFnName
+      // | BinOp of SourceRange * BinaryOperation
 
       type TypeReference =
-        | TUnit
-        | TBool
-        | TInt64
-        | TUInt64
-        | TInt8
-        | TUInt8
-        | TInt16
-        | TUInt16
-        | TInt32
-        | TUInt32
-        | TInt128
-        | TUInt128
-        | TFloat
-        | TChar
-        | TString
-        | TDateTime
-        | TUuid
+        | TUnit of SourceRange
+        | TBool of SourceRange
+        | TInt64 of SourceRange
+        // | TUInt64
+        // | TInt8
+        // | TUInt8
+        // | TInt16
+        // | TUInt16
+        // | TInt32
+        // | TUInt32
+        // | TInt128
+        // | TUInt128
+        | TFloat of SourceRange
+        | TChar of SourceRange
+        | TString of SourceRange
+      // | TDateTime
+      // | TUuid
 
-        | TList of TypeReference
-        | TTuple of TypeReference * TypeReference * List<TypeReference>
-        | TDict of TypeReference
-        | TCustomType of Name * typeArgs: List<TypeReference>
+      // | TList of SourceRange * TypeReference
+      // | TTuple of TypeReference * TypeReference * List<TypeReference>
+      // | TDict of TypeReference
+      // | TCustomType of Name * typeArgs: List<TypeReference>
+      // | TFn of List<TypeReference> * TypeReference
+      // | TDB of  TypeReference
+      // | TVariable of String
 
-        | TFn of List<TypeReference> * TypeReference
+      type StringSegment = StringText of String
+      //| StringInterpolation of Expr
 
-        | TDB of TypeReference
+      // type PipeExpr =
+      //   | EPipeInfix of Infix * Expr
+      //   | EPipeLambda of pats: List<LetPattern> * body: Expr
 
-        | TVariable of String
+      //   | EPipeEnum of
+      //     typeName: UnresolvedEnumTypeName *
+      //     caseName: String *
+      //     fields: List<Expr>
 
-      type StringSegment =
-        | StringText of String
-        | StringInterpolation of Expr
+      //   | EPipeFnCall of
+      //     fnName: Name *
+      //     typeArgs: List<TypeReference> *
+      //     args: List<Expr>
 
-      type PipeExpr =
-        | EPipeInfix of ID * Infix * Expr
-        | EPipeLambda of ID * pats: List<LetPattern> * body: Expr
+      //   | EPipeVariableOrUserFunction of String
 
-        | EPipeEnum of
-          ID *
-          typeName: UnresolvedEnumTypeName *
-          caseName: String *
-          fields: List<Expr>
+      // type MatchCase =
+      //   { pat: MatchPattern
+      //     whenCondition: Stdlib.Option.Option<Expr>
+      //     rhs: Expr }
 
-        | EPipeFnCall of
-          ID *
-          fnName: Name *
+      type Expr =
+        | EUnit of SourceRange
+        | EBool of SourceRange * Bool
+        | EInt64 of SourceRange * Int64
+        // | EUInt64 of UInt64
+        // | EInt8 of Int8
+        // | EUInt8 of UInt8
+        // | EInt16 of Int16
+        // | EUInt16 of UInt16
+        // | EInt32 of Int32
+        // | EUInt32 of UInt32
+        // | EInt128 of Int128
+        // | EUInt128 of UInt128
+        // | EFloat of Sign * String * String
+        // | EChar of String
+        | EString of SourceRange * StringSegment
+        // | EList of  List<Expr>
+        // | EDict of List<String * Expr>
+        // | ETuple of Expr * Expr * List<Expr>
+        // | ERecord of Name * List<String * Expr>
+        // | ERecordUpdate of record: Expr * updates: List<String * Expr>
+        // | EEnum of
+        //   typeName: UnresolvedEnumTypeName *
+        //   caseName: String *
+        //   fields: List<Expr>
+
+        | ELet of SourceRange * LetPattern * Expr * Expr
+        | EVariable of SourceRange * String
+        // | EFieldAccess of Expr * String
+        // | EIf of
+        //   cond: Expr *
+        //   thenExpr: Expr *
+        //   elseExpr: Stdlib.Option.Option<Expr>
+        // | EPipe of Expr * List<PipeExpr>
+        // | EMatch of arg: Expr * cases: List<MatchCase>
+        | EFnName of Name
+        | EInfix of SourceRange * Infix * Expr * Expr
+        // | ELambda of List<LetPattern> * Expr
+        | EApply of
+          SourceRange *
+          Expr *
           typeArgs: List<TypeReference> *
           args: List<Expr>
 
-        | EPipeVariableOrUserFunction of ID * String
 
-      type MatchCase =
-        { pat: MatchPattern
-          whenCondition: Stdlib.Option.Option<Expr>
-          rhs: Expr }
+      // type Const =
+      //   | CUnit
+      //   | CBool of Bool
+      //   | CInt64 of Int64
+      //   | CUInt64 of UInt64
+      //   | CInt8 of Int8
+      //   | CUInt8 of UInt8
+      //   | CInt16 of Int16
+      //   | CUInt16 of UInt16
+      //   | CInt32 of Int32
+      //   | CUInt32 of UInt32
+      //   | CInt128 of Int128
+      //   | CUInt128 of UInt128
+      //   | CFloat of Sign * String * String
+      //   | CChar of Char
+      //   | CString of String
+      //   | CList of List<Const>
+      //   | CDict of List<String * Const>
+      //   | CTuple of Const * Const * List<Const>
+      //   | CEnum of UnresolvedEnumTypeName * caseName: String * fields: List<Const>
 
-      type Expr =
-        | EUnit of ID
-        | EBool of ID * Bool
-        | EInt64 of ID * Int64
-        | EUInt64 of ID * UInt64
-        | EInt8 of ID * Int8
-        | EUInt8 of ID * UInt8
-        | EInt16 of ID * Int16
-        | EUInt16 of ID * UInt16
-        | EInt32 of ID * Int32
-        | EUInt32 of ID * UInt32
-        | EInt128 of ID * Int128
-        | EUInt128 of ID * UInt128
-        | EFloat of ID * Sign * String * String
-        | EChar of ID * String
-        | EString of ID * List<StringSegment>
+      // module TypeDeclaration =
+      //   type RecordField =
+      //     { name: String
+      //       typ: TypeReference
+      //       description: String }
 
-        | EList of ID * List<Expr>
-        | EDict of ID * List<String * Expr>
-        | ETuple of ID * Expr * Expr * List<Expr>
-        | ERecord of ID * Name * List<String * Expr>
-        | ERecordUpdate of ID * record: Expr * updates: List<String * Expr>
+      //   type EnumField =
+      //     { typ: TypeReference
+      //       label: Stdlib.Option.Option<String>
+      //       description: String }
 
-        | EEnum of
-          ID *
-          typeName: UnresolvedEnumTypeName *
-          caseName: String *
-          fields: List<Expr>
+      //   type EnumCase =
+      //     { name: String
+      //       fields: List<EnumField>
+      //       description: String }
 
-        | ELet of ID * LetPattern * Expr * Expr
-        | EVariable of ID * String
-        | EFieldAccess of ID * Expr * String
+      //   type Definition =
+      //     | Alias of TypeReference
+      //     | Record of List<RecordField>
+      //     | Enum of List<EnumCase>
 
-        | EIf of
-          ID *
-          cond: Expr *
-          thenExpr: Expr *
-          elseExpr: Stdlib.Option.Option<Expr>
+      //   type TypeDeclaration =
+      //     { typeParams: List<String>
+      //       definition: Definition }
 
-        | EPipe of ID * Expr * List<PipeExpr>
-        | EMatch of ID * arg: Expr * cases: List<MatchCase>
-        | EFnName of ID * Name
-        | EInfix of ID * Infix * Expr * Expr
-        | ELambda of ID * List<LetPattern> * Expr
-        | EApply of ID * Expr * typeArgs: List<TypeReference> * args: List<Expr>
-        | EPlaceHolder
-
-      type Const =
-        | CUnit
-        | CBool of Bool
-        | CInt64 of Int64
-        | CUInt64 of UInt64
-        | CInt8 of Int8
-        | CUInt8 of UInt8
-        | CInt16 of Int16
-        | CUInt16 of UInt16
-        | CInt32 of Int32
-        | CUInt32 of UInt32
-        | CInt128 of Int128
-        | CUInt128 of UInt128
-        | CFloat of Sign * String * String
-        | CChar of Char
-        | CString of String
-        | CList of List<Const>
-        | CDict of List<String * Const>
-        | CTuple of Const * Const * List<Const>
-        | CEnum of UnresolvedEnumTypeName * caseName: String * fields: List<Const>
-
-      module TypeDeclaration =
-        type RecordField =
-          { name: String
-            typ: TypeReference
-            description: String }
-
-        type EnumField =
-          { typ: TypeReference
-            label: Stdlib.Option.Option<String>
-            description: String }
-
-        type EnumCase =
-          { name: String
-            fields: List<EnumField>
-            description: String }
-
-        type Definition =
-          | Alias of TypeReference
-          | Record of List<RecordField>
-          | Enum of List<EnumCase>
-
-        type TypeDeclaration =
-          { typeParams: List<String>
-            definition: Definition }
-
-      module Handler =
-        type CronInterval =
-          | EveryFortnight
-          | EveryWeek
-          | EveryDay
-          | Every12Hours
-          | EveryHour
-          | EveryMinute
-
-        type Spec =
-          | HTTP of route: String * method: String
-          | Worker of name: String
-          | Cron of name: String * interval: CronInterval
-          | REPL of name: String
-
-        type Handler = { ast: Expr; spec: Spec }
-
-
-      type DB =
-        { name: String
-          version: Int64
-          typ: TypeReference }
-
-      type UserType =
-        { name: ProgramTypes.TypeName.UserProgram
-          description: String
-          declaration: TypeDeclaration.TypeDeclaration }
-
-
-      module UserFunction =
-        type Parameter =
-          { name: String
-            typ: TypeReference
-            description: String }
-
-        type UserFunction =
-          { name: ProgramTypes.FnName.UserProgram
-            typeParams: List<String>
-            parameters: List<Parameter>
-            returnType: TypeReference
-            description: String
-            body: Expr }
-
-
-      type UserConstant =
-        { name: ProgramTypes.ConstantName.UserProgram
-          description: String
-          body: Const }
 
 
       module PackageFn =
         type Parameter =
-          { name: String
+          { sourceRange: SourceRange
+            name: String
             typ: TypeReference
-            description: String }
+          ///description: String
+          }
 
         type PackageFn =
-          { name: ProgramTypes.FnName.Package
-            body: Expr
-            typeParams: List<String>
+          { sourceRange: SourceRange
+            name: Name
+            //typeParams: List<String>
             parameters: List<Parameter>
             returnType: TypeReference
-            description: String }
+            body: Expr
+          ///description: String
+          }
 
-      type PackageType =
-        { name: ProgramTypes.TypeName.Package
-          declaration: TypeDeclaration.TypeDeclaration
-          description: String }
+      // type PackageType =
+      //   { name: ProgramTypes.TypeName.Package
+      //     declaration: TypeDeclaration.TypeDeclaration
+      //     description: String }
 
-      type PackageConstant =
-        { name: ProgramTypes.ConstantName.Package
-          body: Const
-          description: String }
+      // type PackageConstant =
+      //   { name: ProgramTypes.ConstantName.Package
+      //     body: Const
+      //     description: String }
+
+
+      type ParsedFile =
+        | PackageFunctions of SourceRange * fns: List<PackageFn.PackageFn>

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -9,52 +9,38 @@ module Darklang =
       type UnresolvedEnumTypeName = List<String>
 
       type LetPattern =
-        | LPUnit of PACKAGE.Darklang.LanguageTools.ID
-        | LPVariable of PACKAGE.Darklang.LanguageTools.ID * name: String
+        | LPUnit of ID
+        | LPVariable of ID * name: String
         | LPTuple of
-          PACKAGE.Darklang.LanguageTools.ID *
+          ID *
           first: LetPattern *
           second: LetPattern *
           theRest: List<LetPattern>
 
       type MatchPattern =
-        | MPUnit of PACKAGE.Darklang.LanguageTools.ID
-        | MPBool of PACKAGE.Darklang.LanguageTools.ID * Bool
-        | MPInt64 of PACKAGE.Darklang.LanguageTools.ID * Int64
-        | MPUInt64 of PACKAGE.Darklang.LanguageTools.ID * UInt64
-        | MPInt8 of PACKAGE.Darklang.LanguageTools.ID * Int8
-        | MPUInt8 of PACKAGE.Darklang.LanguageTools.ID * UInt8
-        | MPInt16 of PACKAGE.Darklang.LanguageTools.ID * Int16
-        | MPUInt16 of PACKAGE.Darklang.LanguageTools.ID * UInt16
-        | MPInt32 of PACKAGE.Darklang.LanguageTools.ID * Int32
-        | MPUInt32 of PACKAGE.Darklang.LanguageTools.ID * UInt32
-        | MPInt128 of PACKAGE.Darklang.LanguageTools.ID * Int128
-        | MPUInt128 of PACKAGE.Darklang.LanguageTools.ID * UInt128
-        | MPFloat of
-          PACKAGE.Darklang.LanguageTools.ID *
-          PACKAGE.Darklang.LanguageTools.Sign *
-          String *
-          String
-        | MPChar of PACKAGE.Darklang.LanguageTools.ID * String
-        | MPString of PACKAGE.Darklang.LanguageTools.ID * String
+        | MPUnit of ID
+        | MPBool of ID * Bool
+        | MPInt64 of ID * Int64
+        | MPUInt64 of ID * UInt64
+        | MPInt8 of ID * Int8
+        | MPUInt8 of ID * UInt8
+        | MPInt16 of ID * Int16
+        | MPUInt16 of ID * UInt16
+        | MPInt32 of ID * Int32
+        | MPUInt32 of ID * UInt32
+        | MPInt128 of ID * Int128
+        | MPUInt128 of ID * UInt128
+        | MPFloat of ID * Sign * String * String
+        | MPChar of ID * String
+        | MPString of ID * String
 
-        | MPList of PACKAGE.Darklang.LanguageTools.ID * List<MatchPattern>
-        | MPListCons of
-          PACKAGE.Darklang.LanguageTools.ID *
-          head: MatchPattern *
-          tail: MatchPattern
-        | MPTuple of
-          PACKAGE.Darklang.LanguageTools.ID *
-          MatchPattern *
-          MatchPattern *
-          List<MatchPattern>
+        | MPList of ID * List<MatchPattern>
+        | MPListCons of ID * head: MatchPattern * tail: MatchPattern
+        | MPTuple of ID * MatchPattern * MatchPattern * List<MatchPattern>
 
-        | MPVariable of PACKAGE.Darklang.LanguageTools.ID * String
+        | MPVariable of ID * String
 
-        | MPEnum of
-          PACKAGE.Darklang.LanguageTools.ID *
-          caseName: String *
-          fieldPats: List<MatchPattern>
+        | MPEnum of ID * caseName: String * fieldPats: List<MatchPattern>
 
       type BinaryOperation =
         | BinOpAnd
@@ -114,29 +100,26 @@ module Darklang =
         | StringInterpolation of Expr
 
       type PipeExpr =
-        | EPipeInfix of PACKAGE.Darklang.LanguageTools.ID * Infix * Expr
-        | EPipeLambda of
-          PACKAGE.Darklang.LanguageTools.ID *
-          pats: List<LetPattern> *
-          body: Expr
+        | EPipeInfix of ID * Infix * Expr
+        | EPipeLambda of ID * pats: List<LetPattern> * body: Expr
 
         | EPipeEnum of
-          PACKAGE.Darklang.LanguageTools.ID *
+          ID *
           typeName: UnresolvedEnumTypeName *
           caseName: String *
           fields: List<Expr>
 
         | EPipeFnCall of
-          PACKAGE.Darklang.LanguageTools.ID *
+          ID *
           fnName: Name *
           typeArgs: List<TypeReference> *
           args: List<Expr>
 
-        | EPipeVariableOrUserFunction of PACKAGE.Darklang.LanguageTools.ID * String
+        | EPipeVariableOrUserFunction of ID * String
 
       type MatchCase =
         { pat: MatchPattern
-          whenCondition: PACKAGE.Darklang.Stdlib.Option.Option<Expr>
+          whenCondition: Stdlib.Option.Option<Expr>
           rhs: Expr }
 
       type Expr =
@@ -199,7 +182,7 @@ module Darklang =
         | CUInt32 of UInt32
         | CInt128 of Int128
         | CUInt128 of UInt128
-        | CFloat of PACKAGE.Darklang.LanguageTools.Sign * String * String
+        | CFloat of Sign * String * String
         | CChar of Char
         | CString of String
         | CList of List<Const>
@@ -215,7 +198,7 @@ module Darklang =
 
         type EnumField =
           { typ: TypeReference
-            label: PACKAGE.Darklang.Stdlib.Option.Option<String>
+            label: Stdlib.Option.Option<String>
             description: String }
 
         type EnumCase =
@@ -256,7 +239,7 @@ module Darklang =
           typ: TypeReference }
 
       type UserType =
-        { name: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.UserProgram
+        { name: ProgramTypes.TypeName.UserProgram
           description: String
           declaration: TypeDeclaration.TypeDeclaration }
 
@@ -268,7 +251,7 @@ module Darklang =
             description: String }
 
         type UserFunction =
-          { name: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.UserProgram
+          { name: ProgramTypes.FnName.UserProgram
             typeParams: List<String>
             parameters: List<Parameter>
             returnType: TypeReference
@@ -277,7 +260,7 @@ module Darklang =
 
 
       type UserConstant =
-        { name: PACKAGE.Darklang.LanguageTools.ProgramTypes.ConstantName.UserProgram
+        { name: ProgramTypes.ConstantName.UserProgram
           description: String
           body: Const }
 
@@ -289,7 +272,7 @@ module Darklang =
             description: String }
 
         type PackageFn =
-          { name: PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Package
+          { name: ProgramTypes.FnName.Package
             body: Expr
             typeParams: List<String>
             parameters: List<Parameter>
@@ -297,11 +280,11 @@ module Darklang =
             description: String }
 
       type PackageType =
-        { name: PACKAGE.Darklang.LanguageTools.ProgramTypes.TypeName.Package
+        { name: ProgramTypes.TypeName.Package
           declaration: TypeDeclaration.TypeDeclaration
           description: String }
 
       type PackageConstant =
-        { name: PACKAGE.Darklang.LanguageTools.ProgramTypes.ConstantName.Package
+        { name: ProgramTypes.ConstantName.Package
           body: Const
           description: String }

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -72,7 +72,7 @@ module.exports = grammar({
 
     // Basics
     unit: $ => "()",
-    type: $ => choice(/Int/, /Bool/, /Float/, /String/, /Char/),
+    type: $ => choice(/Unit/, /Int/, /Bool/, /Float/, /String/, /Char/),
     identifier: $ => /[a-zA-Z_][a-zA-Z0-9_]*/,
   },
 });

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -289,6 +289,10 @@
       "members": [
         {
           "type": "PATTERN",
+          "value": "Unit"
+        },
+        {
+          "type": "PATTERN",
           "value": "Int"
         },
         {

--- a/tree-sitter-darklang/src/parser.c
+++ b/tree-sitter-darklang/src/parser.c
@@ -8,9 +8,9 @@
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 82
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 33
+#define SYMBOL_COUNT 34
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 19
+#define TOKEN_COUNT 20
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 13
 #define MAX_ALIAS_SEQUENCE_LENGTH 7
@@ -34,21 +34,22 @@ enum {
   aux_sym_type_token3 = 15,
   aux_sym_type_token4 = 16,
   aux_sym_type_token5 = 17,
-  sym_identifier = 18,
-  sym_source_file = 19,
-  sym_fn_def = 20,
-  sym_fn_params_def = 21,
-  sym_fn_param_def = 22,
-  sym_expression = 23,
-  sym_let_expression = 24,
-  sym_function_call = 25,
-  sym_string_literal = 26,
-  sym_infix_operator = 27,
-  sym_infix_operation = 28,
-  sym_type = 29,
-  aux_sym_source_file_repeat1 = 30,
-  aux_sym_fn_params_def_repeat1 = 31,
-  aux_sym_function_call_repeat1 = 32,
+  aux_sym_type_token6 = 18,
+  sym_identifier = 19,
+  sym_source_file = 20,
+  sym_fn_def = 21,
+  sym_fn_params_def = 22,
+  sym_fn_param_def = 23,
+  sym_expression = 24,
+  sym_let_expression = 25,
+  sym_function_call = 26,
+  sym_string_literal = 27,
+  sym_infix_operator = 28,
+  sym_infix_operation = 29,
+  sym_type = 30,
+  aux_sym_source_file_repeat1 = 31,
+  aux_sym_fn_params_def_repeat1 = 32,
+  aux_sym_function_call_repeat1 = 33,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -70,6 +71,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_type_token3] = "type_token3",
   [aux_sym_type_token4] = "type_token4",
   [aux_sym_type_token5] = "type_token5",
+  [aux_sym_type_token6] = "type_token6",
   [sym_identifier] = "identifier",
   [sym_source_file] = "source_file",
   [sym_fn_def] = "fn_def",
@@ -106,6 +108,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_type_token3] = aux_sym_type_token3,
   [aux_sym_type_token4] = aux_sym_type_token4,
   [aux_sym_type_token5] = aux_sym_type_token5,
+  [aux_sym_type_token6] = aux_sym_type_token6,
   [sym_identifier] = sym_identifier,
   [sym_source_file] = sym_source_file,
   [sym_fn_def] = sym_fn_def,
@@ -193,6 +196,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_type_token5] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_type_token6] = {
     .visible = false,
     .named = false,
   },
@@ -367,9 +374,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [31] = 25,
   [32] = 18,
   [33] = 30,
-  [34] = 29,
+  [34] = 34,
   [35] = 35,
-  [36] = 36,
+  [36] = 29,
   [37] = 37,
   [38] = 37,
   [39] = 17,
@@ -422,436 +429,481 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(27);
-      if (lookahead == '"') ADVANCE(37);
-      if (lookahead == '(') ADVANCE(32);
-      if (lookahead == ')') ADVANCE(33);
-      if (lookahead == '+') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == ':') ADVANCE(30);
-      if (lookahead == '=') ADVANCE(31);
-      if (lookahead == 'B') ADVANCE(64);
-      if (lookahead == 'C') ADVANCE(57);
-      if (lookahead == 'F') ADVANCE(60);
-      if (lookahead == 'I') ADVANCE(63);
-      if (lookahead == 'S') ADVANCE(69);
-      if (lookahead == 'i') ADVANCE(61);
-      if (lookahead == 'l') ADVANCE(55);
+      if (eof) ADVANCE(30);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '(') ADVANCE(35);
+      if (lookahead == ')') ADVANCE(36);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(44);
+      if (lookahead == ':') ADVANCE(33);
+      if (lookahead == '=') ADVANCE(34);
+      if (lookahead == 'B') ADVANCE(71);
+      if (lookahead == 'C') ADVANCE(62);
+      if (lookahead == 'F') ADVANCE(66);
+      if (lookahead == 'I') ADVANCE(70);
+      if (lookahead == 'S') ADVANCE(76);
+      if (lookahead == 'U') ADVANCE(67);
+      if (lookahead == 'i') ADVANCE(68);
+      if (lookahead == 'l') ADVANCE(60);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(36);
-      if (lookahead == '"') ADVANCE(37);
+      if (lookahead == '\n') ADVANCE(39);
+      if (lookahead == '"') ADVANCE(40);
       if (lookahead == '(') ADVANCE(3);
-      if (lookahead == '+') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'i') ADVANCE(61);
-      if (lookahead == 'l') ADVANCE(55);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(44);
+      if (lookahead == 'i') ADVANCE(68);
+      if (lookahead == 'l') ADVANCE(60);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(1)
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(36);
-      if (lookahead == '+') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'i') ADVANCE(13);
+      if (lookahead == '\n') ADVANCE(39);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(44);
+      if (lookahead == 'i') ADVANCE(15);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
-      if (lookahead == ')') ADVANCE(42);
+      if (lookahead == ')') ADVANCE(45);
       END_STATE();
     case 4:
-      if (lookahead == 'a') ADVANCE(19);
+      if (lookahead == 'a') ADVANCE(20);
       END_STATE();
     case 5:
-      if (lookahead == 'a') ADVANCE(23);
+      if (lookahead == 'a') ADVANCE(26);
       END_STATE();
     case 6:
-      if (lookahead == 'e') ADVANCE(22);
+      if (lookahead == 'e') ADVANCE(24);
       END_STATE();
     case 7:
-      if (lookahead == 'g') ADVANCE(49);
+      if (lookahead == 'g') ADVANCE(54);
       END_STATE();
     case 8:
       if (lookahead == 'h') ADVANCE(4);
       END_STATE();
     case 9:
-      if (lookahead == 'i') ADVANCE(12);
+      if (lookahead == 'i') ADVANCE(14);
       END_STATE();
     case 10:
-      if (lookahead == 'l') ADVANCE(45);
+      if (lookahead == 'i') ADVANCE(25);
       END_STATE();
     case 11:
-      if (lookahead == 'l') ADVANCE(17);
+      if (lookahead == 'l') ADVANCE(50);
       END_STATE();
     case 12:
-      if (lookahead == 'n') ADVANCE(7);
+      if (lookahead == 'l') ADVANCE(19);
       END_STATE();
     case 13:
-      if (lookahead == 'n') ADVANCE(34);
+      if (lookahead == 'n') ADVANCE(10);
       END_STATE();
     case 14:
-      if (lookahead == 'n') ADVANCE(21);
+      if (lookahead == 'n') ADVANCE(7);
       END_STATE();
     case 15:
-      if (lookahead == 'o') ADVANCE(16);
+      if (lookahead == 'n') ADVANCE(37);
       END_STATE();
     case 16:
-      if (lookahead == 'o') ADVANCE(10);
+      if (lookahead == 'n') ADVANCE(23);
       END_STATE();
     case 17:
-      if (lookahead == 'o') ADVANCE(5);
+      if (lookahead == 'o') ADVANCE(18);
       END_STATE();
     case 18:
-      if (lookahead == 'r') ADVANCE(9);
+      if (lookahead == 'o') ADVANCE(11);
       END_STATE();
     case 19:
-      if (lookahead == 'r') ADVANCE(51);
+      if (lookahead == 'o') ADVANCE(5);
       END_STATE();
     case 20:
-      if (lookahead == 't') ADVANCE(18);
+      if (lookahead == 'r') ADVANCE(56);
       END_STATE();
     case 21:
-      if (lookahead == 't') ADVANCE(43);
+      if (lookahead == 'r') ADVANCE(9);
       END_STATE();
     case 22:
-      if (lookahead == 't') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(21);
       END_STATE();
     case 23:
-      if (lookahead == 't') ADVANCE(47);
+      if (lookahead == 't') ADVANCE(48);
       END_STATE();
     case 24:
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(24)
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (lookahead == 't') ADVANCE(31);
       END_STATE();
     case 25:
-      if (eof) ADVANCE(27);
-      if (lookahead == '"') ADVANCE(37);
-      if (lookahead == '(') ADVANCE(3);
-      if (lookahead == '+') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'l') ADVANCE(55);
+      if (lookahead == 't') ADVANCE(46);
+      END_STATE();
+    case 26:
+      if (lookahead == 't') ADVANCE(52);
+      END_STATE();
+    case 27:
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(25)
+          lookahead == ' ') SKIP(27)
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 26:
-      if (eof) ADVANCE(27);
-      if (lookahead == '+') ADVANCE(40);
-      if (lookahead == '-') ADVANCE(41);
-      if (lookahead == 'B') ADVANCE(15);
+    case 28:
+      if (eof) ADVANCE(30);
+      if (lookahead == '"') ADVANCE(40);
+      if (lookahead == '(') ADVANCE(3);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(44);
+      if (lookahead == 'l') ADVANCE(60);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(28)
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 29:
+      if (eof) ADVANCE(30);
+      if (lookahead == '+') ADVANCE(43);
+      if (lookahead == '-') ADVANCE(44);
+      if (lookahead == 'B') ADVANCE(17);
       if (lookahead == 'C') ADVANCE(8);
-      if (lookahead == 'F') ADVANCE(11);
-      if (lookahead == 'I') ADVANCE(14);
-      if (lookahead == 'S') ADVANCE(20);
+      if (lookahead == 'F') ADVANCE(12);
+      if (lookahead == 'I') ADVANCE(16);
+      if (lookahead == 'S') ADVANCE(22);
+      if (lookahead == 'U') ADVANCE(13);
       if (lookahead == 'l') ADVANCE(6);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(26)
-      END_STATE();
-    case 27:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 28:
-      ACCEPT_TOKEN(anon_sym_let);
-      END_STATE();
-    case 29:
-      ACCEPT_TOKEN(anon_sym_let);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          lookahead == ' ') SKIP(29)
       END_STATE();
     case 30:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(anon_sym_let);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      if (lookahead == ')') ADVANCE(42);
+      ACCEPT_TOKEN(anon_sym_let);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(anon_sym_in);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 35:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == ')') ADVANCE(45);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(anon_sym_in);
+      END_STATE();
+    case 38:
       ACCEPT_TOKEN(anon_sym_in);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 36:
+    case 39:
       ACCEPT_TOKEN(anon_sym_LF);
-      if (lookahead == '\n') ADVANCE(36);
+      if (lookahead == '\n') ADVANCE(39);
       END_STATE();
-    case 37:
+    case 40:
       ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
-    case 38:
+    case 41:
       ACCEPT_TOKEN(aux_sym_string_literal_token1);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(38);
+          lookahead == ' ') ADVANCE(41);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(39);
-      END_STATE();
-    case 39:
-      ACCEPT_TOKEN(aux_sym_string_literal_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(39);
-      END_STATE();
-    case 40:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      END_STATE();
-    case 41:
-      ACCEPT_TOKEN(anon_sym_DASH);
+          lookahead != '\n') ADVANCE(42);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(sym_unit);
+      ACCEPT_TOKEN(aux_sym_string_literal_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(42);
       END_STATE();
     case 43:
-      ACCEPT_TOKEN(aux_sym_type_token1);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 44:
+      ACCEPT_TOKEN(anon_sym_DASH);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(sym_unit);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(aux_sym_type_token1);
+      END_STATE();
+    case 47:
       ACCEPT_TOKEN(aux_sym_type_token1);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      END_STATE();
-    case 45:
-      ACCEPT_TOKEN(aux_sym_type_token2);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(aux_sym_type_token2);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(aux_sym_type_token3);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 48:
+      ACCEPT_TOKEN(aux_sym_type_token2);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(aux_sym_type_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(aux_sym_type_token3);
+      END_STATE();
+    case 51:
       ACCEPT_TOKEN(aux_sym_type_token3);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(aux_sym_type_token4);
-      END_STATE();
-    case 50:
-      ACCEPT_TOKEN(aux_sym_type_token4);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      END_STATE();
-    case 51:
-      ACCEPT_TOKEN(aux_sym_type_token5);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 52:
+      ACCEPT_TOKEN(aux_sym_type_token4);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(aux_sym_type_token4);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(aux_sym_type_token5);
+      END_STATE();
+    case 55:
       ACCEPT_TOKEN(aux_sym_type_token5);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(68);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(72);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(71);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(50);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      ACCEPT_TOKEN(aux_sym_type_token6);
       END_STATE();
     case 57:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'h') ADVANCE(53);
+      ACCEPT_TOKEN(aux_sym_type_token6);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(62);
+      if (lookahead == 'a') ADVANCE(74);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(46);
+      if (lookahead == 'a') ADVANCE(80);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(66);
+      if (lookahead == 'e') ADVANCE(78);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(35);
+      if (lookahead == 'g') ADVANCE(55);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(56);
+      if (lookahead == 'h') ADVANCE(58);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(70);
+      if (lookahead == 'i') ADVANCE(69);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     case 64:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(79);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(51);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(64);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(38);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(61);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(77);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(72);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      END_STATE();
+    case 72:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'o') ADVANCE(65);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 65:
+    case 73:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == 'o') ADVANCE(59);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 66:
+    case 74:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(54);
+      if (lookahead == 'r') ADVANCE(57);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 67:
+    case 75:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(58);
+      if (lookahead == 'r') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 68:
+    case 76:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(52);
+      if (lookahead == 't') ADVANCE(75);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 69:
+    case 77:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(67);
+      if (lookahead == 't') ADVANCE(49);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 70:
+    case 78:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(44);
+      if (lookahead == 't') ADVANCE(32);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 71:
+    case 79:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(29);
+      if (lookahead == 't') ADVANCE(47);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 72:
+    case 80:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(48);
+      if (lookahead == 't') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
-    case 73:
+    case 81:
       ACCEPT_TOKEN(sym_identifier);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
       END_STATE();
     default:
       return false;
@@ -860,87 +912,87 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 26},
+  [1] = {.lex_state = 29},
   [2] = {.lex_state = 1},
   [3] = {.lex_state = 1},
   [4] = {.lex_state = 1},
   [5] = {.lex_state = 1},
   [6] = {.lex_state = 1},
-  [7] = {.lex_state = 25},
-  [8] = {.lex_state = 25},
-  [9] = {.lex_state = 25},
-  [10] = {.lex_state = 25},
-  [11] = {.lex_state = 25},
-  [12] = {.lex_state = 25},
-  [13] = {.lex_state = 25},
-  [14] = {.lex_state = 25},
-  [15] = {.lex_state = 25},
-  [16] = {.lex_state = 25},
+  [7] = {.lex_state = 28},
+  [8] = {.lex_state = 28},
+  [9] = {.lex_state = 28},
+  [10] = {.lex_state = 28},
+  [11] = {.lex_state = 28},
+  [12] = {.lex_state = 28},
+  [13] = {.lex_state = 28},
+  [14] = {.lex_state = 28},
+  [15] = {.lex_state = 28},
+  [16] = {.lex_state = 28},
   [17] = {.lex_state = 1},
   [18] = {.lex_state = 1},
-  [19] = {.lex_state = 25},
-  [20] = {.lex_state = 25},
-  [21] = {.lex_state = 25},
-  [22] = {.lex_state = 25},
-  [23] = {.lex_state = 25},
-  [24] = {.lex_state = 25},
+  [19] = {.lex_state = 28},
+  [20] = {.lex_state = 28},
+  [21] = {.lex_state = 28},
+  [22] = {.lex_state = 28},
+  [23] = {.lex_state = 28},
+  [24] = {.lex_state = 28},
   [25] = {.lex_state = 1},
-  [26] = {.lex_state = 25},
-  [27] = {.lex_state = 25},
-  [28] = {.lex_state = 25},
+  [26] = {.lex_state = 28},
+  [27] = {.lex_state = 28},
+  [28] = {.lex_state = 28},
   [29] = {.lex_state = 1},
   [30] = {.lex_state = 1},
-  [31] = {.lex_state = 25},
-  [32] = {.lex_state = 25},
-  [33] = {.lex_state = 25},
-  [34] = {.lex_state = 25},
-  [35] = {.lex_state = 26},
-  [36] = {.lex_state = 26},
+  [31] = {.lex_state = 28},
+  [32] = {.lex_state = 28},
+  [33] = {.lex_state = 28},
+  [34] = {.lex_state = 29},
+  [35] = {.lex_state = 29},
+  [36] = {.lex_state = 28},
   [37] = {.lex_state = 2},
   [38] = {.lex_state = 2},
   [39] = {.lex_state = 2},
-  [40] = {.lex_state = 26},
+  [40] = {.lex_state = 29},
   [41] = {.lex_state = 2},
-  [42] = {.lex_state = 26},
-  [43] = {.lex_state = 26},
+  [42] = {.lex_state = 29},
+  [43] = {.lex_state = 29},
   [44] = {.lex_state = 0},
   [45] = {.lex_state = 2},
   [46] = {.lex_state = 2},
   [47] = {.lex_state = 0},
   [48] = {.lex_state = 0},
   [49] = {.lex_state = 2},
-  [50] = {.lex_state = 25},
+  [50] = {.lex_state = 28},
   [51] = {.lex_state = 2},
-  [52] = {.lex_state = 26},
-  [53] = {.lex_state = 26},
-  [54] = {.lex_state = 26},
-  [55] = {.lex_state = 26},
+  [52] = {.lex_state = 29},
+  [53] = {.lex_state = 29},
+  [54] = {.lex_state = 29},
+  [55] = {.lex_state = 29},
   [56] = {.lex_state = 0},
   [57] = {.lex_state = 0},
   [58] = {.lex_state = 0},
-  [59] = {.lex_state = 24},
-  [60] = {.lex_state = 38},
-  [61] = {.lex_state = 24},
+  [59] = {.lex_state = 27},
+  [60] = {.lex_state = 41},
+  [61] = {.lex_state = 27},
   [62] = {.lex_state = 0},
   [63] = {.lex_state = 0},
   [64] = {.lex_state = 0},
   [65] = {.lex_state = 0},
   [66] = {.lex_state = 0},
-  [67] = {.lex_state = 24},
+  [67] = {.lex_state = 27},
   [68] = {.lex_state = 0},
-  [69] = {.lex_state = 38},
+  [69] = {.lex_state = 41},
   [70] = {.lex_state = 0},
   [71] = {.lex_state = 0},
-  [72] = {.lex_state = 38},
+  [72] = {.lex_state = 41},
   [73] = {.lex_state = 0},
-  [74] = {.lex_state = 38},
+  [74] = {.lex_state = 41},
   [75] = {.lex_state = 0},
   [76] = {.lex_state = 0},
   [77] = {.lex_state = 0},
   [78] = {.lex_state = 0},
-  [79] = {.lex_state = 24},
-  [80] = {.lex_state = 24},
-  [81] = {.lex_state = 24},
+  [79] = {.lex_state = 27},
+  [80] = {.lex_state = 27},
+  [81] = {.lex_state = 27},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -961,6 +1013,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_type_token3] = ACTIONS(1),
     [aux_sym_type_token4] = ACTIONS(1),
     [aux_sym_type_token5] = ACTIONS(1),
+    [aux_sym_type_token6] = ACTIONS(1),
     [sym_identifier] = ACTIONS(1),
   },
   [1] = {
@@ -1516,6 +1569,26 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DASH,
       sym_unit,
   [726] = 2,
+    STATE(70), 1,
+      sym_type,
+    ACTIONS(99), 6,
+      aux_sym_type_token1,
+      aux_sym_type_token2,
+      aux_sym_type_token3,
+      aux_sym_type_token4,
+      aux_sym_type_token5,
+      aux_sym_type_token6,
+  [738] = 2,
+    STATE(64), 1,
+      sym_type,
+    ACTIONS(99), 6,
+      aux_sym_type_token1,
+      aux_sym_type_token2,
+      aux_sym_type_token3,
+      aux_sym_type_token4,
+      aux_sym_type_token5,
+      aux_sym_type_token6,
+  [750] = 2,
     ACTIONS(95), 2,
       anon_sym_let,
       sym_identifier,
@@ -1525,25 +1598,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS,
       anon_sym_DASH,
       sym_unit,
-  [738] = 2,
-    STATE(70), 1,
-      sym_type,
-    ACTIONS(99), 5,
-      aux_sym_type_token1,
-      aux_sym_type_token2,
-      aux_sym_type_token3,
-      aux_sym_type_token4,
-      aux_sym_type_token5,
-  [749] = 2,
-    STATE(64), 1,
-      sym_type,
-    ACTIONS(99), 5,
-      aux_sym_type_token1,
-      aux_sym_type_token2,
-      aux_sym_type_token3,
-      aux_sym_type_token4,
-      aux_sym_type_token5,
-  [760] = 4,
+  [762] = 4,
     ACTIONS(101), 1,
       anon_sym_in,
     ACTIONS(103), 1,
@@ -1553,7 +1608,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(83), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [774] = 4,
+  [776] = 4,
     ACTIONS(105), 1,
       anon_sym_in,
     ACTIONS(107), 1,
@@ -1563,7 +1618,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(83), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [788] = 4,
+  [790] = 4,
     ACTIONS(79), 1,
       anon_sym_in,
     ACTIONS(81), 1,
@@ -1573,7 +1628,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(83), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [802] = 2,
+  [804] = 2,
     STATE(26), 1,
       sym_infix_operator,
     ACTIONS(87), 4,
@@ -1581,7 +1636,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_let,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [812] = 4,
+  [814] = 4,
     ACTIONS(109), 1,
       anon_sym_in,
     ACTIONS(111), 1,
@@ -1591,7 +1646,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(83), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [826] = 3,
+  [828] = 3,
     STATE(26), 1,
       sym_infix_operator,
     ACTIONS(81), 2,
@@ -1600,7 +1655,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(93), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [838] = 3,
+  [840] = 3,
     STATE(26), 1,
       sym_infix_operator,
     ACTIONS(93), 2,
@@ -1609,7 +1664,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(113), 2,
       ts_builtin_sym_end,
       anon_sym_let,
-  [850] = 4,
+  [852] = 4,
     ACTIONS(115), 1,
       anon_sym_COLON,
     ACTIONS(117), 1,
@@ -1619,7 +1674,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(44), 2,
       sym_fn_param_def,
       aux_sym_fn_params_def_repeat1,
-  [864] = 3,
+  [866] = 3,
     ACTIONS(87), 1,
       anon_sym_LF,
     STATE(22), 1,
@@ -1628,7 +1683,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_in,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [876] = 4,
+  [878] = 4,
     ACTIONS(123), 1,
       anon_sym_in,
     ACTIONS(125), 1,
@@ -1638,7 +1693,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(83), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [890] = 4,
+  [892] = 4,
     ACTIONS(127), 1,
       anon_sym_COLON,
     ACTIONS(129), 1,
@@ -1648,7 +1703,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(44), 2,
       sym_fn_param_def,
       aux_sym_fn_params_def_repeat1,
-  [904] = 4,
+  [906] = 4,
     ACTIONS(129), 1,
       anon_sym_LPAREN,
     ACTIONS(131), 1,
@@ -1658,40 +1713,40 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(47), 2,
       sym_fn_param_def,
       aux_sym_fn_params_def_repeat1,
-  [918] = 2,
+  [920] = 2,
     ACTIONS(11), 1,
       anon_sym_LF,
     ACTIONS(9), 3,
       anon_sym_in,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [927] = 2,
+  [929] = 2,
     ACTIONS(133), 2,
       anon_sym_let,
       sym_identifier,
     ACTIONS(135), 2,
       anon_sym_DQUOTE,
       sym_unit,
-  [936] = 2,
+  [938] = 2,
     ACTIONS(97), 1,
       anon_sym_LF,
     ACTIONS(95), 3,
       anon_sym_in,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [945] = 1,
+  [947] = 1,
     ACTIONS(97), 4,
       ts_builtin_sym_end,
       anon_sym_let,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [952] = 1,
+  [954] = 1,
     ACTIONS(11), 4,
       ts_builtin_sym_end,
       anon_sym_let,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [959] = 3,
+  [961] = 3,
     ACTIONS(137), 1,
       ts_builtin_sym_end,
     ACTIONS(139), 1,
@@ -1699,7 +1754,7 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(54), 2,
       sym_fn_def,
       aux_sym_source_file_repeat1,
-  [970] = 3,
+  [972] = 3,
     ACTIONS(5), 1,
       anon_sym_let,
     ACTIONS(142), 1,
@@ -1707,89 +1762,89 @@ static const uint16_t ts_small_parse_table[] = {
     STATE(54), 2,
       sym_fn_def,
       aux_sym_source_file_repeat1,
-  [981] = 2,
+  [983] = 2,
     ACTIONS(146), 1,
       anon_sym_LPAREN,
     ACTIONS(144), 2,
       anon_sym_COLON,
       sym_unit,
-  [989] = 2,
+  [991] = 2,
     ACTIONS(150), 1,
       anon_sym_LPAREN,
     ACTIONS(148), 2,
       anon_sym_COLON,
       sym_unit,
-  [997] = 1,
+  [999] = 1,
     ACTIONS(152), 2,
       anon_sym_EQ,
       anon_sym_RPAREN,
-  [1002] = 1,
+  [1004] = 1,
     ACTIONS(154), 1,
       sym_identifier,
-  [1006] = 1,
+  [1008] = 1,
     ACTIONS(156), 1,
       aux_sym_string_literal_token1,
-  [1010] = 1,
+  [1012] = 1,
     ACTIONS(158), 1,
       sym_identifier,
-  [1014] = 1,
+  [1016] = 1,
     ACTIONS(160), 1,
       anon_sym_DQUOTE,
-  [1018] = 1,
+  [1020] = 1,
     ACTIONS(162), 1,
       anon_sym_DQUOTE,
-  [1022] = 1,
+  [1024] = 1,
     ACTIONS(164), 1,
       anon_sym_RPAREN,
-  [1026] = 1,
+  [1028] = 1,
     ACTIONS(166), 1,
       ts_builtin_sym_end,
-  [1030] = 1,
+  [1032] = 1,
     ACTIONS(168), 1,
       anon_sym_DQUOTE,
-  [1034] = 1,
+  [1036] = 1,
     ACTIONS(170), 1,
       sym_identifier,
-  [1038] = 1,
+  [1040] = 1,
     ACTIONS(172), 1,
       anon_sym_DQUOTE,
-  [1042] = 1,
+  [1044] = 1,
     ACTIONS(174), 1,
       aux_sym_string_literal_token1,
-  [1046] = 1,
+  [1048] = 1,
     ACTIONS(176), 1,
       anon_sym_EQ,
-  [1050] = 1,
+  [1052] = 1,
     ACTIONS(178), 1,
       anon_sym_EQ,
-  [1054] = 1,
+  [1056] = 1,
     ACTIONS(180), 1,
       aux_sym_string_literal_token1,
-  [1058] = 1,
+  [1060] = 1,
     ACTIONS(182), 1,
       anon_sym_COLON,
-  [1062] = 1,
+  [1064] = 1,
     ACTIONS(184), 1,
       aux_sym_string_literal_token1,
-  [1066] = 1,
+  [1068] = 1,
     ACTIONS(186), 1,
       anon_sym_COLON,
-  [1070] = 1,
+  [1072] = 1,
     ACTIONS(188), 1,
       anon_sym_EQ,
-  [1074] = 1,
+  [1076] = 1,
     ACTIONS(190), 1,
       anon_sym_EQ,
-  [1078] = 1,
+  [1080] = 1,
     ACTIONS(192), 1,
       anon_sym_EQ,
-  [1082] = 1,
+  [1084] = 1,
     ACTIONS(194), 1,
       sym_identifier,
-  [1086] = 1,
+  [1088] = 1,
     ACTIONS(196), 1,
       sym_identifier,
-  [1090] = 1,
+  [1092] = 1,
     ACTIONS(198), 1,
       sym_identifier,
 };
@@ -1829,52 +1884,52 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(33)] = 714,
   [SMALL_STATE(34)] = 726,
   [SMALL_STATE(35)] = 738,
-  [SMALL_STATE(36)] = 749,
-  [SMALL_STATE(37)] = 760,
-  [SMALL_STATE(38)] = 774,
-  [SMALL_STATE(39)] = 788,
-  [SMALL_STATE(40)] = 802,
-  [SMALL_STATE(41)] = 812,
-  [SMALL_STATE(42)] = 826,
-  [SMALL_STATE(43)] = 838,
-  [SMALL_STATE(44)] = 850,
-  [SMALL_STATE(45)] = 864,
-  [SMALL_STATE(46)] = 876,
-  [SMALL_STATE(47)] = 890,
-  [SMALL_STATE(48)] = 904,
-  [SMALL_STATE(49)] = 918,
-  [SMALL_STATE(50)] = 927,
-  [SMALL_STATE(51)] = 936,
-  [SMALL_STATE(52)] = 945,
-  [SMALL_STATE(53)] = 952,
-  [SMALL_STATE(54)] = 959,
-  [SMALL_STATE(55)] = 970,
-  [SMALL_STATE(56)] = 981,
-  [SMALL_STATE(57)] = 989,
-  [SMALL_STATE(58)] = 997,
-  [SMALL_STATE(59)] = 1002,
-  [SMALL_STATE(60)] = 1006,
-  [SMALL_STATE(61)] = 1010,
-  [SMALL_STATE(62)] = 1014,
-  [SMALL_STATE(63)] = 1018,
-  [SMALL_STATE(64)] = 1022,
-  [SMALL_STATE(65)] = 1026,
-  [SMALL_STATE(66)] = 1030,
-  [SMALL_STATE(67)] = 1034,
-  [SMALL_STATE(68)] = 1038,
-  [SMALL_STATE(69)] = 1042,
-  [SMALL_STATE(70)] = 1046,
-  [SMALL_STATE(71)] = 1050,
-  [SMALL_STATE(72)] = 1054,
-  [SMALL_STATE(73)] = 1058,
-  [SMALL_STATE(74)] = 1062,
-  [SMALL_STATE(75)] = 1066,
-  [SMALL_STATE(76)] = 1070,
-  [SMALL_STATE(77)] = 1074,
-  [SMALL_STATE(78)] = 1078,
-  [SMALL_STATE(79)] = 1082,
-  [SMALL_STATE(80)] = 1086,
-  [SMALL_STATE(81)] = 1090,
+  [SMALL_STATE(36)] = 750,
+  [SMALL_STATE(37)] = 762,
+  [SMALL_STATE(38)] = 776,
+  [SMALL_STATE(39)] = 790,
+  [SMALL_STATE(40)] = 804,
+  [SMALL_STATE(41)] = 814,
+  [SMALL_STATE(42)] = 828,
+  [SMALL_STATE(43)] = 840,
+  [SMALL_STATE(44)] = 852,
+  [SMALL_STATE(45)] = 866,
+  [SMALL_STATE(46)] = 878,
+  [SMALL_STATE(47)] = 892,
+  [SMALL_STATE(48)] = 906,
+  [SMALL_STATE(49)] = 920,
+  [SMALL_STATE(50)] = 929,
+  [SMALL_STATE(51)] = 938,
+  [SMALL_STATE(52)] = 947,
+  [SMALL_STATE(53)] = 954,
+  [SMALL_STATE(54)] = 961,
+  [SMALL_STATE(55)] = 972,
+  [SMALL_STATE(56)] = 983,
+  [SMALL_STATE(57)] = 991,
+  [SMALL_STATE(58)] = 999,
+  [SMALL_STATE(59)] = 1004,
+  [SMALL_STATE(60)] = 1008,
+  [SMALL_STATE(61)] = 1012,
+  [SMALL_STATE(62)] = 1016,
+  [SMALL_STATE(63)] = 1020,
+  [SMALL_STATE(64)] = 1024,
+  [SMALL_STATE(65)] = 1028,
+  [SMALL_STATE(66)] = 1032,
+  [SMALL_STATE(67)] = 1036,
+  [SMALL_STATE(68)] = 1040,
+  [SMALL_STATE(69)] = 1044,
+  [SMALL_STATE(70)] = 1048,
+  [SMALL_STATE(71)] = 1052,
+  [SMALL_STATE(72)] = 1056,
+  [SMALL_STATE(73)] = 1060,
+  [SMALL_STATE(74)] = 1064,
+  [SMALL_STATE(75)] = 1068,
+  [SMALL_STATE(76)] = 1072,
+  [SMALL_STATE(77)] = 1076,
+  [SMALL_STATE(78)] = 1080,
+  [SMALL_STATE(79)] = 1084,
+  [SMALL_STATE(80)] = 1088,
+  [SMALL_STATE(81)] = 1092,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -1954,7 +2009,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
   [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
   [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
   [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
   [166] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
   [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
@@ -1964,9 +2019,9 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
   [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
   [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
   [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
   [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
   [190] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
   [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),


### PR DESCRIPTION
I accidentally did a few things at once:
- removed IDs from `writtenTypes.dark` (I don't think we need them)
- removed PT.FnName.Package reference from writtenTypes.dark
- commented out parts of `writtenTypes` that `grammar.js` doesn't yet support (I think it makes sense to keep these roughly matching)
- add source text `Range`s to various nodes in WrittenTypes, to help with Syntax Highlighting, Completions, etc.


We'll probably have to add `Range`s in a few more places shortly to get complete syntax highlighting, but what's here should be enough to get both syntax highlighting and completions working at least _a bit_.