### PR TITLE
PT2RT: Fix MPOr + add some tests

### DIFF
--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -282,6 +282,21 @@ module MatchPattern =
         |> List.map (fun (pat, symbolMap, _) ->
           let rec updateRegisters pattern =
             match pattern with
+            | RT.MPUnit -> RT.MPUnit
+            | RT.MPBool b -> RT.MPBool b
+            | RT.MPInt8 i -> RT.MPInt8 i
+            | RT.MPUInt8 i -> RT.MPUInt8 i
+            | RT.MPInt16 i -> RT.MPInt16 i
+            | RT.MPUInt16 i -> RT.MPUInt16 i
+            | RT.MPInt32 i -> RT.MPInt32 i
+            | RT.MPUInt32 i -> RT.MPUInt32 i
+            | RT.MPInt64 i -> RT.MPInt64 i
+            | RT.MPUInt64 i -> RT.MPUInt64 i
+            | RT.MPInt128 i -> RT.MPInt128 i
+            | RT.MPUInt128 i -> RT.MPUInt128 i
+            | RT.MPFloat f -> RT.MPFloat f
+            | RT.MPChar c -> RT.MPChar c
+            | RT.MPString s -> RT.MPString s
             | RT.MPVariable reg ->
               // when we find a variable, check if it should use a common register
               match Map.tryFindKey (fun _ v -> v = reg) symbolMap with
@@ -302,7 +317,6 @@ module MatchPattern =
             | RT.MPEnum(name, fields) ->
               RT.MPEnum(name, List.map updateRegisters fields)
             | RT.MPOr patterns -> RT.MPOr(NEList.map updateRegisters patterns)
-            | other -> other
           updateRegisters pat)
 
       let patterns =

--- a/backend/testfiles/execution/language/flow-control/ematch.dark
+++ b/backend/testfiles/execution/language/flow-control/ematch.dark
@@ -826,12 +826,11 @@ module PatternGrouping =
 
   (match (1L,2L) with
    | (x,2L) | (2L,y) when x == y -> "fail"
-   | _ -> "fail") = Builtin.testDerrorMessage "There is no variable named: y"
+   | _ -> "fail") = Builtin.testDerrorMessage "There is no variable named: x"
 
-  // CLEANUP this should fail as the two sides bind different sets of variables
   (match (1L,2L) with
     | (x,y) | (x,_) when y > 0L -> "fail"
-    | _ -> "pass") = "fail"
+    | _ -> "pass") = Builtin.testDerrorMessage "There is no variable named: y"
 
   // CLEANUP these should fail when we have at-rest checking
   (match [1L;2L] with
@@ -842,7 +841,13 @@ module PatternGrouping =
    | (x, "test") | ("test", x) -> x
    | _ -> "fail") = 1L
 
+  (match (Stdlib.Result.Result.Ok 1L, Stdlib.Result.Result.Error "error") with
+   | (Ok _ , Ok _) -> "pass"
+   | (Error err, Ok _) | (Ok _, Error err)  -> err) = "error"
 
+  (match (Stdlib.Result.Result.Error "error", Stdlib.Result.Result.Ok 1L) with
+   | (Ok _ , Ok _) -> "pass"
+   | (Error err, Ok _) | (Ok _, Error err)  -> err) = "error"
 
 
 // CLEANUP these tests made sense when the old interpreter forced

--- a/backend/tests/Tests/PT2RT.Tests.fs
+++ b/backend/tests/Tests/PT2RT.Tests.fs
@@ -536,6 +536,51 @@ module Expr =
            RT.MatchUnmatched ],
          3)
 
+    let combinedPatSameVarDifferentPos =
+      t
+        "match (Stdlib.Result.Result.Ok 1L, Stdlib.Result.Result.Error \"error\") with\n| (Error err, Ok _) | (Ok _, Error err) -> err"
+        E.Match.combinedPatSameVarDifferentPos
+        (8,
+         [ RT.LoadVal(2, RT.DInt64 1L)
+           RT.CreateEnum(
+             1,
+             RT.FQTypeName.fqPackage PM.Types.Enums.resultId,
+             [],
+             "Ok",
+             [ 2 ]
+           )
+           RT.LoadVal(4, RT.DString "error")
+           RT.CreateEnum(
+             3,
+             RT.FQTypeName.fqPackage PM.Types.Enums.resultId,
+             [],
+             "Error",
+             [ 4 ]
+           )
+           RT.CreateTuple(0, 1, 3, [])
+
+           RT.CheckMatchPatternAndExtractVars(
+             0,
+             (RT.MPOr(
+               NEList.ofList
+                 (RT.MPTuple(
+                   RT.MPEnum("Error", [ RT.MPVariable 7 ]),
+                   RT.MPEnum("Ok", [ RT.MPVariable 6 ]),
+                   []
+                 ))
+                 [ RT.MPTuple(
+                     RT.MPEnum("Ok", [ RT.MPVariable 6 ]),
+                     RT.MPEnum("Error", [ RT.MPVariable 7 ]),
+                     []
+                   ) ]
+             )),
+             2
+           )
+           RT.CopyVal(5, 7)
+           RT.JumpBy 1
+
+           RT.MatchUnmatched ],
+         5)
 
     let tests =
       testList
@@ -548,7 +593,8 @@ module Expr =
           listCons
           tuple
           combinedPatterns
-          combinedPatternsWithVarAndWhenCond ]
+          combinedPatternsWithVarAndWhenCond
+          combinedPatSameVarDifferentPos ]
 
   module Pipes =
     let lambda =

--- a/packages/darklang/cli/local-install/main.dark
+++ b/packages/darklang/cli/local-install/main.dark
@@ -48,7 +48,6 @@ module Darklang =
       let selfUpdateIfRelevant () : Stdlib.Result.Result<Unit, String> =
         // if not installed, ignore -- nothing to self-update
 
-        // CLEANUP: what should we do if we fail to get the OS?
         let configPath =
           match (Stdlib.Cli.OS.getOS ()) with
           | Ok Windows ->

--- a/packages/darklang/stdlib/result.dark
+++ b/packages/darklang/stdlib/result.dark
@@ -244,8 +244,7 @@ module Darklang =
           match (acc, result) with
           | (Ok acc, Ok result) ->
             Stdlib.Result.Result.Ok(Stdlib.List.pushBack acc result)
-          | (Ok _, Error err) -> Stdlib.Result.Result.Error err
-          | (Error err, _) -> Stdlib.Result.Result.Error err)
+          | (Ok _, Error err) | (Error err, _) -> Stdlib.Result.Result.Error err)
 
 
       /// Returns a list of all the values that are {{Ok <var value>}}, and ignores any values that are {{Error <var msg>}}.


### PR DESCRIPTION
No changelog

We had an issue when pattern matching with OR patterns that share variable names. This PR ensures variables bind to the same register. 

Previously, in patterns like:
```fsharp
match (Stdlib.Result.Result.Ok 1L, Stdlib.Result.Result.Error "error") with
| (Error err, Ok _) 
| (Ok _, Error err) -> err
```
The err variable was incorrectly bound to different registers in each branch (6 and 7). 
```fsharp
MPOr
   { head = MPTuple (MPEnum ("Error", [MPVariable 6]), MPEnum ("Ok", [MPVariable 7]), [])
     tail = [MPTuple (MPEnum ("Ok", [MPVariable 6]), MPEnum ("Error", [MPVariable 7]), [])]}
              
```
