### PR TITLE
Tree-sitter-darklang: Fix let_expression to handle lp_tuple correctly

### DIFF
--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -727,6 +727,24 @@ let exprs =
     t "simple let expr" "let x = 1L\n  x" "let x =\n  1L\nx" [] [] [] false
     t "let expr with indent" "let x =\n  1L\nx" "let x =\n  1L\nx" [] [] [] false
 
+    t
+      "tuple destructuring"
+      "let (var1, var2) =\n  var3\n(var1, var2)"
+      "let (var1, var2) =\n  var3\n(var1, var2)"
+      []
+      []
+      []
+      false
+
+    t
+      "tuple destructuring 2"
+      "let (var1, var2) =\n  (var3, var4)\n(var1, var2)"
+      "let (var1, var2) =\n  (var3, var4)\n(var1, var2)"
+      []
+      []
+      []
+      false
+
     // field access
     t "field access 1" "person.name" "person.name" [] [] [] false
     t

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -454,14 +454,14 @@ module Darklang =
           (node: ParsedNode)
           : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
           let keywordLetNode = findField node "keyword_let"
-          let identifierNode = findField node "identifier"
+          let patternNode = findField node "pattern"
           let symbolEqualsNode = findField node "symbol_equals"
           let expr = findAndParseRequired node "expr" Expr.parse
           let body = findAndParseRequired node "body" Expr.parse
 
