### PR TITLE
Perform minimal type checking for dictSet function,

### DIFF
--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -230,37 +230,7 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [ DDict(vt, o); DString k; v ] ->
-          // Our algorithm to avoid excessive type checking for this 'set' function:
-          // First, we get any random key which already exists in the map.
-          // Secondly, because the values already existing in this map are already
-          // guaranteed to be the same type (or else we would have no map here),
-          // we create a list of the old random (key, value) pair with the new
-          // (key, value) pair and check if this new list is type safe.
-          // If so, we add the new (key, value) pair to the map.
-          let alwaysTrue _ _ = true
-          // Get random key in map, without searching the whole map
-          match Map.tryFindKey alwaysTrue o with
-          | Some oldKey ->
-            // Get value belonging to old key
-            // Note: The Prelude module shadows the normal 'find'
-            // function which raises an exception if there's no matching key
-            // so we have to perform unnecessary pattern matching, or edit Prelude
-            // to have a `Map.findUnsafe` function.
-            match Map.find oldKey o with
-            | Some oldVal ->
-              let typeList = [ (oldKey, oldVal); (k, v) ]
-              // Implicit: below function call will raise an exception if
-              // type of new key/value pair differs from type of old key/value pair
-              let _ = TypeChecker.DvalCreator.dict vm.threadID vt typeList
-              let map = DDict(vt, Map.add k v o)
-              Ply map
-            | None ->
-              // This case is impossible
-              // Maybe we should raise an error or do something else here?
-              TypeChecker.DvalCreator.dict vm.threadID vt [ (k, v) ] |> Ply
-          | None ->
-            // The None case means the existing map is empty
-            TypeChecker.DvalCreator.dict vm.threadID vt [ (k, v) ] |> Ply
+          TypeChecker.DvalCreator.dictAddEntry vm.threadID vt o (k, v) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -249,12 +249,14 @@ let fns : List<BuiltInFn> =
             match Map.find oldKey o with
             | Some oldVal ->
               let typeList = [ (oldKey, oldVal); (k, v) ]
-              // Implicit: below function call will raise an exception if not type safe.
+              // Implicit: below function call will raise an exception if
+              // type of new key/value pair differs from type of old key/value pair
               let _ = TypeChecker.DvalCreator.dict vm.threadID vt typeList
               let map = DDict(vt, Map.add k v o)
               Ply map
             | None ->
               // This case is impossible
+              // Maybe we should raise an error or do something else here?
               TypeChecker.DvalCreator.dict vm.threadID vt [ (k, v) ] |> Ply
           | None ->
             // The None case means the existing map is empty

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -226,11 +226,44 @@ let fns : List<BuiltInFn> =
           Param.make "val" varA "" ]
       returnType = (TDict(TVariable "a"))
       description =
