### PR TITLE
Stop referencing LibCloud (and LibService indirectly) in CLI projects

### DIFF
--- a/backend/src/BuiltinCliHost/BuiltinCliHost.fsproj
+++ b/backend/src/BuiltinCliHost/BuiltinCliHost.fsproj
@@ -19,8 +19,6 @@
     <ProjectReference Include="../BuiltinExecution/BuiltinExecution.fsproj" />
     <ProjectReference Include="../BuiltinCli/BuiltinCli.fsproj" />
     <ProjectReference Include="../LibCliExecution/LibCliExecution.fsproj" />
-    <ProjectReference Include="../LibCloud/LibCloud.fsproj" />
-
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -79,7 +79,6 @@ let builtIns : RT.BuiltIns =
   { fns = fns |> Map.fromListBy _.name
     constants = constants |> Map.fromListBy _.name }
 
-let packageManager = LibCloud.PackageManager.packageManager
 
 let execute
   (parentState : RT.ExecutionState)
@@ -103,7 +102,7 @@ let execute
     let state =
       Exe.createState
         builtIns
-        packageManager
+        LibCliExecution.PackageManager.packageManager
         Exe.noTracing
         sendException
         notify

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -52,8 +52,7 @@ let builtIns : RT.BuiltIns =
   { fns = fns |> Map.fromListBy _.name
     constants = constants |> Map.fromListBy _.name }
 
-let packageManager =
-  LibCliExecution.PackageManager.packageManager LibCloud.Config.packageManagerUrl
+let packageManager = LibCliExecution.PackageManager.packageManager
 
 let state () =
   let program : RT.Program =

--- a/backend/src/LibCliExecution/PackageManager.fs
+++ b/backend/src/LibCliExecution/PackageManager.fs
@@ -701,7 +701,14 @@ module ET2PT = ExternalTypesToProgramTypes
 /// The baseUrl is expected to be something like
 /// - https://dark-packages.darklang.io normally
 /// - http://dark-packages.dlio.localhost:11001 for local dev
-let packageManager (baseUrl : string) : RT.PackageManager =
+let baseUrl =
+  match
+    System.Environment.GetEnvironmentVariable "DARK_CONFIG_PACKAGE_MANAGER_BASE_URL"
+  with
+  | null -> "https://packages.darklang.com"
+  | var -> var
+
+let packageManager : RT.PackageManager =
   let httpClient = new System.Net.Http.HttpClient() // CLEANUP pass this in as param? or mutate it externally?
 
   let withCache (f : 'name -> Ply<Option<'value>>) =


### PR DESCRIPTION
Referencing LibService (indirectly) causes errors on start of the CLI executable, since LibService/Config.fs demands a bunch of environment variables to be set.