### PR TITLE
Tree-sitter grammar: support Record update

### DIFF
--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -361,15 +361,10 @@ module TextToTextRoundtripping =
     ("Person2 {name =\"John\"; age = 30L} " |> roundtripCliScript) = "Person2 { name = \"John\"; age = 30L }"
     ("Person3 {name =\"John\"; age = 30L; hasPet = true} " |> roundtripCliScript) = "Person3 { name = \"John\"; age = 30L; hasPet = true }"
 
-
-    // // enum literals TODO
-    // type MyEnum =
-    //   | A
-    //   | B of String * Int64
-
-    // ("MyEnum.A" |> roundtripCliScript) = "MyEnum.A"
-    // ("MyEnum.B (\"test\", 12L)" |> roundtripCliScript) = "MyEnum.B (\"test\", 12L)"
-
+    // record update
+    ("{ RecordForUpdate { x = 4L; y = 1L } with y = 2L }" |> roundtripCliScript) = "{ RecordForUpdate { x = 4L; y = 1L } with y = 2L }"
+    ("{ myRec with y = 2L }" |> roundtripCliScript) = "{ myRec with y = 2L }"
+    ("{ myRec with y = 2L; z = 42L }" |> roundtripCliScript) = "{ myRec with y = 2L; z = 42L }"
 
     // enum literal
     ("Color.Red" |> roundtripCliScript) = "Color.Red"

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -443,6 +443,82 @@ module Darklang =
             createUnparseableError node
 
 
+        let parseRecordUpdate
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          if node.typ == "record_update" then
+            let openBrace = findField node "symbol_open_brace"
+            let closeBrace = findField node "symbol_close_brace"
+            let recordExpr = findAndParseRequired node "record" Expr.parse
+            let keywordWith = findField node "keyword_with"
+
+            let fieldUpdates =
+              (findNodeByFieldName node "field_updates")
+              |> Stdlib.Option.map (fun fieldUpdatesNode ->
+                fieldUpdatesNode.children
+                |> Stdlib.List.chunkBySize 2L
+                |> Builtin.unwrap
+                |> Stdlib.List.map (fun chunk ->
+                  match chunk with
+                  | [ fieldNode; _separator ] ->
+                    let fieldNameNode =
+                      findAndParseRequired fieldNode "field_name" (fun node ->
+                        ((node.range, node.text)) |> Stdlib.Result.Result.Ok)
+
+                    let symbolEqualsNode = findField fieldNode "symbol_equals"
+
+                    let valueNode =
+                      findAndParseRequired fieldNode "value" Expr.parse
+
+                    match fieldNameNode, symbolEqualsNode, valueNode with
+                    | Ok fieldName, Ok symEquals, Ok value ->
+                      ((fieldName, symEquals.range, value))
+                      |> Stdlib.Result.Result.Ok
+                    | _ -> createUnparseableError fieldNode
+
+                  | [ fieldNode ] ->
+                    let fieldNameNode =
+                      findAndParseRequired fieldNode "field_name" (fun node ->
+                        ((node.range, node.text)) |> Stdlib.Result.Result.Ok)
+
+                    let symbolEqualsNode = findField fieldNode "symbol_equals"
+
+                    let valueNode =
+                      findAndParseRequired fieldNode "value" Expr.parse
+
+                    match fieldNameNode, symbolEqualsNode, valueNode with
+                    | Ok fieldName, Ok symEquals, Ok value ->
+                      ((fieldName, symEquals.range, value))
+                      |> Stdlib.Result.Result.Ok
+                    | _ -> createUnparseableError fieldNode
+                  | _ -> createUnparseableError chunk))
+
+              |> Stdlib.Option.withDefault []
+
+            let fieldUpdates = fieldUpdates |> Stdlib.Result.collect
+
+            match openBrace, closeBrace, recordExpr, keywordWith, fieldUpdates with
+            | Ok openBrace,
+              Ok closeBrace,
+              Ok recordExpr,
+              Ok keywordWith,
+              Ok fieldUpdates ->
+              (WrittenTypes.Expr.ERecordUpdate(
+                node.range,
+                recordExpr,
+                fieldUpdates,
+                openBrace.range,
+                closeBrace.range,
+                keywordWith.range
+              ))
+              |> Stdlib.Result.Result.Ok
+
+            | _ -> createUnparseableError node
+
+
+
+
+
         let parseEnumLiteral
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
@@ -606,6 +682,7 @@ module Darklang =
               |> Stdlib.Result.Result.Ok
 
             | _ -> createUnparseableError node