-        "Returns a copy of <param dict> with the <param key> set to <param val>"
+        "Returns a copy of <param dict> with the <param key> set to <param val>.
+        If the key already exists in the Dict, an exception is raised."
       fn =
         (function
         | _, vm, _, [ DDict(vt, o); DString k; v ] ->
-          TypeChecker.DvalCreator.dictAddEntry vm.threadID vt o (k, v) |> Ply
+          TypeChecker.DvalCreator.dictAddEntry
+            vm.threadID
+            vt
+            o
+            (k, v)
+            TypeChecker.ThrowIfDuplicate
+          |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "dictSetOverridingDuplicates" 0
+      typeParams = []
+      parameters =
+        [ Param.make "dict" (TDict(TVariable "a")) ""
+          Param.make "key" TString ""
+          Param.make "val" varA "" ]
+      returnType = (TDict(TVariable "a"))
+      description =
+        "Returns a copy of <param dict> with the <param key> set to <param val>.
+        If the key already exists in the Dict, the previous value is overwritten."
+      fn =
+        (function
+        | _, vm, _, [ DDict(vt, o); DString k; v ] ->
+          TypeChecker.DvalCreator.dictAddEntry
+            vm.threadID
+            vt
+            o
+            (k, v)
+            TypeChecker.ReplaceValue
+          |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -464,11 +464,9 @@ module DvalCreator =
     (threadID : ThreadID)
     (typeName : FQTypeName.FQTypeName)
     (typeArgs : List<ValueType>)
-    : Ply<
-        FQTypeName.FQTypeName *
-        List<string * ValueType> *
-        NEList<TypeDeclaration.EnumCase>
-       >
+    : Ply<FQTypeName.FQTypeName *
+      List<string * ValueType> *
+      NEList<TypeDeclaration.EnumCase>>
     =
     uply {
       let! (resolvedName, typeArgs, definition) =
@@ -591,11 +589,9 @@ module DvalCreator =
     (threadID : ThreadID)
     (typeName : FQTypeName.FQTypeName)
     (typeArgs : List<ValueType>)
-    : Ply<
-        FQTypeName.FQTypeName *
-        List<string * ValueType> *
-        NEList<TypeDeclaration.RecordField>
-       >
+    : Ply<FQTypeName.FQTypeName *
+      List<string * ValueType> *
+      NEList<TypeDeclaration.RecordField>>
     =
     uply {
       let! (resolvedName, typeArgs, definition) =

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -351,7 +351,22 @@ module DvalCreator =
 
     DDict(typ, entries)
 
-
+  let dictAddEntry
+    (threadID : ThreadID)
+    (typ : ValueType)
+    (entries : DvalMap)
+    (newEntry : string * Dval)
+    : Dval =
+    if Map.isEmpty entries then
+      dict threadID typ [ newEntry ]
+    else
+      let (k, v) = newEntry
+      let (oldKey, oldVal) = Map.minKeyValue entries
+      let typeList = [ (oldKey, oldVal); (k, v) ]
+      // Implicit: below function call will raise an exception if
+      // type of new key/value pair differs from type of old key/value pair
+      let _ = dict threadID typ typeList
+      DDict(typ, Map.add k v entries)
 
   let optionNone (innerType : ValueType) : Dval =
     DEnum(Dval.optionType, Dval.optionType, [ innerType ], "None", [])
@@ -438,9 +453,11 @@ module DvalCreator =
     (threadID : ThreadID)
     (typeName : FQTypeName.FQTypeName)
     (typeArgs : List<ValueType>)
-    : Ply<FQTypeName.FQTypeName *
-      List<string * ValueType> *
-      NEList<TypeDeclaration.EnumCase>>
+    : Ply<
+        FQTypeName.FQTypeName *
+        List<string * ValueType> *
+        NEList<TypeDeclaration.EnumCase>
+       >
     =
     uply {
       let! (resolvedName, typeArgs, definition) =
@@ -563,9 +580,11 @@ module DvalCreator =
     (threadID : ThreadID)
     (typeName : FQTypeName.FQTypeName)
     (typeArgs : List<ValueType>)
-    : Ply<FQTypeName.FQTypeName *
-      List<string * ValueType> *
-      NEList<TypeDeclaration.RecordField>>
+    : Ply<
+        FQTypeName.FQTypeName *
+        List<string * ValueType> *
+        NEList<TypeDeclaration.RecordField>
+       >
     =
     uply {
       let! (resolvedName, typeArgs, definition) =

--- a/backend/testfiles/execution/stdlib/dict.dark
+++ b/backend/testfiles/execution/stdlib/dict.dark
@@ -147,6 +147,9 @@ module Set =
   Stdlib.Dict.set_v0 (Dict { key1 = "val1before" }) "key1" "val1after" =
     Builtin.testDerrorMessage "Cannot add two dictionary entries with the same key `key1`"
 
+  Stdlib.Dict.set_v0 (Dict { key1 = "val1"; key2 = "val2" }) "key2" "newVal2" =
+    Builtin.testDerrorMessage "Cannot add two dictionary entries with the same key `key2`"
+
   Dict { key1 = "val1"; key2 = 2L } =
     Builtin.testDerrorMessage "Cannot add an Int64 (2) to a dict of String. Failed at key `key2`."
 

--- a/backend/testfiles/execution/stdlib/dict.dark
+++ b/backend/testfiles/execution/stdlib/dict.dark
@@ -164,15 +164,18 @@ module Set =
 
 
 module SetOverridingDuplicates =
-  Stdlib.Dict.setOverridingDuplicates (Dict { key1 = "val1" }) "key2" "val2" =
+  Stdlib.Dict.setOverridingDuplicates_v0 (Dict { key1 = "val1" }) "key2" "val2" =
     (Dict { key1 = "val1"; key2 = "val2" })
 
-  Stdlib.Dict.setOverridingDuplicates (Dict { key1 = "val1" }) "key2" 2L =
+  Stdlib.Dict.setOverridingDuplicates_v0 (Dict { key1 = "val1" }) "key2" 2L =
     Builtin.testDerrorMessage "PACKAGE.Darklang.Stdlib.Dict.setOverridingDuplicates's 3rd parameter `val` expects String, but got Int64 (2)"
 
   // (where this differs from .set)
-  Stdlib.Dict.setOverridingDuplicates (Dict { key1 = "val1before" }) "key1" "val1after" =
+  Stdlib.Dict.setOverridingDuplicates_v0 (Dict { key1 = "val1before" }) "key1" "val1after" =
     (Dict { key1 = "val1after" })
+
+  Stdlib.Dict.setOverridingDuplicates_v0 (Dict { key1 = "val1"; key2 = "val2" }) "key2" "newVal2" =
+    (Dict { key1 = "val1"; key2 = "newVal2" })
 
 
 module Singleton =

--- a/backend/testfiles/execution/stdlib/dict.dark
+++ b/backend/testfiles/execution/stdlib/dict.dark
@@ -153,6 +153,12 @@ module Set =
   Stdlib.Dict.set_v0 (Dict { key1 = "val1" }) "key2" 2L =
     Builtin.testDerrorMessage "PACKAGE.Darklang.Stdlib.Dict.set's 3rd parameter `val` expects String, but got Int64 (2)"
 
+  Stdlib.Dict.set_v0 (Dict { }) "key1" "val1" =
+    (Dict { key1 = "val1" })
+
+  Stdlib.Dict.set_v0 (Dict { }) "key1" 2L =
+    (Dict { key1 = 2L })
+
 
 module SetOverridingDuplicates =
   Stdlib.Dict.setOverridingDuplicates (Dict { key1 = "val1" }) "key2" "val2" =

--- a/packages/darklang/stdlib/dict.dark
+++ b/packages/darklang/stdlib/dict.dark
@@ -33,9 +33,7 @@ module Darklang =
 
       /// Returns a copy of <param dict> with the <param key> set to <param val>
       let setOverridingDuplicates (dict: Dict<'a>) (key: String) (``val``: 'a) : Dict<'a> =
-        dict
-        |> remove key
-        |> set key ``val``
+        Builtin.dictSetOverridingDuplicates_v0 dict key ``val``
 
 
       /// If the <param dict> contains <param key>, returns a copy of <param dict> with <param key> and its associated value removed. Otherwise, returns <param dict> unchanged.

--- a/scripts/build/_build-server
+++ b/scripts/build/_build-server
@@ -10,7 +10,7 @@ import sys
 import threading
 import signal
 
-run_tests = True
+run_tests = False
 
 # When compiling code, use the optimized version of the build. This causes
 # --optimize to be passed to the compile script.

--- a/scripts/build/_build-server
+++ b/scripts/build/_build-server
@@ -10,7 +10,7 @@ import sys
 import threading
 import signal
 
-run_tests = False
+run_tests = True
 
 # When compiling code, use the optimized version of the build. This causes
 # --optimize to be passed to the compile script.


### PR DESCRIPTION
## What is the problem/goal being addressed?

There's a performance problem with the `dictSet` function: the dictionary is a map, which we convert to a list, only for the dictionary type-checking function to convert it back to a map.

Suboptimal performance comes from two things:
1. Converting a map to a list, only to convert the list back to a map (and adding one key).
2. Type checking every single element in the dictionary, which is unnecessary because we accept that the map is type safe as a prerequisite for the `dictSet` function.

## What is the solution to this problem?

I think we can perform fewer operations while upholding type safety.

1. Get any key/value pair from the map (preferably without searching the whole map).
2. Compare the types of the old key/value pairvwith the new key/value pair we wish to insert
3. If the old pair and the new pair have the same types, insert them into the existing map (else, raise an error)

No need to check the type of every single element, or convert the map to a list, which are both O(n) operations.

## What are the changes here? How do they solve the problem and what other product impacts do they cause?

Commit only contains changes to a bit of purely functional code, and all the Dict.set tests which passed before still pass now.

I also added two new tests, adding different key/value pairs to empty dictionaries.

## Has this information been included in the comments?

The general idea is commented.

## Other notes

I wanted to add a test to check if a type error is raised when we:

1. Remove everything from a (string, int) dictionary
2. Set a key/value pair of some different type like (string, string)

but I wasn't sure how to write multi-line tests as there didn't seem to be any in the files I looked at. I think my code won't introduce any regression in that regard because it passes the exact same arguments to the type-checking function, except the list to type-check is shorter.

As an alternative to this approach, if we want to type check N elements but not to covert the whole map to a list, we can call Maq.toSeq and iterate through a number of elements smaller than the length of the map, but I'm not sure what we gain with that approach.