### PR TITLE
Improve enum_literal parsing

### DIFF
--- a/backend/testfiles/execution/stdlib/language-tools/semanticTokenization.dark
+++ b/backend/testfiles/execution/stdlib/language-tools/semanticTokenization.dark
@@ -639,7 +639,7 @@ module TokenizePipeExpression =
       (TokenType.Number, (0L, 20L), (0L, 21L))
       (TokenType.Symbol, (0L, 21L), (0L, 22L)) ]
 
-  ("1L |> MyEnum.A()" |> tokenize) =
+  ("1L |> MyEnum.A" |> tokenize) =
     [ (TokenType.Number, (0L, 0L), (0L, 1L))
       (TokenType.Symbol, (0L, 1L), (0L, 2L))
       (TokenType.Operator, (0L, 3L), (0L, 5L))
@@ -647,7 +647,7 @@ module TokenizePipeExpression =
       (TokenType.Symbol, (0L, 12L), (0L, 13L))
       (TokenType.EnumMember, (0L, 13L), (0L, 14L)) ]
 
-  ("1L |> Stdlib.Result.Result.Ok()" |> tokenize) =
+  ("1L |> Stdlib.Result.Result.Ok" |> tokenize) =
     [ (TokenType.Number, (0L, 0L), (0L, 1L))
       (TokenType.Symbol, (0L, 1L), (0L, 2L))
       (TokenType.Operator, (0L, 3L), (0L, 5L))

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -792,10 +792,10 @@ let exprs =
       false
 
     // enum literal
-    t "simple enum literal" "Tests.MyEnum.A()" "MyEnum.A()" [ myEnum ] [] [] false
+    t "simple enum literal" "Tests.MyEnum.A" "MyEnum.A" [ myEnum ] [] [] false
     t
       "enum with type args"
-      "Generic<Int64>.A(1L)"
+      "Generic<Int64>.A 1L"
       "Generic<Int64>.A(1L)"
       []
       []
@@ -803,23 +803,23 @@ let exprs =
       false
     t
       "option none, short"
-      "Stdlib.Option.Option.None()"
-      "PACKAGE.Darklang.Stdlib.Option.Option.None()"
+      "Stdlib.Option.Option.None"
+      "PACKAGE.Darklang.Stdlib.Option.Option.None"
       []
       []
       []
       false
     t
       "option none, long"
-      "PACKAGE.Darklang.Stdlib.Option.Option.None()"
-      "PACKAGE.Darklang.Stdlib.Option.Option.None()"
+      "PACKAGE.Darklang.Stdlib.Option.Option.None"
+      "PACKAGE.Darklang.Stdlib.Option.Option.None"
       []
       []
       []
       false
     t
       "option some"
-      "PACKAGE.Darklang.Stdlib.Option.Option.Some(1L)"
+      "PACKAGE.Darklang.Stdlib.Option.Option.Some 1L"
       "PACKAGE.Darklang.Stdlib.Option.Option.Some(1L)"
       []
       []
@@ -1274,7 +1274,7 @@ else
       false
     t
       "match, enum"
-      "match Stdlib.Result.Result.Ok(5L) with\n| Ok(5L) -> true\n| Error(e) -> false"
+      "match Stdlib.Result.Result.Ok 5L with\n| Ok(5L) -> true\n| Error(e) -> false"
       "match PACKAGE.Darklang.Stdlib.Result.Result.Ok(5L) with\n| Ok(5L) ->\n  true\n| Error(e) ->\n  false"
       []
       []
@@ -1344,8 +1344,8 @@ else
       false
     t
       "pipe, into enum"
-      "3L |> Stdlib.Result.Result.Ok()"
-      "3L\n|> PACKAGE.Darklang.Stdlib.Result.Result.Ok()"
+      "3L |> Stdlib.Result.Result.Ok"
+      "3L\n|> PACKAGE.Darklang.Stdlib.Result.Result.Ok"
       []
       []
       []
@@ -1644,8 +1644,8 @@ let constantDeclarations =
     // enums
     t
       "option, none"
-      "const none = Stdlib.Option.Option.None()"
-      "const none = PACKAGE.Darklang.Stdlib.Option.Option.None()"
+      "const none = Stdlib.Option.Option.None"
+      "const none = PACKAGE.Darklang.Stdlib.Option.Option.None"
       []
       []
       []

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -801,9 +801,6 @@ module Darklang =
           | "record_literal" -> parseRecordLiteral node
           | "record_update" -> parseRecordUpdate node
           | "enum_literal" -> parseEnumLiteral node
-          // | "enum_field" ->
-            // Builtin.debug "*********" (parseCase (node.children |> Stdlib.List.head |> Builtin.unwrap))
-            // parseCase (node.children |> Stdlib.List.head |> Builtin.unwrap)
 
           // assigning and accessing variables
           | "let_expression" -> parseLetExpr node

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -801,6 +801,9 @@ module Darklang =
           | "record_literal" -> parseRecordLiteral node
           | "record_update" -> parseRecordUpdate node
           | "enum_literal" -> parseEnumLiteral node
+          // | "enum_field" ->
+            // Builtin.debug "*********" (parseCase (node.children |> Stdlib.List.head |> Builtin.unwrap))
+            // parseCase (node.children |> Stdlib.List.head |> Builtin.unwrap)
 
           // assigning and accessing variables
           | "let_expression" -> parseLetExpr node

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -273,7 +273,7 @@ module Darklang =
             | Error e -> PrettyPrinter.ProgramTypes.NameResolutionError.source e
 
           match fields with
-          | [] -> $"{typeNamePart}.{caseName}()"
+          | [] -> $"{typeNamePart}.{caseName}"
           | fields ->
             let fieldPart =
               fields
@@ -358,7 +358,7 @@ module Darklang =
 
         | MPEnum(_id, caseName, fieldPats) ->
           match fieldPats with
-          | [] -> $"{caseName}()"
+          | [] -> $"{caseName}"
           | fieldPats ->
             let fieldPart =
               fieldPats
@@ -464,7 +464,7 @@ module Darklang =
             | Error e -> PrettyPrinter.ProgramTypes.NameResolutionError.source e
 
           match fields with
-          | [] -> $"{typeNamePart}.{caseName}()"
+          | [] -> $"{typeNamePart}.{caseName}"
           | fields ->
             let fieldPart =
               fields
@@ -578,7 +578,7 @@ module Darklang =
               |> fun parts -> $"<{parts}>"
 
           match fields with
-          | [] -> $"{typeNamePart}{typeArgsPart}.{caseName}()"
+          | [] -> $"{typeNamePart}{typeArgsPart}.{caseName}"
           | fields ->
             let fieldPart =
               fields

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -347,11 +347,20 @@ module.exports = grammar({
     //
     // match pattern - enum
     mp_enum: $ =>
-      seq(
-        field("case_name", $.enum_case_identifier),
-        field("symbol_open_paren", alias("(", $.symbol)),
-        optional(field("enum_fields", $.mp_enum_fields)),
-        field("symbol_close_paren", alias(")", $.symbol)),
+      prec.right(
+        seq(
+          field("case_name", $.enum_case_identifier),
+          optional(
+            choice(
+              seq(
+                field("symbol_open_paren", alias("(", $.symbol)),
+                field("enum_fields", $.mp_enum_fields),
+                field("symbol_close_paren", alias(")", $.symbol)),
+              ),
+              field("enum_fields", $.match_pattern),
+            ),
+          ),
+        ),
       ),
 
     mp_enum_fields: $ => enum_fields_base($, $.match_pattern),

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -1291,29 +1291,28 @@ function enum_literal_base($, enum_fields) {
       field("type_name", $.qualified_type_name),
       field("symbol_dot", alias(".", $.symbol)),
       field("case_name", $.enum_case_identifier),
-      seq(
-        field("symbol_open_paren", alias("(", $.symbol)),
-        optional(
-          choice(
-            seq(
-              $.indent,
-              field("enum_fields", enum_fields),
-              optional($.dedent),
-            ),
+      optional(
+        choice(
+          seq(
+            field("symbol_open_paren", alias(token.immediate("("), $.symbol)),
             field("enum_fields", enum_fields),
+            field("symbol_close_paren", alias(")", $.symbol)),
           ),
+          field("enum_fields", enum_fields),
         ),
-        field("symbol_close_paren", alias(")", $.symbol)),
       ),
     ),
   );
 }
 function enum_fields_base($, fields) {
   return prec.right(
-    seq(
+    choice(
       fields,
-      repeat(
-        prec.right(seq(field("symbol_comma", alias(",", $.symbol)), fields)),
+      seq(
+        fields,
+        repeat(
+          prec.right(seq(field("symbol_comma", alias(",", $.symbol)), fields)),
+        ),
       ),
     ),
   );

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -2180,59 +2180,81 @@
       }
     },
     "mp_enum": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "case_name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "enum_case_identifier"
-          }
-        },
-        {
-          "type": "FIELD",
-          "name": "symbol_open_paren",
-          "content": {
-            "type": "ALIAS",
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "case_name",
             "content": {
-              "type": "STRING",
-              "value": "("
-            },
-            "named": true,
-            "value": "symbol"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "enum_fields",
-              "content": {
-                "type": "SYMBOL",
-                "name": "mp_enum_fields"
-              }
-            },
-            {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "enum_case_identifier"
             }
-          ]
-        },
-        {
-          "type": "FIELD",
-          "name": "symbol_close_paren",
-          "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "STRING",
-              "value": ")"
-            },
-            "named": true,
-            "value": "symbol"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_open_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": "("
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "enum_fields",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "mp_enum_fields"
+                        }
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_close_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ")"
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "match_pattern"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
-        }
-      ]
+        ]
+      }
     },
     "mp_enum_fields": {
       "type": "PREC_RIGHT",

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -822,55 +822,29 @@
             }
           },
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
               {
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "CHOICE",
+                    "type": "SEQ",
                     "members": [
                       {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "indent"
-                          },
-                          {
-                            "type": "FIELD",
-                            "name": "enum_fields",
+                        "type": "FIELD",
+                        "name": "symbol_open_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "IMMEDIATE_TOKEN",
                             "content": {
-                              "type": "SYMBOL",
-                              "name": "const_enum_fields"
+                              "type": "STRING",
+                              "value": "("
                             }
                           },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "dedent"
-                              },
-                              {
-                                "type": "BLANK"
-                              }
-                            ]
-                          }
-                        ]
+                          "named": true,
+                          "value": "symbol"
+                        }
                       },
                       {
                         "type": "FIELD",
@@ -879,26 +853,34 @@
                           "type": "SYMBOL",
                           "name": "const_enum_fields"
                         }
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_close_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ")"
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
                       }
                     ]
                   },
                   {
-                    "type": "BLANK"
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "const_enum_fields"
+                    }
                   }
                 ]
               },
               {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
+                "type": "BLANK"
               }
             ]
           }
