### PR TITLE
Tree-sitter grammar: support field access

### DIFF
--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -388,6 +388,10 @@ module TextToTextRoundtripping =
 
     // field access
     ("person.name" |> roundtripCliScript) = "person.name"
+    ("(Person { name =\"Janice\" }).name" |> roundtripCliScript) = "(Person { name = \"Janice\" }).name"
+    ("record.someField.anotherFieldInsideThat" |> roundtripCliScript) = "record.someField.anotherFieldInsideThat"
+    ("person.age + 1L" |> roundtripCliScript) = "(person.age) + (1L)"
+
 
     // if expressions
     ("if true then 1L" |> roundtripCliScript) = "if true then\n  1L"

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -386,6 +386,9 @@ module TextToTextRoundtripping =
     // TODO: this is ugly
     ("let x = 1L\n  x" |> roundtripCliScript) = "let x =\n  1L\nx"
 
+    // field access
+    ("person.name" |> roundtripCliScript) = "person.name"
+
     // if expressions
     ("if true then 1L" |> roundtripCliScript) = "if true then\n  1L"
     ("if true then 1L else 2L" |> roundtripCliScript) = "if true then\n  1L\nelse\n  2L"

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -513,6 +513,28 @@ module Darklang =
           else
             createUnparseableError node
 
+        let parseFieldAccess
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          if node.typ == "field_access" then
+            let expr = findAndParseRequired node "expr" Expr.parse
+            let symbolDotNode = findField node "symbol_dot"
+            let fieldName = findField node "field_name"
+
+            match expr, symbolDotNode, fieldName with
+            | Ok expr, Ok symbolDot, Ok field ->
+              (WrittenTypes.Expr.EFieldAccess(
+                node.range,
+                expr,
+                (field.range, field.text),
+                symbolDot.range
+              ))
+              |> Stdlib.Result.Result.Ok
+
+            | _ -> createUnparseableError node
+
+          else
+            createUnparseableError node
 
         let parseInfixOperation
           (node: ParsedNode)
@@ -692,6 +714,8 @@ module Darklang =
           | "variable_identifier" ->
             (WrittenTypes.Expr.EVariable(node.range, getText node))
             |> Stdlib.Result.Result.Ok
+
+          | "field_access" -> parseFieldAccess node
 
           | "if_expression" -> parseIfExpression node
 

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -467,6 +467,16 @@ module Darklang =
           // x
           | EVariable(range, _varName) -> [ makeToken range TokenType.VariableName ]
 
+          // person.name
+          | EFieldAccess(range, expr, (r, fieldName), symbolDot) ->
+            [ // person
+              Expr.tokenize expr
+              // .
+              [ makeToken symbolDot TokenType.Symbol ]
+              // name
+              [ makeToken r TokenType.Property ] ]
+            |> Stdlib.List.flatten
+
           // if true then 1 else 2
           | EIf(range, cond, thenExpr, elseExpr, keywordIf, keywordThen, keywordElse) ->
             let elseKeyword =

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -224,6 +224,12 @@ module Darklang =
 
         | EVariable of Range * String
 
+        | EFieldAccess of
+          Range *
+          Expr *
+          fieldName: (Range * String) *
+          symbolDot: Range
+
         | EIf of
           Range *
           cond: Expr *

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -331,6 +331,9 @@ module Darklang =
 
           | EVariable(_, var) -> ProgramTypes.Expr.EVariable (gid ()) var
 
+          | EFieldAccess(_, expr, (_, fieldName), _) ->
+            ProgramTypes.Expr.EFieldAccess(gid (), toPT onMissing expr, fieldName)
+
           | EIf(_, cond, thenExpr, elseExpr, _, _, _) ->
             let elseExpr =
               elseExpr |> Stdlib.Option.map (fun es -> Expr.toPT onMissing es)

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -601,7 +601,6 @@ module Darklang =
 
         | EFieldAccess(id, expr, fieldName) ->
           let exprPart = PrettyPrinter.ProgramTypes.expr expr
-          // Builtin.debug "expr" expr
 
           // TODO: only sometimes need to wrap exprPart in parens
           match expr with

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -604,7 +604,7 @@ module Darklang =
 
           // TODO: only sometimes need to wrap exprPart in parens
 
