### PR TITLE
Move parsing from semantic tokens to docSync

### DIFF
--- a/backend/src/BuiltinExecution/Libs/Parser.fs
+++ b/backend/src/BuiltinExecution/Libs/Parser.fs
@@ -68,20 +68,22 @@ let fns : List<BuiltInFn> =
 
               let sourceText =
                 let lines = String.splitOnNewline sourceCode
+                if lines.Length = 0 then
+                  ""
+                else
+                  match startPos.Row with
+                  | row when row = endPos.Row ->
+                    lines[row][startPos.Column .. (endPos.Column - 1)]
+                  | _ ->
+                    let firstLine = lines[startPos.Row][startPos.Column ..]
+                    let middleLines =
+                      if startPos.Row + 1 <= endPos.Row - 1 then
+                        lines[startPos.Row + 1 .. endPos.Row - 1]
+                      else
+                        []
+                    let lastLine = lines[endPos.Row][.. endPos.Column - 1]
 
-                match startPos.Row with
-                | row when row = endPos.Row ->
-                  lines[row][startPos.Column .. (endPos.Column - 1)]
-                | _ ->
-                  let firstLine = lines[startPos.Row][startPos.Column ..]
-                  let middleLines =
-                    if startPos.Row + 1 <= endPos.Row - 1 then
-                      lines[startPos.Row + 1 .. endPos.Row - 1]
-                    else
-                      []
-                  let lastLine = lines[endPos.Row][.. endPos.Column - 1]
-
-                  String.concat "\n" (firstLine :: middleLines @ [ lastLine ])
+                    String.concat "\n" (firstLine :: middleLines @ [ lastLine ])
 
               let fieldName =
                 if cursor.FieldName = null then

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -77,6 +77,12 @@ module ParseToSimplifiedTree =
                               children = [] } ] } ] } ] }
 
 
+  ("" |> Builtin.parserParseToSimplifiedTree) = ParsedNode
+    { typ = "source_file"
+      fieldName = PACKAGE.Darklang.Stdlib.Option.Option.None
+      text = ""
+      sourceRange = range (0L, 0L) (0L, 0L)
+      children = [] }
 
 // These tests are a huge pain to write and maintain
 // Let's focus on roundtripping tests, largely,

--- a/packages/darklang/languageServerProtocol/common.dark
+++ b/packages/darklang/languageServerProtocol/common.dark
@@ -98,12 +98,12 @@ module Darklang =
           start: Position.Position
 
           /// The range's end position.
-          ``end``: Position.Position
+          end_: Position.Position
         }
 
       let toJson (r: Range) : Json =
         Json.Object
-          [ ("start", Position.toJson r.start); ("end", Position.toJson r.``end``) ]
+          [ ("start", Position.toJson r.start); ("end", Position.toJson r.end_) ]
 
 
 

--- a/packages/darklang/languageTools/lsp-server/aaaa_state.dark
+++ b/packages/darklang/languageTools/lsp-server/aaaa_state.dark
@@ -1,7 +1,10 @@
 module Darklang =
   module LanguageTools =
     module LspServer =
-      type DocumentInScope = { uri: String; text: String }
+      type DocumentInScope =
+        { uri: String
+          text: String
+          parsed: Stdlib.Result.Result<WrittenTypes.ParsedFile, String> }
 
       type LspState =
         {

--- a/packages/darklang/languageTools/lsp-server/docSync.dark
+++ b/packages/darklang/languageTools/lsp-server/docSync.dark
@@ -38,12 +38,20 @@ module Darklang =
           (request:
             LanguageServerProtocol.DocumentSync.TextDocument.DidOpenTextDocumentNotification.DidOpenTextDocumentParams.DidOpenTextDocumentParams)
           : LspState =
+          let parsed =
+            request.textDocument.text
+            |> Parser.parseToSimplifiedTree
+            |> Parser.parseCliScript
+
           { state with
               documentsInScope =
                 Stdlib.Dict.set
                   state.documentsInScope
                   request.textDocument.uri
-                  request.textDocument.text }
+                  (LanguageTools.LspServer.DocumentInScope
+                    { uri = request.textDocument.uri
+                      text = request.textDocument.text
+                      parsed = parsed }) }
 
 
         let handleTextDocumentDidSave
@@ -59,12 +67,18 @@ module Darklang =
             state
 
           | Some text ->
+            let parsed =
+              text |> Parser.parseToSimplifiedTree |> Parser.parseCliScript
+
             { state with
                 documentsInScope =
                   Stdlib.Dict.set
                     state.documentsInScope
                     request.textDocument.uri
-                    text }
+                    (LanguageTools.LspServer.DocumentInScope
+                      { uri = request.textDocument.uri
+                        text = text
+                        parsed = parsed }) }
 
 
         let handleTextDocumentDidClose

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -222,8 +222,7 @@ module Darklang =
             |> logAndSendToClient
 
           | Some docText ->
-            let parsed =
-              docText |> Parser.parseToSimplifiedTree |> Parser.parseCliScript
+            let parsed = docText.parsed
 
             match parsed with
             | Ok parsedFile ->
@@ -264,6 +263,8 @@ module Darklang =
                       "Couldn't parse this part of the file")
 
                 sendDiagnostic requestParams.textDocument.uri diagnostics
+
+              | _ -> ()
 
 
             | Error parseError ->

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -157,7 +157,7 @@ module Darklang =
                 LanguageServerProtocol.Position.Position
                   { line = lineStart
                     character = characterStart }
-              ``end`` =
+              end_ =
                 LanguageServerProtocol.Position.Position
                   { line = lineEnd
                     character = characterEnd } }
@@ -283,7 +283,7 @@ module Darklang =
                     { start =
                         LanguageServerProtocol.Position.Position
                           { line = 0UL; character = 0UL }
-                      ``end`` =
+                      end_ =
                         LanguageServerProtocol.Position.Position
                           { line = 0UL; character = 0UL } })
 


### PR DESCRIPTION


No changelog

This PR :
- moves the parsing from semantic tokens to docSync
- prevents the extension from crashing with empty files