@@ -909,40 +891,49 @@
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
             "type": "SYMBOL",
             "name": "consts"
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "PREC_RIGHT",
-              "value": 0,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_comma",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ","
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "consts"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "PREC_RIGHT",
+                  "value": 0,
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_comma",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
                       },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "consts"
+                      {
+                        "type": "SYMBOL",
+                        "name": "consts"
+                      }
+                    ]
                   }
-                ]
+                }
               }
-            }
+            ]
           }
         ]
       }
@@ -2247,40 +2238,49 @@
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
             "type": "SYMBOL",
             "name": "match_pattern"
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "PREC_RIGHT",
-              "value": 0,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_comma",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ","
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "match_pattern"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "PREC_RIGHT",
+                  "value": 0,
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_comma",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
                       },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "match_pattern"
+                      {
+                        "type": "SYMBOL",
+                        "name": "match_pattern"
+                      }
+                    ]
                   }
-                ]
+                }
               }
-            }
+            ]
           }
         ]
       }
@@ -4230,55 +4230,29 @@
             }
           },
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
               {
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "CHOICE",
+                    "type": "SEQ",
                     "members": [
                       {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "indent"
-                          },
-                          {
-                            "type": "FIELD",
-                            "name": "enum_fields",
+                        "type": "FIELD",
+                        "name": "symbol_open_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "IMMEDIATE_TOKEN",
                             "content": {
-                              "type": "SYMBOL",
-                              "name": "enum_fields"
+                              "type": "STRING",
+                              "value": "("
                             }
                           },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "dedent"
-                              },
-                              {
-                                "type": "BLANK"
-                              }
-                            ]
-                          }
-                        ]
+                          "named": true,
+                          "value": "symbol"
+                        }
                       },
                       {
                         "type": "FIELD",
@@ -4287,26 +4261,34 @@
                           "type": "SYMBOL",
                           "name": "enum_fields"
                         }
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_close_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ")"
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
                       }
                     ]
                   },
                   {
-                    "type": "BLANK"
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "enum_fields"
+                    }
                   }
                 ]
               },
               {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
+                "type": "BLANK"
               }
             ]
           }
