### PR TITLE
WIP: writtenTypes refactors

### DIFF
--- a/backend/testfiles/execution/stdlib/semanticTokenization.dark
+++ b/backend/testfiles/execution/stdlib/semanticTokenization.dark
@@ -1586,67 +1586,67 @@ module TokenizeMatchExpression =
                     (TokenType.Keyword, (2L, 14L), (2L, 19L)) ]
 
 
-module TokenizeModuleDeclaration =
-  ("module MyModule =\n  type ID = Int64" |> tokenize) = [ (TokenType.Keyword,
-                                                            (0L, 0L),
-                                                            (0L, 6L))
-                                                           (TokenType.ModuleName,
-                                                            (0L, 7L),
-                                                            (0L, 15L))
-                                                           (TokenType.Keyword,
-                                                            (1L, 2L),
-                                                            (1L, 6L))
-                                                           (TokenType.TypeName,
-                                                            (1L, 7L),
-                                                            (1L, 9L))
-                                                           (TokenType.Symbol,
-                                                            (1L, 10L),
-                                                            (1L, 11L))
-                                                           (TokenType.TypeName,
-                                                            (1L, 12L),
-                                                            (1L, 17L)) ]
+// module TokenizeModuleDeclaration =
+//   ("module MyModule =\n  type ID = Int64" |> tokenize) = [ (TokenType.Keyword,
+//                                                             (0L, 0L),
+//                                                             (0L, 6L))
+//                                                            (TokenType.ModuleName,
+//                                                             (0L, 7L),
+//                                                             (0L, 15L))
+//                                                            (TokenType.Keyword,
+//                                                             (1L, 2L),
+//                                                             (1L, 6L))
+//                                                            (TokenType.TypeName,
+//                                                             (1L, 7L),
+//                                                             (1L, 9L))
+//                                                            (TokenType.Symbol,
+//                                                             (1L, 10L),
+//                                                             (1L, 11L))
+//                                                            (TokenType.TypeName,
+//                                                             (1L, 12L),
+//                                                             (1L, 17L)) ]
 