-          $"({exprPart}).{fieldName}"
+          $"{exprPart}.{fieldName}"
 
         | EVariable(_id, name) -> name
 

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -601,10 +601,13 @@ module Darklang =
 
         | EFieldAccess(id, expr, fieldName) ->
           let exprPart = PrettyPrinter.ProgramTypes.expr expr
+          // Builtin.debug "expr" expr
 
           // TODO: only sometimes need to wrap exprPart in parens
-
-          $"{exprPart}.{fieldName}"
+          match expr with
+          | EVariable(_, _) -> $"{exprPart}.{fieldName}"
+          | EFieldAccess(_, _, _) -> $"{exprPart}.{fieldName}"
+          | _ -> $"({exprPart}).{fieldName}"
 
         | EVariable(_id, name) -> name
 

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -10,6 +10,7 @@ const PREC = {
   SUM: 3,
   PRODUCT: 4,
   EXPONENT: 5,
+  FIELDACCESS: 7,
 };
 
 const logicalOperators = choice("&&", "||");
@@ -216,15 +217,13 @@ module.exports = grammar({
       ),
 
     let_expression: $ =>
-      prec.right(
-        seq(
-          field("keyword_let", alias("let", $.keyword)),
-          field("identifier", $.variable_identifier),
-          field("symbol_equals", alias("=", $.symbol)),
-          field("expr", $.expression),
-          "\n",
-          field("body", $.expression),
-        ),
+      seq(
+        field("keyword_let", alias("let", $.keyword)),
+        field("identifier", $.variable_identifier),
+        field("symbol_equals", alias("=", $.symbol)),
+        field("expr", $.expression),
+        "\n",
+        field("body", $.expression),
       ),
 
     //
@@ -537,10 +536,13 @@ module.exports = grammar({
     // field access
     // e.g. `person.name`
     field_access: $ =>
-      seq(
-        field("expr", $.expression),
-        field("symbol_dot", alias(".", $.symbol)),
-        field("field_name", $.variable_identifier),
+      prec(
+        PREC.FIELDACCESS,
+        seq(
+          field("expr", $.expression),
+          field("symbol_dot", alias(".", $.symbol)),
+          field("field_name", $.variable_identifier),
+        ),
       ),
 
     //

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -184,6 +184,8 @@ module.exports = grammar({
 
         $.infix_operation,
         $.function_call,
+
+        $.field_access,
       ),
     paren_expression: $ =>
       seq(
@@ -214,13 +216,15 @@ module.exports = grammar({
       ),
 
     let_expression: $ =>
-      seq(
-        field("keyword_let", alias("let", $.keyword)),
-        field("identifier", $.variable_identifier),
-        field("symbol_equals", alias("=", $.symbol)),
-        field("expr", $.expression),
-        "\n",
-        field("body", $.expression),
+      prec.right(
+        seq(
+          field("keyword_let", alias("let", $.keyword)),
+          field("identifier", $.variable_identifier),
+          field("symbol_equals", alias("=", $.symbol)),
+          field("expr", $.expression),
+          "\n",
+          field("body", $.expression),
+        ),
       ),
 
     //
@@ -528,6 +532,15 @@ module.exports = grammar({
             ),
           ),
         ),
+      ),
+
+    // field access
+    // e.g. `person.name`
+    field_access: $ =>
+      seq(
+        field("expr", $.expression),
+        field("symbol_dot", alias(".", $.symbol)),
+        field("field_name", $.variable_identifier),
       ),
 
     //

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -773,67 +773,63 @@
       ]
     },
     "let_expression": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "keyword_let",
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "keyword_let",
+          "content": {
+            "type": "ALIAS",
             "content": {
-              "type": "ALIAS",
-              "content": {
-                "type": "STRING",
-                "value": "let"
-              },
-              "named": true,
-              "value": "keyword"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "identifier",
-            "content": {
-              "type": "SYMBOL",
-              "name": "variable_identifier"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "symbol_equals",
-            "content": {
-              "type": "ALIAS",
-              "content": {
-                "type": "STRING",
-                "value": "="
-              },
-              "named": true,
-              "value": "symbol"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "expr",
-            "content": {
-              "type": "SYMBOL",
-              "name": "expression"
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "\n"
-          },
-          {
-            "type": "FIELD",
-            "name": "body",
-            "content": {
-              "type": "SYMBOL",
-              "name": "expression"
-            }
+              "type": "STRING",
+              "value": "let"
+            },
+            "named": true,
+            "value": "keyword"
           }
-        ]
-      }
+        },
+        {
+          "type": "FIELD",
+          "name": "identifier",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_equals",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "="
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "expr",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "\n"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        }
+      ]
     },
     "string_literal": {
       "type": "CHOICE",
@@ -2308,38 +2304,42 @@
       }
     },
     "field_access": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "expr",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "symbol_dot",
-          "content": {
-            "type": "ALIAS",
+      "type": "PREC",
+      "value": 7,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "expr",
             "content": {
-              "type": "STRING",
-              "value": "."
-            },
-            "named": true,
-            "value": "symbol"
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "symbol_dot",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "."
+              },
+              "named": true,
+              "value": "symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "field_name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "variable_identifier"
+            }
           }
