### PR TITLE
Real semantic tokenization (syntax highlighting) in lang. server

### DIFF
--- a/packages/darklang/json-rpc.dark
+++ b/packages/darklang/json-rpc.dark
@@ -273,17 +273,19 @@ module Darklang =
           (errorCode: Int64)
           (errorMessage: String)
           (errorData: Stdlib.Option.Option<Json>)
-          : String =
+          : Json =
           let errorDetailFeilds =
-            [ Some(("code", Json.Number errorCode))
-              Some(("message", Json.String errorMessage))
+            [ Stdlib.Option.Option.Some(
+                ("code", Json.Number(Stdlib.Int64.toFloat errorCode))
+              )
+              Stdlib.Option.Option.Some(("message", Json.String errorMessage))
               (errorData |> Stdlib.Option.map (fun data -> ("data", data))) ]
             |> Stdlib.Option.values
 
           let fields =
             [ (requestId |> Stdlib.Option.map (fun id -> ("id", requestIdToJson id)))
-              Some(("jsonrpc", Json.String "2.0"))
-              Some(("error", Json.Object errorDetailFeilds)) ]
+              Stdlib.Option.Option.Some(("jsonrpc", Json.String "2.0"))
+              Stdlib.Option.Option.Some(("error", Json.Object errorDetailFeilds)) ]
             |> Stdlib.Option.values
 
-          (Json.Object fields) |> Stdlib.AltJson.format
+          Json.Object fields

--- a/packages/darklang/languageServerProtocol/language/semanticToken.dark
+++ b/packages/darklang/languageServerProtocol/language/semanticToken.dark
@@ -4,6 +4,14 @@ module Darklang =
   module LanguageServerProtocol =
     module SemanticTokens =
 
+      // module TokenFormat =
+      //   type TokenFormat = | Relative
+
+      //   let toJson (f: TokenFormat) : Json =
+      //     match f with
+      //     | Relative -> Json.String "relative"
+
+
       /// This type doesn't directly correspond to any part of the LSP spec,
       /// but is a representation of the `data` represented in the `SemanticTokens` type,
       /// used when the client and server agree upon the `'relative'` `TokenFormat`.
@@ -370,10 +378,6 @@ module Darklang =
 
   //------- 'textDocument/semanticTokens' -----
 
-  export namespace TokenFormat {
-    export const Relative: 'relative' = 'relative';
-  }
-  export type TokenFormat = 'relative';
 
 
   /// @proposed

--- a/packages/darklang/languageServerProtocol/language/semanticToken.dark
+++ b/packages/darklang/languageServerProtocol/language/semanticToken.dark
@@ -4,6 +4,43 @@ module Darklang =
   module LanguageServerProtocol =
     module SemanticTokens =
 
