### PR TITLE
Tree-sitter grammar: support Function Type Reference

### DIFF
--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -241,7 +241,7 @@ type TypeReference =
   | TTuple of TypeReference * TypeReference * List<TypeReference>
   | TDict of TypeReference
 
-  | TFn of NEList<TypeReference> * TypeReference
+  | TFn of arguments : NEList<TypeReference> * ret : TypeReference
 
   | TDB of TypeReference
   // A named variable, eg `a` in `List<a>`, matches anything

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -248,6 +248,16 @@ module TextToTextRoundtripping =
     ("type MyTuple3 = (String * Int64 * Bool)" |> roundtripCliScript) = "type MyTuple3 =\n  (String * Int64 * Bool)"
     ("type MyTuple = (String * Int64 * Bool * Unit)" |> roundtripCliScript) = "type MyTuple =\n  (String * Int64 * Bool * Unit)"
 
+    ("type MyFn = 'a -> String" |> roundtripCliScript) = "type MyFn =\n  'a -> String"
+    ("type MyFn = 'a -> 'b -> 'c" |> roundtripCliScript) = "type MyFn =\n  'a -> 'b -> 'c"
+    ("type MyFn = 'a -> 'b -> 'c -> 'd" |> roundtripCliScript) = "type MyFn =\n  'a -> 'b -> 'c -> 'd"
+
+    ("type MyFn = (String * Int64 * Bool) -> Dict<Int64> -> List<List<String>>"
+     |> roundtripCliScript) = "type MyFn =\n  (String * Int64 * Bool) -> Dict<Int64> -> List<List<String>>"
+
+    ("type MyFn = PACKAGE.Darklang.LanguageTools.ID -> 'a -> 'b"
+     |> roundtripCliScript) = "type MyFn =\n  PACKAGE.Darklang.LanguageTools.ID -> 'a -> 'b"
+
     ("type MyVar = 'a" |> roundtripCliScript) = "type MyVar =\n  'a"
 
     // single-part qualified name

--- a/packages/darklang/languageTools/parser/typeReference.dark
+++ b/packages/darklang/languageTools/parser/typeReference.dark
@@ -132,6 +132,36 @@ module Darklang =
 
                 | _ -> createUnparseableError node
 
+              | "fn_type_reference" ->
+                let returnTypeNode =
+                  firstChild.children
+                  |> Stdlib.List.last
+                  |> Builtin.unwrap
+                  |> TypeReference.parse
+
+                let argsNodes =
+                  firstChild.children
+                  |> Stdlib.List.dropLast
+                  |> Stdlib.List.chunkBySize 2L
+                  |> Builtin.unwrap
+                  |> Stdlib.List.map (fun chunk ->
+                    match chunk with
+                    | [ typeNode; arrowNode ] ->
+                      match TypeReference.parse typeNode with
+                      | Ok typeRef ->
+                        (typeRef, arrowNode.range) |> Stdlib.Result.Result.Ok
+                      | Error _ -> createUnparseableError node
+                    | [ typeNode ] -> createUnparseableError node
+                    | _ -> createUnparseableError node)
+
+                let args = argsNodes |> Stdlib.Result.collect
+
+                match returnTypeNode, args with
+                | Ok returnType, Ok args ->
+                  (TBuiltin.TFn firstChild.range args returnType) |> builtin
+
+                | _ -> createUnparseableError node
+
               | "variable_type_reference" ->
                 let variableName = findField firstChild "variable"
 

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -154,6 +154,17 @@ module Darklang =
                 [ makeToken rc TokenType.Symbol ] ]
               |> Stdlib.List.flatten
 
+            | TFn(r, args, ret) ->
+              [ (args
+                 |> Stdlib.List.map (fun (arg, symbolArrow) ->
+                   [ TypeReference.tokenize arg
+                     [ makeToken symbolArrow TokenType.Symbol ] ]
+                   |> Stdlib.List.flatten)
+                 |> Stdlib.List.flatten)
+
+                TypeReference.tokenize ret ]
+              |> Stdlib.List.flatten
+
             | TVariable(r, _) -> [ makeToken r TokenType.TypeName ]
 
         let tokenize

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -78,6 +78,11 @@ module Darklang =
             typ: TypeReference.TypeReference *
             closeBrace: Range
 
+          | TFn of
+            Range *
+            arguments: List<TypeReference.TypeReference * Range> *
+            ret: TypeReference.TypeReference
+
           | TVariable of Range * String
 
 

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -92,6 +92,13 @@ module Darklang =
 
               ProgramTypes.TypeReference.TDict valueType
 
+            | TFn(_range, args, returnType) ->
+              let args =
+                Stdlib.List.map args (fun (t, _) -> TypeReference.toPT onMissing t)
+
+              let returnType = TypeReference.toPT onMissing returnType
+
+              ProgramTypes.TypeReference.TFn(args, returnType)
 
             | TVariable(_range, name) -> ProgramTypes.TypeReference.TVariable name
 

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -214,8 +214,7 @@ module Darklang =
             args
             |> Stdlib.List.map (fun arg ->
               PrettyPrinter.ProgramTypes.typeReference arg)
