### PR TITLE
Update dev-setup docs

### DIFF
--- a/docs/dev-setup/README.md
+++ b/docs/dev-setup/README.md
@@ -39,8 +39,6 @@ That said, you can run Dark in WSL2 (Windows Subsystem for Linux):
 - You need to clone the dark repo with the git `core.autocrlf` setting set to
   `false`. You can configure this by running `git config --global core.autocrlf false`.
   If you have already cloned dark, you will need to reclone it.
-- This section of the guide is incomplete. Please [create an
-  issue](https://github.com/darklang/dark/issues) if you find something doesn't work.
 
 ## Building and running for the first time
 


### PR DESCRIPTION
I recently tested setting up Dark on a Windows machine, and it worked without any issues
A few others have also successfully set up Darklang on Windows, and we’ve helped them work through the issues they ran into.

specifications of the machine it was tested on:
OS Version: Windows 11 pro 24H2
Architecture: x64
