### PR TITLE
fix pubsub emulator startup issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
       bash-completion \
       openssh-server \
       dnsutils \
+      openjdk-11-jdk \
       # .NET dependencies - https://github.com/dotnet/dotnet-docker/blob/master/src/runtime-deps/3.1/bionic/amd64/Dockerfile
       libc6 \
       libgcc1 \
@@ -220,6 +221,12 @@ RUN /home/dark/install-gz-file \
   --amd64-sha256=704a31cd89911a0f7d1741ee9ca32ca0f5496b06370bf398dfc5b7d3a31ef563 \
   --url=https://github.com/jpillora/chisel/releases/download/v1.9.1/chisel_1.9.1_linux_${TARGETARCH}.gz \
   --target=/usr/bin/chisel
+
+############################
+# Java version management
+############################
+# Set Java 11 as default for gcloud tools (including PubSub emulator)
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 ############################
 # PubSub


### PR DESCRIPTION
I ran into an issue with the devcontainer yesterday where the pubsub emulator wasn't running due to some Java dependency issue. This seemed to fix it for me. That said, I haven't seen the issue since, incl. on other branches, so going to leave this as a Draft until I see it again