### PR TITLE
potential enum fix

### DIFF
--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -318,6 +318,7 @@ module.exports = grammar({
     // match pattern - list cons
     mp_list_cons: $ =>
       prec.right(
+        1,
         seq(
           field("head", $.match_pattern),
           field("symbol_double_colon", alias("::", $.symbol)),
@@ -660,7 +661,8 @@ module.exports = grammar({
     // List
     // TODO: allow multi-line lists where a newline is 'interpreted' as a list delimiter (i.e. no ; needed)
     list_literal: $ => list_literal_base($, $.list_content),
-    list_content: $ => list_content_base($, $.expression),
+    list_content: $ =>
+      list_content_base($, choice($.paren_expression, $.simple_expression)),
 
     //
     // Dict
@@ -1194,6 +1196,7 @@ function enum_literal_base($, enum_fields) {
           field("enum_fields", enum_fields),
         ),
       ),
+      optional(/\n/),
     ),
   );
 }
@@ -1213,7 +1216,7 @@ function enum_fields_base($, fields) {
         ),
         field("symbol_close_paren", alias(")", $.symbol)),
       ),
-      prec.right(repeat1(prec.right(fields))),
+      prec.right(repeat1(fields)),
     ),
   );
 }

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -857,6 +857,18 @@
                 "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "\\n"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
@@ -942,12 +954,8 @@
             "content": {
               "type": "REPEAT1",
               "content": {
-                "type": "PREC_RIGHT",
-                "value": 0,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "consts"
-                }
+                "type": "SYMBOL",
+                "name": "consts"
               }
             }
           }
@@ -1968,7 +1976,7 @@
     },
     "mp_list_cons": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2223,12 +2231,8 @@
             "content": {
               "type": "REPEAT1",
               "content": {
-                "type": "PREC_RIGHT",
-                "value": 0,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "match_pattern"
-                }
+                "type": "SYMBOL",
+                "name": "match_pattern"
               }
             }
           }
@@ -3558,8 +3562,17 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paren_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "simple_expression"
+                }
+              ]
             },
             {
               "type": "REPEAT",
@@ -3580,8 +3593,17 @@
                     }
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "expression"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "paren_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "simple_expression"
+                      }
+                    ]
                   }
                 ]
               }
@@ -3609,8 +3631,17 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "paren_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "simple_expression"
+                }
+              ]
             },
             {
               "type": "REPEAT",
@@ -3622,8 +3653,17 @@
                     "name": "newline"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "expression"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "paren_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "simple_expression"
+                      }
+                    ]
                   }
                 ]
               }
@@ -4297,6 +4337,18 @@
                 "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "\\n"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
@@ -4382,12 +4434,8 @@
             "content": {
               "type": "REPEAT1",
               "content": {
-                "type": "PREC_RIGHT",
-                "value": 0,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
+                "type": "SYMBOL",
+                "name": "expression"
               }
             }
           }
@@ -5432,6 +5480,18 @@
                 "type": "BLANK"
               }
             ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "\\n"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }
@@ -5517,12 +5577,8 @@
             "content": {
               "type": "REPEAT1",
               "content": {
-                "type": "PREC_RIGHT",
-                "value": 0,
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                }
+                "type": "SYMBOL",
+                "name": "expression"
               }
             }
           }

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -2023,11 +2023,15 @@
       "required": true,
       "types": [
         {
-          "type": "expression",
+          "type": "newline",
           "named": true
         },
         {
-          "type": "newline",
+          "type": "paren_expression",
+          "named": true
+        },
+        {
+          "type": "simple_expression",
           "named": true
         },
         {

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
@@ -182,3 +182,50 @@ MyEnum.TwoArgs
     )
   )
 )
