### PR TITLE
Build binaries for remaining runtimes (windows and mac)

### DIFF
--- a/scripts/build/dotnet-publish-all-clis.sh
+++ b/scripts/build/dotnet-publish-all-clis.sh
@@ -13,8 +13,7 @@ mkdir -p clis
 # Parallelism set to 1 here to avoid running out of memory.
 # TODO: do better with gnu parallel or with this solution that I couldn't make work:
 # https://stackoverflow.com/a/43951971/104021
-# runtimes="linux-x64 linux-musl-x64 linux-arm64 osx-x64 osx-arm64 win-x64 win-arm64"
-runtimes="linux-x64 linux-arm64"
+runtimes="linux-x64 linux-musl-x64 linux-arm64 osx-x64 osx-arm64 win-x64 win-arm64"
 for rt in $runtimes; do
   echo "Building for runtime: $rt"
 
@@ -31,6 +30,11 @@ for rt in $runtimes; do
 
   target="clis/darklang-$release-$rt"
   echo "Moving to $target"
-  mv "backend/Build/out/Cli/Release/net8.0/$rt/publish/Cli" "$target"
-  gzip "$target"
+  if [[ $rt == win-* ]]; then
+    mv "backend/Build/out/Cli/Release/net8.0/$rt/publish/Cli.exe" "$target.exe"
+    gzip "$target.exe"
+  else
+    mv "backend/Build/out/Cli/Release/net8.0/$rt/publish/Cli" "$target"
+    gzip "$target"
+  fi
 done


### PR DESCRIPTION


Changelog:

```
Area of change
- Build binaries for remaining runtimes 
```

This PR enables building the binaries for windows and macOS, and fixes the windows binary build by adding the .exe extension