### PR TITLE
Fix semantic tokenization

### DIFF
--- a/backend/src/BuiltinExecution/Libs/NoModule.fs
+++ b/backend/src/BuiltinExecution/Libs/NoModule.fs
@@ -365,7 +365,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, _, [] -> incorrectArgs ()
-        | _, _, [ dval ] ->
+        | state, _, [ dval ] ->
           match dval with
 
           // success: extract `Some` out of an Option
@@ -397,7 +397,9 @@ let fns : List<BuiltInFn> =
                   _,
                   "None",
                   []) ->
-            raiseUntargetedRTE (RuntimeError.oldError "expected Some, got None")
+            "expected Some, got None"
+            |> RuntimeError.oldError
+            |> raiseRTE state.caller
 
           // Error: expected Ok, got Error
           | DEnum(FQName.Package({ owner = "Darklang"
@@ -408,26 +410,22 @@ let fns : List<BuiltInFn> =
                   _,
                   "Error",
                   [ value ]) ->
-            value
-            |> DvalReprDeveloper.toRepr
-            |> fun err ->
-                raiseUntargetedRTE (
-                  RuntimeError.oldError $"expected Ok, got Error:\n{err}"
-                )
+            $"expected Ok, got Error:\n{value |> DvalReprDeveloper.toRepr}"
             |> RuntimeError.oldError
-            |> raiseUntargetedRTE
+            |> raiseRTE state.caller
 
 
           // Error: single dval, but not an Option or Result
           | otherDval ->
-            RuntimeError.oldError
-              $"Unwrap called with non-Option/non-Result {otherDval}"
-            |> raiseUntargetedRTE
+            $"Unwrap called with non-Option/non-Result {otherDval}"
+            |> RuntimeError.oldError
+            |> raiseRTE state.caller
 
-        | multipleArgs ->
-          RuntimeError.oldError
-            $"unwrap called with multiple arguments: {multipleArgs}"
-          |> raiseUntargetedRTE)
+        | state, _, multipleArgs ->
+          $"unwrap called with multiple arguments: {multipleArgs}"
+          |> RuntimeError.oldError
+          |> raiseRTE state.caller)
+
       sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated } ]

--- a/packages/darklang/cli/cli.dark
+++ b/packages/darklang/cli/cli.dark
@@ -3,7 +3,10 @@ module Darklang =
     type Command =
       | Help
       | RunScript of String * List<String>
-      | RunFunction of fnName: String * args: List<String> * flagValue: String
+      | RunFunction of
+        fnName: String *
+        flagValue: Stdlib.Option.Option<String> *
+        args: List<String>
       | Show of String
       | Infer of String * String
       | Invalid of List<String>
@@ -11,7 +14,7 @@ module Darklang =
 
     let showFn (name: String) (owner: String) (modules: List<String>) : Int64 =
       let fns =
-        PACKAGE.Darklang.Stdlib.HttpClient.request
+        Stdlib.HttpClient.request
           "GET"
           "http://dark-packages.dlio.localhost:11003/functions/"
           []
@@ -19,20 +22,20 @@ module Darklang =
 
       let statusCode =
         fns
-        |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.statusCode)
+        |> Stdlib.Result.map (fun response -> response.statusCode)
         |> Builtin.unwrap
 
       let parsedFns =
         if statusCode == 200L then
           fns
-          |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
+          |> Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
-          |> Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>>
+          |> Stdlib.String.fromBytesWithReplacement
+          |> Builtin.Json.parse<List<Darklang.LanguageTools.ProgramTypes.PackageFn.PackageFn>>
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.Option.Option.Some
+          |> Stdlib.Option.Option.Some
         else
-          PACKAGE.Darklang.Stdlib.Option.Option.None
+          Stdlib.Option.Option.None
 
       match parsedFns with
       | None ->
@@ -40,19 +43,17 @@ module Darklang =
         1L
       | Some fn ->
         let packageSpecificFunction =
