### PR TITLE
Prodexec security

### DIFF
--- a/containers/prodexec/run.sh
+++ b/containers/prodexec/run.sh
@@ -13,7 +13,7 @@ nohup chisel server --authfile /home/dark/auth.json --port "$DARK_CONFIG_PRODEXE
 
 
 # Set up ssh auth
-RUN echo "dark:$DARK_CONFIG_PRODEXEC_SSH_PASSWORD" | sudo chpasswd
+echo "dark:$DARK_CONFIG_PRODEXEC_SSH_PASSWORD" | sudo chpasswd
 sudo service ssh start
 
 

--- a/scripts/production/connect-to-prod-exec
+++ b/scripts/production/connect-to-prod-exec
@@ -3,6 +3,21 @@
 
 set -euo pipefail
 
+# To run commands in production, we run prodexec. For security, we don't keep it
+# running, just create it as needed and then delete the project when we're done.
+# Creating the service happens in terraform, so this script doesn't do it.
+
+# Check if the service is running
+output=$(gcloud run services list --region=us-central1 --filter="metadata.name=prodexec")
+if [[ $output == *"prodexec"* ]]; then
+  echo "Prodexec service running, continuing"
+else
+  echo "Prodexec service not running, you need to start it using terraform:"
+  echo "  $ cd tf"
+  echo "  $ terraform plan -var='create_resource=true' -out plan.out"
+  echo "  $ terraform apply plan.out"
+fi
+
 # we have a separate username and password for the chisel, HD server, and the ssh server
 username=$(gcloud secrets versions access latest --secret prodexec-chisel-username)
 password=$(gcloud secrets versions access latest --secret prodexec-chisel-password)
@@ -11,7 +26,13 @@ ssh_password=$(gcloud secrets versions access latest --secret prodexec-ssh-passw
 # Google won't let us reach the server unless we are authenticated
 header="Authorization: Bearer $(gcloud auth print-identity-token)"
 
+url=$(gcloud run services describe --region us-central1 prodexec --format="value(status.url)")
+
 sshpass -p "$ssh_password" \
   ssh \
-  -o ProxyCommand="chisel client --auth '$username:$password' --header '$header' https://prodexec-d4mr6gl3ia-uc.a.run.app stdio:%h:%p" \
+  -o ProxyCommand="chisel client --auth '$username:$password' --header '$header' '$url' stdio:%h:%p" \
  "dark@localhost"
+
+
+echo "We're done. Please delete prodexec when you're done."
+echo "  $ gcloud run services delete bwdserver"

--- a/tf/cloudrun.tf
+++ b/tf/cloudrun.tf
@@ -95,7 +95,14 @@ resource "google_cloud_run_v2_service" "bwdserver" {
   depends_on = [google_project_service.apis["run.googleapis.com"]]
 }
 
+variable "create_prodexec" {
+  description = "Whether to create prodexec or not"
+  type        = bool
+  default     = false
+}
+
 resource "google_cloud_run_v2_service" "prodexec" {
+  count = var.create_prodexec ? 1 : 0
   lifecycle {
     ignore_changes = [
       template[0].containers[0].image, client, client_version


### PR DESCRIPTION
Improve security for prodexec. Now instead of running all the time, we only run it when we use it. It does need to be addressable on the public internet with a url, but restrict the time there a lot (it's still behind google auth).