+      /// This type doesn't directly correspond to any part of the LSP spec,
+      /// but is a representation of the `data` represented in the `SemanticTokens` type,
+      /// used when the client and server agree upon the `'relative'` `TokenFormat`.
+      ///
+      /// Note: our (Darklang's internal) use case does not yet use token modifiers,
+      /// so we have not tried to implement that here,
+      /// and hardcode "0" in the relevant `data` field parts.
+      module RelativeSemanticToken =
+        type RelativeSemanticToken<'TokenType> =
+          {
+            /// The difference in lines from the previous token
+            deltaLine: UInt64
+
+            /// The difference in characters (columns) from the previous token on the same line
+            /// , or from the start of the line if it's the first token on that line
+            deltaStart: UInt64
+
+            /// The length of the token
+            length: UInt64
+
+            /// The index in the `tokenTypes` array declared in the legend of the semantic token provider
+            tokenType: 'TokenType
+          }
+
+        /// Maps a `List<RelativeSemanticToken>` to a flat `List<UInt>` list
+        /// representing the semantic tokens, with five numbers per token.
+        let mapListToFlatDataForResult<'TokenType>
+          (typeToValue: 'TokenType -> UInt64)
+          (tokens: List<RelativeSemanticToken<'TokenType>>)
+          : List<UInt64> =
+          tokens
+          |> Stdlib.List.map (fun t ->
+            [ t.deltaLine; t.deltaStart; t.length; typeToValue t.tokenType; 0UL ])
+          |> Stdlib.List.flatten
+
+
+
       module SemanticTokensLegend =
         type SemanticTokensLegend =
           {
@@ -336,7 +373,6 @@ module Darklang =
   export namespace TokenFormat {
     export const Relative: 'relative' = 'relative';
   }
-
   export type TokenFormat = 'relative';
 
 

--- a/packages/darklang/languageServerProtocol/language/semanticToken.dark
+++ b/packages/darklang/languageServerProtocol/language/semanticToken.dark
@@ -19,13 +19,19 @@ module Darklang =
       /// Note: our (Darklang's internal) use case does not yet use token modifiers,
       /// so we have not tried to implement that here,
       /// and hardcode "0" in the relevant `data` field parts.
+      ///
+      /// Note: the deltaLine and deltaStart fields are relative to the
+      /// _start_ of the previous token, not the end of it. This can be
+      /// surprising, but allows for overlapping tokens, which may be present
+      /// in some languages.
       module RelativeSemanticToken =
         type RelativeSemanticToken<'TokenType> =
           {
-            /// The difference in lines from the previous token
+            /// The difference in lines from the start of the previous token
             deltaLine: UInt64
 
-            /// The difference in characters (columns) from the previous token on the same line
+            /// The difference in characters (columns)
+            /// from the start of the previous token on the same line
             /// , or from the start of the line if it's the first token on that line
             deltaStart: UInt64
 

--- a/packages/darklang/languageServerProtocol/language/semanticToken.dark
+++ b/packages/darklang/languageServerProtocol/language/semanticToken.dark
@@ -24,7 +24,7 @@ module Darklang =
             /// The length of the token
             length: UInt64
 
-            /// The index in the `tokenTypes` array declared in the legend of the semantic token provider
+            /// The type of semantic token (i.e. keyword, string, operator, etc.)
             tokenType: 'TokenType
           }
 

--- a/packages/darklang/languageTools/lsp-server/docSync.dark
+++ b/packages/darklang/languageTools/lsp-server/docSync.dark
@@ -69,9 +69,11 @@ module Darklang =
 
         let handleTextDocumentDidClose
           (state: LspState)
-          (request:
+          (requestParams:
             LanguageServerProtocol.DocumentSync.TextDocument.DidCloseTextDocumentNotification.DidCloseTextDocumentParams.DidCloseTextDocumentParams)
           : LspState =
           { state with
               documentsInScope =
-                Stdlib.Dict.remove state.documentsInScope parsed.textDocument.uri }
+                Stdlib.Dict.remove
+                  state.documentsInScope
+                  requestParams.textDocument.uri }

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -17,6 +17,51 @@ module Darklang =
         let tokenModifiers = []
 
 
+        // (for quick reference while this is in progress)
+        // let double (i: Int) : Int = i + i
+        module WrittenTypesToRelativeSemanticTokens =
+          module TokenType =
+            type TokenType =
+              | Keyword
+              | Function
+              | Parameter
+              | Type
+              | String
+              | Operator
+              | Variable
+
+            let toUInt (t: TokenType) : UInt64 =
+              match t with
+              | Keyword -> 0UL
+              | Function -> 1UL
+              | Parameter -> 2UL
+              | Type -> 3UL
+              | String -> 4UL
+              | Operator -> 5UL
+              | Variable -> 6UL
+
+          module DarkToken =
+            type DarkToken =
+              LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken<TokenType.TokenType>
+
+            let mapListToFlatDataForResult (tokens: List<DarkToken>) : List<UInt64> =
+              LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.mapListToFlatDataForResult<TokenType.TokenType>
+                TokenType.toUInt
+                tokens
+
+          let mapParsedFile
+            (wt: WrittenTypes.ParsedFile)
+            : List<DarkToken.DarkToken> =
+            match wt with
+            | PackageFunctions(_, fns) ->
+              // TODO: make this real
+              [ DarkToken.DarkToken
+                  { deltaLine = 0UL
+                    deltaStart = 0UL
+                    length = 3UL
+                    tokenType = TokenType.TokenType.Keyword } ]
+
+
         let hardcodedServerCapabilities
           ()
           : LanguageServerProtocol.SemanticTokens.SemanticTokenProviderOptions.SemanticTokenProviderOptions =
@@ -45,246 +90,61 @@ module Darklang =
         let handleSemanticTokensRequest
           (state: LspState)
           (requestId: JsonRPC.RequestId)
-          (_requestParams:
+          (requestParams:
             LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensParams.SemanticTokensParams)
           : LspState =
-          // TODO: prepare and return a 'real' response,
-          // mapping from WrittenTypes
-          let bogusResponse =
-            LanguageServerProtocol
-              .SemanticTokens
-              .SemanticTokensRequest
-              .SemanticTokensResult
-              .SemanticTokensResult
-              .SemanticTokens(
-                LanguageServerProtocol.SemanticTokens.SemanticTokens.SemanticTokens
-                  { resultId = Stdlib.Option.Option.None
-                    data =
-                      [
-                        // Reported tokens are all in a big list of UInts -- five #s per reported token.
-                        // The following translates to:
+          let relevantDoc =
+            Stdlib.Dict.get state.documentsInScope requestParams.textDocument.uri
 
-                        //                    the first token, ...
-                        0UL // (deltaLine)      starts 0 lines after the previous token
-                        0UL // (deltaStart)     starts 0 characters after the previous token
-                        3UL // (length)         is 3 characters long
-                        0UL // (tokenType)      is a keyword (in the `initialize` handshake, "keyword" is the 0th token type we declared)
-                        0UL // (tokenModifiers) has no modifiers
-                        //                      ^ _would_ be a bit-wise representation of the modifiers, but we have none
-
-                        // (the .dark file that I've been testing against starts with the word `let` so this works out well)
-                        ] }
-              )
-
-          let bogusResponseJson =
-            bogusResponse
-            |> LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensResult.toJson
-            |> (fun r ->
-              JsonRPC.Response.Ok.make (Stdlib.Option.Option.Some requestId) r)
+          match relevantDoc with
+          | None ->
+            (JsonRPC.Response.Error.make
+              (Stdlib.Option.Option.Some requestId)
+              JsonRPC.Response.Error.KnownErrorCodes.internalError
+              $"Failed to find document text in language server's cache: {requestParams.textDocument.uri}"
+              Stdlib.Option.Option.None)
             |> Stdlib.AltJson.format
+            |> logAndSendToClient
 
-          logAndSendToClient bogusResponseJson
+          | Some docText ->
+            let parsed =
+              docText |> Parser.parse |> Parser.parseNodeToWrittenTypesSourceFile
+
+            match parsed with
+            | Ok parsedFile ->
+              let data =
+                parsedFile
+                |> WrittenTypesToRelativeSemanticTokens.mapParsedFile
+                |> WrittenTypesToRelativeSemanticTokens.DarkToken.mapListToFlatDataForResult
+
+              let result =
+                LanguageServerProtocol
+                  .SemanticTokens
+                  .SemanticTokensRequest
+                  .SemanticTokensResult
+                  .SemanticTokensResult
+                  .SemanticTokens(
+                    LanguageServerProtocol.SemanticTokens.SemanticTokens.SemanticTokens
+                      { resultId = Stdlib.Option.Option.None
+                        data = data }
+                  )
+
+              let resultJson =
+                result
+                |> LanguageServerProtocol.SemanticTokens.SemanticTokensRequest.SemanticTokensResult.toJson
+                |> (fun r ->
+                  JsonRPC.Response.Ok.make (Stdlib.Option.Option.Some requestId) r)
+                |> Stdlib.AltJson.format
+
+              logAndSendToClient resultJson
+
+            | Error parseError ->
+              (JsonRPC.Response.Error.make
+                (Stdlib.Option.Option.Some requestId)
+                JsonRPC.Response.Error.KnownErrorCodes.internalError
+                $"Couldn't parse code for syntax highlighting: {requestParams.textDocument.uri}"
+                Stdlib.Option.Option.None)
+              |> Stdlib.AltJson.format
+              |> logAndSendToClient
 
           state
-
-
-(*
-// following are attempts at semantic-tree-ifying our parsed code, to be highlighted by VS Code
-
-// v1 - this is ChatGPT-generated, largely, and is kinda broken but proved the point
-// connection.onRequest(
-//   SemanticTokensRequest.type,
-//   ({ textDocument }): SemanticTokens => {
-//     const tokens: number[] = [];
-//     let lastLine = 0;
-//     let lastStartChar = 0;
-
-//     const encodeToken = (
-//       line: number,
-//       startChar: number,
-//       length: number,
-//       tokenType: number,
-//     ) => {
-//       const deltaLine = line - lastLine;
-//       const deltaStart =
-//         deltaLine === 0 ? startChar - lastStartChar : startChar;
-
-//       tokens.push(deltaLine, deltaStart, length, tokenType, 0); // Assuming no tokenModifiers for simplicity
-
-//       lastLine = line;
-//       lastStartChar = startChar + length;
-//     };
-
-//     console.log("Processing semantic tokens request");
-
-//     const content = documents.get(textDocument.uri)?.getText() || "";
-//     const tree = parser.parse(content);
-
-//     const processNode = (node: any) => {
-//       //console.log("processing node", node);
-//       const { type, startPosition, endPosition } = node;
-//       const line = startPosition.row;
-//       const startChar = startPosition.column;
-//       const length = endPosition.column - startPosition.column;
-
-//       switch (type) {
-//         case "let":
-//           encodeToken(line, startChar, length, 0);
-//           break;
-
-//         case "identifier":
-//           if (
-//             node.parent &&
-//             node.parent.type === "fn_def" &&
-//             node.parent.name === node
-//           ) {
-//             encodeToken(line, startChar, length, 1);
-//           } else {
-//             encodeToken(line, startChar, length, 6);
-//           }
-//           break;
-
-//         case "fn_param_def":
-//           encodeToken(line, startChar, length, 2);
-//           break;
-
-//         case "Int":
-//         case "Bool":
-//         case "Float":
-//         case "String":
-//         case "Char":
-//           encodeToken(line, startChar, length, 3);
-//           break;
-
-//         case "string_literal":
-//           encodeToken(line, startChar, length, 4);
-//           break;
-
-//         case "+":
-//         case "-":
-//           encodeToken(line, startChar, length, 5);
-//           break;
-
-//         default:
-//           break;
-//       }
-
-//       // Recurse through child nodes
-//       for (const child of node.children) {
-//         processNode(child);
-//       }
-//     };
-
-//     processNode(tree.rootNode);
-
-//     console.log("Encoded tokens:", tokens);
-//     return {
-//       data: tokens,
-//     };
-//   },
-// );
-
-// v2: _manually_ returning the tokens that we want, for the exact code of:
-//```
-//let add (a: Int) (b: Int): Int =
-//  let sum = a + b
-//  sum
-//```
-connection.onRequest(
-  SemanticTokensRequest.type,
-  ({ textDocument }): SemanticTokens => {
-    // our token types
-    // | 0 | keyword   | words 'let' and 'in'            |
-    // | 1 | function  | function names/identifiers      |
-    // | 2 | parameter | function parameter identifiers  |
-    // | 3 | type      | type names like Int, Bool, etc. |
-    // | 4 | string    | string literals                 |
-    // | 5 | operator  | operators like +, -             |
-    // | 6 | variable  | general identifiers             |
-
-    // code sample:
-    // ```fsharp
-    // let add (a: Int) (b: Int): Int =
-    //   let sum = a + b
-    //   sum
-    // ```
-
-    // | thing | ΔLine | ΔStart | length | type | modifier |
-    // |-------|-------|--------|--------|------|----------|
-    // | let   | 0     |      0 |      3 |    0 |        0 |
-    // | add   | 0     |      1 |      3 |    6 |        0 |
-    // | a     | ...   |        |        |      |          |
-    // | Int   |       |        |        |      |          |
-    // | b     |       |        |        |      |          |
-    // | Int   |       |        |        |      |          |
-    // | Int   |       |        |        |      |          |
-    // | let   |       |        |        |      |          |
-    // | sum   |       |        |        |      |          |
-    // | a     |       |        |        |      |          |
-    // | b     |       |        |        |      |          |
-    // | sum   |       |        |        |      |          |
-    // |       |       |        |        |      |          |
-
-    // deltaLine: The difference in lines from the previous token.
-    // deltaStart: The difference in characters (columns) from the previous token on the same line (or from the start of the line if it's the first token on that line).
-    // length: The length of the token.
-    // tokenType: The index in the token types array declared in the legend of the semantic token provider.
-    // tokenModifiers: A bitset representing the token modifiers. Each bit of the value represents an index in the token modifiers array declared in the legend of the semantic token provider.
-
-    // prettier-ignore
-    const tokens =
-      [ 0, 0, 3, 0, 0, // let
-        0, 1, 3, 6, 0. // add
-        // TODO: continue
-      ]
-
-    return {
-      data: tokens,
-    };
-  },
-);
-
-// vFuture TODO: in a future pass, use this tree to replace all the below syntax-highlighting logic
-// our parser includes a lot of things that _shouldn't_ be tokenized
-// (like `fn_def`s which are really just wrappers around other tokens)
-// , and the other tokens should use context such as "in a `fn_def`" to determine their type
-
-// TODO: typescriptify this
-// function simplifyTree(cursor: any): any {
-//   let children = [];
-
-//   if (cursor.gotoFirstChild()) {
-//     do {
-//       children.push(simplifyTree(cursor));
-//     } while (cursor.gotoNextSibling());
-
-//     cursor.gotoParent();
-//   }
-
-//   return {
-//     typ: cursor.nodeType,
-//     text: cursor.nodeText,
-//     fieldName: cursor.currentFieldName(),
-//     children: children,
-//     startPosition: cursor.startPosition,
-//     endPosition: cursor.endPosition,
-//   };
-// }
-//
-// connection.onRequest(
-//   SemanticTokensRequest.type,
-//   ({ textDocument }): SemanticTokens => {
-//     console.log("Processing semantic tokens request");
-//
-//     const content = documents.get(textDocument.uri)?.getText() || "";
-//     const tree = parser.parse(content);
-//
-//     let simpleTree = simplifyTree(tree.rootNode.walk());
-//     console.log("simpletree", simpleTree);
-//
-//     // TODO: continue
-//
-//     return { data: [] };
-//   },
-// );
-*)

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -53,12 +53,12 @@ module Darklang =
             |> (Stdlib.List.fold
               (([], Parser.Point { row = 0L; column = 0L }))
               (fun acc token ->
-                let (tokensSoFar, endOfLastToken) = acc
+                let (tokensSoFar, startOfLastToken) = acc
 
                 let (deltaLine, deltaStart) =
-                  match token.sourceRange.start.row - endOfLastToken.row with
+                  match token.sourceRange.start.row - startOfLastToken.row with
                   | 0L ->
-                    (0UL, token.sourceRange.start.column - endOfLastToken.column)
+                    (0UL, token.sourceRange.start.column - startOfLastToken.column)
                   | lineDiff -> (lineDiff, token.sourceRange.start.column)
 
                 let newToken =
@@ -73,7 +73,7 @@ module Darklang =
                         |> Builtin.unwrap
                       tokenType = token.tokenType }
 
-                (Stdlib.List.push tokensSoFar newToken, token.sourceRange.end_)))
+                (Stdlib.List.push tokensSoFar newToken, token.sourceRange.start)))
             |> Stdlib.Tuple2.first
             |> Stdlib.List.reverse
 

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -37,8 +37,20 @@ module Darklang =
           let toRelativeTokens
             (tokens: List<LanguageTools.SemanticTokens.SemanticToken>)
             : List<LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken<LanguageTools.SemanticTokens.TokenType>> =
-            (Stdlib.List.fold
-              tokens
+            tokens
+            |> Stdlib.List.sortByComparator_v0 (fun a b ->
+              // TODO: sort by rows, too
+              // TODO: handle equality?
+              if
+                Stdlib.Int64.lessThan
+                  a.sourceRange.start.column
+                  b.sourceRange.start.column
+              then
+                -1L
+              else
+                1L)
+            |> Builtin.unwrap
+            |> (Stdlib.List.fold
               (([], Parser.Point { row = 0L; column = 0L }))
               (fun acc token ->
                 let (tokensSoFar, endOfLastToken) = acc
@@ -61,8 +73,9 @@ module Darklang =
                         |> Builtin.unwrap
                       tokenType = token.tokenType }
 
-                (Stdlib.List.push tokensSoFar newToken, token.sourceRange)))
+                (Stdlib.List.push tokensSoFar newToken, token.sourceRange.end_)))
             |> Stdlib.Tuple2.first