-  ("""module MyModule =
-  type ID = Int64
-  let myFn (i: Int64): Int64 = 1L
-  const x = 100L
-  1L"""
-   |> tokenize) = [ (TokenType.Keyword, (0L, 0L), (0L, 6L))
-                    (TokenType.ModuleName, (0L, 7L), (0L, 15L))
-                    (TokenType.Keyword, (1L, 2L), (1L, 6L))
-                    (TokenType.TypeName, (1L, 7L), (1L, 9L))
-                    (TokenType.Symbol, (1L, 10L), (1L, 11L))
-                    (TokenType.TypeName, (1L, 12L), (1L, 17L))
-                    (TokenType.Keyword, (2L, 2L), (2L, 5L))
-                    (TokenType.FunctionName, (2L, 6L), (2L, 10L))
-                    (TokenType.Symbol, (2L, 11L), (2L, 12L))
-                    (TokenType.ParameterName, (2L, 12L), (2L, 13L))
-                    (TokenType.Symbol, (2L, 13L), (2L, 14L))
-                    (TokenType.TypeName, (2L, 15L), (2L, 20L))
-                    (TokenType.Symbol, (2L, 20L), (2L, 21L))
-                    (TokenType.Symbol, (2L, 21L), (2L, 22L))
-                    (TokenType.TypeName, (2L, 23L), (2L, 28L))
-                    (TokenType.Symbol, (2L, 29L), (2L, 30L))
-                    (TokenType.Number, (2L, 31L), (2L, 32L))
-                    (TokenType.Symbol, (2L, 32L), (2L, 33L))
-                    (TokenType.Keyword, (3L, 2L), (3L, 7L))
-                    (TokenType.VariableName, (3L, 8L), (3L, 9L))
-                    (TokenType.Symbol, (3L, 10L), (3L, 11L))
-                    (TokenType.Number, (3L, 12L), (3L, 15L))
-                    (TokenType.Symbol, (3L, 15L), (3L, 16L))
-                    (TokenType.Number, (4L, 2L), (4L, 3L))
-                    (TokenType.Symbol, (4L, 3L), (4L, 4L)) ]
+// ("""module MyModule =
+// type ID = Int64
+// let myFn (i: Int64): Int64 = 1L
+// const x = 100L
+// 1L"""
+//  |> tokenize) = [ (TokenType.Keyword, (0L, 0L), (0L, 6L))
+//                   (TokenType.ModuleName, (0L, 7L), (0L, 15L))
+//                   (TokenType.Keyword, (1L, 2L), (1L, 6L))
+//                   (TokenType.TypeName, (1L, 7L), (1L, 9L))
+//                   (TokenType.Symbol, (1L, 10L), (1L, 11L))
+//                   (TokenType.TypeName, (1L, 12L), (1L, 17L))
+//                   (TokenType.Keyword, (2L, 2L), (2L, 5L))
+//                   (TokenType.FunctionName, (2L, 6L), (2L, 10L))
+//                   (TokenType.Symbol, (2L, 11L), (2L, 12L))
+//                   (TokenType.ParameterName, (2L, 12L), (2L, 13L))
+//                   (TokenType.Symbol, (2L, 13L), (2L, 14L))
+//                   (TokenType.TypeName, (2L, 15L), (2L, 20L))
+//                   (TokenType.Symbol, (2L, 20L), (2L, 21L))
+//                   (TokenType.Symbol, (2L, 21L), (2L, 22L))
+//                   (TokenType.TypeName, (2L, 23L), (2L, 28L))
+//                   (TokenType.Symbol, (2L, 29L), (2L, 30L))
+//                   (TokenType.Number, (2L, 31L), (2L, 32L))
+//                   (TokenType.Symbol, (2L, 32L), (2L, 33L))
+//                   (TokenType.Keyword, (3L, 2L), (3L, 7L))
+//                   (TokenType.VariableName, (3L, 8L), (3L, 9L))
+//                   (TokenType.Symbol, (3L, 10L), (3L, 11L))
+//                   (TokenType.Number, (3L, 12L), (3L, 15L))
+//                   (TokenType.Symbol, (3L, 15L), (3L, 16L))
+//                   (TokenType.Number, (4L, 2L), (4L, 3L))
+//                   (TokenType.Symbol, (4L, 3L), (4L, 4L)) ]
 
 
-  ("""module MyModule1 =
-  module MyModule2 =
-    module MyModule3 =
-      1L"""
-   |> tokenize) = [ (TokenType.Keyword, (0L, 0L), (0L, 6L))
-                    (TokenType.ModuleName, (0L, 7L), (0L, 16L))
-                    (TokenType.Keyword, (1L, 2L), (1L, 8L))
-                    (TokenType.ModuleName, (1L, 9L), (1L, 18L))
-                    (TokenType.Keyword, (2L, 4L), (2L, 10L))
-                    (TokenType.ModuleName, (2L, 11L), (2L, 20L))
-                    (TokenType.Number, (3L, 6L), (3L, 7L))
-                    (TokenType.Symbol, (3L, 7L), (3L, 8L)) ]
+// ("""module MyModule1 =
+// module MyModule2 =
+//   module MyModule3 =
+//     1L"""
+//  |> tokenize) = [ (TokenType.Keyword, (0L, 0L), (0L, 6L))
+//                   (TokenType.ModuleName, (0L, 7L), (0L, 16L))
+//                   (TokenType.Keyword, (1L, 2L), (1L, 8L))
+//                   (TokenType.ModuleName, (1L, 9L), (1L, 18L))
+//                   (TokenType.Keyword, (2L, 4L), (2L, 10L))
+//                   (TokenType.ModuleName, (2L, 11L), (2L, 20L))
+//                   (TokenType.Number, (3L, 6L), (3L, 7L))
+//                   (TokenType.Symbol, (3L, 7L), (3L, 8L)) ]

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -1656,11 +1656,25 @@ let moduleDeclarations =
     t
       "module with types, fns, and consts"
       """module MyModule =
-  type ID = Int64
-  type MyString = String
-  let myFn (i: Int64): Int64 = 1L
-  const x = 100L"""
+    type ID = Int64
+    type MyString = String
+    let myFn (i: Int64): Int64 = 1L
+    const x = 100L"""
       "module MyModule =\n  type ID =\n    Int64\n\n  type MyString =\n    String\n\n  let myFn (i: Int64): Int64 =\n    1L\n\n  const x = 100L"
+      []
+      []
+      []
+      false
+
+    t
+      "module with types, fns, consts, and exprs"
+      """module MyModule =
+    type ID = Int64
+    type MyString = String
+    let myFn (i: Int64): Int64 = 1L
+    const x = 100L
+    1L"""
+      "module MyModule =\n  type ID =\n    Int64\n\n  type MyString =\n    String\n\n  let myFn (i: Int64): Int64 =\n    1L\n\n  const x = 100L\n\n  1L"
       []
       []
       []
@@ -1669,13 +1683,13 @@ let moduleDeclarations =
     t
       "module with types, fns, conts, and newlines"
       """module MyModule =
