### PR TITLE
Tree-sitter grammar: support DB type reference

### DIFF
--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -119,6 +119,7 @@ module ParseNodeToWrittenTypes =
                       PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeIdentifier
                         { range = range (0L, 5L) (0L, 9L)
                           name = "MyID" }
+                    typeParams = []
                     definition =
                       PACKAGE
                         .Darklang
@@ -260,6 +261,8 @@ module TextToTextRoundtripping =
 
     ("type MyDB = DB<'a>" |> roundtripCliScript) = "type MyDB =\n  DB<'a>"
     ("type MyDB = DB<Person>" |> roundtripCliScript) = "type MyDB =\n  DB<Person>"
+    ("type MyDB<'a> = DB<'a>" |> roundtripCliScript) = "type MyDB<'a> =\n  DB<'a>"
+    ("type GenericDB = DB<Generic<String>>" |> roundtripCliScript) = "type GenericDB =\n  DB<Generic<String>>"
 
     ("type MyVar = 'a" |> roundtripCliScript) = "type MyVar =\n  'a"
 
@@ -269,11 +272,15 @@ module TextToTextRoundtripping =
     // fully-qualified package name (multi-part)
     ("type MyOption = PACKAGE.Darklang.Stdlib.Option.Option" |> roundtripCliScript) = "type MyOption =\n  PACKAGE.Darklang.Stdlib.Option.Option"
     ("type MyOption = Stdlib.Option.Option" |> roundtripCliScript) = "type MyOption =\n  PACKAGE.Darklang.Stdlib.Option.Option"
+    ("type MyOption = Stdlib.Option.Option<Int64>" |> roundtripCliScript) = "type MyOption =\n  PACKAGE.Darklang.Stdlib.Option.Option<Int64>"
 
 
   module TypeDeclaration =
     ("type SimpleAlias = Unit" |> roundtripCliScript) = "type SimpleAlias =\n  Unit"
-
+    // with type params
+    ("type MyType<'a> = List<'a>" |> roundtripCliScript) = "type MyType<'a> =\n  List<'a>"
+    ("type MyType<'a, 'b> = (List<'a> * List<'b>)" |> roundtripCliScript) = "type MyType<'a, 'b> =\n  (List<'a> * List<'b>)"
+    ("type Generic<'a> = { x: 'a }" |> roundtripCliScript) = "type Generic<'a> =\n  { x: 'a }"
     // // Enum type TODO
     // ("type Thing = | A | B of Int64 | C of String * Bool" |> roundtripCliScript) = "type Thing =\n  | A\n  | B of Int64\n  | C of String * Bool"
 

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -610,6 +610,9 @@ else
     // with type params
     ("let myFn<'a> (param: 'a): Unit  = ()" |> roundtripCliScript) = "let myFn<'a> (param: 'a): Unit =\n  ()"
 
+    ("let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit  = ()"
+     |> roundtripCliScript) = "let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit =\n  ()"
+
 
   module FnCalls =
     //package function call

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -258,6 +258,9 @@ module TextToTextRoundtripping =
     ("type MyFn = PACKAGE.Darklang.LanguageTools.ID -> 'a -> 'b"
      |> roundtripCliScript) = "type MyFn =\n  PACKAGE.Darklang.LanguageTools.ID -> 'a -> 'b"
 
+    ("type MyDB = DB<'a>" |> roundtripCliScript) = "type MyDB =\n  DB<'a>"
+    ("type MyDB = DB<Person>" |> roundtripCliScript) = "type MyDB =\n  DB<Person>"
+
     ("type MyVar = 'a" |> roundtripCliScript) = "type MyVar =\n  'a"
 
     // single-part qualified name

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -281,9 +281,9 @@ module TextToTextRoundtripping =
     ("type MyType<'a> = List<'a>" |> roundtripCliScript) = "type MyType<'a> =\n  List<'a>"
     ("type MyType<'a, 'b> = (List<'a> * List<'b>)" |> roundtripCliScript) = "type MyType<'a, 'b> =\n  (List<'a> * List<'b>)"
     ("type Generic<'a> = { x: 'a }" |> roundtripCliScript) = "type Generic<'a> =\n  { x: 'a }"
+
     // // Enum type TODO
     // ("type Thing = | A | B of Int64 | C of String * Bool" |> roundtripCliScript) = "type Thing =\n  | A\n  | B of Int64\n  | C of String * Bool"
-
 
     // record type
     ("type Person = {name: String}" |> roundtripCliScript) = "type Person =\n  { name: String }"
@@ -590,6 +590,7 @@ else
     ("PACKAGE.Darklang.Stdlib.Bool.and true false" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Bool.and true false"
     ("Stdlib.Bool.and true false" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.Bool.and true false"
     ("Builtin.int64Add 1L 2L" |> roundtripCliScript) = "Builtin.int64Add 1L 2L"
+    ("Builtin.jsonParse<Bool> \"true\"" |> roundtripCliScript) = "Builtin.jsonParse<Bool> \"true\""
 
   module FunctionDeclaration =
     // single 'normal' param
@@ -606,6 +607,8 @@ else
     ("let isHigher (a: Int64) (b: Int64) : Bool = Stdlib.Int64.greaterThan a b"
      |> roundtripCliScript) = "let isHigher (a: Int64) (b: Int64): Bool =\n  PACKAGE.Darklang.Stdlib.Int64.greaterThan a b"
 
+    // with type params
+    ("let myFn<'a> (param: 'a): Unit  = ()" |> roundtripCliScript) = "let myFn<'a> (param: 'a): Unit =\n  ()"
 
 
   module FnCalls =

--- a/packages/darklang/languageTools/lsp-server/semanticTokens.dark
+++ b/packages/darklang/languageTools/lsp-server/semanticTokens.dark
@@ -27,7 +27,8 @@ module Darklang =
             "variable" // [8] for general identifiers
             "function" // [9] for function names/identifiers
             "property" // [10] for field names
-            "enumMember" ] // [11] for enum case names
+            "enumMember" // [11] for enum case names
+            "typeParameter" ] // [12] for type parameter names
 
         let tokenModifiers = []
 
@@ -55,6 +56,7 @@ module Darklang =
 
             | Property -> 10UL
             | EnumMember -> 11UL
+            | TypeParameter -> 12UL
 
           let toRelativeTokens
             (tokens: List<LanguageTools.SemanticTokens.SemanticToken>)

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -918,9 +918,10 @@ module Darklang =
 
             match fnNameNode, args with
             | Ok fnName, Ok args ->
+              let typeArgs = fnName.typeArgs
               let fnName = WrittenTypes.Expr.EFnName(node.range, fnName)
 
-              (WrittenTypes.Expr.EApply(node.range, fnName, [], args))
+              (WrittenTypes.Expr.EApply(node.range, fnName, typeArgs, args))
               |> Stdlib.Result.Result.Ok
 
             | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/parser/functionDeclaration.dark
+++ b/packages/darklang/languageTools/parser/functionDeclaration.dark
@@ -81,6 +81,39 @@ module Darklang =
               findAndParseRequired node "name" (fun node ->
                 (Identifiers.parseFn node) |> Stdlib.Result.Result.Ok)
 