+
 
         let parseLetPattern
           (node: ParsedNode)
@@ -889,6 +966,7 @@ module Darklang =
           | "tuple_literal" -> parseTupleLiteral node
 
           | "record_literal" -> parseRecordLiteral node
+          | "record_update" -> parseRecordUpdate node
           | "enum_literal" -> parseEnumLiteral node
 
           // assigning and accessing variables

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -569,6 +569,37 @@ module Darklang =
               [ makeToken symbolCloseBrace TokenType.Symbol ] ]
             |> Stdlib.List.flatten
 
+          //{ RecordForUpdate { x = 4L; y = 1L } with y = 2L }
+          | ERecordUpdate(range,
+                          record,
+                          updates,
+                          symbolOpenBrace,
+                          symbolCloseBrace,
+                          keywordWith) ->
+            let record = Expr.tokenize record
+
+            let updates =
+              updates
+              |> Stdlib.List.map (fun (name, symbolEquals, value) ->
+                let (range, _) = name
+
+                [ // x
+                  [ makeToken range TokenType.Property ]
+                  // =
+                  [ makeToken symbolEquals TokenType.Symbol ]
+                  // 4L
+                  Expr.tokenize value ]
+                |> Stdlib.List.flatten)
+              |> Stdlib.List.flatten
+
+            [ // { RecordForUpdate { x = 4L; y = 1L }
+              record
+              // with
+              [ makeToken keywordWith TokenType.Keyword ]
+              // y = 2L
+              updates ]
+            |> Stdlib.List.flatten
+
 
           // Option.Option.Some 1L
           | EEnum(range, typeName, caseName, fields, symbolDot) ->

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -270,6 +270,14 @@ module Darklang =
           symbolOpenBrace: Range *
           symbolCloseBrace: Range
 
+        | ERecordUpdate of
+          Range *
+          record: Expr *
+          updates: List<(Range * String) * Range * Expr> *
+          symbolOpenBrace: Range *
+          symbolCloseBrace: Range *
+          keywordWith: Range
+
         | EEnum of
           Range *
           typeName: (Range * List<String>) *

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -369,6 +369,17 @@ module Darklang =
 
             ProgramTypes.Expr.ERecord(gid (), typeName, fields)
 
+          | ERecordUpdate(_, record, updates, _, _, _) ->
+            let record = toPT onMissing record
+
+            let updates =
+              updates
+              |> Stdlib.List.map (fun (name, _, expr) ->
+                let name = name |> Stdlib.Tuple2.second
+                (name, toPT onMissing expr))
+
+            ProgramTypes.Expr.ERecordUpdate(gid (), record, updates)
+
           | EEnum(_, typeName, caseName, fields, _) ->
             let sr = Stdlib.Tuple2.first typeName
             let unresolvedTypeName = Stdlib.Tuple2.second typeName

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -739,7 +739,7 @@ module Darklang =
 
           // TODO: don't always need the parens
 
-          $"{{ ({recordPart}) with {updatePart} }}"
+          $"{{ {recordPart} with {updatePart} }}"
 
         | EConstant(_id, constant) ->
           match constant with

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -116,6 +116,35 @@ module.exports = grammar({
         field("type", $.type_reference),
       ),
 
+    // Record update
+    // e.g. { RecordForUpdate { x = 4L; y = 1L } with y = 2L }
+    record_update: $ =>
+      seq(
+        field("symbol_open_brace", alias("{", $.symbol)),
+        field("record", $.expression),
+        field("keyword_with", alias("with", $.keyword)),
+        field("field_updates", $.record_update_fields),
+        field("symbol_close_brace", alias("}", $.symbol)),
+      ),
+
+    record_update_fields: $ =>
+      seq(
+        $.record_update_field,
+        repeat(
+          seq(
+            field("symbol_semicolon", alias(";", $.symbol)),
+            $.record_update_field,
+          ),
+        ),
+      ),
+
+    record_update_field: $ =>
+      seq(
+        field("field_name", $.variable_identifier),
+        field("symbol_equals", alias("=", $.symbol)),
+        field("value", $.expression),
+      ),
+
     //
     // Enums
     // e.g. `type Color = Red | Green | Blue`
@@ -299,6 +328,8 @@ module.exports = grammar({
 
         $.field_access,
         $.lambda_expression,
+
+        $.record_update,
       ),
 
     paren_expression: $ =>

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -372,6 +372,134 @@
         }
       ]
     },
