### PR TITLE
Add a List.chunkBySize function

### DIFF
--- a/backend/testfiles/execution/stdlib/list.dark
+++ b/backend/testfiles/execution/stdlib/list.dark
@@ -605,7 +605,7 @@ PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [] 4L = PACKAGE.Darklang.Stdlib.Resu
   []
 
 PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L; 3L; 4L ] 0L = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Size must be greater than zero"
+  PACKAGE.Darklang.Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero
 
 PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L; 3L; 4L ] -1L = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Size must be greater than zero"
+  PACKAGE.Darklang.Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero

--- a/backend/testfiles/execution/stdlib/list.dark
+++ b/backend/testfiles/execution/stdlib/list.dark
@@ -588,3 +588,24 @@ PACKAGE.Darklang.Stdlib.List.groupByWithKey_v0 [] (fun x -> x) = []
 PACKAGE.Darklang.Stdlib.List.dropLast [ 1L; 2L; 3L; 4L; 5L ] = [ 1L; 2L; 3L; 4L ]
 PACKAGE.Darklang.Stdlib.List.dropLast [ 1L ] = []
 PACKAGE.Darklang.Stdlib.List.dropLast [] = []
+
+PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L; 3L; 4L; 5L ] 2L = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  [ [ 1L; 2L ]; [ 3L; 4L ]; [ 5L ] ]
+
+PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L; 3L; 4L; 5L; 6L ] 3L = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  [ [ 1L; 2L; 3L ]; [ 4L; 5L; 6L ] ]
+
+PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L; 3L ] 1L = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  [ [ 1L ]; [ 2L ]; [ 3L ] ]
+
+PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L ] 3L = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  [ [ 1L; 2L ] ]
+
+PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [] 4L = PACKAGE.Darklang.Stdlib.Result.Result.Ok
+  []
+
+PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L; 3L; 4L ] 0L = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "Size must be greater than zero"
+
+PACKAGE.Darklang.Stdlib.List.chunkBySize_v0 [ 1L; 2L; 3L; 4L ] -1L = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "Size must be greater than zero"

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -445,3 +445,35 @@ module Darklang =
         | head :: tail ->
           f head
           Stdlib.List.iter tail f
+
+
+      /// Helper function for chunkBySize. Recursively divides a list into chunks of a given size.
+      let chunkBySizeHelper
+        (size: Int64)
+        (currentList: List<'a>)
+        (accum: List<List<'a>>)
+        : List<List<'a>> =
+        match currentList with
+        | [] -> Stdlib.List.reverse accum
+        | _ ->
+          let taken = Stdlib.List.take currentList size
+          let rest = Stdlib.List.drop currentList size
+
+          let newAccum =
+            if Stdlib.List.isEmpty taken then
+              accum
+            else
+              Stdlib.List.push accum taken
+
+          chunkBySizeHelper size rest newAccum
+
+      /// Chunks <param list> into sublists of specified maximum <param size>.
+      /// If <param size> is less than or equal to zero, returns an error
+      let chunkBySize
+        (list: List<'a>)
+        (size: Int64)
+        : Stdlib.Result.Result<List<List<'a>>, String> =
+        if size <= 0L then
+          Stdlib.Result.Result.Error "Size must be greater than zero"
+        else
+          Stdlib.Result.Result.Ok(Stdlib.List.chunkBySizeHelper size list [])

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -467,13 +467,16 @@ module Darklang =
 
           chunkBySizeHelper size rest newAccum
 
+      type ChunkBySizeError = | SizeMustBeGreaterThanZero
+
       /// Chunks <param list> into sublists of specified maximum <param size>.
       /// If <param size> is less than or equal to zero, returns an error
       let chunkBySize
         (list: List<'a>)
         (size: Int64)
-        : Stdlib.Result.Result<List<List<'a>>, String> =
+        : Stdlib.Result.Result<List<List<'a>>, ChunkBySizeError> =
         if size <= 0L then
-          Stdlib.Result.Result.Error "Size must be greater than zero"
+          Stdlib.Result.Result.Error
+            Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero
         else
           Stdlib.Result.Result.Ok(Stdlib.List.chunkBySizeHelper size list [])


### PR DESCRIPTION
Changelog:

```
Stdlib 
- Add a `chunkBySize` function to List module
```
