### PR TITLE
Preserve CLI build artifacts in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,7 @@ jobs:
             - tree-sitter-darklang/build
           key: v4-cli-{{ checksum "../checksum" }}
       - store_artifacts: { path: rundir }
+      - store_artifacts: { path: clis }
       - store_test_results: { path: rundir/test_results }
       - slack-notify-job-failure
       - deploy-lock-remove-on-fail

--- a/scripts/build/dotnet-publish-all-clis.sh
+++ b/scripts/build/dotnet-publish-all-clis.sh
@@ -17,6 +17,7 @@ mkdir -p clis
 runtimes="linux-x64 linux-arm64"
 for rt in $runtimes; do
   echo "Building for runtime: $rt"
+
   ./scripts/build/_dotnet-wrapper publish \
     -c Release \
     src/Cli/Cli.fsproj \
@@ -27,7 +28,9 @@ for rt in $runtimes; do
     /p:PublishReadyToRun=false \
     --self-contained true \
     --runtime "$rt"
+
   target="clis/darklang-$release-$rt"
-  mv backend/Build/out/Cli/Release/net8.0/$rt/publish/Cli "$target"
+  echo "Moving to $target"
+  mv "backend/Build/out/Cli/Release/net8.0/$rt/publish/Cli" "$target"
   gzip "$target"
 done


### PR DESCRIPTION
I noticed that the CI artifacts of the `build-cli` step were empty - this fixes that.

edit: Ah, maybe this was intentional? Since each executable is ~12MB, I guess these could add up.
@pbiggar what do you think?