+            |> Stdlib.List.reverse
 
 
           let toLspFormat

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -17,49 +17,62 @@ module Darklang =
         let tokenModifiers = []
 
 
-        // (for quick reference while this is in progress)
-        // let double (i: Int) : Int = i + i
-        module WrittenTypesToRelativeSemanticTokens =
-          module TokenType =
-            type TokenType =
-              | Keyword
-              | Function
-              | Parameter
-              | Type
-              | String
-              | Operator
-              | Variable
+        /// Maps from "exact" semantic tokens that try to remain ignorant of
+        /// the LSP's data format, into the UInt64-based format that the LSP
+        /// _does_ expect.
+        module EncodeSemanticTokens =
+          let tokenType
+            (t: Darklang.LanguageTools.SemanticTokens.TokenType)
+            : UInt64 =
+            match t with
+            | Keyword -> 0UL
+            | Function -> 1UL
+            | Parameter -> 2UL
+            | Type -> 3UL
+            | String -> 4UL
+            | Operator -> 5UL
+            | Variable -> 6UL
 
-            let toUInt (t: TokenType) : UInt64 =
-              match t with
-              | Keyword -> 0UL
-              | Function -> 1UL
-              | Parameter -> 2UL
-              | Type -> 3UL
-              | String -> 4UL
-              | Operator -> 5UL
-              | Variable -> 6UL
 
