### PR TITLE
Tree-sitter-darklang grammar fixes

### DIFF
--- a/backend/testfiles/httphandler/_simple-request-headers.test
+++ b/backend/testfiles/httphandler/_simple-request-headers.test
@@ -1,11 +1,11 @@
 [http-handler GET /]
-( let _ = "CLEANUP: Bring this test back once we can parse `"(\""`"
-  let body =
-  (request.headers
-   |> PACKAGE.Darklang.Stdlib.List.map (fun (k,v) -> "(\"" ++ k ++ "\", \"" ++ v ++ "\")")
-   |> PACKAGE.Darklang.Stdlib.String.join ",\n"
-   |> PACKAGE.Darklang.Stdlib.String.toBytes)
- PACKAGE.Darklang.Stdlib.Http.response body 200L)
+(let _ = "CLEANUP: Bring this test back once we can parse `"(\""`"
+let body =
+  request.headers
+  |> PACKAGE.Darklang.Stdlib.List.map (fun (k,v) -> "(\"" ++ k ++ "\", \"" ++ v ++ "\")")
+  |> PACKAGE.Darklang.Stdlib.String.join ",\n"
+  |> PACKAGE.Darklang.Stdlib.String.toBytes
+PACKAGE.Darklang.Stdlib.Http.response body 200L)
 
 [request]
 GET / HTTP/1.1

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -697,6 +697,7 @@ let exprs =
       false
     // TODO: this is ugly
     t "simple let expr" "let x = 1L\n  x" "let x =\n  1L\nx" [] [] [] false
+    t "let expr with indent" "let x =\n  1L\nx" "let x =\n  1L\nx" [] [] [] false
 
     // field access
     t "field access 1" "person.name" "person.name" [] [] [] false

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -790,12 +790,12 @@ module.exports = grammar({
         field("keyword_let", alias("let", $.keyword)),
         field("identifier", $.variable_identifier),
         field("symbol_equals", alias("=", $.symbol)),
-        choice(seq(field("expr", $.expression), "\n"), $.indented_block),
+        choice(
+          seq(field("expr", $.expression), "\n"),
+          seq($.indent, field("expr", $.expression), $.dedent, optional("\n")),
+        ),
         field("body", $.expression),
       ),
-
-    indented_block: $ =>
-      seq($.indent, field("expr", $.expression), $.dedent, optional("\n")),
 
     // ---------------------
     // Pipe expressions

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -1108,7 +1108,12 @@ function enum_literal_base($, enum_fields) {
       field("type_name", $.qualified_type_name),
       field("symbol_dot", alias(".", $.symbol)),
       field("case_name", $.enum_case_identifier),
-      optional(field("enum_fields", enum_fields)),
+      optional(
+        choice(
+          seq($.indent, field("enum_fields", enum_fields), $.dedent),
+          field("enum_fields", enum_fields),
+        ),
+      ),
     ),
   );
 }

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -790,10 +790,12 @@ module.exports = grammar({
         field("keyword_let", alias("let", $.keyword)),
         field("identifier", $.variable_identifier),
         field("symbol_equals", alias("=", $.symbol)),
-        field("expr", $.expression),
-        "\n",
+        choice(seq(field("expr", $.expression), "\n"), $.indented_block),
         field("body", $.expression),
       ),
+
+    indented_block: $ =>
+      seq($.indent, field("expr", $.expression), $.dedent, optional("\n")),
 
     // ---------------------
     // Pipe expressions

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -756,12 +756,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "enum_fields",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "const_enum_fields"
-                }
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "indent"
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "enum_fields",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "const_enum_fields"
+                        }
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "dedent"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "const_enum_fields"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -3814,12 +3840,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "enum_fields",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "enum_fields"
-                }
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "indent"
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "enum_fields",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "enum_fields"
+                        }
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "dedent"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "enum_fields"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"
@@ -4522,16 +4574,30 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "expr",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "\n"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "expr",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "\n"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "indented_block"
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -4540,6 +4606,39 @@
             "type": "SYMBOL",
             "name": "expression"
           }
+        }
+      ]
+    },
+    "indented_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "indent"
+        },
+        {
+          "type": "FIELD",
+          "name": "expr",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dedent"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "\n"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -4807,12 +4906,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "FIELD",
-                "name": "enum_fields",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "pipe_enum_fields"
-                }
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "indent"
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "enum_fields",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "pipe_enum_fields"
+                        }
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "dedent"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "pipe_enum_fields"
+                    }
+                  }
+                ]
               },
               {
                 "type": "BLANK"

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -4594,8 +4594,37 @@
               ]
             },
             {
-              "type": "SYMBOL",
-              "name": "indented_block"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "indent"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "expr",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "dedent"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "\n"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -4606,39 +4635,6 @@
             "type": "SYMBOL",
             "name": "expression"
           }
-        }
-      ]
-    },
-    "indented_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "indent"
-        },
-        {
-          "type": "FIELD",
-          "name": "expr",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
-        },
-        {
-          "type": "SYMBOL",
-          "name": "dedent"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "\n"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
     },

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1421,36 +1421,6 @@
     }
   },
   {
-    "type": "indented_block",
-    "named": true,
-    "fields": {
-      "expr": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "expression",
-            "named": true
-          }
-        ]
-      }
-    },
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "dedent",
-          "named": true
-        },
-        {
-          "type": "indent",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "infix_operation",
     "named": true,
     "fields": {
@@ -1824,7 +1794,7 @@
       },
       "expr": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
           {
             "type": "expression",
@@ -1864,11 +1834,15 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
-          "type": "indented_block",
+          "type": "dedent",
+          "named": true
+        },
+        {
+          "type": "indent",
           "named": true
         }
       ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -415,6 +415,20 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "dedent",
+          "named": true
+        },
+        {
+          "type": "indent",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -1011,6 +1025,20 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "dedent",
+          "named": true
+        },
+        {
+          "type": "indent",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -1380,6 +1408,36 @@
     "children": {
       "multiple": true,
       "required": false,
+      "types": [
+        {
+          "type": "dedent",
+          "named": true
+        },
+        {
+          "type": "indent",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "indented_block",
+    "named": true,
+    "fields": {
+      "expr": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
       "types": [
         {
           "type": "dedent",
@@ -1766,7 +1824,7 @@
       },
       "expr": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "expression",
@@ -1804,6 +1862,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "indented_block",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -2599,6 +2667,20 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "dedent",
+          "named": true
+        },
+        {
+          "type": "indent",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
@@ -141,3 +141,54 @@ Stdlib.Option.Option.Some 1L
   )
 )
 
+==================
+Enum - fully qualified with indented args
+==================
+
+Stdlib.Option.Option.Some
+  1L
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (enum_literal
+        (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+        (symbol)
+        (enum_case_identifier)
+        (indent)
+        (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
+        (dedent)
+      )
+    )
+  )
+)
+
+
+
+==================
+Enum - with two args no parens and indented
+==================
+
+MyEnum.TwoArgs
+  1L
+  2L
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (enum_literal
+        (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
+        (indent)
+        (enum_fields
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+        )
+        (dedent)
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
@@ -32,11 +32,9 @@ x
   (expression
     (let_expression
       (keyword) (variable_identifier) (symbol)
-      (indented_block
-        (indent)
-        (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-        (dedent)
-      )
+      (indent)
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (dedent)
       (expression (simple_expression (variable_identifier)))
     )
   )
@@ -92,24 +90,22 @@ x
   (expression
     (let_expression
       (keyword) (variable_identifier) (symbol)
-      (indented_block
-        (indent)
-        (expression
-          (pipe_expression
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-            (pipe_exprs
-              (symbol)
-              (pipe_expr
-                (pipe_enum
-                  (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-                  (symbol) (enum_case_identifier)
-                )
+      (indent)
+      (expression
+        (pipe_expression
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          (pipe_exprs
+            (symbol)
+            (pipe_expr
+              (pipe_enum
+                (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+                (symbol) (enum_case_identifier)
               )
             )
           )
         )
-        (dedent)
       )
+      (dedent)
       (expression (simple_expression (variable_identifier)))
     )
   )
@@ -135,41 +131,39 @@ wtTest
       (keyword)
       (variable_identifier)
       (symbol)
-      (indented_block
-        (indent)
-        (expression
-          (pipe_expression
-            (expression
-              (pipe_expression
-                (expression
-                  (pipe_expression
-                    (expression (simple_expression (variable_identifier)))
-                    (pipe_exprs
-                      (symbol)
-                      (pipe_expr
-                        (pipe_fn_call
-                          (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                        )
+      (indent)
+      (expression
+        (pipe_expression
+          (expression
+            (pipe_expression
+              (expression
+                (pipe_expression
+                  (expression (simple_expression (variable_identifier)))
+                  (pipe_exprs
+                    (symbol)
+                    (pipe_expr
+                      (pipe_fn_call
+                        (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
                       )
                     )
                   )
                 )
-                (pipe_exprs
-                  (symbol)
-                  (pipe_expr (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (fn_identifier))))
-                )
               )
-            )
-            (pipe_exprs
-              (symbol)
-              (pipe_expr
-                (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (fn_identifier)))
+              (pipe_exprs
+                (symbol)
+                (pipe_expr (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (fn_identifier))))
               )
             )
           )
+          (pipe_exprs
+            (symbol)
+            (pipe_expr
+              (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (fn_identifier)))
+            )
+          )
         )
-        (dedent)
       )
+      (dedent)
       (expression (simple_expression (variable_identifier)))
     )
   )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
@@ -1,0 +1,176 @@
+==================
+simple let_expression
+==================
+
+let x = 1L
+x
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword) (variable_identifier) (symbol)
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (expression (simple_expression (variable_identifier)))
+    )
+  )
+)
+
+
+==================
+simple let_expression -with indent
+==================
+
+let x =
+  1L
+x
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword) (variable_identifier) (symbol)
+      (indented_block
+        (indent)
+        (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+        (dedent)
+      )
+      (expression (simple_expression (variable_identifier)))
+    )
+  )
+)
+
+
+
+==================
+let expression with pipes -inline
+==================
+
+let x = 1L |> Stdlib.Option.Option.Some
+x
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword) (variable_identifier) (symbol)
+      (expression
+        (pipe_expression
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          (pipe_exprs
+            (symbol)
+            (pipe_expr
+              (pipe_enum
+                (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+                (symbol) (enum_case_identifier)
+              )
+            )
+          )
+        )
+      )
+      (expression (simple_expression (variable_identifier)))
+    )
+  )
+)
+
+
+==================
+let expression with one pipe -indented
+==================
+
+let x =
+  1L
+  |> Stdlib.Option.Option.Some
+x
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword) (variable_identifier) (symbol)
+      (indented_block
+        (indent)
+        (expression
+          (pipe_expression
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (pipe_exprs
+              (symbol)
+              (pipe_expr
+                (pipe_enum
+                  (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+                  (symbol) (enum_case_identifier)
+                )
+              )
+            )
+          )
+        )
+        (dedent)
+      )
+      (expression (simple_expression (variable_identifier)))
+    )
+  )
+)
+
+
+==================
+let expression with multiple pipes -indented
+==================
+
+let wtTest =
+  testSource
+  |> LanguageTools.Parser.ParserTest.initialParse
+  |> Test.parseTest
+  |> Builtin.unwrap
+wtTest
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword)
+      (variable_identifier)
+      (symbol)
+      (indented_block
+        (indent)
+        (expression
+          (pipe_expression
+            (expression
+              (pipe_expression
+                (expression
+                  (pipe_expression
+                    (expression (simple_expression (variable_identifier)))
+                    (pipe_exprs
+                      (symbol)
+                      (pipe_expr
+                        (pipe_fn_call
+                          (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                        )
+                      )
+                    )
+                  )
+                )
+                (pipe_exprs
+                  (symbol)
+                  (pipe_expr (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (fn_identifier))))
+                )
+              )
+            )
+            (pipe_exprs
+              (symbol)
+              (pipe_expr
+                (pipe_fn_call (qualified_fn_name (module_identifier) (symbol) (fn_identifier)))
+              )
+            )
+          )
+        )
+        (dedent)
+      )
+      (expression (simple_expression (variable_identifier)))
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
@@ -259,3 +259,42 @@ List with newlines
     )
   )
 )
+
+
+==================
+Enum List
+==================
+
+[
+  ErrorSegment.ErrorSegment.String
+    "RTETODO typeChecker.toSegments"
+]
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (list_literal
+        (symbol)
+        (list_content
+          (expression
+            (simple_expression
+              (enum_literal
+                (qualified_type_name (module_identifier) (symbol) (type_identifier))
+                (symbol)
+                (enum_case_identifier)
+                (indent)
+                (enum_fields
+                  (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+                )
+                (dedent)
+              )
+            )
+          )
+        )
+        (symbol)
+      )
+    )
+  )
+)


### PR DESCRIPTION

No changelog

This PR adds some tree-sitter-darklang grammar tests, and fixes the following issues: 
Issue 1: 
```
[ ErrorSegment.ErrorSegment.String
	"RTETODO typeChecker.toSegments" ] 
```

This was parsed as a list of two elements (an enum and a string literal), rather than a list of one element (an enum with one field)

Issue 2:
```
let x =
  1L
  |> Stdlib.Option.Option.Some
x
```
The body (`x`) of the let_expression was parsed as part of the pipe, as if it was a field of the enum.

