### PR TITLE
Avoid Map -> List -> Map conversion in Dict.fromListOverwritingDuplicates

### DIFF
--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -100,19 +100,22 @@ let fns : List<BuiltInFn> =
         | _, _, _, [ DList(_, []) ] -> DDict(VT.unknown, Map.empty) |> Ply
 
         | _, vm, _, [ DList(ValueType.Known(KTTuple(_keyType, valueType, [])), l) ] ->
-          let f acc dv =
+          let f (accType, accMap) dv =
             match dv with
-            | DTuple(DString k, value, []) -> Map.add k value acc
+            | DTuple(DString k, value, []) ->
+              TypeChecker.DvalCreator.dictAddEntry
+                vm.threadID
+                accType
+                accMap
+                (k, value)
+                TypeChecker.ReplaceValue
             | _ ->
               Exception.raiseInternal
                 "Not string tuples in fromListOverwritingDuplicates"
                 [ "dval", dv ]
 
-          List.fold f Map.empty l
-          // CLEANUP: performance
-          |> Map.toList
-          |> TypeChecker.DvalCreator.dict vm.threadID valueType
-          |> Ply
+          let (typ, map) = List.fold f (valueType, Map.empty) l
+          DDict(typ, map) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -231,13 +231,14 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [ DDict(vt, o); DString k; v ] ->
-          TypeChecker.DvalCreator.dictAddEntry
-            vm.threadID
-            vt
-            o
-            (k, v)
-            TypeChecker.ThrowIfDuplicate
-          |> Ply
+          let (typ, map) =
+            TypeChecker.DvalCreator.dictAddEntry
+              vm.threadID
+              vt
+              o
+              (k, v)
+              TypeChecker.ThrowIfDuplicate
+          DDict(typ, map) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -257,13 +258,14 @@ let fns : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [ DDict(vt, o); DString k; v ] ->
-          TypeChecker.DvalCreator.dictAddEntry
-            vm.threadID
-            vt
-            o
-            (k, v)
-            TypeChecker.ReplaceValue
-          |> Ply
+          let (typ, map) =
+            TypeChecker.DvalCreator.dictAddEntry
+              vm.threadID
+              vt
+              o
+              (k, v)
+              TypeChecker.ReplaceValue
+          DDict(typ, map) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -362,7 +362,7 @@ module DvalCreator =
     (entries : DvalMap)
     (newEntry : string * Dval)
     (overwrite : OverwriteBehaviour)
-    : Dval =
+    : ValueType * DvalMap =
     let (k, v) = newEntry
     match overwrite with
     | ThrowIfDuplicate when Map.containsKey k entries ->
@@ -373,7 +373,7 @@ module DvalCreator =
     | ThrowIfDuplicate ->
       let vt = Dval.toValueType v
       match VT.merge typ vt with
-      | Ok merged -> DDict(merged, Map.add k v entries)
+      | Ok merged -> (merged, Map.add k v entries)
       | Error() ->
         RTE.Dicts.Error.TriedToAddMismatchedData(k, typ, vt, v)
         |> RTE.Error.Dict


### PR DESCRIPTION
This small change to improve the performance of the `Dict.fromListOverwritingDuplicates` function has two commits.

The first commit changes the return type of `TypeChecker.DvalCreator.dictAddEntry` from `Dval` to `ValueType * DvalMap` to make the function easier to reuse in different contexts (like when folding over a data structure).

There isn't anything spooky about that: `TypeChecker.DvalCreator.dict` folds over a tuple of the same type internally before returning a `DDict`.

The only difference between how `DvalCreator.dict` and `DvalCreator.dictAddEntry` handle it is that it's the caller's responsibility to construct the `DDict` when using `dictAddEntry` (because the caller may want to do some additional checks or transformation in each fold iteration and we don't want to pattern match for `DDict` repeatedly which we would have to do if we still returned `DDict` from `dictAddEntry`).

The first commit was preparation to help with the second commit which contains the change we want. It modifies the folder function for `Dict.fromListOverwritingDuplicates` (in `Dict.fs`) to call `dictAddEntry` on each iteration of the fold, which performs type-checking for us and lets us remove the conversion to list.

I think there is some constant overhead by calling `dictAddEntry` on each iteration, since calling that function means we type-check all of the elements in each fold. We could add some code to remove that but I didn't know if the extra complexity would be worth it or how to profile the difference.

All the tests pass the same way as before (and we have 6 tests for `Dict.fromListOverwritingDuplicates` which seems good and adequate assurance).