+            let typeParams =
+              match findNodeByFieldName node "type_params" with
+              | Some typeParamsNode ->
+                typeParamsNode
+                |> findNodeByFieldName "params"
+                |> Stdlib.Option.map (fun node ->
+                  node.children
+                  |> Stdlib.List.chunkBySize 2L
+                  |> Builtin.unwrap
+                  |> Stdlib.List.map (fun chunk ->
+                    match chunk with
+                    | [ typeParamNode ] ->
+                      let name =
+                        typeParamNode |> findField "variable" |> Builtin.unwrap
+
+                      (typeParamNode.range, name.text) |> Stdlib.Result.Result.Ok
+
+                    | [ typeParamNode; _separator ] ->
+                      let name =
+                        typeParamNode |> findField "variable" |> Builtin.unwrap
+
+                      (typeParamNode.range, name.text) |> Stdlib.Result.Result.Ok
+
+                    | _ ->
+                      (createUnparseableError chunk) |> Stdlib.Result.Result.Error))
+
+              | None -> Stdlib.Option.Option.None
+
+            let typeParams =
+              match typeParams with
+              | Some typeParams -> typeParams |> Stdlib.Result.collect
+              | None -> [] |> Stdlib.Result.Result.Ok
+
             let paramsNode =
               findAndParseRequired node "params" FunctionDeclaration.parseParams
 
@@ -94,6 +127,7 @@ module Darklang =
 
             match
               nameNode,
+              typeParams,
               paramsNode,
               returnTypeNode,
               bodyNode,
@@ -101,10 +135,18 @@ module Darklang =
               symColonNode,
               symEqualsNode
             with
-            | Ok name, Ok params, Ok rt, Ok body, Ok keywordLet, Ok colon, Ok equals ->
+            | Ok name,
+              Ok typeParams,
+              Ok params,
+              Ok rt,
+              Ok body,
+              Ok keywordLet,
+              Ok colon,
+              Ok equals ->
               (WrittenTypes.FnDeclaration.FnDeclaration
                 { range = node.range
                   name = name
+                  typeParams = typeParams
                   parameters = params
                   returnType = rt
                   body = body

--- a/packages/darklang/languageTools/parser/identifiers.dark
+++ b/packages/darklang/languageTools/parser/identifiers.dark
@@ -55,30 +55,30 @@ module Darklang =
           : Stdlib.Result.Result<WrittenTypes.QualifiedTypeIdentifier, String> =
           if node.typ == "qualified_type_name" then
             let filteredChildren =
-              node.children
-              |> Stdlib.List.filter (fun n ->
-                n.typ != "type_args"
-                && n.fieldName != Stdlib.Option.Option.Some "symbol_open_angle"
-                && n.fieldName != Stdlib.Option.Option.Some "symbol_close_angle")
+              node.children |> Stdlib.List.filter (fun n -> n.typ != "type_args")
 
             let (modules, typeIdentifierNode) =
               extractModuleIdentifiers filteredChildren
 
-            let typeArgsNodes =
-              node
-              |> findNodeByFieldName "type_args"
-              |> Stdlib.Option.map (fun typeArgsNode ->
-                typeArgsNode.children
-                |> Stdlib.List.chunkBySize 2L
-                |> Builtin.unwrap
-                |> Stdlib.List.map (fun chunk ->
-                  match chunk with
-                  | [ typeArg; _ ] -> TypeReference.parse typeArg
-                  | [ typeArg ] -> TypeReference.parse typeArg
-                  | _ -> createUnparseableError chunk))
+            let args =
+              match findNodeByFieldName node "type_args" with
+              | Some typeArgs ->
+                typeArgs
+                |> findNodeByFieldName "args"
+                |> Stdlib.Option.map (fun typeArgsNode ->
+                  typeArgsNode.children
+                  |> Stdlib.List.chunkBySize 2L
+                  |> Builtin.unwrap
+                  |> Stdlib.List.map (fun chunk ->
+                    match chunk with
+                    | [ typeArg; _ ] -> TypeReference.parse typeArg
+                    | [ typeArg ] -> TypeReference.parse typeArg
+                    | _ -> createUnparseableError chunk))
+
+              | None -> Stdlib.Option.Option.None
 
             let typeArgs =
-              match typeArgsNodes with
+              match args with
               | Some typeArgs -> typeArgs |> Stdlib.Result.collect
               | None -> [] |> Stdlib.Result.Result.Ok
 
@@ -91,6 +91,7 @@ module Darklang =
                   typeArgs = typeArgs })
               |> Stdlib.Result.Result.Ok
             | Error _ -> createUnparseableError node
+
           else
             Stdlib.Result.Result.Error
               $"Can't parse qualified_type_name from {node.typ}"

--- a/packages/darklang/languageTools/parser/identifiers.dark
+++ b/packages/darklang/languageTools/parser/identifiers.dark
@@ -54,14 +54,43 @@ module Darklang =
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.QualifiedTypeIdentifier, String> =
           if node.typ == "qualified_type_name" then
-            let (modules, typeIdentifierNode) =
-              extractModuleIdentifiers node.children
+            let filteredChildren =
+              node.children
+              |> Stdlib.List.filter (fun n ->
+                n.typ != "type_args"
+                && n.fieldName != Stdlib.Option.Option.Some "symbol_open_angle"
+                && n.fieldName != Stdlib.Option.Option.Some "symbol_close_angle")
 
-            (WrittenTypes.QualifiedTypeIdentifier
-              { range = node.range
-                modules = modules
-                typ = parseType typeIdentifierNode })
-            |> Stdlib.Result.Result.Ok
+            let (modules, typeIdentifierNode) =
+              extractModuleIdentifiers filteredChildren
+
+            let typeArgsNodes =
+              node
+              |> findNodeByFieldName "type_args"
+              |> Stdlib.Option.map (fun typeArgsNode ->
+                typeArgsNode.children
+                |> Stdlib.List.chunkBySize 2L
+                |> Builtin.unwrap
+                |> Stdlib.List.map (fun chunk ->
+                  match chunk with
+                  | [ typeArg; _ ] -> TypeReference.parse typeArg
+                  | [ typeArg ] -> TypeReference.parse typeArg
+                  | _ -> createUnparseableError chunk))
+
+            let typeArgs =
+              match typeArgsNodes with
+              | Some typeArgs -> typeArgs |> Stdlib.Result.collect
+              | None -> [] |> Stdlib.Result.Result.Ok
+
+            match typeArgs with
+            | Ok typeArgs ->
+              (WrittenTypes.QualifiedTypeIdentifier
+                { range = node.range
+                  modules = modules
+                  typ = parseType typeIdentifierNode
+                  typeArgs = typeArgs })
+              |> Stdlib.Result.Result.Ok
+            | Error _ -> createUnparseableError node
           else
             Stdlib.Result.Result.Error
               $"Can't parse qualified_type_name from {node.typ}"

--- a/packages/darklang/languageTools/parser/identifiers.dark
+++ b/packages/darklang/languageTools/parser/identifiers.dark
@@ -49,6 +49,31 @@ module Darklang =
         let parseFn (n: ParsedNode) : WrittenTypes.FnIdentifier =
           WrittenTypes.FnIdentifier { range = n.range; name = n.text }
 
+        let extractTypeArgs
+          (node: ParsedNode)
+          : Stdlib.Result.Result<List<WrittenTypes.Range * String>, WrittenTypes.Unparseable> =
+          let args =
+            match findNodeByFieldName node "type_args" with
+            | Some typeArgs ->
+              typeArgs
+              |> findNodeByFieldName "args"
+              |> Stdlib.Option.map (fun typeArgsNode ->
+                typeArgsNode.children
+                |> Stdlib.List.chunkBySize 2L
+                |> Builtin.unwrap
+                |> Stdlib.List.map (fun chunk ->
+                  match chunk with
+                  | [ typeArg; _ ] -> TypeReference.parse typeArg
+                  | [ typeArg ] -> TypeReference.parse typeArg
+                  | _ -> createUnparseableError chunk))
+
+            | None -> Stdlib.Option.Option.None
+
+          match args with
+          | Some typeArgs -> typeArgs |> Stdlib.Result.collect
+          | None -> [] |> Stdlib.Result.Result.Ok
+
+
 
         let parseQualifiedType
           (node: ParsedNode)