@@ -4317,40 +4299,49 @@
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
             "type": "SYMBOL",
             "name": "expression"
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "PREC_RIGHT",
-              "value": 0,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_comma",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ","
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "expression"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "PREC_RIGHT",
+                  "value": 0,
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_comma",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
                       },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "expression"
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      }
+                    ]
                   }
-                ]
+                }
               }
-            }
+            ]
           }
         ]
       }
@@ -5721,55 +5712,29 @@
             }
           },
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
-              {
-                "type": "FIELD",
-                "name": "symbol_open_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": "("
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
-              },
               {
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "CHOICE",
+                    "type": "SEQ",
                     "members": [
                       {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "indent"
-                          },
-                          {
-                            "type": "FIELD",
-                            "name": "enum_fields",
+                        "type": "FIELD",
+                        "name": "symbol_open_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "IMMEDIATE_TOKEN",
                             "content": {
-                              "type": "SYMBOL",
-                              "name": "pipe_enum_fields"
+                              "type": "STRING",
+                              "value": "("
                             }
                           },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "dedent"
-                              },
-                              {
-                                "type": "BLANK"
-                              }
-                            ]
-                          }
-                        ]
+                          "named": true,
+                          "value": "symbol"
+                        }
                       },
                       {
                         "type": "FIELD",
@@ -5778,26 +5743,34 @@
                           "type": "SYMBOL",
                           "name": "pipe_enum_fields"
                         }
