### PR TITLE
Tree-sitter-darklang: fix function declaration

### DIFF
--- a/backend/testfiles/execution/stdlib/semanticTokenization.dark
+++ b/backend/testfiles/execution/stdlib/semanticTokenization.dark
@@ -447,60 +447,60 @@ module TokenizeFunctionDeclaration =
                                                        (0L, 30L),
                                                        (0L, 31L)) ]
 
-  ("let add (a: Int64) (b: Int64) : Int64 = a + b" |> tokenize) = [ (TokenType.Keyword,
-                                                                     (0L, 0L),
-                                                                     (0L, 3L))
-                                                                    (TokenType.FunctionName,
-                                                                     (0L, 4L),
-                                                                     (0L, 7L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 8L),
-                                                                     (0L, 9L))
-                                                                    (TokenType.ParameterName,
-                                                                     (0L, 9L),
-                                                                     (0L, 10L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 10L),
-                                                                     (0L, 11L))
-                                                                    (TokenType.TypeName,
-                                                                     (0L, 12L),
-                                                                     (0L, 17L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 17L),
-                                                                     (0L, 18L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 19L),
-                                                                     (0L, 20L))
-                                                                    (TokenType.ParameterName,
-                                                                     (0L, 20L),
-                                                                     (0L, 21L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 21L),
-                                                                     (0L, 22L))
-                                                                    (TokenType.TypeName,
-                                                                     (0L, 23L),
-                                                                     (0L, 28L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 28L),
-                                                                     (0L, 29L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 30L),
-                                                                     (0L, 31L))
-                                                                    (TokenType.TypeName,
-                                                                     (0L, 32L),
-                                                                     (0L, 37L))
-                                                                    (TokenType.Symbol,
-                                                                     (0L, 38L),
-                                                                     (0L, 39L))
-                                                                    (TokenType.VariableName,
-                                                                     (0L, 40L),
-                                                                     (0L, 41L))
-                                                                    (TokenType.Operator,
-                                                                     (0L, 42L),
-                                                                     (0L, 43L))
-                                                                    (TokenType.VariableName,
-                                                                     (0L, 44L),
-                                                                     (0L, 45L)) ]
+  ("let add (a: Int64) (b: Int64) : Int64 = (a + b)" |> tokenize) = [ (TokenType.Keyword,
+                                                                       (0L, 0L),
+                                                                       (0L, 3L))
+                                                                      (TokenType.FunctionName,
+                                                                       (0L, 4L),
+                                                                       (0L, 7L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 8L),
+                                                                       (0L, 9L))
+                                                                      (TokenType.ParameterName,
+                                                                       (0L, 9L),
+                                                                       (0L, 10L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 10L),
+                                                                       (0L, 11L))
+                                                                      (TokenType.TypeName,
+                                                                       (0L, 12L),
+                                                                       (0L, 17L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 17L),
+                                                                       (0L, 18L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 19L),
+                                                                       (0L, 20L))
+                                                                      (TokenType.ParameterName,
+                                                                       (0L, 20L),
+                                                                       (0L, 21L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 21L),
+                                                                       (0L, 22L))
+                                                                      (TokenType.TypeName,
+                                                                       (0L, 23L),
+                                                                       (0L, 28L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 28L),
+                                                                       (0L, 29L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 30L),
+                                                                       (0L, 31L))
+                                                                      (TokenType.TypeName,
+                                                                       (0L, 32L),
+                                                                       (0L, 37L))
+                                                                      (TokenType.Symbol,
+                                                                       (0L, 38L),
+                                                                       (0L, 39L))
+                                                                      (TokenType.VariableName,
+                                                                       (0L, 41L),
+                                                                       (0L, 42L))
+                                                                      (TokenType.Operator,
+                                                                       (0L, 43L),
+                                                                       (0L, 44L))
+                                                                      (TokenType.VariableName,
+                                                                       (0L, 45L),
+                                                                       (0L, 46L)) ]
 
 
   ("let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit = ()" |> tokenize) = [ (TokenType.Keyword,

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -1451,7 +1451,7 @@ let functionDeclarations =
 
     t
       "single package param"
-      "let double2 (i: PACKAGE.Darklang.LanguageTools.ID) : Int64 = i + i"
+      "let double2 (i: PACKAGE.Darklang.LanguageTools.ID) : Int64 = (i + i)"
       "let double2 (i: PACKAGE.Darklang.LanguageTools.ID): Int64 =\n  (i) + (i)"
       []
       []
@@ -1469,7 +1469,7 @@ let functionDeclarations =
 
     t
       "multiple param"
-      "let isHigher (a: Int64) (b: Int64) : Bool = Stdlib.Int64.greaterThan a b"
+      "let isHigher (a: Int64) (b: Int64) : Bool =\n  Stdlib.Int64.greaterThan a b"
       "let isHigher (a: Int64) (b: Int64): Bool =\n  PACKAGE.Darklang.Stdlib.Int64.greaterThan a b"
       []
       []
@@ -1487,7 +1487,7 @@ let functionDeclarations =
 
     t
       "two type params"
-      "let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit  = ()"
+      "let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit = ()"
       "let myFn<'a, 'b> (paramOne: 'a) (paramTwo: 'b): Unit =\n  ()"
       []
       []
@@ -1496,7 +1496,7 @@ let functionDeclarations =
 
     t
       "package fn call"
-      "let sum (a : Int64) (b : Int64) : Int64 = PACKAGE.Darklang.Stdlib.Int64.add a b"
+      "let sum (a : Int64) (b : Int64) : Int64 =\n  PACKAGE.Darklang.Stdlib.Int64.add a b"
       "let sum (a: Int64) (b: Int64): Int64 =\n  PACKAGE.Darklang.Stdlib.Int64.add a b"
       []
       []

--- a/backend/tests/Tests/TreeSitter.Tests.fs
+++ b/backend/tests/Tests/TreeSitter.Tests.fs
@@ -13,13 +13,14 @@ let toStringTest =
   testCase "Basic function declaration parse test"
   <| fun _ ->
     let parser = new Parser(Language = DarklangLanguage.create ())
-    let source = "let increment (i: Int64): Int64 = i + 1L" |> Encoding.UTF8.GetBytes
+    let source =
+      "let increment (i: Int64): Int64 = (i + 1L)" |> Encoding.UTF8.GetBytes
 
     let tree = parser.Parse(source, InputEncoding.Utf8, None)
 
     Expect.equal
       (tree.Root.ToString())
-      "(source_file (fn_decl keyword_let: (keyword) name: (fn_identifier) params: (fn_decl_params (fn_decl_param symbol_left_paren: (symbol) identifier: (variable_identifier) symbol_colon: (symbol) typ: (type_reference (builtin_type)) symbol_right_paren: (symbol))) symbol_colon: (symbol) return_type: (type_reference (builtin_type)) symbol_equals: (symbol) body: (expression (infix_operation left: (expression (simple_expression (variable_identifier))) operator: (operator) right: (expression (simple_expression (int64_literal digits: (digits (positive_digits)) suffix: (symbol))))))))"
+      "(source_file (fn_decl keyword_let: (keyword) name: (fn_identifier) params: (fn_decl_params (fn_decl_param symbol_left_paren: (symbol) identifier: (variable_identifier) symbol_colon: (symbol) typ: (type_reference (builtin_type)) symbol_right_paren: (symbol))) symbol_colon: (symbol) return_type: (type_reference (builtin_type)) symbol_equals: (symbol) body: (paren_expression symbol_left_paren: (symbol) expr: (expression (infix_operation left: (expression (simple_expression (variable_identifier))) operator: (operator) right: (expression (simple_expression (int64_literal digits: (digits (positive_digits)) suffix: (symbol)))))) symbol_right_paren: (symbol))))"
       ""
 
 let tests = testList "TreeSitter" [ toStringTest ]

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -142,7 +142,10 @@ module.exports = grammar({
         field("symbol_colon", alias(":", $.symbol)),
         field("return_type", $.type_reference),
         field("symbol_equals", alias("=", $.symbol)),
-        field("body", $.expression),
+        choice(
+          seq($.indent, field("body", $.expression), $.dedent),
+          field("body", choice($.simple_expression, $.paren_expression)),
+        ),
       ),
     fn_decl_params: $ => repeat1(choice($.unit, $.fn_decl_param)),
     fn_decl_param: $ =>

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -973,12 +973,47 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "indent"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "body",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "dedent"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "simple_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "paren_expression"
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1159,6 +1159,14 @@
           {
             "type": "expression",
             "named": true
+          },
+          {
+            "type": "paren_expression",
+            "named": true
+          },
+          {
+            "type": "simple_expression",
+            "named": true
           }
         ]
       },
@@ -1232,6 +1240,20 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "dedent",
+          "named": true
+        },
+        {
+          "type": "indent",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
@@ -24,7 +24,7 @@ Builtin.printLine (myFn ())
     (symbol)
     (type_reference (builtin_type))
     (symbol)
-    (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+    (simple_expression (string_literal (symbol) (string_content) (symbol)))
   )
   (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
   (expression

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -411,3 +411,62 @@ match true with
     )
   )
 )