@@ -60,27 +85,7 @@ module Darklang =
             let (modules, typeIdentifierNode) =
               extractModuleIdentifiers filteredChildren
 
-            let args =
-              match findNodeByFieldName node "type_args" with
-              | Some typeArgs ->
-                typeArgs
-                |> findNodeByFieldName "args"
-                |> Stdlib.Option.map (fun typeArgsNode ->
-                  typeArgsNode.children
-                  |> Stdlib.List.chunkBySize 2L
-                  |> Builtin.unwrap
-                  |> Stdlib.List.map (fun chunk ->
-                    match chunk with
-                    | [ typeArg; _ ] -> TypeReference.parse typeArg
-                    | [ typeArg ] -> TypeReference.parse typeArg
-                    | _ -> createUnparseableError chunk))
-
-              | None -> Stdlib.Option.Option.None
-
-            let typeArgs =
-              match args with
-              | Some typeArgs -> typeArgs |> Stdlib.Result.collect
-              | None -> [] |> Stdlib.Result.Result.Ok
+            let typeArgs = extractTypeArgs node
 
             match typeArgs with
             | Ok typeArgs ->
@@ -100,14 +105,25 @@ module Darklang =
         let parseQualifiedFunction
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.QualifiedFnIdentifier, String> =
-          if node.typ == "qualified_fn_name" then
-            let (modules, fnIdentifierNode) = extractModuleIdentifiers node.children
+          let filteredChildren =
+            node.children |> Stdlib.List.filter (fun n -> n.typ != "type_args")
 
-            (WrittenTypes.QualifiedFnIdentifier
-              { range = node.range
-                modules = modules
-                fn = parseFn fnIdentifierNode })
-            |> Stdlib.Result.Result.Ok
+          if node.typ == "qualified_fn_name" then
+            let (modules, fnIdentifierNode) =
+              extractModuleIdentifiers filteredChildren
+
+            let typeArgs = extractTypeArgs node
+
+            match typeArgs with
+            | Ok typeArgs ->
+              (WrittenTypes.QualifiedFnIdentifier
+                { range = node.range
+                  modules = modules
+                  fn = parseFn fnIdentifierNode
+                  typeArgs = typeArgs })
+              |> Stdlib.Result.Result.Ok
+            | Error _ -> createUnparseableError node
+
           else
             Stdlib.Result.Result.Error
               $"Can't parse qualified_fn_name from {node.typ}"

--- a/packages/darklang/languageTools/parser/typeDeclaration.dark
+++ b/packages/darklang/languageTools/parser/typeDeclaration.dark
@@ -161,17 +161,46 @@ module Darklang =
               findAndParseRequired node "name" (fun node ->
                 (Identifiers.parseType node) |> Stdlib.Result.Result.Ok)
 
+            let typeParamsNodes =
+              node
+              |> findNodeByFieldName "type_params"
+              |> Stdlib.Option.map (fun node ->
+                node.children
+                |> Stdlib.List.chunkBySize 2L
+                |> Builtin.unwrap
+                |> Stdlib.List.map (fun chunk ->
+                  match chunk with
+                  | [ typeParamNode ] ->
+                    (typeParamNode.range, typeParamNode.text)
+                    |> Stdlib.Result.Result.Ok
+
+                  | [ typeParamNode; _separator ] ->
+                    (typeParamNode.range, typeParamNode.text)
+                    |> Stdlib.Result.Result.Ok
+
+                  | _ ->
+                    (createUnparseableError chunk) |> Stdlib.Result.Result.Error))
+
+            let typParams =
+              match typeParamsNodes with
+              | Some typeParams -> typeParams |> Stdlib.Result.collect
+              | None -> [] |> Stdlib.Result.Result.Ok
+
             let defNode =
               findAndParseRequired node "typ" TypeDeclaration.parseDefinition
 
             let keywordTypeNode = findField node "keyword_type"
             let symbolEqualsNode = findField node "symbol_equals"
 
-            match nameNode, defNode, keywordTypeNode, symbolEqualsNode with
-            | Ok name, Ok def, Ok keywordType, Ok symbolEquals ->
+            match
+              nameNode, defNode, typParams, keywordTypeNode, symbolEqualsNode
+            with
+            | Ok name, Ok def, Ok typeParams, Ok keywordType, Ok symbolEquals ->
+
               (WrittenTypes.TypeDeclaration.TypeDeclaration
                 { range = node.range
                   name = name
+                  typeParams = typeParams
                   definition = def
                   keywordType = keywordType.range
                   symbolEquals = symbolEquals.range })

--- a/packages/darklang/languageTools/parser/typeDeclaration.dark
+++ b/packages/darklang/languageTools/parser/typeDeclaration.dark
@@ -173,12 +173,16 @@ module Darklang =
                   |> Stdlib.List.map (fun chunk ->
                     match chunk with
                     | [ typeParamNode ] ->
-                      (typeParamNode.range, typeParamNode.text)
-                      |> Stdlib.Result.Result.Ok
+                      let name =
+                        typeParamNode |> findField "variable" |> Builtin.unwrap
+
+                      (typeParamNode.range, name.text) |> Stdlib.Result.Result.Ok
 
                     | [ typeParamNode; _separator ] ->
-                      (typeParamNode.range, typeParamNode.text)
-                      |> Stdlib.Result.Result.Ok
+                      let name =
+                        typeParamNode |> findField "variable" |> Builtin.unwrap
+
+                      (typeParamNode.range, name.text) |> Stdlib.Result.Result.Ok
 
                     | _ ->
                       (createUnparseableError chunk) |> Stdlib.Result.Result.Error))

--- a/packages/darklang/languageTools/parser/typeDeclaration.dark
+++ b/packages/darklang/languageTools/parser/typeDeclaration.dark
@@ -161,28 +161,32 @@ module Darklang =
               findAndParseRequired node "name" (fun node ->
                 (Identifiers.parseType node) |> Stdlib.Result.Result.Ok)
 
-            let typeParamsNodes =
-              node
-              |> findNodeByFieldName "type_params"
-              |> Stdlib.Option.map (fun node ->
-                node.children
-                |> Stdlib.List.chunkBySize 2L
-                |> Builtin.unwrap
-                |> Stdlib.List.map (fun chunk ->
-                  match chunk with
-                  | [ typeParamNode ] ->
-                    (typeParamNode.range, typeParamNode.text)
-                    |> Stdlib.Result.Result.Ok
+            let typeParams =
+              match findNodeByFieldName node "type_params" with
+              | Some typeParamsNode ->
+                typeParamsNode
+                |> findNodeByFieldName "params"
+                |> Stdlib.Option.map (fun node ->
+                  node.children
+                  |> Stdlib.List.chunkBySize 2L
+                  |> Builtin.unwrap
+                  |> Stdlib.List.map (fun chunk ->
+                    match chunk with
+                    | [ typeParamNode ] ->
+                      (typeParamNode.range, typeParamNode.text)
+                      |> Stdlib.Result.Result.Ok
 
-                  | [ typeParamNode; _separator ] ->
-                    (typeParamNode.range, typeParamNode.text)
-                    |> Stdlib.Result.Result.Ok
+                    | [ typeParamNode; _separator ] ->
+                      (typeParamNode.range, typeParamNode.text)
+                      |> Stdlib.Result.Result.Ok
 
-                  | _ ->
-                    (createUnparseableError chunk) |> Stdlib.Result.Result.Error))
+                    | _ ->
+                      (createUnparseableError chunk) |> Stdlib.Result.Result.Error))
+
+              | None -> Stdlib.Option.Option.None
 
             let typParams =
