### PR TITLE
Package manager: parse+decode fetched JSON without any reflection

### DIFF
--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -87,7 +87,8 @@ let packageManagerBaseUrl =
   | null -> "https://packages.darklang.com"
   | var -> var
 
-let packageManager = LibPackageManager.packageManager packageManagerBaseUrl
+let packageManager =
+  LibPackageManager.PackageManager.packageManager packageManagerBaseUrl
 
 let execute
   (parentState : RT.ExecutionState)

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -60,7 +60,8 @@ let packageManagerBaseUrl =
   | null -> "https://packages.darklang.com"
   | var -> var
 
-let packageManager = LibPackageManager.packageManager packageManagerBaseUrl
+let packageManager =
+  LibPackageManager.PackageManager.packageManager packageManagerBaseUrl
 
 
 let state () =

--- a/backend/src/LibPackageManager/ExternalTypesToProgramTypes.fs
+++ b/backend/src/LibPackageManager/ExternalTypesToProgramTypes.fs
@@ -1,0 +1,405 @@
+// See README.md
+module LibPackageManager.ExternalTypesToProgramTypes
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+
+open Prelude
+
+module RT = LibExecution.RuntimeTypes
+module PT = LibExecution.ProgramTypes
+module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
+module PT2DT = LibExecution.ProgramTypesToDarkTypes
+
+open Types
+
+module EPT = ProgramTypes
+
+module NameResolutionError =
+  module NameType =
+    let toPT
+      (nameType : NameResolutionError.NameType)
+      : LibExecution.NameResolutionError.NameType =
+      match nameType with
+      | NameResolutionError.Type -> LibExecution.NameResolutionError.Type
+      | NameResolutionError.Function -> LibExecution.NameResolutionError.Function
+      | NameResolutionError.Constant -> LibExecution.NameResolutionError.Constant
+
+  module ErrorType =
+    let toPT
+      (err : NameResolutionError.ErrorType)
+      : LibExecution.NameResolutionError.ErrorType =
+      match err with
+      | NameResolutionError.ErrorType.NotFound ->
+        LibExecution.NameResolutionError.NotFound
+      | NameResolutionError.MissingEnumModuleName caseName ->
+        LibExecution.NameResolutionError.MissingEnumModuleName caseName
+      | NameResolutionError.InvalidPackageName ->
+        LibExecution.NameResolutionError.InvalidPackageName
+      | NameResolutionError.ExpectedEnumButNot ->
+        LibExecution.NameResolutionError.ExpectedEnumButNot
+      | NameResolutionError.ExpectedRecordButNot ->
+        LibExecution.NameResolutionError.ExpectedRecordButNot
+
+  module Error =
+    let toPT
+      (err : NameResolutionError.Error)
+      : LibExecution.NameResolutionError.Error =
+      { errorType = ErrorType.toPT err.errorType
+        nameType = NameType.toPT err.nameType
+        names = err.names }
+
+module NameResolution =
+  let toPT (f : 's -> 'p) (result : EPT.NameResolution<'s>) : PT.NameResolution<'p> =
+    match result with
+    | Ok name -> Ok(f name)
+    | Error err -> Error(NameResolutionError.Error.toPT err)
+
+
+module Sign =
+  let toPT (s : Sign) : Prelude.Sign =
+    match s with
+    | Positive -> Prelude.Positive
+    | Negative -> Prelude.Negative
+
+module TypeName =
+  module Package =
+    let toPT (p : EPT.FQTypeName.Package) : PT.FQTypeName.Package =
+      { owner = p.owner; modules = p.modules; name = p.name; version = p.version }
+
+  let toPT (fqfn : EPT.FQTypeName.FQTypeName) : PT.FQTypeName.FQTypeName =
+    match fqfn with
+    | EPT.FQTypeName.Package p -> PT.FQTypeName.Package(Package.toPT p)
+
+
+module FnName =
+  module Builtin =
+    let toPT (b : EPT.FQFnName.Builtin) : PT.FQFnName.Builtin =
+      { name = b.name; version = b.version }
+
+  module Package =
+    let toPT (p : EPT.FQFnName.Package) : PT.FQFnName.Package =
+      { owner = p.owner; modules = p.modules; name = p.name; version = p.version }
+
+  let toPT (fqfn : EPT.FQFnName.FQFnName) : PT.FQFnName.FQFnName =
+    match fqfn with
+    | EPT.FQFnName.Builtin s -> PT.FQFnName.Builtin(Builtin.toPT s)
+    | EPT.FQFnName.Package p -> PT.FQFnName.Package(Package.toPT p)
+
+module ConstantName =
+  module Builtin =
+    let toPT (b : EPT.FQConstantName.Builtin) : PT.FQConstantName.Builtin =
+      { name = b.name; version = b.version }
+
+  module Package =
+    let toPT (p : EPT.FQConstantName.Package) : PT.FQConstantName.Package =
+      { owner = p.owner; modules = p.modules; name = p.name; version = p.version }
+
+  let toPT
+    (fqfn : EPT.FQConstantName.FQConstantName)
+    : PT.FQConstantName.FQConstantName =
+    match fqfn with
+    | EPT.FQConstantName.Builtin s -> PT.FQConstantName.Builtin(Builtin.toPT s)
+    | EPT.FQConstantName.Package p -> PT.FQConstantName.Package(Package.toPT p)
+
+
+
+module InfixFnName =
+  let toPT (name : ProgramTypes.InfixFnName) : PT.InfixFnName =
+    match name with
+    | EPT.ArithmeticPlus -> PT.ArithmeticPlus
+    | EPT.ArithmeticMinus -> PT.ArithmeticMinus
+    | EPT.ArithmeticMultiply -> PT.ArithmeticMultiply
+    | EPT.ArithmeticDivide -> PT.ArithmeticDivide
+    | EPT.ArithmeticModulo -> PT.ArithmeticModulo
+    | EPT.ArithmeticPower -> PT.ArithmeticPower
+    | EPT.ComparisonGreaterThan -> PT.ComparisonGreaterThan
+    | EPT.ComparisonGreaterThanOrEqual -> PT.ComparisonGreaterThanOrEqual
+    | EPT.ComparisonLessThan -> PT.ComparisonLessThan
+    | EPT.ComparisonLessThanOrEqual -> PT.ComparisonLessThanOrEqual
+    | EPT.ComparisonEquals -> PT.ComparisonEquals
+    | EPT.ComparisonNotEquals -> PT.ComparisonNotEquals
+    | EPT.StringConcat -> PT.StringConcat
+
+module TypeReference =
+  let rec toPT (t : EPT.TypeReference) : PT.TypeReference =
+    match t with
+    | EPT.TInt64 -> PT.TInt64
+    | EPT.TUInt64 -> PT.TUInt64
+    | EPT.TInt8 -> PT.TInt8
+    | EPT.TUInt8 -> PT.TUInt8
+    | EPT.TInt16 -> PT.TInt16
+    | EPT.TUInt16 -> PT.TUInt16
+    | EPT.TInt32 -> PT.TInt32
+    | EPT.TUInt32 -> PT.TUInt32
+    | EPT.TInt128 -> PT.TInt128
+    | EPT.TUInt128 -> PT.TUInt128
+    | EPT.TFloat -> PT.TFloat
+    | EPT.TBool -> PT.TBool
+    | EPT.TUnit -> PT.TUnit
+    | EPT.TString -> PT.TString
+    | EPT.TList typ -> PT.TList(toPT typ)
+    | EPT.TTuple(firstType, secondType, otherTypes) ->
+      PT.TTuple(toPT firstType, toPT secondType, List.map toPT otherTypes)
+    | EPT.TDict typ -> PT.TDict(toPT typ)
+    | EPT.TDB typ -> PT.TDB(toPT typ)
+    | EPT.TDateTime -> PT.TDateTime
+    | EPT.TChar -> PT.TChar
+    | EPT.TUuid -> PT.TUuid
+    | EPT.TCustomType(t, typeArgs) ->
+      PT.TCustomType(NameResolution.toPT TypeName.toPT t, List.map toPT typeArgs)
+    | EPT.TVariable(name) -> PT.TVariable(name)
+    | EPT.TFn(paramTypes, returnType) ->
+      PT.TFn(NEList.map toPT paramTypes, toPT returnType)
+
+module BinaryOperation =
+  let toPT (binop : EPT.BinaryOperation) : PT.BinaryOperation =
+    match binop with
+    | EPT.BinOpAnd -> PT.BinOpAnd
+    | EPT.BinOpOr -> PT.BinOpOr
+
+module Infix =
+  let toPT (infix : EPT.Infix) : PT.Infix =
+    match infix with
+    | EPT.InfixFnCall(fn) -> PT.InfixFnCall(InfixFnName.toPT fn)
+    | EPT.BinOp binop -> PT.BinOp(BinaryOperation.toPT binop)
+
+module LetPattern =
+  let rec toPT (p : EPT.LetPattern) : PT.LetPattern =
+    match p with
+    | EPT.LPVariable(id, str) -> PT.LPVariable(id, str)
+    | EPT.LPTuple(id, first, second, theRest) ->
+      PT.LPTuple(id, toPT first, toPT second, List.map toPT theRest)
+
+module MatchPattern =
+  let rec toPT (p : EPT.MatchPattern) : PT.MatchPattern =
+    match p with
+    | EPT.MPVariable(id, str) -> PT.MPVariable(id, str)
+    | EPT.MPEnum(id, caseName, fieldPats) ->
+      PT.MPEnum(id, caseName, List.map toPT fieldPats)
+    | EPT.MPInt64(id, i) -> PT.MPInt64(id, i)
+    | EPT.MPUInt64(id, i) -> PT.MPUInt64(id, i)
+    | EPT.MPInt8(id, i) -> PT.MPInt8(id, i)
+    | EPT.MPUInt8(id, i) -> PT.MPUInt8(id, i)
+    | EPT.MPInt16(id, i) -> PT.MPInt16(id, i)
+    | EPT.MPUInt16(id, i) -> PT.MPUInt16(id, i)
+    | EPT.MPInt32(id, i) -> PT.MPInt32(id, i)
+    | EPT.MPUInt32(id, i) -> PT.MPUInt32(id, i)
+    | EPT.MPInt128(id, i) -> PT.MPInt128(id, i)
+    | EPT.MPUInt128(id, i) -> PT.MPUInt128(id, i)
+    | EPT.MPBool(id, b) -> PT.MPBool(id, b)
+    | EPT.MPChar(id, c) -> PT.MPChar(id, c)
+    | EPT.MPString(id, s) -> PT.MPString(id, s)
+    | EPT.MPFloat(id, s, w, f) -> PT.MPFloat(id, Sign.toPT s, w, f)
+    | EPT.MPUnit id -> PT.MPUnit id
+    | EPT.MPTuple(id, first, second, theRest) ->
+      PT.MPTuple(id, toPT first, toPT second, List.map toPT theRest)
+    | EPT.MPList(id, pats) -> PT.MPList(id, List.map toPT pats)
+    | EPT.MPListCons(id, head, tail) -> PT.MPListCons(id, toPT head, toPT tail)
+
+
+module Expr =
+  let rec toPT (e : EPT.Expr) : PT.Expr =
+    match e with
+    | EPT.EChar(id, char) -> PT.EChar(id, char)
+    | EPT.EInt64(id, num) -> PT.EInt64(id, num)
+    | EPT.EUInt64(id, num) -> PT.EUInt64(id, num)
+    | EPT.EInt8(id, num) -> PT.EInt8(id, num)
+    | EPT.EUInt8(id, num) -> PT.EUInt8(id, num)
+    | EPT.EInt16(id, num) -> PT.EInt16(id, num)
+    | EPT.EUInt16(id, num) -> PT.EUInt16(id, num)
+    | EPT.EInt32(id, num) -> PT.EInt32(id, num)
+    | EPT.EUInt32(id, num) -> PT.EUInt32(id, num)
+    | EPT.EInt128(id, num) -> PT.EInt128(id, num)
+    | EPT.EUInt128(id, num) -> PT.EUInt128(id, num)
+    | EPT.EString(id, segment) -> PT.EString(id, List.map stringSegmentToPT segment)
+    | EPT.EFloat(id, sign, whole, fraction) ->
+      PT.EFloat(id, Sign.toPT sign, whole, fraction)
+    | EPT.EBool(id, b) -> PT.EBool(id, b)
+    | EPT.EUnit id -> PT.EUnit id
+    | EPT.EConstant(id, name) ->
+      PT.EConstant(id, NameResolution.toPT ConstantName.toPT name)
+    | EPT.EVariable(id, var) -> PT.EVariable(id, var)
+    | EPT.EFieldAccess(id, obj, fieldname) ->
+      PT.EFieldAccess(id, toPT obj, fieldname)
+    | EPT.EApply(id, name, typeArgs, args) ->
+      PT.EApply(
+        id,
+        toPT name,
+        List.map TypeReference.toPT typeArgs,
+        NEList.map toPT args
+      )
+    | EPT.ELambda(id, pats, body) ->
+      PT.ELambda(id, NEList.map LetPattern.toPT pats, toPT body)
+    | EPT.ELet(id, pat, rhs, body) ->
+      PT.ELet(id, LetPattern.toPT pat, toPT rhs, toPT body)
+    | EPT.EIf(id, cond, thenExpr, elseExpr) ->
+      PT.EIf(id, toPT cond, toPT thenExpr, Option.map toPT elseExpr)
+    | EPT.EList(id, exprs) -> PT.EList(id, List.map toPT exprs)
+    | EPT.ETuple(id, first, second, theRest) ->
+      PT.ETuple(id, toPT first, toPT second, List.map toPT theRest)
+    | EPT.ERecord(id, typeName, fields) ->
+      PT.ERecord(
+        id,
+        NameResolution.toPT TypeName.toPT typeName,
+        List.map (Tuple2.mapSecond toPT) fields
+      )
+    | EPT.ERecordUpdate(id, record, updates) ->
+      PT.ERecordUpdate(
+        id,
+        toPT record,
+        updates |> NEList.map (fun (name, expr) -> (name, toPT expr))
+      )
+    | EPT.EPipe(pipeID, expr1, rest) ->
+      PT.EPipe(pipeID, toPT expr1, List.map pipeExprToPT rest)
+    | EPT.EEnum(id, typeName, caseName, exprs) ->
+      PT.EEnum(
+        id,
+        NameResolution.toPT TypeName.toPT typeName,
+        caseName,
+        List.map toPT exprs
+      )
+    | EPT.EMatch(id, mexpr, cases) ->
+      PT.EMatch(id, toPT mexpr, List.map matchCaseToPT cases)
+    | EPT.EInfix(id, infix, arg1, arg2) ->
+      PT.EInfix(id, Infix.toPT infix, toPT arg1, toPT arg2)
+    | EPT.EDict(id, pairs) -> PT.EDict(id, List.map (Tuple2.mapSecond toPT) pairs)
+    | EPT.EFnName(id, name) -> PT.EFnName(id, NameResolution.toPT FnName.toPT name)
+
+  and stringSegmentToPT (segment : EPT.StringSegment) : PT.StringSegment =
+    match segment with
+    | EPT.StringText text -> PT.StringText text
+    | EPT.StringInterpolation expr -> PT.StringInterpolation(toPT expr)
+
+  and pipeExprToPT (pipeExpr : EPT.PipeExpr) : PT.PipeExpr =
+    match pipeExpr with
+    | EPT.EPipeVariable(id, name, exprs) ->
+      PT.EPipeVariable(id, name, List.map toPT exprs)
+    | EPT.EPipeLambda(id, pats, body) ->
+      PT.EPipeLambda(id, NEList.map LetPattern.toPT pats, toPT body)
+    | EPT.EPipeInfix(id, infix, first) ->
+      PT.EPipeInfix(id, Infix.toPT infix, toPT first)
+    | EPT.EPipeFnCall(id, fnName, typeArgs, args) ->
+      PT.EPipeFnCall(
+        id,
+        NameResolution.toPT FnName.toPT fnName,
+        List.map TypeReference.toPT typeArgs,
+        List.map toPT args
+      )
+    | EPT.EPipeEnum(id, typeName, caseName, fields) ->
+      PT.EPipeEnum(
+        id,
+        NameResolution.toPT TypeName.toPT typeName,
+        caseName,
+        List.map toPT fields
+      )
+
+  and matchCaseToPT (case : EPT.MatchCase) : PT.MatchCase =
+    { pat = MatchPattern.toPT case.pat
+      whenCondition = Option.map toPT case.whenCondition
+      rhs = toPT case.rhs }
+
+module Deprecation =
+  let toPT
+    (f : 'name1 -> 'name2)
+    (d : EPT.Deprecation<'name1>)
+    : PT.Deprecation<'name2> =
+    match d with
+    | EPT.NotDeprecated -> PT.NotDeprecated
+    | EPT.RenamedTo name -> PT.RenamedTo(f name)
+    | EPT.ReplacedBy name -> PT.ReplacedBy(f name)
+    | EPT.DeprecatedBecause reason -> PT.DeprecatedBecause reason
+
+module TypeDeclaration =
+  module RecordField =
+    let toPT (f : EPT.TypeDeclaration.RecordField) : PT.TypeDeclaration.RecordField =
+      { name = f.name; typ = TypeReference.toPT f.typ; description = f.description }
+
+  module EnumField =
+    let toPT (f : EPT.TypeDeclaration.EnumField) : PT.TypeDeclaration.EnumField =
+      { typ = TypeReference.toPT f.typ
+        label = f.label
+        description = f.description }
+
+  module EnumCase =
+    let toPT (c : EPT.TypeDeclaration.EnumCase) : PT.TypeDeclaration.EnumCase =
+      { name = c.name
+        fields = List.map EnumField.toPT c.fields
+        description = c.description }
+
+  module Definition =
+    let toPT (d : EPT.TypeDeclaration.Definition) : PT.TypeDeclaration.Definition =
+      match d with
+      | EPT.TypeDeclaration.Alias typ ->
+        PT.TypeDeclaration.Alias(TypeReference.toPT typ)
+      | EPT.TypeDeclaration.Record fields ->
+        PT.TypeDeclaration.Record(NEList.map RecordField.toPT fields)
+      | EPT.TypeDeclaration.Enum cases ->
+        PT.TypeDeclaration.Enum(NEList.map EnumCase.toPT cases)
+
+  let toPT (d : EPT.TypeDeclaration.TypeDeclaration) : PT.TypeDeclaration.T =
+    { typeParams = d.typeParams; definition = Definition.toPT d.definition }
+
+module PackageFn =
+  module Parameter =
+    let toPT (p : EPT.PackageFn.Parameter) : PT.PackageFn.Parameter =
+      { name = p.name; typ = TypeReference.toPT p.typ; description = p.description }
+
+  let toPT (fn : EPT.PackageFn.PackageFn) : PT.PackageFn.T =
+    { name = FnName.Package.toPT fn.name
+      parameters = NEList.map Parameter.toPT fn.parameters
+      returnType = TypeReference.toPT fn.returnType
+      description = fn.description
+      deprecated = Deprecation.toPT FnName.toPT fn.deprecated
+      body = Expr.toPT fn.body
+      typeParams = fn.typeParams
+      id = fn.id
+      tlid = fn.tlid }
+
+module PackageType =
+  let toPT (pt : EPT.PackageType) : PT.PackageType.T =
+    { name = TypeName.Package.toPT pt.name
+      description = pt.description
+      declaration = TypeDeclaration.toPT pt.declaration
+      deprecated = Deprecation.toPT TypeName.toPT pt.deprecated
+      id = pt.id
+      tlid = pt.tlid }
+
+module Const =
+  let rec toPT (c : EPT.Const) : PT.Const =
+    match c with
+    | EPT.CInt64 i -> PT.CInt64 i
+    | EPT.CUInt64 i -> PT.CUInt64 i
+    | EPT.CInt8 i -> PT.CInt8 i
+    | EPT.CUInt8 i -> PT.CUInt8 i
+    | EPT.CInt16 i -> PT.CInt16 i
+    | EPT.CUInt16 i -> PT.CUInt16 i
+    | EPT.CInt32 i -> PT.CInt32 i
+    | EPT.CUInt32 i -> PT.CUInt32 i
+    | EPT.CInt128 i -> PT.CInt128 i
+    | EPT.CUInt128 i -> PT.CUInt128 i
+    | EPT.CBool b -> PT.CBool b
+    | EPT.CString s -> PT.CString s
+    | EPT.CChar c -> PT.CChar c
+    | EPT.CFloat(s, w, f) -> PT.CFloat(Sign.toPT s, w, f)
+    | EPT.CUnit -> PT.CUnit
+    | EPT.CTuple(first, second, rest) ->
+      PT.CTuple(toPT first, toPT second, List.map toPT rest)
+    | EPT.CEnum(typeName, caseName, fields) ->
+      PT.CEnum(
+        NameResolution.toPT TypeName.toPT typeName,
+        caseName,
+        List.map toPT fields
+      )
+    | EPT.CList l -> PT.CList(List.map toPT l)
+    | EPT.CDict pairs -> PT.CDict(List.map (Tuple2.mapSecond toPT) pairs)
+
+
+module PackageConstant =
+  let toPT (c : EPT.PackageConstant) : PT.PackageConstant.T =
+    { name = ConstantName.Package.toPT c.name
+      description = c.description
+      deprecated = Deprecation.toPT ConstantName.toPT c.deprecated
+      id = c.id
+      tlid = c.tlid
+      body = Const.toPT c.body }

--- a/backend/src/LibPackageManager/JsonDeserialization.fs
+++ b/backend/src/LibPackageManager/JsonDeserialization.fs
@@ -1,0 +1,810 @@
+// Please see the README.
+module rec LibPackageManager.JsonDeserialization
+
+open SimpleJson
+open Types
+
+#nowarn "40"
+
+module ID =
+  let decoder : JsonDecoder<ID> = Decoders.uint64
+
+module TLID =
+  let decoder : JsonDecoder<TLID> = Decoders.uint64
+
+module Sign =
+  let decoder : JsonDecoder<Sign> =
+    [ ("Positive", Decoders.enum0Fields Sign.Positive)
+      ("Negative", Decoders.enum0Fields Sign.Negative) ]
+    |> Map.ofList
+    |> Decoders.du
+
+
+module NameResolutionError =
+  module ErrorType =
+    type DU = NameResolutionError.ErrorType
+
+    let decoder : JsonDecoder<DU> =
+      [ ("NotFound", Decoders.enum0Fields DU.NotFound)
+        ("ExpectedEnumButNot", Decoders.enum0Fields DU.ExpectedEnumButNot)
+        ("ExpectedRecordButNot", Decoders.enum0Fields DU.ExpectedRecordButNot)
+        ("MissingEnumModuleName",
+         Decoders.enum1Field Decoders.string DU.MissingEnumModuleName)
+        ("InvalidPackageName", Decoders.enum0Fields DU.InvalidPackageName) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module NameType =
+    type DU = NameResolutionError.NameType
+
+    let decoder : JsonDecoder<DU> =
+      [ ("Type", Decoders.enum0Fields DU.Type)
+        ("Constant", Decoders.enum0Fields DU.Constant)
+        ("Function", Decoders.enum0Fields DU.Function) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module Error =
+    let decoder : JsonDecoder<NameResolutionError.Error> =
+      Decoders.obj3Fields
+        "NameResolution"
+        ("errorType", ErrorType.decoder)
+        ("nameType", NameType.decoder)
+        ("names", Decoders.list Decoders.string)
+        (fun errType nameType names ->
+          { errorType = errType; nameType = nameType; names = names })
+
+
+module ProgramTypes =
+  module NameResolution =
+    let decoder
+      (inner : JsonDecoder<'TInner>)
+      : JsonDecoder<ProgramTypes.NameResolution<'TInner>> =
+      [ ("Ok", Decoders.enum1Field inner Ok)
+        ("Error", Decoders.enum1Field NameResolutionError.Error.decoder Error) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module FQTypeName =
+    module Package =
+      let decoder : JsonDecoder<ProgramTypes.FQTypeName.Package> =
+        Decoders.obj4Fields
+          "FQTypeName.Package"
+          ("owner", Decoders.string)
+          ("modules", Decoders.list Decoders.string)
+          ("name", Decoders.string)
+          ("version", Decoders.int32)
+          (fun owner modules name version ->
+            { owner = owner; modules = modules; name = name; version = version })
+
+    module FQTypeName =
+      type DU = ProgramTypes.FQTypeName.FQTypeName
+
+      let decoder : JsonDecoder<DU> =
+        [ ("Package", Decoders.enum1Field Package.decoder DU.Package) ]
+        |> Map.ofList
+        |> Decoders.du
+
+
+  module FQFnName =
+    module Builtin =
+      let decoder : JsonDecoder<ProgramTypes.FQFnName.Builtin> =
+        Decoders.obj2Fields
+          "FQFnName.Builtin"
+          ("name", Decoders.string)
+          ("version", Decoders.int32)
+          (fun name version -> { name = name; version = version })
+
+    module Package =
+      let decoder : JsonDecoder<ProgramTypes.FQFnName.Package> =
+        Decoders.obj4Fields
+          "FQFnName.Package"
+          ("owner", Decoders.string)
+          ("modules", Decoders.list Decoders.string)
+          ("name", Decoders.string)
+          ("version", Decoders.int32)
+          (fun owner modules name version ->
+            { owner = owner; modules = modules; name = name; version = version })
+
+    module FQFnName =
+      type DU = ProgramTypes.FQFnName.FQFnName
+
+      let decoder : JsonDecoder<DU> =
+        [ ("Builtin", Decoders.enum1Field Builtin.decoder DU.Builtin)
+          ("Package", Decoders.enum1Field Package.decoder DU.Package) ]
+        |> Map.ofList
+        |> Decoders.du
+
+
+  module FQConstantName =
+    module Builtin =
+      let decoder : JsonDecoder<ProgramTypes.FQConstantName.Builtin> =
+        Decoders.obj2Fields
+          "FQConstantName.Builtin"
+          ("name", Decoders.string)
+          ("version", Decoders.int32)
+          (fun name version -> { name = name; version = version })
+
+    module Package =
+      let decoder : JsonDecoder<ProgramTypes.FQConstantName.Package> =
+        Decoders.obj4Fields
+          "FQConstantName.Package"
+          ("owner", Decoders.string)
+          ("modules", Decoders.list Decoders.string)
+          ("name", Decoders.string)
+          ("version", Decoders.int32)
+          (fun owner modules name version ->
+            { owner = owner; modules = modules; name = name; version = version })
+
+    module FQConstantName =
+      type DU = ProgramTypes.FQConstantName.FQConstantName
+
+      let decoder : JsonDecoder<DU> =
+        [ ("Builtin", Decoders.enum1Field Builtin.decoder DU.Builtin)
+          ("Package", Decoders.enum1Field Package.decoder DU.Package) ]
+        |> Map.ofList
+        |> Decoders.du
+
+  module TypeReference =
+    type DU = ProgramTypes.TypeReference
+
+    let rec decoder : JsonDecoder<DU> =
+      [ ("TVariable", Decoders.enum1Field Decoders.string DU.TVariable)
+        ("TUnit", Decoders.enum0Fields DU.TUnit)
+        ("TBool", Decoders.enum0Fields DU.TBool)
+        ("TInt64", Decoders.enum0Fields DU.TInt64)
+        ("TUInt64", Decoders.enum0Fields DU.TUInt64)
+        ("TInt8", Decoders.enum0Fields DU.TInt8)
+        ("TUInt8", Decoders.enum0Fields DU.TUInt8)
+        ("TInt16", Decoders.enum0Fields DU.TInt16)
+        ("TUInt16", Decoders.enum0Fields DU.TUInt16)
+        ("TInt32", Decoders.enum0Fields DU.TInt32)
+        ("TUInt32", Decoders.enum0Fields DU.TUInt32)
+        ("TInt128", Decoders.enum0Fields DU.TInt128)
+        ("TUInt128", Decoders.enum0Fields DU.TUInt128)
+        ("TFloat", Decoders.enum0Fields DU.TFloat)
+        ("TChar", Decoders.enum0Fields DU.TChar)
+        ("TString", Decoders.enum0Fields DU.TString)
+        ("TDateTime", Decoders.enum0Fields DU.TDateTime)
+        ("TUuid", Decoders.enum0Fields DU.TUuid)
+        ("TList", Decoders.enum1Field (fun ctx -> decoder ctx) DU.TList)
+        ("TTuple",
+         Decoders.enum3Fields
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun first second rest -> DU.TTuple(first, second, rest)))
+        ("TDict", Decoders.enum1Field (fun ctx -> decoder ctx) DU.TDict)
+        ("TCustomType",
+         Decoders.enum2Fields
+           (NameResolution.decoder FQTypeName.FQTypeName.decoder)
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun name typeArgs -> DU.TCustomType(name, typeArgs)))
+        ("TDB", Decoders.enum1Field (fun ctx -> decoder ctx) DU.TDB)
+        ("TFn",
+         Decoders.enum2Fields
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun ctx -> decoder ctx)
+           (fun typeArgs returnType ->
+             DU.TFn(
+               NEList.ofListUnsafe
+                 "TODO: PT.TypeRef.TFn should have an NEList in Dark"
+                 []
+                 typeArgs,
+               returnType
+             ))) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module LetPattern =
+    type DU = ProgramTypes.LetPattern
+
+    let rec decoder : JsonDecoder<DU> =
+      [ ("LPVariable",
+         Decoders.enum2Fields ID.decoder Decoders.string (fun id name ->
+           DU.LPVariable(id, name)))
+        ("LPTuple",
+         Decoders.enum4Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id first second rest -> DU.LPTuple(id, first, second, rest))) ]
+      |> Map.ofList
+      |> Decoders.du
+
+  module MatchPattern =
+    type DU = ProgramTypes.MatchPattern
+
+    let rec decoder : JsonDecoder<DU> =
+      [ ("MPVariable",
+         Decoders.enum2Fields ID.decoder Decoders.string (fun id name ->
+           DU.MPVariable(id, name)))
+        ("MPUnit", Decoders.enum1Field ID.decoder DU.MPUnit)
+        ("MPBool",
+         Decoders.enum2Fields ID.decoder Decoders.bool (fun id value ->
+           DU.MPBool(id, value)))
+        ("MPInt64",
+         Decoders.enum2Fields ID.decoder Decoders.int64 (fun id value ->
+           DU.MPInt64(id, value)))
+        ("MPUInt64",
+         Decoders.enum2Fields ID.decoder Decoders.uint64 (fun id value ->
+           DU.MPUInt64(id, value)))
+        ("MPInt8",
+         Decoders.enum2Fields ID.decoder Decoders.int8 (fun id value ->
+           DU.MPInt8(id, value)))
+        ("MPUInt8",
+         Decoders.enum2Fields ID.decoder Decoders.uint8 (fun id value ->
+           DU.MPUInt8(id, value)))
+        ("MPInt16",
+         Decoders.enum2Fields ID.decoder Decoders.int16 (fun id value ->
+           DU.MPInt16(id, value)))
+        ("MPUInt16",
+         Decoders.enum2Fields ID.decoder Decoders.uint16 (fun id value ->
+           DU.MPUInt16(id, value)))
+        ("MPInt32",
+         Decoders.enum2Fields ID.decoder Decoders.int32 (fun id value ->
+           DU.MPInt32(id, value)))
+        ("MPUInt32",
+         Decoders.enum2Fields ID.decoder Decoders.uint32 (fun id value ->
+           DU.MPUInt32(id, value)))
+        ("MPInt128",
+         Decoders.enum2Fields ID.decoder Decoders.int128 (fun id value ->
+           DU.MPInt128(id, value)))
+        ("MPUInt128",
+         Decoders.enum2Fields ID.decoder Decoders.uint128 (fun id value ->
+           DU.MPUInt128(id, value)))
+        ("MPFloat",
+         Decoders.enum4Fields
+           ID.decoder
+           Sign.decoder
+           Decoders.string
+           Decoders.string
+           (fun id sign mantissa exponent ->
+             DU.MPFloat(id, sign, mantissa, exponent)))
+        ("MPChar",
+         Decoders.enum2Fields ID.decoder Decoders.string (fun id value ->
+           DU.MPChar(id, value)))
+        ("MPString",
+         Decoders.enum2Fields ID.decoder Decoders.string (fun id value ->
+           DU.MPString(id, value)))
+        ("MPList",
+         Decoders.enum2Fields
+           ID.decoder
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id value -> DU.MPList(id, value)))
+        ("MPListCons",
+         Decoders.enum3Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (fun id head tail -> DU.MPListCons(id, head, tail)))
+        ("MPTuple",
+         Decoders.enum4Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id first second rest -> DU.MPTuple(id, first, second, rest)))
+        ("MPEnum",
+         Decoders.enum3Fields
+           ID.decoder
+           Decoders.string
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id caseName fieldPats -> DU.MPEnum(id, caseName, fieldPats))) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module BinaryOperation =
+    type DU = ProgramTypes.BinaryOperation
+
+    let decoder : JsonDecoder<DU> =
+      [ ("BinOpAnd", Decoders.enum0Fields DU.BinOpAnd)
+        ("BinOpOr", Decoders.enum0Fields DU.BinOpOr) ]
+      |> Map.ofList
+      |> Decoders.du
+
+  module InfixFnName =
+    type DU = ProgramTypes.InfixFnName
+
+    let decoder : JsonDecoder<DU> =
+      [ ("ArithmeticPlus", Decoders.enum0Fields DU.ArithmeticPlus)
+        ("ArithmeticMinus", Decoders.enum0Fields DU.ArithmeticMinus)
+        ("ArithmeticMultiply", Decoders.enum0Fields DU.ArithmeticMultiply)
+        ("ArithmeticDivide", Decoders.enum0Fields DU.ArithmeticDivide)
+        ("ArithmeticModulo", Decoders.enum0Fields DU.ArithmeticModulo)
+        ("ArithmeticPower", Decoders.enum0Fields DU.ArithmeticPower)
+        ("ComparisonGreaterThan", Decoders.enum0Fields DU.ComparisonGreaterThan)
+        ("ComparisonGreaterThanOrEqual",
+         Decoders.enum0Fields DU.ComparisonGreaterThanOrEqual)
+        ("ComparisonLessThan", Decoders.enum0Fields DU.ComparisonLessThan)
+        ("ComparisonLessThanOrEqual",
+         Decoders.enum0Fields DU.ComparisonLessThanOrEqual)
+        ("ComparisonEquals", Decoders.enum0Fields DU.ComparisonEquals)
+        ("ComparisonNotEquals", Decoders.enum0Fields DU.ComparisonNotEquals)
+        ("StringConcat", Decoders.enum0Fields DU.StringConcat) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module Infix =
+    type DU = ProgramTypes.Infix
+
+    let decoder : JsonDecoder<DU> =
+      [ ("InfixFnCall", Decoders.enum1Field InfixFnName.decoder DU.InfixFnCall)
+        ("BinOp", Decoders.enum1Field BinaryOperation.decoder DU.BinOp) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module StringSegment =
+    type DU = ProgramTypes.StringSegment
+
+    let decoder : JsonDecoder<DU> =
+      [ ("StringText", Decoders.enum1Field Decoders.string DU.StringText)
+        ("StringInterpolation",
+         Decoders.enum1Field (fun ctx -> Expr.decoder ctx) DU.StringInterpolation) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module PipeExpr =
+    type DU = ProgramTypes.PipeExpr
+
+    let rec decoder : JsonDecoder<DU> =
+      [ ("EPipeVariable",
+         Decoders.enum3Fields
+           ID.decoder
+           Decoders.string
+           (Decoders.list (fun ctx -> Expr.decoder ctx))
+           (fun id name args -> DU.EPipeVariable(id, name, args)))
+        ("EPipeLambda",
+         Decoders.enum3Fields
+           ID.decoder
+           (Decoders.list (LetPattern.decoder))
+           (fun ctx -> Expr.decoder ctx)
+           (fun id pats body ->
+             DU.EPipeLambda(
+               id,
+               pats
+               |> NEList.ofListUnsafe
+                 "TODO: Expr.EPipeLambda should have an NEList in Dark"
+                 [],
+               body
+             )))
+        ("EPipeInfix",
+         Decoders.enum3Fields
+           ID.decoder
+           Infix.decoder
+           (fun ctx -> Expr.decoder ctx)
+           (fun id infix expr -> DU.EPipeInfix(id, infix, expr)))
+        ("EPipeFnCall",
+         Decoders.enum4Fields
+           ID.decoder
+           (NameResolution.decoder FQFnName.FQFnName.decoder)
+           (Decoders.list (fun ctx -> TypeReference.decoder ctx))
+           (Decoders.list (fun ctx -> Expr.decoder ctx))
+           (fun id name typeArgs args -> DU.EPipeFnCall(id, name, typeArgs, args)))
+        ("EPipeEnum",
+         Decoders.enum4Fields
+           ID.decoder
+           (NameResolution.decoder FQTypeName.FQTypeName.decoder)
+           Decoders.string
+           (Decoders.list (fun ctx -> Expr.decoder ctx))
+           (fun id typeName caseName fields ->
+             DU.EPipeEnum(id, typeName, caseName, fields))) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module Expr =
+    type DU = ProgramTypes.Expr
+
+    let rec decoder : JsonDecoder<DU> =
+      [ ("EUnit", Decoders.enum1Field ID.decoder DU.EUnit)
+        ("EBool",
+         Decoders.enum2Fields ID.decoder Decoders.bool (fun id value ->
+           DU.EBool(id, value)))
+        ("EInt64",
+         Decoders.enum2Fields ID.decoder Decoders.int64 (fun id value ->
+           DU.EInt64(id, value)))
+        ("EUInt64",
+         Decoders.enum2Fields ID.decoder Decoders.uint64 (fun id value ->
+           DU.EUInt64(id, value)))
+        ("EInt8",
+         Decoders.enum2Fields ID.decoder Decoders.int8 (fun id value ->
+           DU.EInt8(id, value)))
+        ("EUInt8",
+         Decoders.enum2Fields ID.decoder Decoders.uint8 (fun id value ->
+           DU.EUInt8(id, value)))
+        ("EInt16",
+         Decoders.enum2Fields ID.decoder Decoders.int16 (fun id value ->
+           DU.EInt16(id, value)))
+        ("EUInt16",
+         Decoders.enum2Fields ID.decoder Decoders.uint16 (fun id value ->
+           DU.EUInt16(id, value)))
+        ("EInt32",
+         Decoders.enum2Fields ID.decoder Decoders.int32 (fun id value ->
+           DU.EInt32(id, value)))
+        ("EUInt32",
+         Decoders.enum2Fields ID.decoder Decoders.uint32 (fun id value ->
+           DU.EUInt32(id, value)))
+        ("EInt128",
+         Decoders.enum2Fields ID.decoder Decoders.int128 (fun id value ->
+           DU.EInt128(id, value)))
+        ("EUInt128",
+         Decoders.enum2Fields ID.decoder Decoders.uint128 (fun id value ->
+           DU.EUInt128(id, value)))
+        ("EFloat",
+         Decoders.enum4Fields
+           ID.decoder
+           Sign.decoder
+           Decoders.string
+           Decoders.string
+           (fun id sign mantissa exponent -> DU.EFloat(id, sign, mantissa, exponent)))
+        ("EChar",
+         Decoders.enum2Fields ID.decoder Decoders.string (fun id value ->
+           DU.EChar(id, value)))
+        ("EString",
+         Decoders.enum2Fields
+           ID.decoder
+           (Decoders.list StringSegment.decoder)
+           (fun id segments -> DU.EString(id, segments)))
+        ("EConstant",
+         Decoders.enum2Fields
+           ID.decoder
+           (NameResolution.decoder FQConstantName.FQConstantName.decoder)
+           (fun id name -> DU.EConstant(id, name)))
+        ("EList",
+         Decoders.enum2Fields
+           ID.decoder
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id value -> DU.EList(id, value)))
+        ("EDict",
+         Decoders.enum2Fields
+           ID.decoder
+           (Decoders.list (Decoders.pair Decoders.string (fun ctx -> decoder ctx)))
+           (fun id value -> DU.EDict(id, value)))
+        ("ETuple",
+         Decoders.enum4Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id first second rest -> DU.ETuple(id, first, second, rest)))
+        ("ERecord",
+         Decoders.enum3Fields
+           ID.decoder
+           (NameResolution.decoder FQTypeName.FQTypeName.decoder)
+           (Decoders.list (Decoders.pair Decoders.string (fun ctx -> decoder ctx)))
+           (fun id name fields -> DU.ERecord(id, name, fields)))
+        ("EEnum",
+         Decoders.enum4Fields
+           ID.decoder
+           (NameResolution.decoder FQTypeName.FQTypeName.decoder)
+           Decoders.string
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id typeName caseName fields ->
+             DU.EEnum(id, typeName, caseName, fields)))
+        ("ELet",
+         Decoders.enum4Fields
+           ID.decoder
+           (LetPattern.decoder)
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (fun id pattern value body -> DU.ELet(id, pattern, value, body)))
+        ("EFieldAccess",
+         Decoders.enum3Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           Decoders.string
+           (fun id expr fieldName -> DU.EFieldAccess(id, expr, fieldName)))
+        ("EVariable",
+         Decoders.enum2Fields ID.decoder Decoders.string (fun id name ->
+           DU.EVariable(id, name)))
+        ("EIf",
+         Decoders.enum4Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (Decoders.option (fun ctx -> decoder ctx))
+           (fun id cond thenExpr elseExpr -> DU.EIf(id, cond, thenExpr, elseExpr)))
+        ("EMatch",
+         Decoders.enum3Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (Decoders.list MatchCase.decoder)
+           (fun id arg cases -> DU.EMatch(id, arg, cases)))
+        ("EPipe",
+         Decoders.enum3Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (Decoders.list (fun ctx -> PipeExpr.decoder ctx))
+           (fun id expr pipeExprs -> DU.EPipe(id, expr, pipeExprs)))
+        ("EInfix",
+         Decoders.enum4Fields
+           ID.decoder
+           Infix.decoder
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (fun id infix left right -> DU.EInfix(id, infix, left, right)))
+        ("ELambda",
+         Decoders.enum3Fields
+           ID.decoder
+           (Decoders.list (LetPattern.decoder))
+           (fun ctx -> decoder ctx)
+           (fun id pats body ->
+             DU.ELambda(
+               id,
+               pats
+               |> NEList.ofListUnsafe
+                 "TODO: Expr.ELambda should have an NEList in Dark"
+                 [],
+               body
+             )))
+        ("EApply",
+         Decoders.enum4Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (Decoders.list (fun ctx -> TypeReference.decoder ctx))
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun id expr typeArgs args ->
+             DU.EApply(
+               id,
+               expr,
+               typeArgs,
+               args
+               |> NEList.ofListUnsafe
+                 "TODO: Expr.EApply should have an NEList in Dark"
+                 []
+             )))
+        ("EFnName",
+         Decoders.enum2Fields
+           ID.decoder
+           (NameResolution.decoder FQFnName.FQFnName.decoder)
+           (fun id name -> DU.EFnName(id, name)))
+        ("ERecordUpdate",
+         Decoders.enum3Fields
+           ID.decoder
+           (fun ctx -> decoder ctx)
+           (Decoders.list (Decoders.pair Decoders.string (fun ctx -> decoder ctx)))
+           (fun id record updates ->
+             DU.ERecordUpdate(
+               id,
+               record,
+               updates
+               |> NEList.ofListUnsafe
+                 "TODO: Expr.ERecordUpdate should have an NEList in Dark"
+                 []
+             ))) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+
+  module MatchCase =
+    let decoder : JsonDecoder<ProgramTypes.MatchCase> =
+      Decoders.obj3Fields
+        "MatchCase"
+        ("pat", (fun ctx -> MatchPattern.decoder ctx))
+        ("whenCondition", Decoders.option (fun ctx -> Expr.decoder ctx))
+        ("rhs", (fun ctx -> Expr.decoder ctx))
+        (fun pat whenCondition rhs ->
+          { pat = pat; whenCondition = whenCondition; rhs = rhs })
+
+
+  module Deprecation =
+    type DU<'name> = ProgramTypes.Deprecation<'name>
+
+    let decoder (nameDecoder : JsonDecoder<'name>) : JsonDecoder<DU<'name>> =
+      [ ("NotDeprecated", Decoders.enum0Fields DU.NotDeprecated)
+        ("RenamedTo", Decoders.enum1Field nameDecoder DU.RenamedTo)
+        ("ReplacedBy", Decoders.enum1Field nameDecoder DU.ReplacedBy)
+        ("DeprecatedBecause",
+         Decoders.enum1Field Decoders.string DU.DeprecatedBecause) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+
+  module TypeDeclaration =
+    module RecordField =
+      let decoder : JsonDecoder<ProgramTypes.TypeDeclaration.RecordField> =
+        Decoders.obj3Fields
+          "TypeDeclaration.RecordField"
+          ("name", Decoders.string)
+          ("typ", (fun ctx -> TypeReference.decoder ctx))
+          ("description", Decoders.string)
+          (fun name typ description ->
+            { name = name; typ = typ; description = description })
+
+
+    module EnumField =
+      let decoder : JsonDecoder<ProgramTypes.TypeDeclaration.EnumField> =
+        Decoders.obj3Fields
+          "TypeDeclaration.EnumField"
+          ("typ", (fun ctx -> TypeReference.decoder ctx))
+          ("label", Decoders.option Decoders.string)
+          ("description", Decoders.string)
+          (fun typ label description ->
+            { typ = typ; label = label; description = description })
+
+    module EnumCase =
+      let decoder : JsonDecoder<ProgramTypes.TypeDeclaration.EnumCase> =
+        Decoders.obj3Fields
+          "TypeDeclaration.EnumCase"
+          ("name", Decoders.string)
+          ("fields", Decoders.list EnumField.decoder)
+          ("description", Decoders.string)
+          (fun name fields description ->
+            { name = name; fields = fields; description = description })
+
+
+    module Definition =
+      type DU = ProgramTypes.TypeDeclaration.Definition
+
+      let decoder : JsonDecoder<DU> =
+        [ ("Alias",
+           Decoders.enum1Field (fun ctx -> TypeReference.decoder ctx) DU.Alias)
+          ("Record",
+           Decoders.enum1Field (Decoders.list RecordField.decoder) (fun fields ->
+             fields
+             |> NEList.ofListUnsafe
+               "TODO: PT.Definition.Record should have an NEList in Dark"
+               []
+             |> DU.Record))
+          ("Enum",
+           Decoders.enum1Field (Decoders.list EnumCase.decoder) (fun cases ->
+             cases
+             |> NEList.ofListUnsafe
+               "TODO: PT.Definition.Enum should have an NEList in Dark"
+               []
+             |> DU.Enum)) ]
+        |> Map.ofList
+        |> Decoders.du
+
+
+    module TypeDeclaration =
+      let decoder : JsonDecoder<ProgramTypes.TypeDeclaration.TypeDeclaration> =
+        Decoders.obj2Fields
+          "TypeDeclaration.TypeDeclaration"
+          ("typeParams", Decoders.list Decoders.string)
+          ("definition", Definition.decoder)
+          (fun typeParams definition ->
+            { typeParams = typeParams; definition = definition })
+
+  module PackageType =
+    let decoder : JsonDecoder<ProgramTypes.PackageType> =
+      Decoders.obj6Fields
+        "PackageType"
+        ("tlid", TLID.decoder)
+        ("id", Decoders.guid)
+        ("name", FQTypeName.Package.decoder)
+        ("declaration", TypeDeclaration.TypeDeclaration.decoder)
+        ("description", Decoders.string)
+        ("deprecated", Deprecation.decoder FQTypeName.FQTypeName.decoder)
+        (fun tlid id name declaration description deprecated ->
+          { tlid = tlid
+            id = id
+            name = name
+            declaration = declaration
+            description = description
+            deprecated = deprecated })
+
+
+  module PackageFn =
+    module Parameter =
+      let decoder : JsonDecoder<ProgramTypes.PackageFn.Parameter> =
+        Decoders.obj3Fields
+          "PackageFn.Parameter"
+          ("name", Decoders.string)
+          ("typ", (fun ctx -> TypeReference.decoder ctx))
+          ("description", Decoders.string)
+          (fun name typ description ->
+            { name = name; typ = typ; description = description })
+
+    module PackageFn =
+      let decoder : JsonDecoder<ProgramTypes.PackageFn.PackageFn> =
+        Decoders.obj9Fields
+          "PackageFn.PackageFn"
+          ("tlid", TLID.decoder)
+          ("id", Decoders.guid)
+          ("name", FQFnName.Package.decoder)
+          ("body", (fun ctx -> Expr.decoder ctx))
+          ("typeParams", Decoders.list Decoders.string)
+          ("parameters", Decoders.list Parameter.decoder)
+          ("returnType", (fun ctx -> TypeReference.decoder ctx))
+          ("description", Decoders.string)
+          ("deprecated", Deprecation.decoder FQFnName.FQFnName.decoder)
+          (fun
+               tlid
+               id
+               name
+               body
+               typeParams
+               parameters
+               returnType
+               description
+               deprecated ->
+            { tlid = tlid
+              id = id
+              name = name
+              body = body
+              typeParams = typeParams
+              parameters =
+                parameters
+                |> NEList.ofListUnsafe
+                  "TODO: PT.PackageFn.PackageFn should have an NEList in Dark"
+                  []
+              returnType = returnType
+              description = description
+              deprecated = deprecated })
+
+  module Const =
+    type DU = ProgramTypes.Const
+
+    let rec decoder : JsonDecoder<DU> =
+      [ ("CInt64", Decoders.enum1Field Decoders.int64 DU.CInt64)
+        ("CUInt64", Decoders.enum1Field Decoders.uint64 DU.CUInt64)
+        ("CInt8", Decoders.enum1Field Decoders.int8 DU.CInt8)
+        ("CUInt8", Decoders.enum1Field Decoders.uint8 DU.CUInt8)
+        ("CInt16", Decoders.enum1Field Decoders.int16 DU.CInt16)
+        ("CUInt16", Decoders.enum1Field Decoders.uint16 DU.CUInt16)
+        ("CInt32", Decoders.enum1Field Decoders.int32 DU.CInt32)
+        ("CUInt32", Decoders.enum1Field Decoders.uint32 DU.CUInt32)
+        ("CInt128", Decoders.enum1Field Decoders.int128 DU.CInt128)
+        ("CUInt128", Decoders.enum1Field Decoders.uint128 DU.CUInt128)
+        ("CBool", Decoders.enum1Field Decoders.bool DU.CBool)
+        ("CString", Decoders.enum1Field Decoders.string DU.CString)
+        ("CChar", Decoders.enum1Field Decoders.string DU.CChar)
+        ("CFloat",
+         Decoders.enum3Fields
+           Sign.decoder
+           Decoders.string
+           Decoders.string
+           (fun sign mantissa exponent -> DU.CFloat(sign, mantissa, exponent)))
+        ("CUnit", Decoders.enum0Fields DU.CUnit)
+        ("CTuple",
+         Decoders.enum3Fields
+           (fun ctx -> decoder ctx)
+           (fun ctx -> decoder ctx)
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun first second rest -> DU.CTuple(first, second, rest)))
+        ("CEnum",
+         Decoders.enum3Fields
+           (NameResolution.decoder FQTypeName.FQTypeName.decoder)
+           Decoders.string
+           (Decoders.list (fun ctx -> decoder ctx))
+           (fun typeName caseName fields -> DU.CEnum(typeName, caseName, fields)))
+        ("CList",
+         Decoders.enum1Field (Decoders.list (fun ctx -> decoder ctx)) DU.CList)
+        ("CDict",
+         Decoders.enum1Field
+           (Decoders.list (Decoders.pair Decoders.string (fun ctx -> decoder ctx)))
+           DU.CDict) ]
+      |> Map.ofList
+      |> Decoders.du
+
+
+  module PackageConstant =
+    let decoder : JsonDecoder<ProgramTypes.PackageConstant> =
+      Decoders.obj6Fields
+        "PackageConstant"
+        ("tlid", TLID.decoder)
+        ("id", Decoders.guid)
+        ("name", FQConstantName.Package.decoder)
+        ("description", Decoders.string)
+        ("deprecated", Deprecation.decoder FQConstantName.FQConstantName.decoder)
+        ("body", (fun ctx -> Const.decoder ctx))
+        (fun tlid id name description deprecated body ->
+          { tlid = tlid
+            id = id
+            name = name
+            description = description
+            deprecated = deprecated
+            body = body })

--- a/backend/src/LibPackageManager/LibPackageManager.fsproj
+++ b/backend/src/LibPackageManager/LibPackageManager.fsproj
@@ -17,6 +17,10 @@
     <ProjectReference Include="../BuiltinExecution/BuiltinExecution.fsproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SimpleJson.fs" />
+    <Compile Include="Types.fs" />
+    <Compile Include="JsonDeserialization.fs" />
+    <Compile Include="ExternalTypesToProgramTypes.fs" />
     <Compile Include="PackageManager.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/backend/src/LibPackageManager/PackageManager.fs
+++ b/backend/src/LibPackageManager/PackageManager.fs
@@ -3,7 +3,7 @@
 ///
 /// TODO: this currently assumes that the package items match the shape
 /// of Dark types defined in @Darklang.LanguageTools.ProgramTypes
-module LibPackageManager
+module LibPackageManager.PackageManager
 
 open System.Threading.Tasks
 open FSharp.Control.Tasks
@@ -15,688 +15,9 @@ module PT = LibExecution.ProgramTypes
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module PT2DT = LibExecution.ProgramTypesToDarkTypes
 
-
-
-type ID = uint64
-type TLID = uint64
-
-type Sign =
-  | Positive
-  | Negative
-
-
-module NameResolutionError =
-  type ErrorType =
-    | NotFound
-    | ExpectedEnumButNot
-    | ExpectedRecordButNot
-    | MissingEnumModuleName of caseName : string
-    | InvalidPackageName
-
-  type NameType =
-    | Function
-    | Type
-    | Constant
-
-  type Error = { errorType : ErrorType; nameType : NameType; names : List<string> }
-
-
-module ProgramTypes =
-  type NameResolution<'a> = Result<'a, NameResolutionError.Error>
-
-  module FQTypeName =
-    type Package =
-      { owner : string; modules : List<string>; name : string; version : int }
-
-    type FQTypeName = Package of Package
-
-
-  module FQFnName =
-    type Builtin = { name : string; version : int }
-    type Package =
-      { owner : string; modules : List<string>; name : string; version : int }
-
-    type FQFnName =
-      | Builtin of Builtin
-      | Package of Package
-
-
-  module FQConstantName =
-    type Builtin = { name : string; version : int }
-    type Package =
-      { owner : string; modules : List<string>; name : string; version : int }
-
-    type FQConstantName =
-      | Builtin of Builtin
-      | Package of Package
-
-
-  type TypeReference =
-    | TVariable of string
-    | TUnit
-    | TBool
-    | TInt64
-    | TUInt64
-    | TInt8
-    | TUInt8
-    | TInt16
-    | TUInt16
-    | TInt32
-    | TUInt32
-    | TInt128
-    | TUInt128
-    | TFloat
-    | TChar
-    | TString
-    | TDateTime
-    | TUuid
-    | TList of TypeReference
-    | TTuple of TypeReference * TypeReference * List<TypeReference>
-    | TDict of TypeReference
-    | TCustomType of
-      NameResolution<FQTypeName.FQTypeName> *
-      typeArgs : List<TypeReference>
-    | TDB of TypeReference
-    | TFn of NEList<TypeReference> * TypeReference
-
-  type LetPattern =
-    | LPVariable of ID * name : string
-    | LPTuple of ID * LetPattern * LetPattern * List<LetPattern>
-
-  type MatchPattern =
-    | MPVariable of ID * string
-    | MPUnit of ID
-    | MPBool of ID * bool
-    | MPInt64 of ID * int64
-    | MPUInt64 of ID * uint64
-    | MPInt8 of ID * int8
-    | MPUInt8 of ID * uint8
-    | MPInt16 of ID * int16
-    | MPUInt16 of ID * uint16
-    | MPInt32 of ID * int32
-    | MPUInt32 of ID * uint32
-    | MPInt128 of ID * System.Int128
-    | MPUInt128 of ID * System.UInt128
-    | MPFloat of ID * Sign * string * string
-    | MPChar of ID * string
-    | MPString of ID * string
-    | MPList of ID * List<MatchPattern>
-    | MPListCons of ID * head : MatchPattern * tail : MatchPattern
-    | MPTuple of ID * MatchPattern * MatchPattern * List<MatchPattern>
-    | MPEnum of ID * caseName : string * fieldPats : List<MatchPattern>
-
-  type BinaryOperation =
-    | BinOpAnd
-    | BinOpOr
-
-  type InfixFnName =
-    | ArithmeticPlus
-    | ArithmeticMinus
-    | ArithmeticMultiply
-    | ArithmeticDivide
-    | ArithmeticModulo
-    | ArithmeticPower
-    | ComparisonGreaterThan
-    | ComparisonGreaterThanOrEqual
-    | ComparisonLessThan
-    | ComparisonLessThanOrEqual
-    | ComparisonEquals
-    | ComparisonNotEquals
-    | StringConcat
-
-  type Infix =
-    | InfixFnCall of InfixFnName
-    | BinOp of BinaryOperation
-
-  type StringSegment =
-    | StringText of string
-    | StringInterpolation of Expr
-
-  and PipeExpr =
-    | EPipeVariable of ID * string * List<Expr>
-    | EPipeLambda of ID * pats : NEList<LetPattern> * body : Expr
-    | EPipeInfix of ID * Infix * Expr
-    | EPipeFnCall of
-      ID *
-      NameResolution<FQFnName.FQFnName> *
-      typeArgs : List<TypeReference> *
-      args : List<Expr>
-    | EPipeEnum of
-      ID *
-      typeName : NameResolution<FQTypeName.FQTypeName> *
-      caseName : string *
-      fields : List<Expr>
-
-
-  and Expr =
-    | EUnit of ID
-
-    | EBool of ID * bool
-    | EInt64 of ID * int64
-    | EUInt64 of ID * uint64
-    | EInt8 of ID * int8
-    | EUInt8 of ID * uint8
-    | EInt16 of ID * int16
-    | EUInt16 of ID * uint16
-    | EInt32 of ID * int32
-    | EUInt32 of ID * uint32
-    | EInt128 of ID * System.Int128
-    | EUInt128 of ID * System.UInt128
-    | EFloat of ID * Sign * string * string
-    | EChar of ID * string
-    | EString of ID * List<StringSegment>
-
-    | EConstant of ID * NameResolution<FQConstantName.FQConstantName>
-
-    | EList of ID * List<Expr>
-    | EDict of ID * List<string * Expr>
-    | ETuple of ID * Expr * Expr * List<Expr>
-    | ERecord of ID * NameResolution<FQTypeName.FQTypeName> * List<string * Expr>
-    | EEnum of
-      ID *
-      typeName : NameResolution<FQTypeName.FQTypeName> *
-      caseName : string *
-      fields : List<Expr>
-
-    | ELet of ID * LetPattern * Expr * Expr
-    | EFieldAccess of ID * Expr * string
-    | EVariable of ID * string
-
-    | EIf of ID * cond : Expr * thenExpr : Expr * elseExpr : Option<Expr>
-    | EMatch of ID * arg : Expr * cases : List<MatchCase>
-    | EPipe of ID * Expr * List<PipeExpr>
-
-    | EInfix of ID * Infix * Expr * Expr
-    | ELambda of ID * pats : NEList<LetPattern> * body : Expr
-    | EApply of ID * Expr * typeArgs : List<TypeReference> * args : NEList<Expr>
-    | EFnName of ID * NameResolution<FQFnName.FQFnName>
-    | ERecordUpdate of ID * record : Expr * updates : NEList<string * Expr>
-
-  and MatchCase = { pat : MatchPattern; whenCondition : Option<Expr>; rhs : Expr }
-
-
-  type Deprecation<'name> =
-    | NotDeprecated
-    | RenamedTo of 'name
-    | ReplacedBy of 'name
-    | DeprecatedBecause of string
-
-
-  module TypeDeclaration =
-    type RecordField = { name : string; typ : TypeReference; description : string }
-
-    type EnumField =
-      { typ : TypeReference; label : Option<string>; description : string }
-
-    type EnumCase = { name : string; fields : List<EnumField>; description : string }
-
-    type Definition =
-      | Alias of TypeReference
-      | Record of NEList<RecordField>
-      | Enum of NEList<EnumCase>
-
-    type TypeDeclaration = { typeParams : List<string>; definition : Definition }
-
-
-  type PackageType =
-    { tlid : TLID
-      id : System.Guid
-      name : FQTypeName.Package
-      declaration : TypeDeclaration.TypeDeclaration
-      description : string
-      deprecated : Deprecation<FQTypeName.FQTypeName> }
-
-
-  module PackageFn =
-    type Parameter = { name : string; typ : TypeReference; description : string }
-
-    type PackageFn =
-      { tlid : TLID
-        id : System.Guid
-        name : FQFnName.Package
-        body : Expr
-        typeParams : List<string>
-        parameters : NEList<Parameter>
-        returnType : TypeReference
-        description : string
-        deprecated : Deprecation<FQFnName.FQFnName> }
-
-  type Const =
-    | CInt64 of int64
-    | CUInt64 of uint64
-    | CInt8 of int8
-    | CUInt8 of uint8
-    | CInt16 of int16
-    | CUInt16 of uint16
-    | CInt32 of int32
-    | CUInt32 of uint32
-    | CInt128 of System.Int128
-    | CUInt128 of System.UInt128
-    | CBool of bool
-    | CString of string
-    | CChar of string
-    | CFloat of Sign * string * string
-    | CUnit
-    | CTuple of first : Const * second : Const * rest : List<Const>
-    | CEnum of
-      NameResolution<FQTypeName.FQTypeName> *
-      caseName : string *
-      List<Const>
-    | CList of List<Const>
-    | CDict of List<string * Const>
-
-
-  type PackageConstant =
-    { tlid : TLID
-      id : System.Guid
-      name : FQConstantName.Package
-      description : string
-      deprecated : Deprecation<FQConstantName.FQConstantName>
-      body : Const }
+open LibPackageManager.Types
 
 module EPT = ProgramTypes
-
-module ExternalTypesToProgramTypes =
-  module NameResolutionError =
-    module NameType =
-      let toPT
-        (nameType : NameResolutionError.NameType)
-        : LibExecution.NameResolutionError.NameType =
-        match nameType with
-        | NameResolutionError.Type -> LibExecution.NameResolutionError.Type
-        | NameResolutionError.Function -> LibExecution.NameResolutionError.Function
-        | NameResolutionError.Constant -> LibExecution.NameResolutionError.Constant
-
-    module ErrorType =
-      let toPT
-        (err : NameResolutionError.ErrorType)
-        : LibExecution.NameResolutionError.ErrorType =
-        match err with
-        | NameResolutionError.ErrorType.NotFound ->
-          LibExecution.NameResolutionError.NotFound
-        | NameResolutionError.MissingEnumModuleName caseName ->
-          LibExecution.NameResolutionError.MissingEnumModuleName caseName
-        | NameResolutionError.InvalidPackageName ->
-          LibExecution.NameResolutionError.InvalidPackageName
-        | NameResolutionError.ExpectedEnumButNot ->
-          LibExecution.NameResolutionError.ExpectedEnumButNot
-        | NameResolutionError.ExpectedRecordButNot ->
-          LibExecution.NameResolutionError.ExpectedRecordButNot
-
-    module Error =
-      let toPT
-        (err : NameResolutionError.Error)
-        : LibExecution.NameResolutionError.Error =
-        { errorType = ErrorType.toPT err.errorType
-          nameType = NameType.toPT err.nameType
-          names = err.names }
-
-  module NameResolution =
-    let toPT
-      (f : 's -> 'p)
-      (result : EPT.NameResolution<'s>)
-      : PT.NameResolution<'p> =
-      match result with
-      | Ok name -> Ok(f name)
-      | Error err -> Error(NameResolutionError.Error.toPT err)
-
-
-  module Sign =
-    let toPT (s : Sign) : Prelude.Sign =
-      match s with
-      | Positive -> Prelude.Positive
-      | Negative -> Prelude.Negative
-
-  module TypeName =
-    module Package =
-      let toPT (p : EPT.FQTypeName.Package) : PT.FQTypeName.Package =
-        { owner = p.owner; modules = p.modules; name = p.name; version = p.version }
-
-    let toPT (fqfn : EPT.FQTypeName.FQTypeName) : PT.FQTypeName.FQTypeName =
-      match fqfn with
-      | EPT.FQTypeName.Package p -> PT.FQTypeName.Package(Package.toPT p)
-
-
-  module FnName =
-    module Builtin =
-      let toPT (b : EPT.FQFnName.Builtin) : PT.FQFnName.Builtin =
-        { name = b.name; version = b.version }
-
-    module Package =
-      let toPT (p : EPT.FQFnName.Package) : PT.FQFnName.Package =
-        { owner = p.owner; modules = p.modules; name = p.name; version = p.version }
-
-    let toPT (fqfn : EPT.FQFnName.FQFnName) : PT.FQFnName.FQFnName =
-      match fqfn with
-      | EPT.FQFnName.Builtin s -> PT.FQFnName.Builtin(Builtin.toPT s)
-      | EPT.FQFnName.Package p -> PT.FQFnName.Package(Package.toPT p)
-
-  module ConstantName =
-    module Builtin =
-      let toPT (b : EPT.FQConstantName.Builtin) : PT.FQConstantName.Builtin =
-        { name = b.name; version = b.version }
-
-    module Package =
-      let toPT (p : EPT.FQConstantName.Package) : PT.FQConstantName.Package =
-        { owner = p.owner; modules = p.modules; name = p.name; version = p.version }
-
-    let toPT
-      (fqfn : EPT.FQConstantName.FQConstantName)
-      : PT.FQConstantName.FQConstantName =
-      match fqfn with
-      | EPT.FQConstantName.Builtin s -> PT.FQConstantName.Builtin(Builtin.toPT s)
-      | EPT.FQConstantName.Package p -> PT.FQConstantName.Package(Package.toPT p)
-
-
-
-  module InfixFnName =
-    let toPT (name : ProgramTypes.InfixFnName) : PT.InfixFnName =
-      match name with
-      | EPT.ArithmeticPlus -> PT.ArithmeticPlus
-      | EPT.ArithmeticMinus -> PT.ArithmeticMinus
-      | EPT.ArithmeticMultiply -> PT.ArithmeticMultiply
-      | EPT.ArithmeticDivide -> PT.ArithmeticDivide
-      | EPT.ArithmeticModulo -> PT.ArithmeticModulo
-      | EPT.ArithmeticPower -> PT.ArithmeticPower
-      | EPT.ComparisonGreaterThan -> PT.ComparisonGreaterThan
-      | EPT.ComparisonGreaterThanOrEqual -> PT.ComparisonGreaterThanOrEqual
-      | EPT.ComparisonLessThan -> PT.ComparisonLessThan
-      | EPT.ComparisonLessThanOrEqual -> PT.ComparisonLessThanOrEqual
-      | EPT.ComparisonEquals -> PT.ComparisonEquals
-      | EPT.ComparisonNotEquals -> PT.ComparisonNotEquals
-      | EPT.StringConcat -> PT.StringConcat
-
-  module TypeReference =
-    let rec toPT (t : EPT.TypeReference) : PT.TypeReference =
-      match t with
-      | EPT.TInt64 -> PT.TInt64
-      | EPT.TUInt64 -> PT.TUInt64
-      | EPT.TInt8 -> PT.TInt8
-      | EPT.TUInt8 -> PT.TUInt8
-      | EPT.TInt16 -> PT.TInt16
-      | EPT.TUInt16 -> PT.TUInt16
-      | EPT.TInt32 -> PT.TInt32
-      | EPT.TUInt32 -> PT.TUInt32
-      | EPT.TInt128 -> PT.TInt128
-      | EPT.TUInt128 -> PT.TUInt128
-      | EPT.TFloat -> PT.TFloat
-      | EPT.TBool -> PT.TBool
-      | EPT.TUnit -> PT.TUnit
-      | EPT.TString -> PT.TString
-      | EPT.TList typ -> PT.TList(toPT typ)
-      | EPT.TTuple(firstType, secondType, otherTypes) ->
-        PT.TTuple(toPT firstType, toPT secondType, List.map toPT otherTypes)
-      | EPT.TDict typ -> PT.TDict(toPT typ)
-      | EPT.TDB typ -> PT.TDB(toPT typ)
-      | EPT.TDateTime -> PT.TDateTime
-      | EPT.TChar -> PT.TChar
-      | EPT.TUuid -> PT.TUuid
-      | EPT.TCustomType(t, typeArgs) ->
-        PT.TCustomType(NameResolution.toPT TypeName.toPT t, List.map toPT typeArgs)
-      | EPT.TVariable(name) -> PT.TVariable(name)
-      | EPT.TFn(paramTypes, returnType) ->
-        PT.TFn(NEList.map toPT paramTypes, toPT returnType)
-
-  module BinaryOperation =
-    let toPT (binop : EPT.BinaryOperation) : PT.BinaryOperation =
-      match binop with
-      | EPT.BinOpAnd -> PT.BinOpAnd
-      | EPT.BinOpOr -> PT.BinOpOr
-
-  module Infix =
-    let toPT (infix : EPT.Infix) : PT.Infix =
-      match infix with
-      | EPT.InfixFnCall(fn) -> PT.InfixFnCall(InfixFnName.toPT fn)
-      | EPT.BinOp binop -> PT.BinOp(BinaryOperation.toPT binop)
-
-  module LetPattern =
-    let rec toPT (p : EPT.LetPattern) : PT.LetPattern =
-      match p with
-      | EPT.LPVariable(id, str) -> PT.LPVariable(id, str)
-      | EPT.LPTuple(id, first, second, theRest) ->
-        PT.LPTuple(id, toPT first, toPT second, List.map toPT theRest)
-
-  module MatchPattern =
-    let rec toPT (p : EPT.MatchPattern) : PT.MatchPattern =
-      match p with
-      | EPT.MPVariable(id, str) -> PT.MPVariable(id, str)
-      | EPT.MPEnum(id, caseName, fieldPats) ->
-        PT.MPEnum(id, caseName, List.map toPT fieldPats)
-      | EPT.MPInt64(id, i) -> PT.MPInt64(id, i)
-      | EPT.MPUInt64(id, i) -> PT.MPUInt64(id, i)
-      | EPT.MPInt8(id, i) -> PT.MPInt8(id, i)
-      | EPT.MPUInt8(id, i) -> PT.MPUInt8(id, i)
-      | EPT.MPInt16(id, i) -> PT.MPInt16(id, i)
-      | EPT.MPUInt16(id, i) -> PT.MPUInt16(id, i)
-      | EPT.MPInt32(id, i) -> PT.MPInt32(id, i)
-      | EPT.MPUInt32(id, i) -> PT.MPUInt32(id, i)
-      | EPT.MPInt128(id, i) -> PT.MPInt128(id, i)
-      | EPT.MPUInt128(id, i) -> PT.MPUInt128(id, i)
-      | EPT.MPBool(id, b) -> PT.MPBool(id, b)
-      | EPT.MPChar(id, c) -> PT.MPChar(id, c)
-      | EPT.MPString(id, s) -> PT.MPString(id, s)
-      | EPT.MPFloat(id, s, w, f) -> PT.MPFloat(id, Sign.toPT s, w, f)
-      | EPT.MPUnit id -> PT.MPUnit id
-      | EPT.MPTuple(id, first, second, theRest) ->
-        PT.MPTuple(id, toPT first, toPT second, List.map toPT theRest)
-      | EPT.MPList(id, pats) -> PT.MPList(id, List.map toPT pats)
-      | EPT.MPListCons(id, head, tail) -> PT.MPListCons(id, toPT head, toPT tail)
-
-
-  module Expr =
-    let rec toPT (e : EPT.Expr) : PT.Expr =
-      match e with
-      | EPT.EChar(id, char) -> PT.EChar(id, char)
-      | EPT.EInt64(id, num) -> PT.EInt64(id, num)
-      | EPT.EUInt64(id, num) -> PT.EUInt64(id, num)
-      | EPT.EInt8(id, num) -> PT.EInt8(id, num)
-      | EPT.EUInt8(id, num) -> PT.EUInt8(id, num)
-      | EPT.EInt16(id, num) -> PT.EInt16(id, num)
-      | EPT.EUInt16(id, num) -> PT.EUInt16(id, num)
-      | EPT.EInt32(id, num) -> PT.EInt32(id, num)
-      | EPT.EUInt32(id, num) -> PT.EUInt32(id, num)
-      | EPT.EInt128(id, num) -> PT.EInt128(id, num)
-      | EPT.EUInt128(id, num) -> PT.EUInt128(id, num)
-      | EPT.EString(id, segment) ->
-        PT.EString(id, List.map stringSegmentToPT segment)
-      | EPT.EFloat(id, sign, whole, fraction) ->
-        PT.EFloat(id, Sign.toPT sign, whole, fraction)
-      | EPT.EBool(id, b) -> PT.EBool(id, b)
-      | EPT.EUnit id -> PT.EUnit id
-      | EPT.EConstant(id, name) ->
-        PT.EConstant(id, NameResolution.toPT ConstantName.toPT name)
-      | EPT.EVariable(id, var) -> PT.EVariable(id, var)
-      | EPT.EFieldAccess(id, obj, fieldname) ->
-        PT.EFieldAccess(id, toPT obj, fieldname)
-      | EPT.EApply(id, name, typeArgs, args) ->
-        PT.EApply(
-          id,
-          toPT name,
-          List.map TypeReference.toPT typeArgs,
-          NEList.map toPT args
-        )
-      | EPT.ELambda(id, pats, body) ->
-        PT.ELambda(id, NEList.map LetPattern.toPT pats, toPT body)
-      | EPT.ELet(id, pat, rhs, body) ->
-        PT.ELet(id, LetPattern.toPT pat, toPT rhs, toPT body)
-      | EPT.EIf(id, cond, thenExpr, elseExpr) ->
-        PT.EIf(id, toPT cond, toPT thenExpr, Option.map toPT elseExpr)
-      | EPT.EList(id, exprs) -> PT.EList(id, List.map toPT exprs)
-      | EPT.ETuple(id, first, second, theRest) ->
-        PT.ETuple(id, toPT first, toPT second, List.map toPT theRest)
-      | EPT.ERecord(id, typeName, fields) ->
-        PT.ERecord(
-          id,
-          NameResolution.toPT TypeName.toPT typeName,
-          List.map (Tuple2.mapSecond toPT) fields
-        )
-      | EPT.ERecordUpdate(id, record, updates) ->
-        PT.ERecordUpdate(
-          id,
-          toPT record,
-          updates |> NEList.map (fun (name, expr) -> (name, toPT expr))
-        )
-      | EPT.EPipe(pipeID, expr1, rest) ->
-        PT.EPipe(pipeID, toPT expr1, List.map pipeExprToPT rest)
-      | EPT.EEnum(id, typeName, caseName, exprs) ->
-        PT.EEnum(
-          id,
-          NameResolution.toPT TypeName.toPT typeName,
-          caseName,
-          List.map toPT exprs
-        )
-      | EPT.EMatch(id, mexpr, cases) ->
-        PT.EMatch(id, toPT mexpr, List.map matchCaseToPT cases)
-      | EPT.EInfix(id, infix, arg1, arg2) ->
-        PT.EInfix(id, Infix.toPT infix, toPT arg1, toPT arg2)
-      | EPT.EDict(id, pairs) -> PT.EDict(id, List.map (Tuple2.mapSecond toPT) pairs)
-      | EPT.EFnName(id, name) -> PT.EFnName(id, NameResolution.toPT FnName.toPT name)
-
-    and stringSegmentToPT (segment : EPT.StringSegment) : PT.StringSegment =
-      match segment with
-      | EPT.StringText text -> PT.StringText text
-      | EPT.StringInterpolation expr -> PT.StringInterpolation(toPT expr)
-
-    and pipeExprToPT (pipeExpr : EPT.PipeExpr) : PT.PipeExpr =
-      match pipeExpr with
-      | EPT.EPipeVariable(id, name, exprs) ->
-        PT.EPipeVariable(id, name, List.map toPT exprs)
-      | EPT.EPipeLambda(id, pats, body) ->
-        PT.EPipeLambda(id, NEList.map LetPattern.toPT pats, toPT body)
-      | EPT.EPipeInfix(id, infix, first) ->
-        PT.EPipeInfix(id, Infix.toPT infix, toPT first)
-      | EPT.EPipeFnCall(id, fnName, typeArgs, args) ->
-        PT.EPipeFnCall(
-          id,
-          NameResolution.toPT FnName.toPT fnName,
-          List.map TypeReference.toPT typeArgs,
-          List.map toPT args
-        )
-      | EPT.EPipeEnum(id, typeName, caseName, fields) ->
-        PT.EPipeEnum(
-          id,
-          NameResolution.toPT TypeName.toPT typeName,
-          caseName,
-          List.map toPT fields
-        )
-
-    and matchCaseToPT (case : EPT.MatchCase) : PT.MatchCase =
-      { pat = MatchPattern.toPT case.pat
-        whenCondition = Option.map toPT case.whenCondition
-        rhs = toPT case.rhs }
-
-  module Deprecation =
-    let toPT
-      (f : 'name1 -> 'name2)
-      (d : EPT.Deprecation<'name1>)
-      : PT.Deprecation<'name2> =
-      match d with
-      | EPT.NotDeprecated -> PT.NotDeprecated
-      | EPT.RenamedTo name -> PT.RenamedTo(f name)
-      | EPT.ReplacedBy name -> PT.ReplacedBy(f name)
-      | EPT.DeprecatedBecause reason -> PT.DeprecatedBecause reason
-
-  module TypeDeclaration =
-    module RecordField =
-      let toPT
-        (f : EPT.TypeDeclaration.RecordField)
-        : PT.TypeDeclaration.RecordField =
-        { name = f.name
-          typ = TypeReference.toPT f.typ
-          description = f.description }
-
-    module EnumField =
-      let toPT (f : EPT.TypeDeclaration.EnumField) : PT.TypeDeclaration.EnumField =
-        { typ = TypeReference.toPT f.typ
-          label = f.label
-          description = f.description }
-
-    module EnumCase =
-      let toPT (c : EPT.TypeDeclaration.EnumCase) : PT.TypeDeclaration.EnumCase =
-        { name = c.name
-          fields = List.map EnumField.toPT c.fields
-          description = c.description }
-
-    module Definition =
-      let toPT (d : EPT.TypeDeclaration.Definition) : PT.TypeDeclaration.Definition =
-        match d with
-        | EPT.TypeDeclaration.Alias typ ->
-          PT.TypeDeclaration.Alias(TypeReference.toPT typ)
-        | EPT.TypeDeclaration.Record fields ->
-          PT.TypeDeclaration.Record(NEList.map RecordField.toPT fields)
-        | EPT.TypeDeclaration.Enum cases ->
-          PT.TypeDeclaration.Enum(NEList.map EnumCase.toPT cases)
-
-    let toPT (d : EPT.TypeDeclaration.TypeDeclaration) : PT.TypeDeclaration.T =
-      { typeParams = d.typeParams; definition = Definition.toPT d.definition }
-
-  module PackageFn =
-    module Parameter =
-      let toPT (p : EPT.PackageFn.Parameter) : PT.PackageFn.Parameter =
-        { name = p.name
-          typ = TypeReference.toPT p.typ
-          description = p.description }
-
-    let toPT (fn : EPT.PackageFn.PackageFn) : PT.PackageFn.T =
-      { name = FnName.Package.toPT fn.name
-        parameters = NEList.map Parameter.toPT fn.parameters
-        returnType = TypeReference.toPT fn.returnType
-        description = fn.description
-        deprecated = Deprecation.toPT FnName.toPT fn.deprecated
-        body = Expr.toPT fn.body
-        typeParams = fn.typeParams
-        id = fn.id
-        tlid = fn.tlid }
-
-  module PackageType =
-    let toPT (pt : EPT.PackageType) : PT.PackageType.T =
-      { name = TypeName.Package.toPT pt.name
-        description = pt.description
-        declaration = TypeDeclaration.toPT pt.declaration
-        deprecated = Deprecation.toPT TypeName.toPT pt.deprecated
-        id = pt.id
-        tlid = pt.tlid }
-
-  module Const =
-    let rec toPT (c : EPT.Const) : PT.Const =
-      match c with
-      | EPT.CInt64 i -> PT.CInt64 i
-      | EPT.CUInt64 i -> PT.CUInt64 i
-      | EPT.CInt8 i -> PT.CInt8 i
-      | EPT.CUInt8 i -> PT.CUInt8 i
-      | EPT.CInt16 i -> PT.CInt16 i
-      | EPT.CUInt16 i -> PT.CUInt16 i
-      | EPT.CInt32 i -> PT.CInt32 i
-      | EPT.CUInt32 i -> PT.CUInt32 i
-      | EPT.CInt128 i -> PT.CInt128 i
-      | EPT.CUInt128 i -> PT.CUInt128 i
-      | EPT.CBool b -> PT.CBool b
-      | EPT.CString s -> PT.CString s
-      | EPT.CChar c -> PT.CChar c
-      | EPT.CFloat(s, w, f) -> PT.CFloat(Sign.toPT s, w, f)
-      | EPT.CUnit -> PT.CUnit
-      | EPT.CTuple(first, second, rest) ->
-        PT.CTuple(toPT first, toPT second, List.map toPT rest)
-      | EPT.CEnum(typeName, caseName, fields) ->
-        PT.CEnum(
-          NameResolution.toPT TypeName.toPT typeName,
-          caseName,
-          List.map toPT fields
-        )
-      | EPT.CList l -> PT.CList(List.map toPT l)
-      | EPT.CDict pairs -> PT.CDict(List.map (Tuple2.mapSecond toPT) pairs)
-
-
-  module PackageConstant =
-    let toPT (c : EPT.PackageConstant) : PT.PackageConstant.T =
-      { name = ConstantName.Package.toPT c.name
-        description = c.description
-        deprecated = Deprecation.toPT ConstantName.toPT c.deprecated
-        id = c.id
-        tlid = c.tlid
-        body = Const.toPT c.body }
-
-
 
 module ET2PT = ExternalTypesToProgramTypes
 
@@ -729,6 +50,7 @@ let packageManager (baseUrl : string) : RT.PackageManager =
 
   let fetch
     (url : string)
+    (decoder : SimpleJson.JsonDecoder<'serverType>)
     (f : 'serverType -> 'cachedType)
     : Ply<Option<'cachedType>> =
     uply {
@@ -737,9 +59,20 @@ let packageManager (baseUrl : string) : RT.PackageManager =
       let! responseStr = response.Content.ReadAsStringAsync()
       try
         if response.StatusCode = System.Net.HttpStatusCode.OK then
-          let deserialized = responseStr |> Json.Vanilla.deserialize<'serverType>
-          let cached = f deserialized
-          return Some cached
+          let deserializedMaybe =
+            SimpleJson.deserialize<'serverType> decoder responseStr
+
+          match deserializedMaybe with
+          | Ok deserialized ->
+            let cached = f deserialized
+            return Some cached
+          | Error e ->
+            return
+              Exception.raiseInternal
+                "Failed to deserialize package item"
+                [ "responseStr", responseStr; "url", url; "error", e ]
+                null
+
         else if response.StatusCode = System.Net.HttpStatusCode.NotFound then
           return None
         else
@@ -762,20 +95,22 @@ let packageManager (baseUrl : string) : RT.PackageManager =
     (modules : List<string>)
     (name : string)
     (version : int)
+    (decoder : SimpleJson.JsonDecoder<'serverType>)
     (f : 'serverType -> 'cachedType)
     : Ply<Option<'cachedType>> =
     let modules = modules |> String.concat "."
     let namestring = $"{owner}.{modules}.{name}_v{version}"
     let url = $"{baseUrl}/{kind}/by-name/{namestring}"
-    fetch url f
+    fetch url decoder f
 
   let fetchById
     (kind : string)
     (id : tlid)
+    (decoder : SimpleJson.JsonDecoder<'serverType>)
     (f : 'serverType -> 'cachedType)
     : Ply<Option<'cachedType>> =
     let url = $"{baseUrl}/{kind}/by-id/{id}"
-    fetch url f
+    fetch url decoder f
 
 
   { getType =
@@ -788,6 +123,7 @@ let packageManager (baseUrl : string) : RT.PackageManager =
           name.modules
           name.name
           name.version
+          JsonDeserialization.ProgramTypes.PackageType.decoder
           conversionFn)
 
     getFn =
@@ -800,13 +136,18 @@ let packageManager (baseUrl : string) : RT.PackageManager =
           name.modules
           name.name
           name.version
+          JsonDeserialization.ProgramTypes.PackageFn.PackageFn.decoder
           conversionFn)
 
     getFnByTLID =
       withCache (fun tlid ->
         let conversionFn (parsed : EPT.PackageFn.PackageFn) : RT.PackageFn.T =
           parsed |> ET2PT.PackageFn.toPT |> PT2RT.PackageFn.toRT
-        fetchById "function" tlid conversionFn)
+        fetchById
+          "function"
+          tlid
+          JsonDeserialization.ProgramTypes.PackageFn.PackageFn.decoder
+          conversionFn)
 
     getConstant =
       withCache (fun name ->
@@ -818,6 +159,7 @@ let packageManager (baseUrl : string) : RT.PackageManager =
           name.modules
           name.name
           name.version
+          JsonDeserialization.ProgramTypes.PackageConstant.decoder
           conversionFn)
 
     init = uply { return () } }

--- a/backend/src/LibPackageManager/README.md
+++ b/backend/src/LibPackageManager/README.md
@@ -1,0 +1,15 @@
+This exists to fetch package items from a Dark-hosted canvas, over HTTP.
+
+There are a handful of endpoints that return package types, constants, and functions.
+
+This project contains...
+
+- the types equivalent to the json data returned by the endpoints
+- the functions to fetch the data from the endpoints
+- the functions to convert the json data into the types
+  (there's some one-off Json parsing and decoding in here, that should probably be extracted out,
+  mostly because our application is AOT-compiled and we can't use traditional reflection-based
+  approaches like those in STJ or Newtonsoft.Json here. I tried using Thoth but didn't love the API.)
+
+CLEANUP this README
+CLEANUP the JSON magic

--- a/backend/src/LibPackageManager/SimpleJson.fs
+++ b/backend/src/LibPackageManager/SimpleJson.fs
@@ -1,0 +1,544 @@
+/// Minimal support for:
+/// - parsing a JSON string into a Json value
+/// - decoding a Json value into some F# type
+///
+/// Note: assumes types generally match the shape of the Json pretty well
+///
+/// This is basically Thoth.Json,
+/// but with some differences on things that bugged me about Thoth.
+///
+/// We need this because our application is AOT-compiled,
+/// and System.Text.Json's reflection-based approach won't work in such an application.
+///
+/// In this,
+/// - 'parsing' and 'decoding' are separate steps,
+///   where 'parsing' is the act of converting a string into a Json value,
+///   and 'decoding' is the act of converting a Json value into some F# type
+/// - 'deserializing' is when you do both
+///
+/// these aren't universal definitions, but they're the ones I'm using here,
+/// because it's otherwise confusing to talk about this stuff.
+module LibPackageManager.SimpleJson
+
+open System.Text.Json
+
+type Json =
+  | Null
+  | Bool of bool
+  | Number of double
+  | String of string
+  | Array of List<Json>
+  | Object of List<string * Json>
+
+type JsonPathPart =
+  | Index of int
+  | Field of string
+
+/// A single 'root' is always implied
+type JsonPath = List<JsonPathPart>
+
+
+// -- PARSING --
+
+type JsonParseError = | NotJson
+exception JsonParseException of JsonParseError
+
+let private dotnetParsingOptions =
+  new JsonDocumentOptions(
+    CommentHandling = JsonCommentHandling.Skip,
+    MaxDepth = System.Int32.MaxValue
+  )
+
+let parseJson (str : string) : Result<Json, JsonParseError> =
+  let rec convert (j : JsonElement) : Json =
+    match j.ValueKind with
+    | JsonValueKind.Null -> Json.Null
+
+    | JsonValueKind.True -> Json.Bool true
+    | JsonValueKind.False -> Json.Bool false
+
+    | JsonValueKind.Number -> j.GetDouble() |> Json.Number
+
+    | JsonValueKind.String -> j.GetString() |> Json.String
+
+    | JsonValueKind.Array ->
+      j.EnumerateArray() |> Seq.map convert |> Seq.toList |> Json.Array
+
+    | JsonValueKind.Object ->
+      j.EnumerateObject()
+      |> Seq.map (fun jp -> (jp.Name, convert jp.Value))
+      |> Seq.toList
+      |> Json.Object
+
+    | _ -> raise (JsonParseException JsonParseError.NotJson)
+
+  // .net does the hard work of actually parsing the JSON
+  let parsedByDotNet =
+    try
+      Ok(JsonDocument.Parse(str, dotnetParsingOptions).RootElement)
+    with _ex ->
+      Error JsonParseError.NotJson
+
+  match parsedByDotNet with
+  | Error err -> Error err
+  | Ok parsed ->
+    try
+      Ok(convert parsed)
+    with JsonParseException ex ->
+      Error ex
+
+
+// -- DECODING --
+type DecodingContext =
+  { path : JsonPath
+    json : Json }
+
+  /// Represents traversing into the json via some index
+  ///
+  /// i.e. `root[0]`
+  member this.Index (index : int) (json : Json) =
+    { path = Index index :: this.path; json = json }
+
+  /// Represents traversing into the json via some field
+  ///
+  /// i.e. `root.fieldName`
+  member this.Field (fieldName : string) (json : Json) =
+    { path = Field fieldName :: this.path; json = json }
+
+
+type JsonDecodeError = DecodingContext * string
+type JsonDecodeResult<'T> = Result<'T, JsonDecodeError>
+
+type JsonDecoder<'T> = DecodingContext -> JsonDecodeResult<'T>
+exception JsonDecodeException of JsonDecodeError
+
+
+module Decoders =
+  // TODO: some of these are untested and almost definitely broken
+  // (i.e. we'll raise an exception on uint8 upon a Number that's too big)
+
+  let value (a : 'a) : JsonDecoder<'a> = fun _ctx -> Ok a
+
+  let bool : JsonDecoder<bool> =
+    fun ctx ->
+      match ctx.json with
+      | Bool b -> Ok b
+      | _ -> Error(ctx, "Expected bool")
+
+  let uint8 : JsonDecoder<uint8> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(uint8 n)
+      | _ -> Error(ctx, "Expected uint8")
+
+  let int8 : JsonDecoder<int8> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(int8 n)
+      | _ -> Error(ctx, "Expected int8")
+
+  let uint16 : JsonDecoder<uint16> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(uint16 n)
+      | _ -> Error(ctx, "Expected uint16")
+
+  let int16 : JsonDecoder<int16> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(int16 n)
+      | _ -> Error(ctx, "Expected int16")
+
+  let uint32 : JsonDecoder<uint32> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(uint32 n)
+      | _ -> Error(ctx, "Expected uint32")
+
+  let int32 : JsonDecoder<int32> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(int32 n)
+      | _ -> Error(ctx, "Expected int32")
+
+  let uint64 : JsonDecoder<uint64> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(uint64 n)
+      | _ -> Error(ctx, "Expected uint64")
+
+  let int64 : JsonDecoder<int64> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(int64 n)
+      | _ -> Error(ctx, "Expected int64")
+
+  let uint128 : JsonDecoder<System.UInt128> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(System.UInt128.Parse(string n))
+      | _ -> Error(ctx, "Expected uint128")
+
+  let int128 : JsonDecoder<System.Int128> =
+    fun ctx ->
+      match ctx.json with
+      | Number n -> Ok(System.Int128.Parse(string n))
+      | _ -> Error(ctx, "Expected int128")
+
+  let pair (d1 : JsonDecoder<'T1>) (d2 : JsonDecoder<'T2>) : JsonDecoder<'T1 * 'T2> =
+    fun ctx ->
+      match ctx.json with
+      | Array [ f1; f2 ] ->
+        match d1 (ctx.Index 0 f1), d2 (ctx.Index 1 f2) with
+        | Ok f1, Ok f2 -> Ok(f1, f2)
+        | Error err, _
+        | _, Error err -> Error err
+      | _ -> Error(ctx, "Expected two fields")
+
+  let string : JsonDecoder<string> =
+    fun ctx ->
+      match ctx.json with
+      | String s -> Ok s
+      | _ -> Error(ctx, "Expected string")
+
+  let guid : JsonDecoder<System.Guid> =
+    fun ctx ->
+      match ctx.json with
+      | String s ->
+        match System.Guid.TryParse(s) with
+        | true, guid -> Ok guid
+        | _ -> Error(ctx, "Expected guid")
+      | _ -> Error(ctx, "Expected guid")
+
+
+  let enum0Fields (ctor : 'T) (fields : List<Json>) : JsonDecoder<'T> =
+    fun ctx ->
+      match fields with
+      | [] -> Ok ctor
+      | _ -> Error(ctx, "Expected one field")
+
+  let enum1Field
+    (d1 : JsonDecoder<'T1>)
+    (ctor : 'T1 -> 'T)
+    (fields : List<Json>)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match fields with
+      | [ f1 ] -> d1 (ctx.Index 0 f1) |> Result.map ctor
+      | _ -> Error(ctx, "Expected one field")
+
+  let enum2Fields
+    (d1 : JsonDecoder<'T1>)
+    (d2 : JsonDecoder<'T2>)
+    (ctor : 'T1 -> 'T2 -> 'T)
+    (fields : List<Json>)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match fields with
+      | [ f1; f2 ] ->
+        match d1 (ctx.Index 1 f1), d2 (ctx.Index 2 f2) with
+        | Ok f1, Ok f2 -> Ok(ctor f1 f2)
+        | Error err, _
+        | _, Error err -> Error err
+      | _ -> Error(ctx, "Expected two fields")
+
+  let enum3Fields
+    (d1 : JsonDecoder<'T1>)
+    (d2 : JsonDecoder<'T2>)
+    (d3 : JsonDecoder<'T3>)
+    (ctor : 'T1 -> 'T2 -> 'T3 -> 'T)
+    (fields : List<Json>)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match fields with
+      | [ f1; f2; f3 ] ->
+        match d1 (ctx.Index 1 f1), d2 (ctx.Index 2 f2), d3 (ctx.Index 3 f3) with
+        | Ok f1, Ok f2, Ok f3 -> Ok(ctor f1 f2 f3)
+        | Error err, _, _
+        | _, Error err, _
+        | _, _, Error err -> Error err
+      | _ -> Error(ctx, "Expected three fields")
+
+  let enum4Fields
+    (d1 : JsonDecoder<'T1>)
+    (d2 : JsonDecoder<'T2>)
+    (d3 : JsonDecoder<'T3>)
+    (d4 : JsonDecoder<'T4>)
+    (ctor : 'T1 -> 'T2 -> 'T3 -> 'T4 -> 'T)
+    (fields : List<Json>)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match fields with
+      | [ f1; f2; f3; f4 ] ->
+        match
+          d1 (ctx.Index 1 f1),
+          d2 (ctx.Index 2 f2),
+          d3 (ctx.Index 3 f3),
+          d4 (ctx.Index 4 f4)
+        with
+        | Ok f1, Ok f2, Ok f3, Ok f4 -> Ok(ctor f1 f2 f3 f4)
+        | Error err, _, _, _
+        | _, Error err, _, _
+        | _, _, Error err, _
+        | _, _, _, Error err -> Error err
+      | _ -> Error(ctx, "Expected four fields")
+
+
+  let du (cases : Map<string, List<Json> -> JsonDecoder<'T>>) : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object [ (caseName, Array fields) ] ->
+        match Map.tryFind caseName cases with
+        | Some decoder -> decoder fields ctx
+        | None -> Error(ctx, sprintf "Unknown enum case: %s" caseName)
+      | _ -> Error(ctx, "Expected enum to be an object with 1 key")
+
+  // this is an enum - NOT expecting null, but rather a DU setup
+  let option (innerDecoder : JsonDecoder<'T>) : JsonDecoder<'T option> =
+    fun ctx ->
+      match ctx.json with
+      | Object [ (caseName, Array fields) ] ->
+        match caseName with
+        | "None" -> enum0Fields None fields ctx
+        | "Some" -> enum1Field innerDecoder Some fields ctx
+        | _ -> Error(ctx, sprintf "Unknown Option case: %s" caseName)
+      | _ -> Error(ctx, "Option enum should be an object with 1 key")
+
+  let result
+    (okDecoder : JsonDecoder<'T1>)
+    (errDecoder : JsonDecoder<'T2>)
+    : JsonDecoder<Result<'T1, 'T2>> =
+    fun ctx ->
+      match ctx.json with
+      | Object [ (caseName, Array fields) ] ->
+        match caseName with
+        | "Ok" -> enum1Field okDecoder Ok fields ctx
+        | "Error" -> enum1Field errDecoder Error fields ctx
+        | _ -> Error(ctx, sprintf "Unknown Result case: %s" caseName)
+      | _ -> Error(ctx, "Result enum should be an object with 1 key")
+
+
+  let list (innerDecoder : JsonDecoder<'T>) : JsonDecoder<List<'T>> =
+    fun ctx ->
+      match ctx.json with
+      | Array items ->
+        (List.foldWithIndex
+          (fun i acc item ->
+            match acc with
+            | Error err -> Error err
+            | Ok decodedItems ->
+              innerDecoder (ctx.Index i item)
+              |> Result.map (fun d -> d :: decodedItems))
+          (Ok [])
+          items)
+        |> Result.map List.reverse
+
+      | _ -> Error(ctx, "Expected a list")
+
+
+  let decodeField (fields : List<string * Json>) (d : string * JsonDecoder<'T>) =
+    fun (ctx : DecodingContext) ->
+      let fieldName, decoder = d
+
+      match fields |> List.find (fun (k, _v) -> k = fieldName) with
+      | None -> Error(ctx, "missing field: " + fieldName)
+      | Some(_, found) ->
+        let fieldCtx = ctx.Field fieldName found
+        match decoder fieldCtx with
+        | Ok decoded -> Ok decoded
+        | Error _ -> Error(fieldCtx, "field of wrong type: " + fieldName)
+
+
+  let obj1Field
+    (name : string)
+    (d1 : string * JsonDecoder<'T1>)
+    (ctor : 'T1 -> 'T)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object fields ->
+        match decodeField fields d1 ctx with
+        | Ok f1 -> Ok(ctor f1)
+        | Error err -> Error err
+
+      | _ -> Error(ctx, sprintf "Expected %s to be an object" name)
+
+  let obj2Fields
+    (name : string)
+    (d1 : string * JsonDecoder<'T1>)
+    (d2 : string * JsonDecoder<'T2>)
+    (ctor : 'T1 -> 'T2 -> 'T)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object fields ->
+        match decodeField fields d1 ctx, decodeField fields d2 ctx with
+        | Ok f1, Ok f2 -> Ok(ctor f1 f2)
+        | Error err, _
+        | _, Error err -> Error err
+
+      | _ -> Error(ctx, sprintf "Expected %s to be an object" name)
+
+  let obj3Fields
+    (name : string)
+    (d1 : string * JsonDecoder<'T1>)
+    (d2 : string * JsonDecoder<'T2>)
+    (d3 : string * JsonDecoder<'T3>)
+    (ctor : 'T1 -> 'T2 -> 'T3 -> 'T)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object fields ->
+        let f1 = decodeField fields d1 ctx
+        let f2 = decodeField fields d2 ctx
+        let f3 = decodeField fields d3 ctx
+
+        match f1, f2, f3 with
+        | Ok f1, Ok f2, Ok f3 -> Ok(ctor f1 f2 f3)
+        | Error err, _, _
+        | _, Error err, _
+        | _, _, Error err -> Error err
+
+      | _ -> Error(ctx, sprintf "Expected %s to be an object" name)
+
+  let obj4Fields
+    (name : string)
+    (d1 : string * JsonDecoder<'T1>)
+    (d2 : string * JsonDecoder<'T2>)
+    (d3 : string * JsonDecoder<'T3>)
+    (d4 : string * JsonDecoder<'T4>)
+    (ctor : 'T1 -> 'T2 -> 'T3 -> 'T4 -> 'T)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object fields ->
+        let f1 = decodeField fields d1 ctx
+        let f2 = decodeField fields d2 ctx
+        let f3 = decodeField fields d3 ctx
+        let f4 = decodeField fields d4 ctx
+
+        match f1, f2, f3, f4 with
+        | Ok f1, Ok f2, Ok f3, Ok f4 -> Ok(ctor f1 f2 f3 f4)
+        | Error err, _, _, _
+        | _, Error err, _, _
+        | _, _, Error err, _
+        | _, _, _, Error err -> Error err
+
+      | _ -> Error(ctx, sprintf "Expected %s to be an object" name)
+
+  let obj5Fields
+    (name : string)
+    (d1 : string * JsonDecoder<'T1>)
+    (d2 : string * JsonDecoder<'T2>)
+    (d3 : string * JsonDecoder<'T3>)
+    (d4 : string * JsonDecoder<'T4>)
+    (d5 : string * JsonDecoder<'T5>)
+    (ctor : 'T1 -> 'T2 -> 'T3 -> 'T4 -> 'T5 -> 'T)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object fields ->
+        let f1 = decodeField fields d1 ctx
+        let f2 = decodeField fields d2 ctx
+        let f3 = decodeField fields d3 ctx
+        let f4 = decodeField fields d4 ctx
+        let f5 = decodeField fields d5 ctx
+
+        match f1, f2, f3, f4, f5 with
+        | Ok f1, Ok f2, Ok f3, Ok f4, Ok f5 -> Ok(ctor f1 f2 f3 f4 f5)
+        | Error err, _, _, _, _
+        | _, Error err, _, _, _
+        | _, _, Error err, _, _
+        | _, _, _, Error err, _
+        | _, _, _, _, Error err -> Error err
+
+      | _ -> Error(ctx, sprintf "Expected %s to be an object" name)
+
+  let obj6Fields
+    (name : string)
+    (d1 : string * JsonDecoder<'T1>)
+    (d2 : string * JsonDecoder<'T2>)
+    (d3 : string * JsonDecoder<'T3>)
+    (d4 : string * JsonDecoder<'T4>)
+    (d5 : string * JsonDecoder<'T5>)
+    (d6 : string * JsonDecoder<'T6>)
+    (ctor : 'T1 -> 'T2 -> 'T3 -> 'T4 -> 'T5 -> 'T6 -> 'T)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object fields ->
+        let f1 = decodeField fields d1 ctx
+        let f2 = decodeField fields d2 ctx
+        let f3 = decodeField fields d3 ctx
+        let f4 = decodeField fields d4 ctx
+        let f5 = decodeField fields d5 ctx
+        let f6 = decodeField fields d6 ctx
+
+        match f1, f2, f3, f4, f5, f6 with
+        | Ok f1, Ok f2, Ok f3, Ok f4, Ok f5, Ok f6 -> Ok(ctor f1 f2 f3 f4 f5 f6)
+        | Error err, _, _, _, _, _
+        | _, Error err, _, _, _, _
+        | _, _, Error err, _, _, _
+        | _, _, _, Error err, _, _
+        | _, _, _, _, Error err, _
+        | _, _, _, _, _, Error err -> Error err
+
+      | _ -> Error(ctx, sprintf "Expected %s to be an object" name)
+
+  let obj9Fields
+    (name : string)
+    (d1 : string * JsonDecoder<'T1>)
+    (d2 : string * JsonDecoder<'T2>)
+    (d3 : string * JsonDecoder<'T3>)
+    (d4 : string * JsonDecoder<'T4>)
+    (d5 : string * JsonDecoder<'T5>)
+    (d6 : string * JsonDecoder<'T6>)
+    (d7 : string * JsonDecoder<'T7>)
+    (d8 : string * JsonDecoder<'T8>)
+    (d9 : string * JsonDecoder<'T9>)
+    (ctor : 'T1 -> 'T2 -> 'T3 -> 'T4 -> 'T5 -> 'T6 -> 'T7 -> 'T8 -> 'T9 -> 'T)
+    : JsonDecoder<'T> =
+    fun ctx ->
+      match ctx.json with
+      | Object fields ->
+        let f1 = decodeField fields d1 ctx
+        let f2 = decodeField fields d2 ctx
+        let f3 = decodeField fields d3 ctx
+        let f4 = decodeField fields d4 ctx
+        let f5 = decodeField fields d5 ctx
+        let f6 = decodeField fields d6 ctx
+        let f7 = decodeField fields d7 ctx
+        let f8 = decodeField fields d8 ctx
+        let f9 = decodeField fields d9 ctx
+
+        match f1, f2, f3, f4, f5, f6, f7, f8, f9 with
+        | Ok f1, Ok f2, Ok f3, Ok f4, Ok f5, Ok f6, Ok f7, Ok f8, Ok f9 ->
+          Ok(ctor f1 f2 f3 f4 f5 f6 f7 f8 f9)
+        | Error err, _, _, _, _, _, _, _, _
+        | _, Error err, _, _, _, _, _, _, _
+        | _, _, Error err, _, _, _, _, _, _
+        | _, _, _, Error err, _, _, _, _, _
+        | _, _, _, _, Error err, _, _, _, _
+        | _, _, _, _, _, Error err, _, _, _
+        | _, _, _, _, _, _, Error err, _, _
+        | _, _, _, _, _, _, _, Error err, _
+        | _, _, _, _, _, _, _, _, Error err -> Error err
+
+      | _ -> Error(ctx, sprintf "Expected %s to be an object" name)
+
+
+// -- DESERIALIZATION --
+type JsonDeserializationError =
+  | ParseError of JsonParseError
+  | DecodeError of JsonDecodeError
+
+let deserialize<'T>
+  (decoder : JsonDecoder<'T>)
+  (json : string)
+  : Result<'T, JsonDeserializationError> =
+  match parseJson json with
+  | Error err -> Error(ParseError err)
+  | Ok parsed ->
+    match decoder { path = []; json = parsed } with
+    | Ok decoded -> Ok decoded
+    | Error err -> Error(DecodeError err)

--- a/backend/src/LibPackageManager/Types.fs
+++ b/backend/src/LibPackageManager/Types.fs
@@ -1,0 +1,287 @@
+﻿// See README in `LibPackageManager`
+
+/// This is basically a clone of the `@Darklang.LanguageTools.ProgramTypes`
+/// module of Darklang types.
+module LibPackageManager.Types
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+
+open Prelude
+
+type ID = uint64
+type TLID = uint64
+
+type Sign =
+  | Positive
+  | Negative
+
+
+module NameResolutionError =
+  type ErrorType =
+    | NotFound
+    | ExpectedEnumButNot
+    | ExpectedRecordButNot
+    | MissingEnumModuleName of caseName : string
+    | InvalidPackageName
+
+  type NameType =
+    | Function
+    | Type
+    | Constant
+
+  type Error = { errorType : ErrorType; nameType : NameType; names : List<string> }
+
+
+module ProgramTypes =
+  type NameResolution<'a> = Result<'a, NameResolutionError.Error>
+
+  module FQTypeName =
+    type Package =
+      { owner : string; modules : List<string>; name : string; version : int }
+
+    type FQTypeName = Package of Package
+
+
+  module FQFnName =
+    type Builtin = { name : string; version : int }
+    type Package =
+      { owner : string; modules : List<string>; name : string; version : int }
+
+    type FQFnName =
+      | Builtin of Builtin
+      | Package of Package
+
+
+  module FQConstantName =
+    type Builtin = { name : string; version : int }
+    type Package =
+      { owner : string; modules : List<string>; name : string; version : int }
+
+    type FQConstantName =
+      | Builtin of Builtin
+      | Package of Package
+
+
+  type TypeReference =
+    | TVariable of string
+    | TUnit
+    | TBool
+    | TInt64
+    | TUInt64
+    | TInt8
+    | TUInt8
+    | TInt16
+    | TUInt16
+    | TInt32
+    | TUInt32
+    | TInt128
+    | TUInt128
+    | TFloat
+    | TChar
+    | TString
+    | TDateTime
+    | TUuid
+    | TList of TypeReference
+    | TTuple of TypeReference * TypeReference * List<TypeReference>
+    | TDict of TypeReference
+    | TCustomType of
+      NameResolution<FQTypeName.FQTypeName> *
+      typeArgs : List<TypeReference>
+    | TDB of TypeReference
+    | TFn of NEList<TypeReference> * TypeReference
+
+  type LetPattern =
+    | LPVariable of ID * name : string
+    | LPTuple of ID * LetPattern * LetPattern * List<LetPattern>
+
+  type MatchPattern =
+    | MPVariable of ID * string
+    | MPUnit of ID
+    | MPBool of ID * bool
+    | MPInt64 of ID * int64
+    | MPUInt64 of ID * uint64
+    | MPInt8 of ID * int8
+    | MPUInt8 of ID * uint8
+    | MPInt16 of ID * int16
+    | MPUInt16 of ID * uint16
+    | MPInt32 of ID * int32
+    | MPUInt32 of ID * uint32
+    | MPInt128 of ID * System.Int128
+    | MPUInt128 of ID * System.UInt128
+    | MPFloat of ID * Sign * string * string
+    | MPChar of ID * string
+    | MPString of ID * string
+    | MPList of ID * List<MatchPattern>
+    | MPListCons of ID * head : MatchPattern * tail : MatchPattern
+    | MPTuple of ID * MatchPattern * MatchPattern * List<MatchPattern>
+    | MPEnum of ID * caseName : string * fieldPats : List<MatchPattern>
+
+  type BinaryOperation =
+    | BinOpAnd
+    | BinOpOr
+
+  type InfixFnName =
+    | ArithmeticPlus
+    | ArithmeticMinus
+    | ArithmeticMultiply
+    | ArithmeticDivide
+    | ArithmeticModulo
+    | ArithmeticPower
+    | ComparisonGreaterThan
+    | ComparisonGreaterThanOrEqual
+    | ComparisonLessThan
+    | ComparisonLessThanOrEqual
+    | ComparisonEquals
+    | ComparisonNotEquals
+    | StringConcat
+
+  type Infix =
+    | InfixFnCall of InfixFnName
+    | BinOp of BinaryOperation
+
+  type StringSegment =
+    | StringText of string
+    | StringInterpolation of Expr
+
+  and PipeExpr =
+    | EPipeVariable of ID * string * List<Expr>
+    | EPipeLambda of ID * pats : NEList<LetPattern> * body : Expr
+    | EPipeInfix of ID * Infix * Expr
+    | EPipeFnCall of
+      ID *
+      NameResolution<FQFnName.FQFnName> *
+      typeArgs : List<TypeReference> *
+      args : List<Expr>
+    | EPipeEnum of
+      ID *
+      typeName : NameResolution<FQTypeName.FQTypeName> *
+      caseName : string *
+      fields : List<Expr>
+
+
+  and Expr =
+    | EUnit of ID
+
+    | EBool of ID * bool
+    | EInt64 of ID * int64
+    | EUInt64 of ID * uint64
+    | EInt8 of ID * int8
+    | EUInt8 of ID * uint8
+    | EInt16 of ID * int16
+    | EUInt16 of ID * uint16
+    | EInt32 of ID * int32
+    | EUInt32 of ID * uint32
+    | EInt128 of ID * System.Int128
+    | EUInt128 of ID * System.UInt128
+    | EFloat of ID * Sign * string * string
+    | EChar of ID * string
+    | EString of ID * List<StringSegment>
+
+    | EConstant of ID * NameResolution<FQConstantName.FQConstantName>
+
+    | EList of ID * List<Expr>
+    | EDict of ID * List<string * Expr>
+    | ETuple of ID * Expr * Expr * List<Expr>
+    | ERecord of ID * NameResolution<FQTypeName.FQTypeName> * List<string * Expr>
+    | EEnum of
+      ID *
+      typeName : NameResolution<FQTypeName.FQTypeName> *
+      caseName : string *
+      fields : List<Expr>
+
+    | ELet of ID * LetPattern * Expr * Expr
+    | EFieldAccess of ID * Expr * string
+    | EVariable of ID * string
+
+    | EIf of ID * cond : Expr * thenExpr : Expr * elseExpr : Option<Expr>
+    | EMatch of ID * arg : Expr * cases : List<MatchCase>
+    | EPipe of ID * Expr * List<PipeExpr>
+
+    | EInfix of ID * Infix * Expr * Expr
+    | ELambda of ID * pats : NEList<LetPattern> * body : Expr
+    | EApply of ID * Expr * typeArgs : List<TypeReference> * args : NEList<Expr>
+    | EFnName of ID * NameResolution<FQFnName.FQFnName>
+    | ERecordUpdate of ID * record : Expr * updates : NEList<string * Expr>
+
+  and MatchCase = { pat : MatchPattern; whenCondition : Option<Expr>; rhs : Expr }
+
+
+  type Deprecation<'name> =
+    | NotDeprecated
+    | RenamedTo of 'name
+    | ReplacedBy of 'name
+    | DeprecatedBecause of string
+
+
+  module TypeDeclaration =
+    type RecordField = { name : string; typ : TypeReference; description : string }
+
+    type EnumField =
+      { typ : TypeReference; label : Option<string>; description : string }
+
+    type EnumCase = { name : string; fields : List<EnumField>; description : string }
+
+    type Definition =
+      | Alias of TypeReference
+      | Record of NEList<RecordField>
+      | Enum of NEList<EnumCase>
+
+    type TypeDeclaration = { typeParams : List<string>; definition : Definition }
+
+
+  type PackageType =
+    { tlid : TLID
+      id : System.Guid
+      name : FQTypeName.Package
+      declaration : TypeDeclaration.TypeDeclaration
+      description : string
+      deprecated : Deprecation<FQTypeName.FQTypeName> }
+
+
+  module PackageFn =
+    type Parameter = { name : string; typ : TypeReference; description : string }
+
+    type PackageFn =
+      { tlid : TLID
+        id : System.Guid
+        name : FQFnName.Package
+        body : Expr
+        typeParams : List<string>
+        parameters : NEList<Parameter>
+        returnType : TypeReference
+        description : string
+        deprecated : Deprecation<FQFnName.FQFnName> }
+
+  type Const =
+    | CInt64 of int64
+    | CUInt64 of uint64
+    | CInt8 of int8
+    | CUInt8 of uint8
+    | CInt16 of int16
+    | CUInt16 of uint16
+    | CInt32 of int32
+    | CUInt32 of uint32
+    | CInt128 of System.Int128
+    | CUInt128 of System.UInt128
+    | CBool of bool
+    | CString of string
+    | CChar of string
+    | CFloat of Sign * string * string
+    | CUnit
+    | CTuple of first : Const * second : Const * rest : List<Const>
+    | CEnum of
+      NameResolution<FQTypeName.FQTypeName> *
+      caseName : string *
+      List<Const>
+    | CList of List<Const>
+    | CDict of List<string * Const>
+
+
+  type PackageConstant =
+    { tlid : TLID
+      id : System.Guid
+      name : FQConstantName.Package
+      description : string
+      deprecated : Deprecation<FQConstantName.FQConstantName>
+      body : Const }

--- a/backend/src/Prelude/Json.fs
+++ b/backend/src/Prelude/Json.fs
@@ -256,6 +256,7 @@ module Vanilla =
     with _ ->
       System.Console.Write("error allowing Vanilla type")
 
+
   let assertSerializable (t : System.Type) : unit =
     if not (isSerializable t) then
       Exception.sendRollbarError

--- a/backend/tests/Tests/PackageManager.Tests.fs
+++ b/backend/tests/Tests/PackageManager.Tests.fs
@@ -1,0 +1,114 @@
+module Tests.PackageManager
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+
+open Expecto
+open Prelude
+open TestUtils.TestUtils
+
+open LibPackageManager
+
+module PMPT = Types.ProgramTypes
+
+module ParsesAndDecodesOk =
+  let deprecation =
+    test "assertFn" {
+      let json = """{ "NotDeprecated": [] }"""
+      let deserialized =
+        SimpleJson.deserialize<PMPT.Deprecation<string>>
+          (JsonDeserialization.ProgramTypes.Deprecation.decoder
+            SimpleJson.Decoders.string)
+          json
+
+      let expected = Ok PMPT.Deprecation.NotDeprecated
+
+      assertEq "msg" expected deserialized
+    }
+
+  let packageType =
+    test "assertFn" {
+      let json =
+        """{
+          "tlid": 112,
+          "id": "f6345e32-f0c6-422a-a9f1-1039a63ce781",
+          "name": { "modules": [ "Stdlib", "Result" ], "name": "Result", "owner": "Darklang", "version": 0 },
+          "description": "",
+          "declaration": {
+            "definition": {
+              "Enum": [
+                [
+                  {
+                    "name": "Ok",
+                    "fields": [ { "description": "", "label": { "None": [] }, "typ": { "TVariable": [ "Ok" ] } } ],
+                    "description": ""
+                  },
+                  {
+                    "name": "Error",
+                    "fields": [ { "description": "", "label": { "None": [] }, "typ": { "TVariable": [ "Err" ] } } ],
+                    "description": ""
+                  }
+                ]
+              ]
+            },
+            "typeParams": [ "Ok", "Err" ]
+          },
+          "deprecated": { "NotDeprecated": [] }
+        }"""
+
+      let deserialized =
+        SimpleJson.deserialize<PMPT.PackageType>
+          JsonDeserialization.ProgramTypes.PackageType.decoder
+          json
+
+      let expected : PMPT.PackageType =
+        { tlid = 112UL
+          id = System.Guid.Parse "f6345e32-f0c6-422a-a9f1-1039a63ce781"
+          name =
+            { owner = "Darklang"
+              modules = [ "Stdlib"; "Result" ]
+              name = "Result"
+              version = 0 }
+          description = ""
+          declaration =
+            { typeParams = [ "Ok"; "Err" ]
+              definition =
+                PMPT.TypeDeclaration.Definition.Enum(
+                  NEList.ofListUnsafe
+                    ""
+                    []
+                    [ { name = "Ok"
+                        fields =
+                          [ { description = ""
+                              label = None
+                              typ = PMPT.TypeReference.TVariable "Ok" } ]
+                        description = "" }
+                      { name = "Error"
+                        fields =
+                          [ { description = ""
+                              label = None
+                              typ = PMPT.TypeReference.TVariable "Err" } ]
+                        description = "" } ]
+                )
+
+            }
+          deprecated = PMPT.Deprecation.NotDeprecated }
+
+      match deserialized with
+      | Ok deserialized -> assertEq "not expected package type" expected deserialized
+
+      | Error(SimpleJson.JsonDeserializationError.ParseError parseError) ->
+        Exception.raiseInternal
+          "Failed to parse package type"
+          [ "json", json; "error", parseError ]
+      | Error(SimpleJson.JsonDeserializationError.DecodeError decodeError) ->
+        debuG "decodeError" decodeError
+        Exception.raiseInternal
+          "Failed to decode package type"
+          [ "json", json; "error", decodeError ]
+    }
+
+let tests =
+  testList
+    "PackageManager"
+    [ ParsesAndDecodesOk.deprecation; ParsesAndDecodesOk.packageType ]

--- a/backend/tests/Tests/Tests.fs
+++ b/backend/tests/Tests/Tests.fs
@@ -51,6 +51,7 @@ let main (args : string array) : int =
         Tests.SqlCompiler.tests
         Tests.TreeSitter.tests
         Tests.Builtin.tests
+        Tests.PackageManager.tests
         Tests.StorageTraces.tests ]
 
     let cancelationTokenSource = new System.Threading.CancellationTokenSource()

--- a/backend/tests/Tests/Tests.fsproj
+++ b/backend/tests/Tests/Tests.fsproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="../../src/BuiltinCloudExecution/BuiltinCloudExecution.fsproj" />
     <ProjectReference Include="../../src/BuiltinDarkInternal/BuiltinDarkInternal.fsproj" />
     <ProjectReference Include="../../src/QueueWorker/QueueWorker.fsproj" />
+    <ProjectReference Include="../../src/LibPackageManager/LibPackageManager.fsproj" />
     <ProjectReference Include="../../src/LibTreeSitter/LibTreeSitter.csproj" />
     <ProjectReference Include="../../src/LibTreeSitter.Darklang/LibTreeSitter.Darklang.csproj" />
     <ProjectReference Include="../TestUtils/TestUtils.fsproj" />
@@ -49,6 +50,7 @@
     <Compile Include="Builtin.Tests.fs" />
     <Compile Include="SqlCompiler.Tests.fs" />
     <Compile Include="TreeSitter.Tests.fs" />
+    <Compile Include="PackageManager.Tests.fs" />
     <Compile Include="Tests.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/packages/darklang/languageTools/programTypes.dark
+++ b/packages/darklang/languageTools/programTypes.dark
@@ -101,6 +101,7 @@ module Darklang =
 
         | TDB of TypeReference
 
+        // TODO: this should be an NEList
         | TFn of List<TypeReference> * TypeReference
 
 


### PR DESCRIPTION
Our F# package manager fetches package items (types, consts, fns) from our dark-packages canvas, over HTTP. Those payloads are in JSON.

Our Json.Vanilla uses System.Text.Json under the hood, which is a reflection-based JSON deserializer.

Our CLI application is AOT-compiled, which puts us in a situation where we can't use run-time reflection.

So, we needed some way to safely deserialize JSON in without using reflection, or by using C# Source Generators (not yet available in F#).

I tried using C# source generators at first, but it broke, and it was broken magic, which is double bad, so abandoned that path.

Then I tried using an F# library Thoth.Json. I didn't quite understand or agree with its types/API, so accidentally started writing an equivalent module, included here as 'SimpleJson'. I don't love inventing a new thing for our use case, but I'm kinda happy with how it turned out.

Anyway - this works. (it might be a bit slow -- I haven't done a perf test, but at least this _unblocks_ us)