-          module DarkToken =
-            type DarkToken =
-              LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken<TokenType.TokenType>
+          let toRelativeTokens
+            (tokens: List<LanguageTools.SemanticTokens.SemanticToken>)
+            : List<LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken<LanguageTools.SemanticTokens.TokenType>> =
+            (Stdlib.List.fold
+              tokens
+              (([], Parser.Point { row = 0L; column = 0L }))
+              (fun acc token ->
+                let (tokensSoFar, endOfLastToken) = acc
 
-            let mapListToFlatDataForResult (tokens: List<DarkToken>) : List<UInt64> =
-              LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.mapListToFlatDataForResult<TokenType.TokenType>
-                TokenType.toUInt
-                tokens
+                let (deltaLine, deltaStart) =
+                  match token.sourceRange.start.row - endOfLastToken.row with
+                  | 0L ->
+                    (0UL, token.sourceRange.start.column - endOfLastToken.column)
+                  | lineDiff -> (lineDiff, token.sourceRange.start.column)
 
-          let mapParsedFile
-            (wt: WrittenTypes.ParsedFile)
-            : List<DarkToken.DarkToken> =
-            match wt with
-            | PackageFunctions(_, fns) ->
-              // TODO: make this real
-              [ DarkToken.DarkToken
-                  { deltaLine = 0UL
-                    deltaStart = 0UL
-                    length = 3UL
-                    tokenType = TokenType.TokenType.Keyword } ]
+                let newToken =
+                  LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken //<LanguageTools.SemanticTokens.TokenType>
+                    { deltaLine = deltaLine
+                      deltaStart =
+                        deltaStart |> Stdlib.UInt64.fromInt64 |> Builtin.unwrap
+                      length =
+                        (token.sourceRange.end_.column
+                         - token.sourceRange.start.column)
+                        |> Stdlib.UInt64.fromInt64
+                        |> Builtin.unwrap
+                      tokenType = token.tokenType }
+
+                (Stdlib.List.push tokensSoFar newToken, token.sourceRange)))
+            |> Stdlib.Tuple2.first
+
+
+          let toLspFormat
+            (tokens:
+              List<LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken>)
+            : List<UInt64> =
+            LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.mapListToFlatDataForResult<Darklang.LanguageTools.SemanticTokens.TokenType>
+              (fun t -> tokenType t)
+              tokens
+
 
 
         let hardcodedServerCapabilities
