### PR TITLE
Replace LibParser with tree-sitter-darklang parser in some test files + some grammar updates

### DIFF
--- a/backend/src/LibExecution/PackageIDs.fs
+++ b/backend/src/LibExecution/PackageIDs.fs
@@ -272,6 +272,9 @@ module Type =
       let scheduleRule =
         p [ "Worker" ] "ScheduleRule" "0669d155-6352-4851-8968-ef676b18d8ad"
 
+    module Test =
+      let private p addl = p ("Test" :: addl)
+      let ptTest = p [] "PTTest" "e6fc7686-68f9-4fbe-a6cb-b615dd41ee7e"
 
   // what we expose to the outside world
   let idForName
@@ -351,6 +354,12 @@ module Fn =
     let executeCliCommand =
       p [ "Cli" ] "executeCliCommand" "9b4aa7ca-82f4-4fc5-be9c-bdfb97ad4ac2"
 
+  module Internal =
+    let private p addl = p ("Internal" :: addl)
+    module Test =
+      let private p addl = p ("Test" :: addl)
+      let parseSingleTestFromFile =
+        p [] "parseSingleTestFromFile" "53f3fbc6-25fd-427a-ab0d-ba0559543c99"
 
   // what we expose to the outside world
   let idForName

--- a/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
@@ -1491,27 +1491,3 @@ module PackageFn =
         deprecated =
           fields |> D.field "deprecated" |> Deprecation.fromDT FQFnName.fromDT }
     | _ -> Exception.raiseInternal "Invalid PackageFn" []
-
-module Internal =
-  module Test =
-    type PTTest =
-      { name : string; lineNumber : int; actual : PT.Expr; expected : PT.Expr }
-
-    let typeName = FQTypeName.fqPackage PackageIDs.Type.Internal.Test.ptTest
-
-    let toDt (t : PTTest) : Dval =
-      let fields =
-        [ "name", DString t.name
-          "lineNumber", DInt64 t.lineNumber
-          "actual", Expr.toDT t.actual
-          "expected", Expr.toDT t.expected ]
-      DRecord(typeName, typeName, [], Map fields)
-
-    let fromDT (d : Dval) : PTTest =
-      match d with
-      | DRecord(_, _, _, fields) ->
-        { name = fields |> D.stringField "name"
-          lineNumber = fields |> D.intField "lineNumber"
-          actual = fields |> D.field "actual" |> Expr.fromDT
-          expected = fields |> D.field "expected" |> Expr.fromDT }
-      | _ -> Exception.raiseInternal "Invalid Test" []

--- a/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
@@ -1491,3 +1491,27 @@ module PackageFn =
         deprecated =
           fields |> D.field "deprecated" |> Deprecation.fromDT FQFnName.fromDT }
     | _ -> Exception.raiseInternal "Invalid PackageFn" []
+
+module Internal =
+  module Test =
+    type PTTest =
+      { name : string; lineNumber : int; actual : PT.Expr; expected : PT.Expr }
+
+    let typeName = FQTypeName.fqPackage PackageIDs.Type.Internal.Test.ptTest
+
+    let toDt (t : PTTest) : Dval =
+      let fields =
+        [ "name", DString t.name
+          "lineNumber", DInt64 t.lineNumber
+          "actual", Expr.toDT t.actual
+          "expected", Expr.toDT t.expected ]
+      DRecord(typeName, typeName, [], Map fields)
+
+    let fromDT (d : Dval) : PTTest =
+      match d with
+      | DRecord(_, _, _, fields) ->
+        { name = fields |> D.stringField "name"
+          lineNumber = fields |> D.intField "lineNumber"
+          actual = fields |> D.field "actual" |> Expr.fromDT
+          expected = fields |> D.field "expected" |> Expr.fromDT }
+      | _ -> Exception.raiseInternal "Invalid Test" []

--- a/backend/testfiles/httpclient/v0/_request-content-type-empty.test
+++ b/backend/testfiles/httpclient/v0/_request-content-type-empty.test
@@ -15,7 +15,7 @@ Hello back
 (let reqHeaders = [("Content-Type", "")]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     {
       statusCode = 200L
@@ -25,4 +25,4 @@ Hello back
           ("content-type", "text/plain; charset=utf-8")
           ("Server", "Kestrel")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes}

--- a/backend/testfiles/httpclient/v0/_request-content-type-invalid.test
+++ b/backend/testfiles/httpclient/v0/_request-content-type-invalid.test
@@ -16,5 +16,5 @@ Content-Length: LENGTH
 [test]
 (let reqHeaders = [("Content-Type", "just an invalid string")]
  let response = PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders []
- response) =
+ response) ==
    Builtin.Test.runtimeError "Invalid content-type header"

--- a/backend/testfiles/httpclient/v0/_response-cookie.test
+++ b/backend/testfiles/httpclient/v0/_response-cookie.test
@@ -18,7 +18,7 @@ Hello back
 // jar", as presumably all other tests will fail if it does.
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -28,4 +28,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes}

--- a/backend/testfiles/httpclient/v0/_response-redirect-304.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-304.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 304L
       headers =

--- a/backend/testfiles/httpclient/v0/_response-redirect-destination.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-destination.test
@@ -16,7 +16,7 @@ Redirect destination reached
 // This is here to be a destination for valid redirect tests
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -26,4 +26,4 @@ Redirect destination reached
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Redirect destination reached" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0}
+      body = "Redirect destination reached" |> PACKAGE.Darklang.Stdlib.String.toBytes}

--- a/backend/testfiles/httpclient/v0/_response-redirect-to-same-place-absolute.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-to-same-place-absolute.test
@@ -12,7 +12,7 @@ Location: http://URL
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 302L
       headers =

--- a/backend/testfiles/httpclient/v0/_uri-with-auth-both.test
+++ b/backend/testfiles/httpclient/v0/_uri-with-auth-both.test
@@ -16,7 +16,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://user:password@URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -25,4 +25,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes}

--- a/backend/testfiles/httpclient/v0/_uri-with-path-fragment.test
+++ b/backend/testfiles/httpclient/v0/_uri-with-path-fragment.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL?q=5#row=5-👨‍👩‍👧‍👦" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -24,4 +24,4 @@ Hello back
           ("content-type", "text/plain; charset=utf-8")
           ("server", "kestrel")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes}

--- a/backend/testfiles/httpclient/v0/basic-delete-helper-function.test
+++ b/backend/testfiles/httpclient/v0/basic-delete-helper-function.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.delete "http://URL") |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -22,5 +22,5 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }
 

--- a/backend/testfiles/httpclient/v0/basic-delete.test
+++ b/backend/testfiles/httpclient/v0/basic-delete.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "delete" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -22,5 +22,5 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }
 

--- a/backend/testfiles/httpclient/v0/basic-get-helper-function.test
+++ b/backend/testfiles/httpclient/v0/basic-get-helper-function.test
@@ -22,4 +22,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toByte }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-get-helper-function.test
+++ b/backend/testfiles/httpclient/v0/basic-get-helper-function.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.get [] "http://URL") |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -22,4 +22,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toByte }

