### PR TITLE
Tree-sitter grammar: support lambda expressions 

### DIFF
--- a/backend/src/LibParser/WrittenTypes.fs
+++ b/backend/src/LibParser/WrittenTypes.fs
@@ -219,6 +219,7 @@ and PipeExpr =
   ///   or a user function with only one argument or type args.
   ///
   /// We resolve this ambiguity during name resolution of WT2PT.
+  // TODO: rename to EPipeVariableOrFnCall
   | EPipeVariableOrUserFunction of id * string
 
 

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -391,6 +391,17 @@ module TextToTextRoundtripping =
     ("(Person { name =\"Janice\" }).name" |> roundtripCliScript) = "(Person { name = \"Janice\" }).name"
     ("record.someField.anotherFieldInsideThat" |> roundtripCliScript) = "record.someField.anotherFieldInsideThat"
     ("person.age + 1L" |> roundtripCliScript) = "(person.age) + (1L)"
+    // lambda
+    ("fun x -> x + 1L" |> roundtripCliScript) = "(fun x ->\n  (x) + (1L))"
+    ("(fun x -> x + 1L)" |> roundtripCliScript) = "(fun x ->\n  (x) + (1L))"
+    ("fun x y -> x * y" |> roundtripCliScript) = "(fun x y ->\n  (x) * (y))"
+    ("fun () -> 1L" |> roundtripCliScript) = "(fun () ->\n  1L)"
+
+    ("fun var -> (Stdlib.String.toUppercase (Stdlib.String.fromChar var))"
+     |> roundtripCliScript) = "(fun var ->\n  PACKAGE.Darklang.Stdlib.String.toUppercase PACKAGE.Darklang.Stdlib.String.fromChar var)"
+
+    ("fun (str1, str2) -> str1 ++ str2" |> roundtripCliScript) = "(fun (str1, str2) ->\n  (str1) ++ (str2))"
+
 
 
     // if expressions

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -511,6 +511,7 @@ else
     ("1L == 2L" |> roundtripCliScript) = "(1L) == (2L)"
     ("1L != 2L" |> roundtripCliScript) = "(1L) != (2L)"
     ("1L ^ 2L" |> roundtripCliScript) = "(1L) ^ (2L)"
+    ("strVar ++ \"str\"" |> roundtripCliScript) = "(strVar) ++ (\"str\")"
     ("true && false" |> roundtripCliScript) = "(true) && (false)"
     ("true || false" |> roundtripCliScript) = "(true) || (false)"
     ("(and true false)" |> roundtripCliScript) = "and true false"

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -588,6 +588,9 @@ module Darklang =
                   WrittenTypes.Infix.BinOp WrittenTypes.BinaryOperation.BinOpAnd
                 | "||" ->
                   WrittenTypes.Infix.BinOp WrittenTypes.BinaryOperation.BinOpOr
+                | "++" ->
+                  WrittenTypes.Infix.InfixFnCall
+                    WrittenTypes.InfixFnName.StringConcat
                 | _ -> createUnparseableError node
 
             let rightArg = findAndParseRequired node "right" Expr.parse

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -604,6 +604,118 @@ module Darklang =
 
             | _ -> createUnparseableError node
 