-              match typeParamsNodes with
+              match typeParams with
               | Some typeParams -> typeParams |> Stdlib.Result.collect
               | None -> [] |> Stdlib.Result.Result.Ok
 

--- a/packages/darklang/languageTools/parser/typeDeclaration.dark
+++ b/packages/darklang/languageTools/parser/typeDeclaration.dark
@@ -189,7 +189,7 @@ module Darklang =
 
               | None -> Stdlib.Option.Option.None
 
-            let typParams =
+            let typeParams =
               match typeParams with
               | Some typeParams -> typeParams |> Stdlib.Result.collect
               | None -> [] |> Stdlib.Result.Result.Ok
@@ -201,10 +201,9 @@ module Darklang =
             let symbolEqualsNode = findField node "symbol_equals"
 
             match
-              nameNode, defNode, typParams, keywordTypeNode, symbolEqualsNode
+              nameNode, defNode, typeParams, keywordTypeNode, symbolEqualsNode
             with
             | Ok name, Ok def, Ok typeParams, Ok keywordType, Ok symbolEquals ->
-
               (WrittenTypes.TypeDeclaration.TypeDeclaration
                 { range = node.range
                   name = name

--- a/packages/darklang/languageTools/parser/typeReference.dark
+++ b/packages/darklang/languageTools/parser/typeReference.dark
@@ -182,11 +182,16 @@ module Darklang =
                 | _ -> createUnparseableError node
 
               | "variable_type_reference" ->
+                let symbolSingleQuote = findField firstChild "symbol_single_quote"
                 let variableName = findField firstChild "variable"
 
-                match variableName with
-                | Ok variableName ->
-                  (TBuiltin.TVariable variableName.range variableName.text)
+                match symbolSingleQuote, variableName with
+                | Ok singleQuote, Ok variableName ->
+                  (TBuiltin.TVariable(
+                    firstChild.range,
+                    singleQuote.range,
+                    (variableName.range, variableName.text)
+                  ))
                   |> builtin
                 | _ -> createUnparseableError node
           else

--- a/packages/darklang/languageTools/parser/typeReference.dark
+++ b/packages/darklang/languageTools/parser/typeReference.dark
@@ -160,6 +160,25 @@ module Darklang =
                 | Ok returnType, Ok args ->
                   (TBuiltin.TFn firstChild.range args returnType) |> builtin
 
+              | "db_type_reference" ->
+                let dbKeyword = findField firstChild "keyword_type_constructor"
+                let openAngle = findField firstChild "symbol_open_angle"
+
+                let typeParamNode =
+                  findAndParseRequired firstChild "typ_param" TypeReference.parse
+
+                let closeAngle = findField firstChild "symbol_close_angle"
+
+                match dbKeyword, openAngle, typeParamNode, closeAngle with
+                | Ok dbKeyword, Ok openAngle, Ok typeParam, Ok closeAngle ->
+                  (TBuiltin.TDB
+                    firstChild.range
+                    dbKeyword.range
+                    openAngle.range
+                    typeParam
+                    closeAngle.range)
+                  |> builtin
+
                 | _ -> createUnparseableError node
 
               | "variable_type_reference" ->

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -61,7 +61,7 @@ module Darklang =
           [ makeToken t.range TokenType.TypeName ]
 
       module QualifiedTypeIdentifier =
-        // Darklang.Stdlib.Option
+        // Darklang.Stdlib.Option<Int64>
         let tokenize
           (q: WrittenTypes.QualifiedTypeIdentifier)
           : List<SemanticToken> =
@@ -71,7 +71,12 @@ module Darklang =
              |> Stdlib.List.flatten)
 
             // Option
-            TypeIdentifier.tokenize q.typ ]
+            TypeIdentifier.tokenize q.typ
+
+            // <Int64>
+            (q.typeArgs
+             |> Stdlib.List.map (fun typeArg -> TypeReference.tokenize typeArg)
+             |> Stdlib.List.flatten) ]
           |> Stdlib.List.flatten
 
       module VariableIdentifier =
@@ -251,6 +256,11 @@ module Darklang =
             [ makeToken t.keywordType TokenType.Keyword ]
             // ID
             [ makeToken t.name.range TokenType.TypeName ]
+
+            (t.typeParams
+             |> Stdlib.List.map (fun (r, typeParam) ->
+               [ makeToken r TokenType.TypeParameter ])
+             |> Stdlib.List.flatten)
             // =
             [ makeToken t.symbolEquals TokenType.Symbol ]
             // UInt64

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -176,7 +176,12 @@ module Darklang =
                 [ makeToken rc TokenType.Symbol ] ]
               |> Stdlib.List.flatten
 
-            | TVariable(r, _) -> [ makeToken r TokenType.TypeName ]
+            | TVariable(r, ra, (rv, _)) ->
+              [ // '
+                [ makeToken ra TokenType.Symbol ]
+                // a
+                [ makeToken rv TokenType.TypeName ] ]
+              |> Stdlib.List.flatten
 
         let tokenize
           (t: WrittenTypes.TypeReference.TypeReference)

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -163,6 +163,12 @@ module Darklang =
                  |> Stdlib.List.flatten)
 
                 TypeReference.tokenize ret ]
+
+            | TDB(r, rk, ro, t, rc) ->
+              [ [ makeToken rk TokenType.Keyword ]
+                [ makeToken ro TokenType.Symbol ]
+                (TypeReference.tokenize t)
+                [ makeToken rc TokenType.Symbol ] ]
               |> Stdlib.List.flatten
 
             | TVariable(r, _) -> [ makeToken r TokenType.TypeName ]

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -95,6 +95,10 @@ module Darklang =
              |> Stdlib.List.map (fun (m, _) -> ModuleIdentifier.tokenize m)
              |> Stdlib.List.flatten)
 
+            (q.typeArgs
+             |> Stdlib.List.map (fun typeArg -> TypeReference.tokenize typeArg)
+             |> Stdlib.List.flatten)
+
             // map
             FnIdentifier.tokenize q.fn ]
           |> Stdlib.List.flatten
@@ -842,6 +846,11 @@ module Darklang =
             [ makeToken fn.keywordLet TokenType.Keyword ]
             // `add`
             FnIdentifier.tokenize fn.name
+            // type parameters
+            (t.typeParams
+             |> Stdlib.List.map (fun (r, typeParam) ->
+               [ makeToken r TokenType.TypeParameter ])
+             |> Stdlib.List.flatten)
             // `(a: Int64) (b: Int64)`
             (fn.parameters
              |> Stdlib.List.map (fun p -> Parameter.tokenize p)

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -30,6 +30,7 @@ module Darklang =
           /// the range corresponds to the `.` after the module name
           modules: List<ModuleIdentifier * Range>
           fn: FnIdentifier
+          typeArgs: List<TypeReference.TypeReference>
         }
 
       type Name = Unresolved of Range * List<String>
@@ -377,6 +378,7 @@ module Darklang =
         type FnDeclaration =
           { range: Range
             name: FnIdentifier
+            typeParams: List<Range * String>
             parameters: List<Parameter>
             returnType: TypeReference.TypeReference
             body: Expr

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -91,7 +91,7 @@ module Darklang =
             typ: TypeReference *
             symbolCloseAngle: Range
 
-          | TVariable of Range * String
+          | TVariable of Range * symbolSingleQuote: Range * name: (Range * String)
 
 
         type TypeReference =

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -17,6 +17,7 @@ module Darklang =
           /// the Range corresponds to the `.` after the module name
           modules: List<ModuleIdentifier * Range>
           typ: TypeIdentifier
+          typeArgs: List<TypeReference.TypeReference>
         }
 
       type VariableIdentifier = { range: Range; name: String }