-        },
-        {
-          "type": "FIELD",
-          "name": "field_name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "variable_identifier"
-          }
-        }
-      ]
+        ]
+      }
     },
     "type_reference": {
       "type": "CHOICE",

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -663,6 +663,10 @@
         {
           "type": "SYMBOL",
           "name": "function_call"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_access"
         }
       ]
     },
@@ -769,63 +773,67 @@
       ]
     },
     "let_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "keyword_let",
-          "content": {
-            "type": "ALIAS",
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "keyword_let",
             "content": {
-              "type": "STRING",
-              "value": "let"
-            },
-            "named": true,
-            "value": "keyword"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "identifier",
-          "content": {
-            "type": "SYMBOL",
-            "name": "variable_identifier"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "symbol_equals",
-          "content": {
-            "type": "ALIAS",
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "let"
+              },
+              "named": true,
+              "value": "keyword"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "identifier",
             "content": {
-              "type": "STRING",
-              "value": "="
-            },
-            "named": true,
-            "value": "symbol"
+              "type": "SYMBOL",
+              "name": "variable_identifier"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "symbol_equals",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "="
+              },
+              "named": true,
+              "value": "symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "expr",
+            "content": {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "\n"
+          },
+          {
+            "type": "FIELD",
+            "name": "body",
+            "content": {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
           }
-        },
-        {
-          "type": "FIELD",
-          "name": "expr",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "\n"
-        },
-        {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
-        }
-      ]
+        ]
+      }
     },
     "string_literal": {
       "type": "CHOICE",
@@ -2298,6 +2306,40 @@
           }
         ]
       }
+    },
+    "field_access": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "expr",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_dot",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "."
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "field_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_identifier"
+          }
+        }
+      ]
     },
     "type_reference": {
       "type": "CHOICE",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -368,6 +368,10 @@
           "named": true
         },
         {
+          "type": "field_access",
+          "named": true
+        },
+        {
           "type": "float_literal",
           "named": true
         },
@@ -456,6 +460,42 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "field_access",
+    "named": true,
+    "fields": {
+      "expr": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "field_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable_identifier",
+            "named": true
+          }
+        ]
+      },
+      "symbol_dot": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
@@ -1,0 +1,17 @@
+==================
+field access
+==================
+
+person.name
+
+---
+
+(source_file
+  (expression
+    (field_access
+      (expression (variable_identifier))
+      (symbol)
+      (variable_identifier)
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
@@ -15,3 +15,65 @@ person.name
     )
   )
 )
+
+==================
+field access - paren defined Record
+==================
+
+(Person { name = "Janice" }).name
+
+---
+
+(source_file
+  (expression
+   (field_access
+      (expression
+        (paren_expression
+          (symbol)
+          (expression
+            (record_literal
+              (qualified_type_name (type_identifier))
+              (symbol)
+              (record_content
+                (record_pair
+                  (variable_identifier)
+                  (symbol)
+                  (expression (string_literal (symbol) (string_content) (symbol)))
+                )
+              )
+              (symbol)
+            )
+          )
+          (symbol)
+        )
+      )
+      (symbol)
+      (variable_identifier)
+    )
+  )
+)
+
+
+==================
+field access - nested
+==================
+
+person.address.street
+
+---
+
+(source_file
+  (expression
+    (field_access
+      (expression
+        (field_access
+          (expression (variable_identifier))
+          (symbol)
+          (variable_identifier)
+        )
+      )
+      (symbol)
+      (variable_identifier)
+    )
+  )
+)


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support field access
```

#5321 