-          (PACKAGE.Darklang.Stdlib.List.filter fn (fun f ->
+          (Stdlib.List.filter fn (fun f ->
             f.name.name
-            == PACKAGE.Darklang.LanguageTools.ProgramTypes.FnName.Name.FnName(name)
+            == Darklang.LanguageTools.ProgramTypes.FnName.Name.FnName(name)
             && f.name.owner == owner
             && f.name.modules == modules))
-          |> PACKAGE.Darklang.Stdlib.List.head
+          |> Stdlib.List.head
 
         let result =
           match packageSpecificFunction with
           | Some f ->
-            Builtin.printLine (
-              PACKAGE.Darklang.PrettyPrinter.ProgramTypes.packageFn f
-            )
+            Builtin.printLine (Darklang.PrettyPrinter.ProgramTypes.packageFn f)
 
             0L
           | None ->
@@ -63,7 +64,7 @@ module Darklang =
 
     let showType (name: String) (owner: String) (modules: List<String>) : Int64 =
       let types =
-        PACKAGE.Darklang.Stdlib.HttpClient.request
+        Stdlib.HttpClient.request
           "GET"
           "http://dark-packages.dlio.localhost:11003/types/"
           []
@@ -71,20 +72,20 @@ module Darklang =
 
       let statusCode =
         types
-        |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.statusCode)
+        |> Stdlib.Result.map (fun response -> response.statusCode)
         |> Builtin.unwrap
 
       let parsedTypes =
         if statusCode == 200L then
           types
-          |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
+          |> Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
-          |> Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageType>>
+          |> Stdlib.String.fromBytesWithReplacement
+          |> Builtin.Json.parse<List<Darklang.LanguageTools.ProgramTypes.PackageType>>
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.Option.Option.Some
+          |> Stdlib.Option.Option.Some
         else
-          PACKAGE.Darklang.Stdlib.Option.Option.None
+          Stdlib.Option.Option.None
 
       match parsedTypes with
       | None ->
@@ -92,18 +93,16 @@ module Darklang =
         1L
       | Some types ->
         let packageSpecificType =
-          (PACKAGE.Darklang.Stdlib.List.filter types (fun t ->
+          (Stdlib.List.filter types (fun t ->
             t.name.name == LanguageTools.ProgramTypes.TypeName.Name.TypeName(name)
             && t.name.owner == owner
             && t.name.modules == modules))
-          |> PACKAGE.Darklang.Stdlib.List.head
+          |> Stdlib.List.head
 
         let result =
           match packageSpecificType with
           | Some t ->
-            Builtin.printLine (
-              PACKAGE.Darklang.PrettyPrinter.ProgramTypes.packageType t
-            )
+            Builtin.printLine (Darklang.PrettyPrinter.ProgramTypes.packageType t)
 
             0L
           | None ->
@@ -114,7 +113,7 @@ module Darklang =
 
     let showConstant (name: String) (owner: String) (modules: List<String>) : Int64 =
       let constants =
-        PACKAGE.Darklang.Stdlib.HttpClient.request
+        Stdlib.HttpClient.request
           "GET"
           "http://dark-packages.dlio.localhost:11003/constants/"
           []
@@ -122,20 +121,20 @@ module Darklang =
 
       let statusCode =
         constants
-        |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.statusCode)
+        |> Stdlib.Result.map (fun response -> response.statusCode)
         |> Builtin.unwrap
 
       let parsedConstants =
         if statusCode == 200L then
           constants
-          |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
+          |> Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
-          |> Builtin.Json.parse<List<PACKAGE.Darklang.LanguageTools.ProgramTypes.PackageConstant>>
+          |> Stdlib.String.fromBytesWithReplacement
+          |> Builtin.Json.parse<List<Darklang.LanguageTools.ProgramTypes.PackageConstant>>
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.Option.Option.Some
+          |> Stdlib.Option.Option.Some
         else
-          PACKAGE.Darklang.Stdlib.Option.Option.None
+          Stdlib.Option.Option.None
 
       match parsedConstants with
       | None ->
@@ -143,20 +142,18 @@ module Darklang =
         1L
       | Some constants ->
         let packageSpecificConstant =
-          (PACKAGE.Darklang.Stdlib.List.filter constants (fun c ->
+          (Stdlib.List.filter constants (fun c ->
             c.name.name
-            == PACKAGE.Darklang.LanguageTools.ProgramTypes.ConstantName.Name.ConstantName
+            == Darklang.LanguageTools.ProgramTypes.ConstantName.Name.ConstantName
               name
             && c.name.owner == owner
             && c.name.modules == modules))
-          |> PACKAGE.Darklang.Stdlib.List.head
+          |> Stdlib.List.head
 
         let result =
           match packageSpecificConstant with
           | Some c ->
-            Builtin.printLine (
-              PACKAGE.Darklang.PrettyPrinter.ProgramTypes.packageConstant c
-            )
+            Builtin.printLine (Darklang.PrettyPrinter.ProgramTypes.packageConstant c)
 
             0L
 
@@ -168,7 +165,7 @@ module Darklang =
 
     let showModule (name: String) : Int64 =
       let modules =
-        PACKAGE.Darklang.Stdlib.HttpClient.request
+        Stdlib.HttpClient.request
           "GET"
           ("http://dark-packages.dlio.localhost:11003/modules/" ++ name)
           []
@@ -176,20 +173,20 @@ module Darklang =
 
       let statusCode =
         modules
-        |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.statusCode)
+        |> Stdlib.Result.map (fun response -> response.statusCode)
         |> Builtin.unwrap
 
       let parsedModules =
         if statusCode == 200L then
           modules
-          |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
+          |> Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
-          |> Builtin.Json.parse<PACKAGE.Darklang.Stdlib.Packages>
+          |> Stdlib.String.fromBytesWithReplacement
+          |> Builtin.Json.parse<Stdlib.Packages>
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.Option.Option.Some
+          |> Stdlib.Option.Option.Some
         else
-          PACKAGE.Darklang.Stdlib.Option.Option.None
+          Stdlib.Option.Option.None
 
 
       match parsedModules with
@@ -197,21 +194,17 @@ module Darklang =
         Builtin.printLine "Error getting package modules"
         1L
       | Some modules ->
-        if
-          modules
-          == PACKAGE.Darklang.Stdlib.Packages
-            { types = []; fns = []; constants = [] }
-        then
+        if modules == Stdlib.Packages { types = []; fns = []; constants = [] } then
           Builtin.printLine "module not found"
           1L
         else
-          let result = modules |> PACKAGE.Darklang.PrettyPrinter.packages
+          let result = modules |> Darklang.PrettyPrinter.packages
           Builtin.printLine result
           0
 
     let showPackage (owner: String) : Int64 =
       let packages =
-        PACKAGE.Darklang.Stdlib.HttpClient.request
+        Stdlib.HttpClient.request
           "GET"
           $"http://dark-packages.dlio.localhost:11003/owner/{owner}"
           []
@@ -219,15 +212,15 @@ module Darklang =
 
       let statusCode =
         packages
-        |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.statusCode)
+        |> Stdlib.Result.map (fun response -> response.statusCode)
         |> Builtin.unwrap
 
       let parsedPackages =
         if statusCode == 200L then
           packages
-          |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
+          |> Stdlib.Result.map (fun response -> response.body)
           |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
+          |> Stdlib.String.fromBytesWithReplacement
           |> Builtin.printLine
 
           0L
@@ -240,26 +233,26 @@ module Darklang =
 
     let runFunction
       (fnName: String)
+      (flagValue: Stdlib.Option.Option<String>)
       (args: List<String>)
-      (flagValue: String)
       : Int64 =
       match flagValue with
-      | "wip-parser" ->
+      | Some "wip-parser" ->
         let args =
           args
-          |> PACKAGE.Darklang.Stdlib.List.map (fun arg ->
+          |> Stdlib.List.map (fun arg ->
             arg
-            |> PACKAGE.Darklang.LanguageTools.Parser.parseToSimplifiedTree
-            |> PACKAGE.Darklang.LanguageTools.Parser.parseCliScript
+            |> Darklang.LanguageTools.Parser.parseToSimplifiedTree
+            |> Darklang.LanguageTools.Parser.parseCliScript
             |> Builtin.unwrap
             |> fun parsedFile ->
                 match parsedFile with
                 | CliScript script -> script.exprsToEval)
-          |> PACKAGE.Darklang.Stdlib.List.flatten
+          |> Stdlib.List.flatten
 
         let exprs =
-          (PACKAGE.Darklang.Stdlib.List.map args (fun arg ->
-            PACKAGE.Darklang.LanguageTools.WrittenTypesToProgramTypes.Expr.toPT arg))
+          (Stdlib.List.map args (fun arg ->
+            Darklang.LanguageTools.WrittenTypesToProgramTypes.Expr.toPT arg))
 
         match Builtin.Cli.executeFunctionWithNewParser fnName exprs with
         | Ok result ->
@@ -284,7 +277,7 @@ module Darklang =
       let systemPrompt =
         (Builtin.File.read "canvases/dark-editor/system-prompt-cli.txt")
         |> Builtin.unwrap
-        |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
+        |> Stdlib.String.fromBytesWithReplacement
 
       let prompt = prompt ++ "\n" ++ systemPrompt
 
@@ -295,9 +288,7 @@ module Darklang =
         Builtin.printLine e
         1L
       | Ok response ->
-        Builtin.File.write
-          (PACKAGE.Darklang.Stdlib.String.toBytes response)
-          scriptPath
+        Builtin.File.write (Stdlib.String.toBytes response) scriptPath
 
         Builtin.printLine $"Generated code saved to {scriptPath}"
         0L
@@ -316,34 +307,25 @@ module Darklang =
           Command.Invalid [ "Invalid package name" ]
 
       | opt :: args ->
-        let hasFlag =
-          (PACKAGE.Darklang.Stdlib.List.last args)
-          |> Builtin.unwrap
-          |> PACKAGE.Darklang.Stdlib.String.startsWith "--flag"
+        // Extract "flag" value from last argument,
+        // which is used like `--flag=wip-parser`.
+        //
+        // TODO: support flags as non-last arguments
+        let flagValue, args = // Option<String>, List<String>
+          match Stdlib.List.last args with
+          | Some last ->
+            if Stdlib.String.startsWith "--flag=" last then
+              let flagValue = Stdlib.String.dropFirst last 7L
+              (Stdlib.Option.Option.Some flagValue, Stdlib.List.dropLast args)
+            else
+              (Stdlib.Option.Option.None, args)
 
-        let flagValue =
-          if hasFlag then
-            (PACKAGE.Darklang.Stdlib.List.last args)
-            |> Builtin.unwrap
-            |> PACKAGE.Darklang.Stdlib.String.dropFirst_v0 7L
-          else
-            ""
+          | None -> (Stdlib.Option.Option.None, args)
 
-        let flag =
-          if hasFlag then
-            (PACKAGE.Darklang.Stdlib.List.last args) |> Builtin.unwrap
-          else
-            ""
 
-        let args =
-          if flag == "" then
-            args
-          else
-            PACKAGE.Darklang.Stdlib.List.dropLast args
-
-        if PACKAGE.Darklang.Stdlib.String.startsWith opt "@" then
-          let name = opt |> PACKAGE.Darklang.Stdlib.String.dropFirst_v0 1L
-          Command.RunFunction name args flagValue
+        if Stdlib.String.startsWith opt "@" then
+          let fnName = opt |> Stdlib.String.dropFirst_v0 1L
+          Command.RunFunction(fnName, flagValue, args)
         else
           Command.RunScript(opt, args)
 
@@ -353,12 +335,13 @@ module Darklang =
     let executeCommand (command: Command) : Int64 =
       match command with
       | RunScript(scriptPath, args) ->
+
         match Builtin.File.read scriptPath with
         | Error e ->
           Builtin.printLine e
           1L
         | Ok script ->
-          let script = PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement script
+          let script = Stdlib.String.fromBytesWithReplacement script
 
           match
             Builtin.Cli.parseAndExecuteScript
@@ -368,9 +351,7 @@ module Darklang =
           with
           | Ok exitCode -> exitCode
           | Error e ->
-            Builtin.printLine (
-              PACKAGE.Darklang.LanguageTools.RuntimeErrors.Error.toString e
-            )
+            Builtin.printLine (Darklang.LanguageTools.RuntimeErrors.Error.toString e)
 
             1L
 
@@ -389,29 +370,26 @@ Options:
 
       | Show name ->
 
-        let fullName = name |> PACKAGE.Darklang.Stdlib.String.dropFirst_v0 1L
+        let fullName = name |> Stdlib.String.dropFirst_v0 1L
 
         let owner =
-          fullName
-          |> PACKAGE.Darklang.Stdlib.String.split "."
-          |> PACKAGE.Darklang.Stdlib.List.head
-          |> Builtin.unwrap
+          fullName |> Stdlib.String.split "." |> Stdlib.List.head |> Builtin.unwrap
 
         let modules =
           fullName
-          |> PACKAGE.Darklang.Stdlib.String.split "."
-          |> (PACKAGE.Darklang.Stdlib.List.drop 1L)
-          |> PACKAGE.Darklang.Stdlib.List.dropLast
+          |> Stdlib.String.split "."
+          |> (Stdlib.List.drop 1L)
+          |> Stdlib.List.dropLast
 
         let name =
           name
-          |> PACKAGE.Darklang.Stdlib.String.dropFirst_v0 1L
-          |> PACKAGE.Darklang.Stdlib.String.split "."
-          |> PACKAGE.Darklang.Stdlib.List.last
+          |> Stdlib.String.dropFirst_v0 1L
+          |> Stdlib.String.split "."
+          |> Stdlib.List.last
           |> Builtin.unwrap
 
         let categoryRequest =
-          PACKAGE.Darklang.Stdlib.HttpClient.request
+          Stdlib.HttpClient.request
             "GET"
             $"http://dark-packages.dlio.localhost:11003/category/{fullName}"
             []
@@ -419,50 +397,45 @@ Options:
 
         let statusCode =
           categoryRequest
-          |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.statusCode)
+          |> Stdlib.Result.map (fun response -> response.statusCode)
           |> Builtin.unwrap
 
         let category =
           if statusCode == 200L then
             categoryRequest
-            |> PACKAGE.Darklang.Stdlib.Result.map (fun response -> response.body)
+            |> Stdlib.Result.map (fun response -> response.body)
             |> Builtin.unwrap
-            |> PACKAGE.Darklang.Stdlib.String.fromBytesWithReplacement
+            |> Stdlib.String.fromBytesWithReplacement
           else
-            "Error" |> PACKAGE.Darklang.Stdlib.String.toBytes
+            "Error" |> Stdlib.String.toBytes
 
         match category with
-        | "fn" -> PACKAGE.Darklang.Cli.showFn name owner modules
-        | "type" -> PACKAGE.Darklang.Cli.showType name owner modules
-        | "constant" -> PACKAGE.Darklang.Cli.showConstant name owner modules
+        | "fn" -> Darklang.Cli.showFn name owner modules
+        | "type" -> Darklang.Cli.showType name owner modules
+        | "constant" -> Darklang.Cli.showConstant name owner modules
         | _ ->
-          let modules =
-            fullName
-            |> PACKAGE.Darklang.Stdlib.String.split "."
-            |> (PACKAGE.Darklang.Stdlib.List.drop 1L)
+          let modules = fullName |> Stdlib.String.split "." |> (Stdlib.List.drop 1L)
 
-          if PACKAGE.Darklang.Stdlib.List.length modules == 0L then
-            PACKAGE.Darklang.Cli.showPackage owner
+          if Stdlib.List.length modules == 0L then
+            Darklang.Cli.showPackage owner
           else
-            PACKAGE.Darklang.Cli.showModule fullName
+            Darklang.Cli.showModule fullName
 
-      | RunFunction(fnName, args, flagValue) ->
-        PACKAGE.Darklang.Cli.runFunction fnName args flagValue
+      | RunFunction(fnName, flagValue, args) ->
+        Darklang.Cli.runFunction fnName flagValue args
 
       | Infer(prompt, scriptPath) ->
         // let script = System.IO.File.ReadAllText scriptPath
         // Call OpenAI API with the prompt and script to generate a new script
         // let generatedScript = callOpenAI(prompt, script)
         // Execute the generated script here
-        PACKAGE.Darklang.Cli.generateCode prompt scriptPath
+        Darklang.Cli.generateCode prompt scriptPath
 
       | Invalid args ->
-        let args = args |> PACKAGE.Darklang.Stdlib.String.join " "
+        let args = args |> Stdlib.String.join " "
         Builtin.printLine $"Invalid command {args}. Use --help for more information."
         1L
 
 
     let executeCliCommand (args: List<String>) : Int64 =
-      args
-      |> PACKAGE.Darklang.Cli.parseArguments
-      |> PACKAGE.Darklang.Cli.executeCommand
+      args |> Darklang.Cli.parseArguments |> Darklang.Cli.executeCommand

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -4,15 +4,28 @@ module Darklang =
     module LspServer =
       module SemanticTokens =
         /// note: these are referenced by their _index_!
-        /// i.e. 'keyword' is 0, 'string' is 4, etc.
+        /// i.e. 'keyword' is 1, 'string' is 5, etc.
+        ///
+        /// Most of these are part of a generally-known set of token types
+        /// defined by the LSP spec, but there are a few that are 'custom'
+        /// for our language:
+        /// - "symbol"
         let tokenTypes =
-          [ "keyword" // for words 'let' and 'in'
-            "function" // for function names/identifiers
-            "parameter" // for function parameter identifiers
-            "type" // for type names like Int, Bool, etc.
-            "string" // for string literals
-            "operator" // for operators like +, -
-            "variable" ] // for general identifiers
+          [ // universal
+            "symbol" // [0] for (, ), [, ], {, }, etc.
+            "keyword" // [1] for words 'let' and 'in'
+
+            // for types and type references
+            "namespace" // [2] for module names
+            "type" // [3] for type names like Int, Bool, etc.
+
+            // for fns and exprs
+            "operator" // [4] for operators like +, -
+            "string" // [5] for string literals
+            "number" // [6] for number literals
+            "parameter" // [7] for function parameter identifiers
+            "variable" // [8] for general identifiers
+            "function" ] // [9] for function names/identifiers
 
         let tokenModifiers = []
 
@@ -25,13 +38,18 @@ module Darklang =
             (t: Darklang.LanguageTools.SemanticTokens.TokenType)
             : UInt64 =
             match t with
-            | Keyword -> 0UL
-            | Function -> 1UL
-            | Parameter -> 2UL
-            | Type -> 3UL
-            | String -> 4UL
-            | Operator -> 5UL
-            | Variable -> 6UL
+            | Symbol -> 0UL
+            | Keyword -> 1UL
+
+            | ModuleName -> 2UL
+            | TypeName -> 3UL
+
+            | Operator -> 4UL
+            | String -> 5UL
+            | Number -> 6UL
+            | ParameterName -> 7UL
+            | VariableName -> 8UL
+            | FunctionName -> 9UL
 
 
           let toRelativeTokens
@@ -140,7 +158,7 @@ module Darklang =
             | Ok parsedFile ->
               let data =
                 parsedFile
-                |> LanguageTools.SemanticTokens.fromParsedFile
+                |> LanguageTools.SemanticTokens.ParsedFile.tokenize
                 |> EncodeSemanticTokens.toRelativeTokens
                 |> EncodeSemanticTokens.toLspFormat
 

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -57,16 +57,19 @@ module Darklang =
             : List<LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken<LanguageTools.SemanticTokens.TokenType>> =
             tokens
             |> Stdlib.List.sortByComparator_v0 (fun a b ->
-              // TODO: sort by rows, too
-              // TODO: handle equality?
-              if
-                Stdlib.Int64.lessThan
-                  a.sourceRange.start.column
-                  b.sourceRange.start.column
-              then
+              let aStart = a.sourceRange.start
+              let bStart = b.sourceRange.start
+
+              if Stdlib.Int64.lessThan aStart.row bStart.row then
                 -1L
+              elif Stdlib.Int64.greaterThan aStart.row bStart.row then
+                1L
+              else if Stdlib.Int64.lessThan aStart.column bStart.column then
+                -1L
+              else if Stdlib.Int64.greaterThan aStart.column bStart.column then
+                1L
               else
-                1L)
+                0L)
             |> Builtin.unwrap
             |> (Stdlib.List.fold
               (([], Parser.Point { row = 0L; column = 0L }))
@@ -77,7 +80,11 @@ module Darklang =
                   match token.sourceRange.start.row - startOfLastToken.row with
                   | 0L ->
                     (0UL, token.sourceRange.start.column - startOfLastToken.column)
-                  | lineDiff -> (lineDiff, token.sourceRange.start.column)
+                  | lineDiff ->
+                    let lineDiff =
+                      lineDiff |> Stdlib.UInt64.fromInt64 |> Builtin.unwrap
+
+                    (lineDiff, token.sourceRange.start.column)
 
                 let newToken =
                   LanguageServerProtocol.SemanticTokens.RelativeSemanticToken.RelativeSemanticToken //<LanguageTools.SemanticTokens.TokenType>

--- a/packages/darklang/languageTools/parser.dark
+++ b/packages/darklang/languageTools/parser.dark
@@ -250,7 +250,10 @@ module Darklang =
                   |> Builtin.unwrap
 
                 keywordType =
-                  node |> findNodeByFieldName "keyword_type" |> Builtin.unwrap
+                  node
+                  |> findNodeByFieldName "keyword_type"
+                  |> Builtin.unwrap
+                  |> getRange
                 symbolEquals =
                   node
                   |> findNodeByFieldName "symbol_equals"

--- a/packages/darklang/languageTools/parser.dark
+++ b/packages/darklang/languageTools/parser.dark
@@ -113,6 +113,15 @@ module Darklang =
           let (modulesInReverse, lastNode) = extractModuleIdentifiersHelper [] nodes
           (Stdlib.List.reverse modulesInReverse, lastNode)
 
+        let parseVariable (n: ParsedNode) : WrittenTypes.VariableIdentifier =
+          WrittenTypes.VariableIdentifier { range = n.sourceRange; name = n.text }
+
+        let parseType (n: ParsedNode) : WrittenTypes.TypeIdentifier =
+          WrittenTypes.TypeIdentifier { range = n.sourceRange; name = n.text }
+
+        let parseFn (n: ParsedNode) : WrittenTypes.FnIdentifier =
+          WrittenTypes.FnIdentifier { range = n.sourceRange; name = n.text }
+
 
         let parseQualifiedType
           (node: ParsedNode)
@@ -124,10 +133,7 @@ module Darklang =
             (WrittenTypes.QualifiedTypeIdentifier
               { range = node.sourceRange
                 modules = modules
-                typ =
-                  WrittenTypes.TypeIdentifier
-                    { range = typeIdentifierNode.sourceRange
-                      name = typeIdentifierNode.text } })
+                typ = parseType typeIdentifierNode })
             |> Stdlib.Result.Result.Ok
           else
             Stdlib.Result.Result.Error