@@ -114,8 +127,9 @@ module Darklang =
             | Ok parsedFile ->
               let data =
                 parsedFile
-                |> WrittenTypesToRelativeSemanticTokens.mapParsedFile
-                |> WrittenTypesToRelativeSemanticTokens.DarkToken.mapListToFlatDataForResult
+                |> LanguageTools.SemanticTokens.fromParsedFile
+                |> EncodeSemanticTokens.toRelativeTokens
+                |> EncodeSemanticTokens.toLspFormat
 
               let result =
                 LanguageServerProtocol

--- a/packages/darklang/languageTools/parser.dark
+++ b/packages/darklang/languageTools/parser.dark
@@ -1,6 +1,8 @@
 module Darklang =
   module LanguageTools =
     module Parser =
+      // TODO: these should be UInts of some size
+      // (UInt8 might even be enough - how many lines are over 255chars?)
       type Point = { row: Int64; column: Int64 }
 
       type Range = { start: Point; end_: Point }
@@ -25,7 +27,7 @@ module Darklang =
 
 
       let parse (text: String) : ParsedNode =
-        Builtins.LanguageTools.Parser.parse text
+        Builtin.Parser.parseToSimplifiedTree text
 
 
       // TODO: maybe re-frame this into expected/actual or something

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -33,15 +33,119 @@ module Darklang =
           tokenType: TokenType }
 
 