+        let parseLetPattern
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.LetPattern, WrittenTypes.Unparseable> =
+          if node.typ == "let_pattern" then
+            match node.children with
+            | [ child ] ->
+              match child.typ with
+              | "unit" ->
+                (WrittenTypes.LetPattern.LPUnit(child.range))
+                |> Stdlib.Result.Result.Ok
+              | "variable_identifier" ->
+                (WrittenTypes.LetPattern.LPVariable(child.range, getText child))
+                |> Stdlib.Result.Result.Ok
+              | "lp_tuple" ->
+                let openParenNode = findField child "symbol_left_paren"
+                let first = findAndParseRequired child "first" Expr.parseLetPattern
+
+                let second = findAndParseRequired child "second" Expr.parseLetPattern
+
+                let findRest =
+                  (findNodeByFieldName child "rest")
+                  |> Stdlib.Option.map (fun restNode ->
+                    restNode.children
+                    |> Stdlib.List.chunkBySize 2L
+                    |> Builtin.unwrap
+                    |> Stdlib.List.map (fun chunk ->
+                      match chunk with
+                      | [ symbol; exprNode ] ->
+                        match Expr.parseLetPattern exprNode with
+                        | Ok expr ->
+                          (symbol.range, expr) |> Stdlib.Result.Result.Ok
+                        | Error _ -> createUnparseableError chunk
+
+                      | [ exprNode ] ->
+                        match Expr.parseLetPattern exprNode with
+                        | Ok expr ->
+                          (Stdlib.Option.Option.None, expr)
+                          |> Stdlib.Result.Result.Ok
+                        | Error _ -> createUnparseableError chunk
+                      | _ -> createUnparseableError chunk))
+
+                let rest =
+                  match findRest with
+                  | Some r -> r |> Stdlib.Result.collect
+                  | None -> [] |> Stdlib.Result.Result.Ok
+
+                let commaSymbol = findField child "symbol_comma"
+                let closeParenNode = findField child "symbol_right_paren"
+
+                match
+                  openParenNode, first, commaSymbol, second, rest, closeParenNode
+                with
+                | Ok openParen,
+                  Ok first,
+                  Ok symComma,
+                  Ok second,
+                  Ok rest,
+                  Ok closeParen ->
+                  (WrittenTypes.LetPattern.LPTuple(
+                    child.range,
+                    first,
+                    symComma.range,
+                    second,
+                    rest,
+                    openParen.range,
+                    closeParen.range
+                  ))
+                  |> Stdlib.Result.Result.Ok
+
+                | _ -> createUnparseableError child
+
+            | _ -> createUnparseableError child
+
+          else
+            createUnparseableError node
+
+
+
+        let parseLambda
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          if node.typ == "lambda_expression" then
+            let keywordFun = findField node "keyword_fun"
+
+            let paramsNode =
+              match findField node "pats" with
+              | Ok paramsNode ->
+                paramsNode.children
+                |> Stdlib.List.map (fun child -> parseLetPattern child)
+                |> Stdlib.Result.collect
+
+              | _ -> createUnparseableError node
+
+
+
+            let arrowNode = findField node "symbol_arrow"
+            let bodyNode = findAndParseRequired node "body" Expr.parse
+
+            match keywordFun, paramsNode, arrowNode, bodyNode with
+            | Ok keywordFun, Ok paramsNode, Ok arrowNode, Ok bodyNode ->
+              (WrittenTypes.Expr.ELambda(
+                node.range,
+                paramsNode,
+                bodyNode,
+                keywordFun.range,
+                arrowNode.range
+              ))
+              |> Stdlib.Result.Result.Ok
+
+            | _ -> createUnparseableError node
+
+
 
         let parseIfExpression
           (node: ParsedNode)
@@ -721,6 +833,7 @@ module Darklang =
 
           // fn calls
           | "infix_operation" -> parseInfixOperation node
+          | "lambda_expression" -> parseLambda node
           | "function_call" -> parseFunctionCall node
 
           | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/programTypes.dark
+++ b/packages/darklang/languageTools/programTypes.dark
@@ -113,6 +113,7 @@ module Darklang =
 
 
       type LetPattern =
+        | LPUnit of ID
         | LPVariable of ID * name: String
         | LPTuple of
           ID *

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -243,7 +243,33 @@ module Darklang =
         module LetPattern =
           let tokenize (lp: WrittenTypes.LetPattern) : List<SemanticToken> =
             match lp with
+            | LPUnit range -> [ makeToken range TokenType.Symbol ]
             | LPVariable(range, _name) -> [ makeToken range TokenType.VariableName ]
+            | LPTuple(range,
+                      first,
+                      symbolComma,
+                      second,
+                      rest,
+                      symbolOpenParen,
+                      symbolCloseParen) ->
+              let rest =
+                rest
+                |> Stdlib.List.map (fun (_, pat) -> LetPattern.tokenize pat)
+                |> Stdlib.List.flatten
+
+              [ // (
+                [ makeToken symbolOpenParen TokenType.Symbol ]
+                // a
+                LetPattern.tokenize first
+                // ,
+                [ makeToken symbolComma TokenType.Symbol ]
+                // b
+                LetPattern.tokenize second
+                // , c
+                rest
+                // )
+                [ makeToken symbolCloseParen TokenType.Symbol ] ]
+              |> Stdlib.List.flatten
 
 
         let tokenize (e: WrittenTypes.Expr) : List<SemanticToken> =
