### PR TITLE
Improve error handling for unmatched match cases

### DIFF
--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -385,7 +385,9 @@ let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
           else
             counter <- counter + failJump
 
-        | MatchUnmatched -> raiseRTE (RTE.Match RTE.Matches.MatchUnmatched)
+        | MatchUnmatched(valueReg) ->
+          let unmatchedValue = registers[valueReg]
+          raiseRTE (RTE.Match(RTE.Matches.MatchUnmatched unmatchedValue))
 
 
         // == Working with Collections ==

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -810,7 +810,8 @@ module Expr =
             instrs @ caseInstrs)
           []
 
-      let instrs = expr.instructions @ caseInstrs @ [ RT.MatchUnmatched ]
+      let instrs =
+        expr.instructions @ caseInstrs @ [ RT.MatchUnmatched expr.resultIn ]
 
       let rcAtEnd = casesAfterFirstPhase |> List.map _.rc |> List.max
 

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -372,7 +372,7 @@ type Instruction =
   /// Could not find matching case in a match expression
   /// CLEANUP we probably need a way to reference back to PT so we can get useful RTEs
   /// TODO probably better as a usage of a broader "Fail" error case.
-  | MatchUnmatched
+  | MatchUnmatched of valueReg : Register
 
 
   // == Working with Collections ==
@@ -713,9 +713,8 @@ module RuntimeError =
     // TODO "When condition should be a boolean" -- this could warn _or_ error -- which do we want?
     // CLEANUP "Match must have at least one case"
     type Error =
-      /// CLEANUP probably need the value -- though if the trace contains
-      /// enough info, this may be enough? enh.
-      | MatchUnmatched
+      /// Could not find matching case for the given value
+      | MatchUnmatched of unmatchedValue : Dval
 
   module Enums =
     type Error =

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -907,13 +907,15 @@ module RuntimeError =
 
       let (caseName, fields) =
         match e with
-        | RuntimeError.Matches.MatchUnmatched -> "MatchUnmatched", []
+        | RuntimeError.Matches.MatchUnmatched unmatchedValue ->
+          "MatchUnmatched", [ Dval.toDT unmatchedValue ]
 
       DEnum(typeName, typeName, [], caseName, fields)
 
     let fromDT (d : Dval) : RuntimeError.Matches.Error =
       match d with
-      | DEnum(_, _, [], "MatchUnmatched", []) -> RuntimeError.Matches.MatchUnmatched
+      | DEnum(_, _, [], "MatchUnmatched", [ unmatchedValue ]) ->
+        RuntimeError.Matches.MatchUnmatched(Dval.fromDT unmatchedValue)
       | _ -> Exception.raiseInternal "Invalid Matches.Error" []
 
   module Records =

--- a/backend/testfiles/execution/language/custom-data/enums.dark
+++ b/backend/testfiles/execution/language/custom-data/enums.dark
@@ -31,7 +31,7 @@ module Errors =
 
     (match MyEnum.C "test" with | C v -> v) = "test"
     (match MyEnum.C "test" with | 5 -> "unmatched because it's not an int" | C v -> v) = "test"
-    (match MyEnum.C "test" with | C -> "unmatched because we didn't provide a space for the field") = Builtin.testDerrorMessage "No matching case found"
+    (match MyEnum.C "test" with | C -> "unmatched because we didn't provide a space for the field") = Builtin.testDerrorMessage "No matching case found for value Errors.User.MyEnum.C(\"test\") in match expression"
     (match MyEnum.C "test" with | D -> "unmatched because case name does not exist" | C _ -> 2) = 2
 
     (MyEnum.C 5L) = Builtin.testDerrorMessage "Failed to create enum. Expected String for field 0 in `C`, but got Int64 (5)"

