### PR TITLE
Implement wildcard match pattern

### DIFF
--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -29,6 +29,7 @@ let rec checkAndExtractLetPattern
 
   match pat, dv with
   | LPVariable extractTo, dv -> true, [ (extractTo, dv) ]
+  | LPWildcard, _ -> true, []
   | LPUnit, DUnit -> true, []
   | LPTuple(first, second, theRest), DTuple(firstVal, secondVal, theRestVal) ->
     match r first firstVal, r second secondVal with

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -203,8 +203,8 @@ type LetPattern =
   /// `let x = 1`
   | LPVariable of id * name : string
 
-  // /// `let _ignored = 1`
-  // | LPIgnored
+  /// `let _ = 1`
+  | LPWildcard of id
 
   // /// let (x) = 1
   //| LPParens of inner : LetPattern
@@ -223,6 +223,7 @@ module LetPattern =
   let rec symbolsUsed (pattern : LetPattern) : Set<string> =
     match pattern with
     | LPVariable(_, name) -> Set.singleton name
+    | LPWildcard _ -> Set.empty
     | LPTuple(_, first, second, rest) ->
       Set.unionMany
         [ symbolsUsed first
@@ -233,6 +234,7 @@ module LetPattern =
   let toID (pattern : LetPattern) : id =
     match pattern with
     | LPVariable(id, _)
+    | LPWildcard id
     | LPTuple(id, _, _, _)
     | LPUnit id -> id
 

--- a/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
@@ -327,6 +327,7 @@ module LetPattern =
     let (caseName, fields) =
       match p with
       | PT.LPVariable(id, name) -> "LPVariable", [ DInt64(int64 id); DString name ]
+      | PT.LPWildcard id -> "LPWildcard", [ DInt64(int64 id) ]
       | PT.LPUnit id -> "LPUnit", [ DInt64(int64 id) ]
       | PT.LPTuple(id, first, second, theRest) ->
         "LPTuple",
@@ -342,6 +343,7 @@ module LetPattern =
     match d with
     | DEnum(_, _, [], "LPVariable", [ DInt64 id; DString name ]) ->
       PT.LPVariable(uint64 id, name)
+    | DEnum(_, _, [], "LPWildcard", [ DInt64 id ]) -> PT.LPWildcard(uint64 id)
     | DEnum(_, _, [], "LPUnit", [ DInt64 id ]) -> PT.LPUnit(uint64 id)
     | DEnum(_,
             _,

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -178,7 +178,9 @@ module LetPattern =
     (p : PT.LetPattern)
     : (RT.LetPattern * Map<string, RT.Register> * int) =
     match p with
-    | PT.LPUnit _ -> RT.LPUnit, Map.empty, rc
+    | PT.LPUnit _ -> RT.LPUnit, symbols, rc
+
+    | PT.LPWildcard _ -> RT.LPWildcard, symbols, rc
 
     | PT.LPTuple(_, first, second, theRest) ->
       let first, symbols, rc = toRT symbols rc first

--- a/backend/src/LibExecution/RTQueryCompiler.fs
+++ b/backend/src/LibExecution/RTQueryCompiler.fs
@@ -421,6 +421,7 @@ and executeInstruction
       =
       match p with
       | RT.LPVariable extractTo -> st.withReg (extractTo, srcVal)
+      | RT.LPWildcard -> st
       | RT.LPUnit -> st
       | RT.LPTuple(first, second, rest) ->
         // For tuples, extract elements if srcVal is a literal tuple
@@ -559,7 +560,9 @@ let compileLambda
   let lambdaParamReg =
     match lambdaImpl.patterns.head with
     | RT.LPVariable reg -> reg
-    | _ -> 0 // Default to 0 if not a simple variable pattern
+    | RT.LPWildcard -> 0
+    | RT.LPUnit -> 0
+    | RT.LPTuple _ -> 0
 
   let initialState =
     // Start with DBRow in the lambda parameter register

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -291,8 +291,8 @@ type LetPattern =
   /// `let x = 1`
   | LPVariable of extractTo : Register
 
-  // /// `let _ = 1`
-  // | LPIgnored
+  /// `let _ = 1`
+  | LPWildcard
 
   /// `let (x, y) = (1, 2)`
   | LPTuple of first : LetPattern * second : LetPattern * theRest : List<LetPattern>

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -319,6 +319,7 @@ module LetPattern =
     let (caseName, fields) =
       match p with
       | LPVariable reg -> "LPVariable", [ DInt32 reg ]
+      | LPWildcard -> "LPWildcard", []
       | LPUnit -> "LPUnit", []
       | LPTuple(first, second, theRest) ->
         "LPTuple",
@@ -331,6 +332,7 @@ module LetPattern =
   let rec fromDT (d : Dval) : LetPattern =
     match d with
     | DEnum(_, _, [], "LPVariable", [ DInt32 reg ]) -> LPVariable(reg)
+    | DEnum(_, _, [], "LPWildcard", []) -> LPWildcard
     | DEnum(_, _, [], "LPUnit", []) -> LPUnit
     | DEnum(_, _, [], "LPTuple", [ first; second; DList(_vtTODO, theRest) ]) ->
       LPTuple(fromDT first, fromDT second, List.map fromDT theRest)

--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -167,7 +167,7 @@ module LetPattern =
 
     match pat with
     | SynPat.Paren(subPat, _) -> mapPat subPat
-    | SynPat.Wild(_) -> WT.LPVariable(gid (), "_")
+    | SynPat.Wild(_) -> WT.LPWildcard(gid ())
     | SynPat.Named(SynIdent(name, _), _, _, _) -> WT.LPVariable(gid (), name.idText)
     | SynPat.Const(SynConst.Unit, _) -> WT.LPUnit(gid ())
 
@@ -689,7 +689,7 @@ module Expr =
 
     // Sequential code: (a; b) -> let _ = a in b
     | SynExpr.Sequential(_, _, a, b, _) ->
-      WT.ELet(id, WT.LPVariable(gid (), "_"), c a, c b)
+      WT.ELet(id, WT.LPWildcard(gid ()), c a, c b)
 
 
     // Pipes (|>)

--- a/backend/src/LibParser/WrittenTypes.fs
+++ b/backend/src/LibParser/WrittenTypes.fs
@@ -53,6 +53,7 @@ type UnresolvedEnumTypeName = List<string>
 type LetPattern =
   | LPUnit of id
   | LPVariable of id * name : string
+  | LPWildcard of id
   | LPTuple of
     id *
     first : LetPattern *

--- a/backend/src/LibParser/WrittenTypesToProgramTypes.fs
+++ b/backend/src/LibParser/WrittenTypesToProgramTypes.fs
@@ -128,6 +128,7 @@ module LetPattern =
             // Track this as a local binding to prevent resolving it as a global
             localBindings = Set.add varName context.localBindings }
       (newContext, PT.LPVariable(id, varName))
+    | WT.LPWildcard id -> (context, PT.LPWildcard id)
     | WT.LPTuple(id, first, second, theRest) ->
       let (context1, first') = toPT context first
       let (context2, second') = toPT context1 second

--- a/backend/src/LibSerialization/Binary/Serializers/PT/Expr.fs
+++ b/backend/src/LibSerialization/Binary/Serializers/PT/Expr.fs
@@ -91,6 +91,9 @@ module LetPattern =
       write w first
       write w second
       List.write w write rest
+    | LPWildcard id ->
+      w.Write 3uy
+      w.Write id
 
   let rec read (r : BinaryReader) : LetPattern =
     match r.ReadByte() with
@@ -107,6 +110,9 @@ module LetPattern =
       let second = read r
       let rest = List.read r read
       LPTuple(id, first, second, rest)
+    | 3uy ->
+      let id = r.ReadUInt64()
+      LPWildcard id
     | b -> raiseFormatError $"Invalid LetPattern tag: {b}"
 
 

--- a/backend/src/LibSerialization/Binary/Serializers/RT/Instructions.fs
+++ b/backend/src/LibSerialization/Binary/Serializers/RT/Instructions.fs
@@ -23,6 +23,7 @@ module LetPattern =
       write w second
       List.write w write theRest
     | LPUnit -> w.Write 2uy
+    | LPWildcard -> w.Write 3uy
 
   let rec read (r : BinaryReader) : LetPattern =
     match r.ReadByte() with
@@ -33,6 +34,7 @@ module LetPattern =
       let theRest = List.read r read
       LPTuple(first, second, theRest)
     | 2uy -> LPUnit
+    | 3uy -> LPWildcard
     | b -> raiseFormatError $"Invalid LetPattern tag: {b}"
 
 

--- a/backend/testfiles/execution/language/basic/elet.dark
+++ b/backend/testfiles/execution/language/basic/elet.dark
@@ -71,6 +71,36 @@ module Shadowing =
      | Ok(Ok x) -> let x = 9L in x + 2L))) = [ 11L; 11L; 11L; 11L ]
 
 