@@ -509,6 +535,22 @@ module Darklang =
               // 1
               Expr.tokenize right ]
             |> Stdlib.List.flatten
+
+          // fun a -> a + 1
+          | ELambda(range, pats, body, keywordFun, symbolArrow) ->
+            [ // fun
+              [ makeToken range TokenType.Keyword ]
+              // a
+              (pats
+               |> Stdlib.List.map (fun pat -> LetPattern.tokenize pat)
+               |> Stdlib.List.flatten)
+              // ->
+              [ makeToken symbolArrow TokenType.Symbol ]
+              // a + 1
+              Expr.tokenize body ]
+            |> Stdlib.List.flatten
+
+
 
           // hacky temp. syntax -- see `grammar.js`
           // (Int64.add 1L 2L)

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -123,7 +123,17 @@ module Darklang =
 
 
       // Expressions
-      type LetPattern = LPVariable of Range * name: String
+      type LetPattern =
+        | LPUnit of Range
+        | LPVariable of Range * name: String
+        | LPTuple of
+          Range *
+          first: LetPattern *
+          symbolComma: Range *
+          second: LetPattern *
+          rest: List<Stdlib.Option.Option<Range> * LetPattern> *
+          symbolOpenParen: Range *
+          symbolCloseParen: Range
 
       type Infix =
         | InfixFnCall of InfixFnName
@@ -240,6 +250,13 @@ module Darklang =
           keywordElse: Stdlib.Option.Option<Range>
 
         | EInfix of Range * op: (Range * Infix) * left: Expr * right: Expr
+
+        | ELambda of
+          Range *
+          pats: List<LetPattern> *
+          body: Expr *
+          keywordFun: Range *
+          symbolArrow: Range
 
         // TODO: I accidentally got away from how we normally represent
         // Expressions - switch to this instead.

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -240,7 +240,14 @@ module Darklang =
         module LetPattern =
           let toPT (p: WrittenTypes.LetPattern) : ProgramTypes.LetPattern =
             match p with
+            | LPUnit _ -> ProgramTypes.LetPattern.LPUnit(gid ())
             | LPVariable(_, name) -> ProgramTypes.LetPattern.LPVariable(gid (), name)
+            | LPTuple(_, first, _, second, rest, _, _) ->
+              let first = toPT first
+              let second = toPT second
+              let rest = Stdlib.List.map rest (fun (_, p) -> toPT p)
+
+              ProgramTypes.LetPattern.LPTuple(gid (), first, second, rest)
 
 
         let toPT
@@ -355,6 +362,12 @@ module Darklang =
               toPT onMissing left,
               toPT onMissing right
             )
+
+          | ELambda(_, pats, body, _, _) ->
+            let pats = Stdlib.List.map pats (fun p -> LetPattern.toPT p)
+            let body = Expr.toPT onMissing body
+
+            ProgramTypes.Expr.ELambda(gid (), pats, body)
 
           | EFnCall(_, fnName, args, _, _) ->
             let fnName = Identifiers.QualifiedFn.toPT onMissing fnName

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -322,6 +322,7 @@ module Darklang =
 
       let letPattern (lp: LanguageTools.ProgramTypes.LetPattern) : String =
         match lp with
+        | LPUnit _id -> "()"
         | LPVariable(_id, name) -> name
         | LPTuple(_id, first, second, theRest) ->
           (Stdlib.List.append [ first; second ] theRest)
@@ -697,7 +698,7 @@ module Darklang =
 
           let bodyPart = PrettyPrinter.ProgramTypes.expr body
 
-          $"(fun {argsPart} -> \n {PrettyPrinter.indent bodyPart})"
+          $"(fun {patsPart} ->\n{PrettyPrinter.indent bodyPart})"
 
         | EApply(_id, fnName, typeArgs, args) ->
           let fnNamePart = PrettyPrinter.ProgramTypes.expr fnName

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -18,6 +18,7 @@ const comparisonOperators = choice("==", "!=", "<", "<=", ">", ">=");
 const additiveOperators = choice("+", "-");
 const multiplicativeOperators = choice("*", "/", "%");
 const exponentOperator = "^";