-          match keywordLetNode, identifierNode, symbolEqualsNode, expr, body with
-          | Ok keywordLet, Ok identifier, Ok symbolEquals, Ok expr, Ok body ->
-            match parseLetPattern identifier with
+          match keywordLetNode, patternNode, symbolEqualsNode, expr, body with
+          | Ok keywordLet, Ok pattern, Ok symbolEquals, Ok expr, Ok body ->
+            match parseLetPattern pattern with
             | Ok pattern ->
               (WrittenTypes.Expr.ELet(
                 node.range,

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -143,11 +143,7 @@ module Darklang =
                   (stringPart.range, stringPart.text) |> Stdlib.Result.Result.Ok)
 
               let (range, contents) =
-                match findContents with
-                | Some contents ->
-                  let (range, contents) = contents
-                  (range, contents)
-                | None -> (stringSegment.range, "")
+                Stdlib.Option.withDefault findContents (stringSegment.range, "")
 
               [ WrittenTypes.StringSegment.StringText(range, contents) ]
 
@@ -465,21 +461,11 @@ module Darklang =
 
           match keywordLetNode, identifierNode, symbolEqualsNode, expr, body with
           | Ok keywordLet, Ok identifier, Ok symbolEquals, Ok expr, Ok body ->
-            match identifier.children with
-            | [ child ] when child.typ == "unit" ->
+            match parseLetPattern identifier with
+            | Ok pattern ->
               (WrittenTypes.Expr.ELet(
                 node.range,
-                WrittenTypes.LetPattern.LPUnit(identifier.range),
-                expr,
-                body,
-                keywordLet.range,
-                symbolEquals.range
-              ))
-
-            | [ child ] when child.typ == "variable_identifier" ->
-              (WrittenTypes.Expr.ELet(
-                node.range,
-                WrittenTypes.LetPattern.LPVariable(identifier.range, identifier.text),
+                pattern,
                 expr,
                 body,
                 keywordLet.range,
@@ -487,30 +473,7 @@ module Darklang =
               ))
               |> Stdlib.Result.Result.Ok
 
-            | [ child ] when child.typ == "lp_tuple" ->
-              baseParseTuple
-                Expr.parseLetPattern
-                child
-                (fun (range, first, comma, second, rest, openParen, closeParen) ->
-                  (WrittenTypes.Expr.ELet(
-                    node.range,
-                    (WrittenTypes.LetPattern.LPTuple(
-                      range,
-                      first,
-                      comma,
-                      second,
-                      rest,
-                      openParen,
-                      closeParen
-                    )),
-                    expr,
-                    body,
-                    keywordLet.range,
-                    symbolEquals.range
-                  ))
-                  |> Stdlib.Result.Result.Ok)
-
-          | _ -> createUnparseableError node
+            | Error _ -> createUnparseableError node
 
 
         let parseFieldAccess

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -465,15 +465,50 @@ module Darklang =
 
           match keywordLetNode, identifierNode, symbolEqualsNode, expr, body with
           | Ok keywordLet, Ok identifier, Ok symbolEquals, Ok expr, Ok body ->
-            (WrittenTypes.Expr.ELet(
-              node.range,
-              WrittenTypes.LetPattern.LPVariable(identifier.range, identifier.text),
-              expr,
-              body,
-              keywordLet.range,
-              symbolEquals.range
-            ))
-            |> Stdlib.Result.Result.Ok
+            match identifier.children with
+            | [ child ] when child.typ == "unit" ->
+              (WrittenTypes.Expr.ELet(
+                node.range,
+                WrittenTypes.LetPattern.LPUnit(identifier.range),
+                expr,
+                body,
+                keywordLet.range,
+                symbolEquals.range
+              ))
+
+            | [ child ] when child.typ == "variable_identifier" ->
+              (WrittenTypes.Expr.ELet(
+                node.range,
+                WrittenTypes.LetPattern.LPVariable(identifier.range, identifier.text),
+                expr,
+                body,
+                keywordLet.range,
+                symbolEquals.range
+              ))
+              |> Stdlib.Result.Result.Ok
+
+            | [ child ] when child.typ == "lp_tuple" ->
+              baseParseTuple
+                Expr.parseLetPattern
+                child
+                (fun (range, first, comma, second, rest, openParen, closeParen) ->
+                  (WrittenTypes.Expr.ELet(
+                    node.range,
+                    (WrittenTypes.LetPattern.LPTuple(
+                      range,
+                      first,
+                      comma,
+                      second,
+                      rest,
+                      openParen,
+                      closeParen
+                    )),
+                    expr,
+                    body,
+                    keywordLet.range,
+                    symbolEquals.range
+                  ))
+                  |> Stdlib.Result.Result.Ok)
 
           | _ -> createUnparseableError node
 

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -817,7 +817,7 @@ module.exports = grammar({
     let_expression: $ =>
       seq(
         field("keyword_let", alias("let", $.keyword)),
-        field("identifier", $.let_pattern),
+        field("pattern", $.let_pattern),
         field("symbol_equals", alias("=", $.symbol)),
         choice(
           seq(field("expr", $.expression), "\n"),

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -817,7 +817,7 @@ module.exports = grammar({
     let_expression: $ =>
       seq(
         field("keyword_let", alias("let", $.keyword)),
-        field("identifier", $.variable_identifier),
+        field("identifier", $.let_pattern),
         field("symbol_equals", alias("=", $.symbol)),
         choice(
           seq(field("expr", $.expression), "\n"),
@@ -949,6 +949,7 @@ module.exports = grammar({
     //
     // Tuple
     tuple_type_reference: $ =>
+      // CLEANUP: make the parens optional
       seq(
         field("symbol_left_paren", alias("(", $.symbol)),
         field("first", $.type_reference),

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -4745,7 +4745,7 @@
         },
         {
           "type": "FIELD",
-          "name": "identifier",
+          "name": "pattern",
           "content": {
             "type": "SYMBOL",
             "name": "let_pattern"

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -4748,7 +4748,7 @@
           "name": "identifier",
           "content": {
             "type": "SYMBOL",
-            "name": "variable_identifier"
+            "name": "let_pattern"
           }
         },
         {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1809,7 +1809,7 @@
         "required": true,
         "types": [
           {
-            "type": "variable_identifier",
+            "type": "let_pattern",
             "named": true
           }
         ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1804,22 +1804,22 @@
           }
         ]
       },
-      "identifier": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "let_pattern",
-            "named": true
-          }
-        ]
-      },
       "keyword_let": {
         "multiple": false,
         "required": true,
         "types": [
           {
             "type": "keyword",
+            "named": true
+          }
+        ]
+      },
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "let_pattern",
             "named": true
           }
         ]

--- a/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
@@ -30,7 +30,7 @@ Builtin.printLine (myFn ())
   (expression
     (let_expression
       (keyword)
-      (variable_identifier)
+      (let_pattern (variable_identifier))
       (symbol)
       (expression
         (infix_operation
@@ -81,7 +81,7 @@ helloworld ()
     (expression
       (let_expression
         (keyword)
-        (variable_identifier)
+        (let_pattern (variable_identifier))
         (symbol)
         (expression
           (apply

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
@@ -10,7 +10,7 @@ x
 (source_file
   (expression
     (let_expression
-      (keyword) (variable_identifier) (symbol)
+      (keyword) (let_pattern (variable_identifier)) (symbol)
       (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
       (expression (simple_expression (variable_identifier)))
     )
@@ -31,7 +31,7 @@ x
 (source_file
   (expression
     (let_expression
-      (keyword) (variable_identifier) (symbol)
+      (keyword) (let_pattern (variable_identifier)) (symbol)
       (indent)
       (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
       (dedent)
@@ -54,7 +54,7 @@ x
 (source_file
   (expression
     (let_expression
-      (keyword) (variable_identifier) (symbol)
+      (keyword) (let_pattern (variable_identifier)) (symbol)
       (expression
         (pipe_expression
           (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
@@ -89,7 +89,7 @@ x
 (source_file
   (expression
     (let_expression
-      (keyword) (variable_identifier) (symbol)
+      (keyword) (let_pattern (variable_identifier)) (symbol)
       (indent)
       (expression
         (pipe_expression
@@ -129,7 +129,7 @@ wtTest
   (expression
     (let_expression
       (keyword)
-      (variable_identifier)
+      (let_pattern (variable_identifier))
       (symbol)
       (indent)
       (expression
@@ -165,6 +165,46 @@ wtTest
       )
       (dedent)
       (expression (simple_expression (variable_identifier)))
+    )
+  )
+)
+
+
+==================
+lp_tuple
+==================
+
+let (tokensSoFar, startOfLastToken) = acc
+(tokensSoFar, startOfLastToken)
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword)
+      (let_pattern
+        (lp_tuple
+          (symbol)
+          (let_pattern (variable_identifier))
+          (symbol)
+          (let_pattern (variable_identifier))
+          (symbol)
+        )
+      )
+      (symbol)
+      (expression (simple_expression (variable_identifier)))
+      (expression
+        (simple_expression
+          (tuple_literal
+            (symbol)
+            (expression (simple_expression (variable_identifier)))
+            (symbol)
+            (expression (simple_expression (variable_identifier)))
+            (symbol)
+          )
+        )
+      )
     )
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -149,7 +149,7 @@ match [ true ] with
         (indent)
         (expression
           (let_expression
-            (keyword) (variable_identifier) (symbol)
+            (keyword) (let_pattern (variable_identifier)) (symbol)
             (expression
               (apply
                 (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -109,7 +109,7 @@ let fn = (fun x -> x + 1L)
 (source_file
   (expression
     (let_expression
-      (keyword) (variable_identifier) (symbol)
+      (keyword) (let_pattern (variable_identifier)) (symbol)
       (expression
         (paren_expression
           (symbol)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/record_update.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/record_update.txt
@@ -59,7 +59,7 @@ let myRec = RecordForUpdate { x = 4L; y = 1L }
   (expression
     (let_expression
       (keyword)
-      (variable_identifier)
+      (let_pattern (variable_identifier))
       (symbol)
       (expression
         (simple_expression (record_literal
@@ -116,7 +116,7 @@ let myRec = RecordForUpdateMultipe { x = 4L; y = 1L; z = 0L }
   (expression
     (let_expression
       (keyword)
-      (variable_identifier)
+      (let_pattern (variable_identifier))
       (symbol)
       (expression
         (simple_expression (record_literal

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/variables.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/variables.txt
@@ -12,7 +12,7 @@ sum
   (expression
     (let_expression
       (keyword)
-      (variable_identifier)
+      (let_pattern (variable_identifier))
       (symbol)
       (expression (infix_operation (expression (simple_expression (variable_identifier))) (operator) (expression (simple_expression (variable_identifier)))))
       (expression (simple_expression (variable_identifier)))
@@ -34,7 +34,7 @@ let sum = i + i
   (expression
     (let_expression
       (keyword)
-      (variable_identifier)
+      (let_pattern (variable_identifier))
       (symbol)
       (expression (infix_operation (expression (simple_expression (variable_identifier))) (operator) (expression (simple_expression (variable_identifier)))))
       (expression (simple_expression (bool_literal (MISSING "bool_literal_token1"))))

--- a/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
@@ -165,7 +165,7 @@ let helloworld () : Int64 =
     (expression
       (let_expression
         (keyword)
-        (variable_identifier)
+        (let_pattern (variable_identifier))
         (symbol)
         (expression
           (apply


### PR DESCRIPTION

No changelog
