### PR TITLE
Build Tree Sitter one time only

### DIFF
--- a/scripts/build/build-tree-sitter.sh
+++ b/scripts/build/build-tree-sitter.sh
@@ -16,11 +16,24 @@
 
 cd ~/ || exit
 
+# Base output directory for compiled libraries
+output_base_dir="app/backend/src/LibTreeSitter/lib"
+
+# Check if target artifacts already exist
+if [[ -f "$output_base_dir/tree-sitter.so" && \
+      -f "$output_base_dir/tree-sitter-linux-x64.so" && \
+      -f "$output_base_dir/tree-sitter-linux-musl-x64.so" && \
+      -f "$output_base_dir/tree-sitter-linux-arm64.so" && \
+      -f "$output_base_dir/tree-sitter-linux-arm.so" && \
+      -f "$output_base_dir/tree-sitter-macos-x64.dylib" && \
+      -f "$output_base_dir/tree-sitter-macos-arm64.dylib" ]]; then
+    echo "Target Tree Sitters artifacts already exist. Skipping clone and build."
+    exit 0
+fi
+
 # Clone the specific branch of the tree-sitter repository
 git clone --depth 1 --branch v0.20.8 https://github.com/tree-sitter/tree-sitter.git
 
-# Base output directory for compiled libraries
-output_base_dir="app/backend/src/LibTreeSitter/lib"
 tree_sitter_sources="tree-sitter/lib/src/lib.c -I tree-sitter/lib/src -I tree-sitter/lib/src/../include"
 
 mkdir -p $output_base_dir

--- a/tree-sitter-darklang/package-lock.json
+++ b/tree-sitter-darklang/package-lock.json
@@ -28,6 +28,7 @@
       "integrity": "sha512-XjTcS3wdTy/2cc/ptMLc/WRyOLECRYcMTrSWyhZnj1oGSOWbHLTklgsgRICU3cPfb0vy+oZCC33M43u6R1HSCA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "tree-sitter": "cli.js"
       }


### PR DESCRIPTION
The task from this [issues list](https://github.com/darklang/dark/issues/5409)


#### What is the problem/goal being addressed?

```
get the devcontainer to not re-download tree-sitter for every container restart
see build-tree-sitter script. It clones every time now but if we already have the artifact, there should be no need to re-clone.
(I ran into this recently when restarting the container on a train without internet)
## What is the solution to this problem?
```
#### Solution 
To add the Tree Sitter artifact checking before building. 