+                      },
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_close_paren",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ")"
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
                       }
                     ]
                   },
                   {
-                    "type": "BLANK"
+                    "type": "FIELD",
+                    "name": "enum_fields",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "pipe_enum_fields"
+                    }
                   }
                 ]
               },
               {
-                "type": "FIELD",
-                "name": "symbol_close_paren",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "STRING",
-                    "value": ")"
-                  },
-                  "named": true,
-                  "value": "symbol"
-                }
+                "type": "BLANK"
               }
             ]
           }
@@ -5808,40 +5781,49 @@
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
             "type": "SYMBOL",
             "name": "expression"
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "PREC_RIGHT",
-              "value": 0,
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "symbol_comma",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ","
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "expression"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "PREC_RIGHT",
+                  "value": 0,
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "FIELD",
+                        "name": "symbol_comma",
+                        "content": {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          "named": true,
+                          "value": "symbol"
+                        }
                       },
-                      "named": true,
-                      "value": "symbol"
-                    }
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "expression"
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      }
+                    ]
                   }
-                ]
+                }
               }
-            }
+            ]
           }
         ]
       }

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -953,6 +953,10 @@
         "required": false,
         "types": [
           {
+            "type": "match_pattern",
+            "named": true
+          },
+          {
             "type": "mp_enum_fields",
             "named": true
           }
@@ -960,7 +964,7 @@
       },
       "symbol_close_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -970,7 +974,7 @@
       },
       "symbol_open_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -393,7 +393,7 @@
       },
       "symbol_close_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -413,7 +413,7 @@
       },
       "symbol_open_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -431,20 +431,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "dedent",
-          "named": true
-        },
-        {
-          "type": "indent",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -1051,7 +1037,7 @@
       },
       "symbol_close_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -1071,7 +1057,7 @@
       },
       "symbol_open_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -1089,20 +1075,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "dedent",
-          "named": true
-        },
-        {
-          "type": "indent",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -2791,7 +2763,7 @@
       },
       "symbol_close_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -2811,7 +2783,7 @@
       },
       "symbol_open_paren": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "symbol",
@@ -2829,20 +2801,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "dedent",
-          "named": true
-        },
-        {
-          "type": "indent",
-          "named": true
-        }
-      ]
     }
   },
   {

--- a/tree-sitter-darklang/test/corpus/exhaustive/constant_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/constant_decls.txt
@@ -371,7 +371,7 @@ const myDict = Dict{one = 1L; two = 2L}
 const declaration - enum
 ==================
 
-const colorRed = Color.Red()
+const colorRed = Color.Red
 
 ---
 
@@ -385,8 +385,6 @@ const colorRed = Color.Red()
         (qualified_type_name (type_identifier))
         (symbol)
         (enum_case_identifier)
-        (symbol)
-        (symbol)
       )
     )
   )