-  type ID = Int64
+    type ID = Int64
 
-  type MyString = String
+    type MyString = String
 
-  let myFn (i: Int64): Int64 = 1L
+    let myFn (i: Int64): Int64 = 1L
 
-  const x = 100L"""
+    const x = 100L"""
       "module MyModule =\n  type ID =\n    Int64\n\n  type MyString =\n    String\n\n  let myFn (i: Int64): Int64 =\n    1L\n\n  const x = 100L"
       []
       []
@@ -1685,11 +1699,11 @@ let moduleDeclarations =
     t
       "nested module declaration"
       """module MyModule1 =
-  type ID = Int64
+  type ID1 = Int64
   module MyModule2 =
-    type ID = Int64
+    type ID2 = Int64
     module MyModule3 =
-      type ID = Int64
+      type ID3 = Int64
       const x = 100L
       1L"""
       "module MyModule1 =\n  type ID =\n    Int64\n\n  module MyModule2 =\n    type ID =\n      Int64\n\n    module MyModule3 =\n      type ID =\n        Int64\n\n      const x = 100L\n\n      1L"
@@ -1741,5 +1755,6 @@ let tests =
       constantDeclarations
       exprs
       functionDeclarations
-      moduleDeclarations
-      sourceFiles ]
+      // moduleDeclarations
+      // sourceFiles
+      ]