@@ -143,14 +149,12 @@ module Darklang =
             (WrittenTypes.QualifiedFnIdentifier
               { range = node.sourceRange
                 modules = modules
-                fn =
-                  WrittenTypes.FnIdentifier
-                    { range = fnIdentifierNode.sourceRange
-                      name = fnIdentifierNode.text } })
+                fn = parseFn fnIdentifierNode })
             |> Stdlib.Result.Result.Ok
           else
             Stdlib.Result.Result.Error
               $"Can't parse qualified_fn_name from {node.typ}"
+
 
 
       module TypeReference =
@@ -229,21 +233,14 @@ module Darklang =
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.TypeDeclaration.TypeDeclaration, String> =
           if node.typ == "type_decl" then
-            let keywordTypeNode =
-              node |> findNodeByFieldName "keyword_type" |> Builtin.unwrap
-
-            let nameNode = node |> findNodeByFieldName "name" |> Builtin.unwrap
-
-            let symbolEqualsNode =
-              node |> findNodeByFieldName "symbol_equals" |> Builtin.unwrap
-
             (WrittenTypes.TypeDeclaration.TypeDeclaration
               { range = node.sourceRange
 
                 name =
-                  WrittenTypes.TypeIdentifier
-                    { range = nameNode.sourceRange
-                      name = nameNode.text }
+                  node
+                  |> findNodeByFieldName "name"
+                  |> Builtin.unwrap
+                  |> Identifiers.parseType
 
                 definition =
                   node
@@ -252,8 +249,13 @@ module Darklang =
                   |> parseDefinition
                   |> Builtin.unwrap
 
-                keywordType = keywordTypeNode.sourceRange
-                symbolEquals = symbolEqualsNode.sourceRange })
+                keywordType =
+                  node |> findNodeByFieldName "keyword_type" |> Builtin.unwrap
+                symbolEquals =
+                  node
+                  |> findNodeByFieldName "symbol_equals"
+                  |> Builtin.unwrap
+                  |> getRange })
             |> Stdlib.Result.Result.Ok
           else
             Stdlib.Result.Result.Error $"Can't parse type_decl from {node.typ}"