+    "record_update": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_open_brace",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "{"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "record",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "keyword_with",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "with"
+            },
+            "named": true,
+            "value": "keyword"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "field_updates",
+          "content": {
+            "type": "SYMBOL",
+            "name": "record_update_fields"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_close_brace",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "}"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
+    },
+    "record_update_fields": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "record_update_field"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_semicolon",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ";"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "record_update_field"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "record_update_field": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "field_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_equals",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "="
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        }
+      ]
+    },
     "type_decl_def_enum": {
       "type": "FIELD",
       "name": "content",
@@ -1194,6 +1322,10 @@
         {
           "type": "SYMBOL",
           "name": "lambda_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "record_update"
         }
       ]
     },

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -524,6 +524,10 @@
           "named": true
         },
         {
+          "type": "record_update",
+          "named": true
+        },
+        {
           "type": "string_literal",
           "named": true
         },
@@ -2049,6 +2053,124 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "record_update",
+    "named": true,
+    "fields": {
+      "field_updates": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "record_update_fields",
+            "named": true
+          }
+        ]
+      },
+      "keyword_with": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "keyword",
+            "named": true
+          }
+        ]
+      },
+      "record": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_brace": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_brace": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "record_update_field",
+    "named": true,
+    "fields": {
+      "field_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable_identifier",
+            "named": true
+          }
+        ]
+      },
+      "symbol_equals": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "record_update_fields",
+    "named": true,
+    "fields": {
+      "symbol_semicolon": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "record_update_field",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/record_update.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/record_update.txt
@@ -1,0 +1,166 @@
+==================
+record update - single field
+==================
+
+{ RecordForUpdate { x = 4L; y = 1L } with y = 2L }
+
+---
+
+(source_file
+  (expression
+    (record_update
+      (symbol)
+      (expression
+        (record_literal
+          (qualified_type_name (type_identifier))
+          (symbol)
+          (record_content
+            (record_pair
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+            (symbol)
+            (record_pair
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+          )
+          (symbol)
+        )
+      )
+      (keyword)
+      (record_update_fields
+        (record_update_field
+          (variable_identifier)
+          (symbol)
+          (expression (int64_literal (digits (positive_digits)) (symbol)))
+        )
+      )
+      (symbol)
+    )
+  )
+)
+
+
+==================
+record update - record as a variable
+==================
+
+let myRec = RecordForUpdate { x = 4L; y = 1L }
+{ myRec with y = 2L }
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword)
+      (variable_identifier)
+      (symbol)
+      (expression
+        (record_literal
+          (qualified_type_name (type_identifier))
+          (symbol)
+          (record_content
+            (record_pair
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+            (symbol)
+            (record_pair
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+          )
+          (symbol)
+        )
+      )
+      (expression
+        (record_update
+          (symbol)
+          (expression (variable_identifier))
+          (keyword)
+          (record_update_fields
+            (record_update_field
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+          )
+          (symbol)
+        )
+      )
+    )
+  )
+)
+
+
+==================
+record update - multiple fields
+==================
+
+let myRec = RecordForUpdateMultipe { x = 4L; y = 1L; z = 0L }
+{ myRec with y = 2L; z = 42L }
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword)
+      (variable_identifier)
+      (symbol)
+      (expression
+        (record_literal
+          (qualified_type_name (type_identifier))
+          (symbol)
+          (record_content
+            (record_pair
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+            (symbol)
+            (record_pair
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+            (symbol)
+            (record_pair
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+          )
+          (symbol)
+        )
+      )
+      (expression
+        (record_update
+          (symbol)
+          (expression (variable_identifier))
+          (keyword)
+          (record_update_fields
+            (record_update_field
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+            (symbol)
+            (record_update_field
+              (variable_identifier)
+              (symbol)
+              (expression (int64_literal (digits (positive_digits)) (symbol)))
+            )
+          )
+          (symbol)
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support Record update
```
#5321 