-      // TODO: lots more mappings...
 
-      let fromParsedFile (wt: WrittenTypes.ParsedFile) : List<SemanticToken> =
-        match wt with
-        | PackageFunctions(_, _fns) ->
-          // TODO: make this real
+      let fromName (name: WrittenTypes.Name) : List<SemanticToken> =
+        match name with
+        | Unresolved(range, _parts) ->
+          [ SemanticToken
+              { sourceRange = range
+                tokenType = TokenType.Variable } ]
+
+
+      let fromLetPattern (lp: WrittenTypes.LetPattern) : List<SemanticToken> =
+        // type LetPattern =
+        //   | LPVariable of SourceRange * name: String
+        []
+
+
+      let fromTypeReference (t: WrittenTypes.TypeReference) : List<SemanticToken> =
+        let tokenRange =
+          match t with
+          | TUnit r -> r
+          | TBool r -> r
+          | TInt64 r -> r
+          | TFloat r -> r
+          | TChar r -> r
+          | TString r -> r
+
+        [ SemanticToken
+            { sourceRange = tokenRange
+              tokenType = TokenType.Type } ]
+
+
+
+      let fromExpr (expr: WrittenTypes.Expr) : List<SemanticToken> =
+        // type Expr =
+        //   | EUnit of SourceRange
+        //   | EBool of SourceRange * Bool
+        //   | EInt64 of SourceRange * Int64
+        //   | EString of SourceRange * StringSegment
+
+        //   | ELet of SourceRange * LetPattern * Expr * Expr
+        //   | EVariable of SourceRange * String
+        //   | EFnName of Name
+        //   | EInfix of SourceRange * Infix * Expr * Expr
+        //   | EApply of
+        //     SourceRange *
+        //     Expr *
+        //     typeArgs: List<TypeReference> *
+        //     args: List<Expr>
+        []
+
+
+      /// assumptions:
+      /// - each param is not broken up with newlines
+      ///   (though newlines between them is OK)
+      ///
+      ///   if we want to allow for newlines in these defs,
+      ///   then we need to capture the sourceRange of the `name:String` as well
+      let fromPackageFnParam
+        (p: WrittenTypes.PackageFn.Parameter)
+        : List<SemanticToken> =
+        let namePart =
+          let namePartStart =
+            Parser.Point
+              { row = p.sourceRange.start.row
+                // skip the `(`
+                column = p.sourceRange.start.column + 1L }
+
+          let namePartEnd =
+            { namePartStart with
+                column = namePartStart.column + (Stdlib.String.length p.name) }
+
           [ SemanticToken
               { sourceRange =
                   Parser.Range
-                    { start = Parser.Point { row = 0L; column = 0L }
-                      end_ = Parser.Point { row = 0L; column = 3L } }
+                    { start = namePartStart
+                      end_ = namePartEnd }
+                tokenType = TokenType.Function } ]
+
+        let typePart = fromTypeReference p.typ
+
+        Stdlib.List.flatten [ namePart; typePart ]
+
+
+      let fromPackageFn
+        (fn: WrittenTypes.PackageFn.PackageFn)
+        : List<SemanticToken> =
+        let letParts =
+          [ SemanticToken
+              { sourceRange =
+                  Parser.Range
+                    { start = fn.sourceRange.start
+                      end_ =
+                        Parser.Point
+                          { row = fn.sourceRange.start.row
+                            column = fn.sourceRange.start.column + 3L } }
                 tokenType = TokenType.Keyword } ]
