### PR TITLE
Fix running internal tests locally

### DIFF
--- a/backend/testfiles/execution/cloud/internal.dark
+++ b/backend/testfiles/execution/cloud/internal.dark
@@ -7,10 +7,7 @@ module Documentation =
   ) > 100L) = true
 
   ((Builtin.DarkInternal.Documentation.list_v0 ())
-   |> PACKAGE.Darklang.Stdlib.List.map (fun f -> (f.name, f))
-   |> PACKAGE.Darklang.Stdlib.Dict.fromList_v0
-   |> Builtin.unwrap
-   |> PACKAGE.Darklang.Stdlib.Dict.get "Int64.add"
+   |> PACKAGE.Darklang.Stdlib.List.findFirst (fun f -> f.name == "Int64.add")
    |> Builtin.unwrap
    |> (fun f -> f.parameters)) = [ PACKAGE.Darklang.Internal.Documentation.BuiltinFunctionParameter
                                      { name = "a"; ``type`` = "Int64" }


### PR DESCRIPTION
Fix internal tests :
We encountered a Stack Overflow error while using `List.map` on a long list. As a temporary solution, we have switched to using `List.findFirst` to address the issue.

Note : the tests were passing in CI but not locally (Release mode vs Debug mode)