+
+
+==================
+match expression - tuple
+==================
+
+match (name, value, keyword) with
+	| (Ok name, Ok value, Ok keyword) -> "success"
+	| _ -> "error"
+
+---
+
+(source_file
+  (expression
+    (match_expression
+      (keyword)
+      (expression
+        (tuple_literal
+          (symbol)
+          (expression (simple_expression (variable_identifier)))
+          (symbol)
+          (expression (simple_expression (variable_identifier)))
+          (tuple_literal_the_rest
+            (symbol)
+            (expression (simple_expression (variable_identifier)))
+          )
+          (symbol)
+        )
+      )
+      (keyword)
+      (match_case
+        (symbol)
+        (match_pattern
+          (tuple
+            (symbol)
+            (match_pattern
+              (enum (enum_case_identifier) (mp_enum_fields (match_pattern (variable))))
+            )
+            (symbol)
+            (match_pattern
+              (enum (enum_case_identifier) (mp_enum_fields (match_pattern (variable))))
+            )
+            (mp_tuple_the_rest
+              (symbol)
+              (match_pattern
+                (enum (enum_case_identifier) (mp_enum_fields (match_pattern (variable))))
+              )
+            )
+            (symbol)))
+        (symbol)
+        (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+      )
+      (match_case
+        (symbol) (match_pattern (variable)) (symbol)
+        (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
@@ -22,7 +22,7 @@ let helloWorld (i: Int64): String = "Hello world"
     (symbol)
     (type_reference (builtin_type))
     (symbol)
-    (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+    (simple_expression (string_literal (symbol) (string_content) (symbol)))
   )
 )
 
@@ -43,7 +43,7 @@ let emptyString (): String = ""
     (symbol)
     (type_reference (builtin_type))
     (symbol)
-    (expression (simple_expression (string_literal (symbol) (symbol))))
+    (simple_expression (string_literal (symbol) (symbol)))
   )
 )
 
@@ -68,14 +68,15 @@ let isHigher (a: Int64) (b: Int64): Bool =
     (symbol)
     (type_reference (builtin_type))
     (symbol)
+    (indent)
     (expression
       (apply
         (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
         (simple_expression (variable_identifier))
         (simple_expression (variable_identifier))
-        (newline)
       )
     )
+    (dedent)
   )
 )
 
@@ -84,8 +85,7 @@ let isHigher (a: Int64) (b: Int64): Bool =
 fn decl with type parameters
 ==================
 
-let myFn<'a> (param: 'a): Unit =
-  ()
+let myFn<'a> (param: 'a): Unit = ()
 
 ---
 
