### PR TITLE
Performance improvement for dictSet function

### DIFF
--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -230,10 +230,8 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [ DDict(vt, o); DString k; v ] ->
-          // CLEANUP terrible perf
-          o
-          |> Map.toList
-          |> (@) [ (k, v) ]
+          // CLEANUP perf
+          Map.foldBack (fun key value acc -> (key, value) :: acc) o [ (k, v) ]
           |> TypeChecker.DvalCreator.dict vm.threadID vt
           |> Ply
         | _ -> incorrectArgs ())


### PR DESCRIPTION
No changelog

## What is the problem/goal being addressed?

There was a `CLEANUP: terrible perf` comment for the dictSet function inside the `backend/src/BuiltInExecution/Libs/Dict.fs` file.

The reason for the poor performance was that `Map.toList` was called, and then the `@` operator (shorthand for the `List.concat` function) was called immediately afterwards to put a key-value pair at the end of the just-created list.

While cons (`(1, 3) :: list`) is an O(1) operation, List.concat/@ is an O(n) operation because it needs to traverse the whole list and put the new tuple at the end.

## What is the solution to this problem?

We can:
1. Delete the call to Map.toList
2. Delete the use of the @ operator
3. Cons a list of all elements in the map starting from the last element to the first element, *passing the tuple we want at the end as the initial list* (which erases the need for the @ operator/List.concat).

## What are the changes here? How do they solve the problem and what other product impacts do they cause?

Code before changes:

```
o
|> Map.toList
|> (@) [ (k, v) ]
|> TypeChecker.DvalCreator.dict vm.threadID vt
|> Ply
```

Code after changes:

```
Map.foldBack (fun key value acc -> (key, value) :: acc) o [ (k, v) ]
|> TypeChecker.DvalCreator.dict vm.threadID vt
|> Ply
```

I think the anonymous function is a bit terse to be readable, so I would probably do

```
let consKV key value acc = (key, value) :: acc
Map.foldBack consKV o [ (k, v) ]
```

instead, if it was my own code, but I didn't see that style anywhere else in this file, so I didn't.

I kept the `CLEANUP: terrible perf` comment since one other place in the Dict.fs file (line 112 as of this commit) mentions performance regarding Map.toList, but I did take the word "terrible" out of the comment since it's better than before at least.

## How are you sure this works/how was this tested?

It's a simple change and `dotnet fsi` can prove it works as intended.

```
let map = Map.empty.Add(1, 3).Add(2, 5).Add(3, 7).Add(4, 9)

// output: [(1, 3); (2, 5); (3, 7); (4, 9)]
Map.toList map

// same output as Map.toList: we fold through from last element to first, starting with an empty list
Map.foldBack (fun key value acc -> (key, value) :: acc) map []

// output: [(1, 3); (2, 5); (3, 7); (4, 9); (5, 11)]
// We pass in an initial list containing (5, 11), so (5, 11) is at the end
Map.foldBack (fun key value acc -> (key, value) :: acc) map [(5, 11)]
```

## What is the reversion plan if this fails after shipping?
It's a small change in purely functional code with equal chance to failing as the current implementation.

## Has this information been included in the comments?
I didn't explain the anonymous function in the comments or our initial list, but I will if it's preferred that I do.