### PR TITLE
 #5423 Followup

### DIFF
--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -56,32 +56,56 @@ module Darklang =
           /// The kind of a completion entry.
           type CompletionItemKind =
             | Text
+            | Method
             | Function
+            | Constructor
             | Field
             | Variable
+            | Class
+            | Interface
             | Module
+            | Property
             | Unit
             | Value
             | Enum
-            | EnumMember
             | Keyword
+            | Snippet
+            | Color
+            | File
+            | Reference
+            | Folder
+            | EnumMember
             | Constant
+            | Struct
+            | Event
             | Operator
             | TypeParameter
 
           let toJson (kind: CompletionItemKind) : Json =
             match kind with
             | Text -> Json.Number 1.0
+            | Method -> Json.Number 2.0
             | Function -> Json.Number 3.0
+            | Constructor -> Json.Number 4.0
             | Field -> Json.Number 5.0
             | Variable -> Json.Number 6.0
+            | Class -> Json.Number 7.0
+            | Interface -> Json.Number 8.0
             | Module -> Json.Number 9.0
+            | Property -> Json.Number 10.0
             | Unit -> Json.Number 11.0
             | Value -> Json.Number 12.0
             | Enum -> Json.Number 13.0
-            | EnumMember -> Json.Number 20.0
             | Keyword -> Json.Number 14.0
+            | Snippet -> Json.Number 15.0
+            | Color -> Json.Number 16.0
+            | File -> Json.Number 17.0
+            | Reference -> Json.Number 18.0
+            | Folder -> Json.Number 19.0
+            | EnumMember -> Json.Number 20.0
             | Constant -> Json.Number 21.0
+            | Struct -> Json.Number 22.0
+            | Event -> Json.Number 23.0
             | Operator -> Json.Number 24.0
             | TypeParameter -> Json.Number 25.0
 

--- a/packages/darklang/languageServerProtocol/language/completion.dark
+++ b/packages/darklang/languageServerProtocol/language/completion.dark
@@ -52,6 +52,39 @@ module Darklang =
 
 
       module CompletionItem =
+        module CompletionItemKind =
+          /// The kind of a completion entry.
+          type CompletionItemKind =
+            | Text
+            | Function
+            | Field
+            | Variable
+            | Module
+            | Unit
+            | Value
+            | Enum
+            | EnumMember
+            | Keyword
+            | Constant
+            | Operator
+            | TypeParameter
+
+          let toJson (kind: CompletionItemKind) : Json =
+            match kind with
+            | Text -> Json.Number 1.0
+            | Function -> Json.Number 3.0
+            | Field -> Json.Number 5.0
+            | Variable -> Json.Number 6.0
+            | Module -> Json.Number 9.0
+            | Unit -> Json.Number 11.0
+            | Value -> Json.Number 12.0
+            | Enum -> Json.Number 13.0
+            | EnumMember -> Json.Number 20.0
+            | Keyword -> Json.Number 14.0
+            | Constant -> Json.Number 21.0
+            | Operator -> Json.Number 24.0
+            | TypeParameter -> Json.Number 25.0
+
         /// A completion item represents a text snippet that is
         /// proposed to complete text that is being typed.
         type CompletionItem =
@@ -68,9 +101,9 @@ module Darklang =
             // /// Additional details for the label
             // labelDetails?: CompletionItemLabelDetails;
 
-            // /// The kind of this completion item. Based of the kind
-            // /// an icon is chosen by the editor.
-            // kind?: CompletionItemKind;
+            /// The kind of this completion item. Based of the kind
+            /// an icon is chosen by the editor.
+            kind: Stdlib.Option.Option<CompletionItemKind.CompletionItemKind>
 
             // /// Tags for this completion item.
             // tags?: CompletionItemTag[];