@@ -397,7 +395,7 @@ const colorRed = Color.Red()
 const declaration - enum with one field
 ==================
 
-const someOne = Stdlib.Option.Option.Some(1L)
+const someOne = Stdlib.Option.Option.Some 1L
 
 ---
 
@@ -411,9 +409,7 @@ const someOne = Stdlib.Option.Option.Some(1L)
         (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
         (symbol)
         (enum_case_identifier)
-        (symbol)
         (const_enum_fields (consts (int64_literal (digits (positive_digits)) (symbol))))
-        (symbol)
       )
     )
   )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Enum.txt
@@ -2,7 +2,7 @@
 Enum - no args
 ==================
 
-MyEnum.NoArgs()
+MyEnum.NoArgs
 
 ---
 
@@ -13,8 +13,6 @@ MyEnum.NoArgs()
         (qualified_type_name (type_identifier))
         (symbol)
         (enum_case_identifier)
-        (symbol)
-        (symbol)
       )
     )
   )
@@ -25,7 +23,7 @@ MyEnum.NoArgs()
 Enum - with one arg
 ==================
 
-MyEnum.OneArg(1L)
+MyEnum.OneArg 1L
 
 ---
 
@@ -36,9 +34,7 @@ MyEnum.OneArg(1L)
         (qualified_type_name (type_identifier))
         (symbol)
         (enum_case_identifier)
-        (symbol)
         (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-        (symbol)
       )
     )
   )
@@ -113,7 +109,7 @@ MyEnum.TwoArgs(1L, 2L)
 Enum - fully qualified
 ==================
 
-Stdlib.Option.Option.None()
+Stdlib.Option.Option.None
 
 ---
 
@@ -130,8 +126,6 @@ Stdlib.Option.Option.None()
         )
         (symbol)
         (enum_case_identifier)
-        (symbol)
-        (symbol)
       )
     )
   )
@@ -179,9 +173,7 @@ Stdlib.Option.Option.Some(
         (symbol)
         (enum_case_identifier)
         (symbol)
-        (indent)
         (enum_fields (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-        (dedent)
         (symbol)
       )
     )
@@ -207,13 +199,11 @@ MyEnum.TwoArgs(
       (enum_literal
         (qualified_type_name (type_identifier)) (symbol) (enum_case_identifier)
         (symbol)
-        (indent)
         (enum_fields
           (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
           (symbol)
           (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
         )
-        (dedent)
         (symbol)
       )
     )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -398,7 +398,7 @@ Builtin.printLine Person { name = "Alice" }
 function call - with an enum as argument
 ==================
 
-Builtin.printLine Stdlib.Option.Option.Some(1L)
+Builtin.printLine Stdlib.Option.Option.Some 1L
 
 ---
 
@@ -411,13 +411,9 @@ Builtin.printLine Stdlib.Option.Option.Some(1L)
           (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
           (symbol)
           (enum_case_identifier)
-          (symbol)
           (enum_fields
-            (expression
-              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
-            )
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
           )
-          (symbol)
         )
       )
       (newline)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
@@ -47,7 +47,7 @@ let expression with pipes -inline
 ==================
 
 let x =
-  1L |> Stdlib.Option.Option.Some()
+  1L |> Stdlib.Option.Option.Some
 x
 
 ---
@@ -65,7 +65,7 @@ x
             (pipe_expr
               (pipe_enum
                 (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-                (symbol) (enum_case_identifier) (symbol) (symbol)
+                (symbol) (enum_case_identifier)
               )
             )
           )
@@ -84,7 +84,7 @@ let expression with one pipe -indented
 
 let x =
   1L
-  |> Stdlib.Option.Option.Some()
+  |> Stdlib.Option.Option.Some
 x
 
 ---
@@ -102,7 +102,7 @@ x
             (pipe_expr
               (pipe_enum
                 (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
-                (symbol) (enum_case_identifier) (symbol) (symbol)
+                (symbol) (enum_case_identifier)
               )
             )
           )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
@@ -305,11 +305,9 @@ Enum List
               (symbol)
               (enum_case_identifier)
               (symbol)
-              (indent)
               (enum_fields
                 (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
               )
-              (dedent)
               (symbol)
             )
           )
@@ -347,6 +345,69 @@ List of constants
           (simple_expression (variable_identifier))
           (newline)
           (simple_expression (variable_identifier))
+          (newline)
+        )
+        (symbol)
+      )
+    )
+  )
+)
+
+
+==================
+List of Enums
+==================
+
+[
+  Stdlib.Option.Option.Some 1L
+  Stdlib.Option.Option.None
+  Stdlib.Option.Option.Some(1L, 2L, 3L)
+  Stdlib.Option.Option.Some(1L, 2L)
+]
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (list_literal
+        (symbol)
+        (list_content
+          (simple_expression
+            (enum_literal
+              (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
+              (enum_fields
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))))
+          (newline)
+          (simple_expression
+            (enum_literal (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)))
+          (newline)
+          (simple_expression
+            (enum_literal (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
+              (symbol)
+              (enum_fields
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                (symbol)
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                (symbol)
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              )
+              (symbol)
+            )
+          )
+          (newline)
+          (simple_expression
+            (enum_literal
+              (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
+              (symbol)
+              (enum_fields
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                (symbol)
+                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              )
+              (symbol)
+            )
+          )
           (newline)
         )
         (symbol)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -173,7 +173,7 @@ pipe expression - infix
 pipe expression - enum
 ==================
 
-3L |> Stdlib.Result.Result.Ok()
+3L |> Stdlib.Result.Result.Ok
 
 ---
 
@@ -185,7 +185,7 @@ pipe expression - enum
         (symbol)
         (pipe_expr
           (pipe_enum
-            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier) (symbol) (symbol)
+            (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier)) (symbol) (enum_case_identifier)
           )
         )
       )

