### PR TITLE
fix build-cli

### DIFF
--- a/backend/src/LibTreeSitter/LibTreeSitter.fsproj
+++ b/backend/src/LibTreeSitter/LibTreeSitter.fsproj
@@ -57,11 +57,11 @@
   </ItemGroup>
   <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
     <EmbeddedResource Include="lib/tree-sitter-win-x64.dll" LogicalName="tree-sitter.dll" />
-    <EmbeddedResource Include="lib/tree-sitter-darklang-win-x64.dll" LogicalName="tree-sitter-darklang.dll" />
+    <EmbeddedResource Include="lib/tree-sitter-darklang-win-x64.dll" LogicalName="tree-sitter-darklang.so" />
   </ItemGroup>
   <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-arm64'">
     <EmbeddedResource Include="lib/tree-sitter-win-arm64.dll" LogicalName="tree-sitter.dll" />
-    <EmbeddedResource Include="lib/tree-sitter-darklang-win-arm64.dll" LogicalName="tree-sitter-darklang.dll" />
+    <EmbeddedResource Include="lib/tree-sitter-darklang-win-arm64.dll" LogicalName="tree-sitter-darklang.so" />
   </ItemGroup>
   <!-- Paket, for NuGet dependencies-->
   <ItemGroup>


### PR DESCRIPTION
The build-cli step failed when running the `build-release-cli-exes` script, this is an attempt to fix it 
It failed with:
<img width="912" alt="Screenshot 2024-12-09 at 15 52 55" src="https://github.com/user-attachments/assets/908b1b2c-c3ef-403b-997b-884a65860c58">
