### PR TITLE
Prompt to overwrite existing .darklang directory

### DIFF
--- a/backend/src/Cli/EmbeddedResources.fs
+++ b/backend/src/Cli/EmbeddedResources.fs
@@ -69,9 +69,21 @@ let extract () : unit =
 
     Environment.SetEnvironmentVariable("DARK_CONFIG_RUNDIR", darklangDir)
 
-    // Only extract if .darklang directory doesn't exist yet
-    if not (Directory.Exists(darklangDir)) then
+    let shouldExtract =
+      if not (Directory.Exists(darklangDir)) then
+        true
+      else
+        // Directory exists, ask user if they want to overwrite
+        printfn $"Found existing .darklang directory at {darklangDir}"
+        printf "Overwrite existing data? (y/n): "
+        let response = Console.ReadLine()
+        response = "y" || response = "Y"
+
+    if shouldExtract then
       printfn $"Setting up Darklang CLI data directory at {darklangDir}"
+
+      // Remove existing directory if it exists
+      if Directory.Exists(darklangDir) then Directory.Delete(darklangDir, true)
 
       // Extract database
       let dbPath = Path.Combine(darklangDir, "data.db")


### PR DESCRIPTION
When launching CLI with existing .darklang dir, ask user if they want to overwrite it rather than silently skipping setup.

(the lack of this sort of mechanism caused some confusion for me a bit ago)