--- a/backend/testfiles/httpclient/v0/basic-get.test
+++ b/backend/testfiles/httpclient/v0/basic-get.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -22,4 +22,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-head-returns-body-helper-function.test
+++ b/backend/testfiles/httpclient/v0/basic-head-returns-body-helper-function.test
@@ -17,7 +17,7 @@ Here's a body!
 // clients successfully ignore it.
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.head "http://URL") |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-head-returns-body.test
+++ b/backend/testfiles/httpclient/v0/basic-head-returns-body.test
@@ -17,7 +17,7 @@ Here's a body!
 // clients successfully ignore it.
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "head" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-head.test
+++ b/backend/testfiles/httpclient/v0/basic-head.test
@@ -13,7 +13,7 @@ Content-Length: 568
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "head" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [

--- a/backend/testfiles/httpclient/v0/basic-options-helper-function.test
+++ b/backend/testfiles/httpclient/v0/basic-options-helper-function.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.options "http://URL") |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -22,4 +22,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
       ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-options.test
+++ b/backend/testfiles/httpclient/v0/basic-options.test
@@ -14,7 +14,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "options" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -22,4 +22,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
       ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-patch.test
+++ b/backend/testfiles/httpclient/v0/basic-patch.test
@@ -16,7 +16,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "patch" "http://URL" [("Content-Type", "application/json; charset=utf-8")] ("5" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -24,4 +24,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
       ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-post-helper-function.test
+++ b/backend/testfiles/httpclient/v0/basic-post-helper-function.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.post "http://URL" [] ("-1" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -23,4 +23,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
       ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-post.test
+++ b/backend/testfiles/httpclient/v0/basic-post.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" [] ("-1" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -23,4 +23,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
       ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-put-helper-function.test
+++ b/backend/testfiles/httpclient/v0/basic-put-helper-function.test
@@ -17,7 +17,7 @@ Hello back
 (let reqHeaders = [("content-type", "application/json; charset=utf-8")]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.put "http://URL" reqHeaders ("string" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -25,4 +25,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
       ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/basic-put.test
+++ b/backend/testfiles/httpclient/v0/basic-put.test
@@ -17,7 +17,7 @@ Hello back
 (let reqHeaders = [("content-type", "application/json; charset=utf-8")]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "put" "http://URL" reqHeaders ("string" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -25,4 +25,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
       ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/request-content-type-unknown-charset.test
+++ b/backend/testfiles/httpclient/v0/request-content-type-unknown-charset.test
@@ -17,7 +17,7 @@ Hello back
 (let reqHeaders = [("Content-Type", "application/json; charset=invalid")]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -26,4 +26,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/request-content-type-unknown-ct.test
+++ b/backend/testfiles/httpclient/v0/request-content-type-unknown-ct.test
@@ -17,7 +17,7 @@ Hello back
 (let reqHeaders = [("Content-Type", "x/notAValidContentType")]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -26,4 +26,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/request-form-simple.test
+++ b/backend/testfiles/httpclient/v0/request-form-simple.test
@@ -15,7 +15,7 @@ Content-Length: 0
 (let reqHeaders = [("Content-type", "application/x-www-form-urlencoded")]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =

--- a/backend/testfiles/httpclient/v0/request-query-param-float.test
+++ b/backend/testfiles/httpclient/v0/request-query-param-float.test
@@ -14,7 +14,7 @@ Content-Length: LENGTH
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL?f=5.7&n=-0L.0L&l=1231325345345345.34534534634634634" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =

--- a/backend/testfiles/httpclient/v0/request-query-param-int.test
+++ b/backend/testfiles/httpclient/v0/request-query-param-int.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL?i=5&n=-1" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =

--- a/backend/testfiles/httpclient/v0/response-header-duplicate.test
+++ b/backend/testfiles/httpclient/v0/response-header-duplicate.test
@@ -16,7 +16,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-300.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-300.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 300L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-301.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-301.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 301L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-302.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-302.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 302L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-303.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-303.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h ->PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 303L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-305.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-305.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 305L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-306.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-306.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 306L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-307.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-307.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 307L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-308.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-308.test
@@ -12,7 +12,7 @@ Location: /v0/response-redirect-destination
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 308L
       headers =

--- a/backend/testfiles/httpclient/v0/response-redirect-to-file.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-to-file.test
@@ -12,7 +12,7 @@ Location: file:////etc/passwd
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 301L
       headers =

--- a/backend/testfiles/httpclient/v0/uri-with-path-basic.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-basic.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/some/2path/hyphen-ated/under_scored" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers = [
@@ -23,4 +23,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/uri-with-path-dots.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-dots.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/some/../2path/hyphen-ated/under_scored/" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -24,4 +24,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httpclient/v0/uri-with-path-slash.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-slash.test
@@ -15,7 +15,7 @@ Hello back
 [test]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/" [] []) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
- {response with headers = respHeaders}) =
+ {response with headers = respHeaders}) ==
    PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200L
       headers =
@@ -24,4 +24,4 @@ Hello back
           ("content-length", "LENGTH")
           ("content-type", "text/plain; charset=utf-8")
         ]
-      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 }
+      body = "Hello back" |> PACKAGE.Darklang.Stdlib.String.toBytes }

--- a/backend/testfiles/httphandler/_simple-request-headers.test
+++ b/backend/testfiles/httphandler/_simple-request-headers.test
@@ -1,9 +1,9 @@
 [http-handler GET /]
 (let body =
-   request.headers
+  (request.headers
    |> PACKAGE.Darklang.Stdlib.List.map (fun (k,v) -> "(\"" ++ k ++ "\", \"" ++ v ++ "\")")
    |> PACKAGE.Darklang.Stdlib.String.join ",\n"
-   |> PACKAGE.Darklang.Stdlib.String.toBytes
+   |> PACKAGE.Darklang.Stdlib.String.toBytes)
  PACKAGE.Darklang.Stdlib.Http.response body 200L)
 
 [request]

--- a/backend/testfiles/httphandler/_simple-request-headers.test
+++ b/backend/testfiles/httphandler/_simple-request-headers.test
@@ -1,5 +1,6 @@
 [http-handler GET /]
-(let body =
+( let _ = "CLEANUP: Bring this test back once we can parse `"(\""`"
+  let body =
   (request.headers
    |> PACKAGE.Darklang.Stdlib.List.map (fun (k,v) -> "(\"" ++ k ++ "\", \"" ++ v ++ "\")")
    |> PACKAGE.Darklang.Stdlib.String.join ",\n"

--- a/backend/testfiles/httphandler/injected-icon-post-length.test
+++ b/backend/testfiles/httphandler/injected-icon-post-length.test
@@ -1,5 +1,5 @@
 [http-handler POST /]
-(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 in
+(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes
 PACKAGE.Darklang.Stdlib.Http.response body 200L)
 
 [request]

--- a/backend/testfiles/httphandler/injected-icon-post-roundtrip.test
+++ b/backend/testfiles/httphandler/injected-icon-post-roundtrip.test
@@ -1,5 +1,5 @@
 [http-handler POST /]
-PACKAGE.Darklang.Stdlib.Http.response (request.body) 200L
+PACKAGE.Darklang.Stdlib.Http.response request.body 200L
 
 [request]
 POST / HTTP/1.1

--- a/backend/testfiles/httphandler/injected-icon-post-roundtrip.test
+++ b/backend/testfiles/httphandler/injected-icon-post-roundtrip.test
@@ -1,5 +1,5 @@
 [http-handler POST /]
-PACKAGE.Darklang.Stdlib.Http.response request.body 200L
+PACKAGE.Darklang.Stdlib.Http.response (request.body) 200L
 
 [request]
 POST / HTTP/1.1

--- a/backend/testfiles/httphandler/query-string.test
+++ b/backend/testfiles/httphandler/query-string.test
@@ -1,5 +1,5 @@
 [http-handler GET /]
-PACKAGE.Darklang.Stdlib.Http.response (request.url |> PACKAGE.Darklang.Stdlib.String.toBytes_v0) 200L
+PACKAGE.Darklang.Stdlib.Http.response (request.url |> PACKAGE.Darklang.Stdlib.String.toBytes) 200L
 
 [request]
 GET /?key=value HTTP/1.1

--- a/backend/testfiles/httphandler/response-with-500.test
+++ b/backend/testfiles/httphandler/response-with-500.test
@@ -1,5 +1,5 @@
 [http-handler POST /]
-(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes in
+(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes
 PACKAGE.Darklang.Stdlib.Http.response body 500L)
 
 [request]

--- a/backend/testfiles/httphandler/simple-injected-string-post.test
+++ b/backend/testfiles/httphandler/simple-injected-string-post.test
@@ -1,5 +1,5 @@
 [http-handler POST /]
-(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes_v0 in
+(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes
 PACKAGE.Darklang.Stdlib.Http.response body 200L)
 
 [request]

--- a/backend/testfiles/httphandler/simple-inline-string-post.test
+++ b/backend/testfiles/httphandler/simple-inline-string-post.test
@@ -1,5 +1,5 @@
 [http-handler POST /]
-(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes_v0
+(let body = request.body |> PACKAGE.Darklang.Stdlib.List.length |> PACKAGE.Darklang.Stdlib.Int64.toString |> PACKAGE.Darklang.Stdlib.String.toBytes
  PACKAGE.Darklang.Stdlib.Http.response body 200L)
 
 [request]

--- a/backend/testfiles/httphandler/simple-response-headers.test
+++ b/backend/testfiles/httphandler/simple-response-headers.test
@@ -1,6 +1,6 @@
 [http-handler GET /]
-(let body = PACKAGE.Darklang.Stdlib.String.toBytes_v0 "1"
- let headers = ["header1", "value1"; "Header2", "Value2"; "Header-3", "Value-3"]
+(let body = PACKAGE.Darklang.Stdlib.String.toBytes "1"
+ let headers = [("header1", "value1"); ("Header2", "Value2"); ("Header-3", "Value-3")]
  PACKAGE.Darklang.Stdlib.Http.responseWithHeaders body headers 200L)
 
 [request]

--- a/backend/testfiles/httphandler/url-custom-domain.test
+++ b/backend/testfiles/httphandler/url-custom-domain.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes request.url) 200L
 
 [domain customdomain.myspecialdomain.com]
 

--- a/backend/testfiles/httphandler/url-custom-domain.test
+++ b/backend/testfiles/httphandler/url-custom-domain.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes_v0 request.url) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
 
 [domain customdomain.myspecialdomain.com]
 

--- a/backend/testfiles/httphandler/url-http.test
+++ b/backend/testfiles/httphandler/url-http.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes request.url) 200L
 
 [request]
 GET /a HTTP/1.1

--- a/backend/testfiles/httphandler/url-http.test
+++ b/backend/testfiles/httphandler/url-http.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes_v0 request.url) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
 
 [request]
 GET /a HTTP/1.1

--- a/backend/testfiles/httphandler/url-https.test
+++ b/backend/testfiles/httphandler/url-https.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes request.url) 200L
 
 [request]
 GET /a HTTP/1.1

--- a/backend/testfiles/httphandler/url-https.test
+++ b/backend/testfiles/httphandler/url-https.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes_v0 request.url) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
 
 [request]
 GET /a HTTP/1.1

--- a/backend/testfiles/httphandler/x-forwarded-proto-ignored.test
+++ b/backend/testfiles/httphandler/x-forwarded-proto-ignored.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes_v0 request.url) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
 
 
 [domain forwarded.myspecialdomain.com]

--- a/backend/testfiles/httphandler/x-forwarded-proto-ignored.test
+++ b/backend/testfiles/httphandler/x-forwarded-proto-ignored.test
@@ -1,5 +1,5 @@
 [http-handler GET /a]
-PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes(request.url)) 200L
+PACKAGE.Darklang.Stdlib.Http.response (PACKAGE.Darklang.Stdlib.String.toBytes request.url) 200L
 
 
 [domain forwarded.myspecialdomain.com]

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -1487,3 +1487,6 @@ let parsePTExpr (code : string) : Task<PT.Expr> =
     | _ -> return Exception.raiseInternal "Error executing parsePTExpr function" []
   }
   |> Ply.toTask
+
+type RTTest =
+  { name : string; lineNumber : int; actual : RT.Expr; expected : RT.Expr }

--- a/backend/tests/Tests/BwdServer.Tests.fs
+++ b/backend/tests/Tests/BwdServer.Tests.fs
@@ -47,14 +47,6 @@ type Test =
 
 let pm = LibCloud.PackageManager.pt
 
-let parse code =
-  LibParser.Parser.parsePTExpr
-    (localBuiltIns pm)
-    pm
-    NR.OnMissing.ThrowError
-    "BwdServer.Tests.fs"
-    code
-
 
 let newline = byte '\n'
 
@@ -206,7 +198,7 @@ let setupTestCanvas (testName : string) (test : Test) : Task<CanvasID * string> 
       test.handlers
       |> Ply.List.mapSequentially (fun handler ->
         uply {
-          let! source = parse handler.code
+          let! source = parsePTExpr handler.code
 
           let spec =
             match handler.version with

--- a/backend/tests/Tests/BwdServer.Tests.fs
+++ b/backend/tests/Tests/BwdServer.Tests.fs
@@ -20,7 +20,6 @@ open Prelude
 
 module RT = LibExecution.RuntimeTypes
 module PT = LibExecution.ProgramTypes
-module NR = LibParser.NameResolver
 module Routing = LibCloud.Routing
 module Canvas = LibCloud.Canvas
 module Serialize = LibCloud.Serialize

--- a/backend/tests/Tests/Canvas.Tests.fs
+++ b/backend/tests/Tests/Canvas.Tests.fs
@@ -17,18 +17,6 @@ module Serialize = LibCloud.Serialize
 module PT = LibExecution.ProgramTypes
 module PTParser = LibExecution.ProgramTypesParser
 module Account = LibCloud.Account
-module NR = LibParser.NameResolver
-
-let pm = LibCloud.PackageManager.pt
-
-let parse (code : string) : Task<PT.Expr> =
-  LibParser.Parser.parseSimple
-    (localBuiltIns pm)
-    pm
-    NR.OnMissing.ThrowError
-    "tests.canvas.fs"
-    code
-  |> Ply.toTask
 
 let testDBOplistRoundtrip : Test =
   testTask "db oplist roundtrip" {
@@ -97,8 +85,8 @@ let testHttpLoadIgnoresDeletedHandler =
 let testSetHandlerAfterDelete =
   testTask "handler set after delete" {
     let! canvasID = initializeTestCanvas "set-handlder-after-delete"
-    let! e1 = parse "5 + 3"
-    let! e2 = parse "5 + 2"
+    let! e1 = parsePTExpr "5 + 3"
+    let! e2 = parsePTExpr "5 + 2"
     let h1 = testHttpRouteHandler "/path" "GET" e1
     let h2 = testHttpRouteHandler "/path" "GET" e2
 

--- a/backend/tests/Tests/HttpClient.Tests.fs
+++ b/backend/tests/Tests/HttpClient.Tests.fs
@@ -31,7 +31,6 @@ module PT = LibExecution.ProgramTypes
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module Exe = LibExecution.Execution
 module PackageIDs = LibExecution.PackageIDs
-module PT2DT = LibExecution.ProgramTypesToDarkTypes
 module C2DT = LibExecution.CommonToDarkTypes
 
 open TestUtils.TestUtils
@@ -94,7 +93,7 @@ let pmPT = LibCloud.PackageManager.pt
 let parseSingleTestFromFile
   (filename : string)
   (test : string)
-  : Ply<PT2DT.Internal.Test.PTTest> =
+  : Ply<Internal.Test.PTTest> =
   uply {
     let! (state : RT.ExecutionState) =
       let canvasID = System.Guid.NewGuid()
@@ -108,12 +107,12 @@ let parseSingleTestFromFile
     let! execResult = LibExecution.Execution.executeFunction state name [] args
 
     match execResult with
-    | Ok dval -> return PT2DT.Internal.Test.fromDT dval
+    | Ok dval -> return Internal.Test.fromDT dval
     | Error _ -> return Exception.raiseInternal "Error executing function" []
 
   }
 
-let parseTest (filename : string) (test : string) : Ply<RTTest> =
+let parseTest (filename : string) (test : string) : Ply<Internal.Test.RTTest> =
   uply {
     let! ptTest = (parseSingleTestFromFile filename test)
     let actual = ptTest.actual |> PT2RT.Expr.toRT
@@ -188,7 +187,7 @@ let makeTest versionName filename =
       let! state = executionStateFor pmPT canvasID false true Map.empty
 
       // Parse the Dark code
-      let! (test : RTTest) =
+      let! (test : Internal.Test.RTTest) =
         darkCode
         |> String.replace "URL" $"{host}/{versionName}/{testName}"
         // CLEANUP: this doesn't use the correct length, as it might be latin1 or

--- a/backend/tests/Tests/HttpClient.Tests.fs
+++ b/backend/tests/Tests/HttpClient.Tests.fs
@@ -30,7 +30,9 @@ module RT = LibExecution.RuntimeTypes
 module PT = LibExecution.ProgramTypes
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module Exe = LibExecution.Execution
-module NR = LibParser.NameResolver
+module PackageIDs = LibExecution.PackageIDs
+module PT2DT = LibExecution.ProgramTypesToDarkTypes
+module C2DT = LibExecution.CommonToDarkTypes
 
 open TestUtils.TestUtils
 
@@ -89,12 +91,40 @@ let updateBody (body : byte array) : byte array =
 
 let pmPT = LibCloud.PackageManager.pt
 
-let parseTest test =
-  LibParser.TestModule.parseSingleTestFromFile
-    (localBuiltIns pmPT)
-    pmPT
-    NR.OnMissing.ThrowError
-    test
+let parseSingleTestFromFile
+  (filename : string)
+  (test : string)
+  : Ply<PT2DT.Internal.Test.PTTest> =
+  uply {
+    let! (state : RT.ExecutionState) =
+      let canvasID = System.Guid.NewGuid()
+      executionStateFor pmPT canvasID false false Map.empty
+
+    let name =
+      RT.FQFnName.FQFnName.Package
+        PackageIDs.Fn.Internal.Test.parseSingleTestFromFile
+
+    let args = NEList.ofList (RT.DString filename) [ RT.DString test ]
+    let! execResult = LibExecution.Execution.executeFunction state name [] args
+
+    match execResult with
+    | Ok dval -> return PT2DT.Internal.Test.fromDT dval
+    | Error _ -> return Exception.raiseInternal "Error executing function" []
+
+  }
+
+let parseTest (filename : string) (test : string) : Ply<RTTest> =
+  uply {
+    let! ptTest = (parseSingleTestFromFile filename test)
+    let actual = ptTest.actual |> PT2RT.Expr.toRT
+    let expected = ptTest.expected |> PT2RT.Expr.toRT
+
+    return
+      { actual = actual
+        expected = expected
+        lineNumber = ptTest.lineNumber
+        name = ptTest.name }
+  }
 
 let makeTest versionName filename =
   // Parse the file contents now, rather than later, so that tests that refer to
@@ -158,7 +188,7 @@ let makeTest versionName filename =
       let! state = executionStateFor pmPT canvasID false true Map.empty
 
       // Parse the Dark code
-      let! (test : LibParser.TestModule.RTTest) =
+      let! (test : RTTest) =
         darkCode
         |> String.replace "URL" $"{host}/{versionName}/{testName}"
         // CLEANUP: this doesn't use the correct length, as it might be latin1 or

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -531,6 +531,14 @@ let exprs =
       []
       false
     t "int list list" "[[1L; 2L]; [3L; 4L]]" "[[1L; 2L]; [3L; 4L]]" [] [] [] false
+    t
+      "list -newline as a separator"
+      "[ true\n false\n true ]"
+      "[true; false; true]"
+      []
+      []
+      []
+      false
 
     // dict literal
     t "empty dict" "Dict { }" "Dict {  }" [] [] [] false
@@ -585,6 +593,15 @@ let exprs =
     t
       "record, 3 fields"
       "Person3 {name =\"John\"; age = 30L; hasPet = true} "
+      "Person3 { name = \"John\"; age = 30L; hasPet = true }"
+      [ person3 ]
+      []
+      []
+      false
+
+    t
+      "record, with newline as separator"
+      "Person3\n {name =\"John\"\n age = 30L\n hasPet = true} "
       "Person3 { name = \"John\"; age = 30L; hasPet = true }"
       [ person3 ]
       []

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -532,7 +532,7 @@ let exprs =
       false
     t "int list list" "[[1L; 2L]; [3L; 4L]]" "[[1L; 2L]; [3L; 4L]]" [] [] [] false
     t
-      "list -newline as a separator"
+      "list with newline as a separator"
       "[ true\n false\n true ]"
       "[true; false; true]"
       []
@@ -600,7 +600,7 @@ let exprs =
       false
 
     t
-      "record, with newline as separator"
+      "record with newline as separator"
       "Person3\n {name =\"John\"\n age = 30L\n hasPet = true} "
       "Person3 { name = \"John\"; age = 30L; hasPet = true }"
       [ person3 ]

--- a/backend/tests/Tests/Queue.Tests.fs
+++ b/backend/tests/Tests/Queue.Tests.fs
@@ -27,14 +27,6 @@ module TCS = LibCloud.TraceCloudStorage
 
 let pmPT = LibCloud.PackageManager.pt
 
-let p (code : string) : Task<PT.Expr> =
-  LibParser.Parser.parsePTExpr
-    (localBuiltIns pmPT)
-    pmPT
-    NR.OnMissing.ThrowError
-    "Queue.Tests.fs"
-    code
-  |> Ply.toTask
 
 // This doesn't actually test input, since it's a cron handler and not an actual event handler
 
@@ -42,8 +34,8 @@ let initializeCanvas (name : string) : Task<CanvasID * tlid> =
   task {
     // set up handler
     let! canvasID = initializeTestCanvas name
-
-    let! e = p "let data = PACKAGE.Darklang.Stdlib.DateTime.now_v0 () in 123"
+    let! e =
+      parsePTExpr "let data = PACKAGE.Darklang.Stdlib.DateTime.now ()\n 123"
     let h = testWorker "test" e
 
     do! Canvas.saveTLIDs canvasID [ (PT.Toplevel.TLHandler h, Serialize.NotDeleted) ]

--- a/backend/tests/Tests/Queue.Tests.fs
+++ b/backend/tests/Tests/Queue.Tests.fs
@@ -17,7 +17,6 @@ open TestUtils.TestUtils
 
 module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
-module NR = LibParser.NameResolver
 module EQ = LibCloud.Queue
 module Canvas = LibCloud.Canvas
 module Serialize = LibCloud.Serialize

--- a/backend/tests/Tests/Queue.Tests.fs
+++ b/backend/tests/Tests/Queue.Tests.fs
@@ -34,8 +34,7 @@ let initializeCanvas (name : string) : Task<CanvasID * tlid> =
   task {
     // set up handler
     let! canvasID = initializeTestCanvas name
-    let! e =
-      parsePTExpr "let data = PACKAGE.Darklang.Stdlib.DateTime.now ()\n 123"
+    let! e = parsePTExpr "let data = PACKAGE.Darklang.Stdlib.DateTime.now ()\n 123"
     let h = testWorker "test" e
 
     do! Canvas.saveTLIDs canvasID [ (PT.Toplevel.TLHandler h, Serialize.NotDeleted) ]

--- a/backend/tests/Tests/QueueSchedulingRules.Tests.fs
+++ b/backend/tests/Tests/QueueSchedulingRules.Tests.fs
@@ -17,25 +17,14 @@ module Canvas = LibCloud.Canvas
 module Serialize = LibCloud.Serialize
 module SR = LibCloud.QueueSchedulingRules
 
-let pmPT = PT.PackageManager.empty
-
-let p (code : string) : Task<PT.Expr> =
-  LibParser.Parser.parsePTExpr
-    (localBuiltIns pmPT)
-    pmPT
-    NR.OnMissing.ThrowError
-    "queueschedulingrules.fs"
-    code
-  |> Ply.toTask
-
 
 let testGetWorkerSchedulesForCanvas =
   testTask "worker schedules for canvas" {
     let! canvasID = initializeTestCanvas "worker-schedules"
 
-    let! e1 = p "1"
-    let! e2 = p "1"
-    let! e3 = p "1"
+    let! e1 = parsePTExpr "1L"
+    let! e2 = parsePTExpr "1L"
+    let! e3 = parsePTExpr "1L"
     let apple = testWorker "apple" e1
     let banana = testWorker "banana" e2
     let cherry = testWorker "cherry" e3

--- a/backend/tests/Tests/QueueSchedulingRules.Tests.fs
+++ b/backend/tests/Tests/QueueSchedulingRules.Tests.fs
@@ -11,7 +11,6 @@ open TestUtils.TestUtils
 
 module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
-module NR = LibParser.NameResolver
 module EQ2 = LibCloud.Queue
 module Canvas = LibCloud.Canvas
 module Serialize = LibCloud.Serialize

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -281,11 +281,10 @@ module Darklang =
 
           match typeNameNode, openBraceNode, recordContents, closeBraceNode with
           | Ok typeName, Ok openBrace, Ok recordContents, Ok closeBrace ->
+            let tn = typeName.text |> Stdlib.String.split "."
+
             let typeNameNode =
-              Darklang.LanguageTools.WrittenTypes.Name.Unresolved(
-                typeName.range,
-                [ typeName.text ]
-              )
+              Darklang.LanguageTools.WrittenTypes.Name.Unresolved(typeName.range, tn)
 
             (WrittenTypes.Expr.ERecord(
               node.range,

--- a/packages/darklang/languageTools/parser/parserTest.dark
+++ b/packages/darklang/languageTools/parser/parserTest.dark
@@ -8,6 +8,16 @@ module Darklang =
           |> LanguageTools.Parser.parseFromTree
           |> Builtin.unwrap
 
+        let parseWTExpr (code: WrittenTypes.ParsedFile) : WrittenTypes.Expr =
+          let exprs =
+            match sourceFile with
+            | SourceFile c -> c.exprsToEval
+            | _ -> []
+
+          match exprs with
+          | [ expr ] -> expr
+          | _ -> failwith "Expected exactly one expression to be parsed"
+
         // TODO: maybe use a proper type instead of string?
         let parsePTExpr
           (code: String)

--- a/packages/darklang/languageTools/parser/parserTest.dark
+++ b/packages/darklang/languageTools/parser/parserTest.dark
@@ -8,16 +8,6 @@ module Darklang =
           |> LanguageTools.Parser.parseFromTree
           |> Builtin.unwrap
 
-        let parseWTExpr (code: WrittenTypes.ParsedFile) : WrittenTypes.Expr =
-          let exprs =
-            match sourceFile with
-            | SourceFile c -> c.exprsToEval
-            | _ -> []
-
-          match exprs with
-          | [ expr ] -> expr
-          | _ -> "Expected exactly one expression to be parsed"
-
         // TODO: maybe use a proper type instead of string?
         let parsePTExpr
           (code: String)

--- a/packages/darklang/languageTools/parser/parserTest.dark
+++ b/packages/darklang/languageTools/parser/parserTest.dark
@@ -16,7 +16,7 @@ module Darklang =
 
           match exprs with
           | [ expr ] -> expr
-          | _ -> failwith "Expected exactly one expression to be parsed"
+          | _ -> "Expected exactly one expression to be parsed"
 
         // TODO: maybe use a proper type instead of string?
         let parsePTExpr

--- a/packages/internal/tests.dark
+++ b/packages/internal/tests.dark
@@ -1,0 +1,62 @@
+module Darklang =
+  module Internal =
+    module Test =
+      type WTTest =
+        { name: String
+          lineNumber: Int64
+          actual: LanguageTools.WrittenTypes.Expr
+          expected: LanguageTools.WrittenTypes.Expr }
+
+      type PTTest =
+        { name: String
+          lineNumber: Int64
+          actual: LanguageTools.ProgramTypes.Expr
+          expected: LanguageTools.ProgramTypes.Expr }
+
+      let parseTest
+        (pf: LanguageTools.WrittenTypes.ParsedFile)
+        : Stdlib.Result.Result<WTTest, String> =
+        let exprsToEval =
+          match pf with
+          | SourceFile s -> s.exprsToEval
+          | _ -> []
+
+        match exprsToEval with
+        | [] -> Stdlib.Result.Result.Error "no exprs to eval"
+        | [ e ] ->
+          match e with
+          | EInfix(r, _, actual, expected) ->
+            (WTTest
+              { name = "test"
+                lineNumber = r.start.row
+                actual = actual
+                expected = expected })
+            |> Stdlib.Result.Result.Ok
+
+          | _ -> Stdlib.Result.Result.Error "expected x = y format"
+
+      // CLEANUP: return result?
+      let parseSingleTestFromFile (filename: String) (testSource: String) : PTTest =
+        let wtTest =
+          testSource
+          |> LanguageTools.Parser.ParserTest.initialParse
+          |> Test.parseTest
+          |> Builtin.unwrap
+
+        let lineNumber = wtTest.lineNumber
+
+        let actual =
+          LanguageTools.WrittenTypesToProgramTypes.Expr.toPT
+            LanguageTools.NameResolver.OnMissing.ThrowError
+            wtTest.actual
+
+        let expected =
+          LanguageTools.WrittenTypesToProgramTypes.Expr.toPT
+            LanguageTools.NameResolver.OnMissing.ThrowError
+            wtTest.expected
+
+        PTTest
+          { name = "test"
+            lineNumber = lineNumber
+            actual = actual
+            expected = expected }

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -361,6 +361,7 @@ module.exports = grammar({
         $.record_literal,
         $.enum_literal,
         $.variable_identifier,
+        $.field_access,
       ),
 
     expression: $ =>
@@ -376,7 +377,6 @@ module.exports = grammar({
         $.infix_operation,
         $.apply,
 
-        $.field_access,
         $.lambda_expression,
         $.pipe_expression,
 
@@ -689,7 +689,6 @@ module.exports = grammar({
               $.record_literal,
               $.paren_expression,
               $.field_access,
-              $.apply,
             ),
           ),
           field("symbol_dot", alias(".", $.symbol)),

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -2007,6 +2007,10 @@
         {
           "type": "SYMBOL",
           "name": "variable_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "field_access"
         }
       ]
     },
@@ -2044,10 +2048,6 @@
         {
           "type": "SYMBOL",
           "name": "apply"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "field_access"
         },
         {
           "type": "SYMBOL",
@@ -3814,10 +3814,6 @@
                 {
                   "type": "SYMBOL",
                   "name": "field_access"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "apply"
                 }
               ]
             }

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -392,21 +392,44 @@
       ]
     },
     "const_list_content": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "consts"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "list_separator",
-                "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "consts"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "list_separator",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ";"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "consts"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
                   "type": "ALIAS",
                   "content": {
                     "type": "STRING",
@@ -414,29 +437,48 @@
                   },
                   "named": true,
                   "value": "symbol"
+                },
+                {
+                  "type": "BLANK"
                 }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "consts"
-              }
-            ]
-          }
+              ]
+            }
+          ]
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "STRING",
-                "value": ";"
-              },
-              "named": true,
-              "value": "symbol"
+              "type": "SYMBOL",
+              "name": "consts"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "newline"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "consts"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "newline"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }
@@ -1606,21 +1648,44 @@
       ]
     },
     "mp_list_content": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "match_pattern"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "list_separator",
-                "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "match_pattern"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "list_separator",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ";"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "match_pattern"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
                   "type": "ALIAS",
                   "content": {
                     "type": "STRING",
@@ -1628,29 +1693,48 @@
                   },
                   "named": true,
                   "value": "symbol"
+                },
+                {
+                  "type": "BLANK"
                 }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "match_pattern"
-              }
-            ]
-          }
+              ]
+            }
+          ]
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "STRING",
-                "value": ";"
-              },
-              "named": true,
-              "value": "symbol"
+              "type": "SYMBOL",
+              "name": "match_pattern"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "newline"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "match_pattern"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "newline"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }
@@ -2963,21 +3047,44 @@
       ]
     },
     "list_content": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "expression"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "list_separator",
-                "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "list_separator",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ";"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
                   "type": "ALIAS",
                   "content": {
                     "type": "STRING",
@@ -2985,29 +3092,48 @@
                   },
                   "named": true,
                   "value": "symbol"
+                },
+                {
+                  "type": "BLANK"
                 }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "expression"
-              }
-            ]
-          }
+              ]
+            }
+          ]
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "STRING",
-                "value": ";"
-              },
-              "named": true,
-              "value": "symbol"
+              "type": "SYMBOL",
+              "name": "expression"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "newline"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "newline"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         }
@@ -3302,36 +3428,78 @@
       ]
     },
     "record_content": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "record_pair"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "record_pair"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "record_separator",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ";"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "record_pair"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "record_separator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ";"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "record_pair"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "newline"
                   },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "record_pair"
+                  {
+                    "type": "SYMBOL",
+                    "name": "record_pair"
+                  }
+                ]
               }
-            ]
-          }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "newline"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -2150,55 +2150,24 @@
       ]
     },
     "string_literal": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "symbol_open_quote",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "\""
-                },
-                "named": true,
-                "value": "symbol"
-              }
+          "type": "FIELD",
+          "name": "symbol_open_quote",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "\""
             },
-            {
-              "type": "FIELD",
-              "name": "symbol_close_quote",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "\""
-                },
-                "named": true,
-                "value": "symbol"
-              }
-            }
-          ]
+            "named": true,
+            "value": "symbol"
+          }
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
-            {
-              "type": "FIELD",
-              "name": "symbol_open_quote",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "\""
-                },
-                "named": true,
-                "value": "symbol"
-              }
-            },
             {
               "type": "FIELD",
               "name": "content",
@@ -2208,19 +2177,22 @@
               }
             },
             {
-              "type": "FIELD",
-              "name": "symbol_close_quote",
-              "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "\""
-                },
-                "named": true,
-                "value": "symbol"
-              }
+              "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "FIELD",
+          "name": "symbol_close_quote",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "\""
+            },
+            "named": true,
+            "value": "symbol"
+          }
         }
       ]
     },
@@ -4349,402 +4321,141 @@
         }
       ]
     },
-    "pipe_infix": {
+    "operator": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "PREC_RIGHT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "^"
-                  },
-                  "named": true,
-                  "value": "operator"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
-              }
-            ]
-          }
+          "type": "STRING",
+          "value": "^"
         },
         {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "*"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "/"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "%"
-                      }
-                    ]
-                  },
-                  "named": true,
-                  "value": "operator"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "STRING",
+              "value": "/"
+            },
+            {
+              "type": "STRING",
+              "value": "%"
+            }
+          ]
         },
         {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "+"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "-"
-                      }
-                    ]
-                  },
-                  "named": true,
-                  "value": "operator"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "+"
+            },
+            {
+              "type": "STRING",
+              "value": "-"
+            }
+          ]
         },
         {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "=="
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "!="
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "<"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "<="
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ">"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ">="
-                      }
-                    ]
-                  },
-                  "named": true,
-                  "value": "operator"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "=="
+            },
+            {
+              "type": "STRING",
+              "value": "!="
+            },
+            {
+              "type": "STRING",
+              "value": "<"
+            },
+            {
+              "type": "STRING",
+              "value": "<="
+            },
+            {
+              "type": "STRING",
+              "value": ">"
+            },
+            {
+              "type": "STRING",
+              "value": ">="
+            }
+          ]
         },
         {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "&&"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "||"
-                      }
-                    ]
-                  },
-                  "named": true,
-                  "value": "operator"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "&&"
+            },
+            {
+              "type": "STRING",
+              "value": "||"
+            }
+          ]
         },
         {
-          "type": "PREC_LEFT",
-          "value": 0,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "operator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "++"
-                  },
-                  "named": true,
-                  "value": "operator"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "right",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
-              }
-            ]
-          }
+          "type": "STRING",
+          "value": "++"
         }
       ]
+    },
+    "pipe_infix": {
+      "type": "PREC_RIGHT",
+      "value": 50,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "symbol_open_paren",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": "("
+              },
+              "named": true,
+              "value": "symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "SYMBOL",
+              "name": "operator"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "symbol_close_paren",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "STRING",
+                "value": ")"
+              },
+              "named": true,
+              "value": "symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "expression"
+            }
+          }
+        ]
+      }
     },
     "pipe_fn_call": {
       "type": "PREC_RIGHT",
@@ -4955,37 +4666,34 @@
       "type": "PREC_LEFT",
       "value": 0,
       "content": {
-        "type": "REPEAT1",
-        "content": {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "symbol_pipe",
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "symbol_pipe",
+            "content": {
+              "type": "ALIAS",
               "content": {
-                "type": "ALIAS",
-                "content": {
-                  "type": "STRING",
-                  "value": "|>"
-                },
-                "named": true,
-                "value": "symbol"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "pipe_expr",
-              "content": {
-                "type": "SYMBOL",
-                "name": "pipe_expr"
-              }
+                "type": "STRING",
+                "value": "|>"
+              },
+              "named": true,
+              "value": "symbol"
             }
-          ]
-        }
+          },
+          {
+            "type": "FIELD",
+            "name": "pipe_expr",
+            "content": {
+              "type": "SYMBOL",
+              "name": "pipe_expr"
+            }
+          }
+        ]
       }
     },
     "pipe_expression": {
-      "type": "PREC",
+      "type": "PREC_LEFT",
       "value": 9,
       "content": {
         "type": "SEQ",
@@ -4999,11 +4707,14 @@
             }
           },
           {
-            "type": "FIELD",
-            "name": "pipe_exprs",
+            "type": "REPEAT1",
             "content": {
-              "type": "SYMBOL",
-              "name": "pipe_exprs"
+              "type": "FIELD",
+              "name": "pipe_exprs",
+              "content": {
+                "type": "SYMBOL",
+                "name": "pipe_exprs"
+              }
             }
           }
         ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1022,10 +1022,6 @@
           "named": true
         },
         {
-          "type": "field_access",
-          "named": true
-        },
-        {
           "type": "if_expression",
           "named": true
         },
@@ -1080,10 +1076,6 @@
         "multiple": false,
         "required": true,
         "types": [
-          {
-            "type": "apply",
-            "named": true
-          },
           {
             "type": "field_access",
             "named": true
@@ -3179,6 +3171,10 @@
         },
         {
           "type": "enum_literal",
+          "named": true
+        },
+        {
+          "type": "field_access",
           "named": true
         },
         {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -2511,6 +2511,11 @@
     }
   },
   {
+    "type": "operator",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "paren_expression",
     "named": true,
     "fields": {
@@ -2680,7 +2685,7 @@
         ]
       },
       "pipe_exprs": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -2696,7 +2701,7 @@
     "named": true,
     "fields": {
       "pipe_expr": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -2706,7 +2711,7 @@
         ]
       },
       "symbol_pipe": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -4416,6 +4421,62 @@
     "named": false
   },
   {
+    "type": "!=",
+    "named": false
+  },
+  {
+    "type": "%",
+    "named": false
+  },
+  {
+    "type": "&&",
+    "named": false
+  },
+  {
+    "type": "*",
+    "named": false
+  },
+  {
+    "type": "+",
+    "named": false
+  },
+  {
+    "type": "++",
+    "named": false
+  },
+  {
+    "type": "-",
+    "named": false
+  },
+  {
+    "type": "/",
+    "named": false
+  },
+  {
+    "type": "<",
+    "named": false
+  },
+  {
+    "type": "<=",
+    "named": false
+  },
+  {
+    "type": "==",
+    "named": false
+  },
+  {
+    "type": ">",
+    "named": false
+  },
+  {
+    "type": ">=",
+    "named": false
+  },
+  {
+    "type": "^",
+    "named": false
+  },
+  {
     "type": "char_or_string_escape_sequence",
     "named": true
   },
@@ -4448,10 +4509,6 @@
     "named": true
   },
   {
-    "type": "operator",
-    "named": true
-  },
-  {
     "type": "positive_digits",
     "named": true
   },
@@ -4462,5 +4519,9 @@
   {
     "type": "unit",
     "named": true
+  },
+  {
+    "type": "||",
+    "named": false
   }
 ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -441,6 +441,10 @@
           "named": true
         },
         {
+          "type": "newline",
+          "named": true
+        },
+        {
           "type": "symbol",
           "named": true
         }
@@ -1947,6 +1951,10 @@
           "named": true
         },
         {
+          "type": "newline",
+          "named": true
+        },
+        {
           "type": "symbol",
           "named": true
         }
@@ -2470,6 +2478,10 @@
           "named": true
         },
         {
+          "type": "newline",
+          "named": true
+        },
+        {
           "type": "symbol",
           "named": true
         }
@@ -2942,6 +2954,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "newline",
+          "named": true
+        },
         {
           "type": "record_pair",
           "named": true

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Record.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Record.txt
@@ -114,3 +114,58 @@ Person {name = "John"; address = Address {city = "New York"; street = "5th Avenu
 )
 
 
+==================
+Record -muliple fields with newline
+==================
+
+Person {
+  name = "John"
+  age = 30L
+  hobbies = ["reading"; "swimming"]
+}
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (record_literal
+        (qualified_type_name (type_identifier))
+        (symbol)
+        (record_content
+          (record_pair
+            (variable_identifier)
+            (symbol)
+            (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+          )
+          (newline)
+          (record_pair
+            (variable_identifier)
+            (symbol)
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          )
+          (newline)
+          (record_pair
+            (variable_identifier)
+            (symbol)
+            (expression
+              (simple_expression
+                (list_literal
+                  (symbol)
+                  (list_content
+                    (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+                    (symbol)
+                    (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+                  )
+                  (symbol)
+                )
+              )
+            )
+          )
+          (newline)
+        )
+        (symbol)
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
@@ -8,9 +8,11 @@ person.name
 
 (source_file
   (expression
-    (field_access (variable_identifier)
-      (symbol)
-      (variable_identifier)
+    (simple_expression
+      (field_access (variable_identifier)
+        (symbol)
+        (variable_identifier)
+      )
     )
   )
 )
@@ -25,28 +27,31 @@ field access - paren defined Record
 
 (source_file
   (expression
-   (field_access
-    (paren_expression
-      (symbol)
-      (expression
-        (simple_expression
-          (record_literal
-            (qualified_type_name (type_identifier))
-            (symbol)
-            (record_content
-              (record_pair
-                (variable_identifier)
+    (simple_expression
+      (field_access
+        (paren_expression
+          (symbol)
+          (expression
+            (simple_expression
+              (record_literal
+                (qualified_type_name (type_identifier))
                 (symbol)
-                (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
-              )
+                (record_content
+                  (record_pair
+                    (variable_identifier)
+                    (symbol)
+                    (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+                  )
+                )
+                (symbol))
             )
-            (symbol))
+          )
+          (symbol)
         )
+        (symbol)
+        (variable_identifier)
       )
-      (symbol)
     )
-    (symbol)
-    (variable_identifier))
   )
 )
 
@@ -61,13 +66,70 @@ person.address.street
 
 (source_file
   (expression
-    (field_access
-      (field_access (variable_identifier)
+    (simple_expression
+      (field_access
+        (field_access (variable_identifier)
+          (symbol)
+          (variable_identifier)
+        )
         (symbol)
         (variable_identifier)
       )
-      (symbol)
-      (variable_identifier)
+    )
+  )
+)
+
+
+==================
+field access fn_call
+==================
+
+(getPerson()).name
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (field_access
+        (paren_expression
+          (symbol)
+          (expression
+            (apply (qualified_fn_name (fn_identifier)) (simple_expression (unit)))
+          )
+          (symbol)
+        )
+        (symbol)
+        (variable_identifier)
+      )
+    )
+  )
+)
+
+
+==================
+field access fn_call - nested
+==================
+
+(getUser()).profile.name
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (field_access
+        (field_access
+          (paren_expression
+            (symbol)
+            (expression (apply (qualified_fn_name (fn_identifier)) (simple_expression (unit))))
+            (symbol)
+          )
+          (symbol)
+          (variable_identifier))
+        (symbol)
+        (variable_identifier)
+      )
     )
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -449,7 +449,7 @@ Builtin.jsonParse<Bool> "true"
 function call - with a field_access as argument
 ==================
 
-PACKAGE.Darklang.Stdlib.Http.response (request.body) 200L
+PACKAGE.Darklang.Stdlib.Http.response request.body 200L
 
 ---
 
@@ -457,10 +457,7 @@ PACKAGE.Darklang.Stdlib.Http.response (request.body) 200L
   (expression
     (apply
       (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-      (paren_expression
-        (symbol)
-        (expression (field_access (variable_identifier) (symbol) (variable_identifier)))
-        (symbol))
+      (simple_expression (field_access (variable_identifier) (symbol) (variable_identifier)))
       (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
       (newline)
     )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -443,3 +443,27 @@ Builtin.jsonParse<Bool> "true"
     )
   )
 )
+
+
+==================
+function call - with a field_access as argument
+==================
+
+PACKAGE.Darklang.Stdlib.Http.response (request.body) 200L
+
+---
+
+(source_file
+  (expression
+    (apply
+      (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+      (paren_expression
+        (symbol)
+        (expression (field_access (variable_identifier) (symbol) (variable_identifier)))
+        (symbol))
+      (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+      (newline)
+    )
+  )
+)
+

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
@@ -228,3 +228,34 @@ List with just a semicolon
       (ERROR
         (symbol))
       (symbol)))))
+
+
+==================
+List with newlines
+==================
+
+[true
+ false
+ true
+ false]
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (list_literal
+        (symbol)
+        (list_content
+          (expression (simple_expression (bool_literal)))
+          (newline)
+          (expression (simple_expression (bool_literal)))
+          (newline)
+          (expression (simple_expression (bool_literal)))
+          (newline)
+          (expression (simple_expression (bool_literal))))
+        (symbol)
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -434,3 +434,64 @@ pipe expression - multiple pipe expressions
     )
   )
 )
+
+
+==================
+pipe expression - multiple pipe expressions with infix
+==================
+
+1L
+|> (+) 2L
+|> (*) 3L
+|> (>) 4L
+
+---
+
+(source_file
+  (expression
+    (pipe_expression
+      (expression
+        (pipe_expression
+          (expression
+            (pipe_expression
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (pipe_exprs
+                (symbol)
+                (pipe_expr
+                  (pipe_infix
+                    (symbol)
+                    (operator)
+                    (symbol)
+                    (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  )
+                )
+              )
+            )
+          )
+          (pipe_exprs
+            (symbol)
+            (pipe_expr
+              (pipe_infix
+                (symbol)
+                (operator)
+                (symbol)
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              )
+            )
+          )
+        )
+      )
+      (pipe_exprs
+        (symbol)
+        (pipe_expr
+          (pipe_infix
+            (symbol)
+            (operator)
+            (symbol)
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          )
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Changelog:

```
Parser:
- Replace LibParser with tree-sitter-darklang parser in some test files
- Add support for multi-line lists and record literals where a newline is considered a delimiter
```
LibParser was replaced in: 
`BwdServer.Tests`, `Canvas.Tests`, `HttpClient.Tests`, `ProgramTypes.Tests`, `Queue.Tests`, `QueueSchedulingRules.Tests.fs`