+module Wildcard =
+  // Simple wildcard - should match any value without binding it
+  (let _ = 5L in 10L) = 10L
+
+  // Wildcard with side effects - the value should still be evaluated
+  (let _ = Builtin.testRuntimeError "test" in 10L) = error="Uncaught exception: test"
+
+  // Wildcard in tuple destructuring
+  (let (x, _) = (1L, 2L) in x) = 1L
+  (let (_, y) = (1L, 2L) in y) = 2L
+  (let (_, _) = (1L, 2L) in 5L) = 5L
+
+  // Multiple wildcards in tuple
+  (let (_, _, _) = (1L, 2L, 3L) in 10L) = 10L
+  (let (x, _, _) = (1L, 2L, 3L) in x) = 1L
+  (let (_, y, _) = (1L, 2L, 3L) in y) = 2L
+  (let (_, _, z) = (1L, 2L, 3L) in z) = 3L
+
+  // Nested wildcards in tuples
+  (let ((_, x), _) = ((1L, 2L), 3L) in x) = 2L
+  (let (_, (_, y)) = (1L, (2L, 3L)) in y) = 3L
+
+  // Wildcard should not bind variable
+  // This should fail because _ is not a variable
+  // (let _ = 5L in _) should give a variable not found error
+
+  // Wildcard with complex values
+  (let _ = [ 1L; 2L; 3L ] in "done") = "done"
+
+
 module Errors =