@@ -182,6 +215,9 @@ module Darklang =
 
         let toJson (item: CompletionItem) : Json =
           [ Stdlib.Option.Option.Some(("label", Json.String item.label))
+
+            item.kind
+            |> Stdlib.Option.map (fun k -> ("kind", CompletionItemKind.toJson k))
 
             item.detail |> Stdlib.Option.map (fun d -> ("detail", Json.String d))
 
@@ -599,44 +635,6 @@ module Darklang =
     /// for fully qualified names and file paths.
     description?: string;
   }
-
-
-  /// The kind of a completion entry.
-  export namespace CompletionItemKind {
-    export const Text: 1 = 1;
-    export const Method: 2 = 2;
-    export const Function: 3 = 3;
-    export const Constructor: 4 = 4;
-    export const Field: 5 = 5;
-    export const Variable: 6 = 6;
-    export const Class: 7 = 7;
-    export const Interface: 8 = 8;
-    export const Module: 9 = 9;
-    export const Property: 10 = 10;
-    export const Unit: 11 = 11;
-    export const Value: 12 = 12;
-    export const Enum: 13 = 13;
-    export const Keyword: 14 = 14;
-    export const Snippet: 15 = 15;
-    export const Color: 16 = 16;
-    export const File: 17 = 17;
-    export const Reference: 18 = 18;
-    export const Folder: 19 = 19;
-    export const EnumMember: 20 = 20;
-    export const Constant: 21 = 21;
-    export const Struct: 22 = 22;
-    export const Event: 23 = 23;
-    export const Operator: 24 = 24;
-    export const TypeParameter: 25 = 25;
-  }
-  export type CompletionItemKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25;
-
-
-
-
-
-
-
 
 
 

--- a/packages/darklang/languageTools/lsp-server/completions.dark
+++ b/packages/darklang/languageTools/lsp-server/completions.dark
@@ -13,12 +13,14 @@ module Darklang =
 
         let createCompletionItem
           (label: String)
+          (kind:
+            LanguageServerProtocol.Completions.CompletionItem.CompletionItemKind.CompletionItemKind)
           (detail: String)
-          (kind: String)
           (insertText: String)
           : LanguageServerProtocol.Completions.CompletionItem.CompletionItem =
           LanguageServerProtocol.Completions.CompletionItem.CompletionItem
             { label = label
+              kind = Stdlib.Option.Option.Some kind
               detail = Stdlib.Option.Option.Some detail
               preselect = Stdlib.Option.Option.Some true
               sortText = Stdlib.Option.Option.Some label
@@ -31,7 +33,7 @@ module Darklang =
               // textEdit = Stdlib.Option.Option.None
               textEditText = Stdlib.Option.Option.None
               commitCharacters = Stdlib.Option.Option.Some [ " " ]
-              data = Stdlib.Option.Option.Some(Json.String kind) }
+              data = Stdlib.Option.Option.None }
 
         let createCompletions
           (wordUnderCursor: String)
@@ -48,7 +50,11 @@ module Darklang =
               "with"
               "fun" ]
             |> Stdlib.List.map (fun k ->
-              createCompletionItem k "keyword" "keyword" k)
+              createCompletionItem
+                k
+                LanguageServerProtocol.Completions.CompletionItem.CompletionItemKind.CompletionItemKind.Keyword
+                "keyword"
+                k)
 
           let functions =
             (PackageManager.Function.getAllFnNames ())
@@ -70,7 +76,11 @@ module Darklang =
                 else
                   f
 
-              createCompletionItem f "function" "function" insertText)
+              createCompletionItem
+                f
+                LanguageServerProtocol.Completions.CompletionItem.CompletionItemKind.CompletionItemKind.Function
+                "function"
+                insertText)
 
           let completions = Stdlib.List.flatten [ keywords; functions ]
 


### PR DESCRIPTION
This PR implements requested change from PR #5423 : adding a CompletionItemKind type

<img width="660" alt="Screenshot 2024-10-24 at 19 15 16" src="https://github.com/user-attachments/assets/09b6733c-1040-4805-8d19-96bced120677">

<img width="683" alt="Screenshot 2024-10-24 at 19 15 32" src="https://github.com/user-attachments/assets/40df4260-85cf-485f-9ecb-a2e5244264af">