+
+
+==================
+test
+==================
+
+MyEnum.OneArg 1L
+2L
+
+---
+
+(source_file
+  (expression
+    (enum_literal
+      (qualified_type_name (type_identifier))
+      (symbol)
+      (enum_case_identifier)
+      (enum_fields
+        (expression
+          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+        )
+      )
+    )
+  )
+  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+)
+
+
+==================
+an enum followed by an expression
+==================
+
+Option.Option.None
+1L
+
+---
+
+(source_file
+  (expression
+    (enum_literal
+      (qualified_type_name (module_identifier) (symbol) (type_identifier))
+      (symbol)
+      (enum_case_identifier)
+    )
+  )
+  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Record.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Record.txt
@@ -66,9 +66,9 @@ Person {name = "John"; age = 30L; hobbies = ["reading"; "swimming"]}
             (expression (simple_expression (list_literal
               (symbol)
               (list_content
-                (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
                 (symbol)
-                (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
               )
               (symbol)))
             )
@@ -183,9 +183,9 @@ Person {
                 (list_literal
                   (symbol)
                   (list_content
-                    (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                    (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
                     (symbol)
-                    (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                    (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
                   )
                   (symbol)
                 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
@@ -27,7 +27,7 @@ Single-item list
       (list_literal
         (symbol)
         (list_content
-          (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))))
+          (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
         (symbol)
       )
     )
@@ -45,21 +45,19 @@ Two-item list
 
 (source_file
   (expression
-    (simple_expression (list_literal
-      (symbol)
-      (list_content
-        (expression
-          (simple_expression (int64_literal
-            (digits
-              (positive_digits))
-            (symbol))))
+    (simple_expression
+      (list_literal
         (symbol)
-        (expression
-          (simple_expression (int64_literal
-            (digits
-              (positive_digits))
-            (symbol)))))
-      (symbol)))))
+        (list_content
+          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+          (symbol)
+          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+        )
+        (symbol)
+      )
+    )
+  )
+)
 
 
 ==================
@@ -72,21 +70,22 @@ Multiple-item list
 
 (source_file
   (expression
-    (simple_expression (list_literal
-      (symbol)
-      (list_content
-        (expression
+    (simple_expression
+      (list_literal
+        (symbol)
+        (list_content
+          (simple_expression (bool_literal))
+          (symbol)
+          (simple_expression (bool_literal))
+          (symbol)
+          (simple_expression (bool_literal))
+          (symbol)
           (simple_expression (bool_literal)))
         (symbol)
-        (expression
-          (simple_expression (bool_literal)))
-        (symbol)
-        (expression
-          (simple_expression (bool_literal)))
-        (symbol)
-        (expression
-          (simple_expression (bool_literal))))
-      (symbol)))))
+      )
+    )
+  )
+)
 
 
 
@@ -100,31 +99,34 @@ Nested list
 
 (source_file
   (expression
-    (simple_expression (list_literal
-      (symbol)
-      (list_content
-        (expression
-          (simple_expression (list_literal
-            (symbol)
-            (list_content
-              (expression
-                (simple_expression (bool_literal)))
-              (symbol)
-              (expression
-                (simple_expression (bool_literal))))
-            (symbol))))
+    (simple_expression
+      (list_literal
         (symbol)
-        (expression
-          (simple_expression (list_literal
-            (symbol)
-            (list_content
-              (expression
-                (simple_expression (bool_literal)))
+        (list_content
+          (simple_expression
+            (list_literal
               (symbol)
-              (expression
-                (simple_expression (bool_literal))))
-            (symbol)))))
-      (symbol)))))
+              (list_content
+                (simple_expression (bool_literal))
+                (symbol)
+                (simple_expression (bool_literal))
+              )
+              (symbol)
+            )
+          )
+          (symbol)
+            (simple_expression (list_literal
+              (symbol)
+              (list_content
+                (simple_expression (bool_literal))
+                (symbol)
+                (simple_expression (bool_literal)))
+              (symbol))))
+        (symbol)
+      )
+    )
+  )
+)
 
 
 ==================
@@ -137,16 +139,20 @@ List with trailing semicolon
 
 (source_file
   (expression
-    (simple_expression (list_literal
-      (symbol)
-      (list_content
-        (expression
-          (simple_expression (bool_literal)))
+    (simple_expression
+      (list_literal
         (symbol)
-        (expression
-          (simple_expression (bool_literal)))
-        (symbol))
-      (symbol)))))
+        (list_content
+          (simple_expression (bool_literal))
+          (symbol)
+          (simple_expression (bool_literal))
+          (symbol)
+        )
+        (symbol)
+      )
+    )
+  )
+)
 
 
 ==================
@@ -159,17 +165,21 @@ List starting with semicolon
 
 (source_file
   (expression
-    (simple_expression (list_literal
-      (symbol)
-      (ERROR
-        (symbol))
-      (list_content
-        (expression
-          (simple_expression (bool_literal)))
+    (simple_expression
+      (list_literal
         (symbol)
-        (expression
-          (simple_expression (bool_literal))))
-        (symbol)))))
+        (ERROR
+          (symbol))
+        (list_content
+          (simple_expression (bool_literal))
+          (symbol)
+          (simple_expression (bool_literal))
+        )
+        (symbol)
+      )
+    )
+  )
+)
 
 
 ==================
@@ -185,10 +195,12 @@ List with missing semicolon
     (simple_expression (list_literal
       (symbol)
       (list_content
-        (expression
-          (simple_expression (bool_literal))))
+        (simple_expression (bool_literal)))
       (ERROR)
-      (symbol)))))
+      (symbol))
+    )
+  )
+)
 
 
 ==================
@@ -204,13 +216,11 @@ List with missing item
     (simple_expression (list_literal
       (symbol)
       (list_content
-        (expression
-          (simple_expression (bool_literal)))
+        (simple_expression (bool_literal))
         (ERROR
           (symbol))
         (symbol)
-        (expression
-          (simple_expression (bool_literal))))
+        (simple_expression (bool_literal)))
       (symbol)))))
 
 
