### PR TITLE
Remove LibParser usage from Cron.Tests and NewParser

### DIFF
--- a/backend/src/LibExecution/CommonToDarkTypes.fs
+++ b/backend/src/LibExecution/CommonToDarkTypes.fs
@@ -1,0 +1,25 @@
+module LibExecution.CommonToDarkTypes
+
+open RuntimeTypes
+
+module Result =
+  let toDT
+    (okType : KnownType)
+    (errorType : KnownType)
+    (r : Result<'a, 'b>)
+    (f : 'a -> Dval)
+    (errToDTFn : 'b -> Dval)
+    : Dval =
+    match r with
+    | Ok v -> Dval.resultOk okType errorType (f v)
+    | Error err -> Dval.resultError okType errorType (errToDTFn err)
+
+  let fromDT (f : Dval -> 'a) (d : Dval) (errToDTFn : Dval -> 'b) : Result<'a, 'b> =
+    match d with
+    | DEnum(tn, _, _typeArgsDEnumTODO, "Ok", [ v ]) when tn = Dval.resultType ->
+      Ok(f v)
+
+    | DEnum(tn, _, _typeArgsDEnumTODO, "Error", [ v ]) when tn = Dval.resultType ->
+      Error(errToDTFn v)
+
+    | _ -> Exception.raiseInternal "Invalid Result" []

--- a/backend/src/LibExecution/LibExecution.fsproj
+++ b/backend/src/LibExecution/LibExecution.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="RuntimeTypes.fs" />
     <Compile Include="Dval.fs" />
     <Compile Include="DvalDecoder.fs" />
+    <Compile Include="CommonToDarkTypes.fs" />
     <Compile Include="RuntimeTypesToDarkTypes.fs" />
     <Compile Include="NameResolutionError.fs" />
     <Compile Include="RuntimeTypesAst.fs" />

--- a/backend/src/LibExecution/PackageIDs.fs
+++ b/backend/src/LibExecution/PackageIDs.fs
@@ -105,6 +105,11 @@ module Type =
       let range = p [] "Range" "e194e06f-a765-483d-b6a5-16856ed547f0"
       let parsedNode = p [] "ParsedNode" "3612c001-663c-4695-9b1c-d3a1582a8057"
 
+    module NameResolver =
+      let private p addl = p ("NameResolver" :: addl)
+      let nameResolverOnMissing =
+        p [] "OnMissing" "3c6057e7-143b-4af8-96c4-c193c1ccfeb3"
+
     module RuntimeError =
       let private p addl = p ("RuntimeErrors" :: addl)
 
@@ -321,6 +326,18 @@ module Fn =
         let toString = p [] "toString" "64a08e23-e4ea-474b-9f77-3d2b1b953879"
         let toErrorMessage =
           p [] "toErrorMessage" "d861d9c4-45da-4789-8f41-b0e481422190"
+
+    module Parser =
+      let private p addl = p ("Parser" :: addl)
+      let parsePTExpr =
+        p [ "ParserTest" ] "parsePTExpr" "d96d3e6b-6c0d-4559-ae36-353eaf738fa9"
+
+      let parseAndPrettyPrint =
+        p
+          [ "ParserTest" ]
+          "parseAndPrettyPrint"
+          "361fb7f2-523b-4b50-8f29-cc99d5f03e3a"
+
 
   module PrettyPrinter =
     module RuntimeTypes =

--- a/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
@@ -1500,3 +1500,25 @@ module PackageFn =
         deprecated =
           fields |> D.field "deprecated" |> Deprecation.fromDT FQFnName.fromDT }
     | _ -> Exception.raiseInternal "Invalid PackageFn" []
+
+
+module Result =
+  let toDT
+    (nameValueType : KnownType)
+    (errorType : KnownType)
+    (r : Result<'a, ProgramTypes.TypeReference>)
+    (inner : 'a -> Dval)
+    : Dval =
+    match r with
+    | Ok v -> Dval.resultOk nameValueType errorType (inner v)
+    | Error err ->
+      Dval.resultError nameValueType errorType (err |> TypeReference.toDT)
+
+  let fromDT (f : Dval -> 'a) (d : Dval) : 'a =
+    match d with
+    | DEnum(tn, _, _typeArgsDEnumTODO, "Ok", [ v ]) when tn = Dval.resultType -> f v
+
+    | DEnum(tn, _, _typeArgsDEnumTODO, "Error", []) when tn = Dval.resultType ->
+      Exception.raiseInternal "Got Error" []
+
+    | _ -> Exception.raiseInternal "Invalid Result" []

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -6,6 +6,7 @@ open RuntimeTypes
 
 module VT = ValueType
 module D = DvalDecoder
+module C2DT = LibExecution.CommonToDarkTypes
 
 
 // TODO: should these be elsewhere?
@@ -143,18 +144,10 @@ module NameResolution =
     (result : NameResolution<'p>)
     : Dval =
     let errType = KTCustomType(typeName, [])
-
-    match result with
-    | Ok name -> Dval.resultOk nameValueType errType (f name)
-    | Error err -> RuntimeError.toDT err |> Dval.resultError nameValueType errType
+    C2DT.Result.toDT nameValueType errType result f RuntimeError.toDT
 
   let fromDT (f : Dval -> 'a) (d : Dval) : NameResolution<'a> =
-    match d with
-    | DEnum(tn, _, _typeArgsDEnumTODO, "Ok", [ v ]) when tn = Dval.resultType ->
-      Ok(f v)
-    | DEnum(tn, _, _typeArgsDEnumTODO, "Error", [ v ]) when tn = Dval.resultType ->
-      Error(RuntimeError.fromDT v)
-    | _ -> Exception.raiseInternal "Invalid NameResolution" []
+    C2DT.Result.fromDT f d RuntimeError.fromDT
 
 
 module TypeReference =

--- a/backend/testfiles/execution/stdlib/parser.dark
+++ b/backend/testfiles/execution/stdlib/parser.dark
@@ -102,22 +102,22 @@ module ParseToSimplifiedTree =
 module ParseNodeToWrittenTypes =
   ("type MyID = Int64"
    |> PACKAGE.Darklang.LanguageTools.Parser.parseToSimplifiedTree
-   |> PACKAGE.Darklang.LanguageTools.Parser.parseCliScript
+   |> PACKAGE.Darklang.LanguageTools.Parser.parseFromTree
    |> Builtin.unwrap) = PACKAGE
     .Darklang
     .LanguageTools
     .WrittenTypes
     .ParsedFile
-    .CliScript(
-      PACKAGE.Darklang.LanguageTools.WrittenTypes.CliScript.CliScript
+    .SourceFile(
+      PACKAGE.Darklang.LanguageTools.WrittenTypes.SourceFile.SourceFile
         { range = range (0L, 0L) (0L, 17L)
           declarations =
             [ PACKAGE
                 .Darklang
                 .LanguageTools
                 .WrittenTypes
-                .CliScript
-                .CliScriptDeclaration
+                .SourceFile
+                .SourceFileDeclaration
                 .Type(
                   (PACKAGE.Darklang.LanguageTools.WrittenTypes.TypeDeclaration.TypeDeclaration
                     { range = range (0L, 0L) (0L, 17L)

--- a/backend/testfiles/execution/stdlib/semanticTokenization.dark
+++ b/backend/testfiles/execution/stdlib/semanticTokenization.dark
@@ -9,7 +9,7 @@ let tokenize
   =
   text
   |> PACKAGE.Darklang.LanguageTools.Parser.parseToSimplifiedTree
-  |> PACKAGE.Darklang.LanguageTools.Parser.parseCliScript
+  |> PACKAGE.Darklang.LanguageTools.Parser.parseFromTree
   |> Builtin.unwrap
   |> PACKAGE.Darklang.LanguageTools.SemanticTokens.ParsedFile.tokenize
   |> Stdlib.List.map (fun token ->

--- a/backend/tests/Tests/Cron.Tests.fs
+++ b/backend/tests/Tests/Cron.Tests.fs
@@ -14,6 +14,8 @@ module Cron = LibCloud.Cron
 module Canvas = LibCloud.Canvas
 module Serialize = LibCloud.Serialize
 module PackageIDs = LibExecution.PackageIDs
+module PT2DT = LibExecution.ProgramTypesToDarkTypes
+module C2DT = LibExecution.CommonToDarkTypes
 let pm = LibCloud.PackageManager.pt
 
 let p (code : string) : Task<RT.Dval> =
@@ -47,10 +49,15 @@ let testCronSanity =
     let! canvasID = initializeTestCanvas "cron-sanity"
 
     let! e = p "5 + 3"
+    let resultExpr =
+      C2DT.Result.fromDT PT2DT.Expr.fromDT e PT2DT.TypeReference.fromDT
+
     let expr =
-      LibExecution.ProgramTypesToDarkTypes.Result.fromDT
-        LibExecution.ProgramTypesToDarkTypes.Expr.fromDT
-        e
+      match resultExpr with
+      | Ok expr -> expr
+      | Error e ->
+        Exception.raiseInternal "Error converting to dark types" [ "error", e ]
+
     let h = testCron "test" PT.Handler.EveryDay expr
     do! Canvas.saveTLIDs canvasID [ (PT.Toplevel.TLHandler h, Serialize.NotDeleted) ]
 
@@ -70,10 +77,15 @@ let testCronJustRan =
     let! canvasID = initializeTestCanvas "cron-just-ran"
 
     let! e = p "5 + 3"
+    let resultExpr =
+      C2DT.Result.fromDT PT2DT.Expr.fromDT e PT2DT.TypeReference.fromDT
+
     let expr =
-      LibExecution.ProgramTypesToDarkTypes.Result.fromDT
-        LibExecution.ProgramTypesToDarkTypes.Expr.fromDT
-        e
+      match resultExpr with
+      | Ok expr -> expr
+      | Error e ->
+        Exception.raiseInternal "Error converting to dark types" [ "error", e ]
+
     let h = testCron "test" PT.Handler.EveryDay expr
 
     do! Canvas.saveTLIDs canvasID [ (PT.Toplevel.TLHandler h, Serialize.NotDeleted) ]

--- a/backend/tests/Tests/Cron.Tests.fs
+++ b/backend/tests/Tests/Cron.Tests.fs
@@ -49,8 +49,7 @@ let testCronSanity =
     let! canvasID = initializeTestCanvas "cron-sanity"
 
     let! e = p "5 + 3"
-    let resultExpr =
-      C2DT.Result.fromDT PT2DT.Expr.fromDT e PT2DT.TypeReference.fromDT
+    let resultExpr = C2DT.Result.fromDT PT2DT.Expr.fromDT e RT.RuntimeError.fromDT
 
     let expr =
       match resultExpr with
@@ -77,8 +76,7 @@ let testCronJustRan =
     let! canvasID = initializeTestCanvas "cron-just-ran"
 
     let! e = p "5 + 3"
-    let resultExpr =
-      C2DT.Result.fromDT PT2DT.Expr.fromDT e PT2DT.TypeReference.fromDT
+    let resultExpr = C2DT.Result.fromDT PT2DT.Expr.fromDT e RT.RuntimeError.fromDT
 
     let expr =
       match resultExpr with

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -4,7 +4,7 @@
 ///   source (input)
 ///   -> parsed TreeSitter tree
 ///   -> parsed CLI Script
-///   -> PT.CliScript
+///   -> PT.SourceFile
 ///   -> pretty-print back to text (expected)
 ///
 module Tests.NewParser
@@ -1523,7 +1523,7 @@ let moduleDeclarations =
   |> testList "module declarations"
 
 
-let cliScripts =
+let sourceFiles =
   [
     // CLEANUP the output here is a bit broken
     t
@@ -1565,4 +1565,4 @@ let tests =
       exprs
       functionDeclarations
       moduleDeclarations
-      cliScripts ]
+      sourceFiles ]

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -20,163 +20,285 @@ open TestUtils.TestUtils
 module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
 module PackageIDs = LibExecution.PackageIDs
-module NR = LibParser.NameResolver
 
 
 let pmPT = LibCloud.PackageManager.pt
 
-let applyFn (fnName : string) (symbol : RT.Dval) : Ply<RT.Dval> =
-  uply {
-    let! parsedExpr =
-      LibParser.Parser.parseRTExpr
-        (localBuiltIns pmPT)
-        pmPT
-        NR.OnMissing.ThrowError
-        "NewParser.Tests.fs"
-        $"{fnName} symbol"
+let t
+  (name : string)
+  (input : string)
+  (expected : string)
+  (extraTypes : List<PT.PackageType.PackageType>)
+  (extraConstants : List<PT.PackageConstant.PackageConstant>)
+  (extraFns : List<PT.PackageFn.PackageFn>)
+  (allowUnresolved : bool)
+  =
+  let fnname =
+    RT.FQFnName.FQFnName.Package
+      PackageIDs.Fn.LanguageTools.Parser.parseAndPrettyPrint
 
-    let! (state : RT.ExecutionState) =
-      let canvasID = System.Guid.NewGuid()
-      executionStateFor pmPT canvasID false false Map.empty
-
-    let symtable = Map [ "symbol", symbol ]
-
-    let! exeResult = LibExecution.Execution.executeExpr state symtable parsedExpr
-
-    match exeResult with
-    | Ok dval -> return dval
-    | Error(_callStack, rte) ->
-      let errorMessageFn =
-        RT.FQFnName.fqPackage
-          PackageIDs.Fn.LanguageTools.RuntimeErrors.Error.toErrorMessage
-
-      let rte = RT.RuntimeError.toDT rte
-
-      let! rteMessage =
-        LibExecution.Execution.executeFunction
-          state
-          errorMessageFn
-          []
-          (NEList.ofList rte [])
-
-      match rteMessage with
-      | Ok(RT.DString msg) -> return RT.DString msg
-      | _ -> return RT.DString(string rte)
-  }
-
-
-
-let t (name : string) (input : string) (expected : string) =
   testTask name {
-    let! actual =
-      (RT.DString input)
-      |> applyFn "PACKAGE.Darklang.LanguageTools.Parser.parseToSimplifiedTree"
-      |> Ply.bind (applyFn "PACKAGE.Darklang.LanguageTools.Parser.parseCliScript")
-      |> Ply.bind (applyFn "Builtin.unwrap")
-      |> Ply.bind (
-        applyFn
-          "PACKAGE.Darklang.LanguageTools.WrittenTypesToProgramTypes.parsedFileAsCliScript"
-      )
-      // TODO: take the definitions from the above line,
-      // and _re-parse_, demanding that there are no name resolution errors (i.e. NotFound).
-      //
-      // _Then_, pretty-print on the next line.
-      //
-      // Otherwise, we're not testing the full round-trip,
-      //   and just falling back to printing the `NotFound`s,
-      //   which contain the `List<String> of the names we couldn't find.
-      |> Ply.bind (applyFn "PACKAGE.Darklang.PrettyPrinter.ProgramTypes.cliScript")
-      |> Ply.toTask
+    let pm =
+      if allowUnresolved then
+        pmPT
+      else
+        PT.PackageManager.withExtras pmPT extraTypes extraConstants extraFns
+    let canvasID = System.Guid.NewGuid()
+    let! state = executionStateFor pm canvasID false false Map.empty
+
+    let args = NEList.singleton (RT.DString input)
+    let! exeResult = LibExecution.Execution.executeFunction state fnname [] args
+    let! actual = state |> unwrapExecutionResult exeResult |> Ply.toTask
 
     return
       Expect.equalDval actual (RT.DString expected) "Didn't round-trip as expected"
   }
 
 
+let tID = System.Guid.NewGuid()
+let person3 : PT.PackageType.PackageType =
+  { id = tID
+    name = { owner = "Tests"; modules = []; name = "Person3" }
+    description = ""
+    deprecated = PT.NotDeprecated
+    declaration =
+      { typeParams = []
+        definition =
+          PT.TypeDeclaration.Record(
+            { head =
+                { name = "name"; typ = PT.TypeReference.TString; description = "" }
+              tail =
+                [ { name = "age"; typ = PT.TypeReference.TInt64; description = "" }
+                  { name = "hasPet"; typ = PT.TypeReference.TBool; description = "" } ] }
+          ) } }
+
+
 let typeReferences =
   [
     // all built-ins
-    t "unit alias" "type MyUnit = Unit" "type MyUnit =\n  Unit"
+    t "unit alias" "type MyUnit = Unit" "type MyUnit =\n  Unit" [] [] [] false
 
-    t "bool alias" "type MyBool = Bool" "type MyBool =\n  Bool"
-    t "int8 alias" "type MyInt8 = Int8" "type MyInt8 =\n  Int8"
-    t "uint8 alias" "type MyUInt8 = UInt8" "type MyUInt8 =\n  UInt8"
-    t "int16 alias" "type MyInt16 = Int16" "type MyInt16 =\n  Int16"
-    t "uint16 alias" "type MyUInt16 = UInt16" "type MyUInt16 =\n  UInt16"
-    t "int32 alias" "type MyInt32 = Int32" "type MyInt32 =\n  Int32"
-    t "uint32 alias" "type MyUInt32 = UInt32" "type MyUInt32 =\n  UInt32"
-    t "int64 alias" "type MyInt64 = Int64" "type MyInt64 =\n  Int64"
-    t "uint64 alias" "type MyUInt64 = UInt64" "type MyUInt64 =\n  UInt64"
-    t "int128 alias" "type MyInt128 = Int128" "type MyInt128 =\n  Int128"
-    t "uint128 alias" "type MyUInt128 = UInt128" "type MyUInt128 =\n  UInt128"
+    t "bool alias" "type MyBool = Bool" "type MyBool =\n  Bool" [] [] [] false
+    t "int8 alias" "type MyInt8 = Int8" "type MyInt8 =\n  Int8" [] [] [] false
+    t "uint8 alias" "type MyUInt8 = UInt8" "type MyUInt8 =\n  UInt8" [] [] [] false
+    t "int16 alias" "type MyInt16 = Int16" "type MyInt16 =\n  Int16" [] [] [] false
+    t
+      "uint16 alias"
+      "type MyUInt16 = UInt16"
+      "type MyUInt16 =\n  UInt16"
+      []
+      []
+      []
+      false
+    t "int32 alias" "type MyInt32 = Int32" "type MyInt32 =\n  Int32" [] [] [] false
+    t
+      "uint32 alias"
+      "type MyUInt32 = UInt32"
+      "type MyUInt32 =\n  UInt32"
+      []
+      []
+      []
+      false
+    t "int64 alias" "type MyInt64 = Int64" "type MyInt64 =\n  Int64" [] [] [] false
+    t
+      "uint64 alias"
+      "type MyUInt64 = UInt64"
+      "type MyUInt64 =\n  UInt64"
+      []
+      []
+      []
+      false
+    t
+      "int128 alias"
+      "type MyInt128 = Int128"
+      "type MyInt128 =\n  Int128"
+      []
+      []
+      []
+      false
+    t
+      "uint128 alias"
+      "type MyUInt128 = UInt128"
+      "type MyUInt128 =\n  UInt128"
+      []
+      []
+      []
+      false
 
-    t "float alias" "type MyFloat = Float" "type MyFloat =\n  Float"
+    t "float alias" "type MyFloat = Float" "type MyFloat =\n  Float" [] [] [] false
 
-    t "char alias" "type MyChar = Char" "type MyChar =\n  Char"
-    t "string alias" "type MyString = String" "type MyString =\n  String"
+    t "char alias" "type MyChar = Char" "type MyChar =\n  Char" [] [] [] false
+    t
+      "string alias"
+      "type MyString = String"
+      "type MyString =\n  String"
+      []
+      []
+      []
+      false
 
-    t "datetime alias" "type MyDateTime = DateTime" "type MyDateTime =\n  DateTime"
-    t "uuid alias" "type MyUuid = Uuid" "type MyUuid =\n  Uuid"
+    t
+      "datetime alias"
+      "type MyDateTime = DateTime"
+      "type MyDateTime =\n  DateTime"
+      []
+      []
+      []
+      false
+    t "uuid alias" "type MyUuid = Uuid" "type MyUuid =\n  Uuid" [] [] [] false
 
     t
       "string list alias"
       "type MyList = List<String>"
       "type MyList =\n  List<String>"
+      []
+      []
+      []
+      false
     t
       "string list list alias"
       "type MyList = List<List<String>>"
       "type MyList =\n  List<List<String>>"
+      []
+      []
+      []
+      false
     t
       "custom type list alias"
       "type MyList = List<MyString>"
       "type MyList =\n  List<MyString>"
-    t "generic list alias" "type MyList = List<'a>" "type MyList =\n  List<'a>"
-    t "int64 dict alias" "type MyDict = Dict<Int64>" "type MyDict =\n  Dict<Int64>"
+      []
+      []
+      []
+      false
+    t
+      "generic list alias"
+      "type MyList = List<'a>"
+      "type MyList =\n  List<'a>"
+      []
+      []
+      []
+      false
+    t
+      "int64 dict alias"
+      "type MyDict = Dict<Int64>"
+      "type MyDict =\n  Dict<Int64>"
+      []
+      []
+      []
+      false
     t
       "custom type dict alias"
       "type MyDict = Dict<MyList>"
       "type MyDict =\n  Dict<MyList>"
+      []
+      []
+      []
+      false
     t
       "tuple2 alias"
       "type MyTuple2 = (String * Int64)"
       "type MyTuple2 =\n  (String * Int64)"
+      []
+      []
+      []
+      false
     t
       "tuple3 alias"
       "type MyTuple3 = (String * Int64 * Bool)"
       "type MyTuple3 =\n  (String * Int64 * Bool)"
+      []
+      []
+      []
+      false
     t
       "tuple4 alias"
       "type MyTuple = (String * Int64 * Bool * Unit)"
       "type MyTuple =\n  (String * Int64 * Bool * Unit)"
+      []
+      []
+      []
+      false
 
-    t "fn with one arg" "type MyFn = 'a -> String" "type MyFn =\n  'a -> String"
-    t "fn with two args" "type MyFn = 'a -> 'b -> 'c" "type MyFn =\n  'a -> 'b -> 'c"
+    t
+      "fn with one arg"
+      "type MyFn = 'a -> String"
+      "type MyFn =\n  'a -> String"
+      []
+      []
+      []
+      false
+    t
+      "fn with two args"
+      "type MyFn = 'a -> 'b -> 'c"
+      "type MyFn =\n  'a -> 'b -> 'c"
+      []
+      []
+      []
+      false
     t
       "fn with three args"
       "type MyFn = 'a -> 'b -> 'c -> 'd"
       "type MyFn =\n  'a -> 'b -> 'c -> 'd"
+      []
+      []
+      []
+      false
     t
       "fn with tuple arg"
       "type MyFn = (String * Int64 * Bool) -> Dict<Int64> -> List<List<String>>"
       "type MyFn =\n  (String * Int64 * Bool) -> Dict<Int64> -> List<List<String>>"
+      []
+      []
+      []
+      false
     t
       "fn with generics"
       "type MyFn = PACKAGE.Darklang.LanguageTools.ID -> 'a -> 'b"
       "type MyFn =\n  PACKAGE.Darklang.LanguageTools.ID -> 'a -> 'b"
+      []
+      []
+      []
+      false
 
-    t "db with generic" "type MyDB = DB<'a>" "type MyDB =\n  DB<'a>"
-    t "db with custom type" "type MyDB = DB<Person>" "type MyDB =\n  DB<Person>"
-    t "db with generic 2" "type MyDB<'a> = DB<'a>" "type MyDB<'a> =\n  DB<'a>"
+    t "db with generic" "type MyDB = DB<'a>" "type MyDB =\n  DB<'a>" [] [] [] false
+    t
+      "db with custom type"
+      "type MyDB = DB<Person>"
+      "type MyDB =\n  DB<Person>"
+      []
+      []
+      []
+      false
+    t
+      "db with generic 2"
+      "type MyDB<'a> = DB<'a>"
+      "type MyDB<'a> =\n  DB<'a>"
+      []
+      []
+      []
+      false
     t
       "db with generic applied"
       "type GenericDB = DB<Generic<String>>"
       "type GenericDB =\n  DB<Generic<String>>"
+      []
+      []
+      []
+      false
 
-    t "variable" "type MyVar = 'a" "type MyVar =\n  'a"
+    t "variable" "type MyVar = 'a" "type MyVar =\n  'a" [] [] [] false
 
 
     // single-part qualified name
-    t "unknown single-part qualified name" "type ID = Test" "type ID =\n  Test"
+    t
+      "unknown single-part qualified name"
+      "type ID = Test"
+      "type ID =\n  Test"
+      []
+      []
+      []
+      false
 
 
     // fully-qualified package name (multi-part)
@@ -184,30 +306,57 @@ let typeReferences =
       "option alias, shortcut name"
       "type MyOption = PACKAGE.Darklang.Stdlib.Option.Option"
       "type MyOption =\n  PACKAGE.Darklang.Stdlib.Option.Option"
+      []
+      []
+      []
+      false
     t
       "option alias, unapplied"
       "type MyOption = Stdlib.Option.Option"
       "type MyOption =\n  PACKAGE.Darklang.Stdlib.Option.Option"
+      []
+      []
+      []
+      false
     t
       "option alias, applied"
       "type MyOption = Stdlib.Option.Option<Int64>"
-      "type MyOption =\n  PACKAGE.Darklang.Stdlib.Option.Option<Int64>" ]
+      "type MyOption =\n  PACKAGE.Darklang.Stdlib.Option.Option<Int64>"
+      []
+      []
+      []
+      false ]
   |> testList "type references"
 
 
 let typeDeclarations =
-  [ t "unit" "type SimpleAlias = Unit" "type SimpleAlias =\n  Unit"
+  [ t "unit" "type SimpleAlias = Unit" "type SimpleAlias =\n  Unit" [] [] [] false
 
     // Alias with type params
-    t "type param list" "type MyType<'a> = List<'a>" "type MyType<'a> =\n  List<'a>"
+    t
+      "type param list"
+      "type MyType<'a> = List<'a>"
+      "type MyType<'a> =\n  List<'a>"
+      []
+      []
+      []
+      false
     t
       "type param tuple"
       "type MyType<'a, 'b> = (List<'a> * List<'b>)"
       "type MyType<'a, 'b> =\n  (List<'a> * List<'b>)"
+      []
+      []
+      []
+      false
     t
       "type param record"
       "type Generic<'a> = { x: 'a }"
       "type Generic<'a> =\n  { x: 'a }"
+      []
+      []
+      []
+      false
 
     // // Enum type TODO
     // ("type Thing = | A | B of Int64 | C of String * Bool"  "type Thing =\n  | A\n  | B of Int64\n  | C of String * Bool"
@@ -217,224 +366,420 @@ let typeDeclarations =
       "record, 1 field"
       "type Person = {name: String}"
       "type Person =\n  { name: String }"
+      []
+      []
+      []
+      false
 
     t
       "record, 2 fields"
       "type Person = {name: String; age: Int64}"
       "type Person =\n  { name: String\n    age: Int64 }"
+      []
+      []
+      []
+      false
     t
       "record, 3 fields"
       "type Person = {name: String; age: Int64; hasPet: Bool}"
       "type Person =\n  { name: String\n    age: Int64\n    hasPet: Bool }"
+      []
+      []
+      []
+      false
     t
       "record, 4 fields"
       "type Person = {name: String; age: Int64; hasPet: Bool; pet: Pet}"
       "type Person =\n  { name: String\n    age: Int64\n    hasPet: Bool\n    pet: Pet }"
+      []
+      []
+      []
+      false
 
     // Enum type decls
     t
       "enum, no fields"
       "type Color = | Red | Green | Blue"
       "type Color =\n  | Red\n  | Green\n  | Blue"
-    t "enum, one field" "type MyEnum = | A of Int64" "type MyEnum =\n  | A of Int64"
+      []
+      []
+      []
+      false
+    t
+      "enum, one field"
+      "type MyEnum = | A of Int64"
+      "type MyEnum =\n  | A of Int64"
+      []
+      []
+      []
+      false
     t
       "enum, 2 tuple field"
       "type MyEnum = | A of Int64 * Int64"
       "type MyEnum =\n  | A of Int64 * Int64"
+      []
+      []
+      []
+      false
     t
       "enum, 3 tuple field"
       "type MyEnum = | A of Int64 * Bool * String | B of Int64"
       "type MyEnum =\n  | A of Int64 * Bool * String\n  | B of Int64"
+      []
+      []
+      []
+      false
     t
       "enum, named tuple fields"
       "type MyEnum = | A of x:Int64 * y:Int64"
       "type MyEnum =\n  | A of x: Int64 * y: Int64"
+      []
+      []
+      []
+      false
     t
       "enum, mult lines"
       "type Color =\n  | Red\n  | Green\n  | Blue"
       "type Color =\n  | Red\n  | Green\n  | Blue"
+      []
+      []
+      []
+      false
     t
       "enum, mult lines with field"
       "type MyEnum =\n  | A of Int64\n  | B of String"
       "type MyEnum =\n  | A of Int64\n  | B of String"
+      []
+      []
+      []
+      false
     t
       "enum, mult lines with named fields"
       "type MyEnum =\n  | A of x: Int64\n  | B of y: String"
       "type MyEnum =\n  | A of x: Int64\n  | B of y: String"
+      []
+      []
+      []
+      false
     t
       "enum, mult lines with named tuple field"
       "type MyEnum =\n  | A of x: Int64 * y: Int64\n  | B of z: String"
-      "type MyEnum =\n  | A of x: Int64 * y: Int64\n  | B of z: String" ]
+      "type MyEnum =\n  | A of x: Int64 * y: Int64\n  | B of z: String"
+      []
+      []
+      []
+      false ]
   |> testList "type declarations"
 
 let exprs =
   [
     // units
-    t "unit literal" "()" "()"
+    t "unit literal" "()" "()" [] [] [] false
 
     // bools
-    t "true literal" "true" "true"
-    t "false literal" "false" "false"
+    t "true literal" "true" "true" [] [] [] false
+    t "false literal" "false" "false" [] [] [] false
 
     // parens (disappear)
-    t "parens, basic" "(true)" "true"
+    t "parens, basic" "(true)" "true" [] [] [] false
 
     // int literals
-    t "int literal 1y" "1y" "1y"
-    t "int literal -1y" "-1y" "-1y"
-    t "int literal 1uy" "1uy" "1uy"
-    t "int literal 1s" "1s" "1s"
-    t "int literal 1us" "1us" "1us"
-    t "int literal 1l" "1l" "1l"
-    t "int literal -1l" "-1l" "-1l"
-    t "int literal 1ul" "1ul" "1ul"
-    t "int literal 0L" "0L" "0L"
-    t "int literal 1900L" "1900L" "1900L"
-    t "int literal -1900L" "-1900L" "-1900L"
-    t "int literal 1UL" "1UL" "1UL"
-    t "int literal 1Q" "1Q" "1Q"
-    t "int literal -1Q" "-1Q" "-1Q"
-    t "int literal 1Q" "1Q" "1Q"
+    t "int literal 1y" "1y" "1y" [] [] [] false
+    t "int literal -1y" "-1y" "-1y" [] [] [] false
+    t "int literal 1uy" "1uy" "1uy" [] [] [] false
+    t "int literal 1s" "1s" "1s" [] [] [] false
+    t "int literal 1us" "1us" "1us" [] [] [] false
+    t "int literal 1l" "1l" "1l" [] [] [] false
+    t "int literal -1l" "-1l" "-1l" [] [] [] false
+    t "int literal 1ul" "1ul" "1ul" [] [] [] false
+    t "int literal 0L" "0L" "0L" [] [] [] false
+    t "int literal 1900L" "1900L" "1900L" [] [] [] false
+    t "int literal -1900L" "-1900L" "-1900L" [] [] [] false
+    t "int literal 1UL" "1UL" "1UL" [] [] [] false
+    t "int literal 1Q" "1Q" "1Q" [] [] [] false
+    t "int literal -1Q" "-1Q" "-1Q" [] [] [] false
+    t "int literal 1Q" "1Q" "1Q" [] [] [] false
 
     // float literals
-    t "float literal -1.0" "-1.0" "-1.0"
-    t "float literal -1.5" "-1.5" "-1.5"
-    t "float literal 1.5" "1.5" "1.5"
-    t "float literal 0.0" "0.0" "0.0"
-    t "float literal 0.775" "0.775" "0.775"
+    t "float literal -1.0" "-1.0" "-1.0" [] [] [] false
+    t "float literal -1.5" "-1.5" "-1.5" [] [] [] false
+    t "float literal 1.5" "1.5" "1.5" [] [] [] false
+    t "float literal 0.0" "0.0" "0.0" [] [] [] false
+    t "float literal 0.775" "0.775" "0.775" [] [] [] false
 
     // string literals
-    t "empty string" "\"\"" "\"\""
-    t "hello" "\"hello\"" "\"hello\""
-    t "hello tab world" "\"hello\\tworld\"" "\"hello\\tworld\""
+    t "empty string" "\"\"" "\"\"" [] [] [] false
+    t "hello" "\"hello\"" "\"hello\"" [] [] [] false
+    t "hello tab world" "\"hello\\tworld\"" "\"hello\\tworld\"" [] [] [] false
 
     // char literals
-    t "the letter a" "'a'" "'a'"
-    t "a newline char" "'\\n'" "'\\n'"
-    t "a tab char" "'\t'" "'\t'"
+    t "the letter a" "'a'" "'a'" [] [] [] false
+    t "a newline char" "'\\n'" "'\\n'" [] [] [] false
+    t "a tab char" "'\t'" "'\t'" [] [] [] false
 
     // list literal
-    t "empty list" "[]" "[]"
-    t "string list" "[\"hello\"]" "[\"hello\"]"
-    t "int list 2" "[1L; 2L]" "[1L; 2L]"
-    t "int list 3" "[1L; 2L; 3L;]" "[1L; 2L; 3L]"
-    t "bool list" "[true; false; true; false]" "[true; false; true; false]"
-    t "int list list" "[[1L; 2L]; [3L; 4L]]" "[[1L; 2L]; [3L; 4L]]"
+    t "empty list" "[]" "[]" [] [] [] false
+    t "string list" "[\"hello\"]" "[\"hello\"]" [] [] [] false
+    t "int list 2" "[1L; 2L]" "[1L; 2L]" [] [] [] false
+    t "int list 3" "[1L; 2L; 3L;]" "[1L; 2L; 3L]" [] [] [] false
+    t
+      "bool list"
+      "[true; false; true; false]"
+      "[true; false; true; false]"
+      []
+      []
+      []
+      false
+    t "int list list" "[[1L; 2L]; [3L; 4L]]" "[[1L; 2L]; [3L; 4L]]" [] [] [] false
 
     // dict literal
-    t "empty dict" "Dict { }" "Dict {  }"
-    t "simple int dict" "Dict { a = 1L }" "Dict { a = 1L }"
+    t "empty dict" "Dict { }" "Dict {  }" [] [] [] false
+    t "simple int dict" "Dict { a = 1L }" "Dict { a = 1L }" [] [] [] false
     t
       "string dict"
       "Dict { a = \"hello\"; b = \"test\" }"
       "Dict { a = \"hello\"; b = \"test\" }"
+      []
+      []
+      []
+      false
     t
       "longer int dict"
       "Dict { a = 1L; b = 2L; c = 3L }"
       "Dict { a = 1L; b = 2L; c = 3L }"
+      []
+      []
+      []
+      false
 
     // tuple literals
-    t "tuple 2" "(1L, \"hello\")" "(1L, \"hello\")"
-    t "tuple 3" "(1L, \"hello\", 2L)" "(1L, \"hello\", 2L)"
-    t "tuple 4" "(1L, \"hello\", 2L, true)" "(1L, \"hello\", 2L, true)"
-    t "tuple with expr" "(1L, 2L + 3L, 4L)" "(1L, (2L) + (3L), 4L)" // CLEANUP
+    t "tuple 2" "(1L, \"hello\")" "(1L, \"hello\")" [] [] [] false
+    t "tuple 3" "(1L, \"hello\", 2L)" "(1L, \"hello\", 2L)" [] [] [] false
+    t
+      "tuple 4"
+      "(1L, \"hello\", 2L, true)"
+      "(1L, \"hello\", 2L, true)"
+      []
+      []
+      []
+      false
+    t "tuple with expr" "(1L, 2L + 3L, 4L)" "(1L, (2L) + (3L), 4L)" [] [] [] false // CLEANUP
 
     // record literals
-    t "record, 1 field" "Person1 {name =\"John\"} " "Person1 { name = \"John\" }"
+    t
+      "record, 1 field"
+      "Person1 {name =\"John\"} "
+      "Person1 { name = \"John\" }"
+      []
+      []
+      []
+      true
     t
       "record, 2 fields"
       "Person2 {name =\"John\"; age = 30L} "
       "Person2 { name = \"John\"; age = 30L }"
+      []
+      []
+      []
+      true
     t
       "record, 3 fields"
       "Person3 {name =\"John\"; age = 30L; hasPet = true} "
       "Person3 { name = \"John\"; age = 30L; hasPet = true }"
+      [ person3 ]
+      []
+      []
+      false
 
     // record update
     t
       "record update 1"
       "{ RecordForUpdate { x = 4L; y = 1L } with y = 2L }"
       "{ RecordForUpdate { x = 4L; y = 1L } with y = 2L }"
-    t "record update 2" "{ myRec with y = 2L }" "{ myRec with y = 2L }"
+      []
+      []
+      []
+      true
+    t "record update 2" "{ myRec with y = 2L }" "{ myRec with y = 2L }" [] [] [] true
     t
       "record update 3"
       "{ myRec with y = 2L; z = 42L }"
       "{ myRec with y = 2L; z = 42L }"
+      []
+      []
+      []
+      false
 
     // enum literal
-    t "simple enum literal" "Color.Red" "Color.Red"
-    t "option none, short" "Stdlib.Option.None" "Stdlib.Option.None"
+    t "simple enum literal" "Color.Red" "Color.Red" [] [] [] false
+    t "option none, short" "Stdlib.Option.None" "Stdlib.Option.None" [] [] [] false
     t
       "option none, long"
       "PACKAGE.Darklang.Stdlib.Option.Option.None"
       "PACKAGE.Darklang.Stdlib.Option.Option.None"
+      []
+      []
+      []
+      false
     t
       "option some"
       "PACKAGE.Darklang.Stdlib.Option.Option.Some 1L"
       "PACKAGE.Darklang.Stdlib.Option.Option.Some(1L)"
-    t "custom enum tupled params" "MyEnum.A(1L, 2L)" "MyEnum.A((1L, 2L))"
-    t "custom enum fn params" "MyEnum.A 1L 2L" "MyEnum.A(1L, 2L)"
+      []
+      []
+      []
+      false
+    t
+      "custom enum tupled params"
+      "MyEnum.A(1L, 2L)"
+      "MyEnum.A((1L, 2L))"
+      []
+      []
+      []
+      false
+    t "custom enum fn params" "MyEnum.A 1L 2L" "MyEnum.A(1L, 2L)" [] [] [] false
 
     // qualified constant
-    t "qualified constant" "Stdlib.List.empty" "PACKAGE.Darklang.Stdlib.List.empty"
+    t
+      "qualified constant"
+      "Stdlib.List.empty"
+      "PACKAGE.Darklang.Stdlib.List.empty"
+      []
+      []
+      []
+      false
 
     // variables and let bindings
-    t "assumed var name" "assumedlyAVariableName" "assumedlyAVariableName"
+    t
+      "assumed var name"
+      "assumedlyAVariableName"
+      "assumedlyAVariableName"
+      []
+      []
+      []
+      false
     // TODO: this is ugly
-    t "simple let expr" "let x = 1L\n  x" "let x =\n  1L\nx"
+    t "simple let expr" "let x = 1L\n  x" "let x =\n  1L\nx" [] [] [] false
 
     // field access
-    t "field access 1" "person.name" "person.name"
+    t "field access 1" "person.name" "person.name" [] [] [] false
     t
       "field access 2"
       "(Person { name =\"Janice\" }).name"
       "(Person { name = \"Janice\" }).name"
+      []
+      []
+      []
+      false
     t
       "nested field access"
       "record.someField.anotherFieldInsideThat"
       "record.someField.anotherFieldInsideThat"
-    t "field access in context" "person.age + 1L" "(person.age) + (1L)"
+      []
+      []
+      []
+      false
+    t
+      "field access in context"
+      "person.age + 1L"
+      "(person.age) + (1L)"
+      []
+      []
+      []
+      false
 
     // lambda
-    t "simple lambda" "fun x -> x + 1L" "(fun x ->\n  (x) + (1L))"
-    t "lambda wrapped with parens" "(fun x -> x + 1L)" "(fun x ->\n  (x) + (1L))"
-    t "lambda, 2 args" "fun x y -> x * y" "(fun x y ->\n  (x) * (y))"
-    t "lambda, unit arg" "fun () -> 1L" "(fun () ->\n  1L)"
+    t "simple lambda" "fun x -> x + 1L" "(fun x ->\n  (x) + (1L))" [] [] [] false
+    t
+      "lambda wrapped with parens"
+      "(fun x -> x + 1L)"
+      "(fun x ->\n  (x) + (1L))"
+      []
+      []
+      []
+      false
+    t "lambda, 2 args" "fun x y -> x * y" "(fun x y ->\n  (x) * (y))" [] [] [] false
+    t "lambda, unit arg" "fun () -> 1L" "(fun () ->\n  1L)" [] [] [] false
     t
       "lambda with notable body"
       "fun var -> (Stdlib.String.toUppercase (Stdlib.String.fromChar var))"
       "(fun var ->\n  PACKAGE.Darklang.Stdlib.String.toUppercase (PACKAGE.Darklang.Stdlib.String.fromChar var))"
+      []
+      []
+      []
+      false
     t
       "lambda with notable body 2"
       "fun (str1, str2) -> str1 ++ str2"
       "(fun (str1, str2) ->\n  (str1) ++ (str2))"
+      []
+      []
+      []
+      false
 
 
     // if expressions
-    t "if, 1" "if true then 1L" "if true then\n  1L"
-    t "if, 2" "if true then 1L else 2L" "if true then\n  1L\nelse\n  2L"
+    t "if, 1" "if true then 1L" "if true then\n  1L" [] [] [] false
+    t
+      "if, 2"
+      "if true then 1L else 2L"
+      "if true then\n  1L\nelse\n  2L"
+      []
+      []
+      []
+      false
     t
       "if, 3"
       "if a < b then 1L else if c > d then 2L"
       "if (a) < (b) then\n  1L\nelse if (c) > (d) then\n  2L"
+      []
+      []
+      []
+      false
     t
       "if, 4"
       "if a < b then 1L else if c > d then 2L else 3L"
       "if (a) < (b) then\n  1L\nelse if (c) > (d) then\n  2L\nelse\n  3L"
+      []
+      []
+      []
+      false
 
-    t "if, 5" "if true then\n 1L" "if true then\n  1L"
-    t "if, 6" "if true then\n 1L\nelse\n 2L" "if true then\n  1L\nelse\n  2L"
+    t "if, 5" "if true then\n 1L" "if true then\n  1L" [] [] [] false
+    t
+      "if, 6"
+      "if true then\n 1L\nelse\n 2L"
+      "if true then\n  1L\nelse\n  2L"
+      []
+      []
+      []
+      false
     t
       "if, 7"
       "if true then\n a\nelse if false then\n c"
       "if true then\n  a\nelse if false then\n  c"
+      []
+      []
+      []
+      false
 
     t
       "if, 8"
       "if a > b then\n a\nelse if c > d then\n c\nelse d"
       "if (a) > (b) then\n  a\nelse if (c) > (d) then\n  c\nelse\n  d"
+      []
+      []
+      []
+      false
 
-    t "if, 9" "if true then\n\ta\nelse\n\tb" "if true then\n  a\nelse\n  b"
+    t
+      "if, 9"
+      "if true then\n\ta\nelse\n\tb"
+      "if true then\n  a\nelse\n  b"
+      []
+      []
+      []
+      false
 
     t
       "if, many branches"
@@ -450,6 +795,10 @@ else if false then
   c
 else if true then
   d"""
+      []
+      []
+      []
+      false
 
     t
       "else for inner if"
@@ -464,6 +813,10 @@ if a > b then
     c
   else
     b"""
+      []
+      []
+      []
+      false
 
     t
       "else for outer if"
@@ -478,6 +831,10 @@ else
     c
 else
   b"""
+      []
+      []
+      []
+      false
 
     t
       "nested if"
@@ -504,231 +861,544 @@ else if (g) > (h) then
   g
 else
   h"""
+      []
+      []
+      []
+      false
 
 
     // match expressions
-    t "match, unit" "match () with\n| () -> true" "match () with\n| () ->\n  true"
+    t
+      "match, unit"
+      "match () with\n| () -> true"
+      "match () with\n| () ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, bool"
       "match true with\n| true -> true"
       "match true with\n| true ->\n  true"
+      []
+      []
+      []
+      false
 
-    t "match, int 1y" "match 1y with\n| 1y -> true" "match 1y with\n| 1y ->\n  true"
+    t
+      "match, int 1y"
+      "match 1y with\n| 1y -> true"
+      "match 1y with\n| 1y ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, int -1y"
       "match -1y with\n| -1y -> true"
       "match -1y with\n| -1y ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, int 0uy"
       "match 0uy with\n| 0uy -> true"
       "match 0uy with\n| 0uy ->\n  true"
-    t "match, int 1s" "match 1s with\n| 1s -> true" "match 1s with\n| 1s ->\n  true"
+      []
+      []
+      []
+      false
+    t
+      "match, int 1s"
+      "match 1s with\n| 1s -> true"
+      "match 1s with\n| 1s ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, int 2us"
       "match 2us with\n| 2us -> true"
       "match 2us with\n| 2us ->\n  true"
-    t "match, int 3l" "match 3l with\n| 3l -> true" "match 3l with\n| 3l ->\n  true"
+      []
+      []
+      []
+      false
+    t
+      "match, int 3l"
+      "match 3l with\n| 3l -> true"
+      "match 3l with\n| 3l ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, int 5ul"
       "match 5ul with\n| 5ul -> true"
       "match 5ul with\n| 5ul ->\n  true"
-    t "match, int 7L" "match 7L with\n| 7L -> true" "match 7L with\n| 7L ->\n  true"
+      []
+      []
+      []
+      false
+    t
+      "match, int 7L"
+      "match 7L with\n| 7L -> true"
+      "match 7L with\n| 7L ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, int 8UL"
       "match 8UL with\n| 8UL -> true"
       "match 8UL with\n| 8UL ->\n  true"
-    t "match, int 9Q" "match 9Q with\n| 9Q -> true" "match 9Q with\n| 9Q ->\n  true"
+      []
+      []
+      []
+      false
+    t
+      "match, int 9Q"
+      "match 9Q with\n| 9Q -> true"
+      "match 9Q with\n| 9Q ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, int 10Z"
       "match 10Z with\n| 10Z -> true"
       "match 10Z with\n| 10Z ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, float 0.9"
       "match 0.9 with\n| 0.9 -> true"
       "match 0.9 with\n| 0.9 ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, string"
       "match \"str\" with\n| \"str\" -> true"
       "match \"str\" with\n| \"str\" ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, char"
       "match 'c' with\n| 'c' -> true"
       "match 'c' with\n| 'c' ->\n  true"
-    t "match, var" "match var with\n| var -> true" "match var with\n| var ->\n  true"
+      []
+      []
+      []
+      false
+    t
+      "match, var"
+      "match var with\n| var -> true"
+      "match var with\n| var ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, str 2"
       "match \"str\" with\n| \"str\" -> true\n| \"other\" -> false"
       "match \"str\" with\n| \"str\" ->\n  true\n| \"other\" ->\n  false"
+      []
+      []
+      []
+      false
     t
       "match, int list 1"
       "match [1L; 2L] with\n| [1L; 2L] -> true"
       "match [1L; 2L] with\n| [1L; 2L] ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, int list 2"
       "match [1L; 2L; 3L] with\n| head :: tail ->\n \"pass\""
       "match [1L; 2L; 3L] with\n| head :: tail ->\n  \"pass\""
+      []
+      []
+      []
+      false
     t
       "match, int tuple"
       "match (1L, 2L) with\n| (1L, 2L) -> true"
       "match (1L, 2L) with\n| (1L, 2L) ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, enum"
       "match Stdlib.Result.Result.Ok 5L with\n| Ok 5L -> true\n| Error e -> false"
       "match PACKAGE.Darklang.Stdlib.Result.Result.Ok(5L) with\n| Ok 5L ->\n  true\n| Error e ->\n  false"
+      []
+      []
+      []
+      false
     t
       "match, string 3"
       "match \"str\" with\n| \"str\" when true -> true"
       "match \"str\" with\n| \"str\" when true ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, when simple"
       "match x with\n| y when y > 1L -> true\n| z when z < 1L -> false\n| w -> w"
       "match x with\n| y when (y) > (1L) ->\n  true\n| z when (z) < (1L) ->\n  false\n| w ->\n  w"
+      []
+      []
+      []
+      false
     t
       "match, ignored 1"
       "match true with\n| _ -> true"
       "match true with\n| _ ->\n  true"
+      []
+      []
+      []
+      false
     t
       "match, ignored 2"
       "match true with\n| _var -> true"
       "match true with\n| _var ->\n  true"
+      []
+      []
+      []
+      false
 
 
     // pipe expression
-    t "pipe, infix" "1L |> (+) 2L" "1L\n|> (+) 2L"
-    t "pipe, into var" "1L |> x" "1L\n|> x"
-    t "pipe, into lambda" "1L |> (fun x -> x + 1L)" "1L\n|> fun x -> (x) + (1L)"
-    t "pipe, into lambda, 2" "1L |> fun x -> x + 1L" "1L\n|> fun x -> (x) + (1L)"
+    t "pipe, infix" "1L |> (+) 2L" "1L\n|> (+) 2L" [] [] [] false
+    t "pipe, into var" "1L |> x" "1L\n|> x" [] [] [] false
+    t
+      "pipe, into lambda"
+      "1L |> (fun x -> x + 1L)"
+      "1L\n|> fun x -> (x) + (1L)"
+      []
+      []
+      []
+      false
+    t
+      "pipe, into lambda, 2"
+      "1L |> fun x -> x + 1L"
+      "1L\n|> fun x -> (x) + (1L)"
+      []
+      []
+      []
+      false
     t
       "pipe, into enum"
       "3L |> Stdlib.Result.Result.Ok"
       "3L\n|> PACKAGE.Darklang.Stdlib.Result.Result.Ok"
-    t "pipe, into enum 2" "33L |> MyEnum.A 21L" "33L\n|> MyEnum.A (21L)"
+      []
+      []
+      []
+      false
+    t
+      "pipe, into enum 2"
+      "33L |> MyEnum.A 21L"
+      "33L\n|> MyEnum.A (21L)"
+      []
+      []
+      []
+      false
     t
       "pipe, into fn call"
       "1L |> Stdlib.Int64.add 2L"
       "1L\n|> PACKAGE.Darklang.Stdlib.Int64.add 2L"
+      []
+      []
+      []
+      false
     t
       "pipe, into fn call 2"
       "1L |> Stdlib.Int64.toString"
       "1L\n|> PACKAGE.Darklang.Stdlib.Int64.toString"
+      []
+      []
+      []
+      false
     t
       "pipe, into fn call 3"
       "\"true\" |> Builtin.jsonParse<Bool>"
       "\"true\"\n|> Builtin.jsonParse<Bool>"
+      []
+      []
+      []
+      false
     t
       "pipe, into fn call 4"
       "Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L"
       "PACKAGE.Darklang.Stdlib.Int64.add 1L 2L\n|> PACKAGE.Darklang.Stdlib.Int64.add 1L"
+      []
+      []
+      []
+      false
     t
       "pipe, into fn call 5"
       "[1L; 2L] |> Stdlib.List.last |> Builtin.unwrap"
       "[1L; 2L]\n|> PACKAGE.Darklang.Stdlib.List.last\n|> Builtin.unwrap"
+      []
+      []
+      []
+      false
 
     // fn calls
     // CLEANUP these are ugly
-    t "fn call, add once" "1L + 2L" "(1L) + (2L)"
-    t "fn call, add twice" "1L + b + 3L" "((1L) + (b)) + (3L)"
-    t "fn call, add thrice" "1L + 2L * 3L - 4L" "((1L) + ((2L) * (3L))) - (4L)"
-    t "fn call, >" "1L > 2L" "(1L) > (2L)"
-    t "fn call, >=" "1L >= 2L" "(1L) >= (2L)"
-    t "fn call, <" "1L < 2L" "(1L) < (2L)"
-    t "fn call, <=" "1L <= 2L" "(1L) <= (2L)"
-    t "fn call, ==" "1L == 2L" "(1L) == (2L)"
-    t "fn call, !=" "1L != 2L" "(1L) != (2L)"
-    t "fn call, ^" "1L ^ 2L" "(1L) ^ (2L)"
-    t "fn call, ++" "strVar ++ \"str\"" "(strVar) ++ (\"str\")"
-    t "fn call, &&" "true && false" "(true) && (false)"
-    t "fn call, ||" "true || false" "(true) || (false)"
-    t "fn call, and short" "and true false" "and true false"
-    t "fn call, and longer" "Bool.and true false" "Bool.and true false"
+    t "fn call, add once" "1L + 2L" "(1L) + (2L)" [] [] [] false
+    t "fn call, add twice" "1L + b + 3L" "((1L) + (b)) + (3L)" [] [] [] false
+    t
+      "fn call, add thrice"
+      "1L + 2L * 3L - 4L"
+      "((1L) + ((2L) * (3L))) - (4L)"
+      []
+      []
+      []
+      false
+    t "fn call, >" "1L > 2L" "(1L) > (2L)" [] [] [] false
+    t "fn call, >=" "1L >= 2L" "(1L) >= (2L)" [] [] [] false
+    t "fn call, <" "1L < 2L" "(1L) < (2L)" [] [] [] false
+    t "fn call, <=" "1L <= 2L" "(1L) <= (2L)" [] [] [] false
+    t "fn call, ==" "1L == 2L" "(1L) == (2L)" [] [] [] false
+    t "fn call, !=" "1L != 2L" "(1L) != (2L)" [] [] [] false
+    t "fn call, ^" "1L ^ 2L" "(1L) ^ (2L)" [] [] [] false
+    t "fn call, ++" "strVar ++ \"str\"" "(strVar) ++ (\"str\")" [] [] [] false
+    t "fn call, &&" "true && false" "(true) && (false)" [] [] [] false
+    t "fn call, ||" "true || false" "(true) || (false)" [] [] [] false
+    t "fn call, and short" "and true false" "and true false" [] [] [] true
+    t "fn call, and longer" "Bool.and true false" "Bool.and true false" [] [] [] true
     t
       "fn call, and longest"
+      "Darklang.Stdlib.Bool.and true false"
       "PACKAGE.Darklang.Stdlib.Bool.and true false"
-      "PACKAGE.Darklang.Stdlib.Bool.and true false"
+      []
+      []
+      []
+      false
     t
       "fn call, and stdlib shortcut"
       "Stdlib.Bool.and true false"
       "PACKAGE.Darklang.Stdlib.Bool.and true false"
-    t "fn call, builtin simple" "Builtin.int64Add 1L 2L" "Builtin.int64Add 1L 2L"
+      []
+      []
+      []
+      false
+    t
+      "fn call, builtin simple"
+      "Builtin.int64Add 1L 2L"
+      "Builtin.int64Add 1L 2L"
+      []
+      []
+      []
+      false
     t
       "fn call, builtin with type arg"
       "Builtin.jsonParse<Bool> \"true\""
-      "Builtin.jsonParse<Bool> \"true\"" ]
+      "Builtin.jsonParse<Bool> \"true\""
+      []
+      []
+      []
+      false ]
   |> testList "exprs"
 
 
 let constantDeclarations =
-  [ t "unit" "const unitConst = ()" "const unitConst = ()"
+  [ t "unit" "const unitConst = ()" "const unitConst = ()" [] [] [] false
 
     // ints
-    t "int8, max" "const maxInt8 = 127y" "const maxInt8 = 127y"
-    t "uint8, max" "const maxUInt8 = 255uy" "const maxUInt8 = 255uy"
-    t "int16, max" "const maxInt16 = 32767s" "const maxInt16 = 32767s"
-    t "uint16, max" "const maxUInt16 = 65535us" "const maxUInt16 = 65535us"
-    t "int32, max" "const maxInt32 = 2147483647l" "const maxInt32 = 2147483647l"
-    t "uint32, max" "const maxUInt32 = 4294967295ul" "const maxUInt32 = 4294967295ul"
+    t "int8, max" "const maxInt8 = 127y" "const maxInt8 = 127y" [] [] [] false
+    t "uint8, max" "const maxUInt8 = 255uy" "const maxUInt8 = 255uy" [] [] [] false
+    t "int16, max" "const maxInt16 = 32767s" "const maxInt16 = 32767s" [] [] [] false
+    t
+      "uint16, max"
+      "const maxUInt16 = 65535us"
+      "const maxUInt16 = 65535us"
+      []
+      []
+      []
+      false
+    t
+      "int32, max"
+      "const maxInt32 = 2147483647l"
+      "const maxInt32 = 2147483647l"
+      []
+      []
+      []
+      false
+    t
+      "uint32, max"
+      "const maxUInt32 = 4294967295ul"
+      "const maxUInt32 = 4294967295ul"
+      []
+      []
+      []
+      false
     t
       "int64, max"
       "const maxInt64 = 9223372036854775807L"
       "const maxInt64 = 9223372036854775807L"
+      []
+      []
+      []
+      false
     t
       "uint64, max"
       "const maxUInt64 = 18446744073709551615UL"
       "const maxUInt64 = 18446744073709551615UL"
+      []
+      []
+      []
+      false
     t
       "int128, max"
       "const maxInt128 = 170141183460469231731687303715884105727Q"
       "const maxInt128 = 170141183460469231731687303715884105727Q"
+      []
+      []
+      []
+      false
     t
       "uint128, max"
       "const maxUInt128 = 340282366920938463463374607431768211455Z"
       "const maxUInt128 = 340282366920938463463374607431768211455Z"
+      []
+      []
+      []
+      false
 
     // bools
-    t "true alias" "const trueConst = true" "const trueConst = true"
-    t "false alias" "const falseConst = false" "const falseConst = false"
+    t "true alias" "const trueConst = true" "const trueConst = true" [] [] [] false
+    t
+      "false alias"
+      "const falseConst = false"
+      "const falseConst = false"
+      []
+      []
+      []
+      false
 
     // strings
-    t "hello" "const greeting = \"hello\"" "const greeting = \"hello\""
-    t "newline" "const newline = '\\n'" "const newline = '\\n'"
+    t
+      "hello"
+      "const greeting = \"hello\""
+      "const greeting = \"hello\""
+      []
+      []
+      []
+      false
+    t "newline" "const newline = '\\n'" "const newline = '\\n'" [] [] [] false
 
     // floats
-    t "pi" "const pi = 3.14159" "const pi = 3.14159"
+    t "pi" "const pi = 3.14159" "const pi = 3.14159" [] [] [] false
 
     // dicts
-    t "dict, empty" "const emptyDict = Dict {}" "const emptyDict = Dict {  }"
-    t "dict, one entry" "const dict = Dict { a = 1L }" "const dict = Dict { a = 1L }"
+    t
+      "dict, empty"
+      "const emptyDict = Dict {}"
+      "const emptyDict = Dict {  }"
+      []
+      []
+      []
+      false
+    t
+      "dict, one entry"
+      "const dict = Dict { a = 1L }"
+      "const dict = Dict { a = 1L }"
+      []
+      []
+      []
+      false
     t
       "dict, two entries"
       "const dict = Dict { a = \"hello\"; b = \"test\" }"
       "const dict = Dict { a = \"hello\"; b = \"test\" }"
+      []
+      []
+      []
+      false
 
     // tuples
-    t "tuple, 2" "const tuple2Const = (1L, 2L)" "const tuple2Const = (1L, 2L)"
+    t
+      "tuple, 2"
+      "const tuple2Const = (1L, 2L)"
+      "const tuple2Const = (1L, 2L)"
+      []
+      []
+      []
+      false
     t
       "tuple, 3"
       "const tuple3Const = (1L, 2L, 3L)"
       "const tuple3Const = (1L, 2L, 3L)"
+      []
+      []
+      []
+      false
 
     // lists
-    t "list, empty" "const emptyList = []" "const emptyList = []"
-    t "list, int" "const listOfInts = [1L; 2L; 3L]" "const listOfInts = [1L; 2L; 3L]"
+    t "list, empty" "const emptyList = []" "const emptyList = []" [] [] [] false
+    t
+      "list, int"
+      "const listOfInts = [1L; 2L; 3L]"
+      "const listOfInts = [1L; 2L; 3L]"
+      []
+      []
+      []
+      false
     t
       "list, list, int"
       "const listOfLists = [[1L; 2L]; [3L; 4L]]"
       "const listOfLists = [[1L; 2L]; [3L; 4L]]"
+      []
+      []
+      []
+      false
 
     // enums
     t
       "option, none"
       "const none = Stdlib.Option.Option.None"
       "const none = PACKAGE.Darklang.Stdlib.Option.Option.None"
+      []
+      []
+      []
+      false
     t
       "option, some 1"
       "const some = Stdlib.Option.Option.Some 1L"
       "const some = PACKAGE.Darklang.Stdlib.Option.Option.Some(1L)"
-    t "enum, tupled args" "const a = MyEnum.A(1L, 2L)" "const a = MyEnum.A((1L, 2L))"
-    t "enum, fn args" "const a = MyEnum.A 1L 2L" "const a = MyEnum.A(1L, 2L)" ]
+      []
+      []
+      []
+      false
+    t
+      "enum, tupled args"
+      "const a = MyEnum.A(1L, 2L)"
+      "const a = MyEnum.A((1L, 2L))"
+      []
+      []
+      []
+      false
+    t
+      "enum, fn args"
+      "const a = MyEnum.A 1L 2L"
+      "const a = MyEnum.A(1L, 2L)"
+      []
+      []
+      []
+      false ]
   |> testList "constant declarations"
 
 let functionDeclarations =
@@ -736,36 +1406,64 @@ let functionDeclarations =
       "single builtin param"
       "let helloWorld (i: Int64): String = \"Hello world\""
       "let helloWorld (i: Int64): String =\n  \"Hello world\""
+      []
+      []
+      []
+      false
 
     t
       "single package param"
       "let double2 (i: PACKAGE.Darklang.LanguageTools.ID) : Int64 = i + i"
       "let double2 (i: PACKAGE.Darklang.LanguageTools.ID): Int64 =\n  (i) + (i)"
+      []
+      []
+      []
+      false
 
     t
       "single unit param"
       "let emptyString () : String = \"\""
       "let emptyString (_: Unit): String =\n  \"\""
+      []
+      []
+      []
+      false
 
     t
       "multiple param"
       "let isHigher (a: Int64) (b: Int64) : Bool = Stdlib.Int64.greaterThan a b"
       "let isHigher (a: Int64) (b: Int64): Bool =\n  PACKAGE.Darklang.Stdlib.Int64.greaterThan a b"
+      []
+      []
+      []
+      false
 
     t
       "single type param"
       "let myFn<'a> (param: 'a): Unit  = ()"
       "let myFn<'a> (param: 'a): Unit =\n  ()"
+      []
+      []
+      []
+      false
 
     t
       "two type params"
       "let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit  = ()"
       "let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit =\n  ()"
+      []
+      []
+      []
+      false
 
     t
       "package fn call"
       "let sum (a : Int64) (b : Int64) : Int64 = PACKAGE.Darklang.Stdlib.Int64.add a b"
-      "let sum (a: Int64) (b: Int64): Int64 =\n  PACKAGE.Darklang.Stdlib.Int64.add a b" ]
+      "let sum (a: Int64) (b: Int64): Int64 =\n  PACKAGE.Darklang.Stdlib.Int64.add a b"
+      []
+      []
+      []
+      false ]
   |> testList "function declarations"
 
 let moduleDeclarations =
@@ -773,6 +1471,10 @@ let moduleDeclarations =
       "simple module"
       "module MyModule =\n  type ID = Int64"
       "module MyModule =\n  type ID =\n    Int64"
+      []
+      []
+      []
+      false
 
     t
       "module with types, fns, and consts"
@@ -782,6 +1484,10 @@ let moduleDeclarations =
   let myFn (i: Int64): Int64 = 1L
   const x = 100L"""
       "module MyModule =\n  type ID =\n    Int64\n\n  type MyString =\n    String\n\n  let myFn (i: Int64): Int64 =\n    1L\n\n  const x = 100L"
+      []
+      []
+      []
+      false
 
     t
       "module with types, fns, conts, and newlines"
@@ -794,6 +1500,10 @@ let moduleDeclarations =
 
   const x = 100L"""
       "module MyModule =\n  type ID =\n    Int64\n\n  type MyString =\n    String\n\n  let myFn (i: Int64): Int64 =\n    1L\n\n  const x = 100L"
+      []
+      []
+      []
+      false
 
     t
       "nested module declaration"
@@ -805,7 +1515,11 @@ let moduleDeclarations =
       type ID = Int64
       const x = 100L
       1L"""
-      "module MyModule1 =\n  type ID =\n    Int64\n\n  module MyModule2 =\n    type ID =\n      Int64\n\n    module MyModule3 =\n      type ID =\n        Int64\n\n      const x = 100L\n\n      1L" ]
+      "module MyModule1 =\n  type ID =\n    Int64\n\n  module MyModule2 =\n    type ID =\n      Int64\n\n    module MyModule3 =\n      type ID =\n        Int64\n\n      const x = 100L\n\n      1L"
+      []
+      []
+      []
+      false ]
   |> testList "module declarations"
 
 
@@ -835,7 +1549,11 @@ let getTitle (bookId: BookID): String =
 let curiousGeorgeBookId =\n  101L
 Builtin.printLine (getTitle curiousGeorgeBookId)
 
-0L" ]
+0L"
+      []
+      []
+      []
+      false ]
   |> testList "cli scripts"
 
 let tests =

--- a/packages/darklang/cli/cli.dark
+++ b/packages/darklang/cli/cli.dark
@@ -64,11 +64,11 @@ module Darklang =
           |> Stdlib.List.map (fun arg ->
             arg
             |> LanguageTools.Parser.parseToSimplifiedTree
-            |> LanguageTools.Parser.parseCliScript
+            |> LanguageTools.Parser.parseFromTree
             |> Builtin.unwrap
             |> fun parsedFile ->
                 match parsedFile with
-                | CliScript script -> script.exprsToEval)
+                | SourceFile source -> source.exprsToEval)
           |> Stdlib.List.flatten
           |> Stdlib.List.map (fun arg ->
             LanguageTools.WrittenTypesToProgramTypes.Expr.toPT onMissing arg)

--- a/packages/darklang/languageTools/lsp-server/docSync.dark
+++ b/packages/darklang/languageTools/lsp-server/docSync.dark
@@ -41,7 +41,7 @@ module Darklang =
           let parsed =
             request.textDocument.text
             |> Parser.parseToSimplifiedTree
-            |> Parser.parseCliScript
+            |> Parser.parseFromTree
 
           { state with
               documentsInScope =
@@ -67,8 +67,7 @@ module Darklang =
             state
 
           | Some text ->
-            let parsed =
-              text |> Parser.parseToSimplifiedTree |> Parser.parseCliScript
+            let parsed = text |> Parser.parseToSimplifiedTree |> Parser.parseFromTree
 
             { state with
                 documentsInScope =

--- a/packages/darklang/languageTools/lsp-server/handleIncomingMessage.dark
+++ b/packages/darklang/languageTools/lsp-server/handleIncomingMessage.dark
@@ -125,7 +125,7 @@ module Darklang =
           match document.parsed with
           | Ok parsedFile ->
             match parsedFile with
-            | CliScript parsed when parsed.unparseableStuff != [] ->
+            | SourceFile parsed when parsed.unparseableStuff != [] ->
               let diagnostics =
                 parsed.unparseableStuff
                 |> Stdlib.List.map (fun unparseable ->

--- a/packages/darklang/languageTools/lsp.dark
+++ b/packages/darklang/languageTools/lsp.dark
@@ -42,6 +42,7 @@ module Darklang =
       type ComputeDiagnosticsOutput = { diagnostics: List<Diagnostic> }
 
       let getDiagnostics (uri: String) (text: String) : String =
+        // CLEANUP: languageToolsParseCliScript doesn't exist
         match Builtin.languageToolsParseCliScript text with
         | Ok() ->
           (ComputeDiagnosticsOutput { diagnostics = [] })

--- a/packages/darklang/languageTools/parser/cliScript.dark
+++ b/packages/darklang/languageTools/parser/cliScript.dark
@@ -2,16 +2,16 @@ module Darklang =
   module LanguageTools =
     module Parser =
       let updateUnparseableStuff
-        (result: WrittenTypes.CliScript.CliScript)
+        (result: WrittenTypes.SourceFile.SourceFile)
         (e: WrittenTypes.Unparseable)
-        : WrittenTypes.CliScript.CliScript =
+        : WrittenTypes.SourceFile.SourceFile =
         { result with
             unparseableStuff = Stdlib.List.pushBack result.unparseableStuff e }
 
       let parseDeclaration
-        (result: Stdlib.Result.Result<WrittenTypes.CliScript.CliScript, String>)
+        (result: Stdlib.Result.Result<WrittenTypes.SourceFile.SourceFile, String>)
         (decl: ParsedNode)
-        : Stdlib.Result.Result<WrittenTypes.CliScript.CliScript, String> =
+        : Stdlib.Result.Result<WrittenTypes.SourceFile.SourceFile, String> =
         Stdlib.Result.map result (fun result ->
           match decl.typ with
           | "type_decl" ->
@@ -19,7 +19,7 @@ module Darklang =
             | Error e -> updateUnparseableStuff result e
             | Ok parsedTypeDef ->
               let newType =
-                WrittenTypes.CliScript.CliScriptDeclaration.Type parsedTypeDef
+                WrittenTypes.SourceFile.SourceFileDeclaration.Type parsedTypeDef
 
               { result with
                   declarations = Stdlib.List.pushBack result.declarations newType }
@@ -30,7 +30,7 @@ module Darklang =
 
             | Ok parsedFnDecl ->
               let newFn =
-                WrittenTypes.CliScript.CliScriptDeclaration.Function parsedFnDecl
+                WrittenTypes.SourceFile.SourceFileDeclaration.Function parsedFnDecl
 
               { result with
                   declarations = Stdlib.List.pushBack result.declarations newFn }
@@ -41,7 +41,8 @@ module Darklang =
 
             | Ok parsedConstDecl ->
               let newConst =
-                WrittenTypes.CliScript.CliScriptDeclaration.Constant parsedConstDecl
+                WrittenTypes.SourceFile.SourceFileDeclaration.Constant
+                  parsedConstDecl
 
               { result with
                   declarations = Stdlib.List.pushBack result.declarations newConst }
@@ -58,7 +59,8 @@ module Darklang =
             | Error e -> updateUnparseableStuff result e
             | Ok parsedModuleDecl ->
               let newModule =
-                WrittenTypes.CliScript.CliScriptDeclaration.Module parsedModuleDecl
+                WrittenTypes.SourceFile.SourceFileDeclaration.Module
+                  parsedModuleDecl
 
               { result with
                   declarations = Stdlib.List.pushBack result.declarations newModule }
@@ -72,12 +74,12 @@ module Darklang =
       /// Map a ParsedNode to a WrittenTypes.ParsedFile
       ///
       /// This is the entrypoint for mapping a ParsedNode to WrittenTypes
-      let parseCliScript
+      let parseFromTree
         (node: ParsedNode)
         : Stdlib.Result.Result<WrittenTypes.ParsedFile, String> =
         if node.typ == "source_file" then
           let init =
-            WrittenTypes.CliScript.CliScript
+            WrittenTypes.SourceFile.SourceFile
               { range = node.range
                 declarations = []
                 unparseableStuff = []
@@ -90,6 +92,6 @@ module Darklang =
               Parser.parseDeclaration
 
           Stdlib.Result.map result (fun parsedResult ->
-            WrittenTypes.ParsedFile.CliScript parsedResult)
+            WrittenTypes.ParsedFile.SourceFile parsedResult)
         else
           Stdlib.Result.Result.Error $"Not a source_file: {node.typ}"

--- a/packages/darklang/languageTools/parser/parserTest.dark
+++ b/packages/darklang/languageTools/parser/parserTest.dark
@@ -1,0 +1,38 @@
+module Darklang =
+  module LanguageTools =
+    module Parser =
+      module ParserTest =
+        let initialParse (code: String) : WrittenTypes.ParsedFile =
+          code
+          |> LanguageTools.Parser.parseToSimplifiedTree
+          |> LanguageTools.Parser.parseCliScript
+          |> Builtin.unwrap
+
+        // TODO: maybe use a proper type instead of string?
+        let parsePTExpr
+          (code: String)
+          : Stdlib.Result.Result<ProgramTypes.Expr, String> =
+          let cliScript = code |> ParserTest.initialParse
+
+          let exprs =
+            match cliScript with
+            | CliScript c -> c.exprsToEval
+            | _ -> []
+
+          let onMissing = LanguageTools.NameResolver.OnMissing.Allow
+
+          match exprs with
+          | [ expr ] ->
+            (onMissing |> WrittenTypesToProgramTypes.Expr.toPT expr)
+            |> Stdlib.Result.Result.Ok
+          | _ ->
+            "Expected exactly one expression to be parsed"
+            |> Stdlib.Result.Result.Error
+
+        let parsePTCliScript (code: String) : ProgramTypes.CliScript.CliScript =
+          code
+          |> ParserTest.initialParse
+          |> WrittenTypesToProgramTypes.parsedFileAsCliScript
+
+        let parseAndPrettyPrint (code: String) : String =
+          code |> ParserTest.parsePTCliScript |> PrettyPrinter.ProgramTypes.cliScript

--- a/packages/darklang/languageTools/parser/parserTest.dark
+++ b/packages/darklang/languageTools/parser/parserTest.dark
@@ -5,18 +5,18 @@ module Darklang =
         let initialParse (code: String) : WrittenTypes.ParsedFile =
           code
           |> LanguageTools.Parser.parseToSimplifiedTree
-          |> LanguageTools.Parser.parseCliScript
+          |> LanguageTools.Parser.parseFromTree
           |> Builtin.unwrap
 
         // TODO: maybe use a proper type instead of string?
         let parsePTExpr
           (code: String)
           : Stdlib.Result.Result<ProgramTypes.Expr, String> =
-          let cliScript = code |> ParserTest.initialParse
+          let sourceFile = code |> ParserTest.initialParse
 
           let exprs =
-            match cliScript with
-            | CliScript c -> c.exprsToEval
+            match sourceFile with
+            | SourceFile c -> c.exprsToEval
             | _ -> []
 
           let onMissing = LanguageTools.NameResolver.OnMissing.Allow
@@ -29,10 +29,12 @@ module Darklang =
             "Expected exactly one expression to be parsed"
             |> Stdlib.Result.Result.Error
 
-        let parsePTCliScript (code: String) : ProgramTypes.CliScript.CliScript =
+        let parsePTSourceFile (code: String) : ProgramTypes.SourceFile.SourceFile =
           code
           |> ParserTest.initialParse
-          |> WrittenTypesToProgramTypes.parsedFileAsCliScript
+          |> WrittenTypesToProgramTypes.parsedFileAsSourceFile
 
         let parseAndPrettyPrint (code: String) : String =
-          code |> ParserTest.parsePTCliScript |> PrettyPrinter.ProgramTypes.cliScript
+          code
+          |> ParserTest.parsePTSourceFile
+          |> PrettyPrinter.ProgramTypes.sourceFile

--- a/packages/darklang/languageTools/programTypes.dark
+++ b/packages/darklang/languageTools/programTypes.dark
@@ -452,13 +452,14 @@ module Darklang =
       //     | TLDB db -> db.tlid
       //     | TLHandler h -> h.tlid
 
-      module CliScript =
+      module SourceFile =
         type Declaration =
           | Type of PackageType.PackageType
           | Constant of PackageConstant.PackageConstant
           | Function of PackageFn.PackageFn
-          | Module of Definitions
+          // db and handlers
+          | Module of Definitions // re-evaluate if this makes sense to be here
 
-        type CliScript =
+        type SourceFile =
           { declarations: List<Declaration>
             exprsToEval: List<Expr> }

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -1232,9 +1232,9 @@ module Darklang =
       module ParsedFile =
         let tokenize (wt: WrittenTypes.ParsedFile) : List<SemanticToken> =
           match wt with
-          | CliScript cliScript ->
+          | SourceFile sourceFile ->
             let declarationsPart =
-              cliScript.declarations
+              sourceFile.declarations
               |> Stdlib.List.map (fun typeOrFn ->
                 match typeOrFn with
                 | Type t -> TypeDeclaration.tokenize t
@@ -1244,7 +1244,7 @@ module Darklang =
               |> Stdlib.List.flatten
 
             let exprsPart =
-              cliScript.exprsToEval
+              sourceFile.exprsToEval
               |> Stdlib.List.map (fun expr -> Expr.tokenize expr)
               |> Stdlib.List.flatten
 

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -501,18 +501,18 @@ module Darklang =
           note: Stdlib.Option.Option<String> }
 
 
-      module CliScript =
-        type CliScriptDeclaration =
+      module SourceFile =
+        type SourceFileDeclaration =
           | Type of TypeDeclaration.TypeDeclaration
           | Function of FnDeclaration.FnDeclaration
           | Constant of ConstantDeclaration.ConstantDeclaration
           | Module of ModuleDeclaration.ModuleDeclaration
 
-        type CliScript =
+        type SourceFile =
           { range: Range
-            declarations: List<CliScript.CliScriptDeclaration>
+            declarations: List<SourceFile.SourceFileDeclaration>
             unparseableStuff: List<Unparseable>
             exprsToEval: List<Expr> }
 
 
-      type ParsedFile = CliScript of CliScript.CliScript
+      type ParsedFile = SourceFile of SourceFile.SourceFile

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -856,17 +856,17 @@ module Darklang =
               body = Expr.toPT onMissing fn.body }
 
 
-      let cliScript
-        (script: WrittenTypes.CliScript.CliScript)
-        : ProgramTypes.CliScript.CliScript =
+      let sourceFile
+        (source: WrittenTypes.SourceFile.SourceFile)
+        : ProgramTypes.SourceFile.SourceFile =
         // CLEANUP potentially complain about unparsable stuff?
-        ProgramTypes.CliScript.CliScript
+        ProgramTypes.SourceFile.SourceFile
           { declarations =
-              script.declarations
+              source.declarations
               |> Stdlib.List.map (fun decl ->
                 match decl with
                 | Type t ->
-                  ProgramTypes.CliScript.Declaration.Type(
+                  ProgramTypes.SourceFile.Declaration.Type(
                     TypeDeclaration.toPackageTypePT
                       NameResolver.OnMissing.Allow
                       "Tests"
@@ -875,7 +875,7 @@ module Darklang =
                   )
 
                 | Constant c ->
-                  ProgramTypes.CliScript.Declaration.Constant(
+                  ProgramTypes.SourceFile.Declaration.Constant(
                     ConstantDeclaration.toPackageConstPT
                       NameResolver.OnMissing.Allow
                       "Tests"
@@ -884,7 +884,7 @@ module Darklang =
                   )
 
                 | Function f ->
-                  ProgramTypes.CliScript.Declaration.Function(
+                  ProgramTypes.SourceFile.Declaration.Function(
                     FunctionDeclaration.toPackageFnPT
                       NameResolver.OnMissing.Allow
                       "Tests"
@@ -893,17 +893,17 @@ module Darklang =
                   )
 
                 | Module m ->
-                  ProgramTypes.CliScript.Declaration.Module(
+                  ProgramTypes.SourceFile.Declaration.Module(
                     ModuleDeclaration.toPT NameResolver.OnMissing.Allow m
                   ))
 
             exprsToEval =
-              script.exprsToEval
+              source.exprsToEval
               |> Stdlib.List.map (fun e -> Expr.toPT NameResolver.OnMissing.Allow e) }
 
 
-      let parsedFileAsCliScript
+      let parsedFileAsSourceFile
         (parsedFile: WrittenTypes.ParsedFile)
-        : ProgramTypes.CliScript.CliScript =
+        : ProgramTypes.SourceFile.SourceFile =
         match parsedFile with
-        | CliScript script -> cliScript script
+        | SourceFile source -> sourceFile source

--- a/packages/darklang/prettyPrinter/cliScript.dark
+++ b/packages/darklang/prettyPrinter/cliScript.dark
@@ -1,11 +1,11 @@
 module Darklang =
   module PrettyPrinter =
     module ProgramTypes =
-      let cliScript
-        (script: LanguageTools.ProgramTypes.CliScript.CliScript)
+      let sourceFile
+        (source: LanguageTools.ProgramTypes.SourceFile.SourceFile)
         : String =
         let declsPart =
-          (Stdlib.List.fold script.declarations [] (fun acc decl ->
+          (Stdlib.List.fold source.declarations [] (fun acc decl ->
             match decl with
             | Module moduleDecl ->
               let prettyPrinted = PrettyPrinter.definitions moduleDecl
@@ -27,7 +27,7 @@ module Darklang =
           |> Stdlib.List.reverse
 
         let exprsPart =
-          (Stdlib.List.fold script.exprsToEval [] (fun acc expr ->
+          (Stdlib.List.fold source.exprsToEval [] (fun acc expr ->
             let prettyPrinted = PrettyPrinter.ProgramTypes.expr expr
             acc |> Stdlib.List.push prettyPrinted))
           |> Stdlib.List.reverse

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -7,7 +7,7 @@
 module Darklang =
   module PrettyPrinter =
     // CLEANUP split into a few files - easier to manage, at this point.
-    // i.e. common, typeReference, expr, declarations, packages, cliScript
+    // i.e. common, typeReference, expr, declarations, packages, sourceFile
     module ProgramTypes =
 
       let nameResolutionError


### PR DESCRIPTION
This PR marks the beginning of our transition from LibParser to the darklang-tree-sitter parser.