+
+        let nameParts = fromName fn.name
+
+        let paramsParts =
+          fn.parameters
+          |> Stdlib.List.map (fun p -> fromPackageFnParam p)
+          |> Stdlib.List.flatten
+
+        let returnTypeParts = fromTypeReference fn.returnType
+
+        let bodyParts = fromExpr fn.body
+
+        Stdlib.List.flatten
+          [ letParts; nameParts; paramsParts; returnTypeParts; bodyParts ]
+
+
+      let fromParsedFile (wt: WrittenTypes.ParsedFile) : List<SemanticToken> =
+        match wt with
+        | PackageFunctions(_, fns) ->
+          // the wrapper doesn't have any tokens itself
+          fns |> Stdlib.List.map (fun fn -> fromPackageFn fn) |> Stdlib.List.flatten

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -1,0 +1,47 @@
+module Darklang =
+  module LanguageTools =
+    module SemanticTokens =
+      // <aliases>
+      type SourceRange = Parser.Range
+      // <aliases>
+
+      type TokenType =
+        | Keyword
+        | Function
+        | Parameter
+        | Type
+        | String
+        | Operator
+        | Variable
+
+
+      /// The LSP[1] communicates in terms of 'relative' semantic tokens,
+      /// referring to 'deltas' of lines/characters since the previously-
+      /// mentioned token. It's a bit easier to think about and map to 'exact'
+      /// semantic tokens, though.
+      ///
+      /// [1] Semantic tokenization is currently only used for our language server,
+      /// which follows the Language Server Protocol. That said, it may prove useful
+      /// to tokenize for other reasons in the future and it's much easier to
+      /// tokenize into an intermediate format rather than mapping directly to the
+      /// data that the LSP expects.
+      ///
+      /// These tokens mean little without reference to a document where the
+      /// 'ranges' live within.
+      type SemanticToken =
+        { sourceRange: SourceRange
+          tokenType: TokenType }
+
+
+      // TODO: lots more mappings...
+
+      let fromParsedFile (wt: WrittenTypes.ParsedFile) : List<SemanticToken> =
+        match wt with
+        | PackageFunctions(_, _fns) ->
+          // TODO: make this real
+          [ SemanticToken
+              { sourceRange =
+                  Parser.Range
+                    { start = Parser.Point { row = 0L; column = 0L }
+                      end_ = Parser.Point { row = 0L; column = 3L } }
+                tokenType = TokenType.Keyword } ]

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -62,6 +62,7 @@ module Darklang =
       let toLowercase (s: String) : String = Builtin.String.toLowercase s
 
 
