### PR TITLE
Tree-sitter grammar: support pipe expression

### DIFF
--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -340,7 +340,7 @@ module Expr =
       | WT.EInfix(id, op, arg1, WT.EPlaceHolder) -> WT.EPipeInfix(id, op, arg1)
       | WT.EEnum(id, typeName, caseName, fields) ->
         WT.EPipeEnum(id, typeName, caseName, fields)
-      | WT.EVariable(id, name) -> WT.EPipeVariableOrUserFunction(id, name)
+      | WT.EVariable(id, name) -> WT.EPipeVariableOrFnCall(id, name)
       | WT.ELambda(id, pats, body) -> WT.EPipeLambda(id, pats, body)
       | other ->
         raiseParserError

--- a/backend/src/LibParser/WrittenTypes.fs
+++ b/backend/src/LibParser/WrittenTypes.fs
@@ -219,8 +219,7 @@ and PipeExpr =
   ///   or a user function with only one argument or type args.
   ///
   /// We resolve this ambiguity during name resolution of WT2PT.
-  // TODO: rename to EPipeVariableOrFnCall
-  | EPipeVariableOrUserFunction of id * string
+  | EPipeVariableOrFnCall of id * string
 
 
 type Const =

--- a/backend/src/LibParser/WrittenTypesToProgramTypes.fs
+++ b/backend/src/LibParser/WrittenTypesToProgramTypes.fs
@@ -363,7 +363,7 @@ module Expr =
 
     uply {
       match pipeExpr with
-      | WT.EPipeVariableOrUserFunction(id, name) ->
+      | WT.EPipeVariableOrFnCall(id, name) ->
         let! resolved =
           let asUserFnName = WT.Name.Unresolved(NEList.singleton name)
           NR.resolveFnName

--- a/backend/testfiles/execution/language/epipe.dark
+++ b/backend/testfiles/execution/language/epipe.dark
@@ -42,6 +42,11 @@ type X = { y: Y }
 type MyEnum = A of Int64 * Int64 * Int64
 (33L |> MyEnum.A 21L 42L) = MyEnum.A 33L 21L 42L
 
+// TODO: test this in Parser.Tests
+(33L |> MyEnum.A 21L 42L) = MyEnum.A(33L, 21L, 42L)
+(33L |> MyEnum.A(21L, 42L)) = MyEnum.A 33L 21L 42L
+(33L |> MyEnum.A(21L, 42L)) = MyEnum.A(33L, 21L, 42L)
+
 (3L |> Stdlib.Result.Result.Ok) = Stdlib.Result.Result.Ok 3L
 
 (4L |> (+) 3L |> Stdlib.Option.Option.Some) = Stdlib.Option.Option.Some 7L

--- a/backend/testfiles/execution/language/epipe.dark
+++ b/backend/testfiles/execution/language/epipe.dark
@@ -41,10 +41,6 @@ type X = { y: Y }
 
 type MyEnum = A of Int64 * Int64 * Int64
 (33L |> MyEnum.A 21L 42L) = MyEnum.A 33L 21L 42L
-
-// TODO: test this in Parser.Tests
-(33L |> MyEnum.A 21L 42L) = MyEnum.A(33L, 21L, 42L)
-(33L |> MyEnum.A(21L, 42L)) = MyEnum.A 33L 21L 42L
 (33L |> MyEnum.A(21L, 42L)) = MyEnum.A(33L, 21L, 42L)
 
 (3L |> Stdlib.Result.Result.Ok) = Stdlib.Result.Result.Ok 3L

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -578,16 +578,15 @@ else
     ("1L |> fun x -> x + 1L" |> roundtripCliScript) = "1L\n|> fun x -> (x) + (1L)"
     ("3L |> Stdlib.Result.Result.Ok" |> roundtripCliScript) = "3L\n|> Stdlib.Result.Result.Ok"
     ("33L |> MyEnum.A(21L)" |> roundtripCliScript) = "33L\n|> MyEnum.A (21L)"
-    ("1L |> Stdlib.Int64.add 2L" |> roundtripCliScript) = "1L\n|> Stdlib.Int64.add 2L"
-    ("1L |> Stdlib.Int64.toString" |> roundtripCliScript) = "1L\n|> Stdlib.Int64.toString"
-    // TODO: why the result is the fqname?
-    ("Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Int64.add 1L 2L\n|> Stdlib.Int64.add 1L"
+    ("1L |> Stdlib.Int64.add 2L" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.add 2L"
+    ("1L |> Stdlib.Int64.toString" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.toString"
+    ("Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Int64.add 1L 2L\n|> PACKAGE.Darklang.Stdlib.Int64.add 1L"
 
     ("""[1L; 2L]
 |> Stdlib.List.last
 |> Builtin.unwrap"""
      |> roundtripCliScript) = """[1L; 2L]
-|> Stdlib.List.last
+|> PACKAGE.Darklang.Stdlib.List.last
 |> Builtin.unwrap"""
 
     // fn calls

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -580,6 +580,7 @@ else
     ("33L |> MyEnum.A(21L)" |> roundtripCliScript) = "33L\n|> MyEnum.A (21L)"
     ("1L |> Stdlib.Int64.add 2L" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.add 2L"
     ("1L |> Stdlib.Int64.toString" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.toString"
+    ("\"true\" |> Builtin.jsonParse<Bool>" |> roundtripCliScript) = "\"true\"\n|> Builtin.jsonParse<Bool>"
     ("Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Int64.add 1L 2L\n|> PACKAGE.Darklang.Stdlib.Int64.add 1L"
 
     ("""[1L; 2L]

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -570,6 +570,26 @@ else
     ("match true with\n| _ -> true" |> roundtripCliScript) = "match true with\n| _ ->\n  true"
     ("match true with\n| _var -> true" |> roundtripCliScript) = "match true with\n| _var ->\n  true"
 
+
+    // pipe expression
+    ("1L |> (+) 2L" |> roundtripCliScript) = "1L\n|> (+) 2L"
+    ("1L |> x" |> roundtripCliScript) = "1L\n|> x"
+    ("1L |> (fun x -> x + 1L)" |> roundtripCliScript) = "1L\n|> fun x -> (x) + (1L)"
+    ("1L |> fun x -> x + 1L" |> roundtripCliScript) = "1L\n|> fun x -> (x) + (1L)"
+    ("3L |> Stdlib.Result.Result.Ok" |> roundtripCliScript) = "3L\n|> Stdlib.Result.Result.Ok"
+    ("33L |> MyEnum.A(21L)" |> roundtripCliScript) = "33L\n|> MyEnum.A (21L)"
+    ("1L |> Stdlib.Int64.add 2L" |> roundtripCliScript) = "1L\n|> Stdlib.Int64.add 2L"
+    ("1L |> Stdlib.Int64.toString" |> roundtripCliScript) = "1L\n|> Stdlib.Int64.toString"
+    // TODO: why the result is the fqname?
+    ("Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Int64.add 1L 2L\n|> Stdlib.Int64.add 1L"
+
+    ("""[1L; 2L]
+|> Stdlib.List.last
+|> Builtin.unwrap"""
+     |> roundtripCliScript) = """[1L; 2L]
+|> Stdlib.List.last
+|> Builtin.unwrap"""
+
     // fn calls
     // TODO: these are ugly
     ("1L + 2L" |> roundtripCliScript) = "(1L) + (2L)"

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -397,8 +397,9 @@ module TextToTextRoundtripping =
     ("Color.Red" |> roundtripCliScript) = "Color.Red"
     ("Stdlib.Option.None" |> roundtripCliScript) = "Stdlib.Option.None"
     ("PACKAGE.Darklang.Stdlib.Option.Option.None" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Option.Option.None"
-    ("PACKAGE.Darklang.Stdlib.Option.Option.Some(1L)" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Option.Option.Some(1L)"
-    ("MyEnum.A(1L, 2L)" |> roundtripCliScript) = "MyEnum.A(1L, 2L)"
+    ("PACKAGE.Darklang.Stdlib.Option.Option.Some 1L" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Option.Option.Some(1L)"
+    ("MyEnum.A(1L, 2L)" |> roundtripCliScript) = "MyEnum.A((1L, 2L))"
+    ("MyEnum.A 1L 2L" |> roundtripCliScript) = "MyEnum.A(1L, 2L)"
 
 
 
@@ -559,7 +560,7 @@ else
 
     ("match (1L, 2L) with\n| (1L, 2L) -> true" |> roundtripCliScript) = "match (1L, 2L) with\n| (1L, 2L) ->\n  true"
 
-    ("match Stdlib.Result.Result.Ok(5L) with\n| Ok(5L) -> true\n| Error(e) -> false"
+    ("match Stdlib.Result.Result.Ok 5L with\n| Ok 5L -> true\n| Error e -> false"
      |> roundtripCliScript) = "match Stdlib.Result.Result.Ok(5L) with\n| Ok 5L ->\n  true\n| Error e ->\n  false"
 
     ("match \"str\" with\n| \"str\" when true -> true" |> roundtripCliScript) = "match \"str\" with\n| \"str\" when true ->\n  true"
@@ -577,7 +578,7 @@ else
     ("1L |> (fun x -> x + 1L)" |> roundtripCliScript) = "1L\n|> fun x -> (x) + (1L)"
     ("1L |> fun x -> x + 1L" |> roundtripCliScript) = "1L\n|> fun x -> (x) + (1L)"
     ("3L |> Stdlib.Result.Result.Ok" |> roundtripCliScript) = "3L\n|> Stdlib.Result.Result.Ok"
-    ("33L |> MyEnum.A(21L)" |> roundtripCliScript) = "33L\n|> MyEnum.A (21L)"
+    ("33L |> MyEnum.A 21L" |> roundtripCliScript) = "33L\n|> MyEnum.A (21L)"
     ("1L |> Stdlib.Int64.add 2L" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.add 2L"
     ("1L |> Stdlib.Int64.toString" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.toString"
     ("\"true\" |> Builtin.jsonParse<Bool>" |> roundtripCliScript) = "\"true\"\n|> Builtin.jsonParse<Bool>"

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -516,9 +516,6 @@ module Darklang =
             | _ -> createUnparseableError node
 
 
-
-
-
         let parseEnumLiteral
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
@@ -531,25 +528,13 @@ module Darklang =
               (findNodeByFieldName node "enum_fields")
               |> Stdlib.Option.map (fun enumFieldsNode ->
                 enumFieldsNode.children
-                |> Stdlib.List.chunkBySize 2L
-                |> Builtin.unwrap
-                |> Stdlib.List.map (fun chunk ->
-                  match chunk with
-                  | [ fieldNode ] ->
-                    match Expr.parse fieldNode with
-                    | Ok field -> field
-                    | Error _ -> WrittenTypes.Unparseable { source = fieldNode }
+                |> Stdlib.List.map (fun child -> Expr.parse child)
+                |> Stdlib.Result.collect)
 
-                  | [ fieldNode; _separator ] ->
-                    match Expr.parse fieldNode with
-                    | Ok field -> field
-                    | Error _ -> WrittenTypes.Unparseable { source = fieldNode }))
+              |> Stdlib.Option.withDefault ([] |> Stdlib.Result.Result.Ok)
 
-              |> Stdlib.Option.withDefault []
-
-
-            match typeNameNode, symbolDotNode, caseNameNode with
-            | Ok typeNameNode, Ok symbolDotNode, Ok caseNameNode ->
+            match typeNameNode, symbolDotNode, caseNameNode, enumFieldsNode with
+            | Ok typeNameNode, Ok symbolDotNode, Ok caseNameNode, Ok enumFieldsNode ->
               (WrittenTypes.Expr.EEnum(
                 node.range,
                 (typeNameNode.range, [ typeNameNode.text ]),

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -593,7 +593,7 @@ module Darklang =
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
           if node.typ == "field_access" then
-            let expr = findAndParseRequired node "expr" Expr.parse
+            let expr = findAndParseRequired node "expr" Expr.parseCase
             let symbolDotNode = findField node "symbol_dot"
             let fieldName = findField node "field_name"
 
@@ -668,6 +668,8 @@ module Darklang =
                   WrittenTypes.Infix.InfixFnCall
                     WrittenTypes.InfixFnName.StringConcat
                 | _ -> createUnparseableError node
+
+              | _ -> createUnparseableError node
 
             let rightArg = findAndParseRequired node "right" Expr.parse
 
@@ -776,8 +778,6 @@ module Darklang =
                 |> Stdlib.Result.collect
 
               | _ -> createUnparseableError node
-
-
 
             let arrowNode = findField node "symbol_arrow"
             let bodyNode = findAndParseRequired node "body" Expr.parse
@@ -900,6 +900,38 @@ module Darklang =
             createUnparseableError node
 
 
+        let parsePipeExpression
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          if node.typ == "pipe_expression" then
+            let expr = findAndParseRequired node "expr" Expr.parse
+
+            let pipeExpr =
+              (findNodeByFieldName node "pipe_exprs")
+              |> Stdlib.Option.map (fun pipeExprNode ->
+                pipeExprNode.children
+                |> Stdlib.List.chunkBySize 2L
+                |> Builtin.unwrap
+                |> Stdlib.List.map (fun chunk ->
+                  match chunk with
+                  | [ pipeSymbol; pipeExpr ] ->
+                    match PipeExpr.parse pipeExpr with
+                    | Ok pipeExpr ->
+                      (pipeSymbol.range, pipeExpr) |> Stdlib.Result.Result.Ok
+                    | Error _ -> createUnparseableError chunk
+                  | _ -> createUnparseableError chunk))
+
+              |> Stdlib.Option.withDefault []
+
+            let pipeExpr = pipeExpr |> Stdlib.Result.collect
+
+            match expr, pipeExpr with
+            | Ok expr, Ok pipeExpr ->
+              (WrittenTypes.Expr.EPipe(node.range, expr, pipeExpr))
+              |> Stdlib.Result.Result.Ok
+            | _ -> createUnparseableError node
+
+
         let parseFunctionCall
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
@@ -977,6 +1009,7 @@ module Darklang =
 
           | "if_expression" -> parseIfExpression node
           | "match_expression" -> parseMatchExpression node
+          | "pipe_expression" -> parsePipeExpression node
 
           // fn calls
           | "infix_operation" -> parseInfixOperation node

--- a/packages/darklang/languageTools/parser/identifiers.dark
+++ b/packages/darklang/languageTools/parser/identifiers.dark
@@ -129,12 +129,7 @@ module Darklang =
                 modules = modules
                 fn = parseFn fnIdentifierNode })
             |> Stdlib.Result.Result.Ok
-          elif node.typ == "fn_identifier" then
-            (WrittenTypes.QualifiedFnIdentifier
-              { range = node.range
-                modules = []
-                fn = parseFn node })
-            |> Stdlib.Result.Result.Ok
+
           else
             Stdlib.Result.Result.Error
               $"Can't parse qualified_fn_name from {node.typ}"

--- a/packages/darklang/languageTools/parser/identifiers.dark
+++ b/packages/darklang/languageTools/parser/identifiers.dark
@@ -56,7 +56,7 @@ module Darklang =
             match findNodeByFieldName node "type_args" with
             | Some typeArgs ->
               typeArgs
-              |> findNodeByFieldName "args"
+              |> findNodeByFieldName "type_args_items"
               |> Stdlib.Option.map (fun typeArgsNode ->
                 typeArgsNode.children
                 |> Stdlib.List.chunkBySize 2L
@@ -123,12 +123,6 @@ module Darklang =
                   typeArgs = typeArgs })
               |> Stdlib.Result.Result.Ok
             | Error _ -> createUnparseableError node
-
-            (WrittenTypes.QualifiedFnIdentifier
-              { range = node.range
-                modules = modules
-                fn = parseFn fnIdentifierNode })
-            |> Stdlib.Result.Result.Ok
 
           else
             Stdlib.Result.Result.Error

--- a/packages/darklang/languageTools/parser/identifiers.dark
+++ b/packages/darklang/languageTools/parser/identifiers.dark
@@ -124,6 +124,17 @@ module Darklang =
               |> Stdlib.Result.Result.Ok
             | Error _ -> createUnparseableError node
 
+            (WrittenTypes.QualifiedFnIdentifier
+              { range = node.range
+                modules = modules
+                fn = parseFn fnIdentifierNode })
+            |> Stdlib.Result.Result.Ok
+          elif node.typ == "fn_identifier" then
+            (WrittenTypes.QualifiedFnIdentifier
+              { range = node.range
+                modules = []
+                fn = parseFn node })
+            |> Stdlib.Result.Result.Ok
           else
             Stdlib.Result.Result.Error
               $"Can't parse qualified_fn_name from {node.typ}"

--- a/packages/darklang/languageTools/parser/matchPattern.dark
+++ b/packages/darklang/languageTools/parser/matchPattern.dark
@@ -316,25 +316,13 @@ module Darklang =
             (findNodeByFieldName node "enum_fields")
             |> Stdlib.Option.map (fun enumFieldsNode ->
               enumFieldsNode.children
-              |> Stdlib.List.chunkBySize 2L
-              |> Builtin.unwrap
-              |> Stdlib.List.map (fun chunk ->
-                match chunk with
-                | [ fieldNode ] ->
-                  match parseMatchPattern fieldNode with
-                  | Ok field -> field
-                  | Error _ -> WrittenTypes.Unparseable { source = fieldNode }
+              |> Stdlib.List.map (fun child -> parseMatchPattern child)
+              |> Stdlib.Result.collect)
 
-                | [ fieldNode; _separator ] ->
-                  match parseMatchPattern fieldNode with
-                  | Ok field -> field
-                  | Error _ -> WrittenTypes.Unparseable { source = fieldNode }))
+            |> Stdlib.Option.withDefault ([] |> Stdlib.Result.Result.Ok)
 
-            |> Stdlib.Option.withDefault []
-
-
-          match caseNameNode with
-          | Ok caseNameNode ->
+          match caseNameNode, enumFieldsNode with
+          | Ok caseNameNode, Ok enumFieldsNode ->
             (WrittenTypes.MatchPattern.MPEnum(
               node.range,
               (caseNameNode.range, caseNameNode.text),

--- a/packages/darklang/languageTools/parser/pipeExpr.dark
+++ b/packages/darklang/languageTools/parser/pipeExpr.dark
@@ -157,14 +157,21 @@ module Darklang =
             |> Stdlib.List.map Expr.parse
             |> Stdlib.Result.collect
 
-          // TODO: Handle typeArgs
+          let typeArgs =
+            node.children
+            |> Stdlib.List.filter (fun c ->
+              match c.fieldName with
+              | Some fName -> fName == "type_args"
+              | None -> false)
+            |> Stdlib.List.map TypeReference.parse
+            |> Stdlib.Result.collect
 
-          match fnNameNode, args with
-          | Ok fnName, Ok args ->
+          match fnNameNode, typeArgs, args with
+          | Ok fnName, Ok typeArgs, Ok args ->
             let name = fnName.text |> Stdlib.String.split "."
             let fnName = WrittenTypes.Name.Unresolved(fnName.range, name)
 
-            (WrittenTypes.PipeExpr.EPipeFnCall(node.range, fnName, [], args))
+            (WrittenTypes.PipeExpr.EPipeFnCall(node.range, fnName, typeArgs, args))
             |> Stdlib.Result.Result.Ok
 
           | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/parser/pipeExpr.dark
+++ b/packages/darklang/languageTools/parser/pipeExpr.dark
@@ -1,0 +1,187 @@
+module Darklang =
+  module LanguageTools =
+    module Parser =
+      module PipeExpr =
+        let parsePipeInfix
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.PipeExpr, WrittenTypes.Unparseable> =
+          let operatorNode = findField node "operator"
+
+          let operator =
+            match operatorNode with
+            | Ok op ->
+              match getText op with
+              | "+" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ArithmeticPlus
+              | "-" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ArithmeticMinus
+              | "*" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ArithmeticMultiply
+              | "/" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ArithmeticDivide
+              | "%" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ArithmeticModulo
+              | "^" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ArithmeticPower
+              | ">" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ComparisonGreaterThan
+              | ">=" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ComparisonGreaterThanOrEqual
+              | "<" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ComparisonLessThan
+              | "<=" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ComparisonLessThanOrEqual
+              | "==" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ComparisonEquals
+              | "!=" ->
+                WrittenTypes.Infix.InfixFnCall
+                  WrittenTypes.InfixFnName.ComparisonNotEquals
+              | "&&" ->
+                WrittenTypes.Infix.BinOp WrittenTypes.BinaryOperation.BinOpAnd
+              | "||" -> WrittenTypes.Infix.BinOp WrittenTypes.BinaryOperation.BinOpOr
+              | "++" ->
+                WrittenTypes.Infix.InfixFnCall WrittenTypes.InfixFnName.StringConcat
+              | op -> createUnparseableError node
+
+            | _ -> createUnparseableError node
+
+          let rightArg = findAndParseRequired node "right" Expr.parse
+
+          match rightArg, operatorNode with
+          | Ok rightArg, Ok operatorNode ->
+            (WrittenTypes.PipeExpr.EPipeInfix(
+              node.range,
+              (operatorNode.range, operator),
+              rightArg
+            ))
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+        let parsePipeLambda
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.PipeExpr, WrittenTypes.Unparseable> =
+          if node.typ == "pipe_lambda" then
+            let keywordFun = findField node "keyword_fun"
+
+            let patsNode =
+              match findField node "pats" with
+              | Ok paramsNode ->
+                paramsNode.children
+                |> Stdlib.List.map (fun child -> Expr.parseLetPattern child)
+                |> Stdlib.Result.collect
+
+              | _ -> createUnparseableError node
+
+            let arrowNode = findField node "symbol_arrow"
+            let bodyNode = findAndParseRequired node "body" Expr.parse
+
+            match patsNode, bodyNode, keywordFun, arrowNode with
+            | Ok pats, Ok body, Ok keywordFun, Ok arrowNode ->
+              (WrittenTypes.PipeExpr.EPipeLambda(
+                node.range,
+                pats,
+                body,
+                keywordFun.range,
+                arrowNode.range
+              ))
+              |> Stdlib.Result.Result.Ok
+
+            | _ -> createUnparseableError node
+
+
+        let parsePipeEnum
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.PipeExpr, WrittenTypes.Unparseable> =
+          let typeNameNode = findField node "type_name"
+          let symbolDotNode = findField node "symbol_dot"
+          let caseNameNode = findField node "case_name"
+
+          let enumFieldsNode =
+            (findNodeByFieldName node "enum_fields")
+            |> Stdlib.Option.map (fun enumFieldsNode ->
+              enumFieldsNode.children
+              |> Stdlib.List.chunkBySize 2L
+              |> Builtin.unwrap
+              |> Stdlib.List.map (fun chunk ->
+                match chunk with
+                | [ fieldNode ] ->
+                  match Expr.parse fieldNode with
+                  | Ok field -> field
+                  | Error _ -> WrittenTypes.Unparseable { source = fieldNode }
+
+                | [ fieldNode; _separator ] ->
+                  match Expr.parse fieldNode with
+                  | Ok field -> field
+                  | Error _ -> WrittenTypes.Unparseable { source = fieldNode }))
+
+            |> Stdlib.Option.withDefault []
+
+          match typeNameNode, symbolDotNode, caseNameNode with
+          | Ok typeNameNode, Ok symbolDotNode, Ok caseNameNode ->
+            (WrittenTypes.PipeExpr.EPipeEnum(
+              node.range,
+              (typeNameNode.range, [ typeNameNode.text ]),
+              (caseNameNode.range, caseNameNode.text),
+              enumFieldsNode,
+              symbolDotNode.range
+            ))
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+
+        let parsePipeFnCall
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.PipeExpr, WrittenTypes.Unparseable> =
+          let fnNameNode = findField node "fn"
+
+          let args =
+            node.children
+            |> Stdlib.List.filter (fun c ->
+              match c.fieldName with
+              | Some fName -> fName == "args"
+              | None -> false)
+            |> Stdlib.List.map Expr.parse
+            |> Stdlib.Result.collect
+
+          // TODO: Handle typeArgs
+
+          match fnNameNode, args with
+          | Ok fnName, Ok args ->
+            let fnName = WrittenTypes.Name.Unresolved(fnName.range, [ fnName.text ])
+
+            (WrittenTypes.PipeExpr.EPipeFnCall(node.range, fnName, [], args))
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+
+        let parse
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.PipeExpr, WrittenTypes.Unparseable> =
+          if node.typ == "pipe_expr" then
+            match node.children with
+            | [] -> createUnparseableError node
+            | [ child ] ->
+              match child.typ with
+              | "pipe_infix" -> parsePipeInfix child
+              | "pipe_lambda" -> parsePipeLambda child
+              | "pipe_enum" -> parsePipeEnum child
+              | "pipe_fn_call" -> parsePipeFnCall child
+              | "pipe_variable_or_fn_call" ->
+                (WrittenTypes.PipeExpr.EPipeVariableOrFnCall(node.range, node.text))
+                |> Stdlib.Result.Result.Ok
+
+            | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/parser/pipeExpr.dark
+++ b/packages/darklang/languageTools/parser/pipeExpr.dark
@@ -73,6 +73,7 @@ module Darklang =
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.PipeExpr, WrittenTypes.Unparseable> =
           if node.typ == "pipe_lambda" then
+            let node = (findField node "pipe_lambda") |> Builtin.unwrap
             let keywordFun = findField node "keyword_fun"
 
             let patsNode =
@@ -160,7 +161,8 @@ module Darklang =
 
           match fnNameNode, args with
           | Ok fnName, Ok args ->
-            let fnName = WrittenTypes.Name.Unresolved(fnName.range, [ fnName.text ])
+            let name = fnName.text |> Stdlib.String.split "."
+            let fnName = WrittenTypes.Name.Unresolved(fnName.range, name)
 
             (WrittenTypes.PipeExpr.EPipeFnCall(node.range, fnName, [], args))
             |> Stdlib.Result.Result.Ok
@@ -180,8 +182,4 @@ module Darklang =
               | "pipe_lambda" -> parsePipeLambda child
               | "pipe_enum" -> parsePipeEnum child
               | "pipe_fn_call" -> parsePipeFnCall child
-              | "pipe_variable_or_fn_call" ->
-                (WrittenTypes.PipeExpr.EPipeVariableOrFnCall(node.range, node.text))
-                |> Stdlib.Result.Result.Ok
-
             | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/parser/pipeExpr.dark
+++ b/packages/darklang/languageTools/parser/pipeExpr.dark
@@ -146,33 +146,35 @@ module Darklang =
         let parsePipeFnCall
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.PipeExpr, WrittenTypes.Unparseable> =
-          let fnNameNode = findField node "fn"
+          match findField node "fn" with
+          | Ok fnNameNode ->
+            let args =
+              node.children
+              |> Stdlib.List.filter (fun c ->
+                match c.fieldName with
+                | Some fName -> fName == "args"
+                | None -> false)
+              |> Stdlib.List.map Expr.parse
+              |> Stdlib.Result.collect
 
-          let args =
-            node.children
-            |> Stdlib.List.filter (fun c ->
-              match c.fieldName with
-              | Some fName -> fName == "args"
-              | None -> false)
-            |> Stdlib.List.map Expr.parse
-            |> Stdlib.Result.collect
+            let typeArgs = Identifiers.extractTypeArgs fnNameNode
 
-          let typeArgs =
-            node.children
-            |> Stdlib.List.filter (fun c ->
-              match c.fieldName with
-              | Some fName -> fName == "type_args"
-              | None -> false)
-            |> Stdlib.List.map TypeReference.parse
-            |> Stdlib.Result.collect
+            match typeArgs, args with
+            | Ok typeArgs, Ok args ->
+              let nameWithoutTyprArgs =
+                fnNameNode.text |> (Stdlib.String.split "<") |> Stdlib.List.head
 
-          match fnNameNode, typeArgs, args with
-          | Ok fnName, Ok typeArgs, Ok args ->
-            let name = fnName.text |> Stdlib.String.split "."
-            let fnName = WrittenTypes.Name.Unresolved(fnName.range, name)
+              let name =
+                match nameWithoutTyprArgs with
+                | Some name -> name |> Stdlib.String.split "."
+                | None -> fnName.text |> Stdlib.String.split "."
 
-            (WrittenTypes.PipeExpr.EPipeFnCall(node.range, fnName, typeArgs, args))
-            |> Stdlib.Result.Result.Ok
+              let fnName = WrittenTypes.Name.Unresolved(fnNameNode.range, name)
+
+              (WrittenTypes.PipeExpr.EPipeFnCall(node.range, fnName, typeArgs, args))
+              |> Stdlib.Result.Result.Ok
+
+            | _ -> createUnparseableError node
 
           | _ -> createUnparseableError node
 

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -276,6 +276,7 @@ module Darklang =
             tokenizeDefinition t.definition ]
           |> Stdlib.List.flatten
 
+      // TODO: maybe this should be inside `Expr` module?
       module MatchPattern =
         let tokenize (p: WrittenTypes.MatchPattern) : List<SemanticToken> =
           match p with
@@ -428,6 +429,74 @@ module Darklang =
                 [ makeToken symbolCloseParen TokenType.Symbol ] ]
               |> Stdlib.List.flatten
 
+        module PipeExpr =
+          let tokenize (pe: WrittenTypes.PipeExpr) : List<SemanticToken> =
+            match pe with
+            | EPipeInfix(_, (opRange, _op), expr) ->
+              [ // (+) 1
+                [ makeToken opRange TokenType.Operator ]
+                // 1
+                Expr.tokenize expr ]
+              |> Stdlib.List.flatten
+
+            | EPipeLambda(_, pats, body, keywordFun, symbolArrow) ->
+              [ // fun
+                [ makeToken keywordFun TokenType.Keyword ]
+                // a
+                (pats
+                 |> Stdlib.List.map (fun pat -> LetPattern.tokenize pat)
+                 |> Stdlib.List.flatten)
+                // ->
+                [ makeToken symbolArrow TokenType.Symbol ]
+                // a + 1
+                Expr.tokenize body ]
+              |> Stdlib.List.flatten
+
+            | EPipeEnum(_, typeName, caseName, fields, symbolDot) ->
+              let typeName =
+                match typeName with
+                | (range, _) -> [ makeToken range TokenType.TypeName ]
+                | _ -> []
+
+              let caseName =
+                match caseName with
+                | (range, _) -> [ makeToken range TokenType.EnumMember ]
+                | _ -> []
+
+              let fields =
+                fields
+                |> Stdlib.List.map (fun expr -> Expr.tokenize expr)
+                |> Stdlib.List.flatten
+
+              [ // Option.Option.Some
+                typeName
+                // .
+                [ makeToken symbolDot TokenType.Symbol ]
+                // Some
+                caseName
+                // 1L
+                fields ]
+              |> Stdlib.List.flatten
+
+            | EPipeFnCall(_, fnName, typeArgs, args) ->
+              let fnName =
+                match fnName with
+                | Unresolved(range, _) -> [ makeToken range TokenType.FunctionName ]
+                | _ -> []
+
+              [ // Darklang.Stdlib.List.map
+                fnName
+                (typeArgs
+                 |> Stdlib.List.map (fun typeArg -> TypeReference.tokenize typeArg)
+                 |> Stdlib.List.flatten)
+                // (1)
+                (args
+                 |> Stdlib.List.map (fun arg -> Expr.tokenize arg)
+                 |> Stdlib.List.flatten) ]
+              |> Stdlib.List.flatten
+
+            | EPipeVariable(range, _varName) ->
+              [ makeToken range TokenType.VariableName ] |> Stdlib.List.flatten
 
         let tokenize (e: WrittenTypes.Expr) : List<SemanticToken> =
           match e with
@@ -761,6 +830,25 @@ module Darklang =
               // | 1 -> 1
               cases ]
             |> Stdlib.List.flatten
+
+          // x |> fn |> fn
+          | EPipe(_, expr, pipeExprs) ->
+            let pipeExprs =
+              pipeExprs
+              |> Stdlib.List.map (fun (pipeSym, pipeExpr) ->
+                [ // |>
+                  [ makeToken pipeSym TokenType.Symbol ]
+                  // fn
+                  Expr.PipeExpr.tokenize pipeExpr ])
+              |> Stdlib.List.flatten
+
+            [ // x
+              Expr.tokenize expr
+              // |> fn
+              (pipeExprs) |> Stdlib.List.flatten ]
+
+            |> Stdlib.List.flatten
+
 
           // x + 1
           | EInfix(_, (opRange, _op), left, right) ->

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -276,7 +276,6 @@ module Darklang =
             tokenizeDefinition t.definition ]
           |> Stdlib.List.flatten
 
-      // TODO: maybe this should be inside `Expr` module?
       module MatchPattern =
         let tokenize (p: WrittenTypes.MatchPattern) : List<SemanticToken> =
           match p with

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -334,6 +334,8 @@ module Darklang =
           keywordMatch: Range *
           keywordWith: Range
 
+        | EPipe of Range * Expr * List<Range * PipeExpr>
+
         | EInfix of Range * op: (Range * Infix) * left: Expr * right: Expr
 
         | ELambda of
@@ -343,11 +345,6 @@ module Darklang =
           keywordFun: Range *
           symbolArrow: Range
 
-        // TODO: I accidentally got away from how we normally represent
-        // Expressions - switch to this instead.
-        // | EApply of Range * lhs: Expr * args: List<Expr>
-        // | EFnName of QualifiedFnIdentifier
-
         | EApply of
           Range *
           lhs: Expr *
@@ -356,6 +353,27 @@ module Darklang =
 
         | EFnName of Range * name: QualifiedFnIdentifier
 
+      type PipeExpr =
+        | EPipeInfix of Range * op: (Range * Infix) * Expr
+        | EPipeLambda of
+          Range *
+          pats: List<LetPattern> *
+          body: Expr *
+          keywordFun: Range *
+          symbolArrow: Range
+        | EPipeEnum of
+          Range *
+          typeName: (Range * List<String>) *
+          caseName: (Range * String) *
+          fields: List<Expr> *
+          /// between the typeName and the caseName
+          symbolDot: Range
+        | EPipeFnCall of
+          Range *
+          fnName: Name *
+          typeArgs: List<TypeReference.TypeReference> *
+          args: List<Expr>
+        | EPipeVariableOrFnCall of Range * String
 
 
       // Fn declarations

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -329,6 +329,54 @@ module Darklang =
             | MPVariable(_, name) ->
               ProgramTypes.MatchPattern.MPVariable(gid (), name)
 
+        module PipeExpr =
+          let toPT
+            (onMissing: NameResolver.OnMissing)
+            (pipeExpr: WrittenTypes.PipeExpr)
+            : ProgramTypes.PipeExpr =
+            match pipeExpr with
+            | EPipeInfix(_, (_, infix), right) ->
+              let right = Expr.toPT onMissing right
+
+              ProgramTypes.PipeExpr.EPipeInfix(gid (), Infix.toPT infix, right)
+
+            | EPipeLambda(_, pats, body, _, _) ->
+              let body = Expr.toPT onMissing body
+              let pats = Stdlib.List.map pats (fun p -> LetPattern.toPT p)
+
+              ProgramTypes.PipeExpr.EPipeLambda(gid (), pats, body)
+
+            | EPipeEnum(_, (sr, typeName), (_, caseName), fields, _) ->
+
+              let typeName =
+                NameResolver.TypeName.resolve
+                  onMissing
+                  []
+                  (WrittenTypes.Name.Unresolved sr typeName)
+
+              let fields = Stdlib.List.map fields (fun e -> Expr.toPT onMissing e)
+
+              ProgramTypes.PipeExpr.EPipeEnum(gid (), typeName, caseName, fields)
+
+            | EPipeFnCall(_, fnName, typeArgs, args) ->
+              let fnName = NameResolver.FnName.resolve onMissing [] fnName
+
+              let typeArgs =
+                Stdlib.List.map typeArgs (fun t -> TypeReference.toPT onMissing t)
+
+              let args = Stdlib.List.map args (fun a -> Expr.toPT onMissing a)
+
+              ProgramTypes.PipeExpr.EPipeFnCall(gid (), fnName, typeArgs, args)
+
+            | EPipeVariableOrFnCall(range, var) ->
+              let asUserFnName = WrittenTypes.Name.Unresolved(range, [ var ])
+
+              let resolved = NameResolver.FnName.resolve onMissing [] asUserFnName
+
+              match resolved with
+              | Ok name -> ProgramTypes.PipeExpr.EPipeFnCall(gid (), name, [], [])
+              | Error _ -> ProgramTypes.PipeExpr.EPipeVariable(gid (), var, [])
+
 
         let toPT
           (onMissing: NameResolver.OnMissing)
@@ -403,17 +451,13 @@ module Darklang =
 
             ProgramTypes.Expr.ERecordUpdate(gid (), record, updates)
 
-          | EEnum(_, typeName, caseName, fields, _) ->
-            let sr = Stdlib.Tuple2.first typeName
-            let unresolvedTypeName = Stdlib.Tuple2.second typeName
-
+          | EEnum(_, (sr, typeName), (_, caseName), fields, _) ->
             let typeName =
               NameResolver.TypeName.resolve
                 onMissing
                 []
-                (WrittenTypes.Name.Unresolved sr unresolvedTypeName)
+                (WrittenTypes.Name.Unresolved sr typeName)
 
-            let caseName = caseName |> Stdlib.Tuple2.second
             let fields = Stdlib.List.map fields (fun expr -> toPT onMissing expr)
 
             ProgramTypes.Expr.EEnum(gid (), typeName, caseName, fields)
@@ -462,6 +506,11 @@ module Darklang =
 
             ProgramTypes.Expr.EMatch(gid (), toPT onMissing expr, cases)
 
+          | EPipe(_, expr, pipeExpr) ->
+            let pipeExpr =
+              pipeExpr |> Stdlib.List.map (fun (_, e) -> PipeExpr.toPT onMissing e)
+
+            ProgramTypes.Expr.EPipe(gid (), toPT onMissing expr, pipeExpr)
 
           // fn calls
           | EInfix(_, (_, op), left, right) ->

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -358,24 +358,29 @@ module Darklang =
 
               ProgramTypes.PipeExpr.EPipeEnum(gid (), typeName, caseName, fields)
 
+            // TODO: rename to EPipeVariableOrFnCall
             | EPipeFnCall(_, fnName, typeArgs, args) ->
-              let fnName = NameResolver.FnName.resolve onMissing [] fnName
+              let (range, name) =
+                match fnName with
+                | Unresolved(range, fnName) -> (range, fnName)
+
+              let resolved =
+                NameResolver.FnName.resolve
+                  onMissing
+                  []
+                  (WrittenTypes.Name.Unresolved(range, name))
 
               let typeArgs =
                 Stdlib.List.map typeArgs (fun t -> TypeReference.toPT onMissing t)
 
               let args = Stdlib.List.map args (fun a -> Expr.toPT onMissing a)
 
-              ProgramTypes.PipeExpr.EPipeFnCall(gid (), fnName, typeArgs, args)
-
-            | EPipeVariableOrFnCall(range, var) ->
-              let asUserFnName = WrittenTypes.Name.Unresolved(range, [ var ])
-
-              let resolved = NameResolver.FnName.resolve onMissing [] asUserFnName
-
               match resolved with
-              | Ok name -> ProgramTypes.PipeExpr.EPipeFnCall(gid (), name, [], [])
-              | Error _ -> ProgramTypes.PipeExpr.EPipeVariable(gid (), var, [])
+              | Ok _ ->
+                ProgramTypes.PipeExpr.EPipeFnCall(gid (), resolved, typeArgs, args)
+              | Error _ ->
+                let name = name |> Stdlib.List.last |> Builtin.unwrap
+                ProgramTypes.PipeExpr.EPipeVariable(gid (), name, typeArgs)
 
 
         let toPT

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -396,7 +396,7 @@ module Darklang =
             |> Stdlib.List.map PrettyPrinter.ProgramTypes.expr
             |> Stdlib.String.join " "
 
-          $"({varName} {exprs})"
+          if exprs == "" then varName else $"({varName} {exprs})"
 
         | EPipeLambda(_id, pats, body) ->
           let argsPart =
@@ -430,10 +430,13 @@ module Darklang =
           let argsPart =
             args
             |> Stdlib.List.map (fun arg -> PrettyPrinter.ProgramTypes.expr arg)
-            |> Stdlib.List.map (fun arg -> $"({arg})")
+            |> Stdlib.List.map (fun arg -> $"{arg}")
             |> Stdlib.String.join " "
 
-          $"{fnNamePart}{typeArgsPart} {argsPart}"
+          if argsPart == "" then
+            $"{fnNamePart}{typeArgsPart}"
+          else
+            $"{fnNamePart}{typeArgsPart} {argsPart}"
 
         // LanguageTools.ID *
         // typeName: LanguageTools.ProgramTypes.TypeName.TypeName *
@@ -639,9 +642,9 @@ module Darklang =
             pipeExprs
             |> Stdlib.List.map (fun pipeExpr ->
               PrettyPrinter.ProgramTypes.pipeExpr pipeExpr)
-            |> Stdlib.String.join " \n|> "
+            |> Stdlib.String.join "\n|> "
 
-          $"{exprPart} \n|> {pipeParts}"
+          $"{exprPart}\n|> {pipeParts}"
 
 
 

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -795,7 +795,7 @@ module.exports = grammar({
     apply: $ =>
       prec.right(
         seq(
-          field("fn", choice($.qualified_fn_name, $.fn_identifier)),
+          field("fn", $.qualified_fn_name),
           field(
             "args",
             repeat1(choice($.paren_expression, $.simple_expression)),
@@ -818,30 +818,15 @@ module.exports = grammar({
     // ---------------------
     // Pipe expressions
     // ---------------------
-
-    pipe_variable_or_fn_call: $ =>
-      seq(field("variable_or_fn_name", $.variable_or_fn_identifier)),
-
     pipe_lambda: $ =>
       choice(
-        seq(
-          field("keyword_fun", alias("fun", $.keyword)),
-          field("pats", $.pipe_lambda_pats),
-          field("symbol_arrow", alias("->", $.symbol)),
-          field("body", $.expression),
-        ),
-
+        field("pipe_lambda", $.lambda_expression),
         seq(
           field("symbol_open_paren", alias("(", $.symbol)),
-          field("keyword_fun", alias("fun", $.keyword)),
-          field("pats", $.pipe_lambda_pats),
-          field("symbol_arrow", alias("->", $.symbol)),
-          field("body", $.expression),
+          field("pipe_lambda", $.lambda_expression),
           field("symbol_close_paren", alias(")", $.symbol)),
         ),
       ),
-
-    pipe_lambda_pats: $ => field("pat", repeat1($.let_pattern)),
 
     pipe_infix: $ =>
       choice(
@@ -941,13 +926,7 @@ module.exports = grammar({
       ),
 
     pipe_expr: $ =>
-      choice(
-        $.pipe_variable_or_fn_call,
-        $.pipe_lambda,
-        $.pipe_infix,
-        $.pipe_fn_call,
-        $.pipe_enum,
-      ),
+      choice($.pipe_lambda, $.pipe_infix, $.pipe_fn_call, $.pipe_enum),
 
     pipe_expression: $ =>
       prec(
@@ -1118,8 +1097,6 @@ module.exports = grammar({
 
     // e.g. `double` in `let double (x: Int) = x + x`
     fn_identifier: $ => prec(PREC.FN_IDENTIFIER, /[a-z_][a-zA-Z0-9_]*/),
-
-    variable_or_fn_identifier: $ => /[a-z_][a-zA-Z0-9_]*/,
 
     // e.g. `Person` in `type MyPerson = ...`
     type_identifier: $ => /[A-Z][a-zA-Z0-9_]*/,

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -818,6 +818,9 @@ module.exports = grammar({
     // ---------------------
     // Pipe expressions
     // ---------------------
+
+    //
+    // Pipe lambda
     pipe_lambda: $ =>
       choice(
         field("pipe_lambda", $.lambda_expression),
@@ -828,6 +831,8 @@ module.exports = grammar({
         ),
       ),
 
+    //
+    // Pipe infix
     pipe_infix: $ =>
       choice(
         // Power
@@ -891,11 +896,19 @@ module.exports = grammar({
         ),
       ),
 
-    // TODO: handle typeArgs?
+    //
+    // Pipe function call
     pipe_fn_call: $ =>
       prec.right(
         seq(
           field("fn", $.qualified_fn_name),
+          optional(
+            seq(
+              field("symbol_open_angle", alias("<", $.symbol)),
+              field("type_args", $.type_reference),
+              field("symbol_close_angle", alias(">", $.symbol)),
+            ),
+          ),
           field(
             "args",
             repeat(choice($.paren_expression, $.simple_expression)),
@@ -903,6 +916,8 @@ module.exports = grammar({
         ),
       ),
 
+    //
+    // Pipe enum
     pipe_enum: $ =>
       prec.right(
         seq(
@@ -928,12 +943,6 @@ module.exports = grammar({
     pipe_expr: $ =>
       choice($.pipe_lambda, $.pipe_infix, $.pipe_fn_call, $.pipe_enum),
 
-    pipe_expression: $ =>
-      prec(
-        PREC.PIPE_EXPR,
-        seq(field("expr", $.expression), field("pipe_exprs", $.pipe_exprs)),
-      ),
-
     pipe_exprs: $ =>
       prec.right(
         repeat1(
@@ -942,6 +951,12 @@ module.exports = grammar({
             field("pipe_expr", $.pipe_expr),
           ),
         ),
+      ),
+
+    pipe_expression: $ =>
+      prec(
+        PREC.PIPE_EXPR,
+        seq(field("expr", $.expression), field("pipe_exprs", $.pipe_exprs)),
       ),
 
     // ---------------------

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -924,13 +924,6 @@ module.exports = grammar({
       prec.right(
         seq(
           field("fn", $.qualified_fn_name),
-          optional(
-            seq(
-              field("symbol_open_angle", alias("<", $.symbol)),
-              field("type_args", $.type_reference),
-              field("symbol_close_angle", alias(">", $.symbol)),
-            ),
-          ),
           field(
             "args",
             repeat(choice($.paren_expression, $.simple_expression)),
@@ -1127,10 +1120,10 @@ module.exports = grammar({
     type_args: $ =>
       seq(
         field("symbol_open_angle", alias(token.immediate("<"), $.symbol)),
-        field("args", $.args),
+        field("type_args_items", $.type_args_items),
         field("symbol_close_angle", alias(token.immediate(">"), $.symbol)),
       ),
-    args: $ =>
+    type_args_items: $ =>
       seq(
         $.type_reference,
         repeat(

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -29,11 +29,7 @@ module.exports = grammar({
 
   externals: $ => [$.indent, $.dedent],
 
-  conflicts: $ => [
-    [$.module_identifier, $.type_identifier],
-    // TODO: deal with this
-    [$.mp_list_cons, $.mp_enum_fields],
-  ],
+  conflicts: $ => [[$.module_identifier, $.type_identifier]],
 
   rules: {
     source_file: $ =>
@@ -303,7 +299,7 @@ module.exports = grammar({
       ),
 
     mp_enum_fields: $ =>
-      prec.left(
+      prec.right(
         choice(
           seq(
             field("symbol_open_paren", alias("(", $.symbol)),
@@ -320,7 +316,7 @@ module.exports = grammar({
             ),
             field("symbol_close_paren", alias(")", $.symbol)),
           ),
-          prec.right(repeat1($.match_pattern)),
+          repeat1(prec.right($.match_pattern)),
         ),
       ),
 

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -1235,43 +1235,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_open_paren",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": "("
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "enum_fields",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "mp_enum_fields"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_close_paren",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ")"
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  }
-                ]
+                "type": "FIELD",
+                "name": "enum_fields",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "mp_enum_fields"
+                }
               },
               {
                 "type": "BLANK"
@@ -1282,38 +1251,93 @@
       }
     },
     "mp_enum_fields": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "match_pattern"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
             "type": "SEQ",
             "members": [
               {
                 "type": "FIELD",
-                "name": "symbol_comma",
+                "name": "symbol_open_paren",
                 "content": {
                   "type": "ALIAS",
                   "content": {
                     "type": "STRING",
-                    "value": ","
+                    "value": "("
                   },
                   "named": true,
                   "value": "symbol"
                 }
               },
               {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "match_pattern"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PREC_RIGHT",
+                      "value": 0,
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "FIELD",
+                            "name": "symbol_comma",
+                            "content": {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              "named": true,
+                              "value": "symbol"
+                            }
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "match_pattern"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              }
+            ]
+          },
+          {
+            "type": "PREC_RIGHT",
+            "value": 0,
+            "content": {
+              "type": "REPEAT1",
+              "content": {
                 "type": "SYMBOL",
                 "name": "match_pattern"
               }
-            ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "simple_expression": {
       "type": "CHOICE",
@@ -2792,43 +2816,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_open_paren",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": "("
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "enum_fields",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "enum_fields"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_close_paren",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ")"
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  }
-                ]
+                "type": "FIELD",
+                "name": "enum_fields",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "enum_fields"
+                }
               },
               {
                 "type": "BLANK"
@@ -2839,38 +2832,93 @@
       }
     },
     "enum_fields": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "expression"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
             "type": "SEQ",
             "members": [
               {
                 "type": "FIELD",
-                "name": "symbol_comma",
+                "name": "symbol_open_paren",
                 "content": {
                   "type": "ALIAS",
                   "content": {
                     "type": "STRING",
-                    "value": ","
+                    "value": "("
                   },
                   "named": true,
                   "value": "symbol"
                 }
               },
               {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PREC_RIGHT",
+                      "value": 0,
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "FIELD",
+                            "name": "symbol_comma",
+                            "content": {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              "named": true,
+                              "value": "symbol"
+                            }
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "expression"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              }
+            ]
+          },
+          {
+            "type": "PREC_RIGHT",
+            "value": 0,
+            "content": {
+              "type": "REPEAT1",
+              "content": {
                 "type": "SYMBOL",
                 "name": "expression"
               }
-            ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "if_expression": {
       "type": "PREC_RIGHT",
@@ -4053,43 +4101,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_open_paren",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": "("
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "enum_fields",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "pipe_enum_fields"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_close_paren",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ")"
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  }
-                ]
+                "type": "FIELD",
+                "name": "enum_fields",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "pipe_enum_fields"
+                }
               },
               {
                 "type": "BLANK"
@@ -4100,38 +4117,93 @@
       }
     },
     "pipe_enum_fields": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "expression"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
             "type": "SEQ",
             "members": [
               {
                 "type": "FIELD",
-                "name": "symbol_comma",
+                "name": "symbol_open_paren",
                 "content": {
                   "type": "ALIAS",
                   "content": {
                     "type": "STRING",
-                    "value": ","
+                    "value": "("
                   },
                   "named": true,
                   "value": "symbol"
                 }
               },
               {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PREC_RIGHT",
+                      "value": 0,
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "FIELD",
+                            "name": "symbol_comma",
+                            "content": {
+                              "type": "ALIAS",
+                              "content": {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              "named": true,
+                              "value": "symbol"
+                            }
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "expression"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              }
+            ]
+          },
+          {
+            "type": "PREC_RIGHT",
+            "value": 0,
+            "content": {
+              "type": "REPEAT1",
+              "content": {
                 "type": "SYMBOL",
                 "name": "expression"
               }
-            ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "pipe_expr": {
       "type": "CHOICE",
@@ -4879,6 +4951,10 @@
     [
       "module_identifier",
       "type_identifier"
+    ],
+    [
+      "mp_list_cons",
+      "mp_enum_fields"
     ]
   ],
   "precedences": [],

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -3993,53 +3993,6 @@
             }
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_open_angle",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": "<"
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "type_args",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "type_reference"
-                    }
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_close_angle",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ">"
-                      },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
             "type": "FIELD",
             "name": "args",
             "content": {
@@ -4850,10 +4803,10 @@
         },
         {
           "type": "FIELD",
-          "name": "args",
+          "name": "type_args_items",
           "content": {
             "type": "SYMBOL",
-            "name": "args"
+            "name": "type_args_items"
           }
         },
         {
@@ -4874,7 +4827,7 @@
         }
       ]
     },
-    "args": {
+    "type_args_items": {
       "type": "SEQ",
       "members": [
         {

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -3945,6 +3945,53 @@
             }
           },
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "symbol_open_angle",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": "<"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "type_args",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "type_reference"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "symbol_close_angle",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ">"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
             "type": "FIELD",
             "name": "args",
             "content": {
@@ -4107,31 +4154,6 @@
         }
       ]
     },
-    "pipe_expression": {
-      "type": "PREC",
-      "value": 10,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "expr",
-            "content": {
-              "type": "SYMBOL",
-              "name": "expression"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "pipe_exprs",
-            "content": {
-              "type": "SYMBOL",
-              "name": "pipe_exprs"
-            }
-          }
-        ]
-      }
-    },
     "pipe_exprs": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -4163,6 +4185,31 @@
             }
           ]
         }
+      }
+    },
+    "pipe_expression": {
+      "type": "PREC",
+      "value": 10,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "expr",
+            "content": {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "pipe_exprs",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipe_exprs"
+            }
+          }
+        ]
       }
     },
     "type_reference": {

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -1251,7 +1251,7 @@
       }
     },
     "mp_enum_fields": {
-      "type": "PREC_LEFT",
+      "type": "PREC_RIGHT",
       "value": 0,
       "content": {
         "type": "CHOICE",
@@ -1326,10 +1326,10 @@
             ]
           },
           {
-            "type": "PREC_RIGHT",
-            "value": 0,
+            "type": "REPEAT1",
             "content": {
-              "type": "REPEAT1",
+              "type": "PREC_RIGHT",
+              "value": 0,
               "content": {
                 "type": "SYMBOL",
                 "name": "match_pattern"
@@ -4904,10 +4904,6 @@
     [
       "module_identifier",
       "type_identifier"
-    ],
-    [
-      "mp_list_cons",
-      "mp_enum_fields"
     ]
   ],
   "precedences": [],

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -3383,17 +3383,8 @@
             "type": "FIELD",
             "name": "fn",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "qualified_fn_name"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "fn_identifier"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "qualified_fn_name"
             }
           },
           {
@@ -3490,68 +3481,16 @@
         }
       ]
     },
-    "pipe_variable_or_fn_call": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "variable_or_fn_name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "variable_or_fn_identifier"
-          }
-        }
-      ]
-    },
     "pipe_lambda": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "keyword_fun",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "fun"
-                },
-                "named": true,
-                "value": "keyword"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "pats",
-              "content": {
-                "type": "SYMBOL",
-                "name": "pipe_lambda_pats"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "symbol_arrow",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "->"
-                },
-                "named": true,
-                "value": "symbol"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "body",
-              "content": {
-                "type": "SYMBOL",
-                "name": "expression"
-              }
-            }
-          ]
+          "type": "FIELD",
+          "name": "pipe_lambda",
+          "content": {
+            "type": "SYMBOL",
+            "name": "lambda_expression"
+          }
         },
         {
           "type": "SEQ",
@@ -3571,44 +3510,10 @@
             },
             {
               "type": "FIELD",
-              "name": "keyword_fun",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "fun"
-                },
-                "named": true,
-                "value": "keyword"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "pats",
+              "name": "pipe_lambda",
               "content": {
                 "type": "SYMBOL",
-                "name": "pipe_lambda_pats"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "symbol_arrow",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "->"
-                },
-                "named": true,
-                "value": "symbol"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "body",
-              "content": {
-                "type": "SYMBOL",
-                "name": "expression"
+                "name": "lambda_expression"
               }
             },
             {
@@ -3627,17 +3532,6 @@
           ]
         }
       ]
-    },
-    "pipe_lambda_pats": {
-      "type": "FIELD",
-      "name": "pat",
-      "content": {
-        "type": "REPEAT1",
-        "content": {
-          "type": "SYMBOL",
-          "name": "let_pattern"
-        }
-      }
     },
     "pipe_infix": {
       "type": "CHOICE",
@@ -4195,10 +4089,6 @@
     "pipe_expr": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "SYMBOL",
-          "name": "pipe_variable_or_fn_call"
-        },
         {
           "type": "SYMBOL",
           "name": "pipe_lambda"
@@ -4914,10 +4804,6 @@
         "type": "PATTERN",
         "value": "[a-z_][a-zA-Z0-9_]*"
       }
-    },
-    "variable_or_fn_identifier": {
-      "type": "PATTERN",
-      "value": "[a-z_][a-zA-Z0-9_]*"
     },
     "type_identifier": {
       "type": "PATTERN",

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -1384,10 +1384,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "tuple_literal"
-        },
-        {
-          "type": "SYMBOL",
           "name": "dict_literal"
         },
         {
@@ -1417,6 +1413,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "tuple_literal"
+        },
+        {
+          "type": "SYMBOL",
           "name": "if_expression"
         },
         {
@@ -1442,6 +1442,10 @@
         {
           "type": "SYMBOL",
           "name": "lambda_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pipe_expression"
         },
         {
           "type": "SYMBOL",
@@ -3021,8 +3025,29 @@
             "type": "FIELD",
             "name": "expr",
             "content": {
-              "type": "SYMBOL",
-              "name": "expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "variable_identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "record_literal"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "paren_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "field_access"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "apply"
+                }
+              ]
             }
           },
           {
@@ -3358,8 +3383,17 @@
             "type": "FIELD",
             "name": "fn",
             "content": {
-              "type": "SYMBOL",
-              "name": "qualified_fn_name"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "qualified_fn_name"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "fn_identifier"
+                }
+              ]
             }
           },
           {
@@ -3455,6 +3489,791 @@
           }
         }
       ]
+    },
+    "pipe_variable_or_fn_call": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "variable_or_fn_name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_or_fn_identifier"
+          }
+        }
+      ]
+    },
+    "pipe_lambda": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "keyword_fun",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "fun"
+                },
+                "named": true,
+                "value": "keyword"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "pats",
+              "content": {
+                "type": "SYMBOL",
+                "name": "pipe_lambda_pats"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "symbol_arrow",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "->"
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "expression"
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "symbol_open_paren",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "("
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "keyword_fun",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "fun"
+                },
+                "named": true,
+                "value": "keyword"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "pats",
+              "content": {
+                "type": "SYMBOL",
+                "name": "pipe_lambda_pats"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "symbol_arrow",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "->"
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "expression"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "symbol_close_paren",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": ")"
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "pipe_lambda_pats": {
+      "type": "FIELD",
+      "name": "pat",
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "SYMBOL",
+          "name": "let_pattern"
+        }
+      }
+    },
+    "pipe_infix": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_open_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "^"
+                  },
+                  "named": true,
+                  "value": "operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_open_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "*"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "/"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "%"
+                      }
+                    ]
+                  },
+                  "named": true,
+                  "value": "operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_open_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "+"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "-"
+                      }
+                    ]
+                  },
+                  "named": true,
+                  "value": "operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_open_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "=="
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "!="
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "<"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "<="
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ">"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ">="
+                      }
+                    ]
+                  },
+                  "named": true,
+                  "value": "operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_open_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "&&"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "||"
+                      }
+                    ]
+                  },
+                  "named": true,
+                  "value": "operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_open_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "("
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": "++"
+                  },
+                  "named": true,
+                  "value": "operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol_close_paren",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ")"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "pipe_fn_call": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "fn",
+            "content": {
+              "type": "SYMBOL",
+              "name": "qualified_fn_name"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "args",
+            "content": {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "paren_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "simple_expression"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pipe_enum": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "type_name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "qualified_type_name"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "symbol_dot",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "."
+              },
+              "named": true,
+              "value": "symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "case_name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "enum_case_identifier"
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "symbol_open_paren",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": "("
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "pipe_enum_fields"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "symbol_close_paren",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ")"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "pipe_enum_fields": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_comma",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "expression"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "pipe_expr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "pipe_variable_or_fn_call"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pipe_lambda"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pipe_infix"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pipe_fn_call"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pipe_enum"
+        }
+      ]
+    },
+    "pipe_expression": {
+      "type": "PREC",
+      "value": 10,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "expr",
+            "content": {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "pipe_exprs",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipe_exprs"
+            }
+          }
+        ]
+      }
+    },
+    "pipe_exprs": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "REPEAT1",
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "symbol_pipe",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "|>"
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "pipe_expr",
+              "content": {
+                "type": "SYMBOL",
+                "name": "pipe_expr"
+              }
+            }
+          ]
+        }
+      }
     },
     "type_reference": {
       "type": "CHOICE",
@@ -4095,6 +4914,10 @@
         "type": "PATTERN",
         "value": "[a-z_][a-zA-Z0-9_]*"
       }
+    },
+    "variable_or_fn_identifier": {
+      "type": "PATTERN",
+      "value": "[a-z_][a-zA-Z0-9_]*"
     },
     "type_identifier": {
       "type": "PATTERN",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -40,32 +40,6 @@
     }
   },
   {
-    "type": "args",
-    "named": true,
-    "fields": {
-      "symbol_comma": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "type_reference",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "bool",
     "named": true,
     "fields": {}
@@ -2157,36 +2131,6 @@
             "named": true
           }
         ]
-      },
-      "symbol_close_angle": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
-      "symbol_open_angle": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
-      "type_args": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "type_reference",
-            "named": true
-          }
-        ]
       }
     }
   },
@@ -3001,16 +2945,6 @@
     "type": "type_args",
     "named": true,
     "fields": {
-      "args": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "args",
-            "named": true
-          }
-        ]
-      },
       "symbol_close_angle": {
         "multiple": false,
         "required": true,
@@ -3030,7 +2964,43 @@
             "named": true
           }
         ]
+      },
+      "type_args_items": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_args_items",
+            "named": true
+          }
+        ]
       }
+    }
+  },
+  {
+    "type": "type_args_items",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_reference",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -22,6 +22,10 @@
         "required": true,
         "types": [
           {
+            "type": "fn_identifier",
+            "named": true
+          },
+          {
             "type": "qualified_fn_name",
             "named": true
           }
@@ -600,11 +604,19 @@
           "named": true
         },
         {
+          "type": "pipe_expression",
+          "named": true
+        },
+        {
           "type": "record_update",
           "named": true
         },
         {
           "type": "simple_expression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
           "named": true
         }
       ]
@@ -619,7 +631,23 @@
         "required": true,
         "types": [
           {
-            "type": "expression",
+            "type": "apply",
+            "named": true
+          },
+          {
+            "type": "field_access",
+            "named": true
+          },
+          {
+            "type": "paren_expression",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "variable_identifier",
             "named": true
           }
         ]
@@ -1936,6 +1964,355 @@
     }
   },
   {
+    "type": "pipe_enum",
+    "named": true,
+    "fields": {
+      "case_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "enum_case_identifier",
+            "named": true
+          }
+        ]
+      },
+      "enum_fields": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "pipe_enum_fields",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_dot": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "type_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "qualified_type_name",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "pipe_enum_fields",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "pipe_expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "pipe_enum",
+          "named": true
+        },
+        {
+          "type": "pipe_fn_call",
+          "named": true
+        },
+        {
+          "type": "pipe_infix",
+          "named": true
+        },
+        {
+          "type": "pipe_lambda",
+          "named": true
+        },
+        {
+          "type": "pipe_variable_or_fn_call",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "pipe_expression",
+    "named": true,
+    "fields": {
+      "expr": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "pipe_exprs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "pipe_exprs",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "pipe_exprs",
+    "named": true,
+    "fields": {
+      "pipe_expr": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "pipe_expr",
+            "named": true
+          }
+        ]
+      },
+      "symbol_pipe": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "pipe_fn_call",
+    "named": true,
+    "fields": {
+      "args": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "paren_expression",
+            "named": true
+          },
+          {
+            "type": "simple_expression",
+            "named": true
+          }
+        ]
+      },
+      "fn": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "qualified_fn_name",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "pipe_infix",
+    "named": true,
+    "fields": {
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "operator",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_paren": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_paren": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "pipe_lambda",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      },
+      "keyword_fun": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "keyword",
+            "named": true
+          }
+        ]
+      },
+      "pats": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "pipe_lambda_pats",
+            "named": true
+          }
+        ]
+      },
+      "symbol_arrow": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "pipe_lambda_pats",
+    "named": true,
+    "fields": {
+      "pat": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "let_pattern",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "pipe_variable_or_fn_call",
+    "named": true,
+    "fields": {
+      "variable_or_fn_name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable_or_fn_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "qualified_fn_name",
     "named": true,
     "fields": {
@@ -2293,10 +2670,6 @@
         },
         {
           "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "tuple_literal",
           "named": true
         },
         {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -439,26 +439,6 @@
             "named": true
           }
         ]
-      },
-      "symbol_close_paren": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
-      "symbol_open_paren": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
       }
     }
   },
@@ -471,8 +451,28 @@
     "type": "enum_fields",
     "named": true,
     "fields": {
+      "symbol_close_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
       "symbol_comma": {
         "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_paren": {
+        "multiple": false,
         "required": false,
         "types": [
           {
@@ -517,29 +517,9 @@
           }
         ]
       },
-      "symbol_close_paren": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
       "symbol_dot": {
         "multiple": false,
         "required": true,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
-      "symbol_open_paren": {
-        "multiple": false,
-        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -1845,8 +1825,28 @@
     "type": "mp_enum_fields",
     "named": true,
     "fields": {
+      "symbol_close_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
       "symbol_comma": {
         "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_paren": {
+        "multiple": false,
         "required": false,
         "types": [
           {
@@ -1983,29 +1983,9 @@
           }
         ]
       },
-      "symbol_close_paren": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
       "symbol_dot": {
         "multiple": false,
         "required": true,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
-      "symbol_open_paren": {
-        "multiple": false,
-        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -2029,8 +2009,28 @@
     "type": "pipe_enum_fields",
     "named": true,
     "fields": {
+      "symbol_close_paren": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
       "symbol_comma": {
         "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_paren": {
+        "multiple": false,
         "required": false,
         "types": [
           {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -22,10 +22,6 @@
         "required": true,
         "types": [
           {
-            "type": "fn_identifier",
-            "named": true
-          },
-          {
             "type": "qualified_fn_name",
             "named": true
           }
@@ -2078,10 +2074,6 @@
         {
           "type": "pipe_lambda",
           "named": true
-        },
-        {
-          "type": "pipe_variable_or_fn_call",
-          "named": true
         }
       ]
     }
@@ -2218,42 +2210,12 @@
     "type": "pipe_lambda",
     "named": true,
     "fields": {
-      "body": {
+      "pipe_lambda": {
         "multiple": false,
         "required": true,
         "types": [
           {
-            "type": "expression",
-            "named": true
-          }
-        ]
-      },
-      "keyword_fun": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "keyword",
-            "named": true
-          }
-        ]
-      },
-      "pats": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "pipe_lambda_pats",
-            "named": true
-          }
-        ]
-      },
-      "symbol_arrow": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "symbol",
+            "type": "lambda_expression",
             "named": true
           }
         ]
@@ -2274,38 +2236,6 @@
         "types": [
           {
             "type": "symbol",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "pipe_lambda_pats",
-    "named": true,
-    "fields": {
-      "pat": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "let_pattern",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "pipe_variable_or_fn_call",
-    "named": true,
-    "fields": {
-      "variable_or_fn_name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "variable_or_fn_identifier",
             "named": true
           }
         ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -2157,6 +2157,36 @@
             "named": true
           }
         ]
+      },
+      "symbol_close_angle": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_angle": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "type_args": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_reference",
+            "named": true
+          }
+        ]
       }
     }
   },

--- a/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
@@ -48,7 +48,7 @@ Builtin.printLine (myFn ())
           (paren_expression
             (symbol)
             (expression
-              (apply (qualified_fn_name (fn_identifier))
+              (apply (fn_identifier)
                 (simple_expression (unit))))
             (symbol)
           )

--- a/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
@@ -48,7 +48,8 @@ Builtin.printLine (myFn ())
           (paren_expression
             (symbol)
             (expression
-              (apply (fn_identifier)
+              (apply
+                (qualified_fn_name (fn_identifier))
                 (simple_expression (unit))))
             (symbol)
           )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
@@ -21,23 +21,20 @@ MyEnum.NoArgs
 Enum - with one arg
 ==================
 
-MyEnum.OneArg(1L)
+MyEnum.OneArg 1L
 
 ---
 
 (source_file
   (expression
-    (simple_expression (enum_literal
-      (qualified_type_name
-        (type_identifier))
-      (symbol)
-      (enum_case_identifier)
-      (symbol)
-      (enum_fields
-        (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+    (simple_expression
+      (enum_literal
+        (qualified_type_name (type_identifier))
+        (symbol)
+        (enum_case_identifier)
+        (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
       )
-      (symbol)
-    ))
+    )
   )
 )
 
@@ -52,27 +49,50 @@ MyEnum.TwoArgs(1L, 2L)
 
 (source_file
   (expression
-    (simple_expression (enum_literal
-    (qualified_type_name
-      (type_identifier))
-    (symbol)
-    (enum_case_identifier)
-    (symbol)
-    (enum_fields
-      (expression
-        (simple_expression (int64_literal
-          (digits
-            (positive_digits))
-          (symbol))))
-      (symbol)
-      (expression
-        (simple_expression (int64_literal
-          (digits
-            (positive_digits))
-          (symbol)))))
-    (symbol)))
+    (simple_expression
+      (enum_literal
+        (qualified_type_name (type_identifier))
+        (symbol)
+        (enum_case_identifier)
+        (enum_fields
+          (expression
+            (tuple_literal
+              (symbol)
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (symbol)
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (symbol)
+            )
+          )
+        )
+      )
+    )
   )
 )
+
+
+==================
+Enum - with two args no parens
+==================
+
+MyEnum.TwoArgs 1L 2L
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (enum_literal
+        (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
+        (enum_fields
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+        )
+      )
+    )
+  )
+)
+
 
 
 ==================
@@ -104,27 +124,20 @@ Stdlib.Option.Option.None
 Enum - fully qualified with args
 ==================
 
-Stdlib.Option.Option.Some(1L)
+Stdlib.Option.Option.Some 1L
 
 ---
 
 (source_file
   (expression
-    (simple_expression (enum_literal
-      (qualified_type_name
-        (module_identifier)
+    (simple_expression
+      (enum_literal
+        (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
         (symbol)
-        (module_identifier)
-        (symbol)
-        (type_identifier)
+        (enum_case_identifier)
+        (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
       )
-      (symbol)
-      (enum_case_identifier)
-      (symbol)
-        (enum_fields
-          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-        )
-      (symbol)
-    ))
+    )
   )
 )
+

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
@@ -8,8 +8,7 @@ person.name
 
 (source_file
   (expression
-    (field_access
-      (expression (simple_expression (variable_identifier)))
+    (field_access (variable_identifier)
       (symbol)
       (variable_identifier)
     )
@@ -27,29 +26,27 @@ field access - paren defined Record
 (source_file
   (expression
    (field_access
+    (paren_expression
+      (symbol)
       (expression
-        (paren_expression
-          (symbol)
-          (expression
-            (simple_expression (record_literal
-              (qualified_type_name (type_identifier))
-              (symbol)
-              (record_content
-                (record_pair
-                  (variable_identifier)
-                  (symbol)
-                  (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
-                )
+        (simple_expression
+          (record_literal
+            (qualified_type_name (type_identifier))
+            (symbol)
+            (record_content
+              (record_pair
+                (variable_identifier)
+                (symbol)
+                (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
               )
-              (symbol)
-            ))
-          )
-          (symbol)
+            )
+            (symbol))
         )
       )
       (symbol)
-      (variable_identifier)
     )
+    (symbol)
+    (variable_identifier))
   )
 )
 
@@ -65,12 +62,9 @@ person.address.street
 (source_file
   (expression
     (field_access
-      (expression
-        (field_access
-          (expression (simple_expression (variable_identifier)))
-          (symbol)
-          (variable_identifier)
-        )
+      (field_access (variable_identifier)
+        (symbol)
+        (variable_identifier)
       )
       (symbol)
       (variable_identifier)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -436,7 +436,7 @@ Builtin.jsonParse<Bool> "true"
     (apply
       (qualified_fn_name
         (module_identifier) (symbol) (fn_identifier)
-        (type_args (symbol) (args (type_reference (builtin_type))) (symbol))
+        (type_args (symbol) (type_args_items (type_reference (builtin_type))) (symbol))
       )
       (simple_expression (string_literal (symbol) (string_content) (symbol)))
       (newline)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -314,7 +314,7 @@ Builtin.printLine (getTitle curiousGeorgeBookId)
       (paren_expression
         (symbol)
         (expression
-          (apply (fn_identifier) (simple_expression (variable_identifier))))
+          (apply (qualified_fn_name (fn_identifier)) (simple_expression (variable_identifier))))
         (symbol)
       )
       (newline)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -366,7 +366,7 @@ Builtin.printLine Person { name = "Alice" }
 function call - with an enum as argument
 ==================
 
-Builtin.printLine Stdlib.Option.Option.Some(1L)
+Builtin.printLine Stdlib.Option.Option.Some 1L
 
 ---
 
@@ -379,13 +379,11 @@ Builtin.printLine Stdlib.Option.Option.Some(1L)
           (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
           (symbol)
           (enum_case_identifier)
-          (symbol)
           (enum_fields
             (expression
               (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
             )
           )
-          (symbol)
         )
       )
       (newline)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -314,18 +314,16 @@ Builtin.printLine (getTitle curiousGeorgeBookId)
       (paren_expression
         (symbol)
         (expression
-          (apply (qualified_fn_name (fn_identifier)) (simple_expression (variable_identifier))))
+          (apply (fn_identifier) (simple_expression (variable_identifier))))
         (symbol)
       )
       (newline)
     )
   )
   (expression
-    (simple_expression
-      (int64_literal
-        (digits
-          (positive_digits))
-        (symbol)))))
+    (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+  )
+)
 
 
 ==================

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
@@ -407,7 +407,7 @@ if a > b then
         (if_expression
           (keyword)
           (expression (infix_operation (expression (simple_expression (variable_identifier))) (operator) (expression (simple_expression (variable_identifier))))) (keyword)
-          (ERROR (fn_identifier))
+          (ERROR (qualified_fn_name (fn_identifier)))
           (indent)
           (expression
             (simple_expression (variable_identifier)))

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
@@ -407,7 +407,7 @@ if a > b then
         (if_expression
           (keyword)
           (expression (infix_operation (expression (simple_expression (variable_identifier))) (operator) (expression (simple_expression (variable_identifier))))) (keyword)
-          (ERROR (qualified_fn_name (fn_identifier)))
+          (ERROR (fn_identifier))
           (indent)
           (expression
             (simple_expression (variable_identifier)))

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -223,13 +223,13 @@ match (5L, 6L) with
     (match_expression
       (keyword)
       (expression
-        (simple_expression (tuple_literal
+        (tuple_literal
           (symbol)
           (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
           (symbol)
           (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
           (symbol)
-        ))
+        )
       )
       (keyword)
       (match_case

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -256,9 +256,9 @@ match (5L, 6L) with
 match expression - test enum
 ==================
 
-match Stdlib.Result.Result.Ok(5L) with
-  | Ok(x) -> x
-  | Error(x) -> x
+match Stdlib.Result.Result.Ok 5L with
+  | Ok x -> x
+  | Error x -> x
 
 ---
 
@@ -267,32 +267,29 @@ match Stdlib.Result.Result.Ok(5L) with
     (match_expression
       (keyword)
       (expression
-        (simple_expression (enum_literal
-          (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier) (symbol) (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))) (symbol)
-        ))
+        (simple_expression
+          (enum_literal
+            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
+            (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
+          )
+        )
       )
       (keyword)
       (match_case
         (symbol)
-        (match_pattern
-          (enum (enum_case_identifier) (symbol) (mp_enum_fields (match_pattern (variable))) (symbol))
-        )
-        (symbol) (expression (simple_expression (variable_identifier))))
+        (match_pattern (enum (enum_case_identifier) (mp_enum_fields (match_pattern (variable)))))
+        (symbol)
+        (expression (simple_expression (variable_identifier))))
       (match_case
         (symbol)
-        (match_pattern
-          (enum
-            (enum_case_identifier)
-            (symbol)
-            (mp_enum_fields (match_pattern (variable)))
-            (symbol)
-          )
-        )
-        (symbol) (expression (simple_expression (variable_identifier)))
+        (match_pattern (enum (enum_case_identifier) (mp_enum_fields (match_pattern (variable)))))
+        (symbol)
+        (expression (simple_expression (variable_identifier)))
       )
     )
   )
 )
+
 
 
 ==================

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -1,0 +1,333 @@
+==================
+pipe expression - function call
+==================
+
+1L |> Stdlib.Int64.toString
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_fn_call
+            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - function call with arguments
+==================
+
+1L |> Stdlib.Int64.add 2L
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_fn_call
+            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+            (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - variable
+==================
+
+5L |> x
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs (symbol) (pipe_expr (pipe_variable_or_fn_call (variable_or_fn_identifier))))
+    )
+  )
+)
+
+
+==================
+pipe expression - let pattern + variable
+==================
+
+let fn = (fun x -> x + 1L)
+1L |> fn
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword) (variable_identifier) (symbol)
+      (expression
+        (paren_expression
+          (symbol)
+          (expression
+            (lambda_expression
+              (keyword)
+              (lambda_pats (let_pattern (variable_identifier)))
+              (symbol)
+              (expression
+                (infix_operation
+                  (expression (simple_expression (variable_identifier)))
+                  (operator)
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                )
+              )
+            )
+          )
+          (symbol)
+        )
+      )
+      (expression
+        (pipe_expression
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          (pipe_exprs (symbol) (pipe_expr (pipe_variable_or_fn_call (variable_or_fn_identifier))))
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - infix
+==================
+
+1L |> (+) 2L
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_infix
+            (symbol) (operator) (symbol)
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - enum
+==================
+
+3L |> Stdlib.Result.Result.Ok
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_enum
+            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - enum with two fields
+==================
+
+33L |> MyEnum.A(21L)
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_enum
+            (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
+            (symbol) (pipe_enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))) (symbol)
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - lambda without parens
+==================
+
+1L |> fun x -> x + 1L
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_lambda
+            (keyword)
+            (pipe_lambda_pats (let_pattern (variable_identifier)))
+            (symbol)
+            (expression
+              (infix_operation
+                (expression (simple_expression (variable_identifier)))
+                (operator)
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - lambda with parens
+==================
+
+1L |> (fun x -> x + 1L)
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression
+        (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+      )
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_lambda
+            (symbol)
+              (keyword)
+              (pipe_lambda_pats (let_pattern (variable_identifier)))
+              (symbol)
+              (expression
+                (infix_operation
+                  (expression (simple_expression (variable_identifier)))
+                  (operator)
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                )
+              )
+            (symbol)
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - pipe a function call into another function call
+==================
+
+Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression
+        (apply
+          (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+        )
+      )
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_fn_call
+            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+            (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - multiple pipe expressions
+==================
+
+[1L; 2L]
+|> Stdlib.List.last
+|> Builtin.unwrap
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression
+        (simple_expression
+          (list_literal
+            (symbol)
+            (list_content
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (symbol)
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            )
+            (symbol)
+          )
+        )
+      )
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier)))
+        )
+        (symbol)
+        (pipe_expr
+          (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (fn_identifier)))
+        )
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -61,7 +61,7 @@ pipe expression - variable
   (expression
     (pipe_expression
       (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-      (pipe_exprs (symbol) (pipe_expr (pipe_variable_or_fn_call (variable_or_fn_identifier))))
+      (pipe_exprs (symbol) (pipe_expr (pipe_fn_call (qualified_fn_name (fn_identifier)))))
     )
   )
 )
@@ -103,7 +103,7 @@ let fn = (fun x -> x + 1L)
       (expression
         (pipe_expression
           (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-          (pipe_exprs (symbol) (pipe_expr (pipe_variable_or_fn_call (variable_or_fn_identifier))))
+          (pipe_exprs (symbol) (pipe_expr (pipe_fn_call (qualified_fn_name (fn_identifier)))))
         )
       )
     )
@@ -204,14 +204,16 @@ pipe expression - lambda without parens
         (symbol)
         (pipe_expr
           (pipe_lambda
-            (keyword)
-            (pipe_lambda_pats (let_pattern (variable_identifier)))
-            (symbol)
-            (expression
-              (infix_operation
-                (expression (simple_expression (variable_identifier)))
-                (operator)
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (lambda_expression
+              (keyword)
+              (lambda_pats (let_pattern (variable_identifier)))
+              (symbol)
+              (expression
+                (infix_operation
+                  (expression (simple_expression (variable_identifier)))
+                  (operator)
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                )
               )
             )
           )
@@ -241,14 +243,16 @@ pipe expression - lambda with parens
         (pipe_expr
           (pipe_lambda
             (symbol)
-              (keyword)
-              (pipe_lambda_pats (let_pattern (variable_identifier)))
-              (symbol)
-              (expression
-                (infix_operation
-                  (expression (simple_expression (variable_identifier)))
-                  (operator)
-                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (lambda_expression
+                (keyword)
+                (lambda_pats (let_pattern (variable_identifier)))
+                (symbol)
+                (expression
+                  (infix_operation
+                    (expression (simple_expression (variable_identifier)))
+                    (operator)
+                    (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  )
                 )
               )
             (symbol)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -50,6 +50,32 @@ pipe expression - function call with arguments
 
 
 ==================
+pipe expression - function call with type arguments
+==================
+
+"true" |> Builtin.jsonParse<Bool>
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_fn_call
+            (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+            (symbol) (type_reference (builtin_type)) (symbol)
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
 pipe expression - variable
 ==================
 

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -65,8 +65,12 @@ pipe expression - function call with type arguments
         (symbol)
         (pipe_expr
           (pipe_fn_call
-            (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-            (symbol) (type_reference (builtin_type)) (symbol)
+            (qualified_fn_name
+              (module_identifier)
+              (symbol)
+              (fn_identifier)
+              (type_args (symbol) (type_args_items (type_reference (builtin_type))) (symbol))
+            )
           )
         )
       )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -192,7 +192,7 @@ pipe expression - enum
 pipe expression - enum with two fields
 ==================
 
-33L |> MyEnum.A(21L)
+33L |> MyEnum.A 21L
 
 ---
 
@@ -205,7 +205,36 @@ pipe expression - enum with two fields
         (pipe_expr
           (pipe_enum
             (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
-            (symbol) (pipe_enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))) (symbol)
+            (pipe_enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+pipe expression - enum with three fields
+==================
+
+33L |> MyEnum.B 21L 12L
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_enum
+            (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
+            (pipe_enum_fields
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            )
           )
         )
       )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/tuple.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/tuple.txt
@@ -8,7 +8,7 @@ tuple two
 
 (source_file
   (expression
-    (simple_expression (tuple_literal
+    (tuple_literal
       (symbol)
       (expression
         (simple_expression (string_literal
@@ -21,7 +21,7 @@ tuple two
           (digits
             (positive_digits))
           (symbol))))
-      (symbol)))))
+      (symbol))))
 
 
 ==================
@@ -34,7 +34,7 @@ tuple three
 
 (source_file
   (expression
-    (simple_expression (tuple_literal
+    (tuple_literal
       (symbol)
       (expression
         (simple_expression (string_literal
@@ -51,7 +51,7 @@ tuple three
         (symbol)
         (expression
           (simple_expression (float_literal))))
-      (symbol)))))
+      (symbol))))
 
 
 ==================
@@ -64,7 +64,7 @@ tuple four
 
 (source_file
   (expression
-    (simple_expression (tuple_literal
+    (tuple_literal
       (symbol)
       (expression
         (simple_expression (string_literal
@@ -84,4 +84,4 @@ tuple four
             (symbol)
             (expression
               (simple_expression (bool_literal))))
-      (symbol)))))
+      (symbol))))

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
@@ -384,7 +384,7 @@ type GenericDB = DB<Generic<String>>
             (db_type_reference
               (keyword)
               (symbol)
-              (type_reference (qualified_type_name (type_identifier) (type_args (symbol) (args (type_reference (builtin_type))) (symbol))))
+              (type_reference (qualified_type_name (type_identifier) (type_args (symbol) (type_args_items (type_reference (builtin_type))) (symbol))))
               (symbol)
             )
           )


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support pipe expression
```
#5321 