### PR TITLE
Tree-sitter-darklang: misc grammar fixes

### DIFF
--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -542,23 +542,6 @@ let exprs =
       []
       []
       false
-
-    t
-      "test"
-      "\"int64Multiply's 2nd argument (`b`) should be an Int64. However, a Float (1.0) was passed instead.
-
-
-
-		Expected: (b: Int64)
-
-		Actual: a Float: 1.0\""
-
-      "\"int64Multiply's 2nd argument (`b`) should be an Int64. However, a Float (1.0) was passed instead.\\n\\n\\n\\n\\t\\tExpected: (b: Int64)\\n\\n\\t\\tActual: a Float: 1.0\""
-      []
-      []
-      []
-      false
-
     t
       "multiline string "
       "\"\"\"int64Multiply's 2nd argument (`b`) should be an Int64. However, a Float (1.0) was passed instead.

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -559,6 +559,30 @@ let exprs =
       []
       false
 
+    t
+      "multiline string "
+      "\"\"\"int64Multiply's 2nd argument (`b`) should be an Int64. However, a Float (1.0) was passed instead.
+
+
+
+		Expected: (b: Int64)
+
+		Actual: a Float: 1.0\"\"\""
+
+      "\"int64Multiply's 2nd argument (`b`) should be an Int64. However, a Float (1.0) was passed instead.\\n\\n\\n\\n\\t\\tExpected: (b: Int64)\\n\\n\\t\\tActual: a Float: 1.0\""
+      []
+      []
+      []
+      false
+
+    t
+      "multiline string - interpolated"
+      "$\"\"\"test {\"1\"}\"\"\" == \"test 1\""
+      "($\"test {\"1\"}\") == (\"test 1\")"
+      []
+      []
+      []
+      false
 
     // char literals
     t "the letter a" "'a'" "'a'" [] [] [] false

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -389,7 +389,6 @@ module.exports = grammar({
         $.list_literal,
         $.dict_literal,
         $.record_literal,
-        $.enum_literal,
         $.variable_identifier,
         $.field_access,
         $.tuple_literal,
@@ -401,6 +400,9 @@ module.exports = grammar({
       choice(
         $.paren_expression,
         $.simple_expression,
+
+        $.enum_literal,
+
         $.if_expression,
         $.let_expression,
 
@@ -432,7 +434,6 @@ module.exports = grammar({
 
     //
     // Strings
-    // TODO: maybe add support for multiline strings (""")
     string_literal: $ =>
       choice(
         seq(

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -453,7 +453,7 @@ module.exports = grammar({
       repeat1(
         choice(
           // higher precedence than escape sequences
-          token.immediate(prec(1, /[^\\"]+/)),
+          token.immediate(prec(1, /[^\\"\n]+/)),
           $.char_or_string_escape_sequence,
         ),
       ),

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -35,9 +35,8 @@ module.exports = grammar({
   rules: {
     source_file: $ =>
       seq(
-        repeat($.module_decl),
         // all type and fn and constant defs first
-        repeat(choice($.type_decl, $.fn_decl, $.const_decl)),
+        repeat(choice($.module_decl, $.type_decl, $.fn_decl, $.const_decl)),
 
         // then the expressions to evaluate, in order
         repeat($.expression),

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -435,10 +435,18 @@ module.exports = grammar({
     // Strings
     // TODO: maybe add support for multiline strings (""")
     string_literal: $ =>
-      seq(
-        field("symbol_open_quote", alias('"', $.symbol)),
-        optional(field("content", $.string_content)),
-        field("symbol_close_quote", alias('"', $.symbol)),
+      choice(
+        seq(
+          field("symbol_open_quote", alias('"', $.symbol)),
+          optional(field("content", $.string_content)),
+          field("symbol_close_quote", alias('"', $.symbol)),
+        ),
+        // multiline strings
+        seq(
+          field("symbol_open_quote", alias('"""', $.symbol)),
+          optional(field("content", $.multiline_string_content)),
+          field("symbol_close_quote", alias('"""', $.symbol)),
+        ),
       ),
 
     string_content: $ =>
@@ -450,15 +458,40 @@ module.exports = grammar({
         ),
       ),
 
+    multiline_string_content: $ =>
+      repeat1(
+        choice(
+          token.immediate(prec(1, /[^\\"]+/)),
+          $.char_or_string_escape_sequence,
+        ),
+      ),
+
     // $"hello {name}
     string_interpolation: $ =>
-      seq(
-        field("symbol_dollar_sign", alias("$", $.symbol)),
-        field("symbol_open_quote", alias('"', $.symbol)),
-        optional(
-          field("string_interpolation_content", $.string_interpolation_content),
+      choice(
+        seq(
+          field("symbol_dollar_sign", alias("$", $.symbol)),
+          field("symbol_open_quote", alias('"', $.symbol)),
+          optional(
+            field(
+              "string_interpolation_content",
+              $.string_interpolation_content,
+            ),
+          ),
+          field("symbol_close_quote", alias('"', $.symbol)),
         ),
-        field("symbol_close_quote", alias('"', $.symbol)),
+        // multiline strings
+        seq(
+          field("symbol_dollar_sign", alias("$", $.symbol)),
+          field("symbol_open_quote", alias('"""', $.symbol)),
+          optional(
+            field(
+              "string_interpolation_content",
+              $.string_interpolation_content,
+            ),
+          ),
+          field("symbol_close_quote", alias('"""', $.symbol)),
+        ),
       ),
 
     string_interpolation_content: $ =>

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -318,7 +318,7 @@ module.exports = grammar({
     //
     // match pattern - list cons
     mp_list_cons: $ =>
-      prec.left(
+      prec.right(
         seq(
           field("head", $.match_pattern),
           field("symbol_double_colon", alias("::", $.symbol)),
@@ -1132,9 +1132,12 @@ function dict_literal_base($, contentRule) {
   );
 }
 function dict_content_base($, dict_pair) {
-  return seq(
-    dict_pair,
-    repeat(seq(field("dict_separator", alias(";", $.symbol)), dict_pair)),
+  return choice(
+    seq(
+      dict_pair,
+      repeat(seq(field("dict_separator", alias(";", $.symbol)), dict_pair)),
+    ),
+    seq(dict_pair, repeat(seq($.newline, dict_pair)), optional($.newline)),
   );
 }
 function dict_pair_base($, value) {

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -7,15 +7,12 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "module_decl"
-          }
-        },
-        {
-          "type": "REPEAT",
-          "content": {
             "type": "CHOICE",
             "members": [
+              {
+                "type": "SYMBOL",
+                "name": "module_decl"
+              },
               {
                 "type": "SYMBOL",
                 "name": "type_decl"

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -2312,10 +2312,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "enum_literal"
-        },
-        {
-          "type": "SYMBOL",
           "name": "variable_identifier"
         },
         {
@@ -2346,6 +2342,10 @@
         {
           "type": "SYMBOL",
           "name": "simple_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enum_literal"
         },
         {
           "type": "SYMBOL",

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -2463,49 +2463,101 @@
       ]
     },
     "string_literal": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "FIELD",
-          "name": "symbol_open_quote",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "\""
-            },
-            "named": true,
-            "value": "symbol"
-          }
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
               "type": "FIELD",
-              "name": "content",
+              "name": "symbol_open_quote",
               "content": {
-                "type": "SYMBOL",
-                "name": "string_content"
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\""
+                },
+                "named": true,
+                "value": "symbol"
               }
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "content",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "string_content"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "symbol_close_quote",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\""
+                },
+                "named": true,
+                "value": "symbol"
+              }
             }
           ]
         },
         {
-          "type": "FIELD",
-          "name": "symbol_close_quote",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "\""
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "symbol_open_quote",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\"\"\""
+                },
+                "named": true,
+                "value": "symbol"
+              }
             },
-            "named": true,
-            "value": "symbol"
-          }
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "content",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "multiline_string_content"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "symbol_close_quote",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\"\"\""
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            }
+          ]
         }
       ]
     },
@@ -2532,63 +2584,151 @@
         ]
       }
     },
+    "multiline_string_content": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "[^\\\\\"]+"
+              }
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "char_or_string_escape_sequence"
+          }
+        ]
+      }
+    },
     "string_interpolation": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "FIELD",
-          "name": "symbol_dollar_sign",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "$"
-            },
-            "named": true,
-            "value": "symbol"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "symbol_open_quote",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "\""
-            },
-            "named": true,
-            "value": "symbol"
-          }
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
               "type": "FIELD",
-              "name": "string_interpolation_content",
+              "name": "symbol_dollar_sign",
               "content": {
-                "type": "SYMBOL",
-                "name": "string_interpolation_content"
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "$"
+                },
+                "named": true,
+                "value": "symbol"
               }
             },
             {
-              "type": "BLANK"
+              "type": "FIELD",
+              "name": "symbol_open_quote",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\""
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "string_interpolation_content",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "string_interpolation_content"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "symbol_close_quote",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\""
+                },
+                "named": true,
+                "value": "symbol"
+              }
             }
           ]
         },
         {
-          "type": "FIELD",
-          "name": "symbol_close_quote",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": "\""
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "symbol_dollar_sign",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "$"
+                },
+                "named": true,
+                "value": "symbol"
+              }
             },
-            "named": true,
-            "value": "symbol"
-          }
+            {
+              "type": "FIELD",
+              "name": "symbol_open_quote",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\"\"\""
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "string_interpolation_content",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "string_interpolation_content"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "symbol_close_quote",
+              "content": {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": "\"\"\""
+                },
+                "named": true,
+                "value": "symbol"
+              }
+            }
+          ]
         }
       ]
     },

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -2570,7 +2570,7 @@
               "value": 1,
               "content": {
                 "type": "PATTERN",
-                "value": "[^\\\\\"]+"
+                "value": "[^\\\\\"\\n]+"
               }
             }
           },

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -666,36 +666,78 @@
       ]
     },
     "const_dict_content": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "const_dict_pair"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "const_dict_pair"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "dict_separator",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ";"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "const_dict_pair"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "dict_separator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ";"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "const_dict_pair"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "newline"
                   },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "const_dict_pair"