--- a/packages/darklang/languageTools/parser/moduleDeclaration.dark
+++ b/packages/darklang/languageTools/parser/moduleDeclaration.dark
@@ -9,19 +9,27 @@ module Darklang =
           | "type_decl" ->
             (TypeDeclaration.parse node)
             |> Stdlib.Result.map (fun x ->
-              WrittenTypes.ModuleDeclaration.Declaration.Type x)
+              WrittenTypes.ModuleDeclaration.Declaration.SourceFileDeclaration(
+                WrittenTypes.SourceFile.SourceFileDeclaration.Type x
+              ))
           | "fn_decl" ->
             (FunctionDeclaration.parse node)
             |> Stdlib.Result.map (fun x ->
-              WrittenTypes.ModuleDeclaration.Declaration.Function x)
+              WrittenTypes.ModuleDeclaration.Declaration.SourceFileDeclaration(
+                WrittenTypes.SourceFile.SourceFileDeclaration.Function x
+              ))
           | "const_decl" ->
             (ConstantDeclaration.parse node)
             |> Stdlib.Result.map (fun x ->
-              WrittenTypes.ModuleDeclaration.Declaration.Constant x)
+              WrittenTypes.ModuleDeclaration.Declaration.SourceFileDeclaration(
+                WrittenTypes.SourceFile.SourceFileDeclaration.Constant x
+              ))
           | "module_decl" ->
             (ModuleDeclaration.parse node)
             |> Stdlib.Result.map (fun x ->
-              WrittenTypes.ModuleDeclaration.Declaration.SubModule x)
+              WrittenTypes.ModuleDeclaration.Declaration.SourceFileDeclaration(
+                WrittenTypes.SourceFile.SourceFileDeclaration.Module x
+              ))
           | "expression" ->
             (Expr.parse node)
             |> Stdlib.Result.map (fun x ->

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -409,11 +409,12 @@ module Darklang =
       // Module declarations
       module ModuleDeclaration =
         type Declaration =
-          | Type of TypeDeclaration.TypeDeclaration
-          | Function of FnDeclaration.FnDeclaration
-          | Constant of ConstantDeclaration.ConstantDeclaration
-          | SubModule of ModuleDeclaration.ModuleDeclaration
+          // | Type of TypeDeclaration.TypeDeclaration
+          // | Function of FnDeclaration.FnDeclaration
+          // | Constant of ConstantDeclaration.ConstantDeclaration
+          // | SubModule of ModuleDeclaration.ModuleDeclaration
           // TODO: handle http handler and db
+          | SourceFileDeclaration of SourceFile.SourceFileDeclaration
           | Expr of Expr
 
         type ModuleDeclaration =

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -876,221 +876,328 @@ module Darklang =
 
             (ProgramTypes.Const.CEnum(typeName, caseName, fields), unresolvedNames)
 
-
       module ModuleDeclaration =
-        let combineSubmodules
-          (submodules: List<ProgramTypes.Definitions>)
-          : ProgramTypes.Definitions =
-          let init =
-            ProgramTypes.Definitions
-              { types = []
-                constants = []
-                fns = []
-                exprs = [] }
-
-          submodules
-          |> Stdlib.List.fold init (fun acc m ->
-            ProgramTypes.Definitions
-              { types = acc.types |> Stdlib.List.append m.types
-                constants = acc.constants |> Stdlib.List.append m.constants
-                fns = acc.fns |> Stdlib.List.append m.fns
-                exprs = acc.exprs |> Stdlib.List.append m.exprs })
-
-        let submoduleToPT
-          (onMissing: NameResolver.OnMissing)
-          (pm: ProgramTypes.PackageManager.PackageManager)
-          (owner: String)
-          (modules: List<String>)
-          (submodule: WrittenTypes.ModuleDeclaration.ModuleDeclaration)
-          : (ProgramTypes.Definitions *
-            List<Parser.Range * RuntimeErrors.NameResolution.Error>)
-          =
-          let (_, m) = submodule.name
-          let modules = Stdlib.List.append modules [ m ]
-
-          let (types, typesUnresolvedNames) =
-            submodule.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | Type t ->
-                let (t, unresolvedNames) =
-                  TypeDeclaration.toPackageTypePT onMissing pm owner modules t
-
-                Stdlib.Option.Option.Some((t, unresolvedNames))
-              | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
-
-          let (fns, fnUnresolvedNames) =
-            submodule.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | Function f ->
-                let (f, unresolvedNames) =
-                  FunctionDeclaration.toPackageFnPT onMissing pm owner modules f
-
-                Stdlib.Option.Option.Some((f, unresolvedNames))
-              | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
-
-          let (constants, constUnresolvedNames) =
-            submodule.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | Constant c ->
-                let (c, unresolvedNames) =
-                  ConstantDeclaration.toPackageConstPT onMissing pm owner modules c
-
-                Stdlib.Option.Option.Some((c, unresolvedNames))
-              | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
-
-          let (exprs, exprUnresolvedNames) =
-            submodule.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | Expr e ->
-                let (expr, exprUnresolvedNames) =
-                  Expr.toPT onMissing pm owner modules e
-
-                let modules = Stdlib.List.push modules owner
-                Stdlib.Option.Option.Some(((expr, modules), exprUnresolvedNames))
-              | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
-
-          let (submodules, subModUnresolvedNames) =
-            submodule.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | SubModule m ->
-                Stdlib.Option.Option.Some(
-                  submoduleToPT onMissing pm owner modules m
-                )
-              | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
-
-          let submodules = combineSubmodules submodules
-
-          let unresolvedNames =
-            Stdlib.List.flatten
-              [ typesUnresolvedNames |> Stdlib.List.flatten
-                fnUnresolvedNames |> Stdlib.List.flatten
-                constUnresolvedNames |> Stdlib.List.flatten
-                exprUnresolvedNames |> Stdlib.List.flatten
-                subModUnresolvedNames |> Stdlib.List.flatten ]
-
-          (ProgramTypes.Definitions
-            { types = types |> Stdlib.List.append submodules.types
-              constants = constants |> Stdlib.List.append submodules.constants
-              fns = fns |> Stdlib.List.append submodules.fns
-              exprs = exprs |> Stdlib.List.append submodules.exprs },
-           unresolvedNames)
-
-
         let toPT
           (onMissing: NameResolver.OnMissing)
           (pm: ProgramTypes.PackageManager.PackageManager)
+          (owner: String)
           (currentModule: List<String>)
           (d: WrittenTypes.ModuleDeclaration.ModuleDeclaration)
           : (ProgramTypes.Definitions *
             List<Parser.Range * RuntimeErrors.NameResolution.Error>)
           =
-          let (_, owner) = d.name
+          let (_, moduleName) = d.name
+          // Builtin.debug "ModuleDeclaration.toPT: moduleName: " moduleName
+          let updatedCurrentModule =
+            // Stdlib.List.append currentModule [ moduleName ]
+            currentModule
 
-          let (types, typesUnresolvedNames) =
+          let (defs, unresolvedNames) =
             d.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | Type t ->
-                let (t, unresolvedNames) =
-                  TypeDeclaration.toPackageTypePT onMissing pm owner currentModule t
+            |> Stdlib.List.filterMap (fun decl ->
+              match decl with
+              | SourceFileDeclaration sf ->
+                let (defs, unresolvedNames) =
+                  declarationsToPT owner updatedCurrentModule sf
 
-                Stdlib.Option.Option.Some((t, unresolvedNames))
+                Stdlib.Option.Option.Some((defs, unresolvedNames))
               | _ -> Stdlib.Option.Option.None)
+
             |> Stdlib.List.unzip
 
-          let (fns, fnUnresolvedNames) =
-            d.declarations
+          // Builtin.debug "ModuleDeclaration.toPT: defs: " defs
+
+          let modules =
+            defs
             |> Stdlib.List.filterMap (fun d ->
               match d with
-              | Function f ->
-                let (f, unresolvedNames) =
-                  FunctionDeclaration.toPackageFnPT
-                    onMissing
-                    pm
-                    owner
-                    currentModule
-                    f
-
-                Stdlib.Option.Option.Some((f, unresolvedNames))
+              | Module m -> Stdlib.Option.Option.Some m
               | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
 
-          let (constants, constUnresolvedNames) =
-            d.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | Constant c ->
-                let (c, unresolvedNames) =
-                  ConstantDeclaration.toPackageConstPT
-                    onMissing
-                    pm
-                    owner
-                    currentModule
-                    c
+          let types =
+            let rootTypes =
+              defs
+              |> Stdlib.List.filterMap (fun d ->
+                match d with
+                | Type t -> Stdlib.Option.Option.Some t
+                | _ -> Stdlib.Option.Option.None)
 
-                Stdlib.Option.Option.Some((c, unresolvedNames))
-              | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
+            let subModuleTypes =
+              modules |> Stdlib.List.map (fun m -> m.types) |> Stdlib.List.flatten
+
+            Stdlib.List.append rootTypes subModuleTypes
+
+          let constants =
+            let rootConstants =
+              defs
+              |> Stdlib.List.filterMap (fun d ->
+                match d with
+                | Constant c -> Stdlib.Option.Option.Some c
+                | _ -> Stdlib.Option.Option.None)
+
+            let subModuleConstants =
+              modules
+              |> Stdlib.List.map (fun m -> m.constants)
+              |> Stdlib.List.flatten
+
+            Stdlib.List.append rootConstants subModuleConstants
+
+          let fns =
+            let rootFns =
+              defs
+              |> Stdlib.List.filterMap (fun d ->
+                match d with
+                | Function f -> Stdlib.Option.Option.Some f
+                | _ -> Stdlib.Option.Option.None)
+
+            let subModuleFns =
+              modules |> Stdlib.List.map (fun m -> m.fns) |> Stdlib.List.flatten
+
+            Stdlib.List.append rootFns subModuleFns
 
           let (exprs, exprUnresolvedNames) =
             d.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
+            |> Stdlib.List.filterMap (fun decl ->
+              match decl with
               | Expr e ->
-                let (expr, unresolvedNames) =
+                let (expr, exprUnresolvedNames) =
                   Expr.toPT onMissing pm owner currentModule e
 
-                Stdlib.Option.Option.Some(((expr, [ owner ]), unresolvedNames))
-              | _ -> Stdlib.Option.Option.None)
-            |> Stdlib.List.unzip
-
-          let moduleUnresolvedNames =
-            Stdlib.List.flatten
-              [ typesUnresolvedNames |> Stdlib.List.flatten
-                fnUnresolvedNames |> Stdlib.List.flatten
-                constUnresolvedNames |> Stdlib.List.flatten
-                exprUnresolvedNames |> Stdlib.List.flatten ]
-
-          let init =
-            ProgramTypes.Definitions
-              { types = []
-                constants = []
-                fns = []
-                exprs = [] }
-
-          let (submodules, subModUnresolvedNames) =
-            d.declarations
-            |> Stdlib.List.filterMap (fun d ->
-              match d with
-              | SubModule m ->
                 Stdlib.Option.Option.Some(
-                  submoduleToPT onMissing pm owner currentModule m
+                  ((expr, updatedCurrentModule), exprUnresolvedNames)
                 )
-              | _ -> Stdlib.Option.Option.Some((init, [])))
+              | _ -> Stdlib.Option.Option.None)
+
             |> Stdlib.List.unzip
 
-          let submodules = ModuleDeclaration.combineSubmodules submodules
-
-          let unresolvedNames =
-            Stdlib.List.flatten
-              [ moduleUnresolvedNames; subModUnresolvedNames |> Stdlib.List.flatten ]
+          let allExprs =
+            Stdlib.List.append
+              exprs
+              (modules |> Stdlib.List.map (fun m -> m.exprs) |> Stdlib.List.flatten)
 
           (ProgramTypes.Definitions
-            { types = types |> Stdlib.List.append submodules.types
-              constants = constants |> Stdlib.List.append submodules.constants
-              fns = fns |> Stdlib.List.append submodules.fns
-              exprs = exprs |> Stdlib.List.append submodules.exprs },
+            { types = types
+              constants = constants
+              fns = fns
+              exprs = allExprs },
            unresolvedNames)
+
+
+
+
+      // let combineSubmodules
+      //   (submodules: List<ProgramTypes.Definitions>)
+      //   : ProgramTypes.Definitions =
+      //   let init =
+      //     ProgramTypes.Definitions
+      //       { types = []
+      //         constants = []
+      //         fns = []
+      //         exprs = [] }
+
+      //   submodules
+      //   |> Stdlib.List.fold init (fun acc m ->
+      //     ProgramTypes.Definitions
+      //       { types = acc.types |> Stdlib.List.append m.types
+      //         constants = acc.constants |> Stdlib.List.append m.constants
+      //         fns = acc.fns |> Stdlib.List.append m.fns
+      //         exprs = acc.exprs |> Stdlib.List.append m.exprs })
+
+      // let submoduleToPT
+      //   (onMissing: NameResolver.OnMissing)
+      //   (pm: ProgramTypes.PackageManager.PackageManager)
+      //   (owner: String)
+      //   (modules: List<String>)
+      //   (submodule: WrittenTypes.ModuleDeclaration.ModuleDeclaration)
+      //   : (ProgramTypes.Definitions *
+      //     List<Parser.Range * RuntimeErrors.NameResolution.Error>)
+      //   =
+      //   let (_, m) = submodule.name
+      //   let modules = Stdlib.List.append modules [ m ]
+
+      //   let (types, typesUnresolvedNames) =
+      //     submodule.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Type t ->
+      //         let (t, unresolvedNames) =
+      //           TypeDeclaration.toPackageTypePT onMissing pm owner modules t
+
+      //         Stdlib.Option.Option.Some((t, unresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let (fns, fnUnresolvedNames) =
+      //     submodule.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Function f ->
+      //         let (f, unresolvedNames) =
+      //           FunctionDeclaration.toPackageFnPT onMissing pm owner modules f
+
+      //         Stdlib.Option.Option.Some((f, unresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let (constants, constUnresolvedNames) =
+      //     submodule.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Constant c ->
+      //         let (c, unresolvedNames) =
+      //           ConstantDeclaration.toPackageConstPT onMissing pm owner modules c
+
+      //         Stdlib.Option.Option.Some((c, unresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let (exprs, exprUnresolvedNames) =
+      //     submodule.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Expr e ->
+      //         let (expr, exprUnresolvedNames) =
+      //           Expr.toPT onMissing pm owner modules e
+
+      //         let modules = Stdlib.List.push modules owner
+      //         Stdlib.Option.Option.Some(((expr, modules), exprUnresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let (submodules, subModUnresolvedNames) =
+      //     submodule.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | SubModule m ->
+      //         Stdlib.Option.Option.Some(
+      //           submoduleToPT onMissing pm owner modules m
+      //         )
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let submodules = combineSubmodules submodules
+
+      //   let unresolvedNames =
+      //     Stdlib.List.flatten
+      //       [ typesUnresolvedNames |> Stdlib.List.flatten
+      //         fnUnresolvedNames |> Stdlib.List.flatten
+      //         constUnresolvedNames |> Stdlib.List.flatten
+      //         exprUnresolvedNames |> Stdlib.List.flatten
+      //         subModUnresolvedNames |> Stdlib.List.flatten ]
+
+      //   (ProgramTypes.Definitions
+      //     { types = types |> Stdlib.List.append submodules.types
+      //       constants = constants |> Stdlib.List.append submodules.constants
+      //       fns = fns |> Stdlib.List.append submodules.fns
+      //       exprs = exprs |> Stdlib.List.append submodules.exprs },
+      //    unresolvedNames)
+
+
+      // let toPT
+      //   (onMissing: NameResolver.OnMissing)
+      //   (pm: ProgramTypes.PackageManager.PackageManager)
+      //   (currentModule: List<String>)
+      //   (d: WrittenTypes.ModuleDeclaration.ModuleDeclaration)
+      //   : (ProgramTypes.Definitions *
+      //     List<Parser.Range * RuntimeErrors.NameResolution.Error>)
+      //   =
+      //   let (_, owner) = d.name
+
+      //   let (types, typesUnresolvedNames) =
+      //     d.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Type t ->
+      //         let (t, unresolvedNames) =
+      //           TypeDeclaration.toPackageTypePT onMissing pm owner currentModule t
+
+      //         Stdlib.Option.Option.Some((t, unresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let (fns, fnUnresolvedNames) =
+      //     d.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Function f ->
+      //         let (f, unresolvedNames) =
+      //           FunctionDeclaration.toPackageFnPT
+      //             onMissing
+      //             pm
+      //             owner
+      //             currentModule
+      //             f
+
+      //         Stdlib.Option.Option.Some((f, unresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let (constants, constUnresolvedNames) =
+      //     d.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Constant c ->
+      //         let (c, unresolvedNames) =
+      //           ConstantDeclaration.toPackageConstPT
+      //             onMissing
+      //             pm
+      //             owner
+      //             currentModule
+      //             c
+
+      //         Stdlib.Option.Option.Some((c, unresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let (exprs, exprUnresolvedNames) =
+      //     d.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | Expr e ->
+      //         let (expr, unresolvedNames) =
+      //           Expr.toPT onMissing pm owner currentModule e
+
+      //         Stdlib.Option.Option.Some(((expr, [ owner ]), unresolvedNames))
+      //       | _ -> Stdlib.Option.Option.None)
+      //     |> Stdlib.List.unzip
+
+      //   let moduleUnresolvedNames =
+      //     Stdlib.List.flatten
+      //       [ typesUnresolvedNames |> Stdlib.List.flatten
+      //         fnUnresolvedNames |> Stdlib.List.flatten
+      //         constUnresolvedNames |> Stdlib.List.flatten
+      //         exprUnresolvedNames |> Stdlib.List.flatten ]
+
+      //   let init =
+      //     ProgramTypes.Definitions
+      //       { types = []
+      //         constants = []
+      //         fns = []
+      //         exprs = [] }
+
+      //   let (submodules, subModUnresolvedNames) =
+      //     d.declarations
+      //     |> Stdlib.List.filterMap (fun d ->
+      //       match d with
+      //       | SubModule m ->
+      //         Stdlib.Option.Option.Some(
+      //           submoduleToPT onMissing pm owner currentModule m
+      //         )
+      //       | _ -> Stdlib.Option.Option.Some((init, [])))
+      //     |> Stdlib.List.unzip
+
+      //   let submodules = ModuleDeclaration.combineSubmodules submodules
+
+      //   let unresolvedNames =
+      //     Stdlib.List.flatten
+      //       [ moduleUnresolvedNames; subModUnresolvedNames |> Stdlib.List.flatten ]
+
+      //   (ProgramTypes.Definitions
+      //     { types = types |> Stdlib.List.append submodules.types
+      //       constants = constants |> Stdlib.List.append submodules.constants
+      //       fns = fns |> Stdlib.List.append submodules.fns
+      //       exprs = exprs |> Stdlib.List.append submodules.exprs },
+      //    unresolvedNames)
 
 
       module TypeDeclaration =
@@ -1339,6 +1446,8 @@ module Darklang =
            unresolvedNames)
 
       let declarationsToPT