@@ -500,7 +502,7 @@ module Darklang =
                 name =
                   (findNodeByFieldName node "identifier")
                   |> Builtin.unwrap
-                  |> getText
+                  |> Identifiers.parseVariable
 
                 typ =
                   (findNodeByFieldName node "typ")
@@ -565,14 +567,13 @@ module Darklang =
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.FnDeclaration.FnDeclaration, String> =
           if node.typ == "fn_decl" then
-            let fnNameNode = node |> findNodeByFieldName "name" |> Builtin.unwrap
-
             (WrittenTypes.FnDeclaration.FnDeclaration
               { range = node.sourceRange
                 name =
-                  WrittenTypes.FnIdentifier
-                    { range = fnNameNode.sourceRange
-                      name = fnNameNode.text }
+                  node
+                  |> findNodeByFieldName "name"
+                  |> Builtin.unwrap
+                  |> Identifiers.parseFn
                 parameters =
                   (findNodeByFieldName node "params")
                   |> Builtin.unwrap

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -6,13 +6,31 @@ module Darklang =
       // <aliases>
 
       type TokenType =
+        // universal
+        | Symbol
         | Keyword
-        | Function
-        | Parameter
-        | Type
-        | String
+
+        // types
+        | ModuleName
+        | TypeName
+
+        // exprs and fns
         | Operator
-        | Variable
+        | String
+        | Number
+        | ParameterName
+        | VariableName
+        | FunctionName
+
+        // FUTURE: these are not yet used
+        | Comment
+
+        | TypeParameter
+
+        | EnumCase // in Option.Some, this would be `Some`
+        | Property // ? maybe this should be used for fields
+        | Method // ? or maybe this should be used for fields
+        | RegularExpression
 
 
       /// The LSP[1] communicates in terms of 'relative' semantic tokens,
@@ -32,129 +50,244 @@ module Darklang =
         { sourceRange: SourceRange
           tokenType: TokenType }
 
+      let makeToken (s: SourceRange) (t: TokenType) : SemanticToken =
+        SemanticToken { sourceRange = s; tokenType = t }
 
 
-      // let fromName (name: WrittenTypes.Name) : List<SemanticToken> =
-      //   match name with
-      //   | Unresolved(range, _parts) ->
-      //     [ SemanticToken
-      //         { sourceRange = range
-      //           tokenType = TokenType.Variable } ]
+      module ModuleIdentifier =
+        let tokenize (m: WrittenTypes.ModuleIdentifier) : List<SemanticToken> =
+          [ makeToken m.range TokenType.ModuleName ]
+
+      module TypeIdentifier =
+        let tokenize (t: WrittenTypes.TypeIdentifier) : List<SemanticToken> =
+          [ makeToken t.range TokenType.TypeName ]
+
+      module QualifiedTypeIdentifier =
+        // Darklang.Stdlib.Option
+        let tokenize
+          (q: WrittenTypes.QualifiedTypeIdentifier)
+          : List<SemanticToken> =
+          [ // Darklang.Stdlib.
+            (q.modules
+             |> Stdlib.List.map (fun (m, _) -> ModuleIdentifier.tokenize m)
+             |> Stdlib.List.flatten)
+
+            // Option
+            TypeIdentifier.tokenize q.typ ]
+          |> Stdlib.List.flatten
+
+      module VariableIdentifier =
+        let tokenize (v: WrittenTypes.VariableIdentifier) : List<SemanticToken> =
+          [ makeToken v.range TokenType.VariableName ]
+
+      module FnIdentifier =
+        let tokenize (fn: WrittenTypes.FnIdentifier) : List<SemanticToken> =
+          [ makeToken fn.range TokenType.FunctionName ]
+
+      module QualifiedFnIdentifier =
+        /// Darklang.Stdlib.List.map
+        let tokenize (q: WrittenTypes.QualifiedFnIdentifier) : List<SemanticToken> =
+          [ // Darklang.Stdlib.List.
+            (q.modules
+             |> Stdlib.List.map (fun (m, _) -> ModuleIdentifier.tokenize m)
+             |> Stdlib.List.flatten)
+
+            // map
+            FnIdentifier.tokenize q.fn ]
+          |> Stdlib.List.flatten
 
 
-      // let fromLetPattern (lp: WrittenTypes.LetPattern) : List<SemanticToken> =
-      //   // type LetPattern =
-      //   //   | LPVariable of SourceRange * name: String
-      //   []
+      module TypeReference =
+        module BuiltIn =
+          let tokenize
+            (t: WrittenTypes.TypeReference.BuiltIn)
+            : List<SemanticToken> =
+            match t with
+            | TUnit r -> [ makeToken r TokenType.TypeName ]
+            | TBool r -> [ makeToken r TokenType.TypeName ]
+            | TInt64 r -> [ makeToken r TokenType.TypeName ]
+            | TFloat r -> [ makeToken r TokenType.TypeName ]
+            | TChar r -> [ makeToken r TokenType.TypeName ]
+            | TString r -> [ makeToken r TokenType.TypeName ]
+
+        let tokenize
+          (t: WrittenTypes.TypeReference.TypeReference)
+          : List<SemanticToken> =
+          match t with
+          | BuiltIn b -> BuiltIn.tokenize b
+          | QualifiedName q -> QualifiedTypeIdentifier.tokenize q
 
 
-      // let fromTypeReference (t: WrittenTypes.TypeReference) : List<SemanticToken> =
-      //   let tokenRange =
-      //     match t with
-      //     | TUnit r -> r
-      //     | TBool r -> r
-      //     | TInt64 r -> r
-      //     | TFloat r -> r
-      //     | TChar r -> r
-      //     | TString r -> r
+      module TypeDeclaration =
+        let tokenizeDefinition
+          (d: WrittenTypes.TypeDeclaration.Definition)
+          : List<SemanticToken> =
+          match d with
+          | Alias typeRef -> TypeReference.tokenize typeRef
 
-      //   [ SemanticToken
-      //       { sourceRange = tokenRange
-      //         tokenType = TokenType.Type } ]
-
-
-
-      // let fromExpr (expr: WrittenTypes.Expr) : List<SemanticToken> =
-      //   // type Expr =
-      //   //   | EUnit of SourceRange
-      //   //   | EBool of SourceRange * Bool
-      //   //   | EInt64 of SourceRange * Int64
-      //   //   | EString of SourceRange * StringSegment
-
-      //   //   | ELet of SourceRange * LetPattern * Expr * Expr
-      //   //   | EVariable of SourceRange * String
-      //   //   | EFnName of Name
-      //   //   | EInfix of SourceRange * Infix * Expr * Expr
-      //   //   | EApply of
-      //   //     SourceRange *
-      //   //     Expr *
-      //   //     typeArgs: List<TypeReference> *
-      //   //     args: List<Expr>
-      //   []
+        // type ID = UInt64
+        let tokenize
+          (t: WrittenTypes.TypeDeclaration.TypeDeclaration)
+          : List<SemanticToken> =
+          [ // type
+            [ makeToken t.keywordType TokenType.Keyword ]
+            // ID
+            [ makeToken t.name.range TokenType.TypeName ]
+            // =
+            [ makeToken t.symbolEquals TokenType.Symbol ]
+            // UInt64
+            tokenizeDefinition t.definition ]
+          |> Stdlib.List.flatten
 
 
-      // /// assumptions:
-      // /// - each param is not broken up with newlines
-      // ///   (though newlines between them is OK)
-      // ///
-      // ///   if we want to allow for newlines in these defs,
-      // ///   then we need to capture the sourceRange of the `name:String` as well
-      // let fromPackageFnParam
-      //   (p: WrittenTypes.PackageFn.Parameter)
-      //   : List<SemanticToken> =
-      //   let namePart =
-      //     let namePartStart =
-      //       Parser.Point
-      //         { row = p.sourceRange.start.row
-      //           // skip the `(`
-      //           column = p.sourceRange.start.column + 1L }
 
-      //     let namePartEnd =
-      //       { namePartStart with
-      //           column = namePartStart.column + (Stdlib.String.length p.name) }
-
-      //     [ SemanticToken
-      //         { sourceRange =
-      //             Parser.Range
-      //               { start = namePartStart
-      //                 end_ = namePartEnd }
-      //           tokenType = TokenType.Parameter } ]
-
-      //   let typePart = fromTypeReference p.typ
-
-      //   Stdlib.List.flatten [ namePart; typePart ]
+      module Expr =
+        module LetPattern =
+          let tokenize (lp: WrittenTypes.LetPattern) : List<SemanticToken> =
+            match lp with
+            | LPVariable(range, _name) -> [ makeToken range TokenType.VariableName ]
 
 
-      // let fromPackageFn
-      //   (fn: WrittenTypes.PackageFn.PackageFn)
-      //   : List<SemanticToken> =
-      //   let letParts =
-      //     [ SemanticToken
-      //         { sourceRange =
-      //             Parser.Range
-      //               { start = fn.sourceRange.start
-      //                 end_ =
-      //                   Parser.Point
-      //                     { row = fn.sourceRange.start.row
-      //                       column = fn.sourceRange.start.column + 3L } }
-      //           tokenType = TokenType.Keyword } ]
+        let tokenize (e: WrittenTypes.Expr) : List<SemanticToken> =
+          match e with
+          // ()
+          | EUnit range -> [ makeToken range TokenType.Symbol ]
 
-      //   let nameParts = fromName fn.name
+          // true
+          | EBool(range, _b) -> [ makeToken range TokenType.Keyword ]
 
-      //   let paramsParts =
-      //     fn.parameters
-      //     |> Stdlib.List.map (fun p -> fromPackageFnParam p)
-      //     |> Stdlib.List.flatten
+          // 12L
+          | EInt64(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
 
-      //   let returnTypeParts = fromTypeReference fn.returnType
+          // "hello"
+          | EString(range, _contentsMaybe, symbolOpenQuote, symbolCloseQuote) ->
+            [ // "
+              [ makeToken symbolOpenQuote TokenType.Symbol ]
 
-      //   let bodyParts = fromExpr fn.body
+              // hello
+              (match contentsMaybe with
+               | Some(contentsRange, _contents) ->
+                 [ makeToken contentsRange TokenType.String ]
+               | None -> [])
 
-      //   Stdlib.List.flatten
-      //     [ letParts; nameParts; paramsParts; returnTypeParts; bodyParts ]
+              // "
+              [ makeToken symbolCloseQuote TokenType.Symbol ] ]
+            |> Stdlib.List.flatten
+
+          // let x = 2
+          // x + 1
+          | ELet(range, lp, expr, body, keywordLet, symbolEquals) ->
+            [ [ makeToken keywordLet TokenType.Keyword ]
+              LetPattern.tokenize lp
+              [ makeToken symbolEquals TokenType.Symbol ]
+              Expr.tokenize expr
+              Expr.tokenize body ]
+            |> Stdlib.List.flatten
+
+          // x
+          | EVariable(range, _varName) -> [ makeToken range TokenType.VariableName ]
+
+          // x + 1
+          | EInfix(_, (opRange, _op), left, right) ->
+            [ // x
+              Expr.tokenize left
+              // +
+              [ makeToken opRange TokenType.Operator ]
+              // 1
+              Expr.tokenize right ]
+            |> Stdlib.List.flatten
+
+          // hacky temp. syntax -- see `grammar.js`
+          // (Int64.add 1L 2L)
+          | EFnCall(range, fnName, args, symbolLeftParen, symbolRightParen) ->
+            [ // (
+              [ makeToken symbolLeftParen TokenType.Symbol ]
+              // Int64.add
+              QualifiedFnIdentifier.tokenize fnName
+              // 1L 2L
+              (args
+               |> Stdlib.List.map (fun arg -> Expr.tokenize arg)
+               |> Stdlib.List.flatten)
+              // )
+              [ makeToken symbolRightParen TokenType.Symbol ] ]
+            |> Stdlib.List.flatten
 
 
-      // let fromTypeDeclaration (t: WrittenTypes.TypeDeclaration) : List<SemanticToken> =
-      //   // TODO
-      //   []
+
+      module FnDeclaration =
+        module UnitParameter =
+          // `()`
+          let tokenize
+            (p: WrittenTypes.FnDeclaration.UnitParameter)
+            : List<SemanticToken> =
+            [ makeToken p.range TokenType.Symbol ]
+
+        // `(a: Int64)`
+        module NormalParameter =
+          let tokenize
+            (p: WrittenTypes.FnDeclaration.NormalParameter)
+            : List<SemanticToken> =
+            [ // `(`
+              [ makeToken p.symbolLeftParen TokenType.Symbol ]
+              // `a`
+              [ makeToken p.name.range TokenType.ParameterName ]
+              // `:`
+              [ makeToken p.symbolColon TokenType.Symbol ]
+              // `Int64`
+              TypeReference.tokenize p.typ
+              // `)`
+              [ makeToken p.symbolRightParen TokenType.Symbol ] ]
+            |> Stdlib.List.flatten
+
+        module Parameter =
+          let tokenize
+            (p: WrittenTypes.FnDeclaration.Parameter)
+            : List<SemanticToken> =
+            match p with
+            | Unit u -> UnitParameter.tokenize u
+            | Normal n -> NormalParameter.tokenize n
 
 
-      let fromParsedFile (wt: WrittenTypes.ParsedFile) : List<SemanticToken> =
-        match wt with
-        | CliScript cliScript ->
-          // cliScript.typesAndFns
-          // |> Stdlib.List.map (fun typeOrFn ->
-          //   match typeOrFn with
-          //   | type t -> fromTypeDeclaration t)
-          // |> Stdlib.List.flatten
-          []
+        // `let add (a: Int64) (b: Int64): Int64 = a + b`
+        let tokenize
+          (fn: WrittenTypes.FnDeclaration.FnDeclaration)
+          : List<SemanticToken> =
+          [ // `let`
+            [ makeToken fn.keywordLet TokenType.Keyword ]
+            // `add`
+            FnIdentifier.tokenize fn.name
+            // `(a: Int64) (b: Int64)`
+            (fn.parameters
+             |> Stdlib.List.map (fun p -> Parameter.tokenize p)
+             |> Stdlib.List.flatten)
+            // `:`
+            [ makeToken fn.symbolColon TokenType.Symbol ]
+            // `Int64`
+            TypeReference.tokenize fn.returnType
+            // `=`
+            [ makeToken fn.symbolEquals TokenType.Operator ]
+            // `a + b`
+            Expr.tokenize fn.body ]
+          |> Stdlib.List.flatten
+
+
+      module ParsedFile =
+        let tokenize (wt: WrittenTypes.ParsedFile) : List<SemanticToken> =
+          match wt with
+          | CliScript cliScript ->
+            let typesAndFnsPart =
+              cliScript.typesAndFns
+              |> Stdlib.List.map (fun typeOrFn ->
+                match typeOrFn with
+                | Type t -> TypeDeclaration.tokenize t
+                | Function fn -> FnDeclaration.tokenize fn)
+              |> Stdlib.List.flatten
+
+            let exprsPart =
+              cliScript.exprsToEval
+              |> Stdlib.List.map (fun expr -> Expr.tokenize expr)
+              |> Stdlib.List.flatten
+
+            Stdlib.List.flatten [ typesAndFnsPart; exprsPart ]

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -117,7 +117,7 @@ module Darklang =
 
         type NormalParameter =
           { range: SourceRange
-            name: String
+            name: VariableIdentifier
             typ: TypeReference.TypeReference
             symbolLeftParen: SourceRange
             symbolColon: SourceRange
@@ -141,8 +141,8 @@ module Darklang =
 
       // Cli scripts
       type CliScriptTypeOrFn =
-        | Function of FnDeclaration.FnDeclaration
         | Type of TypeDeclaration.TypeDeclaration
+        | Function of FnDeclaration.FnDeclaration
 
       type CliScript =
         { range: SourceRange

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -214,7 +214,7 @@ module Darklang =
 
             | Normal p ->
               ProgramTypes.UserFunction.Parameter
-                { name = p.name
+                { name = p.name.name
                   typ = TypeReference.toPT p.typ
                   description = "" }
 

--- a/user-code/darklang/scripts/sample-for-testing-extension.dark
+++ b/user-code/darklang/scripts/sample-for-testing-extension.dark
@@ -1,1 +1,1 @@
-let double (i: Int) : Int = i + i
+let double (i: Int): Int = i + i

--- a/user-code/darklang/scripts/sample-for-testing-extension.dark
+++ b/user-code/darklang/scripts/sample-for-testing-extension.dark
@@ -1,1 +1,1 @@
-let double (i: Int): Int = i + i
+let double (i: Int) : Int = i + i

--- a/user-code/darklang/scripts/sample-for-testing-extension.dark
+++ b/user-code/darklang/scripts/sample-for-testing-extension.dark
@@ -1,1 +1,2 @@
+type ID = Int64
 let double (i: Int) : Int = i + i


### PR DESCRIPTION
I [recently gutted](#5215) our semantic tokenization (used by our LSP server for the VS Code extension) in order to get some WrittenTypes changes mergeable.

This PR
- brings it back, with more complete tokenization
- improves error reporting in CLI (if something fails and we have a source, we now print the TLID of failure)
- fixes CLI executions when `--flag` isn't included


https://github.com/darklang/dark/assets/906686/c8d1dcf4-fda1-484c-a8ba-5ccb9b140099