--- a/backend/testfiles/execution/language/flow-control/ematch.dark
+++ b/backend/testfiles/execution/language/flow-control/ematch.dark
@@ -649,7 +649,7 @@ module Option =
 
 module Errors =
   (match "nothing matches" with
-   | "not this" -> "fail") = Builtin.testDerrorMessage "No matching case found"
+   | "not this" -> "fail") = Builtin.testDerrorMessage "No matching case found for value \"nothing matches\" in match expression"
 
   (match Builtin.testRuntimeError "cond is error" with
    | 5L -> "fail"
@@ -695,12 +695,12 @@ module TypeErrors =
   // enum with more pattern params than actual args
   (match TestType.NoArgs with
    | NoArgs _ -> "wrong number") =
-    Builtin.testDerrorMessage "No matching case found"
+    Builtin.testDerrorMessage "No matching case found for value TypeErrors.TestType.NoArgs in match expression"
 
   // enum with fewer pattern params than actual args
   (match TestType.OneArg 1L with
    | OneArg -> "wrong number") = Builtin.testDerrorMessage
-    "No matching case found"
+    "No matching case found for value TypeErrors.TestType.OneArg(1) in match expression"
 
   // TODO implement MPIgnored
   // // enum with a single wildcard
@@ -766,7 +766,7 @@ module GuardClause =
   (match 5L with
    | 2L when x > 2L -> false
    | 3L -> true) =
-    (Builtin.testDerrorMessage "No matching case found")
+    (Builtin.testDerrorMessage "No matching case found for value 5 in match expression")
 
   (match Stdlib.Result.Result.Error 5L with
    | Ok x when x > 2L -> false

--- a/backend/tests/Tests/Interpreter.Tests.fs
+++ b/backend/tests/Tests/Interpreter.Tests.fs
@@ -202,7 +202,7 @@ module Match =
     tFail
       "match true with\n| false -> \"first branch\""
       E.Match.notMatched
-      (RTE.Match RTE.Matches.MatchUnmatched)
+      (RTE.Match(RTE.Matches.MatchUnmatched(RT.DBool true)))
 
   let withVar = t "match true with\n| x -> x" E.Match.withVar (RT.DBool true)
 

--- a/backend/tests/Tests/PT2RT.Tests.fs
+++ b/backend/tests/Tests/PT2RT.Tests.fs
@@ -308,7 +308,7 @@ module Expr =
            RT.JumpBy 1
 
            // handle the case where no branches match
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          1)
 
     let notMatched =
@@ -327,7 +327,7 @@ module Expr =
            RT.JumpBy 1
 
            // handle the case where no branches match
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          1)
 
     let withVar =
@@ -341,7 +341,7 @@ module Expr =
            RT.CopyVal(1, 2)
            RT.JumpBy 1
 
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          1)
 
     let withVarAndWhenCondition =
@@ -389,7 +389,7 @@ module Expr =
            RT.JumpBy 1
 
            // handle the case where no branches match
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          1)
 
     let list =
@@ -413,7 +413,7 @@ module Expr =
            RT.JumpBy 1
 
            // handle the case where no branches match
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          3)
 
     let listCons =
@@ -436,7 +436,7 @@ module Expr =
            RT.JumpBy 1
 
            // handle the case where no branches match
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          3)
 
     let tuple =
@@ -460,7 +460,7 @@ module Expr =
            RT.JumpBy 1
 
            // handle the case where no branches match
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          3)
 
     let combinedPatterns =
@@ -490,7 +490,7 @@ module Expr =
            RT.CopyVal(3, 5)
            RT.JumpBy 1
 
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          3)
 
     let combinedPatternsWithVarAndWhenCond =
@@ -533,7 +533,7 @@ module Expr =
            RT.CopyVal(3, 5)
            RT.JumpBy 1
 
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          3)
 
     let combinedPatSameVarDifferentPos =
@@ -579,7 +579,7 @@ module Expr =
            RT.CopyVal(5, 7)
            RT.JumpBy 1
 
-           RT.MatchUnmatched ],
+           RT.MatchUnmatched 0 ],
          5)
 
     let tests =

--- a/packages/darklang/languageTools/runtimeErrors.dark
+++ b/packages/darklang/languageTools/runtimeErrors.dark
@@ -55,7 +55,7 @@ module Darklang =
 
         module Matches =
           type Error =
-            | MatchUnmatched
+            | MatchUnmatched of unmatchedValue: Dval
 
         module Enums =
           type Error =

--- a/packages/darklang/prettyPrinter/runtimeError.dark
+++ b/packages/darklang/prettyPrinter/runtimeError.dark
@@ -219,9 +219,11 @@ module Darklang =
               ES.String ")" ]
 
           | Match err ->
-            // TODO: better if we have No matching case found for {caseName} here
             match err with
-            | MatchUnmatched -> [ ES.String "No matching case found"]
+            | MatchUnmatched unmatchedValue ->
+                [ ES.String "No matching case found for value "
+                  ES.FullValue unmatchedValue
+                  ES.String " in match expression" ]
 
           | ParseTimeNameResolution err ->
             [ES.String (nameResolutionError err)]

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -240,8 +240,59 @@ module Darklang =
 
       module Dval =
         let valueTypeName (dv: LanguageTools.RuntimeTypes.Dval) : String =
