### PR TITLE
Add syntax highlighting functionality to `view function/type/constant` command

### DIFF
--- a/packages/darklang/cli/cliColors.dark
+++ b/packages/darklang/cli/cliColors.dark
@@ -5,10 +5,25 @@ module Darklang =
 
     module CliColors =
       // Foreground colors (text)
-      let magenta = "\x1b[38;5;133m"
-      let purple = "\x1b[38;5;147m"
+      let white = "\x1b[97m"
       let gray = "\x1b[90m"
       let darkGray = "\x1b[38;5;145m"
+
+      let red = "\x1b[0;31m"
+      let green = "\x1b[0;32m"
+      let yellow = "\x1b[1;33m"
+      let blue = "\x1b[0;34m"
+
+      let magenta = "\x1b[38;5;133m"
+      let purple = "\x1b[38;5;147m"
+      let lightPurple = "\x1b[38;5;99m"
+      let pink = "\x1b[38;5;217m"
+
+      let cyan = "\x1b[38;5;51m"
+      let lightBlue = "\x1b[38;5;117m"
+
+      let orange = "\x1b[38;5;208m"
+      let peach = "\x1b[38;5;223m"
 
       // Background colors
       let purpleBg = "\x1b[48;5;61m"

--- a/packages/darklang/cli/command.dark
+++ b/packages/darklang/cli/command.dark
@@ -259,7 +259,8 @@ module Darklang =
           | Some packageFn ->
             // Pretty print the function details
             let prettyPrinted = PrettyPrinter.ProgramTypes.packageFn packageFn
-            let newState = { state with commandResult = CommandResult.Success $"Function: {fullyQualifiedName}\n\n{prettyPrinted}" }
+            let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+            let newState = { state with commandResult = CommandResult.Success $"Function: {fullyQualifiedName}\n\n{highlighted}" }
             (newState, [])
           | None ->
             (createErrorState state $"Function found but details could not be retrieved: {fullyQualifiedName}", [])
@@ -272,7 +273,8 @@ module Darklang =
             | Some packageType ->
               // Pretty print the type details
               let prettyPrinted = PrettyPrinter.ProgramTypes.packageType packageType
-              let newState = { state with commandResult = CommandResult.Success $"Type: {fullyQualifiedName}\n\n{prettyPrinted}" }
+              let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+              let newState = { state with commandResult = CommandResult.Success $"Type: {fullyQualifiedName}\n\n{highlighted}" }
               (newState, [])
             | None ->
               (createErrorState state $"Type found but details could not be retrieved: {fullyQualifiedName}", [])
@@ -285,7 +287,8 @@ module Darklang =
               | Some packageConst ->
                 // Pretty print the constant details
                 let prettyPrinted = PrettyPrinter.ProgramTypes.packageConstant packageConst
-                let newState = { state with commandResult = CommandResult.Success $"Constant: {fullyQualifiedName}\n\n{prettyPrinted}" }
+                let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+                let newState = { state with commandResult = CommandResult.Success $"Constant: {fullyQualifiedName}\n\n{highlighted}" }
                 (newState, [])
               | None ->
                 (createErrorState state $"Constant found but details could not be retrieved: {fullyQualifiedName}", [])
@@ -466,7 +469,9 @@ module Darklang =
                         let prettyPrinted =
                           PrettyPrinter.ProgramTypes.packageFn fn
 
-                        let newState = { state with commandResult = CommandResult.Success $"Function: {entityName}\n\n{prettyPrinted}" }
+                        let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+
+                        let newState = { state with commandResult = CommandResult.Success $"Function: {entityName}\n\n{highlighted}" }
                         (newState, [])
 
                       | [], types, [] ->
@@ -479,7 +484,9 @@ module Darklang =
                         let prettyPrinted =
                           PrettyPrinter.ProgramTypes.packageType typ
 
-                        let newState = { state with commandResult = CommandResult.Success $"Type: {entityName}\n\n{prettyPrinted}" }
+                        let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+
+                        let newState = { state with commandResult = CommandResult.Success $"Type: {entityName}\n\n{highlighted}" }
                         (newState, [])
 
                       | [], [], constants ->
@@ -492,7 +499,9 @@ module Darklang =
                         let prettyPrinted =
                           PrettyPrinter.ProgramTypes.packageConstant constant
 
-                        let newState = { state with commandResult = CommandResult.Success $"Constant: {entityName}\n\n{prettyPrinted}" }
+                        let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+
+                        let newState = { state with commandResult = CommandResult.Success $"Constant: {entityName}\n\n{highlighted}" }
                         (newState, [])
 
                       | _ ->