+        (owner: String)
+        (currentModules: List<String>)
         (d: WrittenTypes.SourceFile.SourceFileDeclaration)
         : (ProgramTypes.SourceFile.Declaration *
           List<Parser.Range * RuntimeErrors.NameResolution.Error>)
@@ -1349,8 +1458,8 @@ module Darklang =
             TypeDeclaration.toPackageTypePT
               NameResolver.OnMissing.Allow
               pm
-              "Tests"
-              []
+              owner
+              currentModules
               t
 
           (ProgramTypes.SourceFile.Declaration.Type t, unresolvedNames)
@@ -1360,8 +1469,8 @@ module Darklang =
             ConstantDeclaration.toPackageConstPT
               NameResolver.OnMissing.Allow
               pm
-              "Tests"
-              []
+              owner
+              currentModules
               c
 
           (ProgramTypes.SourceFile.Declaration.Constant c, unresolvedNames)
@@ -1372,16 +1481,23 @@ module Darklang =
             FunctionDeclaration.toPackageFnPT
               NameResolver.OnMissing.Allow
               pm
-              "Tests"
-              []
+              owner
+              currentModules
               f
 
           (ProgramTypes.SourceFile.Declaration.Function f, unresolvedNames)
 
         | Module m ->
-          // TODO: should owner be added to ModuleDeclaration.toPT?
+          let (_, moduleName) = m.name
+          let currentModules = Stdlib.List.append currentModules [ moduleName ]
+
           let (m, unresolvedNames) =
