### PR TITLE
Misc tree-sitter grammar fixes

### DIFF
--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -1302,6 +1302,22 @@ else
       []
       []
       []
+      false
+    t
+      "fn call with indentation"
+      """Stdlib.Tuple3.mapAllThree
+  (fun x -> Stdlib.String.toUppercase x)
+  (fun x -> x - 2L)
+  (fun x -> Stdlib.String.toUppercase x)
+  ("one", 2L, "pi")
+"""
+      """PACKAGE.Darklang.Stdlib.Tuple3.mapAllThree (fun x ->
+  PACKAGE.Darklang.Stdlib.String.toUppercase x) (fun x ->
+  (x) - (2L)) (fun x ->
+  PACKAGE.Darklang.Stdlib.String.toUppercase x) ("one", 2L, "pi")"""
+      []
+      []
+      []
       false ]
   |> testList "exprs"
 

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -607,6 +607,14 @@ let exprs =
       []
       []
       false
+    t
+      "dict with double_backtick_identifier"
+      "Dict { ``Content-Length`` = 1L }"
+      "Dict { ``Content-Length`` = 1L }"
+      []
+      []
+      []
+      false
 
     // tuple literals
     t "tuple 2" "(1L, \"hello\")" "(1L, \"hello\")" [] [] [] false

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -128,7 +128,7 @@ module.exports = grammar({
 
     const_dict_literal: $ => dict_literal_base($, $.const_dict_content),
     const_dict_content: $ => dict_content_base($, $.const_dict_pair),
-    const_dict_pair: $ => dict_pair_base($, $.expression, $.consts),
+    const_dict_pair: $ => dict_pair_base($, $.consts),
 
     const_enum_literal: $ => enum_literal_base($, $.const_enum_fields),
     const_enum_fields: $ => enum_fields_base($, $.consts),
@@ -633,7 +633,7 @@ module.exports = grammar({
     // Dict
     dict_literal: $ => dict_literal_base($, $.dict_content),
     dict_content: $ => dict_content_base($, $.dict_pair),
-    dict_pair: $ => dict_pair_base($, $.expression, $.expression),
+    dict_pair: $ => dict_pair_base($, $.expression),
 
     //
     // Tuples
@@ -1076,6 +1076,8 @@ module.exports = grammar({
     newline: $ => /\n/,
 
     unit: $ => "()",
+
+    double_backtick_identifier: $ => token(seq("``", /[^`]+/, "``")),
   },
 });
 
@@ -1127,9 +1129,9 @@ function dict_content_base($, dict_pair) {
     repeat(seq(field("dict_separator", alias(";", $.symbol)), dict_pair)),
   );
 }
-function dict_pair_base($, key, value) {
+function dict_pair_base($, value) {
   return seq(
-    field("key", key),
+    field("key", choice($.variable_identifier, $.double_backtick_identifier)),
     field("symbol_equals", alias("=", $.symbol)),
     field("value", value),
   );

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -28,6 +28,7 @@ module.exports = grammar({
   name: "darklang",
 
   externals: $ => [$.indent, $.dedent],
+  extras: $ => [/[\s\uFEFF\u2060\u200B\u00A0]/, $._inline_comment],
 
   conflicts: $ => [[$.module_identifier, $.type_identifier]],
 
@@ -41,6 +42,8 @@ module.exports = grammar({
         // then the expressions to evaluate, in order
         repeat($.expression),
       ),
+
+    _inline_comment: _ => token(seq("//", /.*/)),
 
     type_params: $ =>
       seq(

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -805,10 +805,18 @@ module.exports = grammar({
     apply: $ =>
       prec.right(
         seq(
+          // TODO: fn should be an expression
           field("fn", $.qualified_fn_name),
-          field(
-            "args",
-            repeat1(choice($.paren_expression, $.simple_expression)),
+          choice(
+            field(
+              "args",
+              repeat1(choice($.paren_expression, $.simple_expression)),
+            ),
+            seq(
+              $.indent,
+              field("args", seq($.expression, repeat(seq(/\n/, $.expression)))),
+              $.dedent,
+            ),
           ),
           // the new line is used as a delimiter
           optional($.newline),

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -28,7 +28,7 @@ module.exports = grammar({
   name: "darklang",
 
   externals: $ => [$.indent, $.dedent],
-  extras: $ => [/[\s\uFEFF\u2060\u200B\u00A0]/, $._inline_comment],
+  extras: $ => [/\s/, $._inline_comment],
 
   conflicts: $ => [[$.module_identifier, $.type_identifier]],
 
@@ -1139,6 +1139,7 @@ function dict_content_base($, dict_pair) {
 }
 function dict_pair_base($, value) {
   return seq(
+    // CLEANUP this should allow for any string (i.e. `This`), without any backticks. may require alternative syntax.
     field("key", choice($.variable_identifier, $.double_backtick_identifier)),
     field("symbol_equals", alias("=", $.symbol)),
     field("value", value),

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -40,6 +40,22 @@
         }
       ]
     },
+    "_inline_comment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "//"
+          },
+          {
+            "type": "PATTERN",
+            "value": ".*"
+          }
+        ]
+      }
+    },
     "type_params": {
       "type": "SEQ",
       "members": [
@@ -5974,7 +5990,11 @@
   "extras": [
     {
       "type": "PATTERN",
-      "value": "\\s"
+      "value": "[\\s\\uFEFF\\u2060\\u200B\\u00A0]"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_inline_comment"
     }
   ],
   "conflicts": [

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -706,8 +706,17 @@
           "type": "FIELD",
           "name": "key",
           "content": {
-            "type": "SYMBOL",
-            "name": "expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "double_backtick_identifier"
+              }
+            ]
           }
         },
         {
@@ -3557,8 +3566,17 @@
           "type": "FIELD",
           "name": "key",
           "content": {
-            "type": "SYMBOL",
-            "name": "expression"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "double_backtick_identifier"
+              }
+            ]
           }
         },
         {
@@ -5985,6 +6003,26 @@
     "unit": {
       "type": "STRING",
       "value": "()"
+    },
+    "double_backtick_identifier": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "``"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^`]+"
+          },
+          {
+            "type": "STRING",
+            "value": "``"
+          }
+        ]
+      }
     }
   },
   "extras": [

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -6075,7 +6075,7 @@
   "extras": [
     {
       "type": "PATTERN",
-      "value": "[\\s\\uFEFF\\u2060\\u200B\\u00A0]"
+      "value": "\\s"
     },
     {
       "type": "SYMBOL",

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -4727,24 +4727,71 @@
             }
           },
           {
-            "type": "FIELD",
-            "name": "args",
-            "content": {
-              "type": "REPEAT1",
-              "content": {
-                "type": "CHOICE",
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "args",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "paren_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "simple_expression"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "SEQ",
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "paren_expression"
+                    "name": "indent"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "args",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "expression"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\n"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "expression"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "simple_expression"
+                    "name": "dedent"
                   }
                 ]
               }
-            }
+            ]
           },
           {
             "type": "CHOICE",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -8,6 +8,10 @@
         "required": true,
         "types": [
           {
+            "type": "expression",
+            "named": true
+          },
+          {
             "type": "paren_expression",
             "named": true
           },
@@ -29,9 +33,17 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "dedent",
+          "named": true
+        },
+        {
+          "type": "indent",
+          "named": true
+        },
         {
           "type": "newline",
           "named": true
@@ -2581,6 +2593,11 @@
     }
   },
   {
+    "type": "newline",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "operator",
     "named": true,
     "fields": {}
@@ -4758,10 +4775,6 @@
   },
   {
     "type": "negative_digits",
-    "named": true
-  },
-  {
-    "type": "newline",
     "named": true
   },
   {

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -298,7 +298,11 @@
         "required": true,
         "types": [
           {
-            "type": "expression",
+            "type": "double_backtick_identifier",
+            "named": true
+          },
+          {
+            "type": "variable_identifier",
             "named": true
           }
         ]
@@ -812,7 +816,11 @@
         "required": true,
         "types": [
           {
-            "type": "expression",
+            "type": "double_backtick_identifier",
+            "named": true
+          },
+          {
+            "type": "variable_identifier",
             "named": true
           }
         ]
@@ -4726,6 +4734,10 @@
   },
   {
     "type": "dedent",
+    "named": true
+  },
+  {
+    "type": "double_backtick_identifier",
     "named": true
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/comments.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/comments.txt
@@ -1,0 +1,79 @@
+==================
+inline comment
+==================
+
+// All the comments should be ignored
+// start
+let x = 1L // left side
+let y = 2L // right side
+let z = x + y // sum
+// result
+z
+// end
+
+---
+
+(source_file
+  (expression
+    (let_expression
+      (keyword)
+      (let_pattern (variable_identifier))
+      (symbol)
+      (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+      (expression
+        (let_expression
+          (keyword)
+          (let_pattern (variable_identifier))
+          (symbol)
+          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          (expression
+            (let_expression
+              (keyword)
+              (let_pattern (variable_identifier))
+              (symbol)
+              (expression
+                (infix_operation
+                  (expression (simple_expression (variable_identifier)))
+                  (operator)
+                  (expression (simple_expression (variable_identifier)))
+                )
+              )
+              (expression (simple_expression (variable_identifier)))
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+==================
+inline comment 2
+==================
+
+// All the comments should be ignored
+
+---
+
+(source_file)
+
+
+==================
+inline comment 3
+==================
+
+// Testing a string with // in it
+"this is a string with // in it"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal (symbol) (string_content) (symbol))
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/constant_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/constant_decls.txt
@@ -349,13 +349,13 @@ const myDict = Dict{one = 1L; two = 2L}
         (symbol)
         (const_dict_content
           (const_dict_pair
-            (expression (simple_expression (variable_identifier)))
+            (variable_identifier)
             (symbol)
             (consts (int64_literal (digits (positive_digits)) (symbol)))
           )
           (symbol)
           (const_dict_pair
-            (expression (simple_expression (variable_identifier)))
+            (variable_identifier)
             (symbol)
             (consts (int64_literal (digits (positive_digits)) (symbol)))
           )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/dicts.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/dicts.txt
@@ -30,8 +30,7 @@ Dict {a = 1L}
       (symbol)
       (dict_content
         (dict_pair
-          (expression
-            (simple_expression (variable_identifier)))
+          (variable_identifier)
           (symbol)
           (expression
             (simple_expression (int64_literal
@@ -56,8 +55,7 @@ Dict {a = 1L; b = 2L}
       (symbol)
       (dict_content
         (dict_pair
-          (expression
-            (simple_expression (variable_identifier)))
+          (variable_identifier)
           (symbol)
           (expression
             (simple_expression (int64_literal
@@ -66,8 +64,7 @@ Dict {a = 1L; b = 2L}
               (symbol)))))
         (symbol)
         (dict_pair
-          (expression
-            (simple_expression (variable_identifier)))
+          (variable_identifier)
           (symbol)
           (expression
             (simple_expression (int64_literal
@@ -92,8 +89,7 @@ Dict {a = 1L; b = 2L; c = 3L}
       (symbol)
       (dict_content
         (dict_pair
-          (expression
-            (simple_expression (variable_identifier)))
+          (variable_identifier)
           (symbol)
           (expression
             (simple_expression (int64_literal
@@ -102,8 +98,7 @@ Dict {a = 1L; b = 2L; c = 3L}
               (symbol)))))
         (symbol)
         (dict_pair
-          (expression
-            (simple_expression (variable_identifier)))
+          (variable_identifier)
           (symbol)
           (expression
             (simple_expression (int64_literal
@@ -112,8 +107,7 @@ Dict {a = 1L; b = 2L; c = 3L}
               (symbol)))))
         (symbol)
         (dict_pair
-          (expression
-            (simple_expression (variable_identifier)))
+          (variable_identifier)
           (symbol)
           (expression
             (simple_expression (int64_literal
@@ -121,3 +115,31 @@ Dict {a = 1L; b = 2L; c = 3L}
                 (positive_digits))
               (symbol))))))
       (symbol)))))
+
+
+==================
+dict - key is a double_backtick_identifier
+==================
+
+Dict { ``Content-Length`` = 1L }
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (dict_literal
+        (keyword)
+        (symbol)
+        (dict_content
+          (dict_pair
+            (double_backtick_identifier)
+            (symbol)
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+          )
+        )
+        (symbol)
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -464,3 +464,98 @@ PACKAGE.Darklang.Stdlib.Http.response request.body 200L
   )
 )
 
+==================
+fn_call - indented args
+==================
+
+Stdlib.Tuple3.mapAllThree
+  (fun x -> Stdlib.String.toUppercase x)
+  (fun x -> x - 2L)
+  (fun x -> Stdlib.String.toUppercase x)
+  ("one", 2L, "pi")
+
+
+---
+
+(source_file
+  (expression
+    (apply
+      (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+      (indent)
+      (expression
+        (paren_expression
+          (symbol)
+          (expression
+            (lambda_expression
+              (keyword)
+              (lambda_pats (let_pattern (variable_identifier)))
+              (symbol)
+              (expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (simple_expression (variable_identifier))
+                )
+              )
+            )
+          )
+          (symbol)
+        )
+      )
+      (expression
+        (paren_expression
+          (symbol)
+          (expression
+            (lambda_expression
+              (keyword)
+              (lambda_pats (let_pattern (variable_identifier)))
+              (symbol)
+              (expression
+                (infix_operation
+                  (expression (simple_expression (variable_identifier)))
+                  (operator)
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                )
+              )
+            )
+          )
+          (symbol)
+        )
+      )
+      (expression
+        (paren_expression
+          (symbol)
+          (expression
+            (lambda_expression
+              (keyword)
+              (lambda_pats (let_pattern (variable_identifier)))
+              (symbol)
+              (expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (simple_expression (variable_identifier))
+                )
+              )
+            )
+          )
+          (symbol)
+        )
+      )
+      (expression
+        (simple_expression
+          (tuple_literal
+            (symbol)
+            (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+            (symbol)
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (tuple_literal_the_rest
+              (symbol)
+              (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+            )
+            (symbol)
+          )
+        )
+      )
+      (dedent)
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -410,7 +410,7 @@ Builtin.printLine Dict {a = 1L}
           (symbol)
           (dict_content
             (dict_pair
-              (expression (simple_expression (variable_identifier)))
+              (variable_identifier)
               (symbol)
               (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
             )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
@@ -407,11 +407,18 @@ if a > b then
         (if_expression
           (keyword)
           (expression (infix_operation (expression (simple_expression (variable_identifier))) (operator) (expression (simple_expression (variable_identifier))))) (keyword)
-          (ERROR (variable_identifier))
-          (indent)
           (expression
-            (simple_expression (variable_identifier)))
-          (dedent)))
-      (expression
-        (simple_expression (variable_identifier)))
-      (dedent))))
+            (apply
+              (qualified_fn_name (fn_identifier))
+              (indent)
+              (expression (simple_expression (variable_identifier)))
+              (dedent)
+            )
+          )
+        )
+      )
+      (expression (simple_expression (variable_identifier)))
+      (dedent)
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -50,9 +50,9 @@ match expression - multiple cases
 ==================
 
 match 6L with
-  | var -> "pass"
-  | 6L -> "fail"
-  | 7L -> "pass"
+| var -> "pass"
+| 6L -> "fail"
+| 7L -> "pass"
 
 ---
 
@@ -82,9 +82,9 @@ match expression - test list
 ==================
 
 match [ true; false] with
-  | [] -> false
-  | [ true; false ] -> true
-  | var -> "fail"
+| [] -> false
+| [ true; false ] -> true
+| var -> "fail"
 
 ---
 
@@ -130,11 +130,11 @@ match expression - test let expression
 ==================
 
 match [ true ] with
-  | var ->
-    let length = Stdlib.List.length var
-    length
-  | [ true ] -> 1L
-  | [] -> 0L
+| var ->
+  let length = Stdlib.List.length var
+  length
+| [ true ] -> 1L
+| [] -> 0L
 
 ---
 
@@ -183,8 +183,8 @@ match expression - test when condition
 ==================
 
 match 5L with
-  | x when x > 0L -> true
-  | x -> false
+| x when x > 0L -> true
+| x -> false
 
 ---
 
@@ -215,8 +215,8 @@ match expression - test tuple
 ==================
 
 match (5L, 6L) with
-  | (w, x)  -> true
-  | (y, z) -> false
+| (w, x)  -> true
+| (y, z) -> false
 
 ---
 
@@ -261,8 +261,8 @@ match expression - test enum
 ==================
 
 match Stdlib.Result.Result.Ok 5L with
-  | Ok x -> x
-  | Error x -> x
+| Ok x -> x
+| Error x -> x
 
 ---
 
@@ -301,8 +301,8 @@ match expression - test list cons
 ==================
 
 match [ 1L; 2L; 3L ] with
-  | head :: tail -> "pass"
-  | [] -> "fail"
+| head :: tail -> "pass"
+| [] -> "fail"
 
 ---
 
@@ -348,7 +348,7 @@ match expression - test list cons with list
 ==================
 
 match [ 1L; 2L; 3L ] with
-  | 1L :: 2L :: [ 3L ] -> 6L
+| 1L :: 2L :: [ 3L ] -> 6L
 
 ---
 
@@ -403,7 +403,7 @@ match expression - test wildcard
 ==================
 
 match true with
-  | _ -> true
+| _ -> true
 
 ---
 
@@ -422,8 +422,8 @@ match expression - tuple
 ==================
 
 match (name, value, keyword) with
-	| (Ok name, Ok value, Ok keyword) -> "success"
-	| _ -> "error"
+| (Ok name, Ok value, Ok keyword) -> "success"
+| _ -> "error"
 
 ---
 


### PR DESCRIPTION
Misc tree-sitter-darklang grammar fixes
- ignore inline comment (//)
- use variable_identifier instead of expression for dictionaries
- add support for indented arguments in apply 