@@ -130,6 +131,7 @@ module Darklang =
         type TypeDeclaration =
           { range: Range
             name: TypeIdentifier
+            typeParams: List<Range * String>
             definition: Definition
             keywordType: Range
             symbolEquals: Range }

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -83,6 +83,13 @@ module Darklang =
             arguments: List<TypeReference.TypeReference * Range> *
             ret: TypeReference.TypeReference
 
+          | TDB of
+            Range *
+            keywordDB: Range *
+            symbolOpenAngle: Range *
+            typ: TypeReference *
+            symbolCloseAngle: Range
+
           | TVariable of Range * String
 
 

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -17,16 +17,24 @@ module Darklang =
           let toPT
             (onMissing: NameResolver.OnMissing)
             (i: WrittenTypes.QualifiedTypeIdentifier)
-            : ProgramTypes.NameResolution<ProgramTypes.FQTypeName.FQTypeName> =
+            : (ProgramTypes.NameResolution<ProgramTypes.FQTypeName.FQTypeName> *
+              List<WrittenTypes.TypeReference.TypeReference>)
+            =
+            let typeArgs =
+              Stdlib.List.map i.typeArgs (fun t -> TypeReference.toPT onMissing t)
+
             let nameToResolve =
               Stdlib.List.append
                 (Stdlib.List.map i.modules (fun (m, _) -> m.name))
                 [ i.typ.name ]
 
-            NameResolver.TypeName.resolve
-              onMissing
-              []
-              (WrittenTypes.Name.Unresolved(i.range, nameToResolve))
+            let typeName =
+              NameResolver.TypeName.resolve
+                onMissing
+                []
+                (WrittenTypes.Name.Unresolved(i.range, nameToResolve))
+
+            (typeName, typeArgs)
 
 
         module Fn =
@@ -113,9 +121,9 @@ module Darklang =
           match t with
           | Builtin b -> Builtin.toPT onMissing b
           | QualifiedName qn ->
-            let typeName = Identifiers.QualifiedType.toPT onMissing qn
+            let (typeName, typeArgs) = Identifiers.QualifiedType.toPT onMissing qn
 
-            ProgramTypes.TypeReference.TCustomType(typeName, [])
+            ProgramTypes.TypeReference.TCustomType(typeName, typeArgs)
 
 
       module TypeDeclaration =
@@ -191,7 +199,9 @@ module Darklang =
           let def = Definition.toPT onMissing d.definition
 
           ProgramTypes.TypeDeclaration.TypeDeclaration
-            { typeParams = []; definition = def }
+            { typeParams =
+                d.typeParams |> Stdlib.List.map (fun p -> p |> Stdlib.Tuple2.second)
+              definition = def }
 
 
         let toPackageTypePT

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -100,6 +100,10 @@ module Darklang =
 
               ProgramTypes.TypeReference.TFn(args, returnType)
 
+            | TDB(_range, _, _, typ, _) ->
+              let typ = TypeReference.toPT onMissing typ
+              ProgramTypes.TypeReference.TDB typ
+
             | TVariable(_range, name) -> ProgramTypes.TypeReference.TVariable name
 
         let toPT

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -486,9 +486,13 @@ module Darklang =
 
           | EApply(_, fn, typeArgs, args) ->
             let fn = toPT onMissing fn
+
+            let typeArgs =
+              Stdlib.List.map typeArgs (fun t -> TypeReference.toPT onMissing t)
+
             let args = Stdlib.List.map args (fun a -> toPT onMissing a)
 
-            ProgramTypes.Expr.EApply(gid (), fn, [], args)
+            ProgramTypes.Expr.EApply(gid (), fn, typeArgs, args)
 
 
       module FunctionDeclaration =
@@ -517,6 +521,9 @@ module Darklang =
           (modules: List<String>)
           (fn: WrittenTypes.FnDeclaration.FnDeclaration)
           : ProgramTypes.PackageFn.PackageFn =