@@ -248,13 +258,13 @@ List with newlines
       (list_literal
         (symbol)
         (list_content
-          (expression (simple_expression (bool_literal)))
+          (simple_expression (bool_literal))
           (newline)
-          (expression (simple_expression (bool_literal)))
+          (simple_expression (bool_literal))
           (newline)
-          (expression (simple_expression (bool_literal)))
+          (simple_expression (bool_literal))
           (newline)
-          (expression (simple_expression (bool_literal))))
+          (simple_expression (bool_literal)))
         (symbol)
       )
     )
@@ -267,8 +277,9 @@ Enum List
 ==================
 
 [
-  ErrorSegment.ErrorSegment.String
+  (ErrorSegment.ErrorSegment.String
     "RTETODO typeChecker.toSegments"
+  )
 ]
 
 ---
@@ -279,19 +290,79 @@ Enum List
       (list_literal
         (symbol)
         (list_content
-          (expression
-            (enum_literal
-              (qualified_type_name (module_identifier) (symbol) (type_identifier))
-              (symbol)
-              (enum_case_identifier)
-              (indent)
-              (enum_fields
-                (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+          (paren_expression
+            (symbol)
+            (expression
+              (enum_literal
+                (qualified_type_name (module_identifier) (symbol) (type_identifier))
+                (symbol)
+                (enum_case_identifier)
+                (indent)
+                (enum_fields
+                  (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                )
+                (dedent)
               )
-              (dedent)
             )
+            (symbol)
           )
+          (newline)
         )
+        (symbol)
+      )
+    )
+  )
+)
+
+
+
+==================
+enum list 2
+==================
+
+[
+  (MyEnum.OneArg 1L)
+  (MyEnum.TwoArgs 1L 2L)
+]
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (list_literal
+        (symbol)
+        (list_content
+          (paren_expression
+            (symbol)
+            (expression
+              (enum_literal
+                (qualified_type_name (type_identifier))
+                (symbol)
+                (enum_case_identifier)
+                (enum_fields
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                )
+              )
+            )
+            (symbol)
+          )
+          (newline)
+          (paren_expression
+            (symbol)
+            (expression
+              (enum_literal
+                (qualified_type_name (type_identifier))
+                (symbol)
+                (enum_case_identifier)
+                (enum_fields
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                )
+              )
+            )
+            (symbol))
+          (newline))
         (symbol)
       )
     )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -95,7 +95,7 @@ match [ true; false] with
       (expression
         (simple_expression (list_literal
           (symbol)
-          (list_content (expression (simple_expression (bool_literal))) (symbol) (expression (simple_expression (bool_literal))))
+          (list_content (simple_expression (bool_literal)) (symbol) (simple_expression (bool_literal)))
           (symbol)
         ))
       )
@@ -142,7 +142,7 @@ match [ true ] with
   (expression
     (match_expression
       (keyword)
-      (expression (simple_expression (list_literal (symbol) (list_content (expression (simple_expression (bool_literal)))) (symbol))))
+      (expression (simple_expression (list_literal (symbol) (list_content (simple_expression (bool_literal))) (symbol))))
       (keyword)
       (match_case
         (symbol) (match_pattern (variable)) (symbol)
@@ -312,11 +312,11 @@ match [ 1L; 2L; 3L ] with
         (simple_expression (list_literal
           (symbol)
           (list_content
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
             (symbol)
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
             (symbol)
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
           )
           (symbol)
         ))
@@ -359,11 +359,11 @@ match [ 1L; 2L; 3L ] with
           (list_literal
             (symbol)
             (list_content
-              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
               (symbol)
-              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
               (symbol)
-              (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
             )
             (symbol)
           )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -415,9 +415,9 @@ pipe expression - multiple pipe expressions
               (list_literal
                 (symbol)
                 (list_content
-                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
                   (symbol)
-                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
                 )
                 (symbol)
               )


### PR DESCRIPTION
Enum literal 
- no fields: `TypeName.CaseName`
- one field: `TypeName.CaseName field1`
- multiple fields: `TypeName.CaseName field1 field2` or `TypeName.CaseName(field1, field2)`
- list of enums: 
  ```
    [ (TypeName.CaseName)
      (TypeName.CaseName field1)
      (TypeName.CaseName field1 field2) ]
  ```
 It could be good if the formatter doesn't do a good job formatting a list of enums, but I'm not very happy with the list solution. Thought?

Hmm, that would mean we need to the same thing with records, which doesn't seem like a good solution either
e.g. 
```
SourceFile {
  range = (range (0L, 0L) (0L, 17L))
  unparseableStuff = []
  exprsToEval = []
}
```