-          //dv |> LanguageTools.RuntimeTypes.Dval.toValueType |> valueType
-          "TODO - use a builtin instead of the thing that was here"
+          // TODO: When a builtin for Dval.toValueType is available, use:
+          // dv |> LanguageTools.RuntimeTypes.Dval.toValueType |> valueType
+          // This mirrors DvalReprDeveloper.toTypeName
+          // If a builtin is ever exposed, we could simplify to: Builtin.dvalToTypeName dv
+          match dv with
+          | DUnit -> "Unit"
+          | DBool _ -> "Bool"
+          | DInt8 _ -> "Int8"
+          | DUInt8 _ -> "UInt8"
+          | DInt16 _ -> "Int16"
+          | DUInt16 _ -> "UInt16"
+          | DInt32 _ -> "Int32"
+          | DUInt32 _ -> "UInt32"
+          | DInt64 _ -> "Int64"
+          | DUInt64 _ -> "UInt64"
+          | DInt128 _ -> "Int128"
+          | DUInt128 _ -> "UInt128"
+          | DFloat _ -> "Float"
+          | DChar _ -> "Char"
+          | DString _ -> "String"
+          | DDateTime _ -> "DateTime"
+          | DUuid _ -> "Uuid"
+          | DTuple(first, second, theRest) ->
+            let types = Stdlib.List.append [ first; second ] theRest
+            types
+            |> Stdlib.List.map (fun item -> valueTypeName item)
+            |> Stdlib.String.join " * "
+            |> fun parts -> "(" ++ parts ++ ")"
+          | DList (vt, _) -> $"List<{valueType vt}>"
+          | DDict (vt, _) -> $"Dict<{valueType vt}>"
+          | DRecord (_, typeName, typeArgs, _) ->
+            let typeArgsPart =
+              match typeArgs with
+              | [] -> ""
+              | args ->
+                args
+                |> Stdlib.List.map (fun t -> valueType t)
+                |> Stdlib.String.join ", "
+                |> fun parts -> $"<{parts}>"
+            (typeName typeName) ++ typeArgsPart
+          | DEnum (_, typeName, typeArgs, _, _) ->
+            let typeArgsPart =
+              match typeArgs with
+              | [] -> ""
+              | args ->
+                args
+                |> Stdlib.List.map (fun t -> valueType t)
+                |> Stdlib.String.join ", "
+                |> fun parts -> $"<{parts}>"
+            (typeName typeName) ++ typeArgsPart
+          | DDB _ -> "Datastore"
+          | DApplicable (AppNamedFn _) -> "Function"
+          | DApplicable (AppLambda _) -> "Lambda"
 
         let makeSpaces (len: Int64) : String =
           (Stdlib.List.repeat len " ") |> Builtin.unwrap |> Stdlib.String.join ""


### PR DESCRIPTION
Before:
```
Encountered a Runtime Error:
No matching case found for value TODO - use a builtin instead of the thing that was here [] in match expression

Call stack (last call at bottom):
- Package Function PACKAGE.Darklang.Cli.executeCliCommand
- Package Function PACKAGE.Darklang.Cli.processMessages
- Package Function PACKAGE.Darklang.Cli.processMessages
```

After:
```
Encountered a Runtime Error:
No matching case found for value List<PACKAGE.Darklang.Cli.Msg> [] in match expression

Call stack (last call at bottom):
- Package Function PACKAGE.Darklang.Cli.executeCliCommand
- Package Function PACKAGE.Darklang.Cli.processMessages
- Package Function PACKAGE.Darklang.Cli.processMessages
```


Before:
```
Error when executing Script. Call-stack:
Call stack (last call at bottom):
- Package Function efe6f721-b143-4de7-b83e-b242470a3d5e

Error: No matching case found
```

After:
```
Error when executing Script. Call-stack:
Call stack (last call at bottom):
- Package Function 9f26463f-4d47-44c0-821e-14a873360efc

Error: No matching case found for value PACKAGE.Darklang.Stdlib.Result.Result<Int64, _>.Ok(2) in match expression
```

This would be much better if we could get the exact line number of the expression, but it already seems like an improvement over what we had — we can work with it for now.