+      // TODO: UInt?
       /// Returns the length of the string
       let length (s: String) : Int64 = Builtin.String.length s
 

--- a/vscode-extension/client/src/extension.ts
+++ b/vscode-extension/client/src/extension.ts
@@ -38,6 +38,13 @@ export function activate(context: ExtensionContext) {
     traceOutputChannel: vscode.window.createOutputChannel(
       "Darklang LSP - Client",
     ),
+
+    // without this, VS Code will try to restart our extension 5 times,
+    // which can be really annoying while debugging
+    connectionOptions: {
+      cancellationStrategy: null,
+      maxRestartCount: 0,
+    },
   };
 
   // start the LSP client -- note: this will also launch the server


### PR DESCRIPTION
This implements syntax highlighting by way of LSP-powered semantic tokenization.

It's incomplete and doesn't handle errors, but real, written all in Darklang, and we can iterate well from here.
![image](https://github.com/darklang/dark/assets/906686/ad8cdbb0-e64f-4e67-b4a3-f29adb5a3140)

From this point, all frameworky stuff is complete, and relevant changes to semantic tokenization should be limited to only the types and fns in `Darklang.LanguageTools.SemanticTokens` (which is wholly ignorant of LSP and VS Code, and currently sits at < 200LOC)

---

Specifically, the language server:
- receives a request (`textDocument/semanticTokens/full`) for semantic tokenization, and extracts `requestParams.textDocument.uri` from the params
- from our language server's local store of text documents cached, fetches the text of the relevant one
  ```fsharp
  let relevantDoc =
    Stdlib.Dict.get state.documentsInScope requestParams.textDocument.uri
  ```
  e.g. `let double (i: Int) : Int = i + i`
- parses that text into `WrittenTypes` via `docText |> Parser.parse |> Parser.parseNodeToWrittenTypesSourceFile`
  e.g.
  ```
  WT.ParsedFile.PackageFunctions(
    range (0L, 0L) (0L, 33L),
    [ WT.PackageFn.PackageFn
        { sourceRange = range (0L, 0L) (0L, 33L)
          name =
            WT.Name.Unresolved(range (0L, 4L) (0L, 11L), [ "double" ])

          parameters =
            [ WT.PackageFn.Parameter
                { sourceRange = range (0L, 12L) (0L, 20L)
                  name = "i"
                  typ = WT.TypeReference.TInt64(range (0L, 16L) (0L, 19L)) } ]

          returnType =
            WT.TypeReference.TInt64(range (0L, 22L) (0L, 25L))

          body =
            WT.Expr.EInfix(
              range (0L, 28L) (0L, 33L),
              WT.Infix.InfixFnCall(WT.InfixFnName.ArithmeticPlus),
              WT.Expr.EVariable(range (0L, 28L) (0L, 29L), "i"),
              WT.Expr.EVariable(range (0L, 32L) (0L, 33L), "i")
            ) } ])
  ```
- from the `WrittenTypes` data, maps to LSP-ignorant, _absolute_ semantic tokens (`LanguageTools.SemanticTokens.fromParsedFile`)
  ```fsharp
  type TokenType =
      | Keyword | Function | Parameter | Type | String | Operator | Variable

  type SemanticToken =
    { sourceRange: SourceRange; tokenType: TokenType }
  ```
- maps from that to "relative semantic tokens" that match well with the response format that the LSP client expects (`EncodeSemanticTokens.toRelativeTokens`), without quite being so opaque as the eventual format
  ```fsharp
  type RelativeSemanticToken<'TokenType> =
    {
      deltaLine: UInt64
      deltaStart: UInt64
      length: UInt64
      tokenType: 'TokenType
    }
  ```
- sorts those tokens by position, and maps to the `List<UInt>` that the client expects (`EncodeSemanticTokens.toLspFormat`)
- returns that `data` in a response

---

In short:
- get document text (`let double (i: Int) : Int = i + i`)
- parse into `WrittenTypes.ParsedFile`
- map that to absolute semantic tokens, which just have "tokenType"+"sourceRange"
- sort those by location, and map to _relative_ semantic tokens
- flatten that data out into the list of UInts that the client expects


---

Big shortcomings:
- doesn't yet highlight everything that it should (mostly blocked by needed changes to the grammar)
- fails if we can't parse entirely.. which, as soon as you edit the code to something we can't parse, the extension crashes. I think that's a ParsedNode->WT problem more than anything, though.

to be followed up on in subsequent PRs