### PR TITLE
Tree-sitter grammar: support variable type reference

### DIFF
--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -233,9 +233,13 @@ module TextToTextRoundtripping =
     ("type MyChar = Char" |> roundtripCliScript) = "type MyChar =\n  Char"
     ("type MyString = String" |> roundtripCliScript) = "type MyString =\n  String"
 
+    ("type MyDateTime = DateTime" |> roundtripCliScript) = "type MyDateTime =\n  DateTime"
+    ("type MyUuid = Uuid" |> roundtripCliScript) = "type MyUuid =\n  Uuid"
+
     ("type MyList = List<String>" |> roundtripCliScript) = "type MyList =\n  List<String>"
     ("type MyList = List<List<String>>" |> roundtripCliScript) = "type MyList =\n  List<List<String>>"
     ("type MyList = List<MyString>" |> roundtripCliScript) = "type MyList =\n  List<MyString>"
+    ("type MyList = List<'a>" |> roundtripCliScript) = "type MyList =\n  List<'a>"
 
     ("type MyDict = Dict<Int64>" |> roundtripCliScript) = "type MyDict =\n  Dict<Int64>"
     ("type MyDict = Dict<MyList>" |> roundtripCliScript) = "type MyDict =\n  Dict<MyList>"
@@ -243,6 +247,9 @@ module TextToTextRoundtripping =
     ("type MyTuple2 = (String * Int64)" |> roundtripCliScript) = "type MyTuple2 =\n  (String * Int64)"
     ("type MyTuple3 = (String * Int64 * Bool)" |> roundtripCliScript) = "type MyTuple3 =\n  (String * Int64 * Bool)"
     ("type MyTuple = (String * Int64 * Bool * Unit)" |> roundtripCliScript) = "type MyTuple =\n  (String * Int64 * Bool * Unit)"
+
+    ("type MyVar = 'a" |> roundtripCliScript) = "type MyVar =\n  'a"
+
     // single-part qualified name
     ("type ID = Test" |> roundtripCliScript) = "type ID =\n  Test"
 

--- a/packages/darklang/languageTools/parser/typeReference.dark
+++ b/packages/darklang/languageTools/parser/typeReference.dark
@@ -29,6 +29,8 @@ module Darklang =
             | "Float" -> (TBuiltin.TFloat node.range) |> builtin
             | "Char" -> (TBuiltin.TChar node.range) |> builtin
             | "String" -> (TBuiltin.TString node.range) |> builtin
+            | "DateTime" -> (TBuiltin.TDateTime node.range) |> builtin
+            | "Uuid" -> (TBuiltin.TUuid node.range) |> builtin
 
             | _ ->
               let firstChild = node.children |> Stdlib.List.head |> Builtin.unwrap
@@ -128,6 +130,15 @@ module Darklang =
                     closeBracket.range)
                   |> builtin
 
+                | _ -> createUnparseableError node
+
+              | "variable_type_reference" ->
+                let variableName = findField firstChild "variable"
+
+                match variableName with
+                | Ok variableName ->
+                  (TBuiltin.TVariable variableName.range variableName.text)
+                  |> builtin
                 | _ -> createUnparseableError node
           else
             createUnparseableError node

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -154,7 +154,7 @@ module Darklang =
                 [ makeToken rc TokenType.Symbol ] ]
               |> Stdlib.List.flatten
 
-            | TVariable (r, _) -> [ makeToken r TokenType.TypeName ]
+            | TVariable(r, _) -> [ makeToken r TokenType.TypeName ]
 
         let tokenize
           (t: WrittenTypes.TypeReference.TypeReference)

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -116,6 +116,8 @@ module Darklang =
             | TFloat r -> [ makeToken r TokenType.TypeName ]
             | TChar r -> [ makeToken r TokenType.TypeName ]
             | TString r -> [ makeToken r TokenType.TypeName ]