--- a/tree-sitter-darklang/test/corpus/exhaustive/module_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/module_decls.txt
@@ -227,10 +227,10 @@ module decl - with functions
 
 module Darklang =
   let returnsOptionNone () : Stdlib.Option.Option<'a> =
-    Stdlib.Option.Option.None()
+    Stdlib.Option.Option.None
 
   let returnsResultOk () : Stdlib.Result.Result<Int64, String> =
-    Stdlib.Result.Result.Ok(5L)
+    Stdlib.Result.Result.Ok 5L
 
 
 ---
@@ -264,8 +264,6 @@ module Darklang =
               (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
               (symbol)
               (enum_case_identifier)
-              (symbol)
-              (symbol)
             )
           )
         )
@@ -293,11 +291,9 @@ module Darklang =
               (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
               (symbol)
               (enum_case_identifier)
-              (symbol)
               (enum_fields
                 (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
               )
-              (symbol)
             )
           )
         )


### PR DESCRIPTION
No changelog

### Current Enum syntax:

- MyEnum.MyCase() // no arg
e.g. `Stdlib.Option.Option.None()`

- MyEnum.MyCase(oneArg)
e.g. `Stdlib.Option.Option.Some(1L)`

- MyEnum.MyCase((tupleArg))
e.g. `Stdlib.Option.Option.Some((1L,2L))`

- MyEnum.MyCase(arg1, arg2)
e.g. `Stdlib.Option.Option.Some(1L,2L)`


### Updated to: 

- MyEnum.MyCase // no arg
e.g. `Stdlib.Option.Option.None`

- MyEnum.MyCase oneArg
e.g. `Stdlib.Option.Option.Some 1L`

- MyEnum.MyCase (tupleArg)
e.g. `Stdlib.Option.Option.Some((1L,2L))`

- MyEnum.MyCase (arg1, arg2)
e.g. `Stdlib.Option.Option.Some(1L,2L)`



Piping into a enum:
- arg1 |> MyEnum.MyCaseWithOneArg
e.g. `1L |>Stdlib.Option.Option.Some`
- (arg1, arg2) |>  MyEnum.MyCaseWithOneTupleArg
e.g. `(1L, 2L) |>Stdlib.Option.Option.Some`
- arg1 |> MyEnum.MyCaseWithTwoArgs 2L
e.g. `1L |>Stdlib.Option.Option.Some 2L` // errors with `Expected 1 fields in PACKAGE.Darklang.Stdlib.Option.Option.Some, but got 2` which is the expected result
