### PR TITLE
Tree-sitter grammar: handle constant expression

### DIFF
--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -401,8 +401,8 @@ module TextToTextRoundtripping =
     ("MyEnum.A(1L, 2L)" |> roundtripCliScript) = "MyEnum.A((1L, 2L))"
     ("MyEnum.A 1L 2L" |> roundtripCliScript) = "MyEnum.A(1L, 2L)"
 
-
-
+    // qualified constant
+    ("Stdlib.List.empty" |> roundtripCliScript) = "PACKAGE.Darklang.Stdlib.List.empty"
 
     // variables and let bindings
     ("assumedlyAVariableName" |> roundtripCliScript) = "assumedlyAVariableName"
@@ -561,7 +561,7 @@ else
     ("match (1L, 2L) with\n| (1L, 2L) -> true" |> roundtripCliScript) = "match (1L, 2L) with\n| (1L, 2L) ->\n  true"
 
     ("match Stdlib.Result.Result.Ok 5L with\n| Ok 5L -> true\n| Error e -> false"
-     |> roundtripCliScript) = "match Stdlib.Result.Result.Ok(5L) with\n| Ok 5L ->\n  true\n| Error e ->\n  false"
+     |> roundtripCliScript) = "match PACKAGE.Darklang.Stdlib.Result.Result.Ok(5L) with\n| Ok 5L ->\n  true\n| Error e ->\n  false"
 
     ("match \"str\" with\n| \"str\" when true -> true" |> roundtripCliScript) = "match \"str\" with\n| \"str\" when true ->\n  true"
 
@@ -577,7 +577,7 @@ else
     ("1L |> x" |> roundtripCliScript) = "1L\n|> x"
     ("1L |> (fun x -> x + 1L)" |> roundtripCliScript) = "1L\n|> fun x -> (x) + (1L)"
     ("1L |> fun x -> x + 1L" |> roundtripCliScript) = "1L\n|> fun x -> (x) + (1L)"