+            | TUuid r -> [ makeToken r TokenType.TypeName ]
+            | TDateTime r -> [ makeToken r TokenType.TypeName ]
             | TList(r, rk, ro, t, rc) ->
               Stdlib.List.flatten (
                 [ [ makeToken r TokenType.TypeName ]
@@ -152,6 +154,7 @@ module Darklang =
                 [ makeToken rc TokenType.Symbol ] ]
               |> Stdlib.List.flatten
 
+            | TVariable (r, _) -> [ makeToken r TokenType.TypeName ]
 
         let tokenize
           (t: WrittenTypes.TypeReference.TypeReference)

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -52,6 +52,8 @@ module Darklang =
           | TFloat of Range
           | TChar of Range
           | TString of Range
+          | TDateTime of Range
+          | TUuid of Range
 
           | TList of
             Range *
@@ -59,13 +61,6 @@ module Darklang =
             openBracket: Range *
             typ: TypeReference.TypeReference *
             closeBracket: Range
-
-          | TDict of
-            Range *
-            keywordDict: Range *
-            openBrace: Range *
-            typ: TypeReference.TypeReference *
-            closeBrace: Range
 
           | TTuple of
             Range *
@@ -76,8 +71,14 @@ module Darklang =
             openParen: Range *
             closeParen: Range
 
-          | TDateTime of Range
-          | TUuid of Range
+          | TDict of
+            Range *
+            keywordDict: Range *
+            openBrace: Range *
+            typ: TypeReference.TypeReference *
+            closeBrace: Range
+
+          | TVariable of Range * String
 
 
         type TypeReference =

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -70,14 +70,12 @@ module Darklang =
             | TFloat _range -> ProgramTypes.TypeReference.TFloat
             | TChar _range -> ProgramTypes.TypeReference.TChar
             | TString _range -> ProgramTypes.TypeReference.TString
+            | TDateTime _range -> ProgramTypes.TypeReference.TDateTime
+            | TUuid _range -> ProgramTypes.TypeReference.TUuid
+
             | TList(_range, _, _, typ, _) ->
               let typ = TypeReference.toPT onMissing typ
               ProgramTypes.TypeReference.TList(typ)
-
-            | TDict(_range, _, _, valueType, _) ->
-              let valueType = TypeReference.toPT onMissing valueType
-
-              ProgramTypes.TypeReference.TDict valueType
 
             | TTuple(_range, firstType, _, secondType, restTypes, _, _) ->
               let firstType = TypeReference.toPT onMissing firstType
@@ -89,9 +87,13 @@ module Darklang =
 
               ProgramTypes.TypeReference.TTuple(firstType, secondType, restTypes)
 
-            | TDateTime _range -> ProgramTypes.TypeReference.TDateTime
-            | TUuid _range -> ProgramTypes.TypeReference.TUuid
+            | TDict(_range, _, _, valueType, _) ->
+              let valueType = TypeReference.toPT onMissing valueType
 
+              ProgramTypes.TypeReference.TDict valueType
+
+
+            | TVariable(_range, name) -> ProgramTypes.TypeReference.TVariable name
 
         let toPT
           (onMissing: NameResolver.OnMissing)

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -806,10 +806,12 @@ module.exports = grammar({
         /Float/,
         /Char/,
         /String/,
+        /DateTime/,
+        /Uuid/,
         $.list_type_reference,
         $.tuple_type_reference,
         $.dict_type_reference,
-        /DateTime/,
+        $.variable_type_reference,
         /Uuid/,
       ),
 
@@ -851,6 +853,15 @@ module.exports = grammar({
         field("symbol_open_angle", alias("<", $.symbol)),
         field("value_type", $.type_reference),
         field("symbol_close_angle", alias(">", $.symbol)),
+      ),
+
+    //
+    // Variable type reference
+    // 'a
+    variable_type_reference: $ =>
+      seq(
+        field("symbol_single_quote", alias("'", $.symbol)),
+        field("variable", $.variable_identifier),
       ),
 
     // ---------------------

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -812,7 +812,6 @@ module.exports = grammar({
         $.tuple_type_reference,
         $.dict_type_reference,
         $.variable_type_reference,
-        /Uuid/,
       ),
 
     //

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -3434,8 +3434,8 @@
           "name": "dict_type_reference"
         },
         {
-          "type": "PATTERN",
-          "value": "DateTime"
+          "type": "SYMBOL",
+          "name": "variable_type_reference"
         },
         {
           "type": "PATTERN",
@@ -3648,6 +3648,32 @@
             },
             "named": true,
             "value": "symbol"
+          }
+        }
+      ]
+    },
+    "variable_type_reference": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_single_quote",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "'"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "variable",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_identifier"
           }
         }
       ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -68,6 +68,10 @@
         {
           "type": "tuple_type_reference",
           "named": true
+        },
+        {
+          "type": "variable_type_reference",
+          "named": true
         }
       ]
     }