@@ -106,7 +106,7 @@ let myFn<'a> (param: 'a): Unit =
       (symbol)
       (type_reference (builtin_type))
       (symbol)
-      (expression (simple_expression (unit)))
+      (simple_expression (unit))
   )
 )
 
@@ -115,8 +115,7 @@ let myFn<'a> (param: 'a): Unit =
 fn decl with two type parameters
 ==================
 
-let myFn<'a, 'b> (param: 'a): 'b =
-  param
+let myFn<'a, 'b> (param: 'a): 'b = param
 
 ---
 (source_file
@@ -140,6 +139,6 @@ let myFn<'a, 'b> (param: 'a): 'b =
     (symbol)
     (type_reference (builtin_type (variable_type_reference (symbol) (variable_identifier))))
     (symbol)
-    (expression (simple_expression (variable_identifier)))
+    (simple_expression (variable_identifier))
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/module_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/module_decls.txt
@@ -118,7 +118,7 @@ module Test =
         (symbol)
         (type_reference (builtin_type))
         (symbol)
-        (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+        (simple_expression (string_literal (symbol) (string_content) (symbol)))
       )
     )
     (dedent)
@@ -167,7 +167,7 @@ module Test =
         (symbol)
         (type_reference (builtin_type))
         (symbol)
-        (expression (simple_expression (string_literal (symbol) (string_content) (symbol))))
+        (simple_expression (string_literal (symbol) (string_content) (symbol)))
       )
     )
     (dedent)
@@ -212,6 +212,90 @@ module Test =
           (const_decl
             (keyword) (constant_identifier) (symbol)
             (consts (bool_literal))
+          )
+        )
+        (dedent)
+      )
+    )
+    (dedent)
+  )
+)
+
+
+==================
+module decl - with functions
+==================
+
+module Darklang =
+  let returnsOptionNone () : Stdlib.Option.Option<'a> =
+    Stdlib.Option.Option.None
+
+  let returnsResultOk () : Stdlib.Result.Result<Int64, String> =
+    Stdlib.Result.Result.Ok 5L
+
+
+---
+
+(source_file
+  (module_decl
+    (keyword) (module_identifier) (symbol)
+    (indent)
+    (module_content
+      (fn_decl
+        (keyword) (fn_identifier) (fn_decl_params (unit)) (symbol)
+        (type_reference
+          (qualified_type_name
+            (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)
+            (type_args
+              (symbol)
+              (type_args_items
+                (type_reference
+                  (builtin_type (variable_type_reference  (symbol) (variable_identifier)))
+                )
+              )
+              (symbol)
+            )
+          )
+        )
+        (symbol)
+        (indent)
+        (expression
+          (simple_expression
+            (enum_literal
+              (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+              (symbol)
+              (enum_case_identifier)
+            )
+          )
+        )
+        (dedent)
+      )
+    )
+    (module_content
+      (fn_decl
+        (keyword) (fn_identifier) (fn_decl_params (unit)) (symbol)
+        (type_reference
+          (qualified_type_name
+            (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)
+            (type_args
+              (symbol)
+              (type_args_items (type_reference (builtin_type)) (symbol) (type_reference (builtin_type)))
+              (symbol)
+            )
+          )
+        )
+        (symbol)
+        (indent)
+        (expression
+          (simple_expression
+            (enum_literal
+              (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+              (symbol)
+              (enum_case_identifier)
+              (enum_fields
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              )
+            )
           )
         )
         (dedent)


### PR DESCRIPTION
No changelog

This PR fixes `fn_decl` parsing 

There was a parsing error when I tried to parse the following code: 
```
module Darklang =
  let returnsOptionNone () : Stdlib.Option.Option<'a> = Stdlib.Option.Option.None
  
  let returnsResultOk () : Stdlib.Result.Result<Int64, String> =
    Stdlib.Result.Result.Ok 5L
```

It was parsed as one function declaration instead of two because there wasn’t a clear delimiter; enums can have fields, so it tried to treat that second `fn_decl` as a field, and errored

This PR handles this issue by:
- forcing the body to be written on a new line and indented for complex expressions
- allowing inline expressions if they are either `simple_expression`, or `paren_expression`

This is how things work now:
```
// have the body on a new line and indented
let returnsOptionNone () : Stdlib.Option.Option<'a> = 
   Stdlib.Option.Option.None
let returnsResultOk () : Stdlib.Result.Result<Int64, String> =
   Stdlib.Result.Result.Ok 5L
   
 // or wrap it in parens 
let returnsOptionNone () : Stdlib.Option.Option<'a> =  (Stdlib.Option.Option.None)
let returnsResultOk () : Stdlib.Result.Result<Int64, String> =
   Stdlib.Result.Result.Ok 5L
   
// no need for parens for simple expressions
let returnsOne () : Int64 = 1L
let returnsResultOk () : Stdlib.Result.Result<Int64, String> =
   Stdlib.Result.Result.Ok 5L
 
```