+                  {
+                    "type": "SYMBOL",
+                    "name": "const_dict_pair"
+                  }
+                ]
               }
-            ]
-          }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "newline"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -1928,7 +1970,7 @@
       ]
     },
     "mp_list_cons": {
-      "type": "PREC_LEFT",
+      "type": "PREC_RIGHT",
       "value": 0,
       "content": {
         "type": "SEQ",
@@ -3526,36 +3568,78 @@
       ]
     },
     "dict_content": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "dict_pair"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "dict_pair"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "dict_separator",
+                    "content": {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "STRING",
+                        "value": ";"
+                      },
+                      "named": true,
+                      "value": "symbol"
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "dict_pair"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "dict_separator",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ";"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "dict_pair"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "newline"
                   },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "dict_pair"
+                  {
+                    "type": "SYMBOL",
+                    "name": "dict_pair"
+                  }
+                ]
               }
-            ]
-          }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "newline"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -251,6 +251,10 @@
         {
           "type": "const_dict_pair",
           "named": true
+        },
+        {
+          "type": "newline",
+          "named": true
         }
       ]
     }
@@ -768,6 +772,10 @@
       "types": [
         {
           "type": "dict_pair",
+          "named": true
+        },
+        {
+          "type": "newline",
           "named": true
         }
       ]

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -2601,6 +2601,21 @@
     }
   },
   {
+    "type": "multiline_string_content",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "char_or_string_escape_sequence",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "newline",
     "named": true,
     "fields": {}
@@ -3417,6 +3432,10 @@
         "required": false,
         "types": [
           {
+            "type": "multiline_string_content",
+            "named": true
+          },
+          {
             "type": "string_content",
             "named": true
           }
@@ -3532,6 +3551,10 @@
         "multiple": false,
         "required": false,
         "types": [
+          {
+            "type": "multiline_string_content",
+            "named": true
+          },
           {
             "type": "string_content",
             "named": true

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1082,6 +1082,10 @@
           "named": true
         },
         {
+          "type": "enum_literal",
+          "named": true
+        },
+        {
           "type": "if_expression",
           "named": true
         },
@@ -3303,10 +3307,6 @@
         },
         {
           "type": "dict_literal",
-          "named": true
-        },
-        {
-          "type": "enum_literal",
           "named": true
         },
         {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
@@ -8,11 +8,11 @@ MyEnum.NoArgs
 
 (source_file
   (expression
-    (simple_expression (enum_literal
+    (enum_literal
       (qualified_type_name (type_identifier))
       (symbol)
       (enum_case_identifier)
-    ))
+    )
   )
 )
 
@@ -27,13 +27,11 @@ MyEnum.OneArg 1L
 
 (source_file
   (expression
-    (simple_expression
-      (enum_literal
-        (qualified_type_name (type_identifier))
-        (symbol)
-        (enum_case_identifier)
-        (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-      )
+    (enum_literal
+      (qualified_type_name (type_identifier))
+      (symbol)
+      (enum_case_identifier)
+      (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
     )
   )
 )
@@ -49,21 +47,19 @@ MyEnum.TwoArgs(1L, 2L)
 
 (source_file
   (expression
-    (simple_expression
-      (enum_literal
-        (qualified_type_name (type_identifier))
-        (symbol)
-        (enum_case_identifier)
-        (enum_fields
-          (expression
-            (simple_expression
-              (tuple_literal
-                (symbol)
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                (symbol)
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                (symbol)
-              )
+    (enum_literal
+      (qualified_type_name (type_identifier))
+      (symbol)
+      (enum_case_identifier)
+      (enum_fields
+        (expression
+          (simple_expression
+            (tuple_literal
+              (symbol)
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (symbol)
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (symbol)
             )
           )
         )
@@ -83,13 +79,11 @@ MyEnum.TwoArgs 1L 2L
 
 (source_file
   (expression
-    (simple_expression
-      (enum_literal
-        (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
-        (enum_fields
-          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-        )
+    (enum_literal
+      (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
+      (enum_fields
+        (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+        (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
       )
     )
   )
@@ -107,7 +101,7 @@ Stdlib.Option.Option.None
 
 (source_file
   (expression
-    (simple_expression (enum_literal
+    (enum_literal
       (qualified_type_name
         (module_identifier)
         (symbol)
@@ -117,7 +111,7 @@ Stdlib.Option.Option.None
       )
       (symbol)
       (enum_case_identifier)
-    ))
+    )
   )
 )
 
@@ -132,13 +126,11 @@ Stdlib.Option.Option.Some 1L
 
 (source_file
   (expression
-    (simple_expression
-      (enum_literal
-        (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-        (symbol)
-        (enum_case_identifier)
-        (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-      )
+    (enum_literal
+      (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+      (symbol)
+      (enum_case_identifier)
+      (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
     )
   )
 )
@@ -154,15 +146,13 @@ Stdlib.Option.Option.Some
 
 (source_file
   (expression
-    (simple_expression
-      (enum_literal
-        (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-        (symbol)
-        (enum_case_identifier)
-        (indent)
-        (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-        (dedent)
-      )
+    (enum_literal
+      (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+      (symbol)
+      (enum_case_identifier)
+      (indent)
+      (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
+      (dedent)
     )
   )
 )
@@ -181,16 +171,14 @@ MyEnum.TwoArgs
 
 (source_file
   (expression
-    (simple_expression
-      (enum_literal
-        (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
-        (indent)
-        (enum_fields
-          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-        )
-        (dedent)
+    (enum_literal
+      (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
+      (indent)
+      (enum_fields
+        (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+        (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
       )
+      (dedent)
     )
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/dicts.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/dicts.txt
@@ -143,3 +143,43 @@ Dict { ``Content-Length`` = 1L }
     )
   )
 )
+
+
+==================
+dict - multiple pairs indented
+==================
+
+Dict
+  { key1 = "val1"
+    key2 = "val1" }
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (dict_literal
+        (keyword)
+        (symbol)
+        (dict_content
+          (dict_pair
+            (variable_identifier)
+            (symbol)
+            (expression
+              (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
+            )
+          )
+          (newline)
+          (dict_pair
+            (variable_identifier)
+            (symbol)
+            (expression
+              (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
+            )
+          )
+        )
+        (symbol)
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -366,7 +366,7 @@ Builtin.printLine Person { name = "Alice" }
 function call - with an enum as argument
 ==================
 
-Builtin.printLine Stdlib.Option.Option.Some 1L
+Builtin.printLine (Stdlib.Option.Option.Some 1L)
 
 ---
 
@@ -374,17 +374,21 @@ Builtin.printLine Stdlib.Option.Option.Some 1L
   (expression
     (apply
       (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-      (simple_expression
-        (enum_literal
-          (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-          (symbol)
-          (enum_case_identifier)
-          (enum_fields
-            (expression
-              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+      (paren_expression
+        (symbol)
+        (expression
+          (enum_literal
+            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+            (symbol)
+            (enum_case_identifier)
+            (enum_fields
+              (expression
+                (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+              )
             )
           )
         )
+        (symbol)
       )
       (newline)
     )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
@@ -280,17 +280,15 @@ Enum List
         (symbol)
         (list_content
           (expression
-            (simple_expression
-              (enum_literal
-                (qualified_type_name (module_identifier) (symbol) (type_identifier))
-                (symbol)
-                (enum_case_identifier)
-                (indent)
-                (enum_fields
-                  (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
-                )
-                (dedent)
+            (enum_literal
+              (qualified_type_name (module_identifier) (symbol) (type_identifier))
+              (symbol)
+              (enum_case_identifier)
+              (indent)
+              (enum_fields
+                (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
               )
+              (dedent)
             )
           )
         )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -271,11 +271,9 @@ match Stdlib.Result.Result.Ok 5L with
     (match_expression
       (keyword)
       (expression
-        (simple_expression
-          (enum_literal
-            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
-            (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-          )
+        (enum_literal
+          (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
+          (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
         )
       )
       (keyword)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -357,36 +357,41 @@ match [ 1L; 2L; 3L ] with
     (match_expression
       (keyword)
       (expression
-        (simple_expression (list_literal
-          (symbol)
-          (list_content
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+        (simple_expression
+          (list_literal
             (symbol)
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (list_content
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (symbol)
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (symbol)
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            )
             (symbol)
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
           )
-          (symbol)
-        ))
+        )
       )
       (keyword)
       (match_case
         (symbol)
         (match_pattern
           (list_cons
+            (match_pattern (int64 (digits (positive_digits)) (symbol)))
+            (symbol)
             (match_pattern
               (list_cons
                 (match_pattern (int64 (digits (positive_digits)) (symbol)))
                 (symbol)
-                (match_pattern (int64 (digits (positive_digits)) (symbol)))
+                (match_pattern
+                  (list
+                    (symbol)
+                    (mp_list_content
+                      (match_pattern (int64 (digits (positive_digits)) (symbol)))
+                    )
+                    (symbol)
+                  )
+                )
               )
-            )
-            (symbol)
-            (match_pattern
-              (list
-                (symbol)
-                (mp_list_content (match_pattern (int64 (digits (positive_digits)) (symbol))))
-                (symbol))
             )
           )
         )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/strings.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/strings.txt
@@ -186,3 +186,61 @@ string with newlines and tabs
     )
   )
 )
+
+
+==================
+multiline string
+==================
+
+"""int64Multiply's 2nd argument (`b`) should be an Int64. However, a Float (1.0) was passed instead.
+
+
+
+		Expected: (b: Int64)
+
+		Actual: a Float: 1.0"""
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal (symbol) (multiline_string_content) (symbol))
+      )
+    )
+  )
+)
+
+
+==================
+multiline string interpolation
+==================
+
+$"""test {"1"}"""
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_interpolation
+          (symbol)
+          (symbol)
+          (string_interpolation_content
+            (string_text)
+            (string_to_eval
+              (symbol)
+              (expression
+                (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
+              )
+              (symbol)
+            )
+          )
+          (symbol)
+        )
+      )
+    )
+  )
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/strings.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/strings.txt
@@ -164,31 +164,6 @@ $"Name: {name}, Age: {age}"
 
 
 ==================
-string with newlines and tabs
-==================
-
-"int64Multiply's 2nd argument (`b`) should be an Int64. However, a Float (1.0) was passed instead.
-
-
-
-		Expected: (b: Int64)
-
-		Actual: a Float: 1.0"
-
----
-
-(source_file
-  (expression
-    (simple_expression
-      (string_segment
-        (string_literal (symbol) (string_content) (symbol))
-      )
-    )
-  )
-)
-
-
-==================
 multiline string
 ==================
 

--- a/tree-sitter-darklang/test/corpus/exhaustive/module_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/module_decls.txt
@@ -259,12 +259,10 @@ module Darklang =
         (symbol)
         (indent)
         (expression
-          (simple_expression
-            (enum_literal
-              (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-              (symbol)
-              (enum_case_identifier)
-            )
+          (enum_literal
+            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+            (symbol)
+            (enum_case_identifier)
           )
         )
         (dedent)
@@ -286,14 +284,12 @@ module Darklang =
         (symbol)
         (indent)
         (expression
-          (simple_expression
-            (enum_literal
-              (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-              (symbol)
-              (enum_case_identifier)
-              (enum_fields
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-              )
+          (enum_literal
+            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
+            (symbol)
+            (enum_case_identifier)
+            (enum_fields
+              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
             )
           )
         )


### PR DESCRIPTION
This PR:
- Fixes mp_list_cons and dictionaries
- Adds support for multiline string
- Allows having type and function declarations before module declarations
- Moves enums from simple_expression to expression