+const stringConcatOperator = "++";
 
 module.exports = grammar({
   name: "darklang",
@@ -328,6 +329,16 @@ module.exports = grammar({
           seq(
             field("left", $.expression),
             field("operator", alias(logicalOperators, $.operator)),
+            field("right", $.expression),
+          ),
+        ),
+
+        // String concatenation
+        prec.left(
+          PREC.SUM,
+          seq(
+            field("left", $.expression),
+            field("operator", alias(stringConcatOperator, $.operator)),
             field("right", $.expression),
           ),
         ),

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -187,6 +187,7 @@ module.exports = grammar({
         $.function_call,
 
         $.field_access,
+        $.lambda_expression,
       ),
     paren_expression: $ =>
       seq(
@@ -544,6 +545,35 @@ module.exports = grammar({
           field("field_name", $.variable_identifier),
         ),
       ),
+
+    //
+    // Lambda expressions
+    lambda_expression: $ =>
+      seq(
+        field("keyword_fun", alias("fun", $.keyword)),
+        field("pats", $.lambda_pats),
+        field("symbol_arrow", alias("->", $.symbol)),
+        field("body", $.expression),
+      ),
+
+    lambda_pats: $ => field("pat", repeat1($.let_pattern)),
+
+    lp_tuple: $ =>
+      seq(
+        field("symbol_left_paren", alias("(", $.symbol)),
+        field("first", $.let_pattern),
+        field("symbol_comma", alias(",", $.symbol)),
+        field("second", $.let_pattern),
+        field(
+          "rest",
+          repeat(
+            seq(field("symbol_comma", alias(",", $.symbol)), $.let_pattern),
+          ),
+        ),
+        field("symbol_right_paren", alias(")", $.symbol)),
+      ),
+
+    let_pattern: $ => choice($.unit, $.lp_tuple, $.variable_identifier),
 
     //
     // Common

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -1303,6 +1303,44 @@
               }
             ]
           }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 3,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "++"
+                  },
+                  "named": true,
+                  "value": "operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
         }
       ]
     },

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -667,6 +667,10 @@
         {
           "type": "SYMBOL",
           "name": "field_access"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lambda_expression"
         }
       ]
     },
@@ -2340,6 +2344,170 @@
           }
         ]
       }
+    },
+    "lambda_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "keyword_fun",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "fun"
+            },
+            "named": true,
+            "value": "keyword"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "pats",
+          "content": {
+            "type": "SYMBOL",
+            "name": "lambda_pats"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_arrow",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "->"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        }
+      ]
+    },
+    "lambda_pats": {
+      "type": "FIELD",
+      "name": "pat",
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "SYMBOL",
+          "name": "let_pattern"
+        }
+      }
+    },
+    "lp_tuple": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_left_paren",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "("
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "first",
+          "content": {
+            "type": "SYMBOL",
+            "name": "let_pattern"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_comma",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ","
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "second",
+          "content": {
+            "type": "SYMBOL",
+            "name": "let_pattern"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "rest",
+          "content": {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "symbol_comma",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "let_pattern"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_right_paren",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ")"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
+    },
+    "let_pattern": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "unit"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lp_tuple"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "variable_identifier"
+        }
+      ]
     },
     "type_reference": {
       "type": "CHOICE",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -408,6 +408,10 @@
           "named": true
         },
         {
+          "type": "lambda_expression",
+          "named": true
+        },
+        {
           "type": "let_expression",
           "named": true
         },
@@ -952,6 +956,68 @@
     }
   },
   {
+    "type": "lambda_expression",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "keyword_fun": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "keyword",
+            "named": true
+          }
+        ]
+      },
+      "pats": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "lambda_pats",
+            "named": true
+          }
+        ]
+      },
+      "symbol_arrow": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "lambda_pats",
+    "named": true,
+    "fields": {
+      "pat": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "let_pattern",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "let_expression",
     "named": true,
     "fields": {
@@ -1005,6 +1071,29 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "let_pattern",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "lp_tuple",
+          "named": true
+        },
+        {
+          "type": "unit",
+          "named": true
+        },
+        {
+          "type": "variable_identifier",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -1113,6 +1202,76 @@
         "types": [
           {
             "type": "type_reference",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "lp_tuple",
+    "named": true,
+    "fields": {
+      "first": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "let_pattern",
+            "named": true
+          }
+        ]
+      },
+      "rest": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "let_pattern",
+            "named": true
+          },
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "second": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "let_pattern",
+            "named": true
+          }
+        ]
+      },
+      "symbol_comma": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_left_paren": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_right_paren": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
             "named": true
           }
         ]

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -227,6 +227,24 @@ a ^ b
   )
 )
 