--- a/packages/darklang/cli/syntaxHighlighting.dark
+++ b/packages/darklang/cli/syntaxHighlighting.dark
@@ -1,0 +1,103 @@
+module Darklang =
+  module Cli =
+    module SyntaxHighlighting =
+
+      /// Maps semantic token types to CLI colors
+      let tokenTypeToCliColor (tokenType: LanguageTools.SemanticTokens.TokenType) : String =
+        match tokenType with
+        | Symbol -> CliColors.blue
+        | Keyword -> CliColors.magenta
+
+        | ModuleName -> CliColors.darkGray
+        | TypeName -> CliColors.lightBlue
+
+        | Operator -> CliColors.lightPurple
+        | String -> CliColors.peach
+        | Number -> CliColors.purple
+        | ParameterName -> CliColors.lightBlue
+        | VariableName -> CliColors.white
+        | FunctionName -> CliColors.lightBlue
+
+        | Comment -> CliColors.gray
+
+        | TypeParameter -> CliColors.purple
+
+        | EnumMember -> CliColors.purple
+        | Property -> CliColors.white
+        | Method -> CliColors.blue
+        | RegularExpression -> CliColors.peach
+
+
+      /// Highlights a single line by inserting color codes at token positions
+      let highlightLine (line: String) (lineTokens: List<LanguageTools.SemanticTokens.SemanticToken>) : String =
+        // create a list of color insertions: (position, colorCode)
+        let insertions =
+          lineTokens
+          |> Stdlib.List.fold [] (fun acc token ->
+              // extract start and end positions for the token
+              let startPos = token.range.start.column
+              let endPos = token.range.end_.column
+              let color = tokenTypeToCliColor token.tokenType
+
+              // add color start and reset positions
+              let colorStart = (startPos, color)
+              let colorEnd = (endPos, CliColors.reset)
+
+              Stdlib.List.append acc [colorStart; colorEnd])
+        |> Stdlib.List.sortBy (fun (pos, _) -> pos)
+
+        // apply insertions from right to left to avoid position shifts when inserting color codes
+        let reversedInsertions = Stdlib.List.reverse insertions
+
+        reversedInsertions
+        |> Stdlib.List.fold line (fun currentLine (pos, colorCode) ->
+            // validate insertion position is within current line bounds
+            if pos >= 0L && pos <= Stdlib.String.length currentLine then
+              let before = Stdlib.String.slice currentLine 0L pos // everything before the position
+              let after = Stdlib.String.dropFirst currentLine pos // everything after the position
+              // insert color code at the position
+              before ++ colorCode ++ after
+            else
+              currentLine)
+
+
+      /// Takes the source code and all semantic tokens, returns the highlighted version
+      let applyTokenColors
+        (sourceCode: String)
+        (tokens: List<LanguageTools.SemanticTokens.SemanticToken>)
+        : String =
+        // Sort tokens by both row and column
+        let sortedTokens =
+          tokens
+          |> Stdlib.List.sortBy (fun token -> (token.range.start.row, token.range.start.column))
+
+        let lines = Stdlib.String.split sourceCode "\n"
+
+        lines
+        |> Stdlib.List.indexedMap (fun lineIndex line ->
+          // For the current line, find all tokens that belong to it by filtering tokens where the row matches the current line index
+          let lineTokens =
+            sortedTokens
+            |> Stdlib.List.filter (fun token -> token.range.start.row == lineIndex)
+
+          if Stdlib.List.isEmpty lineTokens then
+            line
+          else
+            highlightLine line lineTokens)
+        |> Stdlib.String.join "\n"
+
+
+      let highlightCode (sourceCode: String) : String =
+        let parsedTree = LanguageTools.Parser.parseToSimplifiedTree sourceCode
+
+        match LanguageTools.Parser.parseFromTree parsedTree with
+        | Ok parsedFile ->
+          let tokens = LanguageTools.SemanticTokens.ParsedFile.tokenize parsedFile
+          if Stdlib.List.isEmpty tokens then
+            // TODO: create a fallback highlighting when parsing and tokenization fail
+            sourceCode
+          else
+            applyTokenColors sourceCode tokens
+
+        | Error _ ->
+          sourceCode


### PR DESCRIPTION
<img width="1274" height="334" alt="image" src="https://github.com/user-attachments/assets/95384c50-5268-445e-8c12-1692402cc3a5" />


Should syntax highlighting be under a flag? Something like:
`--highlight` or `--style=highlighted` and `--style=plain`