+          let typeParams =
+            fn.typeParams |> Stdlib.List.map (fun p -> p |> Stdlib.Tuple2.second)
+
           ProgramTypes.PackageFn.PackageFn
             { tlid = gtlid ()
               id = Stdlib.Uuid.generate ()
@@ -525,7 +532,7 @@ module Darklang =
                   { owner = owner
                     modules = modules
                     name = fn.name.name }
-              typeParams = []
+              typeParams = typeParams
               parameters =
                 fn.parameters
                 |> Stdlib.List.map (fun p ->

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -112,7 +112,8 @@ module Darklang =
               let typ = TypeReference.toPT onMissing typ
               ProgramTypes.TypeReference.TDB typ
 
-            | TVariable(_range, name) -> ProgramTypes.TypeReference.TVariable name
+            | TVariable(_range, _, (_, name)) ->
+              ProgramTypes.TypeReference.TVariable name
 
         let toPT
           (onMissing: NameResolver.OnMissing)

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -850,7 +850,7 @@ module Darklang =
           | [] -> ""
           | _ ->
             p.declaration.typeParams
-            |> Stdlib.List.map (fun typeParam -> $"'{typeParam}")
+            |> Stdlib.List.map (fun typeParam -> $"{typeParam}")
             |> Stdlib.String.join ", "
             |> fun parts -> $"<{parts}>"
 

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -850,7 +850,7 @@ module Darklang =
           | [] -> ""
           | _ ->
             p.declaration.typeParams
-            |> Stdlib.List.map (fun typeParam -> $"{typeParam}")
+            |> Stdlib.List.map (fun typeParam -> $"'{typeParam}")
             |> Stdlib.String.join ", "
             |> fun parts -> $"<{parts}>"
 

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -813,6 +813,8 @@ module.exports = grammar({
         $.dict_type_reference,
         $.fn_type_reference,
         $.variable_type_reference,
+
+        $.db_type_reference,
       ),
 
     //
@@ -875,6 +877,15 @@ module.exports = grammar({
         ),
       ),
 
+    // DB type reference
+    // DB<'a>
+    db_type_reference: $ =>
+      seq(
+        field("keyword_type_constructor", alias("DB", $.keyword)),
+        field("symbol_open_angle", alias("<", $.symbol)),
+        field("typ_param", $.type_reference),
+        field("symbol_close_angle", alias(">", $.symbol)),
+      ),
     //
     // Variable type reference
     // 'a

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -47,6 +47,7 @@ module.exports = grammar({
       seq(
         field("keyword_let", alias("let", $.keyword)),
         field("name", $.fn_identifier),
+        optional(field("type_params", $.type_params)),
         field("params", $.fn_decl_params),
         field("symbol_colon", alias(":", $.symbol)),
         field("return_type", $.type_reference),
@@ -70,11 +71,12 @@ module.exports = grammar({
       seq(
         field("keyword_type", alias("type", $.keyword)),
         field("name", $.type_identifier),
-        optional(field("type_params", $.type_decl_type_params)),
+        optional(field("type_params", $.type_params)),
         field("symbol_equals", alias("=", $.symbol)),
         field("typ", $.type_decl_def),
       ),
-    type_decl_type_params: $ =>
+
+    type_params: $ =>
       seq(
         field("symbol_open_angle", alias("<", $.symbol)),
         field("params", $.params),
@@ -918,8 +920,11 @@ module.exports = grammar({
     // ---------------------
     qualified_fn_name: $ =>
       seq(
-        repeat(seq($.module_identifier, alias(".", $.symbol))),
-        $.fn_identifier,
+        seq(
+          repeat(seq($.module_identifier, alias(".", $.symbol))),
+          $.fn_identifier,
+        ),
+        optional(field("type_args", $.type_args)),
       ),
 
     qualified_type_name: $ =>
@@ -932,9 +937,9 @@ module.exports = grammar({
       ),
     type_args: $ =>
       seq(
-        field("symbol_open_angle", alias("<", $.symbol)),
+        field("symbol_open_angle", alias(token.immediate("<"), $.symbol)),
         field("args", $.args),
-        field("symbol_close_angle", alias(">", $.symbol)),
+        field("symbol_close_angle", alias(token.immediate(">"), $.symbol)),
       ),
     args: $ =>
       seq(

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -70,17 +70,17 @@ module.exports = grammar({
       seq(
         field("keyword_type", alias("type", $.keyword)),
         field("name", $.type_identifier),
-        optional(
-          seq(
-            field("symbol_open_angle", alias("<", $.symbol)),
-            field("type_params", $.type_decl_type_params),
-            field("symbol_close_angle", alias(">", $.symbol)),
-          ),
-        ),
+        optional(field("type_params", $.type_decl_type_params)),
         field("symbol_equals", alias("=", $.symbol)),
         field("typ", $.type_decl_def),
       ),
     type_decl_type_params: $ =>
+      seq(
+        field("symbol_open_angle", alias("<", $.symbol)),
+        field("params", $.params),
+        field("symbol_close_angle", alias(">", $.symbol)),
+      ),
+    params: $ =>
       seq(
         $.variable_type_reference,
         repeat(
@@ -927,16 +927,15 @@ module.exports = grammar({
           repeat(seq($.module_identifier, alias(".", $.symbol))),
           field("type_identifier", $.type_identifier),
         ),
-        optional(
-          seq(
-            field("symbol_open_angle", alias("<", $.symbol)),
-            field("type_args", $.type_args),
-            field("symbol_close_angle", alias(">", $.symbol)),
-          ),
-        ),
+        optional(field("type_args", $.type_args)),
       ),
-
     type_args: $ =>
+      seq(
+        field("symbol_open_angle", alias("<", $.symbol)),
+        field("args", $.args),
+        field("symbol_close_angle", alias(">", $.symbol)),
+      ),
+    args: $ =>
       seq(
         $.type_reference,
         repeat(

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -79,10 +79,11 @@ module.exports = grammar({
     type_params: $ =>
       seq(
         field("symbol_open_angle", alias(token.immediate("<"), $.symbol)),
-        field("params", $.params),
+        field("params", $.type_params_items),
         field("symbol_close_angle", alias(token.immediate(">"), $.symbol)),
       ),
-    params: $ =>
+    // TODO: inline this into type_params
+    type_params_items: $ =>
       seq(
         $.variable_type_reference,
         repeat(

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -78,9 +78,9 @@ module.exports = grammar({
 
     type_params: $ =>
       seq(
-        field("symbol_open_angle", alias("<", $.symbol)),
+        field("symbol_open_angle", alias(token.immediate("<"), $.symbol)),
         field("params", $.params),
-        field("symbol_close_angle", alias(">", $.symbol)),
+        field("symbol_close_angle", alias(token.immediate(">"), $.symbol)),
       ),
     params: $ =>
       seq(

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -903,6 +903,7 @@ module.exports = grammar({
         field("typ_param", $.type_reference),
         field("symbol_close_angle", alias(">", $.symbol)),
       ),
+
     //
     // Variable type reference
     // 'a

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -70,8 +70,25 @@ module.exports = grammar({
       seq(
         field("keyword_type", alias("type", $.keyword)),
         field("name", $.type_identifier),
+        optional(
+          seq(
+            field("symbol_open_angle", alias("<", $.symbol)),
+            field("type_params", $.type_decl_type_params),
+            field("symbol_close_angle", alias(">", $.symbol)),
+          ),
+        ),
         field("symbol_equals", alias("=", $.symbol)),
         field("typ", $.type_decl_def),
+      ),
+    type_decl_type_params: $ =>
+      seq(
+        $.variable_type_reference,
+        repeat(
+          seq(
+            field("symbol_comma", alias(",", $.symbol)),
+            $.variable_type_reference,
+          ),
+        ),
       ),
 
     type_decl_def: $ =>
@@ -906,8 +923,25 @@ module.exports = grammar({
 
     qualified_type_name: $ =>
       seq(
-        repeat(seq($.module_identifier, alias(".", $.symbol))),
-        $.type_identifier,
+        seq(
+          repeat(seq($.module_identifier, alias(".", $.symbol))),
+          field("type_identifier", $.type_identifier),
+        ),
+        optional(
+          seq(
+            field("symbol_open_angle", alias("<", $.symbol)),
+            field("type_args", $.type_args),
+            field("symbol_close_angle", alias(">", $.symbol)),
+          ),
+        ),
+      ),
+
+    type_args: $ =>
+      seq(
+        $.type_reference,
+        repeat(
+          seq(field("symbol_comma", alias(",", $.symbol)), $.type_reference),
+        ),
       ),
 
     /** e.g. `x` in `let double (x: Int) = x + x`

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -269,8 +269,11 @@
           "content": {
             "type": "ALIAS",
             "content": {
-              "type": "STRING",
-              "value": "<"
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "<"
+              }
             },
             "named": true,
             "value": "symbol"
@@ -290,8 +293,11 @@
           "content": {
             "type": "ALIAS",
             "content": {
-              "type": "STRING",
-              "value": ">"
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": ">"
+              }
             },
             "named": true,
             "value": "symbol"

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -206,6 +206,53 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "symbol_open_angle",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "<"
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "type_params",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "type_decl_type_params"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "symbol_close_angle",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": ">"
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "FIELD",
           "name": "symbol_equals",
           "content": {
@@ -224,6 +271,40 @@
           "content": {
             "type": "SYMBOL",
             "name": "type_decl_def"
+          }
+        }
+      ]
+    },
+    "type_decl_type_params": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "variable_type_reference"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol_comma",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "variable_type_reference"
+              }
+            ]
           }
         }
       ]
@@ -3818,29 +3899,119 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "module_identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "type_identifier",
+              "content": {
+                "type": "SYMBOL",
+                "name": "type_identifier"
+              }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "symbol_open_angle",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "<"
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "type_args",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "type_args"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "symbol_close_angle",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": ">"
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "type_args": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "type_reference"
+        },
+        {
           "type": "REPEAT",
           "content": {
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "module_identifier"
+                "type": "FIELD",
+                "name": "symbol_comma",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
               },
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "."
-                },
-                "named": true,
-                "value": "symbol"
+                "type": "SYMBOL",
+                "name": "type_reference"
               }
             ]
           }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "type_identifier"
         }
       ]
     },

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -3448,6 +3448,10 @@
         {
           "type": "SYMBOL",
           "name": "variable_type_reference"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "db_type_reference"
         }
       ]
     },
@@ -3701,6 +3705,58 @@
           }
         ]
       }
+    },
+    "db_type_reference": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "keyword_type_constructor",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "DB"
+            },
+            "named": true,
+            "value": "keyword"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_open_angle",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "<"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "typ_param",
+          "content": {
+            "type": "SYMBOL",
+            "name": "type_reference"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_close_angle",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ">"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
     },
     "variable_type_reference": {
       "type": "SEQ",

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -54,6 +54,22 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "type_params",
+              "content": {
+                "type": "SYMBOL",
+                "name": "type_params"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "FIELD",
           "name": "params",
           "content": {
@@ -213,7 +229,7 @@
               "name": "type_params",
               "content": {
                 "type": "SYMBOL",
-                "name": "type_decl_type_params"
+                "name": "type_params"
               }
             },
             {
@@ -244,7 +260,7 @@
         }
       ]
     },
-    "type_decl_type_params": {
+    "type_params": {
       "type": "SEQ",
       "members": [
         {
@@ -3877,29 +3893,50 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "module_identifier"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "."
-                },
-                "named": true,
-                "value": "symbol"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "module_identifier"
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                ]
               }
-            ]
-          }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "fn_identifier"
+            }
+          ]
         },
         {
-          "type": "SYMBOL",
-          "name": "fn_identifier"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "type_args",
+              "content": {
+                "type": "SYMBOL",
+                "name": "type_args"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -3967,8 +4004,11 @@
           "content": {
             "type": "ALIAS",
             "content": {
-              "type": "STRING",
-              "value": "<"
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "<"
+              }
             },
             "named": true,
             "value": "symbol"
@@ -3988,8 +4028,11 @@
           "content": {
             "type": "ALIAS",
             "content": {
-              "type": "STRING",
-              "value": ">"
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": ">"
+              }
             },
             "named": true,
             "value": "symbol"

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -284,7 +284,7 @@
           "name": "params",
           "content": {
             "type": "SYMBOL",
-            "name": "params"
+            "name": "type_params_items"
           }
         },
         {
@@ -305,7 +305,7 @@
         }
       ]
     },
-    "params": {
+    "type_params_items": {
       "type": "SEQ",
       "members": [
         {

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -209,43 +209,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "symbol_open_angle",
-                  "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "STRING",
-                      "value": "<"
-                    },
-                    "named": true,
-                    "value": "symbol"
-                  }
-                },
-                {
-                  "type": "FIELD",
-                  "name": "type_params",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "type_decl_type_params"
-                  }
-                },
-                {
-                  "type": "FIELD",
-                  "name": "symbol_close_angle",
-                  "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "STRING",
-                      "value": ">"
-                    },
-                    "named": true,
-                    "value": "symbol"
-                  }
-                }
-              ]
+              "type": "FIELD",
+              "name": "type_params",
+              "content": {
+                "type": "SYMBOL",
+                "name": "type_decl_type_params"
+              }
             },
             {
               "type": "BLANK"
@@ -276,6 +245,45 @@
       ]
     },
     "type_decl_type_params": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_open_angle",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "<"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "params",
+          "content": {
+            "type": "SYMBOL",
+            "name": "params"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_close_angle",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ">"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
+    },
+    "params": {
       "type": "SEQ",
       "members": [
         {
@@ -3936,43 +3944,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "FIELD",
-                  "name": "symbol_open_angle",
-                  "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "STRING",
-                      "value": "<"
-                    },
-                    "named": true,
-                    "value": "symbol"
-                  }
-                },
-                {
-                  "type": "FIELD",
-                  "name": "type_args",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "type_args"
-                  }
-                },
-                {
-                  "type": "FIELD",
-                  "name": "symbol_close_angle",
-                  "content": {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "STRING",
-                      "value": ">"
-                    },
-                    "named": true,
-                    "value": "symbol"
-                  }
-                }
-              ]
+              "type": "FIELD",
+              "name": "type_args",
+              "content": {
+                "type": "SYMBOL",
+                "name": "type_args"
+              }
             },
             {
               "type": "BLANK"
@@ -3982,6 +3959,45 @@
       ]
     },
     "type_args": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "symbol_open_angle",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "<"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "args",
+          "content": {
+            "type": "SYMBOL",
+            "name": "args"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_close_angle",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": ">"
+            },
+            "named": true,
+            "value": "symbol"
+          }
+        }
+      ]
+    },
+    "args": {
       "type": "SEQ",
       "members": [
         {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -58,6 +58,10 @@
       "required": false,
       "types": [
         {
+          "type": "db_type_reference",
+          "named": true
+        },
+        {
           "type": "dict_type_reference",
           "named": true
         },
@@ -165,6 +169,52 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "db_type_reference",
+    "named": true,
+    "fields": {
+      "keyword_type_constructor": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "keyword",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_angle": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_angle": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "typ_param": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_reference",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -40,6 +40,32 @@
     }
   },
   {
+    "type": "args",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_reference",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "bool",
     "named": true,
     "fields": {}
@@ -1864,6 +1890,32 @@
     }
   },
   {
+    "type": "params",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "variable_type_reference",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "paren_expression",
     "named": true,
     "fields": {
@@ -1926,26 +1978,6 @@
     "type": "qualified_type_name",
     "named": true,
     "fields": {
-      "symbol_close_angle": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
-      "symbol_open_angle": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
       "type_args": {
         "multiple": false,
         "required": false,
@@ -2641,9 +2673,29 @@
     "type": "type_args",
     "named": true,
     "fields": {
-      "symbol_comma": {
-        "multiple": true,
-        "required": false,
+      "args": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "args",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_angle": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_angle": {
+        "multiple": false,
+        "required": true,
         "types": [
           {
             "type": "symbol",
@@ -2651,16 +2703,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "type_reference",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -2687,29 +2729,9 @@
           }
         ]
       },
-      "symbol_close_angle": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
       "symbol_equals": {
         "multiple": false,
         "required": true,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      },
-      "symbol_open_angle": {
-        "multiple": false,
-        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -3043,9 +3065,29 @@
     "type": "type_decl_type_params",
     "named": true,
     "fields": {
-      "symbol_comma": {
-        "multiple": true,
-        "required": false,
+      "params": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "params",
+            "named": true
+          }
+        ]
+      },
+      "symbol_close_angle": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_angle": {
+        "multiple": false,
+        "required": true,
         "types": [
           {
             "type": "symbol",
@@ -3053,16 +3095,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "variable_type_reference",
-          "named": true
-        }
-      ]
     }
   },
   {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1925,10 +1925,51 @@
   {
     "type": "qualified_type_name",
     "named": true,
-    "fields": {},
+    "fields": {
+      "symbol_close_angle": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_angle": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "type_args": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_args",
+            "named": true
+          }
+        ]
+      },
+      "type_identifier": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "module_identifier",
@@ -1936,10 +1977,6 @@
         },
         {
           "type": "symbol",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
           "named": true
         }
       ]
@@ -2601,6 +2638,32 @@
     }
   },
   {
+    "type": "type_args",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_reference",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "type_decl",
     "named": true,
     "fields": {
@@ -2624,9 +2687,29 @@
           }
         ]
       },
+      "symbol_close_angle": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
       "symbol_equals": {
         "multiple": false,
         "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "symbol_open_angle": {
+        "multiple": false,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -2640,6 +2723,16 @@
         "types": [
           {
             "type": "type_decl_def",
+            "named": true
+          }
+        ]
+      },
+      "type_params": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_decl_type_params",
             "named": true
           }
         ]
@@ -2941,6 +3034,32 @@
       "types": [
         {
           "type": "type_decl_enum_case",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "type_decl_type_params",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "variable_type_reference",
           "named": true
         }
       ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -719,6 +719,16 @@
             "named": true
           }
         ]
+      },
+      "type_params": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_params",
+            "named": true
+          }
+        ]
       }
     }
   },
@@ -1954,7 +1964,18 @@
   {
     "type": "qualified_fn_name",
     "named": true,
-    "fields": {},
+    "fields": {
+      "type_args": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_args",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -2754,7 +2775,7 @@
         "required": false,
         "types": [
           {
-            "type": "type_decl_type_params",
+            "type": "type_params",
             "named": true
           }
         ]
@@ -3062,7 +3083,12 @@
     }
   },
   {
-    "type": "type_decl_type_params",
+    "type": "type_identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "type_params",
     "named": true,
     "fields": {
       "params": {
@@ -3096,11 +3122,6 @@
         ]
       }
     }
-  },
-  {
-    "type": "type_identifier",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "type_reference",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1900,32 +1900,6 @@
     }
   },
   {
-    "type": "params",
-    "named": true,
-    "fields": {
-      "symbol_comma": {
-        "multiple": true,
-        "required": false,
-        "types": [
-          {
-            "type": "symbol",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "variable_type_reference",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "paren_expression",
     "named": true,
     "fields": {
@@ -3096,7 +3070,7 @@
         "required": true,
         "types": [
           {
-            "type": "params",
+            "type": "type_params_items",
             "named": true
           }
         ]
@@ -3121,6 +3095,32 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "type_params_items",
+    "named": true,
+    "fields": {
+      "symbol_comma": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "variable_type_reference",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -426,3 +426,24 @@ Builtin.printLine Dict {a = 1L}
     )
   )
 )
+
+==================
+function call - with type arguments
+==================
+
+Builtin.jsonParse<Bool> "true"
+
+---
+
+(source_file
+  (expression
+    (apply
+      (qualified_fn_name
+        (module_identifier) (symbol) (fn_identifier)
+        (type_args (symbol) (args (type_reference (builtin_type))) (symbol))
+      )
+      (simple_expression (string_literal (symbol) (string_content) (symbol)))
+      (newline)
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
@@ -407,7 +407,7 @@ if a > b then
         (if_expression
           (keyword)
           (expression (infix_operation (expression (simple_expression (variable_identifier))) (operator) (expression (simple_expression (variable_identifier))))) (keyword)
-          (ERROR (qualified_fn_name (fn_identifier)))
+          (ERROR (fn_identifier))
           (indent)
           (expression
             (simple_expression (variable_identifier)))

--- a/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
@@ -78,3 +78,34 @@ let isHigher (a: Int64) (b: Int64): Bool =
     )
   )
 )
+
+
+==================
+fn decl with type parameters
+==================
+
+let myFn<'a> (param: 'a): Unit =
+  ()
+
+---
+
+(source_file
+   (fn_decl
+      (keyword)
+      (fn_identifier)
+      (type_params (symbol) (params (variable_type_reference (symbol) (variable_identifier))) (symbol))
+      (fn_decl_params
+        (fn_decl_param
+          (symbol)
+          (variable_identifier)
+          (symbol)
+          (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+          (symbol)
+        )
+      )
+      (symbol)
+      (type_reference (builtin_type))
+      (symbol)
+      (expression (simple_expression (unit)))
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
@@ -93,7 +93,7 @@ let myFn<'a> (param: 'a): Unit =
    (fn_decl
       (keyword)
       (fn_identifier)
-      (type_params (symbol) (params (variable_type_reference (symbol) (variable_identifier))) (symbol))
+      (type_params (symbol) (type_params_items (variable_type_reference (symbol) (variable_identifier))) (symbol))
       (fn_decl_params
         (fn_decl_param
           (symbol)
@@ -107,5 +107,39 @@ let myFn<'a> (param: 'a): Unit =
       (type_reference (builtin_type))
       (symbol)
       (expression (simple_expression (unit)))
+  )
+)
+
+
+==================
+fn decl with two type parameters
+==================
+
+let myFn<'a, 'b> (param: 'a): 'b =
+  param
+
+---
+(source_file
+  (fn_decl
+    (keyword) (fn_identifier)
+    (type_params
+      (symbol)
+      (type_params_items (variable_type_reference (symbol) (variable_identifier))
+      (symbol)
+      (variable_type_reference (symbol) (variable_identifier)))
+      (symbol))
+    (fn_decl_params
+      (fn_decl_param
+        (symbol)
+        (variable_identifier)
+        (symbol)
+        (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+        (symbol)
+      )
+    )
+    (symbol)
+    (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+    (symbol)
+    (expression (simple_expression (variable_identifier)))
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_decls.txt
@@ -64,7 +64,7 @@ type MyID = Test
     symbol_equals: (symbol)
     typ: (type_decl_def
           (type_decl_def_alias
-            (type_reference (qualified_type_name (type_identifier)))
+            (type_reference (qualified_type_name type_identifier: (type_identifier)))
           )
         )
   )

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
@@ -276,3 +276,120 @@ type MyFn = 'a -> 'b -> 'c -> String
     )
   )
 )
+
+
+==================
+type reference - DB
+==================
+
+type MyDB = DB<'a>
+
+---
+
+(source_file
+  (type_decl
+    (keyword)
+    (type_identifier)
+    (symbol)
+    (type_decl_def
+      (type_decl_def_alias
+        (type_reference
+          (builtin_type (db_type_reference (keyword) (symbol) (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier)))) (symbol)))
+        )
+      )
+    )
+  )
+)
+
+
+==================
+type reference - DB with a variable record type
+==================
+
+type MyRecord = {x: String}
+type MyDB = DB<MyRecord>
+
+---
+(source_file
+  (type_decl
+    (keyword)
+    (type_identifier)
+    (symbol)
+    (type_decl_def
+      (type_decl_def_record
+        (symbol)
+        (type_decl_def_record_fields (type_decl_def_record_field (variable_identifier) (symbol) (type_reference (builtin_type))))
+        (symbol)
+      )
+    )
+  )
+  (type_decl
+    (keyword)
+    (type_identifier)
+    (symbol)
+    (type_decl_def
+      (type_decl_def_alias
+        (type_reference
+          (builtin_type
+            (db_type_reference
+              (keyword)
+              (symbol)
+              (type_reference (qualified_type_name (type_identifier)))
+              (symbol)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+type reference - DB with type parameters
+==================
+
+type Generic<'a> = { x: 'a }
+
+type GenericDB = DB<Generic<String>>
+
+---
+
+(source_file
+  (type_decl
+    (keyword) (type_identifier)
+    (type_decl_type_params (symbol) (params (variable_type_reference (symbol) (variable_identifier))) (symbol))
+    (symbol)
+    (type_decl_def
+      (type_decl_def_record
+        (symbol)
+        (type_decl_def_record_fields
+          (type_decl_def_record_field
+            (variable_identifier)
+            (symbol)
+            (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+          )
+        )
+        (symbol)
+      )
+    )
+  )
+
+  (type_decl
+    (keyword) (type_identifier) (symbol)
+    (type_decl_def
+      (type_decl_def_alias
+        (type_reference
+          (builtin_type
+            (db_type_reference
+              (keyword)
+              (symbol)
+              (type_reference (qualified_type_name (type_identifier) (type_args (symbol) (args (type_reference (builtin_type))) (symbol))))
+              (symbol)
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
@@ -279,7 +279,7 @@ type MyFn = 'a -> 'b -> 'c -> String
 
 
 ==================
-type reference - DB
+type reference - DB -simple
 ==================
 
 type MyDB = DB<'a>
@@ -346,7 +346,7 @@ type MyDB = DB<MyRecord>
 
 
 ==================
-type reference - DB with type parameters
+type reference - DB
 ==================
 
 type Generic<'a> = { x: 'a }
@@ -358,7 +358,7 @@ type GenericDB = DB<Generic<String>>
 (source_file
   (type_decl
     (keyword) (type_identifier)
-    (type_params (symbol) (params (variable_type_reference (symbol) (variable_identifier))) (symbol))
+    (type_params (symbol) (type_params_items (variable_type_reference (symbol) (variable_identifier))) (symbol))
     (symbol)
     (type_decl_def
       (type_decl_def_record

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
@@ -358,7 +358,7 @@ type GenericDB = DB<Generic<String>>
 (source_file
   (type_decl
     (keyword) (type_identifier)
-    (type_decl_type_params (symbol) (params (variable_type_reference (symbol) (variable_identifier))) (symbol))
+    (type_params (symbol) (params (variable_type_reference (symbol) (variable_identifier))) (symbol))
     (symbol)
     (type_decl_def
       (type_decl_def_record


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support DB type reference
```

#5321 