-  (let (a, _) = 1 in a) = error="Could not deconstruct value 1 into pattern ([variable], [variable])"
-  (let (a, _) = (1, 2, 3) in a) = error="Could not deconstruct value (1, 2, 3) into pattern ([variable], [variable])"
+  (let (a, _) = 1 in a) = error="Could not deconstruct value 1 into pattern ([variable], _)"
+  (let (a, _) = (1, 2, 3) in a) = error="Could not deconstruct value (1, 2, 3) into pattern ([variable], _)"

--- a/backend/tests/TestUtils/PTShortcuts.fs
+++ b/backend/tests/TestUtils/PTShortcuts.fs
@@ -40,6 +40,7 @@ let eTuple (first : Expr) (second : Expr) (theRest : Expr list) : Expr =
 
 let lpUnit () : LetPattern = LPUnit(gid ())
 let lpVar (name : string) : LetPattern = LPVariable(gid (), name)
+let lpWildcard () : LetPattern = LPWildcard(gid ())
 let lpTuple
   (first : LetPattern)
   (second : LetPattern)

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -731,6 +731,7 @@ module Expect =
 
       match actual, expected with
       | LPVariable(_, name), LPVariable(_, name') -> check path name name'
+      | LPWildcard _, LPWildcard _ -> ()
       | LPUnit(_), LPUnit(_) -> ()
       | LPTuple(_, first, second, theRest), LPTuple(_, first', second', theRest') ->
         let all = first :: second :: theRest
@@ -743,6 +744,7 @@ module Expect =
 
       // exhaustive match
       | LPVariable _, _
+      | LPWildcard _, _
       | LPUnit _, _
       | LPTuple _, _ -> errorFn path (string actual) (string expected)
 

--- a/packages/darklang/languageTools/programTypes.dark
+++ b/packages/darklang/languageTools/programTypes.dark
@@ -73,6 +73,7 @@ type TypeReference =
 type LetPattern =
   | LPUnit of ID
   | LPVariable of ID * name: String
+  | LPWildcard of ID
   | LPTuple of
     ID *
     first: LetPattern *

--- a/packages/darklang/languageTools/runtimeTypes.dark
+++ b/packages/darklang/languageTools/runtimeTypes.dark
@@ -106,6 +106,7 @@ type ValueType =
 
 type LetPattern =
   | LPVariable of reg: Register
+  | LPWildcard
   | LPUnit
   | LPTuple of
     first: LetPattern *

--- a/packages/darklang/languageTools/semanticTokens.dark
+++ b/packages/darklang/languageTools/semanticTokens.dark
@@ -524,6 +524,7 @@ module Expr =
       match lp with
       | LPUnit range -> [ makeToken range TokenType.Symbol ]
       | LPVariable(range, _name) -> [ makeToken range TokenType.VariableName ]
+      | LPWildcard range -> [ makeToken range TokenType.Symbol ]
       | LPTuple(range,
                 first,
                 symbolComma,

--- a/packages/darklang/languageTools/writtenTypes.dark
+++ b/packages/darklang/languageTools/writtenTypes.dark
@@ -123,6 +123,7 @@ module TypeReference =
 type LetPattern =
   | LPUnit of Range
   | LPVariable of Range * name: String
+  | LPWildcard of Range
   | LPTuple of
     Range *
     first: LetPattern *

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -278,6 +278,7 @@ module Expr =
       : (Context * ProgramTypes.LetPattern) =
       match p with
       | LPUnit _ -> (context, ProgramTypes.LetPattern.LPUnit(gid ()))
+      | LPWildcard _ -> (context, ProgramTypes.LetPattern.LPWildcard(gid ()))
       | LPVariable(_, name) ->
         let shadowsFunctionName =
           match context.currentFnName with

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -394,6 +394,7 @@ let letPattern (lp: LanguageTools.ProgramTypes.LetPattern) : String =
   match lp with
   | LPUnit _id -> "()"
   | LPVariable(_id, name) -> name
+  | LPWildcard _id -> "_"
   | LPTuple(_id, first, second, theRest) ->
     (Stdlib.List.append [ first; second ] theRest)
     |> Stdlib.List.map (fun item -> letPattern item)

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -275,6 +275,7 @@ let letPattern (pat: LanguageTools.RuntimeTypes.LetPattern) : String =
   | LPVariable _reg ->
     // TODO clearly this is not ideal.
     "[variable]"
+  | LPWildcard -> "_"
   | LPUnit -> "()"
   | LPTuple(first, second, theRest) ->
     let parts = Stdlib.List.append [ first; second ] theRest


### PR DESCRIPTION
`_` in let patterns now properly discards values instead of binding them as a variable, matching standard ML-family semantics. This enables correct scoping, clearer error messages, and lays groundwork for future exhaustiveness checking.

---

Add LPWildcard case to LetPattern types across the codebase. The wildcard pattern `_` now properly matches any value without binding it to a variable, distinguishing it from a regular variable named "_".

Changes:
- Added LPWildcard to LetPattern in all type definitions (PT, RT, WT, and language tools)
- Updated parser to recognize `_` as LPWildcard instead of LPVariable
- Updated type converters to handle LPWildcard conversion
- Updated interpreter to match wildcards without extracting bindings
- Added binary serialization support for LPWildcard
- Updated pretty printers and semantic tokens for wildcard display
- Added comprehensive tests for wildcard patterns in tuples and let bindings
- Fixed symbol threading in ProgramTypesToRuntimeTypes to preserve symbols
  from previous patterns when processing wildcards