-    ("3L |> Stdlib.Result.Result.Ok" |> roundtripCliScript) = "3L\n|> Stdlib.Result.Result.Ok"
+    ("3L |> Stdlib.Result.Result.Ok" |> roundtripCliScript) = "3L\n|> PACKAGE.Darklang.Stdlib.Result.Result.Ok"
     ("33L |> MyEnum.A 21L" |> roundtripCliScript) = "33L\n|> MyEnum.A (21L)"
     ("1L |> Stdlib.Int64.add 2L" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.add 2L"
     ("1L |> Stdlib.Int64.toString" |> roundtripCliScript) = "1L\n|> PACKAGE.Darklang.Stdlib.Int64.toString"

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -85,7 +85,6 @@ module Darklang =
                     WrittenTypes.Expr.EInt128(node.range, intPart, sfx.range)
                   | "uint128_literal" ->
                     WrittenTypes.Expr.EUInt128(node.range, intPart, sfx.range)
-                  | _ -> createUnparseableError node
 
                 expr |> Stdlib.Result.Result.Ok
 
@@ -502,9 +501,11 @@ module Darklang =
 
           match typeNameNode, symbolDotNode, caseNameNode, enumFieldsNode with
           | Ok typeNameNode, Ok symbolDotNode, Ok caseNameNode, Ok enumFieldsNode ->
+            let typeName = typeNameNode.text |> Stdlib.String.split "."
+
             (WrittenTypes.Expr.EEnum(
               node.range,
-              (typeNameNode.range, [ typeNameNode.text ]),
+              (typeNameNode.range, typeName),
               (caseNameNode.range, caseNameNode.text),
               enumFieldsNode,
               symbolDotNode.range
@@ -882,6 +883,19 @@ module Darklang =
           | _ -> createUnparseableError node
 
 
+        let parseConstant
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
+          let constNameNode = Identifiers.parseQualifiedConstant node
+
+          match constNameNode with
+          | Ok constNameNode ->
+            (WrittenTypes.Expr.EConstant(node.range, constNameNode))
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> createUnparseableError node
+
+
         /// this parses one of the Expr cases
         let parseCase
           (node: ParsedNode)
@@ -934,6 +948,8 @@ module Darklang =
           | "infix_operation" -> parseInfixOperation node
           | "lambda_expression" -> parseLambda node
           | "apply" -> parseFunctionCall node
+
+          | "qualified_const_name" -> parseConstant node
 
           | _ -> createUnparseableError node
 

--- a/packages/darklang/languageTools/parser/identifiers.dark
+++ b/packages/darklang/languageTools/parser/identifiers.dark
@@ -49,6 +49,9 @@ module Darklang =
         let parseFn (n: ParsedNode) : WrittenTypes.FnIdentifier =
           WrittenTypes.FnIdentifier { range = n.range; name = n.text }
 
+        let parseConst (n: ParsedNode) : WrittenTypes.ConstantIdentifier =
+          WrittenTypes.ConstantIdentifier { range = n.range; name = n.text }
+
         let extractTypeArgs
           (node: ParsedNode)
           : Stdlib.Result.Result<List<WrittenTypes.Range * String>, WrittenTypes.Unparseable> =
@@ -126,3 +129,21 @@ module Darklang =
           else
             Stdlib.Result.Result.Error
               $"Can't parse qualified_fn_name from {node.typ}"
+
+
+        let parseQualifiedConstant
+          (node: ParsedNode)
+          : Stdlib.Result.Result<WrittenTypes.QualifiedConstantIdentifier, String> =
+          if node.typ == "qualified_const_name" then
+            let (modules, constIdentifierNode) =
+              extractModuleIdentifiers node.children
+
+            (WrittenTypes.QualifiedConstantIdentifier
+              { range = node.range
+                modules = modules
+                constant = parseConst constIdentifierNode })
+            |> Stdlib.Result.Result.Ok
+
+          else
+            Stdlib.Result.Result.Error
+              $"Can't parse qualified_const_name from {node.typ}"

--- a/packages/darklang/languageTools/parser/pipeExpr.dark
+++ b/packages/darklang/languageTools/parser/pipeExpr.dark
@@ -120,9 +120,11 @@ module Darklang =
 
           match typeNameNode, symbolDotNode, caseNameNode, enumFieldsNode with
           | Ok typeNameNode, Ok symbolDotNode, Ok caseNameNode, Ok enumFieldsNode ->
+            let typeName = typeNameNode.text |> Stdlib.String.split "."
+
             (WrittenTypes.PipeExpr.EPipeEnum(
               node.range,
-              (typeNameNode.range, [ typeNameNode.text ]),
+              (typeNameNode.range, typeName),
               (caseNameNode.range, caseNameNode.text),
               enumFieldsNode,
               symbolDotNode.range

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -83,6 +83,23 @@ module Darklang =
         let tokenize (v: WrittenTypes.VariableIdentifier) : List<SemanticToken> =
           [ makeToken v.range TokenType.VariableName ]
 
+      module ConstantIdentifier =
+        let tokenize (c: WrittenTypes.ConstantIdentifier) : List<SemanticToken> =
+          [ makeToken c.range TokenType.VariableName ]
+
+      module QualifiedConstIdentifier =
+        let tokenize
+          (q: WrittenTypes.QualifiedConstantIdentifier)
+          : List<SemanticToken> =
+          [ // Darklang.Stdlib.List
+            (q.modules
+             |> Stdlib.List.map (fun (m, _) -> ModuleIdentifier.tokenize m)
+             |> Stdlib.List.flatten)
+
+            // empty
+            ConstantIdentifier.tokenize q.constant ]
+          |> Stdlib.List.flatten
+
       module FnIdentifier =
         let tokenize (fn: WrittenTypes.FnIdentifier) : List<SemanticToken> =
           [ makeToken fn.range TokenType.FunctionName ]
@@ -747,6 +764,8 @@ module Darklang =
           // x
           | EVariable(range, _varName) -> [ makeToken range TokenType.VariableName ]
 
+          | EConstant(range, c) -> QualifiedConstIdentifier.tokenize c
+
           // person.name
           | EFieldAccess(_range, expr, (r, fieldName), symbolDot) ->
             [ // person
@@ -869,8 +888,6 @@ module Darklang =
               // a + 1
               Expr.tokenize body ]
             |> Stdlib.List.flatten
-
-
 
           // hacky temp. syntax -- see `grammar.js`
           // Int64.add (1L) (2L)

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -22,6 +22,16 @@ module Darklang =
 
       type VariableIdentifier = { range: Range; name: String }
 
+      type ConstantIdentifier = { range: Range; name: String }
+
+      type QualifiedConstantIdentifier =
+        {
+          range: Range
+          /// the range corresponds to the `.` after the module name
+          modules: List<ModuleIdentifier * Range>
+          constant: ConstantIdentifier
+        }
+
       type FnIdentifier = { range: Range; name: String }
 
       type QualifiedFnIdentifier =
@@ -352,6 +362,8 @@ module Darklang =
           args: List<Expr>
 
         | EFnName of Range * name: QualifiedFnIdentifier
+
+        | EConstant of Range * name: QualifiedConstantIdentifier
 
       type PipeExpr =
         | EPipeInfix of Range * op: (Range * Infix) * Expr

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -55,6 +55,23 @@ module Darklang =
               []
               (WrittenTypes.Name.Unresolved(i.range, nameToResolve))
 
+        module Const =
+          let toPT (c: WrittenTypes.ConstantIdentifier) : String = c.name
+
+        module QualifiedConst =
+          let toPT
+            (onMissing: NameResolver.OnMissing)
+            (c: WrittenTypes.QualifiedConstantIdentifier)
+            : ProgramTypes.NameResolution<ProgramTypes.FQConstantName.FQConstantName> =
+            let nameToResolve =
+              Stdlib.List.append
+                (Stdlib.List.map c.modules (fun (cn, _) -> cn.name))
+                [ c.constant.name ]
+
+            NameResolver.ConstantName.resolve
+              onMissing
+              []
+              (WrittenTypes.Name.Unresolved(c.range, nameToResolve))
 
       module TypeReference =
         module Builtin =
@@ -476,7 +493,17 @@ module Darklang =
               toPT onMissing body
             )
 
-          | EVariable(_, var) -> ProgramTypes.Expr.EVariable (gid ()) var
+          | EVariable(range, var) ->
+            let unresolved = WrittenTypes.Name.Unresolved(range, [ var ])
+            let constant = NameResolver.ConstantName.resolve onMissing [] unresolved
+
+            match constant with
+            | Ok _ -> ProgramTypes.Expr.EConstant(gid (), constant)
+            | Error _ -> ProgramTypes.Expr.EVariable (gid ()) var
+
+          | EConstant(_, c) ->
+            let constant = Identifiers.QualifiedConst.toPT onMissing c
+            ProgramTypes.Expr.EConstant(gid (), constant)
 
           | EFieldAccess(_, expr, (_, fieldName), _) ->
             ProgramTypes.Expr.EFieldAccess(gid (), toPT onMissing expr, fieldName)

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -357,6 +357,14 @@ module.exports = grammar({
         $.pipe_expression,
 
         $.record_update,
+
+        $.qualified_const_name,
+      ),
+
+    qualified_const_name: $ =>
+      seq(
+        repeat(seq($.module_identifier, alias(".", $.symbol))),
+        $.constant_identifier,
       ),
 
     paren_expression: $ =>
@@ -1113,6 +1121,9 @@ module.exports = grammar({
           seq(field("symbol_comma", alias(",", $.symbol)), $.type_reference),
         ),
       ),
+
+    // e.g. `newline` in `const newline = '\n'`
+    constant_identifier: $ => /[a-z_][a-zA-Z0-9_]*/,
 
     /** e.g. `x` in `let double (x: Int) = x + x`
      *

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -1342,6 +1342,40 @@
         {
           "type": "SYMBOL",
           "name": "record_update"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "qualified_const_name"
+        }
+      ]
+    },
+    "qualified_const_name": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "module_identifier"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "."
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_identifier"
         }
       ]
     },
@@ -4856,6 +4890,10 @@
           }
         }
       ]
+    },
+    "constant_identifier": {
+      "type": "PATTERN",
+      "value": "[a-z_][a-zA-Z0-9_]*"
     },
     "variable_identifier": {
       "type": "PREC",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -172,6 +172,11 @@
     }
   },
   {
+    "type": "constant_identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "db_type_reference",
     "named": true,
     "fields": {
@@ -555,6 +560,10 @@
         },
         {
           "type": "pipe_expression",
+          "named": true
+        },
+        {
+          "type": "qualified_const_name",
           "named": true
         },
         {
@@ -2214,6 +2223,29 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "qualified_const_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "constant_identifier",
+          "named": true
+        },
+        {
+          "type": "module_identifier",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/constant.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/constant.txt
@@ -1,0 +1,15 @@
+==================
+package constant
+==================
+
+Stdlib.List.empty
+
+---
+
+(source_file
+  (expression
+    (qualified_const_name
+      (module_identifier) (symbol) (module_identifier) (symbol) (constant_identifier)
+    )
+  )
+)


### PR DESCRIPTION
Changelog:

```
Tree-sitter grammar
- add support for constant expression
```

#5321 