-            |> Stdlib.String.join ", "
-            |> fun parts -> "(" ++ parts ++ ")"
+            |> Stdlib.String.join " -> "
 
           $"{argPart} -> {PrettyPrinter.ProgramTypes.typeReference ret}"
         | _ ->

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -811,6 +811,7 @@ module.exports = grammar({
         $.list_type_reference,
         $.tuple_type_reference,
         $.dict_type_reference,
+        $.fn_type_reference,
         $.variable_type_reference,
       ),
 
@@ -832,7 +833,7 @@ module.exports = grammar({
         field("first", $.type_reference),
         field("symbol_asterisk", alias("*", $.symbol)),
         field("second", $.type_reference),
-        field("rest", optional($.type_reference_tuple_the_rest)),
+        optional(field("rest", $.type_reference_tuple_the_rest)),
         field("symbol_right_paren", alias(")", $.symbol)),
       ),
 
@@ -852,6 +853,24 @@ module.exports = grammar({
         field("symbol_open_angle", alias("<", $.symbol)),
         field("value_type", $.type_reference),
         field("symbol_close_angle", alias(">", $.symbol)),
+      ),
+
+    //
+    // Function type reference
+    //  'a -> 'b -> 'c
+    fn_type_reference: $ =>
+      prec.right(
+        seq(
+          $.type_reference,
+          repeat1(
+            prec.left(
+              seq(
+                field("symbol_arrow", alias("->", $.symbol)),
+                $.type_reference,
+              ),
+            ),
+          ),
+        ),
       ),
 
     //

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -3422,6 +3422,14 @@
           "value": "String"
         },
         {
+          "type": "PATTERN",
+          "value": "DateTime"
+        },
+        {
+          "type": "PATTERN",
+          "value": "Uuid"
+        },
+        {
           "type": "SYMBOL",
           "name": "list_type_reference"
         },
@@ -3435,11 +3443,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "variable_type_reference"
+          "name": "fn_type_reference"
         },
         {
-          "type": "PATTERN",
-          "value": "Uuid"
+          "type": "SYMBOL",
+          "name": "variable_type_reference"
         }
       ]
     },
@@ -3541,20 +3549,20 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "rest",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "rest",
+              "content": {
                 "type": "SYMBOL",
                 "name": "type_reference_tuple_the_rest"
-              },
-              {
-                "type": "BLANK"
               }
-            ]
-          }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -3651,6 +3659,48 @@
           }
         }
       ]
+    },
+    "fn_type_reference": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "type_reference"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "PREC_LEFT",
+              "value": 0,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "symbol_arrow",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": "->"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "type_reference"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     },
     "variable_type_reference": {
       "type": "SEQ",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -62,6 +62,10 @@
           "named": true
         },
         {
+          "type": "fn_type_reference",
+          "named": true
+        },
+        {
           "type": "list_type_reference",
           "named": true
         },
@@ -721,6 +725,32 @@
     "type": "fn_identifier",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "fn_type_reference",
+    "named": true,
+    "fields": {
+      "symbol_arrow": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "type_reference",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "if_expression",

--- a/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/type_refs.txt
@@ -163,3 +163,97 @@ type MyVar = 'a
     )
   )
 )
+
+
+==================
+type reference - fn
+==================
+
+type MyFn = 'a -> String
+
+---
+
+(source_file
+  (type_decl
+    (keyword)
+    (type_identifier)
+    (symbol)
+    (type_decl_def
+      (type_decl_def_alias
+        (type_reference
+          (builtin_type
+            (fn_type_reference
+              (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+              (symbol)
+              (type_reference (builtin_type))
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+type reference - fn with two args
+==================
+
+type MyFn = 'a -> 'b -> String
+
+---
+
+(source_file
+  (type_decl
+    (keyword)
+    (type_identifier)
+    (symbol)
+    (type_decl_def
+      (type_decl_def_alias
+        (type_reference
+          (builtin_type
+            (fn_type_reference
+              (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+              (symbol)
+              (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+              (symbol)
+              (type_reference (builtin_type))
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+type reference - fn with multiple args
+==================
+
+type MyFn = 'a -> 'b -> 'c -> String
+
+---
+
+(source_file
+  (type_decl
+    (keyword) (type_identifier) (symbol)
+    (type_decl_def
+      (type_decl_def_alias
+        (type_reference
+          (builtin_type
+            (fn_type_reference
+              (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+              (symbol)
+              (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+              (symbol)
+              (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
+              (symbol)
+              (type_reference (builtin_type))
+            )
+          )
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Changelog:

```
Tree-sitter-darklang
- Update the grammar to support function type reference
```

#5321 