### PR TITLE
try to skip license req when building vscode ext

### DIFF
--- a/scripts/publish-vs-code-extension
+++ b/scripts/publish-vs-code-extension
@@ -9,6 +9,6 @@ if [ -z "$VS_CODE_MARKETPLACE_PUBLISH_TOKEN" ]; then
 fi
 cd vscode-extension
 npm i
-vsce package
+vsce package --skip-license
 vsce publish -p $VS_CODE_MARKETPLACE_PUBLISH_TOKEN
 echo "Published VS Code extension"


### PR DESCRIPTION
CI spun for 10mins without this: https://app.circleci.com/pipelines/github/darklang/dark/6996/workflows/e4f4c199-c147-41b7-945d-3e7d51fa31b0/jobs/57826