### PR TITLE
Improve UX of view command

### DIFF
--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -630,6 +630,13 @@ let fns : List<BuiltInFn> =
             match result with
             | Ok() -> return Dval.resultOk KTUnit KTString DUnit
             | Error err -> return Dval.resultError KTUnit KTString (DString err)
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
     { name = fn "cliGetTerminalHeight" 0
       typeParams = []
       parameters = [ Param.make "unit" TUnit "" ]

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -630,6 +630,63 @@ let fns : List<BuiltInFn> =
             match result with
             | Ok() -> return Dval.resultOk KTUnit KTString DUnit
             | Error err -> return Dval.resultError KTUnit KTString (DString err)
+    { name = fn "cliGetTerminalHeight" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TInt64
+      description = "Get the current terminal viewport height in number of lines"
+      fn =
+        (function
+        | _, _, [], [ DUnit ] ->
+          uply {
+            try
+              // First try environment variable (most reliable across different terminals)
+              match System.Environment.GetEnvironmentVariable("LINES") with
+              | null ->
+                // Try Console.WindowHeight
+                let height = System.Console.WindowHeight
+
+                // If we get exactly 24, it might be a default value
+                // Let's try alternative methods
+                if height = 24 then
+                  // On Unix systems, try tput command
+                  if
+                    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                      System.Runtime.InteropServices.OSPlatform.Linux
+                    )
+                    || System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                      System.Runtime.InteropServices.OSPlatform.OSX
+                    )
+                  then
+                    try
+                      let p = new System.Diagnostics.Process()
+                      p.StartInfo.FileName <- "/bin/sh"
+                      p.StartInfo.Arguments <-
+                        "-c \"tput lines 2>/dev/null || echo 24\""
+                      p.StartInfo.UseShellExecute <- false
+                      p.StartInfo.RedirectStandardOutput <- true
+                      p.StartInfo.CreateNoWindow <- true
+                      if p.Start() then
+                        let output = p.StandardOutput.ReadToEnd().Trim()
+                        p.WaitForExit()
+                        match System.Int32.TryParse(output) with
+                        | true, h when h > 0 -> return DInt64(int64 h)
+                        | _ -> return DInt64(int64 height)
+                      else
+                        return DInt64(int64 height)
+                    with _ ->
+                      return DInt64(int64 height)
+                  else
+                    return DInt64(int64 height)
+                else
+                  return DInt64(int64 height)
+              | lines ->
+                match System.Int32.TryParse(lines) with
+                | true, h when h > 0 -> return DInt64(int64 h)
+                | _ -> return DInt64 24L
+            with _ ->
+              // Fallback if unable to detect terminal size
+              return DInt64 24L
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/BuiltinCliHost/Libs/Cli.fs
+++ b/backend/src/BuiltinCliHost/Libs/Cli.fs
@@ -701,6 +701,70 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "cliGetTerminalWidth" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TInt64
+      description = "Get the current terminal viewport width in number of columns"
+      fn =
+        (function
+        | _, _, [], [ DUnit ] ->
+          uply {
+            try
+              // First try environment variable (most reliable across different terminals)
+              match System.Environment.GetEnvironmentVariable("COLUMNS") with
+              | null ->
+                // Try Console.WindowWidth
+                let width = System.Console.WindowWidth
+
+                // If we get exactly 80, it might be a default value
+                // Let's try alternative methods
+                if width = 80 then
+                  // On Unix systems, try tput command
+                  if
+                    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                      System.Runtime.InteropServices.OSPlatform.Linux
+                    )
+                    || System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                      System.Runtime.InteropServices.OSPlatform.OSX
+                    )
+                  then
+                    try
+                      let p = new System.Diagnostics.Process()
+                      p.StartInfo.FileName <- "/bin/sh"
+                      p.StartInfo.Arguments <-
+                        "-c \"tput cols 2>/dev/null || echo 80\""
+                      p.StartInfo.UseShellExecute <- false
+                      p.StartInfo.RedirectStandardOutput <- true
+                      p.StartInfo.CreateNoWindow <- true
+                      if p.Start() then
+                        let output = p.StandardOutput.ReadToEnd().Trim()
+                        p.WaitForExit()
+                        match System.Int32.TryParse(output) with
+                        | true, w when w > 0 -> return DInt64(int64 w)
+                        | _ -> return DInt64(int64 width)
+                      else
+                        return DInt64(int64 width)
+                    with _ ->
+                      return DInt64(int64 width)
+                  else
+                    return DInt64(int64 width)
+                else
+                  return DInt64(int64 width)
+              | columns ->
+                match System.Int32.TryParse(columns) with
+                | true, w when w > 0 -> return DInt64(int64 w)
+                | _ -> return DInt64 80L
+            with _ ->
+              // Fallback if unable to detect terminal size
+              return DInt64 80L
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
     { name = fn "getBuildHash" 0
       typeParams = []
       parameters = [ Param.make "unit" TUnit "" ]

--- a/packages/darklang/cli/cli.dark
+++ b/packages/darklang/cli/cli.dark
@@ -23,12 +23,6 @@ module Darklang =
       // Handle rendering based on the interaction mode
       let stateAfterRender =
         match state.interactionMode with
-        // In NonInteractive mode, just render and exit
-        // (we do this if you enter any command explicitly when starting the CLI)
-        | NonInteractive ->
-          Builtin.print (render state)
-          { state with isExiting = true }
-
         // In Regular mode, don't clear the screen, just print the prompt
         | Regular ->
           if state.needsFullRedraw then
@@ -77,7 +71,15 @@ module Darklang =
     let executeCliCommand (args: List<String>) : Int64 =
       let (state, initialMsgs) = init args
       let state = processMessages state initialMsgs
-      runInternalLoop state
+      match state.interactionMode with
+      | NonInteractive ->
+        match state.commandResult with
+        | Success msg -> Builtin.printLine msg; 0L
+        | Error msg -> Builtin.printLine $"Error: {msg}"; 1L
+        | Info msg -> Builtin.printLine msg; 0L
+        | None -> 0L
+      | _ ->
+        runInternalLoop state
 
 
     module ExecutionError =

--- a/packages/darklang/cli/command.dark
+++ b/packages/darklang/cli/command.dark
@@ -462,7 +462,7 @@ module Darklang =
 
         // Check cache first
         match viewingState.entityCache |> Stdlib.List.findFirst (fun (key, _) -> key == cacheKey) with
-        | Some (_, cachedDef) -> (cachedDef, viewingState)
+        | Some ((_, cachedDef)) -> (cachedDef, viewingState)
         | None ->
           // Create new definition and add to cache
           let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted

--- a/packages/darklang/cli/command.dark
+++ b/packages/darklang/cli/command.dark
@@ -39,67 +39,6 @@ module Darklang =
           //execute: List<String> -> Unit
           }
 
-      /// Display control constants
-      module Display =
-        let clearScreen = "\x1b[2J\x1b[H"
-        let enterAltScreen = "\x1b[?1049h"
-        let exitAltScreen = "\x1b[?1049l"
-
-      let renderView (content: ViewContent) (clearScreen: Bool) : String =
-        match content with
-        | ModuleView (category, items, selectedIndex) ->
-          let categoryName = entityCategoryToString category
-          let formattedItems =
-            items
-            |> Stdlib.List.indexedMap (fun index item ->
-              if index == selectedIndex then
-                $"{CliColors.magenta}[{item}]{CliColors.reset}"
-              else
-                item)
-          let itemsDisplay = if Stdlib.List.isEmpty formattedItems then "(none)" else Stdlib.String.join formattedItems ", "
-          itemsDisplay
-
-        | EntityDefinitionView entityDef ->
-          let totalLines = entityDef.lines |> Stdlib.List.length
-          let contentHeight = getContentViewportHeight totalLines
-          let safeContentHeight = Stdlib.Int64.max 1L contentHeight
-
-          // Ensure scroll position is within bounds
-          let maxScrollPos = Stdlib.Int64.max 0L (totalLines - safeContentHeight)
-          let adjustedScrollPos =
-            entityDef.scrollPosition
-            |> Stdlib.Int64.max 0L
-            |> Stdlib.Int64.min maxScrollPos
-
-          let visibleLines =
-            entityDef.lines
-            |> Stdlib.List.drop adjustedScrollPos
-            |> Stdlib.List.take safeContentHeight
-
-          $"{CliColors.blue}{entityDef.name}\n\n" ++ (visibleLines |> Stdlib.String.join "\n")
-
-      /// Wraps the content with a help bar and clears the screen if needed
-      let renderViewingInterface (content: String) (clearScreen: Bool) : String =
-        let clearAndHome = if clearScreen then Display.clearScreen else ""
-        let helpBar = $"{CliColors.gray}↑/↓: categories  ←/→: items  Enter: expand/collapse  b: back  q: quit{CliColors.reset}\n\n"
-        $"{clearAndHome}{content}\n{helpBar}"
-
-      let getTerminalHeight () : Int64 =
-        Builtin.cliGetTerminalHeight ()
-
-      /// Calculates the content viewport height for entity definitions
-      let getContentViewportHeight (totalLines: Int64) : Int64 =
-        let viewportHeight = getTerminalHeight ()
-        let reservedLines = 5L // title (2) + help bar (2) + spacing (1)
-        let availableHeight = Stdlib.Int64.max 1L (viewportHeight - reservedLines)
-        Stdlib.Int64.min totalLines availableHeight
-
-      let renderEntityInterface (entityName: String) (lines: List<String>) (scrollPosition: Int64) : String =
-        let entityDef = EntityDefinition { name = entityName; lines = lines; scrollPosition = scrollPosition }
-        let content = ViewContent.EntityDefinitionView entityDef
-        let visibleContent = renderView content true
-        renderViewingInterface visibleContent true
-
 
       type GeneralCommand =
         | Status // if in the middle of something, will tell you
@@ -211,186 +150,6 @@ module Darklang =
         | Some idx -> Stdlib.Option.Option.Some (Stdlib.String.slice fullyQualifiedName 0L idx)
         | None -> Stdlib.Option.Option.None
 
-      /// Converts an EntityCategory to its string representation
-      let entityCategoryToString (category: EntityCategory) : String =
-        match category with
-        | Functions -> "functions"
-        | Types -> "types"
-        | Constants -> "constants"
-        | Submodules -> "submodules"
-
-      /// Converts a category index to an EntityCategory
-      let indexToEntityCategory (index: Int64) : EntityCategory =
-        match index with
-        | 0L -> EntityCategory.Functions
-        | 1L -> EntityCategory.Types
-        | 2L -> EntityCategory.Constants
-        | 3L -> EntityCategory.Submodules
-        | _ -> EntityCategory.Functions  // Default fallback
-
-      /// Converts an EntityCategory to its index
-      let entityCategoryToIndex (category: EntityCategory) : Int64 =
-        match category with
-        | Functions -> 0L
-        | Types -> 1L
-        | Constants -> 2L
-        | Submodules -> 3L
-
-      /// Entity lookup that finds an entity by name and returns its type and pretty-printed definition
-      let findEntity (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) (name: String) : Stdlib.Option.Option<(String * String)> =
-        let constantResult =
-          moduleContent.constants
-          |> Stdlib.List.findFirst (fun c -> c.name.name == name)
-          |> Stdlib.Option.map (fun c -> ("Constant", PrettyPrinter.ProgramTypes.packageConstant c))
-
-        let functionResult =
-          moduleContent.fns
-          |> Stdlib.List.findFirst (fun f -> f.name.name == name)
-          |> Stdlib.Option.map (fun f -> ("Function", PrettyPrinter.ProgramTypes.packageFn f))
-
-        let typeResult =
-          moduleContent.types
-          |> Stdlib.List.findFirst (fun t -> t.name.name == name)
-          |> Stdlib.Option.map (fun t -> ("Type", PrettyPrinter.ProgramTypes.packageType t))
-
-        // Return the first match found (constants, then functions, then types)
-        match constantResult with
-        | Some _ -> constantResult
-        | None ->
-          match functionResult with
-          | Some _ -> functionResult
-          | None -> typeResult
-
-      /// Gets entities from moduleContent for a given category
-      let getEntitiesForCategory (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) (category: EntityCategory) (currentEntityName: String) : List<String> =
-        match category with
-        | Functions -> moduleContent.fns |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name)
-        | Types -> moduleContent.types |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name)
-        | Constants -> moduleContent.constants |> Stdlib.List.map (fun constant -> LanguageTools.ProgramTypes.PackageConstant.nameToString constant.name)
-        | Submodules ->
-          (moduleContent.submodules
-            |> Stdlib.List.map (fun m ->
-              m
-              |> Stdlib.List.map (fun singleModulePath ->
-                Stdlib.String.join singleModulePath "."))
-            |> Stdlib.List.flatten
-            |> Stdlib.List.filter (fun submodule ->
-              // Filter out the current module itself from the submodules list
-              submodule != currentEntityName))
-
-
-      /// Formats a section of entities for display with expandable state and scrolling
-      let formatEntitySection (viewingState: ViewingState) (category: EntityCategory) (entities: List<String>) : String =
-        let sectionName = entityCategoryToString category
-        let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 category
-
-        let expandIndicator = if isExpanded then $"{CliColors.purple}▼{CliColors.reset}" else $"{CliColors.purple}▶{CliColors.reset}"
-        let selectionIndicator = if viewingState.selectedCategory == category then "→ " else "  "
-        let header = $"{selectionIndicator}{expandIndicator} {sectionName} {CliColors.gray}({entities |> Stdlib.List.length |> Stdlib.Int64.toString}){CliColors.reset}"
-
-        if Stdlib.List.isEmpty entities then
-          $"{header}\n\n(none)\n"
-        else if isExpanded then
-          // Extract just the names without module prefixes
-          let shortNames =
-            entities
-            |> Stdlib.List.map (fun fullName ->
-              fullName
-              |> Stdlib.String.split "."
-              |> Stdlib.List.last
-              |> Stdlib.Option.withDefault fullName)
-
-          if viewingState.selectedCategory == category && viewingState.selectedItemIndex >= 0L then
-            let content = ViewContent.ModuleView (category, shortNames, viewingState.selectedItemIndex)
-            let itemsDisplay = renderView content false
-            $"{header}\n\n{itemsDisplay}\n"
-          else
-            $"{header}\n\n" ++ (Stdlib.String.join shortNames ", ") ++ "\n"
-        else
-          $"{header}\n"
-
-
-      /// Formats a section of entities for display with simple list (for non-interactive mode)
-      let formatEntitySectionSimple (sectionName: String) (entities: List<String>) : String =
-        if Stdlib.List.isEmpty entities then
-          $"{sectionName}:\n\n(none)\n"
-        else
-          $"{sectionName}:\n\n" ++ (Stdlib.String.join entities "\n") ++ "\n"
-
-      /// Formats module content for non-interactive display (original simple list)
-      let formatModuleContentSimple (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) : String =
-        let functionsSection =
-          formatEntitySectionSimple
-            "functions"
-            (moduleContent.fns
-              |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
-
-        let typesSection =
-          formatEntitySectionSimple
-            "types"
-            (moduleContent.types
-              |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
-
-        let constantsSection =
-          formatEntitySectionSimple
-            "constants"
-            (moduleContent.constants
-              |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
-
-        let submodulesSection =
-          formatEntitySectionSimple
-            "submodules"
-            ((moduleContent.submodules
-              |> Stdlib.List.map (fun m ->
-                m
-                |> Stdlib.List.map (fun s -> s |> Stdlib.String.join ".")))
-              |> Stdlib.List.flatten)
-
-        functionsSection ++
-        typesSection ++
-        constantsSection ++
-        submodulesSection
-
-      let formatModuleContent (viewingState: ViewingState) : String =
-        let functionsSection =
-          formatEntitySection
-            viewingState
-            EntityCategory.Functions
-            (viewingState.moduleContent.fns
-              |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
-
-        let typesSection =
-          formatEntitySection
-            viewingState
-            EntityCategory.Types
-            (viewingState.moduleContent.types
-              |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
-
-        let constantsSection =
-          formatEntitySection
-            viewingState
-            EntityCategory.Constants
-            (viewingState.moduleContent.constants
-              |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
-
-        let submodulesSection =
-          formatEntitySection
-            viewingState
-            EntityCategory.Submodules
-            ((viewingState.moduleContent.submodules
-              |> Stdlib.List.map (fun m ->
-                m
-                |> Stdlib.List.map (fun singleModulePath ->
-                  Stdlib.String.join singleModulePath "."))
-              |> Stdlib.List.flatten
-              |> Stdlib.List.filter (fun submodule ->
-                submodule != viewingState.entityName)))
-
-        $"{CliColors.blue}Module: {viewingState.entityName}{CliColors.reset}\n\n" ++
-        functionsSection ++ "\n" ++
-        typesSection ++ "\n" ++
-        constantsSection ++ "\n" ++
-        submodulesSection
 
       let createSearchQuery (currentModule: List<String>) (text: String) : LanguageTools.ProgramTypes.Search.SearchQuery =
         LanguageTools.ProgramTypes.Search.SearchQuery
@@ -453,59 +212,6 @@ module Darklang =
             (newState, [])
         | Error e ->
           let newState = { state with commandResult = CommandResult.Error e }
-          (newState, [])
-
-
-      /// Gets an entity definition from cache or creates a new one
-      let getOrCreateEntityDefinition (viewingState: ViewingState) (entityType: String) (fullyQualifiedName: String) (prettyPrinted: String) : (EntityDefinition * ViewingState) =
-        let cacheKey = $"{entityType}:{fullyQualifiedName}"
-
-        // Check cache first
-        match viewingState.entityCache |> Stdlib.List.findFirst (fun (key, _) -> key == cacheKey) with
-        | Some ((_, cachedDef)) -> (cachedDef, viewingState)
-        | None ->
-          // Create new definition and add to cache
-          let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
-          let lines = highlighted |> Stdlib.String.split "\n"
-          let entityDefinition = EntityDefinition { name = $"{entityType}: {fullyQualifiedName}"; lines = lines; scrollPosition = 0L }
-          let newCache = viewingState.entityCache |> Stdlib.List.push (cacheKey, entityDefinition)
-          let newViewingState = { viewingState with entityCache = newCache }
-          (entityDefinition, newViewingState)
-
-      let renderEntityDefinition (state: State) (entityType: String) (fullyQualifiedName: String) (prettyPrinted: String) : (State * List<Msg>) =
-        match state.viewingState with
-        | Some viewingState ->
-          let (entityDefinition, updatedViewingState) = getOrCreateEntityDefinition viewingState entityType fullyQualifiedName prettyPrinted
-          let completeInterface = renderEntityInterface entityDefinition.name entityDefinition.lines entityDefinition.scrollPosition
-          let finalViewingState = { updatedViewingState with entityDefinition = Stdlib.Option.Option.Some entityDefinition }
-          let newState =
-            { state with
-                commandResult = CommandResult.Success completeInterface
-                viewingState = Stdlib.Option.Option.Some finalViewingState
-                needsFullRedraw = true }
-          (newState, [])
-        | None ->
-          let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
-          let newState =
-            { state with
-                commandResult = CommandResult.Success $"{entityType}: {fullyQualifiedName}\n\n{highlighted}" }
-          (newState, [])
-
-      /// Helper function to view an entity by its fully qualified name
-      let viewEntityByName (state: State) (fullyQualifiedName: String) : (State * List<Msg>) =
-        let modules = fullyQualifiedName |> Stdlib.String.split "." |> Stdlib.List.dropLast
-        let text = fullyQualifiedName |> Stdlib.String.split "." |> Stdlib.List.last |> Builtin.unwrap
-
-        let query = createSearchQuery modules text
-        let moduleContent = LanguageTools.PackageManager.Search.search query
-
-        match findEntity moduleContent text with
-        | Some ((entityType, prettyPrinted)) ->
-          renderEntityDefinition state entityType fullyQualifiedName prettyPrinted
-        | None ->
-          let newState =
-            { state with
-                commandResult = CommandResult.Error $"Entity not found: {fullyQualifiedName}" }
           (newState, [])
 
 
@@ -682,13 +388,12 @@ module Darklang =
                        Stdlib.List.isEmpty moduleContent.types &&
                        Stdlib.List.isEmpty moduleContent.constants then
 
-                        viewEntityByName state entityName
+                        CommandHelpers.View.EntityLookup.viewEntityByName state entityName
 
                     else
                       match state.interactionMode with
                       | NonInteractive ->
-                        // Use the simple format function
-                        let moduleView = formatModuleContentSimple moduleContent
+                        let moduleView = CommandHelpers.View.Rendering.formatModuleContentSimple moduleContent
                         let newState = { state with commandResult = CommandResult.Success moduleView }
                         (newState, [])
                       | _ ->
@@ -702,11 +407,12 @@ module Darklang =
                               selectedItemIndex = initialItemIndex
                               expandedCategories = [ EntityCategory.Functions ]
                               entityDefinition = Stdlib.Option.Option.None
-                              entityCache = [] }
-                        let moduleView = formatModuleContent viewingState
+                              entityCache = []
+                              viewportScrollPosition = 0L }
+                        let moduleView = CommandHelpers.View.Rendering.formatModuleContent viewingState
                         // Enter alternate screen buffer when first entering view mode, then render interface
-                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
-                        let completeInterface = renderViewingInterface moduleView true
+                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then CommandHelpers.View.Rendering.Display.enterAltScreen else ""
+                        let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
                         let newState =
                           { state with
                               commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
@@ -728,31 +434,31 @@ module Darklang =
                        Stdlib.List.isEmpty moduleContent.types &&
                        Stdlib.List.isEmpty moduleContent.constants then
                       // check if the entity is a function, type, or constant
-                      viewEntityByName state fullyQualifiedName
+                      CommandHelpers.View.EntityLookup.viewEntityByName state fullyQualifiedName
 
                     else
                       match state.interactionMode with
                       | NonInteractive ->
                         let functionsSection =
-                          formatEntitySectionSimple
+                          CommandHelpers.View.Rendering.formatEntitySectionSimple
                             "functions"
                             (moduleContent.fns
                               |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
 
                         let typesSection =
-                          formatEntitySectionSimple
+                          CommandHelpers.View.Rendering.formatEntitySectionSimple
                             "types"
                             (moduleContent.types
                               |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
 
                         let constantsSection =
-                          formatEntitySectionSimple
+                          CommandHelpers.View.Rendering.formatEntitySectionSimple
                             "constants"
                             (moduleContent.constants
                               |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
 
                         let submodulesSection =
-                          formatEntitySectionSimple
+                          CommandHelpers.View.Rendering.formatEntitySectionSimple
                             "submodules"
                             ((moduleContent.submodules
                               |> Stdlib.List.map (fun m ->
@@ -780,11 +486,12 @@ module Darklang =
                               selectedItemIndex = initialItemIndex
                               expandedCategories = [ EntityCategory.Functions ]
                               entityDefinition = Stdlib.Option.Option.None
-                              entityCache = [] }
-                        let moduleView = formatModuleContent viewingState
+                              entityCache = []
+                              viewportScrollPosition = 0L }
+                        let moduleView = CommandHelpers.View.Rendering.formatModuleContent viewingState
                         // Enter alternate screen buffer when first entering view mode, then render interface
-                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
-                        let completeInterface = renderViewingInterface moduleView true
+                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then CommandHelpers.View.Rendering.Display.enterAltScreen else ""
+                        let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
                         let newState =
                           { state with
                               commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
@@ -1173,24 +880,11 @@ module Darklang =
                       (newState, [])
 
                     | Module(owner, submodules) ->
-                      // In a module, show all functions, types, and constants
-                      // Construct the module prefix
                       let modulePrefix = constructModulePrefix owner submodules
 
                       let query = createSearchQuery (modulePrefix |> Stdlib.String.split ".") ""
                       let moduleContent = LanguageTools.PackageManager.Search.search query
-
-                      // Create a simple viewing state for non-interactive display
-                      let simpleViewingState =
-                        ViewingState
-                          { moduleContent = moduleContent
-                            entityName = modulePrefix
-                            selectedCategory = EntityCategory.Functions
-                            selectedItemIndex = -1L
-                            expandedCategories = []
-                            entityDefinition = Stdlib.Option.Option.None
-                            entityCache = [] }
-                      let moduleView = formatModuleContent simpleViewingState
+                      let moduleView = CommandHelpers.View.Rendering.formatModuleContentSimple moduleContent
 
                       let newState = { state with commandResult = CommandResult.Success moduleView }
                       (newState, [])
@@ -1310,7 +1004,7 @@ module Darklang =
                         match extractModulePrefix typeName with
                         | Some modulePrefix ->
                           let fullyQualifiedName = modulePrefix ++ "." ++ entityName
-                          viewEntityByName state fullyQualifiedName
+                          CommandHelpers.View.EntityLookup.viewEntityByName state fullyQualifiedName
                         | None ->
                           let newState = { state with commandResult = CommandResult.Error "Cannot determine module context" }
                           (newState, [])
@@ -1321,7 +1015,7 @@ module Darklang =
                         match extractModulePrefix fnName with
                         | Some modulePrefix ->
                           let fullyQualifiedName = modulePrefix ++ "." ++ entityName
-                          viewEntityByName state fullyQualifiedName
+                          CommandHelpers.View.EntityLookup.viewEntityByName state fullyQualifiedName
                         | None ->
                           let newState = { state with commandResult = CommandResult.Error "Cannot determine module context" }
                           (newState, [])
@@ -1332,7 +1026,7 @@ module Darklang =
                         match extractModulePrefix constName with
                         | Some modulePrefix ->
                           let fullyQualifiedName = modulePrefix ++ "." ++ entityName
-                          viewEntityByName state fullyQualifiedName
+                          CommandHelpers.View.EntityLookup.viewEntityByName state fullyQualifiedName
                         | None ->
                           let newState = { state with commandResult = CommandResult.Error "Cannot determine module context" }
                           (newState, [])

--- a/packages/darklang/cli/command.dark
+++ b/packages/darklang/cli/command.dark
@@ -405,14 +405,14 @@ module Darklang =
                               entityName = entityName
                               selectedCategory = EntityCategory.Functions
                               selectedItemIndex = initialItemIndex
-                              expandedCategories = [ EntityCategory.Functions ]
+                              expandedCategories = []
                               entityDefinition = Stdlib.Option.Option.None
                               entityCache = []
                               viewportScrollPosition = 0L }
                         let moduleView = CommandHelpers.View.Rendering.formatModuleContent viewingState
                         // Enter alternate screen buffer when first entering view mode, then render interface
-                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then CommandHelpers.View.Rendering.Display.enterAltScreen else ""
-                        let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
+                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Terminal.Display.enterAltScreen else ""
+                        let completeInterface = CommandHelpers.View.Rendering.renderModuleViewingInterface moduleView
                         let newState =
                           { state with
                               commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
@@ -484,14 +484,14 @@ module Darklang =
                               entityName = fullyQualifiedName
                               selectedCategory = EntityCategory.Functions
                               selectedItemIndex = initialItemIndex
-                              expandedCategories = [ EntityCategory.Functions ]
+                              expandedCategories = []
                               entityDefinition = Stdlib.Option.Option.None
                               entityCache = []
                               viewportScrollPosition = 0L }
                         let moduleView = CommandHelpers.View.Rendering.formatModuleContent viewingState
                         // Enter alternate screen buffer when first entering view mode, then render interface
-                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then CommandHelpers.View.Rendering.Display.enterAltScreen else ""
-                        let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
+                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Terminal.Display.enterAltScreen else ""
+                        let completeInterface = CommandHelpers.View.Rendering.renderModuleViewingInterface moduleView
                         let newState =
                           { state with
                               commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)

--- a/packages/darklang/cli/command.dark
+++ b/packages/darklang/cli/command.dark
@@ -467,7 +467,7 @@ module Darklang =
                               |> Stdlib.List.flatten)
 
                         let moduleView =
-                          $"Module: {fullyQualifiedName}\n\n" ++
+                          $"Module: {fullyQualifiedName}\n" ++
                           functionsSection ++ "\n" ++
                           typesSection ++ "\n" ++
                           constantsSection ++ "\n" ++

--- a/packages/darklang/cli/command.dark
+++ b/packages/darklang/cli/command.dark
@@ -310,6 +310,47 @@ module Darklang =
           $"{header}\n"
 
 
+      /// Formats a section of entities for display with simple list (for non-interactive mode)
+      let formatEntitySectionSimple (sectionName: String) (entities: List<String>) : String =
+        if Stdlib.List.isEmpty entities then
+          $"{sectionName}:\n\n(none)\n"
+        else
+          $"{sectionName}:\n\n" ++ (Stdlib.String.join entities "\n") ++ "\n"
+
+      /// Formats module content for non-interactive display (original simple list)
+      let formatModuleContentSimple (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) : String =
+        let functionsSection =
+          formatEntitySectionSimple
+            "functions"
+            (moduleContent.fns
+              |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
+
+        let typesSection =
+          formatEntitySectionSimple
+            "types"
+            (moduleContent.types
+              |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
+
+        let constantsSection =
+          formatEntitySectionSimple
+            "constants"
+            (moduleContent.constants
+              |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
+
+        let submodulesSection =
+          formatEntitySectionSimple
+            "submodules"
+            ((moduleContent.submodules
+              |> Stdlib.List.map (fun m ->
+                m
+                |> Stdlib.List.map (fun s -> s |> Stdlib.String.join ".")))
+              |> Stdlib.List.flatten)
+
+        functionsSection ++
+        typesSection ++
+        constantsSection ++
+        submodulesSection
+
       let formatModuleContent (viewingState: ViewingState) : String =
         let functionsSection =
           formatEntitySection
@@ -644,26 +685,33 @@ module Darklang =
                         viewEntityByName state entityName
 
                     else
-                      // Create viewing state with functions expanded and first item selected
-                      let initialItemIndex = if Stdlib.List.isEmpty moduleContent.fns then -1L else 0L
-                      let viewingState =
-                        ViewingState
-                          { moduleContent = moduleContent
-                            entityName = entityName
-                            selectedCategory = EntityCategory.Functions
-                            selectedItemIndex = initialItemIndex
-                            expandedCategories = [ EntityCategory.Functions ]
-                            entityDefinition = Stdlib.Option.Option.None
-                            entityCache = [] }
-                      let moduleView = formatModuleContent viewingState
-                      // Enter alternate screen buffer when first entering view mode, then render interface
-                      let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
-                      let completeInterface = renderViewingInterface moduleView true
-                      let newState =
-                        { state with
-                            commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
-                            viewingState = Stdlib.Option.Option.Some viewingState }
-                      (newState, [])
+                      match state.interactionMode with
+                      | NonInteractive ->
+                        // Use the simple format function
+                        let moduleView = formatModuleContentSimple moduleContent
+                        let newState = { state with commandResult = CommandResult.Success moduleView }
+                        (newState, [])
+                      | _ ->
+                        // Interactive format for regular and refresh-screen modes
+                        let initialItemIndex = if Stdlib.List.isEmpty moduleContent.fns then -1L else 0L
+                        let viewingState =
+                          ViewingState
+                            { moduleContent = moduleContent
+                              entityName = entityName
+                              selectedCategory = EntityCategory.Functions
+                              selectedItemIndex = initialItemIndex
+                              expandedCategories = [ EntityCategory.Functions ]
+                              entityDefinition = Stdlib.Option.Option.None
+                              entityCache = [] }
+                        let moduleView = formatModuleContent viewingState
+                        // Enter alternate screen buffer when first entering view mode, then render interface
+                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
+                        let completeInterface = renderViewingInterface moduleView true
+                        let newState =
+                          { state with
+                              commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
+                              viewingState = Stdlib.Option.Option.Some viewingState }
+                        (newState, [])
 
                   | Module(owner, submodules) ->
                     // Construct the fully qualified entity name
@@ -683,26 +731,65 @@ module Darklang =
                       viewEntityByName state fullyQualifiedName
 
                     else
-                      // Create viewing state with functions expanded and first item selected
-                      let initialItemIndex = if Stdlib.List.isEmpty moduleContent.fns then -1L else 0L
-                      let viewingState =
-                        ViewingState
-                          { moduleContent = moduleContent
-                            entityName = fullyQualifiedName
-                            selectedCategory = EntityCategory.Functions
-                            selectedItemIndex = initialItemIndex
-                            expandedCategories = [ EntityCategory.Functions ]
-                            entityDefinition = Stdlib.Option.Option.None
-                            entityCache = [] }
-                      let moduleView = formatModuleContent viewingState
-                      // Enter alternate screen buffer when first entering view mode, then render interface
-                      let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
-                      let completeInterface = renderViewingInterface moduleView true
-                      let newState =
-                        { state with
-                            commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
-                            viewingState = Stdlib.Option.Option.Some viewingState }
-                      (newState, [])
+                      match state.interactionMode with
+                      | NonInteractive ->
+                        let functionsSection =
+                          formatEntitySectionSimple
+                            "functions"
+                            (moduleContent.fns
+                              |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
+
+                        let typesSection =
+                          formatEntitySectionSimple
+                            "types"
+                            (moduleContent.types
+                              |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
+
+                        let constantsSection =
+                          formatEntitySectionSimple
+                            "constants"
+                            (moduleContent.constants
+                              |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
+
+                        let submodulesSection =
+                          formatEntitySectionSimple
+                            "submodules"
+                            ((moduleContent.submodules
+                              |> Stdlib.List.map (fun m ->
+                                m
+                                |> Stdlib.List.map (fun s -> s |> Stdlib.String.join ".")))
+                              |> Stdlib.List.flatten)
+
+                        let moduleView =
+                          $"Module: {fullyQualifiedName}\n\n" ++
+                          functionsSection ++ "\n" ++
+                          typesSection ++ "\n" ++
+                          constantsSection ++ "\n" ++
+                          submodulesSection
+
+                        let newState = { state with commandResult = CommandResult.Success moduleView }
+                        (newState, [])
+                      | _ ->
+                        // Interactive format for regular and refresh-screen modes
+                        let initialItemIndex = if Stdlib.List.isEmpty moduleContent.fns then -1L else 0L
+                        let viewingState =
+                          ViewingState
+                            { moduleContent = moduleContent
+                              entityName = fullyQualifiedName
+                              selectedCategory = EntityCategory.Functions
+                              selectedItemIndex = initialItemIndex
+                              expandedCategories = [ EntityCategory.Functions ]
+                              entityDefinition = Stdlib.Option.Option.None
+                              entityCache = [] }
+                        let moduleView = formatModuleContent viewingState
+                        // Enter alternate screen buffer when first entering view mode, then render interface
+                        let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
+                        let completeInterface = renderViewingInterface moduleView true
+                        let newState =
+                          { state with
+                              commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
+                              viewingState = Stdlib.Option.Option.Some viewingState }
+                        (newState, [])
 
                   | _ ->
                     // Not in a module context

--- a/packages/darklang/cli/command.dark
+++ b/packages/darklang/cli/command.dark
@@ -39,6 +39,67 @@ module Darklang =
           //execute: List<String> -> Unit
           }
 
+      /// Display control constants
+      module Display =
+        let clearScreen = "\x1b[2J\x1b[H"
+        let enterAltScreen = "\x1b[?1049h"
+        let exitAltScreen = "\x1b[?1049l"
+
+      let renderView (content: ViewContent) (clearScreen: Bool) : String =
+        match content with
+        | ModuleView (category, items, selectedIndex) ->
+          let categoryName = entityCategoryToString category
+          let formattedItems =
+            items
+            |> Stdlib.List.indexedMap (fun index item ->
+              if index == selectedIndex then
+                $"{CliColors.magenta}[{item}]{CliColors.reset}"
+              else
+                item)
+          let itemsDisplay = if Stdlib.List.isEmpty formattedItems then "(none)" else Stdlib.String.join formattedItems ", "
+          itemsDisplay
+
+        | EntityDefinitionView entityDef ->
+          let totalLines = entityDef.lines |> Stdlib.List.length
+          let contentHeight = getContentViewportHeight totalLines
+          let safeContentHeight = Stdlib.Int64.max 1L contentHeight
+
+          // Ensure scroll position is within bounds
+          let maxScrollPos = Stdlib.Int64.max 0L (totalLines - safeContentHeight)
+          let adjustedScrollPos =
+            entityDef.scrollPosition
+            |> Stdlib.Int64.max 0L
+            |> Stdlib.Int64.min maxScrollPos
+
+          let visibleLines =
+            entityDef.lines
+            |> Stdlib.List.drop adjustedScrollPos
+            |> Stdlib.List.take safeContentHeight
+
+          $"{CliColors.blue}{entityDef.name}\n\n" ++ (visibleLines |> Stdlib.String.join "\n")
+
+      /// Wraps the content with a help bar and clears the screen if needed
+      let renderViewingInterface (content: String) (clearScreen: Bool) : String =
+        let clearAndHome = if clearScreen then Display.clearScreen else ""
+        let helpBar = $"{CliColors.gray}↑/↓: categories  ←/→: items  Enter: expand/collapse  b: back  q: quit{CliColors.reset}\n\n"
+        $"{clearAndHome}{content}\n{helpBar}"
+
+      let getTerminalHeight () : Int64 =
+        Builtin.cliGetTerminalHeight ()
+
+      /// Calculates the content viewport height for entity definitions
+      let getContentViewportHeight (totalLines: Int64) : Int64 =
+        let viewportHeight = getTerminalHeight ()
+        let reservedLines = 5L // title (2) + help bar (2) + spacing (1)
+        let availableHeight = Stdlib.Int64.max 1L (viewportHeight - reservedLines)
+        Stdlib.Int64.min totalLines availableHeight
+
+      let renderEntityInterface (entityName: String) (lines: List<String>) (scrollPosition: Int64) : String =
+        let entityDef = EntityDefinition { name = entityName; lines = lines; scrollPosition = scrollPosition }
+        let content = ViewContent.EntityDefinitionView entityDef
+        let visibleContent = renderView content true
+        renderViewingInterface visibleContent true
+
 
       type GeneralCommand =
         | Status // if in the middle of something, will tell you
@@ -150,47 +211,141 @@ module Darklang =
         | Some idx -> Stdlib.Option.Option.Some (Stdlib.String.slice fullyQualifiedName 0L idx)
         | None -> Stdlib.Option.Option.None
 
-      /// Creates an error state with the given message
-      let createErrorState (state: State) (message: String) : State =
-        { state with commandResult = CommandResult.Error message }
+      /// Converts an EntityCategory to its string representation
+      let entityCategoryToString (category: EntityCategory) : String =
+        match category with
+        | Functions -> "functions"
+        | Types -> "types"
+        | Constants -> "constants"
+        | Submodules -> "submodules"
+
+      /// Converts a category index to an EntityCategory
+      let indexToEntityCategory (index: Int64) : EntityCategory =
+        match index with
+        | 0L -> EntityCategory.Functions
+        | 1L -> EntityCategory.Types
+        | 2L -> EntityCategory.Constants
+        | 3L -> EntityCategory.Submodules
+        | _ -> EntityCategory.Functions  // Default fallback
+
+      /// Converts an EntityCategory to its index
+      let entityCategoryToIndex (category: EntityCategory) : Int64 =
+        match category with
+        | Functions -> 0L
+        | Types -> 1L
+        | Constants -> 2L
+        | Submodules -> 3L
+
+      /// Entity lookup that finds an entity by name and returns its type and pretty-printed definition
+      let findEntity (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) (name: String) : Stdlib.Option.Option<(String * String)> =
+        let constantResult =
+          moduleContent.constants
+          |> Stdlib.List.findFirst (fun c -> c.name.name == name)
+          |> Stdlib.Option.map (fun c -> ("Constant", PrettyPrinter.ProgramTypes.packageConstant c))
+
+        let functionResult =
+          moduleContent.fns
+          |> Stdlib.List.findFirst (fun f -> f.name.name == name)
+          |> Stdlib.Option.map (fun f -> ("Function", PrettyPrinter.ProgramTypes.packageFn f))
+
+        let typeResult =
+          moduleContent.types
+          |> Stdlib.List.findFirst (fun t -> t.name.name == name)
+          |> Stdlib.Option.map (fun t -> ("Type", PrettyPrinter.ProgramTypes.packageType t))
+
+        // Return the first match found (constants, then functions, then types)
+        match constantResult with
+        | Some _ -> constantResult
+        | None ->
+          match functionResult with
+          | Some _ -> functionResult
+          | None -> typeResult
+
+      /// Gets entities from moduleContent for a given category
+      let getEntitiesForCategory (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) (category: EntityCategory) (currentEntityName: String) : List<String> =
+        match category with
+        | Functions -> moduleContent.fns |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name)
+        | Types -> moduleContent.types |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name)
+        | Constants -> moduleContent.constants |> Stdlib.List.map (fun constant -> LanguageTools.ProgramTypes.PackageConstant.nameToString constant.name)
+        | Submodules ->
+          (moduleContent.submodules
+            |> Stdlib.List.map (fun m ->
+              m
+              |> Stdlib.List.map (fun singleModulePath ->
+                Stdlib.String.join singleModulePath "."))
+            |> Stdlib.List.flatten
+            |> Stdlib.List.filter (fun submodule ->
+              // Filter out the current module itself from the submodules list
+              submodule != currentEntityName))
 
 
-      /// Formats a section of entities for display
-      let formatEntitySection (sectionName: String) (entities: List<String>) : String =
+      /// Formats a section of entities for display with expandable state and scrolling
+      let formatEntitySection (viewingState: ViewingState) (category: EntityCategory) (entities: List<String>) : String =
+        let sectionName = entityCategoryToString category
+        let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 category
+
+        let expandIndicator = if isExpanded then $"{CliColors.purple}▼{CliColors.reset}" else $"{CliColors.purple}▶{CliColors.reset}"
+        let selectionIndicator = if viewingState.selectedCategory == category then "→ " else "  "
+        let header = $"{selectionIndicator}{expandIndicator} {sectionName} {CliColors.gray}({entities |> Stdlib.List.length |> Stdlib.Int64.toString}){CliColors.reset}"
+
         if Stdlib.List.isEmpty entities then
-          $"{sectionName}:\n\n(none)\n"
-        else
-          $"{sectionName}:\n\n" ++ (Stdlib.String.join entities "\n") ++ "\n"
+          $"{header}\n\n(none)\n"
+        else if isExpanded then
+          // Extract just the names without module prefixes
+          let shortNames =
+            entities
+            |> Stdlib.List.map (fun fullName ->
+              fullName
+              |> Stdlib.String.split "."
+              |> Stdlib.List.last
+              |> Stdlib.Option.withDefault fullName)
 
-      let formatModuleContent (entityName: String) (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) : String =
+          if viewingState.selectedCategory == category && viewingState.selectedItemIndex >= 0L then
+            let content = ViewContent.ModuleView (category, shortNames, viewingState.selectedItemIndex)
+            let itemsDisplay = renderView content false
+            $"{header}\n\n{itemsDisplay}\n"
+          else
+            $"{header}\n\n" ++ (Stdlib.String.join shortNames ", ") ++ "\n"
+        else
+          $"{header}\n"
+
+
+      let formatModuleContent (viewingState: ViewingState) : String =
         let functionsSection =
           formatEntitySection
-            "functions"
-            (moduleContent.fns
+            viewingState
+            EntityCategory.Functions
+            (viewingState.moduleContent.fns
               |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
 
         let typesSection =
           formatEntitySection
-            "types"
-            (moduleContent.types
+            viewingState
+            EntityCategory.Types
+            (viewingState.moduleContent.types
               |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
 
         let constantsSection =
           formatEntitySection
-            "constants"
-            (moduleContent.constants
+            viewingState
+            EntityCategory.Constants
+            (viewingState.moduleContent.constants
               |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
 
         let submodulesSection =
           formatEntitySection
-            "submodules"
-            ((moduleContent.submodules
+            viewingState
+            EntityCategory.Submodules
+            ((viewingState.moduleContent.submodules
               |> Stdlib.List.map (fun m ->
                 m
-                |> Stdlib.List.map (fun s -> s |> Stdlib.String.join ".")))
-              |> Stdlib.List.flatten)
+                |> Stdlib.List.map (fun singleModulePath ->
+                  Stdlib.String.join singleModulePath "."))
+              |> Stdlib.List.flatten
+              |> Stdlib.List.filter (fun submodule ->
+                submodule != viewingState.entityName)))
 
-        $"Module: {entityName}\n\n" ++
+        $"{CliColors.blue}Module: {viewingState.entityName}{CliColors.reset}\n\n" ++
         functionsSection ++ "\n" ++
         typesSection ++ "\n" ++
         constantsSection ++ "\n" ++
@@ -260,105 +415,57 @@ module Darklang =
           (newState, [])
 
 
+      /// Gets an entity definition from cache or creates a new one
+      let getOrCreateEntityDefinition (viewingState: ViewingState) (entityType: String) (fullyQualifiedName: String) (prettyPrinted: String) : (EntityDefinition * ViewingState) =
+        let cacheKey = $"{entityType}:{fullyQualifiedName}"
+
+        // Check cache first
+        match viewingState.entityCache |> Stdlib.List.findFirst (fun (key, _) -> key == cacheKey) with
+        | Some (_, cachedDef) -> (cachedDef, viewingState)
+        | None ->
+          // Create new definition and add to cache
+          let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+          let lines = highlighted |> Stdlib.String.split "\n"
+          let entityDefinition = EntityDefinition { name = $"{entityType}: {fullyQualifiedName}"; lines = lines; scrollPosition = 0L }
+          let newCache = viewingState.entityCache |> Stdlib.List.push (cacheKey, entityDefinition)
+          let newViewingState = { viewingState with entityCache = newCache }
+          (entityDefinition, newViewingState)
+
+      let renderEntityDefinition (state: State) (entityType: String) (fullyQualifiedName: String) (prettyPrinted: String) : (State * List<Msg>) =
+        match state.viewingState with
+        | Some viewingState ->
+          let (entityDefinition, updatedViewingState) = getOrCreateEntityDefinition viewingState entityType fullyQualifiedName prettyPrinted
+          let completeInterface = renderEntityInterface entityDefinition.name entityDefinition.lines entityDefinition.scrollPosition
+          let finalViewingState = { updatedViewingState with entityDefinition = Stdlib.Option.Option.Some entityDefinition }
+          let newState =
+            { state with
+                commandResult = CommandResult.Success completeInterface
+                viewingState = Stdlib.Option.Option.Some finalViewingState
+                needsFullRedraw = true }
+          (newState, [])
+        | None ->
+          let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+          let newState =
+            { state with
+                commandResult = CommandResult.Success $"{entityType}: {fullyQualifiedName}\n\n{highlighted}" }
+          (newState, [])
+
       /// Helper function to view an entity by its fully qualified name
       let viewEntityByName (state: State) (fullyQualifiedName: String) : (State * List<Msg>) =
         let modules = fullyQualifiedName |> Stdlib.String.split "." |> Stdlib.List.dropLast
         let text = fullyQualifiedName |> Stdlib.String.split "." |> Stdlib.List.last |> Builtin.unwrap
 
         let query = createSearchQuery modules text
+        let moduleContent = LanguageTools.PackageManager.Search.search query
 
-        let moduleContent =
-          LanguageTools.PackageManager.Search.search query
-
-
-        match moduleContent.fns, moduleContent.types, moduleContent.constants with
-        | [], [], [] ->
+        match findEntity moduleContent text with
+        | Some ((entityType, prettyPrinted)) ->
+          renderEntityDefinition state entityType fullyQualifiedName prettyPrinted
+        | None ->
           let newState =
             { state with
-                commandResult =
-                  CommandResult.Error $"No entities found for: {fullyQualifiedName}" }
-
+                commandResult = CommandResult.Error $"Entity not found: {fullyQualifiedName}" }
           (newState, [])
-
-        | fns, [], [] ->
-          let fn =
-            fns
-            |> Stdlib.List.filter (fun fn -> fn.name.name == text)
-            |> Stdlib.List.head
-
-          match fn with
-          | None ->
-            let newState =
-              { state with
-                  commandResult =
-                    CommandResult.Error $"Function not found: {fullyQualifiedName}" }
-            (newState, [])
-
-          | Some fn ->
-            let prettyPrinted = PrettyPrinter.ProgramTypes.packageFn fn
-
-            let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
-
-            let newState =
-              { state with
-                  commandResult =
-                    CommandResult.Success $"Function: {fullyQualifiedName}\n\n{highlighted}" }
-
-            (newState, [])
-
-        | [], types, [] ->
-          let typ =
-            types
-            |> Stdlib.List.filter (fun typ -> typ.name.name == text)
-            |> Stdlib.List.head
-
-          match typ with
-          | None ->
-            let newState =
-              { state with
-                  commandResult =
-                    CommandResult.Error $"Type not found: {fullyQualifiedName}" }
-            (newState, [])
-
-          | Some typ ->
-            let prettyPrinted = PrettyPrinter.ProgramTypes.packageType typ
-
-            let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
-
-            let newState =
-              { state with
-                  commandResult =
-                    CommandResult.Success $"Type: {fullyQualifiedName}\n\n{highlighted}" }
-
-            (newState, [])
-
-        | [], [], constants ->
-          let constant =
-            constants
-            |> Stdlib.List.filter (fun c -> c.name.name == text)
-            |> Stdlib.List.head
-
-          match constant with
-          | None ->
-            let newState =
-              { state with
-                  commandResult =
-                    CommandResult.Error $"Constant not found: {fullyQualifiedName}" }
-            (newState, [])
-            s
-          | Some constant ->
-            let prettyPrinted = PrettyPrinter.ProgramTypes.packageConstant constant
-
-            let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
-
-            let newState =
-              { state with
-                  commandResult =
-                    CommandResult.Success $"Constant: {fullyQualifiedName}\n\n{highlighted}" }
-
-            (newState, [])
-
-        | _ -> (createErrorState state $"Entity not found: {fullyQualifiedName}", [])
 
 
       /// Returns commands available in the current state
@@ -537,8 +644,25 @@ module Darklang =
                         viewEntityByName state entityName
 
                     else
-                      let moduleView = formatModuleContent entityName moduleContent
-                      let newState = { state with commandResult = CommandResult.Success moduleView }
+                      // Create viewing state with functions expanded and first item selected
+                      let initialItemIndex = if Stdlib.List.isEmpty moduleContent.fns then -1L else 0L
+                      let viewingState =
+                        ViewingState
+                          { moduleContent = moduleContent
+                            entityName = entityName
+                            selectedCategory = EntityCategory.Functions
+                            selectedItemIndex = initialItemIndex
+                            expandedCategories = [ EntityCategory.Functions ]
+                            entityDefinition = Stdlib.Option.Option.None
+                            entityCache = [] }
+                      let moduleView = formatModuleContent viewingState
+                      // Enter alternate screen buffer when first entering view mode, then render interface
+                      let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
+                      let completeInterface = renderViewingInterface moduleView true
+                      let newState =
+                        { state with
+                            commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
+                            viewingState = Stdlib.Option.Option.Some viewingState }
                       (newState, [])
 
                   | Module(owner, submodules) ->
@@ -559,10 +683,25 @@ module Darklang =
                       viewEntityByName state fullyQualifiedName
 
                     else
-                      let moduleView =
-                        formatModuleContent fullyQualifiedName moduleContent
-
-                      let newState = { state with commandResult = CommandResult.Success moduleView }
+                      // Create viewing state with functions expanded and first item selected
+                      let initialItemIndex = if Stdlib.List.isEmpty moduleContent.fns then -1L else 0L
+                      let viewingState =
+                        ViewingState
+                          { moduleContent = moduleContent
+                            entityName = fullyQualifiedName
+                            selectedCategory = EntityCategory.Functions
+                            selectedItemIndex = initialItemIndex
+                            expandedCategories = [ EntityCategory.Functions ]
+                            entityDefinition = Stdlib.Option.Option.None
+                            entityCache = [] }
+                      let moduleView = formatModuleContent viewingState
+                      // Enter alternate screen buffer when first entering view mode, then render interface
+                      let enterAltScreen = if Stdlib.Option.isNone state.viewingState then Display.enterAltScreen else ""
+                      let completeInterface = renderViewingInterface moduleView true
+                      let newState =
+                        { state with
+                            commandResult = CommandResult.Success (enterAltScreen ++ completeInterface)
+                            viewingState = Stdlib.Option.Option.Some viewingState }
                       (newState, [])
 
                   | _ ->
@@ -954,7 +1093,17 @@ module Darklang =
                       let query = createSearchQuery (modulePrefix |> Stdlib.String.split ".") ""
                       let moduleContent = LanguageTools.PackageManager.Search.search query
 
-                      let moduleView = formatModuleContent modulePrefix moduleContent
+                      // Create a simple viewing state for non-interactive display
+                      let simpleViewingState =
+                        ViewingState
+                          { moduleContent = moduleContent
+                            entityName = modulePrefix
+                            selectedCategory = EntityCategory.Functions
+                            selectedItemIndex = -1L
+                            expandedCategories = []
+                            entityDefinition = Stdlib.Option.Option.None
+                            entityCache = [] }
+                      let moduleView = formatModuleContent simpleViewingState
 
                       let newState = { state with commandResult = CommandResult.Success moduleView }
                       (newState, [])

--- a/packages/darklang/cli/commandHelpers/view.dark
+++ b/packages/darklang/cli/commandHelpers/view.dark
@@ -17,7 +17,6 @@ module Darklang =
           | 1L -> EntityCategory.Types
           | 2L -> EntityCategory.Constants
           | 3L -> EntityCategory.Submodules
-          | _ -> EntityCategory.Functions  // Default fallback
 
         /// Converts an EntityCategory to its index
         let entityCategoryToIndex (category: EntityCategory) : Int64 =
@@ -33,69 +32,80 @@ module Darklang =
           let renderView (content: ViewContent) : String =
             match content with
             | ModuleView (category, items, selectedIndex) ->
-              let formattedItems =
-                items
-                |> Stdlib.List.indexedMap (fun index item ->
-                  if index == selectedIndex then
-                    $"{CliColors.magenta}[{item}]{CliColors.reset}"
-                  else
-                    item)
-              if Stdlib.List.isEmpty formattedItems then "(none)" else Stdlib.String.join formattedItems ", "
+              if Stdlib.List.isEmpty items then
+                "(none)"
+              else
+                // Calculate how many items we can show (adapts based on terminal size)
+                let terminalWidth = Terminal.getWidth ()
+                let avgItemLength = 15L
+                let itemsPerLine = Stdlib.Int64.max 1L (terminalWidth |> Stdlib.Int64.divide (avgItemLength + 2L))
+
+                let maxLines =
+                  if terminalWidth > 120L then 10L
+                  else if terminalWidth > 80L then 5L
+                  else 3L
+
+                let maxViewportItems = itemsPerLine * maxLines
+
+                // If we have more items than can fit, show a viewport around the selected item
+                if (items |> Stdlib.List.length) > maxViewportItems && selectedIndex >= 0L then
+                  let totalItems = items |> Stdlib.List.length
+                  let halfViewport = maxViewportItems |> Stdlib.Int64.divide 2L
+
+                  // Calculate viewport start, keeping selected item in center when possible
+                  let viewportStart =
+                    (Stdlib.Int64.max 0L (selectedIndex - halfViewport))
+                    |> Stdlib.Int64.min (totalItems - maxViewportItems)
+
+                  let viewportEnd = Stdlib.Int64.min totalItems (viewportStart + maxViewportItems)
+
+                  let visibleItems =
+                    items
+                    |> Stdlib.List.drop viewportStart
+                    |> Stdlib.List.take (viewportEnd - viewportStart)
+
+                  let formattedItems =
+                    visibleItems
+                    |> Stdlib.List.indexedMap (fun localIndex item ->
+                      let globalIndex = viewportStart + localIndex
+                      if globalIndex == selectedIndex then
+                        $"{CliColors.magenta}[{item}]{CliColors.reset}"
+                      else
+                        item)
+
+                  // Add indicators for hidden items
+                  let prefix = if viewportStart > 0L then "... " else ""
+                  let suffix = if viewportEnd < totalItems then " ..." else ""
+
+                  prefix ++ (Stdlib.String.join formattedItems ", ") ++ suffix
+                else
+                  // Show all items if they fit
+                  let formattedItems =
+                    items
+                    |> Stdlib.List.indexedMap (fun index item ->
+                      if index == selectedIndex then
+                        $"{CliColors.magenta}[{item}]{CliColors.reset}"
+                      else
+                        item)
+                  Stdlib.String.join formattedItems ", "
 
             | EntityDefinitionView entityDef ->
-              // Calculate actual display lines accounting for wrapping
-              let terminalWidth = Terminal.getWidth ()
-              let displayLinesInfo =
-                entityDef.lines
-                |> Stdlib.List.map (fun line ->
-                  (line, Terminal.calculateWrappedLineCount line terminalWidth))
+              // Line-based scrolling
+              let totalLines = entityDef.lines |> Stdlib.List.length
+              let viewportHeight = Terminal.getViewportHeight totalLines 5L
 
-              let totalDisplayLines =
-                displayLinesInfo
-                |> Stdlib.List.fold 0L (fun acc (_, count) -> acc + count)
-
-              let viewportHeight = Terminal.getContentViewportHeight totalDisplayLines
-              let safeViewportHeight = Stdlib.Int64.max 1L viewportHeight
-
-              // Calculate scroll position in terms of display lines
-              let maxScrollPos =
-                if totalDisplayLines <= safeViewportHeight then
-                  0L
-                else
-                  totalDisplayLines - safeViewportHeight
-
+              // Ensure scroll position is within bounds (allow scrolling to line 0)
+              let maxScrollPos = Stdlib.Int64.max 0L (totalLines - viewportHeight)
               let adjustedScrollPos =
                 entityDef.scrollPosition
                 |> Stdlib.Int64.max 0L
                 |> Stdlib.Int64.min maxScrollPos
 
-              // Find which logical lines to show based on display line scroll position
+              // Get visible lines using simple slicing
               let visibleLines =
-                displayLinesInfo
-                |> Stdlib.List.fold ([], (0L, adjustedScrollPos, safeViewportHeight))
-                  (fun acc lineInfo ->
-                    let (accLines, state) = acc
-                    let (currentDisplayLine, skipLines, remainingViewport) = state
-                    let (line, wrappedCount) = lineInfo
-
-                    if remainingViewport <= 0L then
-                      // Viewport is full
-                      (accLines, (currentDisplayLine + wrappedCount, skipLines, remainingViewport))
-                    else if skipLines >= wrappedCount then
-                      // Skip this entire logical line
-                      (accLines, (currentDisplayLine + wrappedCount, skipLines - wrappedCount, remainingViewport))
-                    else if skipLines > 0L then
-                      // Partially skip this line (edge case for wrapped lines)
-                      let displayCount = Stdlib.Int64.min wrappedCount remainingViewport
-                      (Stdlib.List.push accLines line, (currentDisplayLine + wrappedCount, 0L, remainingViewport - displayCount))
-                    else
-                      // Include this line
-                      let displayCount = Stdlib.Int64.min wrappedCount remainingViewport
-                      (Stdlib.List.push accLines line, (currentDisplayLine + wrappedCount, 0L, remainingViewport - displayCount))
-                  )
-                |> fun result ->
-                  let (lines, _) = result
-                  lines |> Stdlib.List.reverse
+                entityDef.lines
+                |> Stdlib.List.drop adjustedScrollPos
+                |> Stdlib.List.take viewportHeight
 
               $"{CliColors.blue}{entityDef.name}\n\n" ++ (visibleLines |> Stdlib.String.join "\n")
 
@@ -224,23 +234,15 @@ module Darklang =
                   |> Stdlib.List.filter (fun submodule ->
                     submodule != viewingState.entityName))
 
-            let moduleHeader = $"{CliColors.blue}Module: {viewingState.entityName}{CliColors.reset}\n"
-
             // Scrollable content (everything below the module title)
-            let scrollableContent =
-              "\n" ++
-              functionsSection ++ "\n" ++
-              typesSection ++ "\n" ++
-              constantsSection ++ "\n" ++
-              submodulesSection
+            let scrollableContent = Rendering.buildScrollableContent viewingState
 
             // Apply viewport scrolling only to the scrollable content
             let scrollableLines = scrollableContent |> Stdlib.String.split "\n"
             let totalScrollableLines = scrollableLines |> Stdlib.List.length
-            let viewportHeight = Terminal.getModuleViewportHeight ()
 
-            // Reserve space for the module header (1 line)
-            let availableScrollHeight = Stdlib.Int64.max 1L (viewportHeight - 1L)
+            // Calculate viewport height for module view
+            let availableScrollHeight = Terminal.getViewportHeight totalScrollableLines 4L
 
             // Ensure scroll position is within bounds
             let maxScrollPos = Stdlib.Int64.max 0L (totalScrollableLines - availableScrollHeight)
@@ -254,8 +256,56 @@ module Darklang =
               |> Stdlib.List.drop adjustedScrollPos
               |> Stdlib.List.take availableScrollHeight
 
-            // Combine fixed header with scrollable content
-            moduleHeader ++ (visibleScrollableLines |> Stdlib.String.join "\n")
+            let contentPart =
+              if Stdlib.List.isEmpty visibleScrollableLines then
+                ""
+              else
+                visibleScrollableLines |> Stdlib.String.join "\n"
+
+            // Always show header, even if no room for content (match entity definition format)
+            $"{CliColors.blue}Module: {viewingState.entityName}{CliColors.reset}\n\n" ++ contentPart
+
+          /// Builds the scrollable content for a viewing state
+          let buildScrollableContent (viewingState: ViewingState) : String =
+            let functionsSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Functions
+                (viewingState.moduleContent.fns
+                  |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
+
+            let typesSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Types
+                (viewingState.moduleContent.types
+                  |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
+
+            let constantsSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Constants
+                (viewingState.moduleContent.constants
+                  |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
+
+            let submodulesSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Submodules
+                (viewingState.moduleContent.submodules
+                  |> Stdlib.List.map (fun m ->
+                    m
+                    |> Stdlib.List.map (fun singleModulePath ->
+                      Stdlib.String.join singleModulePath "."))
+                  |> Stdlib.List.flatten
+                  |> Stdlib.List.filter (fun submodule ->
+                    submodule != viewingState.entityName))
+
+            "\n" ++
+            functionsSection ++ "\n" ++
+            typesSection ++ "\n" ++
+            constantsSection ++ "\n" ++
+            submodulesSection
 
         module Navigation =
           type ScrollDirection = Up | Down | PageUp | PageDown
@@ -264,7 +314,11 @@ module Darklang =
           let handleModuleViewportScroll (state: State) (direction: ScrollDirection) : (State * List<Msg>) =
             match state.viewingState with
             | Some viewingState ->
-              let viewportHeight = Terminal.getModuleViewportHeight ()
+              // Build the scrollable content to calculate total lines
+              let scrollableContent = Rendering.buildScrollableContent viewingState
+              let scrollableLines = scrollableContent |> Stdlib.String.split "\n"
+              let totalLines = scrollableLines |> Stdlib.List.length
+              let viewportHeight = Terminal.getViewportHeight totalLines 4L
 
               let newScrollPos =
                 match direction with
@@ -291,14 +345,10 @@ module Darklang =
             | Some viewingState ->
               match viewingState.entityDefinition with
               | Some entityDef ->
-                let terminalWidth = Terminal.getWidth ()
-                let totalDisplayLines =
-                  entityDef.lines
-                  |> Stdlib.List.fold 0L (fun acc line ->
-                    acc + Terminal.calculateWrappedLineCount line terminalWidth)
-
-                let contentHeight = Terminal.getContentViewportHeight totalDisplayLines
-                let maxScroll = Stdlib.Int64.max 0L (totalDisplayLines - contentHeight)
+                // Line-based scrolling
+                let totalLines = entityDef.lines |> Stdlib.List.length
+                let contentHeight = Terminal.getViewportHeight totalLines 5L
+                let maxScroll = Stdlib.Int64.max 0L (totalLines - contentHeight)
 
                 let scrollAmount =
                   match direction with
@@ -326,55 +376,37 @@ module Darklang =
             | None ->
               (state, [])
 
-          /// Calculate the line position of a category header in the scrollable content
-          let calculateCategoryLinePosition (viewingState: ViewingState) (targetCategory: EntityCategory) : Int64 =
-            let blankLineAfterModuleTitle = 1L // blank line after "Module: X"
-            let targetIndex = View.entityCategoryToIndex targetCategory
+          /// Find the line position of a category header by searching in the built content
+          let findCategoryLinePosition (scrollableContent: String) (targetCategory: EntityCategory) : Int64 =
+            let categoryName = View.entityCategoryToString targetCategory
+            let lines = scrollableContent |> Stdlib.String.split "\n"
 
-            // Count lines for each category before the target
-            let categories = [EntityCategory.Functions; EntityCategory.Types; EntityCategory.Constants; EntityCategory.Submodules]
+            // Look for line containing the category name (simple string search)
+            lines
+            |> Stdlib.List.indexedMap (fun index line -> (index, line))
+            |> Stdlib.List.findFirst (fun (_, line) -> line |> Stdlib.String.contains categoryName)
+            |> Stdlib.Option.map (fun (index, _) -> index)
+            |> Stdlib.Option.withDefault 0L
 
-            let linesBeforeTarget =
-              categories
-              |> Stdlib.List.take targetIndex
-              |> Stdlib.List.fold 0L (fun acc category ->
-                let entities = EntityLookup.getEntitiesForCategory viewingState.moduleContent category viewingState.entityName
-                let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 category
-
-                let headerLine = 1L
-                let contentLines =
-                  if Stdlib.List.isEmpty entities then
-                    2L // blank line + "(none)" + blank line
-                  else if isExpanded then
-                    3L // blank line + content + blank line
-                  else
-                    1L // blank line after header
-
-                acc + headerLine + contentLines
-              )
-
-            blankLineAfterModuleTitle + linesBeforeTarget
-
-          /// Helper function to ensure a category is visible in the scrollable viewport area
+          /// Scroll to make a category visible (simple approach)
           let ensureCategoryVisible (viewingState: ViewingState) (category: EntityCategory) : Int64 =
-            let categoryLine = calculateCategoryLinePosition viewingState category
-            let viewportHeight = Terminal.getModuleViewportHeight ()
-            let availableScrollHeight = Stdlib.Int64.max 1L (viewportHeight - 1L)
+            // Build scrollable content and find category position in it
+            let scrollableContent = Rendering.buildScrollableContent viewingState
+            let categoryLine = findCategoryLinePosition scrollableContent category
+            let scrollableLines = scrollableContent |> Stdlib.String.split "\n"
+            let totalLines = scrollableLines |> Stdlib.List.length
+            let viewportHeight = Terminal.getViewportHeight totalLines 4L
+
             let currentScrollPos = viewingState.viewportScrollPosition
             let viewportTop = currentScrollPos
-            let viewportBottom = currentScrollPos + availableScrollHeight - 1L
+            let viewportBottom = currentScrollPos + viewportHeight - 1L
 
-            if categoryLine < viewportTop then
-              // Category is above viewport, scroll up to show it at the top
+            // If category is not visible, scroll to show it
+            if categoryLine < viewportTop || categoryLine > viewportBottom then
+              // Category is outside viewport - scroll to show it at the top
               Stdlib.Int64.max 0L categoryLine
-            else if categoryLine > viewportBottom then
-              // Category is below viewport, scroll down to show it near the top
-              Stdlib.Int64.max 0L (categoryLine - 2L) // Show category header 2 lines from top
-            else if categoryLine > (viewportTop + (availableScrollHeight |> Stdlib.Int64.divide 2L)) then
-              // Category is in lower half, move it to upper half for better visibility
-              Stdlib.Int64.max 0L (categoryLine - 2L)
             else
-              // Category is already visible in upper half, keep current position
+              // Category is already visible - keep current scroll position
               currentScrollPos
 
           /// Helper function to update selection and redraw view with auto-scroll to keep selection visible

--- a/packages/darklang/cli/commandHelpers/view.dark
+++ b/packages/darklang/cli/commandHelpers/view.dark
@@ -28,11 +28,6 @@ module Darklang =
           | Submodules -> 3L
 
         module Rendering =
-          /// Display control constants
-          module Display =
-            let clearScreen = "\x1b[2J\x1b[H"
-            let enterAltScreen = "\x1b[?1049h"
-            let exitAltScreen = "\x1b[?1049l"
 
           /// Renders view content based on type
           let renderView (content: ViewContent) : String =
@@ -49,17 +44,17 @@ module Darklang =
 
             | EntityDefinitionView entityDef ->
               // Calculate actual display lines accounting for wrapping
-              let terminalWidth = getTerminalWidth ()
+              let terminalWidth = Terminal.getWidth ()
               let displayLinesInfo =
                 entityDef.lines
                 |> Stdlib.List.map (fun line ->
-                  (line, calculateWrappedLineCount line terminalWidth))
+                  (line, Terminal.calculateWrappedLineCount line terminalWidth))
 
               let totalDisplayLines =
                 displayLinesInfo
                 |> Stdlib.List.fold 0L (fun acc (_, count) -> acc + count)
 
-              let viewportHeight = getContentViewportHeight totalDisplayLines
+              let viewportHeight = Terminal.getContentViewportHeight totalDisplayLines
               let safeViewportHeight = Stdlib.Int64.max 1L viewportHeight
 
               // Calculate scroll position in terms of display lines
@@ -104,50 +99,23 @@ module Darklang =
 
               $"{CliColors.blue}{entityDef.name}\n\n" ++ (visibleLines |> Stdlib.String.join "\n")
 
-          /// Wraps the content with a help bar
-          let renderViewingInterface (content: String) : String =
+          /// Wraps the content with a help bar for module viewing
+          let renderModuleViewingInterface (content: String) : String =
             let helpBar = $"{CliColors.gray}↑/↓: categories  ←/→: entities  Enter: expand/view  b: back  q: quit{CliColors.reset}\n\n"
-            $"{Display.clearScreen}{content}\n{helpBar}"
+            $"{Terminal.Display.clearScreen}{content}\n{helpBar}"
 
-          /// Gets terminal height
-          let getTerminalHeight () : Int64 =
-            Builtin.cliGetTerminalHeight ()
+          /// Wraps the content with a help bar for entity definition viewing
+          let renderEntityViewingInterface (content: String) : String =
+            let helpBar = $"{CliColors.gray}↑/↓: scroll  ←/→: page  Enter: collapse  b: back  q: quit{CliColors.reset}\n\n"
+            $"{Terminal.Display.clearScreen}{content}\n{helpBar}"
 
-          /// Gets terminal width
-          let getTerminalWidth () : Int64 =
-            Builtin.cliGetTerminalWidth ()
-
-          /// Calculate how many display lines a logical line will take when wrapped
-          let calculateWrappedLineCount (line: String) (terminalWidth: Int64) : Int64 =
-            let lineLength = Stdlib.String.length line
-            let safeTerminalWidth = Stdlib.Int64.max 1L terminalWidth
-            if lineLength <= safeTerminalWidth then
-              1L
-            else
-              let quotient = lineLength |> Stdlib.Int64.divide safeTerminalWidth
-              match lineLength |> Stdlib.Int64.remainder safeTerminalWidth with
-              | Ok remainder -> if remainder == 0L then quotient else quotient + 1L
-              | Error _ -> quotient + 1L
-
-          /// Calculates the content viewport height for entity definitions
-          let getContentViewportHeight (totalLines: Int64) : Int64 =
-            let viewportHeight = getTerminalHeight ()
-            let reservedLines = 5L // title (2) + help bar (2) + spacing (1)
-            let availableHeight = Stdlib.Int64.max 1L (viewportHeight - reservedLines)
-            Stdlib.Int64.min availableHeight totalLines
-
-          /// Calculates the module viewport height for scrollable module content
-          let getModuleViewportHeight () : Int64 =
-            let viewportHeight = getTerminalHeight ()
-            let reservedLines = 3L // help bar (2) + spacing (1)
-            Stdlib.Int64.max 1L (viewportHeight - reservedLines)
 
           /// Renders entity interface with scrolling
           let renderEntityInterface (entityName: String) (lines: List<String>) (scrollPosition: Int64) : String =
             let entityDef = EntityDefinition { name = entityName; lines = lines; scrollPosition = scrollPosition }
             let content = ViewContent.EntityDefinitionView entityDef
             let visibleContent = renderView content
-            renderViewingInterface visibleContent
+            renderEntityViewingInterface visibleContent
 
           /// Formats a section of entities for display with expandable state and scrolling
           let formatEntitySection (viewingState: ViewingState) (category: EntityCategory) (entities: List<String>) : String =
@@ -269,7 +237,7 @@ module Darklang =
             // Apply viewport scrolling only to the scrollable content
             let scrollableLines = scrollableContent |> Stdlib.String.split "\n"
             let totalScrollableLines = scrollableLines |> Stdlib.List.length
-            let viewportHeight = getModuleViewportHeight ()
+            let viewportHeight = Terminal.getModuleViewportHeight ()
 
             // Reserve space for the module header (1 line)
             let availableScrollHeight = Stdlib.Int64.max 1L (viewportHeight - 1L)
@@ -296,7 +264,7 @@ module Darklang =
           let handleModuleViewportScroll (state: State) (direction: ScrollDirection) : (State * List<Msg>) =
             match state.viewingState with
             | Some viewingState ->
-              let viewportHeight = Rendering.getModuleViewportHeight ()
+              let viewportHeight = Terminal.getModuleViewportHeight ()
 
               let newScrollPos =
                 match direction with
@@ -307,7 +275,7 @@ module Darklang =
 
               let newViewingState = { viewingState with viewportScrollPosition = newScrollPos }
               let moduleView = Rendering.formatModuleContent newViewingState
-              let completeInterface = Rendering.renderViewingInterface moduleView
+              let completeInterface = Rendering.renderModuleViewingInterface moduleView
               let newState =
                 { state with
                     viewingState = Stdlib.Option.Option.Some newViewingState
@@ -323,13 +291,13 @@ module Darklang =
             | Some viewingState ->
               match viewingState.entityDefinition with
               | Some entityDef ->
-                let terminalWidth = Rendering.getTerminalWidth ()
+                let terminalWidth = Terminal.getWidth ()
                 let totalDisplayLines =
                   entityDef.lines
                   |> Stdlib.List.fold 0L (fun acc line ->
-                    acc + Rendering.calculateWrappedLineCount line terminalWidth)
+                    acc + Terminal.calculateWrappedLineCount line terminalWidth)
 
-                let contentHeight = Rendering.getContentViewportHeight totalDisplayLines
+                let contentHeight = Terminal.getContentViewportHeight totalDisplayLines
                 let maxScroll = Stdlib.Int64.max 0L (totalDisplayLines - contentHeight)
 
                 let scrollAmount =
@@ -390,7 +358,7 @@ module Darklang =
           /// Helper function to ensure a category is visible in the scrollable viewport area
           let ensureCategoryVisible (viewingState: ViewingState) (category: EntityCategory) : Int64 =
             let categoryLine = calculateCategoryLinePosition viewingState category
-            let viewportHeight = Rendering.getModuleViewportHeight ()
+            let viewportHeight = Terminal.getModuleViewportHeight ()
             let availableScrollHeight = Stdlib.Int64.max 1L (viewportHeight - 1L)
             let currentScrollPos = viewingState.viewportScrollPosition
             let viewportTop = currentScrollPos
@@ -413,21 +381,19 @@ module Darklang =
           let updateSelection (state: State) (category: EntityCategory) (itemIndex: Int64) : (State * List<Msg>) =
             match state.viewingState with
             | Some viewingState ->
-              let entities = EntityLookup.getEntitiesForCategory viewingState.moduleContent category viewingState.entityName
-              let shouldExpandNewCategory = Stdlib.Bool.not (Stdlib.List.isEmpty entities)
-
+              // If switching to a different category, collapse all. If staying in same category, preserve expanded state
               let newExpandedCategories =
-                if shouldExpandNewCategory then
-                  [category]
+                if category == viewingState.selectedCategory then
+                  viewingState.expandedCategories  // Keep current expanded state when navigating within category
                 else
-                  []
+                  []  // Collapse when switching categories
 
               let tempViewingState = { viewingState with selectedCategory = category; selectedItemIndex = itemIndex; expandedCategories = newExpandedCategories }
               let newScrollPosition = ensureCategoryVisible tempViewingState category
 
               let newViewingState = { tempViewingState with entityDefinition = Stdlib.Option.Option.None; viewportScrollPosition = newScrollPosition }
               let moduleView = Rendering.formatModuleContent newViewingState
-              let completeInterface = Rendering.renderViewingInterface moduleView
+              let completeInterface = Rendering.renderModuleViewingInterface moduleView
               let newState = { state with viewingState = Stdlib.Option.Option.Some newViewingState; commandResult = CommandResult.Success completeInterface; needsFullRedraw = true }
               (newState, [])
             | None ->
@@ -501,7 +467,7 @@ module Darklang =
                 | Some _ ->
                   let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.None }
                   let moduleView = Rendering.formatModuleContent newViewingState
-                  let completeInterface = Rendering.renderViewingInterface moduleView
+                  let completeInterface = Rendering.renderModuleViewingInterface moduleView
                   let newState =
                     { state with
                         viewingState = Stdlib.Option.Option.Some newViewingState
@@ -533,7 +499,7 @@ module Darklang =
                 | None ->
                   handleModuleViewportScroll state ScrollDirection.PageDown
               | Q ->
-                let exitAlternateScreen = Rendering.Display.exitAltScreen
+                let exitAlternateScreen = Terminal.Display.exitAltScreen
                 let newState =
                   { state with
                       viewingState = Stdlib.Option.Option.None
@@ -580,7 +546,7 @@ module Darklang =
                 { state with
                     commandResult = CommandResult.Error $"Entity not found: {fullyQualifiedName}" }
               (newState, [])
-            
+
           /// Entity lookup that finds an entity by name and returns its type and pretty-printed definition
           let findEntity (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) (name: String) : Stdlib.Option.Option<(String * String)> =
             let constantResult =

--- a/packages/darklang/cli/commandHelpers/view.dark
+++ b/packages/darklang/cli/commandHelpers/view.dark
@@ -1,0 +1,640 @@
+module Darklang =
+  module Cli =
+    module CommandHelpers =
+      module View =
+        /// Converts an EntityCategory to its string representation
+        let entityCategoryToString (category: EntityCategory) : String =
+          match category with
+          | Functions -> "functions"
+          | Types -> "types"
+          | Constants -> "constants"
+          | Submodules -> "submodules"
+
+        /// Converts a category index to an EntityCategory
+        let indexToEntityCategory (index: Int64) : EntityCategory =
+          match index with
+          | 0L -> EntityCategory.Functions
+          | 1L -> EntityCategory.Types
+          | 2L -> EntityCategory.Constants
+          | 3L -> EntityCategory.Submodules
+          | _ -> EntityCategory.Functions  // Default fallback
+
+        /// Converts an EntityCategory to its index
+        let entityCategoryToIndex (category: EntityCategory) : Int64 =
+          match category with
+          | Functions -> 0L
+          | Types -> 1L
+          | Constants -> 2L
+          | Submodules -> 3L
+
+        module Rendering =
+          /// Display control constants
+          module Display =
+            let clearScreen = "\x1b[2J\x1b[H"
+            let enterAltScreen = "\x1b[?1049h"
+            let exitAltScreen = "\x1b[?1049l"
+
+          /// Renders view content based on type
+          let renderView (content: ViewContent) : String =
+            match content with
+            | ModuleView (category, items, selectedIndex) ->
+              let formattedItems =
+                items
+                |> Stdlib.List.indexedMap (fun index item ->
+                  if index == selectedIndex then
+                    $"{CliColors.magenta}[{item}]{CliColors.reset}"
+                  else
+                    item)
+              if Stdlib.List.isEmpty formattedItems then "(none)" else Stdlib.String.join formattedItems ", "
+
+            | EntityDefinitionView entityDef ->
+              // Calculate actual display lines accounting for wrapping
+              let terminalWidth = getTerminalWidth ()
+              let displayLinesInfo =
+                entityDef.lines
+                |> Stdlib.List.map (fun line ->
+                  (line, calculateWrappedLineCount line terminalWidth))
+
+              let totalDisplayLines =
+                displayLinesInfo
+                |> Stdlib.List.fold 0L (fun acc (_, count) -> acc + count)
+
+              let viewportHeight = getContentViewportHeight totalDisplayLines
+              let safeViewportHeight = Stdlib.Int64.max 1L viewportHeight
+
+              // Calculate scroll position in terms of display lines
+              let maxScrollPos =
+                if totalDisplayLines <= safeViewportHeight then
+                  0L
+                else
+                  totalDisplayLines - safeViewportHeight
+
+              let adjustedScrollPos =
+                entityDef.scrollPosition
+                |> Stdlib.Int64.max 0L
+                |> Stdlib.Int64.min maxScrollPos
+
+              // Find which logical lines to show based on display line scroll position
+              let visibleLines =
+                displayLinesInfo
+                |> Stdlib.List.fold ([], (0L, adjustedScrollPos, safeViewportHeight))
+                  (fun acc lineInfo ->
+                    let (accLines, state) = acc
+                    let (currentDisplayLine, skipLines, remainingViewport) = state
+                    let (line, wrappedCount) = lineInfo
+
+                    if remainingViewport <= 0L then
+                      // Viewport is full
+                      (accLines, (currentDisplayLine + wrappedCount, skipLines, remainingViewport))
+                    else if skipLines >= wrappedCount then
+                      // Skip this entire logical line
+                      (accLines, (currentDisplayLine + wrappedCount, skipLines - wrappedCount, remainingViewport))
+                    else if skipLines > 0L then
+                      // Partially skip this line (edge case for wrapped lines)
+                      let displayCount = Stdlib.Int64.min wrappedCount remainingViewport
+                      (Stdlib.List.push accLines line, (currentDisplayLine + wrappedCount, 0L, remainingViewport - displayCount))
+                    else
+                      // Include this line
+                      let displayCount = Stdlib.Int64.min wrappedCount remainingViewport
+                      (Stdlib.List.push accLines line, (currentDisplayLine + wrappedCount, 0L, remainingViewport - displayCount))
+                  )
+                |> fun result ->
+                  let (lines, _) = result
+                  lines |> Stdlib.List.reverse
+
+              $"{CliColors.blue}{entityDef.name}\n\n" ++ (visibleLines |> Stdlib.String.join "\n")
+
+          /// Wraps the content with a help bar
+          let renderViewingInterface (content: String) : String =
+            let helpBar = $"{CliColors.gray}↑/↓: categories  ←/→: entities  Enter: expand/view  b: back  q: quit{CliColors.reset}\n\n"
+            $"{Display.clearScreen}{content}\n{helpBar}"
+
+          /// Gets terminal height
+          let getTerminalHeight () : Int64 =
+            Builtin.cliGetTerminalHeight ()
+
+          /// Gets terminal width
+          let getTerminalWidth () : Int64 =
+            Builtin.cliGetTerminalWidth ()
+
+          /// Calculate how many display lines a logical line will take when wrapped
+          let calculateWrappedLineCount (line: String) (terminalWidth: Int64) : Int64 =
+            let lineLength = Stdlib.String.length line
+            let safeTerminalWidth = Stdlib.Int64.max 1L terminalWidth
+            if lineLength <= safeTerminalWidth then
+              1L
+            else
+              let quotient = lineLength |> Stdlib.Int64.divide safeTerminalWidth
+              match lineLength |> Stdlib.Int64.remainder safeTerminalWidth with
+              | Ok remainder -> if remainder == 0L then quotient else quotient + 1L
+              | Error _ -> quotient + 1L
+
+          /// Calculates the content viewport height for entity definitions
+          let getContentViewportHeight (totalLines: Int64) : Int64 =
+            let viewportHeight = getTerminalHeight ()
+            let reservedLines = 5L // title (2) + help bar (2) + spacing (1)
+            let availableHeight = Stdlib.Int64.max 1L (viewportHeight - reservedLines)
+            Stdlib.Int64.min availableHeight totalLines
+
+          /// Calculates the module viewport height for scrollable module content
+          let getModuleViewportHeight () : Int64 =
+            let viewportHeight = getTerminalHeight ()
+            let reservedLines = 3L // help bar (2) + spacing (1)
+            Stdlib.Int64.max 1L (viewportHeight - reservedLines)
+
+          /// Renders entity interface with scrolling
+          let renderEntityInterface (entityName: String) (lines: List<String>) (scrollPosition: Int64) : String =
+            let entityDef = EntityDefinition { name = entityName; lines = lines; scrollPosition = scrollPosition }
+            let content = ViewContent.EntityDefinitionView entityDef
+            let visibleContent = renderView content
+            renderViewingInterface visibleContent
+
+          /// Formats a section of entities for display with expandable state and scrolling
+          let formatEntitySection (viewingState: ViewingState) (category: EntityCategory) (entities: List<String>) : String =
+            let sectionName = View.entityCategoryToString category
+            let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 category
+
+            let expandIndicator = if isExpanded then $"{CliColors.purple}▼{CliColors.reset}" else $"{CliColors.purple}▶{CliColors.reset}"
+            let selectionIndicator = if viewingState.selectedCategory == category then "→ " else "  "
+            let header = $"{selectionIndicator}{expandIndicator} {sectionName} {CliColors.gray}({entities |> Stdlib.List.length |> Stdlib.Int64.toString}){CliColors.reset}"
+
+            if Stdlib.List.isEmpty entities then
+              $"{header}\n\n(none)\n"
+            else if isExpanded then
+              // Extract just the names without module prefixes
+              let shortNames =
+                entities
+                |> Stdlib.List.map (fun fullName ->
+                  fullName
+                  |> Stdlib.String.split "."
+                  |> Stdlib.List.last
+                  |> Stdlib.Option.withDefault fullName)
+
+              if viewingState.selectedCategory == category && viewingState.selectedItemIndex >= 0L then
+                let content = ViewContent.ModuleView (category, shortNames, viewingState.selectedItemIndex)
+                let itemsDisplay = renderView content
+                $"{header}\n\n{itemsDisplay}\n"
+              else
+                $"{header}\n\n" ++ (Stdlib.String.join shortNames ", ") ++ "\n"
+            else
+              $"{header}\n"
+
+          /// Formats a section of entities for display with simple list (for non-interactive mode)
+          let formatEntitySectionSimple (sectionName: String) (entities: List<String>) : String =
+            if Stdlib.List.isEmpty entities then
+              $"{sectionName}:\n\n(none)\n"
+            else
+              $"{sectionName}:\n\n" ++ (Stdlib.String.join entities "\n") ++ "\n"
+
+          /// Formats module content for non-interactive display
+          let formatModuleContentSimple (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) : String =
+            let functionsSection =
+              formatEntitySectionSimple
+                "functions"
+                (moduleContent.fns
+                  |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
+
+            let typesSection =
+              formatEntitySectionSimple
+                "types"
+                (moduleContent.types
+                  |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
+
+            let constantsSection =
+              formatEntitySectionSimple
+                "constants"
+                (moduleContent.constants
+                  |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
+
+            let submodulesSection =
+              formatEntitySectionSimple
+                "submodules"
+                (moduleContent.submodules
+                  |> Stdlib.List.map (fun m ->
+                    m
+                    |> Stdlib.List.map (fun s -> s |> Stdlib.String.join "."))
+                  |> Stdlib.List.flatten)
+
+            functionsSection ++
+            typesSection ++
+            constantsSection ++
+            submodulesSection
+
+          /// Formats module content for interactive display
+          let formatModuleContent (viewingState: ViewingState) : String =
+            let functionsSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Functions
+                (viewingState.moduleContent.fns
+                  |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name))
+
+            let typesSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Types
+                (viewingState.moduleContent.types
+                  |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name))
+
+            let constantsSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Constants
+                (viewingState.moduleContent.constants
+                  |> Stdlib.List.map (fun c -> LanguageTools.ProgramTypes.PackageConstant.nameToString c.name))
+
+            let submodulesSection =
+              formatEntitySection
+                viewingState
+                EntityCategory.Submodules
+                (viewingState.moduleContent.submodules
+                  |> Stdlib.List.map (fun m ->
+                    m
+                    |> Stdlib.List.map (fun singleModulePath ->
+                      Stdlib.String.join singleModulePath "."))
+                  |> Stdlib.List.flatten
+                  |> Stdlib.List.filter (fun submodule ->
+                    submodule != viewingState.entityName))
+
+            let moduleHeader = $"{CliColors.blue}Module: {viewingState.entityName}{CliColors.reset}\n"
+
+            // Scrollable content (everything below the module title)
+            let scrollableContent =
+              "\n" ++
+              functionsSection ++ "\n" ++
+              typesSection ++ "\n" ++
+              constantsSection ++ "\n" ++
+              submodulesSection
+
+            // Apply viewport scrolling only to the scrollable content
+            let scrollableLines = scrollableContent |> Stdlib.String.split "\n"
+            let totalScrollableLines = scrollableLines |> Stdlib.List.length
+            let viewportHeight = getModuleViewportHeight ()
+
+            // Reserve space for the module header (1 line)
+            let availableScrollHeight = Stdlib.Int64.max 1L (viewportHeight - 1L)
+
+            // Ensure scroll position is within bounds
+            let maxScrollPos = Stdlib.Int64.max 0L (totalScrollableLines - availableScrollHeight)
+            let adjustedScrollPos =
+              viewingState.viewportScrollPosition
+              |> Stdlib.Int64.max 0L
+              |> Stdlib.Int64.min maxScrollPos
+
+            let visibleScrollableLines =
+              scrollableLines
+              |> Stdlib.List.drop adjustedScrollPos
+              |> Stdlib.List.take availableScrollHeight
+
+            // Combine fixed header with scrollable content
+            moduleHeader ++ (visibleScrollableLines |> Stdlib.String.join "\n")
+
+        module Navigation =
+          type ScrollDirection = Up | Down | PageUp | PageDown
+
+          /// Helper function to handle module viewport scrolling
+          let handleModuleViewportScroll (state: State) (direction: ScrollDirection) : (State * List<Msg>) =
+            match state.viewingState with
+            | Some viewingState ->
+              let viewportHeight = Rendering.getModuleViewportHeight ()
+
+              let newScrollPos =
+                match direction with
+                | Up -> Stdlib.Int64.max 0L (viewingState.viewportScrollPosition - 1L)
+                | Down -> viewingState.viewportScrollPosition + 1L // Will be bounded in formatModuleContent
+                | PageUp -> Stdlib.Int64.max 0L (viewingState.viewportScrollPosition - viewportHeight)
+                | PageDown -> viewingState.viewportScrollPosition + viewportHeight // Will be bounded in formatModuleContent
+
+              let newViewingState = { viewingState with viewportScrollPosition = newScrollPos }
+              let moduleView = Rendering.formatModuleContent newViewingState
+              let completeInterface = Rendering.renderViewingInterface moduleView
+              let newState =
+                { state with
+                    viewingState = Stdlib.Option.Option.Some newViewingState
+                    commandResult = CommandResult.Success completeInterface
+                    needsFullRedraw = true }
+              (newState, [])
+            | None ->
+              (state, [])
+
+          /// Helper function to handle entity definition scrolling
+          let handleEntityScroll (state: State) (direction: ScrollDirection) : (State * List<Msg>) =
+            match state.viewingState with
+            | Some viewingState ->
+              match viewingState.entityDefinition with
+              | Some entityDef ->
+                let terminalWidth = Rendering.getTerminalWidth ()
+                let totalDisplayLines =
+                  entityDef.lines
+                  |> Stdlib.List.fold 0L (fun acc line ->
+                    acc + Rendering.calculateWrappedLineCount line terminalWidth)
+
+                let contentHeight = Rendering.getContentViewportHeight totalDisplayLines
+                let maxScroll = Stdlib.Int64.max 0L (totalDisplayLines - contentHeight)
+
+                let scrollAmount =
+                  match direction with
+                  | PageUp | PageDown -> contentHeight
+                  | _ -> 1L
+
+                let newScrollPos =
+                  match direction with
+                    | Up -> Stdlib.Int64.max 0L (entityDef.scrollPosition - scrollAmount)
+                    | Down -> Stdlib.Int64.min maxScroll (entityDef.scrollPosition + scrollAmount)
+                    | PageUp -> Stdlib.Int64.max 0L (entityDef.scrollPosition - scrollAmount)
+                    | PageDown -> Stdlib.Int64.min maxScroll (entityDef.scrollPosition + scrollAmount)
+
+                let newEntityDef = { entityDef with scrollPosition = newScrollPos }
+                let completeInterface = Rendering.renderEntityInterface newEntityDef.name newEntityDef.lines newEntityDef.scrollPosition
+                let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.Some newEntityDef }
+                let newState =
+                  { state with
+                      viewingState = Stdlib.Option.Option.Some newViewingState
+                      commandResult = CommandResult.Success completeInterface
+                      needsFullRedraw = true }
+                (newState, [])
+              | None ->
+                (state, [])
+            | None ->
+              (state, [])
+
+          /// Calculate the line position of a category header in the scrollable content
+          let calculateCategoryLinePosition (viewingState: ViewingState) (targetCategory: EntityCategory) : Int64 =
+            let blankLineAfterModuleTitle = 1L // blank line after "Module: X"
+            let targetIndex = View.entityCategoryToIndex targetCategory
+
+            // Count lines for each category before the target
+            let categories = [EntityCategory.Functions; EntityCategory.Types; EntityCategory.Constants; EntityCategory.Submodules]
+
+            let linesBeforeTarget =
+              categories
+              |> Stdlib.List.take targetIndex
+              |> Stdlib.List.fold 0L (fun acc category ->
+                let entities = EntityLookup.getEntitiesForCategory viewingState.moduleContent category viewingState.entityName
+                let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 category
+
+                let headerLine = 1L
+                let contentLines =
+                  if Stdlib.List.isEmpty entities then
+                    2L // blank line + "(none)" + blank line
+                  else if isExpanded then
+                    3L // blank line + content + blank line
+                  else
+                    1L // blank line after header
+
+                acc + headerLine + contentLines
+              )
+
+            blankLineAfterModuleTitle + linesBeforeTarget
+
+          /// Helper function to ensure a category is visible in the scrollable viewport area
+          let ensureCategoryVisible (viewingState: ViewingState) (category: EntityCategory) : Int64 =
+            let categoryLine = calculateCategoryLinePosition viewingState category
+            let viewportHeight = Rendering.getModuleViewportHeight ()
+            let availableScrollHeight = Stdlib.Int64.max 1L (viewportHeight - 1L)
+            let currentScrollPos = viewingState.viewportScrollPosition
+            let viewportTop = currentScrollPos
+            let viewportBottom = currentScrollPos + availableScrollHeight - 1L
+
+            if categoryLine < viewportTop then
+              // Category is above viewport, scroll up to show it at the top
+              Stdlib.Int64.max 0L categoryLine
+            else if categoryLine > viewportBottom then
+              // Category is below viewport, scroll down to show it near the top
+              Stdlib.Int64.max 0L (categoryLine - 2L) // Show category header 2 lines from top
+            else if categoryLine > (viewportTop + (availableScrollHeight |> Stdlib.Int64.divide 2L)) then
+              // Category is in lower half, move it to upper half for better visibility
+              Stdlib.Int64.max 0L (categoryLine - 2L)
+            else
+              // Category is already visible in upper half, keep current position
+              currentScrollPos
+
+          /// Helper function to update selection and redraw view with auto-scroll to keep selection visible
+          let updateSelection (state: State) (category: EntityCategory) (itemIndex: Int64) : (State * List<Msg>) =
+            match state.viewingState with
+            | Some viewingState ->
+              let entities = EntityLookup.getEntitiesForCategory viewingState.moduleContent category viewingState.entityName
+              let shouldExpandNewCategory = Stdlib.Bool.not (Stdlib.List.isEmpty entities)
+
+              let newExpandedCategories =
+                if shouldExpandNewCategory then
+                  [category]
+                else
+                  []
+
+              let tempViewingState = { viewingState with selectedCategory = category; selectedItemIndex = itemIndex; expandedCategories = newExpandedCategories }
+              let newScrollPosition = ensureCategoryVisible tempViewingState category
+
+              let newViewingState = { tempViewingState with entityDefinition = Stdlib.Option.Option.None; viewportScrollPosition = newScrollPosition }
+              let moduleView = Rendering.formatModuleContent newViewingState
+              let completeInterface = Rendering.renderViewingInterface moduleView
+              let newState = { state with viewingState = Stdlib.Option.Option.Some newViewingState; commandResult = CommandResult.Success completeInterface; needsFullRedraw = true }
+              (newState, [])
+            | None ->
+              (state, [])
+
+          /// Handle key presses in viewing mode
+          let handleViewingModeKey (state: State) (viewingState: ViewingState) (key: Stdlib.Cli.Stdin.Key.Key) (modifiers: Stdlib.Cli.Stdin.Modifiers.Modifiers) : (State * List<Msg>) =
+            // Check for viewport scrolling (Ctrl+Arrow or Shift+Arrow for mouse wheel)
+            match (key, modifiers.shift, modifiers.ctrl) with
+            | (UpArrow, _, true) | (UpArrow, true, false) ->
+              match viewingState.entityDefinition with
+              | Some _ -> handleEntityScroll state ScrollDirection.Up
+              | None -> handleModuleViewportScroll state ScrollDirection.Up
+            | (DownArrow, _, true) | (DownArrow, true, false) ->
+              match viewingState.entityDefinition with
+              | Some _ -> handleEntityScroll state ScrollDirection.Down
+              | None -> handleModuleViewportScroll state ScrollDirection.Down
+            | _ ->
+              match key with
+              | UpArrow ->
+                match viewingState.entityDefinition with
+                | Some _ ->
+                  handleEntityScroll state ScrollDirection.Up
+                | None ->
+                  let currentIndex = View.entityCategoryToIndex viewingState.selectedCategory
+                  let newIndex = Stdlib.Int64.max 0L (currentIndex - 1L)
+                  let newCategory = View.indexToEntityCategory newIndex
+                  updateSelection state newCategory (-1L)
+              | DownArrow ->
+                match viewingState.entityDefinition with
+                | Some _ ->
+                  handleEntityScroll state ScrollDirection.Down
+                | None ->
+                  let currentIndex = View.entityCategoryToIndex viewingState.selectedCategory
+                  let newIndex = Stdlib.Int64.min 3L (currentIndex + 1L)
+                  let newCategory = View.indexToEntityCategory newIndex
+                  updateSelection state newCategory (-1L)
+              | Enter ->
+                let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 viewingState.selectedCategory
+                if isExpanded && viewingState.selectedItemIndex >= 0L then
+                  (state, [Msg.ShowItemDefinition viewingState.selectedCategory viewingState.selectedItemIndex])
+                else
+                  (state, [Msg.ToggleCategory viewingState.selectedCategory])
+              | LeftArrow ->
+                match viewingState.entityDefinition with
+                | Some _ ->
+                  handleEntityScroll state ScrollDirection.PageUp
+                | None ->
+                  let currentExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 viewingState.selectedCategory
+                  if currentExpanded then
+                    let currentEntities = EntityLookup.getEntitiesForCategory viewingState.moduleContent viewingState.selectedCategory viewingState.entityName
+                    let newItemIndex = Stdlib.Int64.max (-1L) (viewingState.selectedItemIndex - 1L)
+                    updateSelection state viewingState.selectedCategory newItemIndex
+                  else
+                    (state, [])
+              | RightArrow ->
+                match viewingState.entityDefinition with
+                | Some _ ->
+                  handleEntityScroll state ScrollDirection.PageDown
+                | None ->
+                  let currentExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 viewingState.selectedCategory
+                  if currentExpanded then
+                    let currentEntities = EntityLookup.getEntitiesForCategory viewingState.moduleContent viewingState.selectedCategory viewingState.entityName
+                    let maxIndex = (currentEntities |> Stdlib.List.length) - 1L
+                    let newItemIndex = Stdlib.Int64.min maxIndex (viewingState.selectedItemIndex + 1L)
+                    updateSelection state viewingState.selectedCategory newItemIndex
+                  else
+                    (state, [])
+              | B ->
+                match viewingState.entityDefinition with
+                | Some _ ->
+                  let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.None }
+                  let moduleView = Rendering.formatModuleContent newViewingState
+                  let completeInterface = Rendering.renderViewingInterface moduleView
+                  let newState =
+                    { state with
+                        viewingState = Stdlib.Option.Option.Some newViewingState
+                        commandResult = CommandResult.Success completeInterface
+                        needsFullRedraw = true }
+                  (newState, [])
+                | None ->
+                  if viewingState.entityName |> Stdlib.String.contains "." then
+                    let parts = viewingState.entityName |> Stdlib.String.split "."
+                    let parentParts = parts |> Stdlib.List.dropLast
+                    match parentParts with
+                    | [] ->
+                      (state, [])
+                    | _ ->
+                      let parentModule = Stdlib.String.join parentParts "."
+                      (state, [Msg.SubmitCommand $"view {parentModule}"])
+                  else
+                    (state, [])
+              | PageUp ->
+                match viewingState.entityDefinition with
+                | Some _ ->
+                  handleEntityScroll state ScrollDirection.PageUp
+                | None ->
+                  handleModuleViewportScroll state ScrollDirection.PageUp
+              | PageDown ->
+                match viewingState.entityDefinition with
+                | Some _ ->
+                  handleEntityScroll state ScrollDirection.PageDown
+                | None ->
+                  handleModuleViewportScroll state ScrollDirection.PageDown
+              | Q ->
+                let exitAlternateScreen = Rendering.Display.exitAltScreen
+                let newState =
+                  { state with
+                      viewingState = Stdlib.Option.Option.None
+                      commandResult = CommandResult.Success (exitAlternateScreen ++ "Exited viewing mode")
+                      needsFullRedraw = true }
+                (newState, [])
+              | _ ->
+                (state, [])
+
+        module EntityLookup =
+          /// Helper function to render entity definition
+          let renderEntityDefinition (state: State) (entityType: String) (fullyQualifiedName: String) (prettyPrinted: String) : (State * List<Msg>) =
+            match state.viewingState with
+            | Some viewingState ->
+              let (entityDefinition, updatedViewingState) = getOrCreateEntityDefinition viewingState entityType fullyQualifiedName prettyPrinted
+              let completeInterface = Rendering.renderEntityInterface entityDefinition.name entityDefinition.lines entityDefinition.scrollPosition
+              let finalViewingState = { updatedViewingState with entityDefinition = Stdlib.Option.Option.Some entityDefinition }
+              let newState =
+                { state with
+                    commandResult = CommandResult.Success completeInterface
+                    viewingState = Stdlib.Option.Option.Some finalViewingState
+                    needsFullRedraw = true }
+              (newState, [])
+            | None ->
+              let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+              let newState =
+                { state with
+                    commandResult = CommandResult.Success $"{entityType}: {fullyQualifiedName}\n\n{highlighted}" }
+              (newState, [])
+
+          /// Helper function to view an entity by its fully qualified name
+          let viewEntityByName (state: State) (fullyQualifiedName: String) : (State * List<Msg>) =
+            let modules = fullyQualifiedName |> Stdlib.String.split "." |> Stdlib.List.dropLast
+            let text = fullyQualifiedName |> Stdlib.String.split "." |> Stdlib.List.last |> Builtin.unwrap
+
+            let query = Command.createSearchQuery modules text
+            let moduleContent = LanguageTools.PackageManager.Search.search query
+
+            match findEntity moduleContent text with
+            | Some ((entityType, prettyPrinted)) ->
+              renderEntityDefinition state entityType fullyQualifiedName prettyPrinted
+            | None ->
+              let newState =
+                { state with
+                    commandResult = CommandResult.Error $"Entity not found: {fullyQualifiedName}" }
+              (newState, [])
+            
+          /// Entity lookup that finds an entity by name and returns its type and pretty-printed definition
+          let findEntity (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) (name: String) : Stdlib.Option.Option<(String * String)> =
+            let constantResult =
+              moduleContent.constants
+              |> Stdlib.List.findFirst (fun c -> c.name.name == name)
+              |> Stdlib.Option.map (fun c -> ("Constant", PrettyPrinter.ProgramTypes.packageConstant c))
+
+            let functionResult =
+              moduleContent.fns
+              |> Stdlib.List.findFirst (fun f -> f.name.name == name)
+              |> Stdlib.Option.map (fun f -> ("Function", PrettyPrinter.ProgramTypes.packageFn f))
+
+            let typeResult =
+              moduleContent.types
+              |> Stdlib.List.findFirst (fun t -> t.name.name == name)
+              |> Stdlib.Option.map (fun t -> ("Type", PrettyPrinter.ProgramTypes.packageType t))
+
+            match constantResult with
+            | Some _ -> constantResult
+            | None ->
+              match functionResult with
+              | Some _ -> functionResult
+              | None -> typeResult
+
+          /// Gets entities from moduleContent for a given category
+          let getEntitiesForCategory (moduleContent: LanguageTools.ProgramTypes.Search.SearchResults) (category: EntityCategory) (currentEntityName: String) : List<String> =
+            match category with
+            | Functions -> moduleContent.fns |> Stdlib.List.map (fun fn -> LanguageTools.ProgramTypes.PackageFn.nameToString fn.name)
+            | Types -> moduleContent.types |> Stdlib.List.map (fun typ -> LanguageTools.ProgramTypes.PackageType.nameToString typ.name)
+            | Constants -> moduleContent.constants |> Stdlib.List.map (fun constant -> LanguageTools.ProgramTypes.PackageConstant.nameToString constant.name)
+            | Submodules ->
+              moduleContent.submodules
+              |> Stdlib.List.map (fun m ->
+                m
+                |> Stdlib.List.map (fun singleModulePath ->
+                  Stdlib.String.join singleModulePath "."))
+              |> Stdlib.List.flatten
+              |> Stdlib.List.filter (fun submodule ->
+                submodule != currentEntityName)
+
+          /// Gets an entity definition from cache or creates a new one
+          let getOrCreateEntityDefinition (viewingState: ViewingState) (entityType: String) (fullyQualifiedName: String) (prettyPrinted: String) : (EntityDefinition * ViewingState) =
+            let cacheKey = $"{entityType}:{fullyQualifiedName}"
+
+            match viewingState.entityCache |> Stdlib.List.findFirst (fun (key, _) -> key == cacheKey) with
+            | Some ((_, cachedDef)) ->
+              // Always reset scroll position to 0 when viewing an entity definition
+              let resetDef = { cachedDef with scrollPosition = 0L }
+              (resetDef, viewingState)
+            | None ->
+              // Create new definition and add to cache
+              let highlighted = Cli.SyntaxHighlighting.highlightCode prettyPrinted
+              let lines = highlighted |> Stdlib.String.split "\n"
+              let entityDefinition = EntityDefinition { name = $"{entityType}: {fullyQualifiedName}"; lines = lines; scrollPosition = 0L }
+              let newCache = viewingState.entityCache |> Stdlib.List.push (cacheKey, entityDefinition)
+              let newViewingState = { viewingState with entityCache = newCache }
+              (entityDefinition, newViewingState)

--- a/packages/darklang/cli/init.dark
+++ b/packages/darklang/cli/init.dark
@@ -22,7 +22,8 @@ module Darklang =
             interactionMode = interactionMode
             needsFullRedraw = true
             isExiting = false
-            completionState = Stdlib.Option.Option.None }
+            completionState = Stdlib.Option.Option.None
+            viewingState = Stdlib.Option.Option.None }
 
       // Return initial state and any initial messages to process
       (state, msgs)

--- a/packages/darklang/cli/init.dark
+++ b/packages/darklang/cli/init.dark
@@ -7,7 +7,7 @@ module Darklang =
           (InteractionMode.Regular, [ Msg.SubmitCommand "help" ])
         | _ ->
           let cmd = (args |> Stdlib.String.join " ")
-          (InteractionMode.NonInteractive, [ Msg.SubmitCommand cmd; Msg.Quit ])
+          (InteractionMode.NonInteractive, [ Msg.SubmitCommand cmd ])
 
       let state =
         State

--- a/packages/darklang/cli/model.dark
+++ b/packages/darklang/cli/model.dark
@@ -102,7 +102,9 @@ module Darklang =
           expandedCategories: List<EntityCategory>
           entityDefinition: Stdlib.Option.Option<EntityDefinition>
           /// Cache for entity definitions to avoid re-computing them
-          entityCache: List<(String * EntityDefinition)> }
+          entityCache: List<(String * EntityDefinition)>
+          /// Viewport scroll position for the module view (how many lines scrolled from top)
+          viewportScrollPosition: Int64 }
 
       type State =
         { /// The current page/view the user is on

--- a/packages/darklang/cli/model.dark
+++ b/packages/darklang/cli/model.dark
@@ -75,6 +75,35 @@ module Darklang =
           completionPrefix: String
         }
 
+      /// Categories of entities that can be displayed in viewing mode
+      type EntityCategory =
+        | Functions
+        | Types
+        | Constants
+        | Submodules
+
+      /// Entity definition with cached content for scrolling
+      type EntityDefinition =
+        { name: String
+          lines: List<String> //  content split into lines for scrolling
+          scrollPosition: Int64 }
+
+      /// Content types
+      type ViewContent =
+        | ModuleView of EntityCategory * List<String> * Int64  // category, items, selectedIndex
+        | EntityDefinitionView of EntityDefinition
+
+      /// Viewing mode state
+      type ViewingState =
+        { moduleContent: LanguageTools.ProgramTypes.Search.SearchResults
+          entityName: String
+          selectedCategory: EntityCategory
+          selectedItemIndex: Int64
+          expandedCategories: List<EntityCategory>
+          entityDefinition: Stdlib.Option.Option<EntityDefinition>
+          /// Cache for entity definitions to avoid re-computing them
+          entityCache: List<(String * EntityDefinition)> }
+
       type State =
         { /// The current page/view the user is on
           currentPage: Page
@@ -112,6 +141,9 @@ module Darklang =
 
           /// The current state of tab completion
           completionState: Stdlib.Option.Option<CompletionState>
+
+          /// Viewing mode state - None when not in viewing mode
+          viewingState: Stdlib.Option.Option<ViewingState>
 
           //accounts: [("stachu", "uhcats"); ("ocean": "oak"); ("paul", "biggar")]
           //currentAccount: "stachu"

--- a/packages/darklang/cli/msg.dark
+++ b/packages/darklang/cli/msg.dark
@@ -25,6 +25,10 @@ module Darklang =
       // -- Command results
       | SetCommandResult of result: CommandResult
 
+      // -- Viewing mode
+      | ToggleCategory of category: EntityCategory
+      | ShowItemDefinition of category: EntityCategory * itemIndex: Int64
+
       // -- Nav.
       //| GoToApp of appId: Uuid
 

--- a/packages/darklang/cli/terminal.dark
+++ b/packages/darklang/cli/terminal.dark
@@ -22,20 +22,14 @@ module Darklang =
         if lineLength <= safeTerminalWidth then
           1L
         else
-          let quotient = lineLength |> Stdlib.Int64.divide safeTerminalWidth
+          // the number of full lines that fit completely in the terminal
+          let fullLineCount = lineLength |> Stdlib.Int64.divide safeTerminalWidth
           match lineLength |> Stdlib.Int64.remainder safeTerminalWidth with
-          | Ok remainder -> if remainder == 0L then quotient else quotient + 1L
-          | Error _ -> quotient + 1L
+          | Ok remainder -> if remainder == 0L then fullLineCount else fullLineCount + 1L
+          | Error _ -> fullLineCount + 1L
 
-      /// Calculates the content viewport height for entity definitions
-      let getContentViewportHeight (totalLines: Int64) : Int64 =
+      /// Calculates viewport height for scrollable content
+      let getViewportHeight (totalLines: Int64) (reservedLines: Int64) : Int64 =
         let viewportHeight = getHeight ()
-        let reservedLines = 5L // title (2) + help bar (2) + spacing (1)
         let availableHeight = Stdlib.Int64.max 1L (viewportHeight - reservedLines)
         Stdlib.Int64.min availableHeight totalLines
-
-      /// Calculates the module viewport height for scrollable module content
-      let getModuleViewportHeight () : Int64 =
-        let viewportHeight = getHeight ()
-        let reservedLines = 3L // help bar (2) + spacing (1)
-        Stdlib.Int64.max 1L (viewportHeight - reservedLines)

--- a/packages/darklang/cli/terminal.dark
+++ b/packages/darklang/cli/terminal.dark
@@ -1,0 +1,41 @@
+module Darklang =
+  module Cli =
+    module Terminal =
+      /// Display control constants
+      module Display =
+        let clearScreen = "\x1b[2J\x1b[H"
+        let enterAltScreen = "\x1b[?1049h"
+        let exitAltScreen = "\x1b[?1049l"
+
+      /// Gets terminal height
+      let getHeight () : Int64 =
+        Builtin.cliGetTerminalHeight ()
+
+      /// Gets terminal width
+      let getWidth () : Int64 =
+        Builtin.cliGetTerminalWidth ()
+
+      /// Calculate how many display lines a logical line will take when wrapped
+      let calculateWrappedLineCount (line: String) (terminalWidth: Int64) : Int64 =
+        let lineLength = Stdlib.String.length line
+        let safeTerminalWidth = Stdlib.Int64.max 1L terminalWidth
+        if lineLength <= safeTerminalWidth then
+          1L
+        else
+          let quotient = lineLength |> Stdlib.Int64.divide safeTerminalWidth
+          match lineLength |> Stdlib.Int64.remainder safeTerminalWidth with
+          | Ok remainder -> if remainder == 0L then quotient else quotient + 1L
+          | Error _ -> quotient + 1L
+
+      /// Calculates the content viewport height for entity definitions
+      let getContentViewportHeight (totalLines: Int64) : Int64 =
+        let viewportHeight = getHeight ()
+        let reservedLines = 5L // title (2) + help bar (2) + spacing (1)
+        let availableHeight = Stdlib.Int64.max 1L (viewportHeight - reservedLines)
+        Stdlib.Int64.min availableHeight totalLines
+
+      /// Calculates the module viewport height for scrollable module content
+      let getModuleViewportHeight () : Int64 =
+        let viewportHeight = getHeight ()
+        let reservedLines = 3L // help bar (2) + spacing (1)
+        Stdlib.Int64.max 1L (viewportHeight - reservedLines)

--- a/packages/darklang/cli/update.dark
+++ b/packages/darklang/cli/update.dark
@@ -274,7 +274,7 @@ module Darklang =
             { intermediateViewingState with viewportScrollPosition = finalScrollPosition }
 
           let moduleView = CommandHelpers.View.Rendering.formatModuleContent newViewingState
-          let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
+          let completeInterface = CommandHelpers.View.Rendering.renderModuleViewingInterface moduleView
           let newState =
             { state with
                 viewingState = Stdlib.Option.Option.Some newViewingState
@@ -299,7 +299,7 @@ module Darklang =
               // Hide the definition - return to module view while preserving selection
               let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.None }
               let moduleView = CommandHelpers.View.Rendering.formatModuleContent newViewingState
-              let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
+              let completeInterface = CommandHelpers.View.Rendering.renderModuleViewingInterface moduleView
               let newState =
                 { state with
                     viewingState = Stdlib.Option.Option.Some newViewingState

--- a/packages/darklang/cli/update.dark
+++ b/packages/darklang/cli/update.dark
@@ -78,6 +78,244 @@ module Darklang =
             cursorPosition = newCursorPos
             completionState = Stdlib.Option.Option.None }
 
+    type ScrollDirection = Up | Down | PageUp | PageDown
+
+    /// Helper function to handle entity definition scrolling
+    let handleEntityScroll (state: State) (direction: ScrollDirection) : (State * List<Msg>) =
+      match state.viewingState with
+      | Some viewingState ->
+        match viewingState.entityDefinition with
+        | Some entityDef ->
+          let totalLines = entityDef.lines |> Stdlib.List.length
+          let contentHeight = Command.getContentViewportHeight totalLines
+          let maxScroll = Stdlib.Int64.max 0L (totalLines - contentHeight)
+
+          let newScrollPos =
+            match direction with
+              | Up -> Stdlib.Int64.max 0L (entityDef.scrollPosition - 1L)
+              | Down -> Stdlib.Int64.min maxScroll (entityDef.scrollPosition + 1L)
+              | PageUp -> Stdlib.Int64.max 0L (entityDef.scrollPosition - contentHeight)
+              | PageDown -> Stdlib.Int64.min maxScroll (entityDef.scrollPosition + contentHeight)
+
+          let newEntityDef = { entityDef with scrollPosition = newScrollPos }
+          let completeInterface = Command.renderEntityInterface newEntityDef.name newEntityDef.lines newEntityDef.scrollPosition
+          let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.Some newEntityDef }
+          let newState =
+            { state with
+                viewingState = Stdlib.Option.Option.Some newViewingState
+                commandResult = CommandResult.Success completeInterface
+                needsFullRedraw = true }
+          (newState, [])
+        | None ->
+          (state, []) // No entity definition to scroll
+      | None ->
+        (state, []) // Not in viewing mode
+
+    /// Helper function to update selection and redraw view
+    let updateSelection (state: State) (category: EntityCategory) (itemIndex: Int64) : (State * List<Msg>) =
+      match state.viewingState with
+      | Some viewingState ->
+        let newViewingState = { viewingState with selectedCategory = category; selectedItemIndex = itemIndex; entityDefinition = Stdlib.Option.Option.None }
+        let moduleView = Command.formatModuleContent newViewingState
+        let completeInterface = Command.renderViewingInterface moduleView true
+        let newState = { state with viewingState = Stdlib.Option.Option.Some newViewingState; commandResult = CommandResult.Success completeInterface; needsFullRedraw = true }
+        (newState, [])
+      | None ->
+        (state, []) // Not in viewing mode
+
+    /// Helper function to handle item navigation (left/right arrows)
+    let handleItemNavigation (state: State) (viewingState: ViewingState) (direction: Int64) : (State * List<Msg>) =
+      let currentExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 viewingState.selectedCategory
+
+      if currentExpanded then
+        let currentEntities = Command.getEntitiesForCategory viewingState.moduleContent viewingState.selectedCategory viewingState.entityName
+        let maxIndex = (currentEntities |> Stdlib.List.length) - 1L
+        let newItemIndex =
+          if direction < 0L then
+            Stdlib.Int64.max (-1L) (viewingState.selectedItemIndex + direction)
+          else
+            Stdlib.Int64.min maxIndex (viewingState.selectedItemIndex + direction)
+        updateSelection state viewingState.selectedCategory newItemIndex
+      else
+        (state, [])
+
+    /// Handle key presses in viewing mode
+    let handleViewingModeKey (state: State) (viewingState: ViewingState) (key: Stdlib.Cli.Stdin.Key.Key) : (State * List<Msg>) =
+      match key with
+      | UpArrow ->
+        match viewingState.entityDefinition with
+        | Some _ ->
+          handleEntityScroll state ScrollDirection.Up
+        | None ->
+          // Move selection up through categories
+          let currentIndex = Command.entityCategoryToIndex viewingState.selectedCategory
+          let newIndex = Stdlib.Int64.max 0L (currentIndex - 1L)
+          let newCategory = Command.indexToEntityCategory newIndex
+          updateSelection state newCategory (-1L)
+      | DownArrow ->
+        match viewingState.entityDefinition with
+        | Some _ ->
+          handleEntityScroll state ScrollDirection.Down
+        | None ->
+          // Move selection down through categories
+          let currentIndex = Command.entityCategoryToIndex viewingState.selectedCategory
+          let newIndex = Stdlib.Int64.min 3L (currentIndex + 1L)
+          let newCategory = Command.indexToEntityCategory newIndex
+          updateSelection state newCategory (-1L)
+      | Enter ->
+        let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 viewingState.selectedCategory
+
+        // If category is expanded and we have an item selected, show its definition
+        // Otherwise, toggle the category expand/collapse
+        if isExpanded && viewingState.selectedItemIndex >= 0L then
+          (state, [Msg.ShowItemDefinition viewingState.selectedCategory viewingState.selectedItemIndex])
+        else
+          // Toggle the category (this will collapse if expanded, expand if collapsed)
+          // Reset item selection when toggling
+          (state, [Msg.ToggleCategory viewingState.selectedCategory])
+      | LeftArrow ->
+        match viewingState.entityDefinition with
+        | Some _ ->
+          handleEntityScroll state ScrollDirection.PageUp
+        | None ->
+          handleItemNavigation state viewingState (-1L)
+      | RightArrow ->
+        match viewingState.entityDefinition with
+        | Some _ ->
+          handleEntityScroll state ScrollDirection.PageDown
+        | None ->
+          handleItemNavigation state viewingState 1L
+      | B ->
+        // If viewing entity definition, go back to module view
+        match viewingState.entityDefinition with
+        | Some _ ->
+          // Reset entity viewing state and return to module view
+          let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.None }
+          let moduleView = Command.formatModuleContent newViewingState
+          let completeInterface = Command.renderViewingInterface moduleView true
+          let newState =
+            { state with
+                viewingState = Stdlib.Option.Option.Some newViewingState
+                commandResult = CommandResult.Success completeInterface
+                needsFullRedraw = true }
+          (newState, [])
+        | None ->
+          // Go back to parent module while staying in viewing mode
+          if viewingState.entityName |> Stdlib.String.contains "." then
+            // Extract parent module path
+            let parts = viewingState.entityName |> Stdlib.String.split "."
+            let parentParts = parts |> Stdlib.List.dropLast
+            match parentParts with
+            | [] ->
+              // No parent, just stay where we are
+              (state, [])
+            | _ ->
+              // Navigate to parent module
+              let parentModule = Stdlib.String.join parentParts "."
+              (state, [Msg.SubmitCommand $"view {parentModule}"])
+          else
+            // Already at top level, can't go back further
+            (state, [])
+      | Q ->
+        // Exit viewing mode and return to regular prompt
+        // Exit alternate screen buffer first
+        let exitAlternateScreen = Command.Display.exitAltScreen
+        let newState =
+          { state with
+              viewingState = Stdlib.Option.Option.None
+              commandResult = CommandResult.Success (exitAlternateScreen ++ "Exited viewing mode")
+              needsFullRedraw = true }
+        (newState, [])
+      | _ ->
+        // Ignore other keys in viewing mode
+        (state, [])
+
+    /// Handle key presses in normal mode
+    let handleNormalModeKey (state: State) (key: Stdlib.Cli.Stdin.Key.Key) (keyChar: String) : (State * List<Msg>) =
+      match key with
+      | Escape ->
+        // Escape key pressed, send Quit message
+        (state, [Msg.Quit])
+
+      | Enter ->
+        // Enter key pressed, submit the current prompt as a command, and add it to history
+        let command = state.mainPrompt
+        let stateWithClearedPrompt =
+          { state with
+              mainPrompt = ""
+              cursorPosition = 0L
+              completionState = Stdlib.Option.Option.None }
+        let newState =
+          addToHistory
+            stateWithClearedPrompt
+            command
+        (newState, [ Msg.SubmitCommand command ])
+
+      | Backspace ->
+        // Backspace key pressed, remove the character before the cursor
+        // Also reset history navigation and update completions
+        if state.cursorPosition > 0L then
+          let beforeCursor = Stdlib.String.slice state.mainPrompt 0L (state.cursorPosition - 1L)
+          let afterCursor = Stdlib.String.dropFirst state.mainPrompt state.cursorPosition
+          let newPrompt = beforeCursor ++ afterCursor
+          let newState =
+            { state with
+                mainPrompt = newPrompt
+                cursorPosition = state.cursorPosition - 1L
+                historyPosition = -1L
+                draftPrompt = ""
+                completionState = Stdlib.Option.Option.None }
+          // Automatically request completions after backspacing
+          (newState, [Msg.RequestCompletion])
+        else
+          (state, [])
+
+      | UpArrow ->
+        // Arrow up pressed, navigate to previous command in history
+        (state, [Msg.NavigateHistoryUp])
+
+      | DownArrow ->
+        // Arrow down pressed, navigate to next command in history
+        (state, [Msg.NavigateHistoryDown])
+
+      | LeftArrow ->
+        // Move cursor left
+        let newCursorPos = Stdlib.Int64.max 0L (state.cursorPosition - 1L)
+        let newState = { state with cursorPosition = newCursorPos; completionState = Stdlib.Option.Option.None }
+        (newState, [])
+
+      | RightArrow ->
+        // Move cursor right
+        let promptLength = Stdlib.String.length state.mainPrompt
+        let newCursorPos = Stdlib.Int64.min promptLength (state.cursorPosition + 1L)
+        let newState = { state with cursorPosition = newCursorPos; completionState = Stdlib.Option.Option.None }
+        (newState, [])
+
+      | Tab ->
+        // Tab key pressed - accept completion if available
+        match state.completionState with
+        | Some _ ->
+          (state, [Msg.AcceptCompletion])
+        | None ->
+          // No completions available, do nothing
+          (state, [])
+
+      | _ ->
+        // For other keys, check if they're textual and insert at cursor position
+        // Also reset history navigation and automatically generate completions
+        let beforeCursor = Stdlib.String.slice state.mainPrompt 0L state.cursorPosition
+        let afterCursor = Stdlib.String.dropFirst state.mainPrompt state.cursorPosition
+        let newPrompt = beforeCursor ++ keyChar ++ afterCursor
+        let newState =
+          { state with
+              mainPrompt = newPrompt
+              cursorPosition = state.cursorPosition + (Stdlib.String.length keyChar)
+              historyPosition = -1L
+              draftPrompt = ""
+              completionState = Stdlib.Option.Option.None }
+        // Automatically request completions after typing
+        (newState, [Msg.RequestCompletion])
+
     let update (state: State) (msg: Msg): (State * List<Msg>) =
       match msg with
       | Quit ->
@@ -98,88 +336,12 @@ module Darklang =
         (newState, [])
 
       | KeyPressed(key, modifiers, keyChar) ->
-        // Handle key presses
-        match key with
-        | Escape ->
-          // Escape key pressed, send Quit message
-          (state, [Msg.Quit])
-
-        | Enter ->
-          // Enter key pressed, submit the current prompt as a command, and add it to history
-          let command = state.mainPrompt
-          let newState =
-            { state with
-                mainPrompt = ""
-                cursorPosition = 0L
-                completionState = Stdlib.Option.Option.None }
-            |> addToHistory command
-          Builtin.printLine ""
-          (newState, [Msg.SubmitCommand command])
-
-        | Backspace ->
-          // Backspace key pressed, remove the character before the cursor
-          // Also reset history navigation and update completions
-          if state.cursorPosition > 0L then
-            let beforeCursor = Stdlib.String.slice state.mainPrompt 0L (state.cursorPosition - 1L)
-            let afterCursor = Stdlib.String.dropFirst state.mainPrompt state.cursorPosition
-            let newPrompt = beforeCursor ++ afterCursor
-            let newState =
-              { state with
-                  mainPrompt = newPrompt
-                  cursorPosition = state.cursorPosition - 1L
-                  historyPosition = -1L
-                  draftPrompt = ""
-                  completionState = Stdlib.Option.Option.None }
-            // Automatically request completions after backspacing
-            (newState, [Msg.RequestCompletion])
-          else
-            (state, [])
-
-        | UpArrow ->
-          // Arrow up pressed, navigate to previous command in history
-          (state, [Msg.NavigateHistoryUp])
-
-        | DownArrow ->
-          // Arrow down pressed, navigate to next command in history
-          (state, [Msg.NavigateHistoryDown])
-
-        | LeftArrow ->
-          // Move cursor left
-          let newCursorPos = Stdlib.Int64.max 0L (state.cursorPosition - 1L)
-          let newState = { state with cursorPosition = newCursorPos; completionState = Stdlib.Option.Option.None }
-          (newState, [])
-
-        | RightArrow ->
-          // Move cursor right
-          let promptLength = Stdlib.String.length state.mainPrompt
-          let newCursorPos = Stdlib.Int64.min promptLength (state.cursorPosition + 1L)
-          let newState = { state with cursorPosition = newCursorPos; completionState = Stdlib.Option.Option.None }
-          (newState, [])
-
-        | Tab ->
-          // Tab key pressed - accept completion if available
-          match state.completionState with
-          | Some _ ->
-            (state, [Msg.AcceptCompletion])
-          | None ->
-            // No completions available, do nothing
-            (state, [])
-
-        | _ ->
-          // For other keys, check if they're textual and insert at cursor position
-          // Also reset history navigation and automatically generate completions
-          let beforeCursor = Stdlib.String.slice state.mainPrompt 0L state.cursorPosition
-          let afterCursor = Stdlib.String.dropFirst state.mainPrompt state.cursorPosition
-          let newPrompt = beforeCursor ++ keyChar ++ afterCursor
-          let newState =
-            { state with
-                mainPrompt = newPrompt
-                cursorPosition = state.cursorPosition + (Stdlib.String.length keyChar)
-                historyPosition = -1L
-                draftPrompt = ""
-                completionState = Stdlib.Option.Option.None }
-          // Automatically request completions after typing
-          (newState, [Msg.RequestCompletion])
+        // Handle key presses - delegate to specialized handlers
+        match state.viewingState with
+        | Some viewingState ->
+          handleViewingModeKey state viewingState key
+        | None ->
+          handleNormalModeKey state key keyChar
 
       | SubmitCommand commandStr ->
         // Process the submitted command
@@ -236,6 +398,73 @@ module Darklang =
               commandResult = result
               needsFullRedraw = true }
         (newState, [])
+
+      | ToggleCategory entityCategory ->
+        match state.viewingState with
+        | Some viewingState ->
+          let currentValue = viewingState.expandedCategories |> Stdlib.List.member_v0 entityCategory
+          let newSelectedItemIndex = if Stdlib.Bool.not currentValue then 0L else -1L
+
+          let newExpandedCategories =
+            if currentValue then
+              viewingState.expandedCategories |> Stdlib.List.filter (fun c -> c != entityCategory)
+            else
+              viewingState.expandedCategories |> Stdlib.List.push entityCategory
+
+          let newViewingState =
+            { viewingState with
+                expandedCategories = newExpandedCategories
+                selectedItemIndex = newSelectedItemIndex
+                entityDefinition = Stdlib.Option.Option.None }
+
+          let moduleView = Command.formatModuleContent newViewingState
+          let completeInterface = Command.renderViewingInterface moduleView true
+          let newState =
+            { state with
+                viewingState = Stdlib.Option.Option.Some newViewingState
+                commandResult = CommandResult.Success completeInterface
+                needsFullRedraw = true }
+          (newState, [])
+        | None ->
+          (state, []) // Not in viewing mode
+
+      | ShowItemDefinition category itemIndex ->
+        // Toggle the definition display of the selected item
+        match state.viewingState with
+        | Some viewingState ->
+          let entities = Command.getEntitiesForCategory viewingState.moduleContent category viewingState.entityName
+
+          let selectedEntity = entities |> Stdlib.List.getAt itemIndex
+          match selectedEntity with
+          | Some entityName ->
+            // Check if this entity's definition is already being displayed
+            match viewingState.entityDefinition with
+            | Some entityDef when entityDef.name |> Stdlib.String.contains entityName ->
+              // Hide the definition - return to module view while preserving selection
+              let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.None }
+              let moduleView = Command.formatModuleContent newViewingState
+              let completeInterface = Command.renderViewingInterface moduleView true
+              let newState =
+                { state with
+                    viewingState = Stdlib.Option.Option.Some newViewingState
+                    commandResult = CommandResult.Success completeInterface
+                    needsFullRedraw = true }
+              (newState, [])
+            | _ ->
+              // Show the definition - need to construct the fully qualified name
+              let fullyQualifiedName =
+                if Stdlib.String.contains entityName "." then
+                  entityName  // Already fully qualified
+                else
+                  // Need to prepend the current module path
+                  viewingState.entityName ++ "." ++ entityName
+              (state, [Msg.SubmitCommand $"view {fullyQualifiedName}"])
+          | None ->
+            let newState = { state with commandResult = CommandResult.Error "Selected item not found"; needsFullRedraw = true }
+            (newState, [])
+        | None ->
+          let newState = { state with commandResult = CommandResult.Error "No module content available"; needsFullRedraw = true }
+          (newState, [])
 
       | RequestCompletion ->
         // Generate completions for the current input

--- a/packages/darklang/cli/update.dark
+++ b/packages/darklang/cli/update.dark
@@ -78,157 +78,6 @@ module Darklang =
             cursorPosition = newCursorPos
             completionState = Stdlib.Option.Option.None }
 
-    type ScrollDirection = Up | Down | PageUp | PageDown
-
-    /// Helper function to handle entity definition scrolling
-    let handleEntityScroll (state: State) (direction: ScrollDirection) : (State * List<Msg>) =
-      match state.viewingState with
-      | Some viewingState ->
-        match viewingState.entityDefinition with
-        | Some entityDef ->
-          let totalLines = entityDef.lines |> Stdlib.List.length
-          let contentHeight = Command.getContentViewportHeight totalLines
-          let maxScroll = Stdlib.Int64.max 0L (totalLines - contentHeight)
-
-          let newScrollPos =
-            match direction with
-              | Up -> Stdlib.Int64.max 0L (entityDef.scrollPosition - 1L)
-              | Down -> Stdlib.Int64.min maxScroll (entityDef.scrollPosition + 1L)
-              | PageUp -> Stdlib.Int64.max 0L (entityDef.scrollPosition - contentHeight)
-              | PageDown -> Stdlib.Int64.min maxScroll (entityDef.scrollPosition + contentHeight)
-
-          let newEntityDef = { entityDef with scrollPosition = newScrollPos }
-          let completeInterface = Command.renderEntityInterface newEntityDef.name newEntityDef.lines newEntityDef.scrollPosition
-          let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.Some newEntityDef }
-          let newState =
-            { state with
-                viewingState = Stdlib.Option.Option.Some newViewingState
-                commandResult = CommandResult.Success completeInterface
-                needsFullRedraw = true }
-          (newState, [])
-        | None ->
-          (state, []) // No entity definition to scroll
-      | None ->
-        (state, []) // Not in viewing mode
-
-    /// Helper function to update selection and redraw view
-    let updateSelection (state: State) (category: EntityCategory) (itemIndex: Int64) : (State * List<Msg>) =
-      match state.viewingState with
-      | Some viewingState ->
-        let newViewingState = { viewingState with selectedCategory = category; selectedItemIndex = itemIndex; entityDefinition = Stdlib.Option.Option.None }
-        let moduleView = Command.formatModuleContent newViewingState
-        let completeInterface = Command.renderViewingInterface moduleView true
-        let newState = { state with viewingState = Stdlib.Option.Option.Some newViewingState; commandResult = CommandResult.Success completeInterface; needsFullRedraw = true }
-        (newState, [])
-      | None ->
-        (state, []) // Not in viewing mode
-
-    /// Helper function to handle item navigation (left/right arrows)
-    let handleItemNavigation (state: State) (viewingState: ViewingState) (direction: Int64) : (State * List<Msg>) =
-      let currentExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 viewingState.selectedCategory
-
-      if currentExpanded then
-        let currentEntities = Command.getEntitiesForCategory viewingState.moduleContent viewingState.selectedCategory viewingState.entityName
-        let maxIndex = (currentEntities |> Stdlib.List.length) - 1L
-        let newItemIndex =
-          if direction < 0L then
-            Stdlib.Int64.max (-1L) (viewingState.selectedItemIndex + direction)
-          else
-            Stdlib.Int64.min maxIndex (viewingState.selectedItemIndex + direction)
-        updateSelection state viewingState.selectedCategory newItemIndex
-      else
-        (state, [])
-
-    /// Handle key presses in viewing mode
-    let handleViewingModeKey (state: State) (viewingState: ViewingState) (key: Stdlib.Cli.Stdin.Key.Key) : (State * List<Msg>) =
-      match key with
-      | UpArrow ->
-        match viewingState.entityDefinition with
-        | Some _ ->
-          handleEntityScroll state ScrollDirection.Up
-        | None ->
-          // Move selection up through categories
-          let currentIndex = Command.entityCategoryToIndex viewingState.selectedCategory
-          let newIndex = Stdlib.Int64.max 0L (currentIndex - 1L)
-          let newCategory = Command.indexToEntityCategory newIndex
-          updateSelection state newCategory (-1L)
-      | DownArrow ->
-        match viewingState.entityDefinition with
-        | Some _ ->
-          handleEntityScroll state ScrollDirection.Down
-        | None ->
-          // Move selection down through categories
-          let currentIndex = Command.entityCategoryToIndex viewingState.selectedCategory
-          let newIndex = Stdlib.Int64.min 3L (currentIndex + 1L)
-          let newCategory = Command.indexToEntityCategory newIndex
-          updateSelection state newCategory (-1L)
-      | Enter ->
-        let isExpanded = viewingState.expandedCategories |> Stdlib.List.member_v0 viewingState.selectedCategory
-
-        // If category is expanded and we have an item selected, show its definition
-        // Otherwise, toggle the category expand/collapse
-        if isExpanded && viewingState.selectedItemIndex >= 0L then
-          (state, [Msg.ShowItemDefinition viewingState.selectedCategory viewingState.selectedItemIndex])
-        else
-          // Toggle the category (this will collapse if expanded, expand if collapsed)
-          // Reset item selection when toggling
-          (state, [Msg.ToggleCategory viewingState.selectedCategory])
-      | LeftArrow ->
-        match viewingState.entityDefinition with
-        | Some _ ->
-          handleEntityScroll state ScrollDirection.PageUp
-        | None ->
-          handleItemNavigation state viewingState (-1L)
-      | RightArrow ->
-        match viewingState.entityDefinition with
-        | Some _ ->
-          handleEntityScroll state ScrollDirection.PageDown
-        | None ->
-          handleItemNavigation state viewingState 1L
-      | B ->
-        // If viewing entity definition, go back to module view
-        match viewingState.entityDefinition with
-        | Some _ ->
-          // Reset entity viewing state and return to module view
-          let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.None }
-          let moduleView = Command.formatModuleContent newViewingState
-          let completeInterface = Command.renderViewingInterface moduleView true
-          let newState =
-            { state with
-                viewingState = Stdlib.Option.Option.Some newViewingState
-                commandResult = CommandResult.Success completeInterface
-                needsFullRedraw = true }
-          (newState, [])
-        | None ->
-          // Go back to parent module while staying in viewing mode
-          if viewingState.entityName |> Stdlib.String.contains "." then
-            // Extract parent module path
-            let parts = viewingState.entityName |> Stdlib.String.split "."
-            let parentParts = parts |> Stdlib.List.dropLast
-            match parentParts with
-            | [] ->
-              // No parent, just stay where we are
-              (state, [])
-            | _ ->
-              // Navigate to parent module
-              let parentModule = Stdlib.String.join parentParts "."
-              (state, [Msg.SubmitCommand $"view {parentModule}"])
-          else
-            // Already at top level, can't go back further
-            (state, [])
-      | Q ->
-        // Exit viewing mode and return to regular prompt
-        // Exit alternate screen buffer first
-        let exitAlternateScreen = Command.Display.exitAltScreen
-        let newState =
-          { state with
-              viewingState = Stdlib.Option.Option.None
-              commandResult = CommandResult.Success (exitAlternateScreen ++ "Exited viewing mode")
-              needsFullRedraw = true }
-        (newState, [])
-      | _ ->
-        // Ignore other keys in viewing mode
-        (state, [])
 
     /// Handle key presses in normal mode
     let handleNormalModeKey (state: State) (key: Stdlib.Cli.Stdin.Key.Key) (keyChar: String) : (State * List<Msg>) =
@@ -339,7 +188,7 @@ module Darklang =
         // Handle key presses - delegate to specialized handlers
         match state.viewingState with
         | Some viewingState ->
-          handleViewingModeKey state viewingState key
+          CommandHelpers.View.Navigation.handleViewingModeKey state viewingState key modifiers
         | None ->
           handleNormalModeKey state key keyChar
 
@@ -404,6 +253,7 @@ module Darklang =
         | Some viewingState ->
           let currentValue = viewingState.expandedCategories |> Stdlib.List.member_v0 entityCategory
           let newSelectedItemIndex = if Stdlib.Bool.not currentValue then 0L else -1L
+          let isExpanding = Stdlib.Bool.not currentValue
 
           let newExpandedCategories =
             if currentValue then
@@ -411,14 +261,20 @@ module Darklang =
             else
               viewingState.expandedCategories |> Stdlib.List.push entityCategory
 
-          let newViewingState =
+          let intermediateViewingState =
             { viewingState with
                 expandedCategories = newExpandedCategories
                 selectedItemIndex = newSelectedItemIndex
                 entityDefinition = Stdlib.Option.Option.None }
 
-          let moduleView = Command.formatModuleContent newViewingState
-          let completeInterface = Command.renderViewingInterface moduleView true
+          // Auto-scroll to show the category when toggling
+          let finalScrollPosition = CommandHelpers.View.Navigation.ensureCategoryVisible intermediateViewingState entityCategory
+
+          let newViewingState =
+            { intermediateViewingState with viewportScrollPosition = finalScrollPosition }
+
+          let moduleView = CommandHelpers.View.Rendering.formatModuleContent newViewingState
+          let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
           let newState =
             { state with
                 viewingState = Stdlib.Option.Option.Some newViewingState
@@ -432,7 +288,7 @@ module Darklang =
         // Toggle the definition display of the selected item
         match state.viewingState with
         | Some viewingState ->
-          let entities = Command.getEntitiesForCategory viewingState.moduleContent category viewingState.entityName
+          let entities = CommandHelpers.View.EntityLookup.getEntitiesForCategory viewingState.moduleContent category viewingState.entityName
 
           let selectedEntity = entities |> Stdlib.List.getAt itemIndex
           match selectedEntity with
@@ -442,8 +298,8 @@ module Darklang =
             | Some entityDef when entityDef.name |> Stdlib.String.contains entityName ->
               // Hide the definition - return to module view while preserving selection
               let newViewingState = { viewingState with entityDefinition = Stdlib.Option.Option.None }
-              let moduleView = Command.formatModuleContent newViewingState
-              let completeInterface = Command.renderViewingInterface moduleView true
+              let moduleView = CommandHelpers.View.Rendering.formatModuleContent newViewingState
+              let completeInterface = CommandHelpers.View.Rendering.renderViewingInterface moduleView
               let newState =
                 { state with
                     viewingState = Stdlib.Option.Option.Some newViewingState


### PR DESCRIPTION
The CLI now supports an interactive mode when viewing modules to:
- Navigate through different entity categories (functions, types, constants, submodules) using arrow keys
- Expand/collapse categories to see their contents
- Select individual items within categories to see definitions

Interactive mode

https://github.com/user-attachments/assets/8b2fb675-8302-47ce-a9aa-76407fe1c813


non-interactive mode

https://github.com/user-attachments/assets/908902c9-5eeb-4544-9a2d-2a407b48c74c



**Future improvements:**

- Search within viewing mode
- Show entity documentation