+==================
+string concatenation operator ++
+==================
+
+a ++ b
+
+---
+
+(source_file
+  (expression
+    (infix_operation
+      (expression (variable_identifier))
+      (operator)
+      (expression (variable_identifier))
+    )
+  )
+)
+
 
 ==================
 basic function call (hacky)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/lambda.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/lambda.txt
@@ -1,0 +1,182 @@
+==================
+lambda - lp_unit
+==================
+
+fun () -> 1L
+
+---
+
+(source_file
+  (expression
+    (lambda_expression
+      (keyword)
+      (lambda_pats (let_pattern (unit)))
+      (symbol)
+      (expression (int64_literal (digits (positive_digits)) (symbol)))
+    )
+  )
+)
+
+
+==================
+lambda - one lp_variable
+==================
+
+fun x -> x + 1L
+
+---
+
+(source_file
+  (expression
+    (lambda_expression
+      (keyword)
+      (lambda_pats (let_pattern (variable_identifier)))
+      (symbol)
+      (expression
+        (infix_operation
+          (expression (variable_identifier))
+          (operator)
+          (expression (int64_literal (digits (positive_digits)) (symbol)))
+        )
+      )
+    )
+  )
+)
+
+==================
+lambda test - wrapped in parens
+==================
+
+(fun x -> x + 1L)
+
+---
+
+(source_file
+  (expression
+    (paren_expression
+      (symbol)
+      (expression
+        (lambda_expression
+          (keyword)
+          (lambda_pats
+            (let_pattern (variable_identifier)))
+          (symbol)
+          (expression
+            (infix_operation
+              (expression (variable_identifier))
+              (operator)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+          )
+        )
+      )
+      (symbol)
+    )
+  )
+)
+
+
+==================
+lambda - two lp_variables
+==================
+
+fun a b -> a * b
+
+---
+
+(source_file
+  (expression
+    (lambda_expression
+      (keyword)
+      (lambda_pats
+        (let_pattern (variable_identifier))
+        (let_pattern (variable_identifier))
+      )
+      (symbol)
+      (expression
+        (infix_operation
+          (expression (variable_identifier))
+          (operator)
+          (expression (variable_identifier))
+        )
+      )
+    )
+  )
+)
+
+
+==================
+lambda - lp_tuple
+==================
+
+fun (str1, str2) -> str1 ++ str2
+
+---
+
+(source_file
+  (expression
+    (lambda_expression
+      (keyword)
+      (lambda_pats
+        (let_pattern
+          (lp_tuple
+            (symbol)
+            (let_pattern (variable_identifier))
+            (symbol)
+            (let_pattern (variable_identifier))
+            (symbol)
+          )
+        )
+      )
+      (symbol)
+      (expression
+        (infix_operation
+          (expression (variable_identifier))
+          (operator)
+          (expression (variable_identifier))
+        )
+      )
+    )
+  )
+)
+
+
+==================
+lambda test - lp_variable and lp_tuple
+==================
+
+fun x (y, z) -> x ++ y ++ z
+
+---
+
+(source_file
+  (expression
+    (lambda_expression
+      (keyword)
+      (lambda_pats
+        (let_pattern (variable_identifier))
+        (let_pattern
+          (lp_tuple
+            (symbol)
+            (let_pattern (variable_identifier))
+            (symbol)
+            (let_pattern (variable_identifier))
+            (symbol)
+          )
+        )
+      )
+      (symbol)
+      (expression
+        (infix_operation
+          (expression
+            (infix_operation
+              (expression (variable_identifier))
+              (operator)
+              (expression (variable_identifier))))
+          (operator)
+          (expression (variable_identifier))
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support lambda expressions
```

#5321 