-            ModuleDeclaration.toPT NameResolver.OnMissing.Allow pm [] m
+            ModuleDeclaration.toPT
+              NameResolver.OnMissing.Allow
+              pm
+              owner
+              currentModules
+              m
 
           (ProgramTypes.SourceFile.Declaration.Module m, unresolvedNames)
 
@@ -1397,7 +1513,8 @@ module Darklang =
         | SourceFile source ->
           let (declarations, declarationsUnresolvedNames) =
             source.declarations
-            |> Stdlib.List.map WrittenTypesToProgramTypes.declarationsToPT
+            |> Stdlib.List.map (fun x ->
+              WrittenTypesToProgramTypes.declarationsToPT "" [] x)
             |> Stdlib.List.unzip
 
           let (exprsToEval, exprsToEvalUnresolvedNames) =
@@ -1416,3 +1533,5 @@ module Darklang =
                 exprsToEval = exprsToEval }
 
           (sourceFile, unresolvedNames)
+
+        | e -> Builtin.debug "got here" e

--- a/packages/darklang/prettyPrinter/moduleDeclaration.dark
+++ b/packages/darklang/prettyPrinter/moduleDeclaration.dark
@@ -258,10 +258,10 @@ module Darklang =
         match modules with
         | [] ->
           [ Module
-              { name =
-                  (c.name
-                   |> PrettyPrinter.ProgramTypes.FQTypeName.Package.fullForReference)
-                  ++ "has no modules"
+              { name = "has no modules"
+                // (c.name
+                //  |> PrettyPrinter.ProgramTypes.FQTypeName.Package.fullForReference)
+                // ++ "has no modules"
                 types = []
                 fns = []
                 constants = []


### PR DESCRIPTION

This is an attempt to refactor WrittenTypes to reduce redundancy when handling SubModules.

This isn't fully working yet; I still have to resolve an issue where an extra module with an empty name appears at the root level
Example: 
```
module = 
  module MyModule1 =
    type ID1 = Int64
    module MyModule2 =
      type ID2 = Int64
      module MyModule3 =
        type ID3 = Int64
```

It might be good to see if there’s a better shape for the types before solving this issue