### PR TITLE
Tree-sitter grammar: support match expressions

### DIFF
--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -499,6 +499,52 @@ else
   h"""
 
 
+    // match expressions
+    ("match () with\n| () -> true" |> roundtripCliScript) = "match () with\n| () ->\n  true"
+    ("match true with\n| true -> true" |> roundtripCliScript) = "match true with\n| true ->\n  true"
+
+    ("match 1y with\n| 1y -> true" |> roundtripCliScript) = "match 1y with\n| 1y ->\n  true"
+    ("match -1y with\n| -1y -> true" |> roundtripCliScript) = "match -1y with\n| -1y ->\n  true"
+    ("match 0uy with\n| 0uy -> true" |> roundtripCliScript) = "match 0uy with\n| 0uy ->\n  true"
+
+    ("match 1s with\n| 1s -> true" |> roundtripCliScript) = "match 1s with\n| 1s ->\n  true"
+    ("match 2us with\n| 2us -> true" |> roundtripCliScript) = "match 2us with\n| 2us ->\n  true"
+
+    ("match 3l with\n| 3l -> true" |> roundtripCliScript) = "match 3l with\n| 3l ->\n  true"
+    ("match 4l with\n| 4l -> true" |> roundtripCliScript) = "match 4l with\n| 4l ->\n  true"
+
+    ("match 5ul with\n| 5ul -> true" |> roundtripCliScript) = "match 5ul with\n| 5ul ->\n  true"
+    ("match 6ul with\n| 6ul -> true" |> roundtripCliScript) = "match 6ul with\n| 6ul ->\n  true"
+
+    ("match 7L with\n| 7L -> true" |> roundtripCliScript) = "match 7L with\n| 7L ->\n  true"
+    ("match 8UL with\n| 8UL -> true" |> roundtripCliScript) = "match 8UL with\n| 8UL ->\n  true"
+
+    ("match 9Q with\n| 9Q -> true" |> roundtripCliScript) = "match 9Q with\n| 9Q ->\n  true"
+    ("match 10Z with\n| 10Z -> true" |> roundtripCliScript) = "match 10Z with\n| 10Z ->\n  true"
+
+    ("match 0.9 with\n| 0.9 -> true" |> roundtripCliScript) = "match 0.9 with\n| 0.9 ->\n  true"
+
+    ("match \"str\" with\n| \"str\" -> true" |> roundtripCliScript) = "match \"str\" with\n| \"str\" ->\n  true"
+    ("match 'c' with\n| 'c' -> true" |> roundtripCliScript) = "match 'c' with\n| 'c' ->\n  true"
+    ("match var with\n| var -> true" |> roundtripCliScript) = "match var with\n| var ->\n  true"
+
+    ("match \"str\" with\n| \"str\" -> true\n| \"other\" -> false"
+     |> roundtripCliScript) = "match \"str\" with\n| \"str\" ->\n  true\n| \"other\" ->\n  false"
+
+    ("match [1L; 2L] with\n| [1L; 2L] -> true" |> roundtripCliScript) = "match [1L; 2L] with\n| [1L; 2L] ->\n  true"
+
+    ("match [1L; 2L; 3L] with\n| head :: tail ->\n \"pass\"" |> roundtripCliScript) = "match [1L; 2L; 3L] with\n| head :: tail ->\n  \"pass\""
+
+    ("match (1L, 2L) with\n| (1L, 2L) -> true" |> roundtripCliScript) = "match (1L, 2L) with\n| (1L, 2L) ->\n  true"
+
+    ("match Stdlib.Result.Result.Ok(5L) with\n| Ok(5L) -> true\n| Error(e) -> false"
+     |> roundtripCliScript) = "match Stdlib.Result.Result.Ok(5L) with\n| Ok 5L ->\n  true\n| Error e ->\n  false"
+
+    ("match \"str\" with\n| \"str\" when true -> true" |> roundtripCliScript) = "match \"str\" with\n| \"str\" when true ->\n  true"
+
+    ("match x with\n| y when y > 1L -> true\n| z when z < 1L -> false\n| w -> w"
+     |> roundtripCliScript) = "match x with\n| y when (y) > (1L) ->\n  true\n| z when (z) < (1L) ->\n  false\n| w ->\n  w"
+
     // fn calls
     // TODO: these are ugly
     ("1L + 2L" |> roundtripCliScript) = "(1L) + (2L)"

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -546,6 +546,7 @@ else
      |> roundtripCliScript) = "match x with\n| y when (y) > (1L) ->\n  true\n| z when (z) < (1L) ->\n  false\n| w ->\n  w"
 
     ("match true with\n| _ -> true" |> roundtripCliScript) = "match true with\n| _ ->\n  true"
+    ("match true with\n| _var -> true" |> roundtripCliScript) = "match true with\n| _var ->\n  true"
 
     // fn calls
     // TODO: these are ugly

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -545,6 +545,8 @@ else
     ("match x with\n| y when y > 1L -> true\n| z when z < 1L -> false\n| w -> w"
      |> roundtripCliScript) = "match x with\n| y when (y) > (1L) ->\n  true\n| z when (z) < (1L) ->\n  false\n| w ->\n  w"
 
+    ("match true with\n| _ -> true" |> roundtripCliScript) = "match true with\n| _ ->\n  true"
+
     // fn calls
     // TODO: these are ugly
     ("1L + 2L" |> roundtripCliScript) = "(1L) + (2L)"

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -756,6 +756,73 @@ module Darklang =
             createUnparseableError node
 
 
+        let parseMatchCase
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchCase, WrittenTypes.Unparseable> =
+          let pipeSym = findField node "symbol_pipe"
+
+          let pattern =
+            findAndParseRequired node "pattern" MatchPattern.parseMatchPattern
+
+          let arrowSym = findField node "symbol_arrow"
+
+          let rhs = findAndParseRequired node "rhs" Expr.parse
+
+          let whenKeywordNode =
+            findAndParseOptional node "when_keyword" (fun node ->
+              node.range |> Stdlib.Result.Result.Ok)
+
+          let guardExprNode = findAndParseOptional node "guard_expr" Expr.parse
+
+          let guardExpr =
+            match whenKeywordNode, guardExprNode with
+            | Some whenKeyword, Some guardExpr ->
+              Stdlib.Option.Option.Some((whenKeyword, guardExpr))
+            | _ -> Stdlib.Option.Option.None
+
+          match pipeSym, pattern, arrowSym, rhs with
+          | Ok pipe, Ok pattern, Ok arrow, Ok rhs ->
+            (WrittenTypes.MatchCase
+              { pat = (pipe.range, pattern, arrow.range)
+                whenCondition = guardExpr
+                rhs = rhs })
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+
+        let parseMatchExpression
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          if node.typ == "match_expression" then
+            let keywordMatchNode = findField node "keyword_match"
+            let exprNode = findAndParseRequired node "arg" Expr.parse
+            let keywordWithNode = findField node "keyword_with"
+
+            let cases =
+              node.children
+              |> Stdlib.List.filter (fun c ->
+                match c.fieldName with
+                | Some fName -> fName == "cases"
+                | None -> false)
+              |> Stdlib.List.map (fun c -> parseMatchCase c)
+              |> Stdlib.Result.collect
+
+            match keywordMatchNode, exprNode, keywordWithNode, cases with
+            | Ok keywordMatch, Ok expr, Ok keywordWith, Ok cases ->
+              (WrittenTypes.Expr.EMatch(
+                node.range,
+                expr,
+                cases,
+                keywordMatch.range,
+                keywordWith.range
+              ))
+              |> Stdlib.Result.Result.Ok
+
+          else
+            createUnparseableError node
+
+
         let parseFunctionCall
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
@@ -833,6 +900,7 @@ module Darklang =
           | "field_access" -> parseFieldAccess node
 
           | "if_expression" -> parseIfExpression node
+          | "match_expression" -> parseMatchExpression node
 
           // fn calls
           | "infix_operation" -> parseInfixOperation node

--- a/packages/darklang/languageTools/parser/matchPattern.dark
+++ b/packages/darklang/languageTools/parser/matchPattern.dark
@@ -383,4 +383,8 @@ module Darklang =
                 (WrittenTypes.MatchPattern.MPVariable(node.range, child.text))
                 |> Stdlib.Result.Result.Ok
 
+              | "wildcard" ->
+                (WrittenTypes.MatchPattern.MPVariable(node.range, "_"))
+                |> Stdlib.Result.Result.Ok
+
             | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/parser/matchPattern.dark
+++ b/packages/darklang/languageTools/parser/matchPattern.dark
@@ -1,0 +1,386 @@
+module Darklang =
+  module LanguageTools =
+    module Parser =
+      module MatchPattern =
+        let parseMPBool
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          let b =
+            match getText node with
+            | "true" -> true |> Stdlib.Result.Result.Ok
+            | "false" -> false |> Stdlib.Result.Result.Ok
+            | _ -> createUnparseableError node
+
+          match b with
+          | Ok b ->
+            (WrittenTypes.MatchPattern.MPBool(node.range, b))
+            |> Stdlib.Result.Result.Ok
+          | Error _ -> createUnparseableError node
+
+        // Helper function for parseMPInt
+        let parseIntByType
+          (intText: String)
+          (typ: String)
+          : Stdlib.Result.Result<_res, _err> =
+          match typ with
+          | "int8" -> Stdlib.Int8.parse intText
+          | "uint8" -> Stdlib.UInt8.parse intText
+          | "int16" -> Stdlib.Int16.parse intText
+          | "uint16" -> Stdlib.UInt16.parse intText
+          | "int32" -> Stdlib.Int32.parse intText
+          | "uint32" -> Stdlib.UInt32.parse intText
+          | "int64" -> Stdlib.Int64.parse intText
+          | "uint64" -> Stdlib.UInt64.parse intText
+          | "int128" -> Stdlib.Int128.parse intText
+          | "uint128" -> Stdlib.UInt128.parse intText
+          | _ -> Stdlib.Result.Result.Error $"Unsupported integer type: {typ}"
+
+        let parseMPInt
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          let supportedInts =
+            [ "int8"
+              "uint8"
+              "int16"
+              "uint16"
+              "int32"
+              "uint32"
+              "int64"
+              "uint64"
+              "int128"
+              "uint128" ]
+
+          if (Stdlib.List.member_v0 supportedInts node.typ) then
+            let intPart = findField node "digits"
+            let suffixPart = findField node "suffix"
+
+            match intPart, suffixPart with
+            | Ok intPart, Ok sfx ->
+              let intText = getText intPart
+
+              match parseIntByType intText node.typ with
+              | Ok parsedValue ->
+                let intPart = (intPart.range, parsedValue)
+
+                let pat =
+                  match node.typ with
+                  | "int8" ->
+                    WrittenTypes.MatchPattern.MPInt8(node.range, intPart, sfx.range)
+                  | "uint8" ->
+                    WrittenTypes.MatchPattern.MPUInt8(node.range, intPart, sfx.range)
+                  | "int16" ->
+                    WrittenTypes.MatchPattern.MPInt16(node.range, intPart, sfx.range)
+                  | "uint16" ->
+                    WrittenTypes.MatchPattern.MPUInt16(
+                      node.range,
+                      intPart,
+                      sfx.range
+                    )
+                  | "int32" ->
+                    WrittenTypes.MatchPattern.MPInt32(node.range, intPart, sfx.range)
+                  | "uint32" ->
+                    WrittenTypes.MatchPattern.MPUInt32(
+                      node.range,
+                      intPart,
+                      sfx.range
+                    )
+                  | "int64" ->
+                    WrittenTypes.MatchPattern.MPInt64(node.range, intPart, sfx.range)
+                  | "uint64" ->
+                    WrittenTypes.MatchPattern.MPUInt64(
+                      node.range,
+                      intPart,
+                      sfx.range
+                    )
+                  | "int128" ->
+                    WrittenTypes.MatchPattern.MPInt128(
+                      node.range,
+                      intPart,
+                      sfx.range
+                    )
+                  | "uint128" ->
+                    WrittenTypes.MatchPattern.MPUInt128(
+                      node.range,
+                      intPart,
+                      sfx.range
+                    )
+                  | _ -> createUnparseableError node
+
+                pat |> Stdlib.Result.Result.Ok
+
+              | Error _ -> createUnparseableError node
+
+          else
+            createUnparseableError node
+
+        let parseMPFloat
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          let floatStr = getText node
+
+          match Stdlib.Float.parse floatStr with
+          | Ok floatValue ->
+            let (sign, whole, remainder) =
+              let (sign, unsignedFloat) =
+                if Stdlib.String.startsWith floatStr "-" then
+                  (Sign.Negative, Stdlib.String.dropFirst floatStr 1L)
+                else
+                  (Sign.Positive, floatStr)
+
+              let parts = Stdlib.String.split unsignedFloat "."
+
+              let whole = parts |> Stdlib.List.head |> Stdlib.Option.withDefault "0"
+
+              let remainder =
+                parts
+                |> Stdlib.List.tail
+                |> Stdlib.Option.withDefault [ "0" ]
+                |> Stdlib.List.head
+                |> Stdlib.Option.withDefault "0"
+
+              (sign, whole, remainder)
+
+            (WrittenTypes.MatchPattern.MPFloat(node.range, sign, whole, remainder))
+            |> Stdlib.Result.Result.Ok
+
+          | Error _ -> createUnparseableError node
+
+        let parseMPString
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          let openQuoteNode = findField node "symbol_open_quote"
+          let closeQuoteNode = findField node "symbol_close_quote"
+
+          let contents =
+            findAndParseOptional node "content" (fun stringPart ->
+              (stringPart.range, stringPart.text) |> Stdlib.Result.Result.Ok)
+
+          match openQuoteNode, closeQuoteNode with
+          | Ok openQuote, Ok closeQuote ->
+            (WrittenTypes.MatchPattern.MPString(
+              node.range,
+              contents,
+              openQuote.range,
+              closeQuote.range
+            ))
+            |> Stdlib.Result.Result.Ok
+          | _ -> createUnparseableError node
+
+        let parseMPChar
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+
+          let openQuoteNode = findField node "symbol_open_single_quote"
+
+          let charNode =
+            findAndParseOptional node "content" (fun charPart ->
+              (charPart.range, charPart.text) |> Stdlib.Result.Result.Ok)
+
+          let closeQuoteNode = findField node "symbol_close_single_quote"
+
+          match openQuoteNode, closeQuoteNode with
+          | Ok openQuote, Ok closeQuote ->
+            (WrittenTypes.MatchPattern.MPChar(
+              node.range,
+              charNode,
+              openQuote.range,
+              closeQuote.range
+            ))
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+        let parseMPList
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          let openBracketNode = findField node "symbol_open_bracket"
+          let closeBracketNode = findField node "symbol_close_bracket"
+
+          let findContent =
+            node
+            |> findNodeByFieldName "content"
+            |> Stdlib.Option.map (fun contentsNode ->
+              contentsNode.children
+              |> Stdlib.List.chunkBySize 2L
+              |> Builtin.unwrap
+              |> Stdlib.List.map (fun chunk ->
+                match chunk with
+                | [ pat; symbol ] ->
+
+                  match parseMatchPattern pat with
+                  | Ok e ->
+                    (e, Stdlib.Option.Option.Some symbol.range)
+                    |> Stdlib.Result.Result.Ok
+                  | Error _ -> createUnparseableError chunk
+
+                | [ pat ] ->
+                  match MatchPattern.parseMatchPattern pat with
+                  | Ok e ->
+                    (e, Stdlib.Option.Option.None) |> Stdlib.Result.Result.Ok
+                  | Error _ -> createUnparseableError pat
+                | _ -> createUnparseableError chunk))
+
+          let contents =
+            match findContent with
+            | Some c -> c |> Stdlib.Result.collect
+            | None -> [] |> Stdlib.Result.Result.Ok
+
+          match openBracketNode, contents, closeBracketNode with
+          | Ok openBracket, Ok contents, Ok closeBracket ->
+            (WrittenTypes.MatchPattern.MPList(
+              node.range,
+              contents,
+              openBracket.range,
+              closeBracket.range
+            ))
+            |> Stdlib.Result.Result.Ok
+          | _ -> createUnparseableError node
+
+        let parseMPListCons
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          let head = findAndParseRequired node "head" MatchPattern.parseMatchPattern
+          let tail = findAndParseRequired node "tail" MatchPattern.parseMatchPattern
+          let consSymbol = findField node "symbol_double_colon"
+
+          match head, tail, consSymbol with
+          | Ok head, Ok tail, Ok consSymbol ->
+            (WrittenTypes.MatchPattern.MPListCons(
+              node.range,
+              head,
+              tail,
+              consSymbol.range
+            ))
+            |> Stdlib.Result.Result.Ok
+
+        let parseMPTuple
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          let openParenNode = findField node "symbol_left_paren"
+
+          let first =
+            findAndParseRequired node "first" MatchPattern.parseMatchPattern
+
+          let second =
+            findAndParseRequired node "second" MatchPattern.parseMatchPattern
+
+          let findRest =
+            (findNodeByFieldName node "rest")
+            |> Stdlib.Option.map (fun restNode ->
+              restNode.children
+              |> Stdlib.List.chunkBySize 2L
+              |> Builtin.unwrap
+              |> Stdlib.List.map (fun chunk ->
+                match chunk with
+                | [ symbol; patNode ] ->
+                  match MatchPattern.parseMatchPattern patNode with
+                  | Ok pat -> (symbol.range, pat) |> Stdlib.Result.Result.Ok
+                  | Error _ -> createUnparseableError chunk
+
+                | [ patNode ] ->
+                  match MatchPattern.parseMatchPattern patNode with
+                  | Ok pat ->
+                    (Stdlib.Option.Option.None, pat) |> Stdlib.Result.Result.Ok
+                  | Error _ -> createUnparseableError chunk
+                | _ -> createUnparseableError chunk))
+
+          let rest =
+            match findRest with
+            | Some r -> r |> Stdlib.Result.collect
+            | None -> [] |> Stdlib.Result.Result.Ok
+
+          let commaSymbol = findField node "symbol_comma"
+          let closeParenNode = findField node "symbol_right_paren"
+
+          match openParenNode, first, commaSymbol, second, rest, closeParenNode with
+          | Ok openPr, Ok first, Ok commaSym, Ok second, Ok rest, Ok closePr ->
+            (WrittenTypes.MatchPattern.MPTuple(
+              node.range,
+              first,
+              commaSym.range,
+              second,
+              rest,
+              openPr.range,
+              closePr.range
+            ))
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+        let parseMPEnum
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          let caseNameNode = findField node "case_name"
+
+          let enumFieldsNode =
+            (findNodeByFieldName node "enum_fields")
+            |> Stdlib.Option.map (fun enumFieldsNode ->
+              enumFieldsNode.children
+              |> Stdlib.List.chunkBySize 2L
+              |> Builtin.unwrap
+              |> Stdlib.List.map (fun chunk ->
+                match chunk with
+                | [ fieldNode ] ->
+                  match parseMatchPattern fieldNode with
+                  | Ok field -> field
+                  | Error _ -> WrittenTypes.Unparseable { source = fieldNode }
+
+                | [ fieldNode; _separator ] ->
+                  match parseMatchPattern fieldNode with
+                  | Ok field -> field
+                  | Error _ -> WrittenTypes.Unparseable { source = fieldNode }))
+
+            |> Stdlib.Option.withDefault []
+
+
+          match caseNameNode with
+          | Ok caseNameNode ->
+            (WrittenTypes.MatchPattern.MPEnum(
+              node.range,
+              (caseNameNode.range, caseNameNode.text),
+              enumFieldsNode
+            ))
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+        let parseMatchPattern
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
+          if node.typ == "match_pattern" then
+            match node.children with
+            | [] -> createUnparseableError node
+            | [ child ] ->
+              match child.typ with
+              | "unit" ->
+                (WrittenTypes.MatchPattern.MPUnit node.range)
+                |> Stdlib.Result.Result.Ok
+              | "bool" -> parseMPBool child
+
+              | "int8" -> parseMPInt child
+              | "uint8" -> parseMPInt child
+              | "int16" -> parseMPInt child
+              | "uint16" -> parseMPInt child
+              | "int32" -> parseMPInt child
+              | "uint32" -> parseMPInt child
+              | "int64" -> parseMPInt child
+              | "uint64" -> parseMPInt child
+              | "int128" -> parseMPInt child
+              | "uint128" -> parseMPInt child
+
+              | "float" -> parseMPFloat child
+
+              | "string" -> parseMPString child
+              | "char" -> parseMPChar child
+
+              | "list" -> parseMPList child
+              | "list_cons" -> parseMPListCons child
+
+              | "tuple" -> parseMPTuple child
+              | "enum" -> parseMPEnum child
+
+              | "variable" ->
+                (WrittenTypes.MatchPattern.MPVariable(node.range, child.text))
+                |> Stdlib.Result.Result.Ok
+
+            | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/parser/matchPattern.dark
+++ b/packages/darklang/languageTools/parser/matchPattern.dark
@@ -37,7 +37,7 @@ module Darklang =
 
         let parseMPInt
           (node: ParsedNode)
-          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
           let supportedInts =
             [ "int8"
               "uint8"

--- a/packages/darklang/languageTools/parser/matchPattern.dark
+++ b/packages/darklang/languageTools/parser/matchPattern.dark
@@ -383,8 +383,4 @@ module Darklang =
                 (WrittenTypes.MatchPattern.MPVariable(node.range, child.text))
                 |> Stdlib.Result.Result.Ok
 
-              | "wildcard" ->
-                (WrittenTypes.MatchPattern.MPVariable(node.range, "_"))
-                |> Stdlib.Result.Result.Ok
-
             | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -237,6 +237,124 @@ module Darklang =
             tokenizeDefinition t.definition ]
           |> Stdlib.List.flatten
 
+      module MatchPattern =
+        let tokenize (p: WrittenTypes.MatchPattern) : List<SemanticToken> =
+          match p with
+          | MPVariable(range, _name) -> [ makeToken range TokenType.VariableName ]
+          | MPUnit(range) -> [ makeToken range TokenType.Symbol ]
+          | MPInt8(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPUInt8(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPInt16(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPUInt16(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPInt32(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPUInt32(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPInt64(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPUInt64(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPInt128(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPUInt128(_, (intPartRange, _), suffixPartRange) ->
+            [ makeToken intPartRange TokenType.Number
+              makeToken suffixPartRange TokenType.Symbol ]
+          | MPFloat(range, _sign, _whole, _fraction) ->
+            [ makeToken range TokenType.Number ]
+          | MPString(range, _contentsMaybe, symbolOpenQuote, symbolCloseQuote) ->
+            [ // "
+              [ makeToken symbolOpenQuote TokenType.Symbol ]
+              // hello
+              [ makeToken range TokenType.String ]
+              // "
+              [ makeToken symbolCloseQuote TokenType.Symbol ] ]
+            |> Stdlib.List.flatten
+          | MPChar(range, _contentsMaybe, symbolOpenQuote, symbolCloseQuote) ->
+            [ // '
+              [ makeToken symbolOpenQuote TokenType.Symbol ]
+              // a
+              [ makeToken range TokenType.String ]
+              // '
+              [ makeToken symbolCloseQuote TokenType.Symbol ] ]
+
+          | MPList(range, contentsMaybe, symbolLeftBracket, symbolRightBracket) ->
+            let contents =
+              contentsMaybe
+              |> Stdlib.List.map (fun (pat, _) -> tokenize pat)
+              |> Stdlib.List.flatten
+
+            [ // [
+              [ makeToken symbolLeftBracket TokenType.Symbol ]
+              // 1 ; 2 ; 3
+              contents
+              // ]
+              [ makeToken symbolRightBracket TokenType.Symbol ] ]
+            |> Stdlib.List.flatten
+
+          | MPListCons(range, head, tail, symbolCons) ->
+            [ // head
+              tokenize head
+              // ::
+              [ makeToken symbolCons TokenType.Symbol ]
+              // tail
+              tokenize tail ]
+            |> Stdlib.List.flatten
+
+          | MPTuple(range,
+                    first,
+                    symbolComma,
+                    second,
+                    rest,
+                    symbolOpenParen,
+                    symbolCloseParen) ->
+            let rest =
+              rest
+              |> Stdlib.List.map (fun (_, pat) -> tokenize pat)
+              |> Stdlib.List.flatten
+
+            [ // (
+              [ makeToken symbolOpenParen TokenType.Symbol ]
+              // 1
+              tokenize first
+              // ,
+              [ makeToken symbolComma TokenType.Symbol ]
+              // 2
+              tokenize second
+              // , 3
+              rest
+              // )
+              [ makeToken symbolCloseParen TokenType.Symbol ] ]
+            |> Stdlib.List.flatten
+
+          | MPEnum(range, caseName, fields) ->
+            let caseName =
+              match caseName with
+              | (range, _) -> [ makeToken range TokenType.EnumMember ]
+              | _ -> []
+
+            let fields =
+              fields
+              |> Stdlib.List.map (fun pat -> tokenize pat)
+              |> Stdlib.List.flatten
+
+            [ // Some
+              caseName
+              // 1L
+              fields ]
+            |> Stdlib.List.flatten
 
 
       module Expr =
@@ -524,6 +642,54 @@ module Darklang =
               elseKeyword
               // 2
               elseExpr ]
+            |> Stdlib.List.flatten
+
+          // match x with
+          // | x when x > 1 -> x
+          // | 1 -> 1
+          | EMatch(range, expr, cases, keywordMatch, symbolWith) ->
+            let cases =
+              cases
+              |> Stdlib.List.map (fun case ->
+                let pipeSym = Stdlib.Tuple3.first case.pat
+                let pattern = Stdlib.Tuple3.second case.pat
+                let arrowSym = Stdlib.Tuple3.third case.pat
+
+                let whenCondition =
+                  Stdlib.Option.mapWithDefault
+                    case.whenCondition
+                    []
+                    (fun (whenKeyword, expr) ->
+                      [ // when
+                        [ makeToken whenKeyword TokenType.Keyword ]
+                        // x > 1
+                        (Expr.tokenize expr) ]
+                      |> Stdlib.List.flatten)
+
+
+                [ // |
+                  [ makeToken pipeSym TokenType.Symbol ]
+                  // x
+                  MatchPattern.tokenize pattern
+                  // when x > 1
+                  whenCondition
+                  // ->
+                  [ makeToken arrowSym TokenType.Symbol ]
+                  // x
+                  Expr.tokenize case.rhs ]
+                |> Stdlib.List.flatten)
+
+              |> Stdlib.List.flatten
+
+            [ // match
+              [ makeToken keywordMatch TokenType.Keyword ]
+              // x
+              Expr.tokenize expr
+              // with
+              [ makeToken symbolWith TokenType.Keyword ]
+              // | x when x > 1 -> x
+              // | 1 -> 1
+              cases ]
             |> Stdlib.List.flatten
 
           // x + 1

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -135,6 +135,55 @@ module Darklang =
           symbolOpenParen: Range *
           symbolCloseParen: Range
 
+      type MatchPattern =
+        | MPUnit of Range
+        | MPBool of Range * Bool
+        | MPInt8 of Range * intPart: (Range * Int8) * suffixPart: Range
+        | MPUInt8 of Range * intPart: (Range * UInt8) * suffixPart: Range
+        | MPInt16 of Range * intPart: (Range * Int16) * suffixPart: Range
+        | MPUInt16 of Range * intPart: (Range * UInt16) * suffixPart: Range
+        | MPInt32 of Range * intPart: (Range * Int32) * suffixPart: Range
+        | MPUInt32 of Range * intPart: (Range * UInt32) * suffixPart: Range
+        | MPInt64 of Range * intPart: (Range * Int64) * suffixPart: Range
+        | MPUInt64 of Range * intPart: (Range * UInt64) * suffixPart: Range
+        | MPInt128 of Range * intPart: (Range * Int128) * suffixPart: Range
+        | MPUInt128 of Range * intPart: (Range * UInt128) * suffixPart: Range
+        | MPFloat of Range * Sign * String * String
+        | MPChar of
+          Range *
+          contents: Stdlib.Option.Option<Range * String> *
+          symbolOpenQuote: Range *
+          symbolCloseQuote: Range
+        | MPString of
+          Range *
+          contents: Stdlib.Option.Option<Range * String> *
+          symbolOpenQuote: Range *
+          symbolCloseQuote: Range
+        | MPList of
+          Range *
+          contents: List<MatchPattern * Stdlib.Option.Option<Range>> *
+          symbolOpenBracket: Range *
+          symbolCloseBracket: Range
+        | MPListCons of
+          Range *
+          head: MatchPattern *
+          tail: MatchPattern *
+          symbolCons: Range
+        | MPTuple of
+          Range *
+          first: MatchPattern *
+          symbolComma: Range *
+          second: MatchPattern *
+          rest: List<Stdlib.Option.Option<Range> * MatchPattern> *
+          symbolOpenParen: Range *
+          symbolCloseParen: Range
+        | MPVariable of Range * String
+        | MPEnum of
+          Range *
+          caseName: (Range * String) *
+          fieldPats: List<MatchPattern>
+
+
       type Infix =
         | InfixFnCall of InfixFnName
         | BinOp of BinaryOperation
@@ -157,6 +206,11 @@ module Darklang =
       type BinaryOperation =
         | BinOpAnd
         | BinOpOr
+
+      type MatchCase =
+        { pat: Range * MatchPattern * Range
+          whenCondition: Stdlib.Option.Option<Range * Expr>
+          rhs: Expr }
 
       type Expr =
         | EUnit of Range
@@ -248,6 +302,13 @@ module Darklang =
           keywordIf: Range *
           keywordThen: Range *
           keywordElse: Stdlib.Option.Option<Range>
+
+        | EMatch of
+          Range *
+          expr: Expr *
+          cases: List<MatchCase> *
+          keywordMatch: Range *
+          keywordWith: Range
 
         | EInfix of Range * op: (Range * Infix) * left: Expr * right: Expr
 

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -249,6 +249,63 @@ module Darklang =
 
               ProgramTypes.LetPattern.LPTuple(gid (), first, second, rest)
 
+        module MatchPattern =
+          let toPT
+            (onMissing: NameResolver.OnMissing)
+            (p: WrittenTypes.MatchPattern)
+            : ProgramTypes.MatchPattern =
+            match p with
+            | MPUnit _ -> ProgramTypes.MatchPattern.MPUnit(gid ())
+            | MPBool(_, b) -> ProgramTypes.MatchPattern.MPBool(gid (), b)
+            | MPInt8(_, (_, i), _) -> ProgramTypes.MatchPattern.MPInt8(gid (), i)
+            | MPUInt8(_, (_, i), _) -> ProgramTypes.MatchPattern.MPUInt8(gid (), i)
+            | MPInt16(_, (_, i), _) -> ProgramTypes.MatchPattern.MPInt16(gid (), i)
+            | MPUInt16(_, (_, i), _) -> ProgramTypes.MatchPattern.MPUInt16(gid (), i)
+            | MPInt32(_, (_, i), _) -> ProgramTypes.MatchPattern.MPInt32(gid (), i)
+            | MPUInt32(_, (_, i), _) -> ProgramTypes.MatchPattern.MPUInt32(gid (), i)
+            | MPInt64(_, (_, i), _) -> ProgramTypes.MatchPattern.MPInt64(gid (), i)
+            | MPUInt64(_, (_, i), _) -> ProgramTypes.MatchPattern.MPUInt64(gid (), i)
+            | MPInt128(_, (_, i), _) -> ProgramTypes.MatchPattern.MPInt128(gid (), i)
+            | MPUInt128(_, (_, i), _) ->
+              ProgramTypes.MatchPattern.MPUInt128(gid (), i)
+            | MPFloat(_, s, w, f) ->
+              ProgramTypes.MatchPattern.MPFloat(gid (), s, w, f)
+            | MPString(_, contents, _, _) ->
+              match contents with
+              | None -> ProgramTypes.MatchPattern.MPString(gid (), "")
+              | Some((_, s)) -> ProgramTypes.MatchPattern.MPString(gid (), s)
+            | MPChar(_, c, _, _) ->
+              match c with
+              | None -> ProgramTypes.MatchPattern.MPChar(gid (), "")
+              | Some((_, c)) -> ProgramTypes.MatchPattern.MPChar(gid (), c)
+
+            | MPList(_, contents, _, _) ->
+              ProgramTypes.MatchPattern.MPList(
+                gid (),
+                Stdlib.List.map contents (fun (p, _) -> toPT onMissing p)
+              )
+            | MPListCons(_, head, tail, _) ->
+              ProgramTypes.MatchPattern.MPListCons(
+                gid (),
+                toPT onMissing head,
+                toPT onMissing tail
+              )
+            | MPTuple(_, first, _, second, rest, _, _) ->
+              ProgramTypes.MatchPattern.MPTuple(
+                gid (),
+                toPT onMissing first,
+                toPT onMissing second,
+                Stdlib.List.map rest (fun (_, p) -> toPT onMissing p)
+              )
+            | MPEnum(_, caseName, fields) ->
+              let caseName = caseName |> Stdlib.Tuple2.second
+              let fields = Stdlib.List.map fields (fun p -> toPT onMissing p)
+
+              ProgramTypes.MatchPattern.MPEnum(gid (), caseName, fields)
+
+            | MPVariable(_, name) ->
+              ProgramTypes.MatchPattern.MPVariable(gid (), name)
+
 
         let toPT
           (onMissing: NameResolver.OnMissing)
@@ -351,6 +408,26 @@ module Darklang =
               toPT onMissing thenExpr,
               elseExpr
             )
+
+          | EMatch(_, expr, cases, _, _) ->
+            let cases =
+              Stdlib.List.map cases (fun case ->
+                let pat =
+                  MatchPattern.toPT onMissing (Stdlib.Tuple3.second case.pat)
+
+                let whenCondition =
+                  case.whenCondition
+                  |> Stdlib.Option.map (fun (_, e) -> toPT onMissing e)
+
+                let rhs = toPT onMissing case.rhs
+
+                ProgramTypes.MatchCase
+                  { pat = pat
+                    whenCondition = whenCondition
+                    rhs = rhs })
+
+            ProgramTypes.Expr.EMatch(gid (), toPT onMissing expr, cases)
+
 
           // fn calls
           | EInfix(_, (_, op), left, right) ->

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -335,29 +335,29 @@ module Darklang =
         | MPVariable(_id, name) -> name
         | MPUnit _id -> "()"
         | MPBool(_id, b) -> Stdlib.Bool.toString b
-        | MPInt64(_id, i) -> Stdlib.Int64.toString i
-        | MPUInt64(_id, i) -> Stdlib.UInt64.toString i
-        | MPInt8(_id, i) -> Stdlib.Int8.toString i
-        | MPUInt8(_id, i) -> Stdlib.UInt8.toString i
-        | MPInt16(_id, i) -> Stdlib.Int16.toString i
-        | MPUInt16(_id, i) -> Stdlib.UInt16.toString i
-        | MPInt32(_id, i) -> Stdlib.Int32.toString i
-        | MPUInt32(_id, i) -> Stdlib.UInt32.toString i
-        | MPInt128(_id, i) -> Stdlib.Int128.toString i
-        | MPUInt128(_id, i) -> Stdlib.UInt128.toString i
+        | MPInt64(_id, i) -> (Stdlib.Int64.toString i) ++ "L"
+        | MPUInt64(_id, i) -> (Stdlib.UInt64.toString i) ++ "UL"
+        | MPInt8(_id, i) -> (Stdlib.Int8.toString i) ++ "y"
+        | MPUInt8(_id, i) -> (Stdlib.UInt8.toString i) ++ "uy"
+        | MPInt16(_id, i) -> (Stdlib.Int16.toString i) ++ "s"
+        | MPUInt16(_id, i) -> (Stdlib.UInt16.toString i) ++ "us"
+        | MPInt32(_id, i) -> (Stdlib.Int32.toString i) ++ "l"
+        | MPUInt32(_id, i) -> (Stdlib.UInt32.toString i) ++ "ul"
+        | MPInt128(_id, i) -> (Stdlib.Int128.toString i) ++ "Q"
+        | MPUInt128(_id, i) -> (Stdlib.UInt128.toString i) ++ "Z"
         | MPFloat(_id, sign, whole, remainder) ->
           let remainderPart = PrettyPrinter.processRemainder remainder
 
           $"{PrettyPrinter.sign sign}{whole}.{remainderPart}"
 
-        | MPChar(_id, c) -> c
+        | MPChar(_id, c) -> $"'{c}'"
         | MPString(_id, s) -> $"\"{PrettyPrinter.escapeSpecialCharacters s}\""
 
         | MPList(_id, items) ->
           items
           |> Stdlib.List.map (fun item ->
             PrettyPrinter.ProgramTypes.matchPattern item)
-          |> Stdlib.String.join ", "
+          |> Stdlib.String.join "; "
           |> fun parts -> "[" ++ parts ++ "]"
 
         | MPListCons(_id, head, tail) ->
@@ -659,7 +659,7 @@ module Darklang =
 
           let argPart = PrettyPrinter.ProgramTypes.expr arg
 
-          $"match {argPart} with \n{casesPart}"
+          $"match {argPart} with\n{casesPart}"
 
 
         | EPipe(_id, expr, pipeExprs) ->

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -186,6 +186,7 @@ module.exports = grammar({
         alias($.mp_tuple, $.tuple),
         alias($.mp_enum, $.enum),
         alias($.variable_identifier, $.variable),
+        alias(/_/, $.wildcard),
       ),
 
     // match pattern - list
@@ -670,6 +671,7 @@ module.exports = grammar({
 
     //
     // Match expression
+    // TODO : allow one-line match expressions (i.e. match x with | 1 -> ...)
     match_expression: $ =>
       prec(
         PREC.MATCH_EXPR,

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -12,6 +12,8 @@ const PREC = {
   EXPONENT: 5,
   MATCH_EXPR: 6,
   FIELDACCESS: 7,
+  VAR_IDENTIFIER: 8,
+  FN_IDENTIFIER: 9,
 };
 
 const logicalOperators = choice("&&", "||");
@@ -186,7 +188,6 @@ module.exports = grammar({
         alias($.mp_tuple, $.tuple),
         alias($.mp_enum, $.enum),
         alias($.variable_identifier, $.variable),
-        alias(/_/, $.wildcard),
       ),
 
     // match pattern - list
@@ -813,10 +814,10 @@ module.exports = grammar({
     /** e.g. `x` in `let double (x: Int) = x + x`
      *
      * for let bindings, params, etc. */
-    variable_identifier: $ => /[a-z][a-zA-Z0-9_]*/,
+    variable_identifier: $ => prec(PREC.VAR_IDENTIFIER, /[a-z_][a-zA-Z0-9_]*/),
 
     // e.g. `double` in `let double (x: Int) = x + x`
-    fn_identifier: $ => /[a-z][a-zA-Z0-9_]*/,
+    fn_identifier: $ => prec(PREC.FN_IDENTIFIER, /[a-z_][a-zA-Z0-9_]*/),
 
     // e.g. `Person` in `type MyPerson = ...`
     type_identifier: $ => /[A-Z][a-zA-Z0-9_]*/,

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -734,6 +734,15 @@
           },
           "named": true,
           "value": "variable"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "PATTERN",
+            "value": "_"
+          },
+          "named": true,
+          "value": "wildcard"
         }
       ]
     },

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -437,7 +437,7 @@
           "name": "case_name",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier_enum_case"
+            "name": "enum_case_identifier"
           }
         },
         {
@@ -557,6 +557,525 @@
       "type": "PATTERN",
       "value": "\\n"
     },
+    "match_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unit"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bool_literal"
+          },
+          "named": true,
+          "value": "bool"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "int8_literal"
+          },
+          "named": true,
+          "value": "int8"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "uint8_literal"
+          },
+          "named": true,
+          "value": "uint8"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "int16_literal"
+          },
+          "named": true,
+          "value": "int16"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "uint16_literal"
+          },
+          "named": true,
+          "value": "uint16"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "int32_literal"
+          },
+          "named": true,
+          "value": "int32"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "uint32_literal"
+          },
+          "named": true,
+          "value": "uint32"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "int64_literal"
+          },
+          "named": true,
+          "value": "int64"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "uint64_literal"
+          },
+          "named": true,
+          "value": "uint64"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "int128_literal"
+          },
+          "named": true,
+          "value": "int128"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "uint128_literal"
+          },
+          "named": true,
+          "value": "uint128"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "float_literal"
+          },
+          "named": true,
+          "value": "float"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "char_literal"
+          },
+          "named": true,
+          "value": "char"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "string_literal"
+          },
+          "named": true,
+          "value": "string"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "mp_list"
+          },
+          "named": true,
+          "value": "list"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "mp_list_cons"
+          },
+          "named": true,
+          "value": "list_cons"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "mp_tuple"
+          },
+          "named": true,
+          "value": "tuple"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "mp_enum"
+          },
+          "named": true,
+          "value": "enum"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_identifier"
+          },
+          "named": true,
+          "value": "variable"
+        }
+      ]
+    },
+    "mp_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_open_bracket",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "["
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "content",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "mp_list_content"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_close_bracket",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "]"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
+    },
+    "mp_list_content": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "match_pattern"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "list_separator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ";"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "match_pattern"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": ";"
+              },
+              "named": true,
+              "value": "symbol"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "mp_list_cons": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "head",
+            "content": {
+              "type": "SYMBOL",
+              "name": "match_pattern"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "symbol_double_colon",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "::"
+              },
+              "named": true,
+              "value": "symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "tail",
+            "content": {
+              "type": "SYMBOL",
+              "name": "match_pattern"
+            }
+          }
+        ]
+      }
+    },
+    "mp_tuple": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_left_paren",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "("
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "first",
+          "content": {
+            "type": "SYMBOL",
+            "name": "match_pattern"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_comma",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ","
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "second",
+          "content": {
+            "type": "SYMBOL",
+            "name": "match_pattern"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "rest",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "mp_tuple_the_rest"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_right_paren",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ")"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
+    },
+    "mp_tuple_the_rest": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "symbol_comma",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": ","
+              },
+              "named": true,
+              "value": "symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "pat",
+            "content": {
+              "type": "SYMBOL",
+              "name": "match_pattern"
+            }
+          }
+        ]
+      }
+    },
+    "mp_enum": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "case_name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "enum_case_identifier"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "symbol_open_paren",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": "("
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "mp_enum_fields"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "symbol_close_paren",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ")"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "mp_enum_fields": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "match_pattern"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_comma",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "match_pattern"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "expression": {
       "type": "CHOICE",
       "members": [
@@ -658,6 +1177,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "match_expression"
+        },
+        {
+          "type": "SYMBOL",
           "name": "infix_operation"
         },
         {
@@ -723,115 +1246,6 @@
         {
           "type": "PATTERN",
           "value": "false"
-        }
-      ]
-    },
-    "function_call": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "symbol_left_paren",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "("
-            },
-            "named": true,
-            "value": "symbol"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "fn",
-          "content": {
-            "type": "SYMBOL",
-            "name": "qualified_fn_name"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "args",
-          "content": {
-            "type": "REPEAT1",
-            "content": {
-              "type": "SYMBOL",
-              "name": "expression"
-            }
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "symbol_right_paren",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": ")"
-            },
-            "named": true,
-            "value": "symbol"
-          }
-        }
-      ]
-    },
-    "let_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "keyword_let",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "let"
-            },
-            "named": true,
-            "value": "keyword"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "identifier",
-          "content": {
-            "type": "SYMBOL",
-            "name": "variable_identifier"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "symbol_equals",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "="
-            },
-            "named": true,
-            "value": "symbol"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "expr",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "\n"
-        },
-        {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
         }
       ]
     },
@@ -2115,7 +2529,7 @@
             "name": "case_name",
             "content": {
               "type": "SYMBOL",
-              "name": "identifier_enum_case"
+              "name": "enum_case_identifier"
             }
           },
           {
@@ -2547,6 +2961,250 @@
         }
       ]
     },
+    "match_expression": {
+      "type": "PREC",
+      "value": 6,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "keyword_match",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "match"
+              },
+              "named": true,
+              "value": "keyword"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "arg",
+            "content": {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "keyword_with",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "with"
+              },
+              "named": true,
+              "value": "keyword"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "cases",
+            "content": {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SYMBOL",
+                "name": "match_case"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "match_case": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_pipe",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "|"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "pattern",
+          "content": {
+            "type": "SYMBOL",
+            "name": "match_pattern"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "when_keyword",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "when"
+                    },
+                    "named": true,
+                    "value": "keyword"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "guard_expr",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_arrow",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "->"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "rhs",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        }
+      ]
+    },
+    "function_call": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_left_paren",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "("
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "fn",
+          "content": {
+            "type": "SYMBOL",
+            "name": "qualified_fn_name"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "args",
+          "content": {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_right_paren",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ")"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
+    },
+    "let_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "keyword_let",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "let"
+            },
+            "named": true,
+            "value": "keyword"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "identifier",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_equals",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "="
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "expr",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "\n"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        }
+      ]
+    },
     "type_reference": {
       "type": "CHOICE",
       "members": [
@@ -2930,7 +3588,7 @@
       "type": "PATTERN",
       "value": "[A-Z][a-zA-Z0-9_]*"
     },
-    "identifier_enum_case": {
+    "enum_case_identifier": {
       "type": "PATTERN",
       "value": "[A-Z][a-zA-Z0-9_]*"
     },

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -734,15 +734,6 @@
           },
           "named": true,
           "value": "variable"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "_"
-          },
-          "named": true,
-          "value": "wildcard"
         }
       ]
     },
@@ -3582,12 +3573,20 @@
       ]
     },
     "variable_identifier": {
-      "type": "PATTERN",
-      "value": "[a-z][a-zA-Z0-9_]*"
+      "type": "PREC",
+      "value": 8,
+      "content": {
+        "type": "PATTERN",
+        "value": "[a-z_][a-zA-Z0-9_]*"
+      }
     },
     "fn_identifier": {
-      "type": "PATTERN",
-      "value": "[a-z][a-zA-Z0-9_]*"
+      "type": "PREC",
+      "value": 9,
+      "content": {
+        "type": "PATTERN",
+        "value": "[a-z_][a-zA-Z0-9_]*"
+      }
     },
     "type_identifier": {
       "type": "PATTERN",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1770,6 +1770,10 @@
         {
           "type": "variable",
           "named": true
+        },
+        {
+          "type": "wildcard",
+          "named": true
         }
       ]
     }
@@ -3097,6 +3101,10 @@
   },
   {
     "type": "unit",
+    "named": true
+  },
+  {
+    "type": "wildcard",
     "named": true
   }
 ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1770,10 +1770,6 @@
         {
           "type": "variable",
           "named": true
-        },
-        {
-          "type": "wildcard",
-          "named": true
         }
       ]
     }
@@ -3101,10 +3097,6 @@
   },
   {
     "type": "unit",
-    "named": true
-  },
-  {
-    "type": "wildcard",
     "named": true
   }
 ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1,5 +1,10 @@
 [
   {
+    "type": "bool",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "bool_literal",
     "named": true,
     "fields": {}
@@ -25,6 +30,42 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "char",
+    "named": true,
+    "fields": {
+      "content": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "character",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_single_quote": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_single_quote": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -252,6 +293,57 @@
     }
   },
   {
+    "type": "enum",
+    "named": true,
+    "fields": {
+      "case_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "enum_case_identifier",
+            "named": true
+          }
+        ]
+      },
+      "enum_fields": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "mp_enum_fields",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "enum_case_identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "enum_fields",
     "named": true,
     "fields": {
@@ -286,7 +378,7 @@
         "required": true,
         "types": [
           {
-            "type": "identifier_enum_case",
+            "type": "enum_case_identifier",
             "named": true
           }
         ]
@@ -417,6 +509,10 @@
         },
         {
           "type": "list_literal",
+          "named": true
+        },
+        {
+          "type": "match_expression",
           "named": true
         },
         {
@@ -705,11 +801,6 @@
     }
   },
   {
-    "type": "identifier_enum_case",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "if_expression",
     "named": true,
     "fields": {
@@ -826,7 +917,59 @@
     }
   },
   {
+    "type": "int128",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "int128_literal",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "int16",
     "named": true,
     "fields": {
       "digits": {
@@ -878,6 +1021,32 @@
     }
   },
   {
+    "type": "int32",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "int32_literal",
     "named": true,
     "fields": {
@@ -904,7 +1073,59 @@
     }
   },
   {
+    "type": "int64",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "int64_literal",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "int8",
     "named": true,
     "fields": {
       "digits": {
@@ -1097,6 +1318,78 @@
     }
   },
   {
+    "type": "list",
+    "named": true,
+    "fields": {
+      "content": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "mp_list_content",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_bracket": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_bracket": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "list_cons",
+    "named": true,
+    "fields": {
+      "head": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "match_pattern",
+            "named": true
+          }
+        ]
+      },
+      "symbol_double_colon": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "tail": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "match_pattern",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "list_content",
     "named": true,
     "fields": {
@@ -1279,9 +1572,294 @@
     }
   },
   {
+    "type": "match_case",
+    "named": true,
+    "fields": {
+      "guard_expr": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "match_pattern",
+            "named": true
+          }
+        ]
+      },
+      "rhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "symbol_arrow": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_pipe": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "when_keyword": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "keyword",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "match_expression",
+    "named": true,
+    "fields": {
+      "arg": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "cases": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "match_case",
+            "named": true
+          }
+        ]
+      },
+      "keyword_match": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "keyword",
+            "named": true
+          }
+        ]
+      },
+      "keyword_with": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "keyword",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "match_pattern",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "bool",
+          "named": true
+        },
+        {
+          "type": "char",
+          "named": true
+        },
+        {
+          "type": "enum",
+          "named": true
+        },
+        {
+          "type": "float",
+          "named": true
+        },
+        {
+          "type": "int128",
+          "named": true
+        },
+        {
+          "type": "int16",
+          "named": true
+        },
+        {
+          "type": "int32",
+          "named": true
+        },
+        {
+          "type": "int64",
+          "named": true
+        },
+        {
+          "type": "int8",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "list_cons",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "tuple",
+          "named": true
+        },
+        {
+          "type": "uint128",
+          "named": true
+        },
+        {
+          "type": "uint16",
+          "named": true
+        },
+        {
+          "type": "uint32",
+          "named": true
+        },
+        {
+          "type": "uint64",
+          "named": true
+        },
+        {
+          "type": "uint8",
+          "named": true
+        },
+        {
+          "type": "unit",
+          "named": true
+        },
+        {
+          "type": "variable",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "module_identifier",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "mp_enum_fields",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "match_pattern",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mp_list_content",
+    "named": true,
+    "fields": {
+      "list_separator": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "match_pattern",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "mp_tuple_the_rest",
+    "named": true,
+    "fields": {
+      "pat": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "match_pattern",
+            "named": true
+          }
+        ]
+      },
+      "symbol_comma": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "paren_expression",
@@ -1497,6 +2075,42 @@
     }
   },
   {
+    "type": "string",
+    "named": true,
+    "fields": {
+      "content": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "string_content",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_quote": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_quote": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "string_content",
     "named": true,
     "fields": {},
@@ -1536,6 +2150,72 @@
         ]
       },
       "symbol_open_quote": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "tuple",
+    "named": true,
+    "fields": {
+      "first": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "match_pattern",
+            "named": true
+          }
+        ]
+      },
+      "rest": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "mp_tuple_the_rest",
+            "named": true
+          }
+        ]
+      },
+      "second": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "match_pattern",
+            "named": true
+          }
+        ]
+      },
+      "symbol_comma": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_left_paren": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_right_paren": {
         "multiple": false,
         "required": true,
         "types": [
@@ -1930,7 +2610,7 @@
         "required": true,
         "types": [
           {
-            "type": "identifier_enum_case",
+            "type": "enum_case_identifier",
             "named": true
           }
         ]
@@ -2102,7 +2782,59 @@
     }
   },
   {
+    "type": "uint128",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "positive_digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "uint128_literal",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "positive_digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "uint16",
     "named": true,
     "fields": {
       "digits": {
@@ -2154,7 +2886,59 @@
     }
   },
   {
+    "type": "uint32",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "positive_digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "uint32_literal",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "positive_digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "uint64",
     "named": true,
     "fields": {
       "digits": {
@@ -2206,6 +2990,32 @@
     }
   },
   {
+    "type": "uint8",
+    "named": true,
+    "fields": {
+      "digits": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "positive_digits",
+            "named": true
+          }
+        ]
+      },
+      "suffix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "uint8_literal",
     "named": true,
     "fields": {
@@ -2232,6 +3042,11 @@
     }
   },
   {
+    "type": "variable",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "variable_identifier",
     "named": true,
     "fields": {}
@@ -2246,6 +3061,10 @@
   },
   {
     "type": "dedent",
+    "named": true
+  },
+  {
+    "type": "float",
     "named": true
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
@@ -11,7 +11,7 @@ MyEnum.NoArgs
     (enum_literal
       (qualified_type_name (type_identifier))
       (symbol)
-      (identifier_enum_case)
+      (enum_case_identifier)
     )
   )
 )
@@ -31,7 +31,7 @@ MyEnum.OneArg(1L)
       (qualified_type_name
         (type_identifier))
       (symbol)
-      (identifier_enum_case)
+      (enum_case_identifier)
       (symbol)
       (enum_fields
         (expression (int64_literal (digits (positive_digits)) (symbol)))
@@ -56,7 +56,7 @@ MyEnum.TwoArgs(1L, 2L)
     (qualified_type_name
       (type_identifier))
     (symbol)
-    (identifier_enum_case)
+    (enum_case_identifier)
     (symbol)
     (enum_fields
       (expression
@@ -94,7 +94,7 @@ Stdlib.Option.Option.None
         (type_identifier)
       )
       (symbol)
-      (identifier_enum_case)
+      (enum_case_identifier)
     )
   )
 )
@@ -119,7 +119,7 @@ Stdlib.Option.Option.Some(1L)
         (type_identifier)
       )
       (symbol)
-      (identifier_enum_case)
+      (enum_case_identifier)
       (symbol)
         (enum_fields
           (expression (int64_literal (digits (positive_digits)) (symbol)))

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -412,7 +412,7 @@ match true with
   (expression
     (match_expression
       (keyword) (expression (bool_literal)) (keyword)
-      (match_case (symbol) (match_pattern (wildcard)) (symbol) (expression (bool_literal)))
+      (match_case (symbol) (match_pattern (variable)) (symbol) (expression (bool_literal)))
     )
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -1,0 +1,399 @@
+==================
+match expression - one case
+==================
+
+match 6L with
+| 6L -> true
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword)
+      (expression (int64_literal (digits (positive_digits)) (symbol)))
+      (keyword)
+      (match_case
+        (symbol)
+        (match_pattern (int64 (digits (positive_digits)) (symbol)))
+        (symbol)
+        (expression (bool_literal))
+      )
+    )
+  )
+)
+
+
+==================
+match expression - two cases
+==================
+
+match true with
+| true -> true
+| false -> false
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword) (expression (bool_literal)) (keyword)
+      (match_case (symbol) (match_pattern (bool)) (symbol) (expression (bool_literal)))
+      (match_case (symbol) (match_pattern (bool)) (symbol) (expression (bool_literal)))
+    )
+  )
+)
+
+
+==================
+match expression - multiple cases
+==================
+
+match 6L with
+  | var -> "pass"
+  | 6L -> "fail"
+  | 7L -> "pass"
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword) (expression (int64_literal (digits (positive_digits)) (symbol))) (keyword)
+      (match_case
+        (symbol) (match_pattern (variable)) (symbol)
+        (expression (string_literal (symbol) (string_content) (symbol)))
+      )
+      (match_case
+        (symbol) (match_pattern (int64 (digits (positive_digits)) (symbol))) (symbol)
+        (expression (string_literal (symbol) (string_content) (symbol)))
+      )
+      (match_case
+        (symbol) (match_pattern (int64 (digits (positive_digits)) (symbol))) (symbol)
+        (expression (string_literal (symbol) (string_content) (symbol)))
+      )
+    )
+  )
+)
+
+
+==================
+match expression - test list
+==================
+
+match [ true; false] with
+  | [] -> false
+  | [ true; false ] -> true
+  | var -> "fail"
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword)
+      (expression
+        (list_literal
+          (symbol)
+          (list_content (expression (bool_literal)) (symbol) (expression (bool_literal)))
+          (symbol)
+        )
+      )
+      (keyword)
+      (match_case
+        (symbol) (match_pattern (list (symbol) (symbol)))
+        (symbol) (expression (bool_literal))
+      )
+      (match_case
+        (symbol)
+        (match_pattern
+          (list
+            (symbol)
+            (mp_list_content (match_pattern (bool)) (symbol) (match_pattern (bool)))
+            (symbol)
+          )
+        )
+        (symbol) (expression (bool_literal))
+      )
+
+      (match_case
+        (symbol) (match_pattern (variable)) (symbol)
+        (expression
+          (string_literal (symbol) (string_content) (symbol))))
+    )
+  )
+)
+
+
+==================
+match expression - test let expression
+==================
+
+match [ true ] with
+  | var ->
+    let length = (Stdlib.List.length var)
+    length
+  | [ true ] -> 1L
+  | [] -> 0L
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword)
+      (expression (list_literal (symbol) (list_content (expression (bool_literal))) (symbol)))
+      (keyword)
+      (match_case
+        (symbol) (match_pattern (variable)) (symbol)
+        (expression
+          (let_expression
+            (keyword) (variable_identifier) (symbol)
+            (expression
+              (function_call
+                (symbol)
+                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                (expression (variable_identifier))
+                (symbol)
+              )
+            )
+            (expression (variable_identifier))
+          )
+        )
+      )
+      (match_case
+        (symbol)
+        (match_pattern (list (symbol) (mp_list_content (match_pattern (bool))) (symbol)))
+        (symbol)
+        (expression (int64_literal (digits (positive_digits)) (symbol)))
+      )
+      (match_case
+        (symbol)
+        (match_pattern (list (symbol) (symbol)))
+        (symbol)
+        (expression (int64_literal (digits (positive_digits)) (symbol)))
+      )
+    )
+  )
+)
+
+
+==================
+match expression - test when condition
+==================
+
+match 5L with
+  | x when x > 0L -> true
+  | x -> false
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword) (expression (int64_literal (digits (positive_digits)) (symbol))) (keyword)
+      (match_case
+        (symbol)
+        (match_pattern (variable))
+        (keyword)
+        (expression
+          (infix_operation
+            (expression (variable_identifier)) (operator) (expression (int64_literal (digits (positive_digits)) (symbol)))
+          )
+        )
+        (symbol) (expression (bool_literal))
+      )
+      (match_case
+        (symbol) (match_pattern (variable)) (symbol) (expression (bool_literal)))
+    )
+  )
+)
+
+
+==================
+match expression - test tuple
+==================
+
+match (5L, 6L) with
+  | (w, x)  -> true
+  | (y, z) -> false
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword)
+      (expression
+        (tuple_literal
+          (symbol)
+          (expression (int64_literal (digits (positive_digits)) (symbol)))
+          (symbol)
+          (expression (int64_literal (digits (positive_digits)) (symbol)))
+          (symbol)
+        )
+      )
+      (keyword)
+      (match_case
+        (symbol)
+        (match_pattern
+          (tuple (symbol) (match_pattern (variable)) (symbol) (match_pattern (variable)) (symbol))
+        )
+        (symbol)
+        (expression (bool_literal)))
+      (match_case
+        (symbol)
+        (match_pattern
+          (tuple (symbol) (match_pattern (variable)) (symbol) (match_pattern (variable)) (symbol))
+        )
+        (symbol)
+        (expression (bool_literal))
+      )
+    )
+  )
+)
+
+
+==================
+match expression - test enum
+==================
+
+match Stdlib.Result.Result.Ok(5L) with
+  | Ok(x) -> x
+  | Error(x) -> x
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword)
+      (expression
+        (enum_literal
+          (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier) (symbol) (enum_fields (expression (int64_literal (digits (positive_digits)) (symbol)))) (symbol)
+        )
+      )
+      (keyword)
+      (match_case
+        (symbol)
+        (match_pattern
+          (enum (enum_case_identifier) (symbol) (mp_enum_fields (match_pattern (variable))) (symbol))
+        )
+        (symbol) (expression (variable_identifier)))
+      (match_case
+        (symbol)
+        (match_pattern
+          (enum
+            (enum_case_identifier)
+            (symbol)
+            (mp_enum_fields (match_pattern (variable)))
+            (symbol)
+          )
+        )
+        (symbol) (expression (variable_identifier))
+      )
+    )
+  )
+)
+
+
+==================
+match expression - test list cons
+==================
+
+match [ 1L; 2L; 3L ] with
+  | head :: tail -> "pass"
+  | [] -> "fail"
+
+---
+
+(source_file
+ (expression
+    (match_expression
+      (keyword)
+      (expression
+        (list_literal
+          (symbol)
+          (list_content
+            (expression (int64_literal (digits (positive_digits)) (symbol)))
+            (symbol)
+            (expression (int64_literal (digits (positive_digits)) (symbol)))
+            (symbol)
+            (expression (int64_literal (digits (positive_digits)) (symbol)))
+          )
+          (symbol)
+        )
+      )
+      (keyword)
+      (match_case
+        (symbol)
+        (match_pattern
+          (list_cons (match_pattern (variable)) (symbol) (match_pattern (variable)))
+        )
+        (symbol)
+        (expression (string_literal (symbol) (string_content) (symbol)))
+      )
+      (match_case
+        (symbol)
+        (match_pattern (list (symbol) (symbol)))
+        (symbol)
+        (expression (string_literal (symbol) (string_content) (symbol)))
+      )
+    )
+  )
+)
+
+
+==================
+match expression - test list cons with list
+==================
+
+match [ 1L; 2L; 3L ] with
+  | 1L :: 2L :: [ 3L ] -> 6L
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword)
+      (expression
+        (list_literal
+          (symbol)
+          (list_content
+            (expression (int64_literal (digits (positive_digits)) (symbol)))
+            (symbol)
+            (expression (int64_literal (digits (positive_digits)) (symbol)))
+            (symbol)
+            (expression (int64_literal (digits (positive_digits)) (symbol)))
+          )
+          (symbol)
+        )
+      )
+      (keyword)
+      (match_case
+        (symbol)
+        (match_pattern
+          (list_cons
+            (match_pattern
+              (list_cons
+                (match_pattern (int64 (digits (positive_digits)) (symbol)))
+                (symbol)
+                (match_pattern (int64 (digits (positive_digits)) (symbol)))
+              )
+            )
+            (symbol)
+            (match_pattern
+              (list
+                (symbol)
+                (mp_list_content (match_pattern (int64 (digits (positive_digits)) (symbol))))
+                (symbol))
+            )
+          )
+        )
+        (symbol)
+        (expression (int64_literal (digits (positive_digits)) (symbol)))
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -397,3 +397,22 @@ match [ 1L; 2L; 3L ] with
     )
   )
 )
+
+
+==================
+match expression - test wildcard
+==================
+
+match true with
+  | _ -> true
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword) (expression (bool_literal)) (keyword)
+      (match_case (symbol) (match_pattern (wildcard)) (symbol) (expression (bool_literal)))
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_decls.txt
@@ -151,7 +151,7 @@ type MyEnum =
           (indent)
           (type_decl_enum_case
             (symbol)
-            (identifier_enum_case))
+            (enum_case_identifier))
           (dedent)
         )
       )
@@ -178,9 +178,9 @@ type MyEnum =
       (type_decl_def_enum
         (type_decl_enum_multi_line
           (indent)
-          (type_decl_enum_case (symbol) (identifier_enum_case))
-          (type_decl_enum_case (symbol) (identifier_enum_case))
-          (type_decl_enum_case (symbol) (identifier_enum_case))
+          (type_decl_enum_case (symbol) (enum_case_identifier))
+          (type_decl_enum_case (symbol) (enum_case_identifier))
+          (type_decl_enum_case (symbol) (enum_case_identifier))
           (dedent)
         )
       )
@@ -205,7 +205,7 @@ type MyEnum = | A of Int64
       (type_decl_def_enum
         (type_decl_enum_single_line
           (type_decl_enum_case
-            (symbol) (identifier_enum_case) (keyword) (type_decl_enum_field (type_reference (builtin_type)))
+            (symbol) (enum_case_identifier) (keyword) (type_decl_enum_field (type_reference (builtin_type)))
           )
         )
       )
@@ -236,7 +236,7 @@ type MyEnum =
           (indent)
           (type_decl_enum_case
             (symbol)
-            (identifier_enum_case)
+            (enum_case_identifier)
             (keyword)
             (type_decl_enum_field
               (type_reference (builtin_type))
@@ -244,13 +244,13 @@ type MyEnum =
           )
           (type_decl_enum_case
             (symbol)
-            (identifier_enum_case)
+            (enum_case_identifier)
             (keyword)
             (type_decl_enum_field
               (type_reference (builtin_type))
             )
           )
-          (type_decl_enum_case (symbol) (identifier_enum_case))
+          (type_decl_enum_case (symbol) (enum_case_identifier))
           (dedent)
         )
       )
@@ -275,9 +275,9 @@ type MyEnum = | A | B | C
     (type_decl_def
       (type_decl_def_enum
         (type_decl_enum_single_line
-          (type_decl_enum_case (symbol) (identifier_enum_case))
-          (type_decl_enum_case (symbol) (identifier_enum_case))
-          (type_decl_enum_case (symbol) (identifier_enum_case))
+          (type_decl_enum_case (symbol) (enum_case_identifier))
+          (type_decl_enum_case (symbol) (enum_case_identifier))
+          (type_decl_enum_case (symbol) (enum_case_identifier))
         )
       )
     )
@@ -305,7 +305,7 @@ type def Enum - multiple cases, one field with label
 
           (type_decl_enum_case
             (symbol)
-            (identifier_enum_case)
+            (enum_case_identifier)
             (keyword)
             (type_decl_enum_field
               (variable_identifier)
@@ -316,7 +316,7 @@ type def Enum - multiple cases, one field with label
 
           (type_decl_enum_case
             (symbol)
-            (identifier_enum_case)
+            (enum_case_identifier)
             (keyword)
             (type_decl_enum_field
               (variable_identifier)
@@ -327,7 +327,7 @@ type def Enum - multiple cases, one field with label
 
           (type_decl_enum_case
             (symbol)
-            (identifier_enum_case)
+            (enum_case_identifier)
             (keyword)
             (type_decl_enum_field
               (variable_identifier)
@@ -370,7 +370,7 @@ type MyEnum =
           (indent)
           (type_decl_enum_case
             (symbol)
-            (identifier_enum_case)
+            (enum_case_identifier)
             (keyword)
             (type_decl_enum_field (type_reference (builtin_type)))
             (symbol)


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support match expressions
```

#5321 