@@ -3181,6 +3185,32 @@
     "type": "variable_identifier",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "variable_type_reference",
+    "named": true,
+    "fields": {
+      "symbol_single_quote": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "variable": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "variable_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "\n",

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
@@ -22,6 +22,8 @@ type MyTuple2 = (Int64 * String)
 type MyTuple3 = (Int64 * String * Bool)
 type MyTuple = (Int64 * String * Bool * Float * Char * Unit)
 type MyDict = Dict<Int64>
+type MyDateTime = DateTime
+type MyUUID = Uuid
 
 ---
 
@@ -42,6 +44,7 @@ type MyDict = Dict<Int64>
   (type_decl (keyword) (type_identifier) (symbol) (type_decl_def (type_decl_def_alias (type_reference (builtin_type)))))
   (type_decl (keyword) (type_identifier) (symbol) (type_decl_def (type_decl_def_alias (type_reference (builtin_type)))))
   (type_decl (keyword) (type_identifier) (symbol) (type_decl_def (type_decl_def_alias (type_reference (builtin_type (list_type_reference (keyword) (symbol) (type_reference (builtin_type)) (symbol)))))))
+  (type_decl (keyword) (type_identifier) (symbol) (type_decl_def (type_decl_def_alias (type_reference (builtin_type (tuple_type_reference (symbol) (type_reference (builtin_type)) (symbol) (type_reference (builtin_type)) (symbol)))))))
   (type_decl
     (keyword)
     (type_identifier)
@@ -52,11 +55,10 @@ type MyDict = Dict<Int64>
           (builtin_type
             (tuple_type_reference
               (symbol)
-              (type_reference
-                (builtin_type))
+              (type_reference (builtin_type))
               (symbol)
-              (type_reference
-                (builtin_type))
+              (type_reference (builtin_type))
+              (type_reference_tuple_the_rest (symbol) (type_reference (builtin_type)))
               (symbol)))))))
   (type_decl
     (keyword)
@@ -68,46 +70,22 @@ type MyDict = Dict<Int64>
           (builtin_type
             (tuple_type_reference
               (symbol)
-              (type_reference
-                (builtin_type))
+              (type_reference (builtin_type))
               (symbol)
-              (type_reference
-                (builtin_type))
+              (type_reference (builtin_type))
               (type_reference_tuple_the_rest
                 (symbol)
-                (type_reference
-                  (builtin_type)))
-              (symbol)))))))
-  (type_decl
-    (keyword)
-    (type_identifier)
-    (symbol)
-    (type_decl_def
-      (type_decl_def_alias
-        (type_reference
-          (builtin_type
-            (tuple_type_reference
-              (symbol)
-              (type_reference
-                (builtin_type))
-              (symbol)
-              (type_reference
-                (builtin_type))
-              (type_reference_tuple_the_rest
+                (type_reference (builtin_type))
                 (symbol)
-                (type_reference
-                  (builtin_type))
+                (type_reference (builtin_type))
                 (symbol)
-                (type_reference
-                  (builtin_type))
+                (type_reference (builtin_type))
                 (symbol)
-                (type_reference
-                  (builtin_type))
-                (symbol)
-                (type_reference
-                  (builtin_type)))
+                (type_reference (builtin_type)))
               (symbol)))))))
   (type_decl (keyword) (type_identifier) (symbol) (type_decl_def (type_decl_def_alias (type_reference (builtin_type (dict_type_reference (keyword) (symbol) (type_reference (builtin_type)) (symbol)))))))
+  (type_decl (keyword) (type_identifier) (symbol) (type_decl_def (type_decl_def_alias (type_reference (builtin_type)))))
+  (type_decl (keyword) (type_identifier) (symbol) (type_decl_def (type_decl_def_alias (type_reference (builtin_type)))))
 )
 
 
@@ -159,6 +137,28 @@ type ID = PACKAGE.Darklang.Stdlib.Option.Option
             (type_identifier)
           )
         )
+      )
+    )
+  )
+)
+
+
+==================
+type reference - variable
+==================
+
+type MyVar = 'a
+
+---
+
+(source_file
+  (type_decl
+    (keyword)
+    (type_identifier)
+    (symbol)
+    (type_decl_def
+      (type_decl_def_alias
+        (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
       )
     )
   )


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support variable type reference
```

This also updates the parser to handle TUuid and TDateTime