### PR TITLE
Initial millisecond-precision DateTime builtins and monotonic timer

### DIFF
--- a/backend/src/BuiltinCli/Libs/Time.fs
+++ b/backend/src/BuiltinCli/Libs/Time.fs
@@ -27,6 +27,25 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      deprecated = NotDeprecated }
+
+    { name = fn "timeNowMs" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TInt64
+      description =
+        "Returns a monotonic timestamp in milliseconds. Useful for measuring "
+        + "elapsed time between two calls (subtract start from end). The absolute "
+        + "value has no defined epoch — only differences are meaningful."
+      fn =
+        (function
+        | _, _, _, [ DUnit ] ->
+          let ts = System.Diagnostics.Stopwatch.GetTimestamp()
+          let ms = ts * 1000L / System.Diagnostics.Stopwatch.Frequency
+          DInt64 ms |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Impure
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/BuiltinExecution/Libs/DateTime.fs
+++ b/backend/src/BuiltinExecution/Libs/DateTime.fs
@@ -11,6 +11,8 @@ module DarkDateTime = LibExecution.DarkDateTime
 
 
 let ISO8601Format = "yyyy-MM-ddTHH:mm:ssZ"
+let ISO8601FormatWithMs = "yyyy-MM-ddTHH:mm:ss.fffZ"
+let ISO8601Formats = [| ISO8601Format; ISO8601FormatWithMs |]
 
 let ISO8601DateParser (s : string) : Result<DarkDateTime.T, unit> =
   let culture = System.Globalization.CultureInfo.InvariantCulture
@@ -22,7 +24,7 @@ let ISO8601DateParser (s : string) : Result<DarkDateTime.T, unit> =
   | date when date.Contains("GMT") -> Error()
   | date when date.EndsWith('z') -> Error()
   | date when
-    System.DateTime.TryParseExact(date, ISO8601Format, culture, styles, &result)
+    System.DateTime.TryParseExact(date, ISO8601Formats, culture, styles, &result)
     ->
     Ok(DarkDateTime.fromDateTime (result.ToUniversalTime()))
   | _ -> Error()
@@ -56,14 +58,22 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "date" TDateTime "" ]
       returnType = TString
       description =
-        "Stringify <param date> to the ISO 8601 format {{YYYY-MM-DD'T'hh:mm:ss'Z'}}"
+        "Stringify <param date> to the ISO 8601 format {{YYYY-MM-DD'T'hh:mm:ss'Z'}} "
+        + "or {{YYYY-MM-DD'T'hh:mm:ss.fff'Z'}} when milliseconds are non-zero"
       fn =
         (function
         | _, _, _, [ DDateTime d ] ->
           let dt = DarkDateTime.toDateTimeUtc d
-          dt.ToString("s", System.Globalization.CultureInfo.InvariantCulture) + "Z"
-          |> DString
-          |> Ply
+          let hasMs = dt.Millisecond <> 0
+
+          let str =
+            if hasMs then
+              dt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+            else
+              dt.ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+              + "Z"
+
+          str |> DString |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
@@ -397,6 +407,109 @@ let fns () : List<BuiltInFn> =
           diff.TotalSeconds |> System.Math.Round |> int64 |> DInt64 |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "dateTimeToMilliseconds" 0
+      typeParams = []
+      parameters = [ Param.make "date" TDateTime "" ]
+      returnType = TInt64
+      description =
+        "Converts <param date> to an <type Int64> representing milliseconds since the Unix epoch"
+      fn =
+        (function
+        | _, _, _, [ DDateTime d ] ->
+          (DarkDateTime.toInstant d).ToUnixTimeMilliseconds() |> DInt64 |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "dateTimeFromMilliseconds" 0
+      typeParams = []
+      parameters = [ Param.make "milliseconds" TInt64 "" ]
+      returnType = TDateTime
+      description =
+        "Converts an <type Int64> representing milliseconds since the Unix epoch into a <type DateTime>"
+      fn =
+        (function
+        | _, _, _, [ DInt64 ms ] ->
+          ms
+          |> Instant.FromUnixTimeMilliseconds
+          |> DarkDateTime.fromInstant
+          |> DDateTime
+          |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "dateTimeAddMilliseconds" 0
+      typeParams = []
+      parameters =
+        [ Param.make "d" TDateTime ""; Param.make "milliseconds" TInt64 "" ]
+      returnType = TDateTime
+      description =
+        "Returns a <type DateTime> <param milliseconds> milliseconds after <param d>"
+      fn =
+        (function
+        | _, _, _, [ DDateTime d; DInt64 ms ] ->
+          d + (NodaTime.Period.FromMilliseconds ms) |> DDateTime |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "dateTimeSubtractMilliseconds" 0
+      typeParams = []
+      parameters =
+        [ Param.make "d" TDateTime ""; Param.make "milliseconds" TInt64 "" ]
+      returnType = TDateTime
+      description =
+        "Returns a <type DateTime> <param milliseconds> milliseconds before <param d>"
+      fn =
+        (function
+        | _, _, _, [ DDateTime d; DInt64 ms ] ->
+          d - (NodaTime.Period.FromMilliseconds ms) |> DDateTime |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "dateTimeMillisecond" 0
+      typeParams = []
+      parameters = [ Param.make "date" TDateTime "" ]
+      returnType = TInt64
+      description =
+        "Returns the millisecond portion of <param date> as an <type Int64> between {{0}} and {{999}}"
+      fn =
+        (function
+        | _, _, _, [ DDateTime d ] -> d.Millisecond |> int64 |> Dval.int64 |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "dateTimeSubtractMs" 0
+      typeParams = []
+      parameters = [ Param.make "end" TDateTime ""; Param.make "start" TDateTime "" ]
+      returnType = TInt64
+      description = "Returns the difference of the two dates, in milliseconds"
+      fn =
+        (function
+        | _, _, _, [ DDateTime endDate; DDateTime startDate ] ->
+          let diff =
+            (DarkDateTime.toInstant endDate) - (DarkDateTime.toInstant startDate)
+
+          diff.TotalMilliseconds |> System.Math.Round |> int64 |> DInt64 |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
       previewable = Pure
       deprecated = NotDeprecated } ]
 

--- a/backend/src/Prelude/Prelude.fs
+++ b/backend/src/Prelude/Prelude.fs
@@ -326,7 +326,11 @@ type NodaTime.Instant with
 
   member this.toIsoString() : string =
     let dt = this.ToDateTimeUtc()
-    dt.ToString("s", System.Globalization.CultureInfo.InvariantCulture) + "Z"
+
+    if dt.Millisecond <> 0 then
+      dt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+    else
+      dt.ToString("s", System.Globalization.CultureInfo.InvariantCulture) + "Z"
 
   // Returns a new datetime with truncated
   member this.truncate() : NodaTime.Instant =
@@ -337,12 +341,16 @@ type NodaTime.Instant with
 
 
   static member ofIsoString(str : string) : NodaTime.Instant =
+    let formats = [| "yyyy-MM-ddTHH:mm:ssZ"; "yyyy-MM-ddTHH:mm:ss.fffZ" |]
+
     let dt =
       System.DateTime.ParseExact(
         str,
-        "yyyy-MM-ddTHH:mm:ssZ",
-        System.Globalization.CultureInfo.InvariantCulture
+        formats,
+        System.Globalization.CultureInfo.InvariantCulture,
+        System.Globalization.DateTimeStyles.None
       )
+
     let utcDateTime = System.DateTime(dt.Ticks, System.DateTimeKind.Utc)
     NodaTime.Instant.FromDateTimeUtc utcDateTime
   static member ofUtcInstant

--- a/backend/testfiles/execution/stdlib/date.dark
+++ b/backend/testfiles/execution/stdlib/date.dark
@@ -33,7 +33,7 @@ module DateParsing =
   p "2018-09-24T17:48:00" = Stdlib.Result.Result.Error "Invalid date format"
   p "2018-09-24T18:09:24+0200" = Stdlib.Result.Result.Error "Invalid date format"
   p "1999-03-22T05:06:07+01:00" = Stdlib.Result.Result.Error "Invalid date format"
-  p "1999-03-22T05:06:07.000Z" = Stdlib.Result.Result.Error "Invalid date format"
+  p "1999-03-22T05:06:07.000Z" = Stdlib.Result.Result.Ok "1999-03-22T05:06:07Z"
   p "2006-06-09T10:20:30.040" = Stdlib.Result.Result.Error "Invalid date format"
   p "2006-06-09T10:20:30.040+02:00" = Stdlib.Result.Result.Error "Invalid date format"
   p "20061204T1020Z" = Stdlib.Result.Result.Error "Invalid date format"
@@ -249,3 +249,82 @@ module Difference =
   s "2020-11-14T14:51:06Z" "2020-11-26T04:37:46Z" = -1000000L
   s "1921-01-01T12:00:00Z" "2021-01-01T12:00:00Z" = -3155760000L
   s "2021-01-01T12:00:00Z" "1921-01-01T12:00:00Z" = 3155760000L
+
+
+module MillisecondParsing =
+  // Fractional seconds are now accepted
+  p "2019-07-28T22:42:36.123Z" = Stdlib.Result.Result.Ok "2019-07-28T22:42:36.123Z"
+  p "2019-07-28T22:42:36.000Z" = Stdlib.Result.Result.Ok "2019-07-28T22:42:36Z"
+  p "2019-07-28T22:42:36.001Z" = Stdlib.Result.Result.Ok "2019-07-28T22:42:36.001Z"
+  p "2019-07-28T22:42:36.999Z" = Stdlib.Result.Result.Ok "2019-07-28T22:42:36.999Z"
+
+  // Original format still works
+  p "2019-07-28T22:42:36Z" = Stdlib.Result.Result.Ok "2019-07-28T22:42:36Z"
+
+  // Fractional seconds with wrong digit count still rejected
+  p "2019-07-28T22:42:36.1Z" = Stdlib.Result.Result.Error "Invalid date format"
+  p "2019-07-28T22:42:36.12Z" = Stdlib.Result.Result.Error "Invalid date format"
+  p "2019-07-28T22:42:36.1234Z" = Stdlib.Result.Result.Error "Invalid date format"
+
+
+module MillisecondConversion =
+  Stdlib.DateTime.toMilliseconds (d "2019-07-28T22:42:36Z") = 1564353756000L
+  Stdlib.DateTime.toMilliseconds (d "1970-01-01T00:00:00Z") = 0L
+
+  1564353756000L
+  |> Stdlib.DateTime.fromMilliseconds
+  |> Stdlib.DateTime.toMilliseconds = 1564353756000L
+
+  1564353756123L
+  |> Stdlib.DateTime.fromMilliseconds
+  |> Stdlib.DateTime.toMilliseconds = 1564353756123L
+
+  1564353756123L
+  |> Stdlib.DateTime.fromMilliseconds
+  |> Stdlib.DateTime.toString_v0 = "2019-07-28T22:42:36.123Z"
+
+  // Round-trip: ms -> DateTime -> ms
+  0L |> Stdlib.DateTime.fromMilliseconds |> Stdlib.DateTime.toMilliseconds = 0L
+  -1000L |> Stdlib.DateTime.fromMilliseconds |> Stdlib.DateTime.toMilliseconds = -1000L
+
+
+module MillisecondField =
+  let dMs (datestr: String) : DateTime =
+    (Stdlib.DateTime.parse datestr) |> Builtin.unwrap
+
+  Stdlib.DateTime.millisecond (dMs "2019-07-28T22:42:36.456Z") = 456L
+  Stdlib.DateTime.millisecond (dMs "2019-07-28T22:42:36.000Z") = 0L
+  Stdlib.DateTime.millisecond (d "2019-07-28T22:42:36Z") = 0L
+  Stdlib.DateTime.millisecond (dMs "2019-07-28T22:42:36.001Z") = 1L
+  Stdlib.DateTime.millisecond (dMs "2019-07-28T22:42:36.999Z") = 999L
+
+
+module AddMilliseconds =
+  let ams (d1: String) (ms: Int64) : DateTime =
+    Stdlib.DateTime.addMilliseconds (d d1) ms
+
+  ams "2020-11-26T04:37:46Z" 0L = (d "2020-11-26T04:37:46Z")
+  (ams "2020-11-26T04:37:46Z" 500L) |> Stdlib.DateTime.millisecond = 500L
+  ams "2020-11-26T04:37:46Z" 1000L = (d "2020-11-26T04:37:47Z")
+  (ams "2020-11-26T04:37:46Z" 1500L) |> Stdlib.DateTime.toString_v0 = "2020-11-26T04:37:47.500Z"
+  (ams "2020-11-26T04:37:46Z" -500L) |> Stdlib.DateTime.toString_v0 = "2020-11-26T04:37:45.500Z"
+
+
+module SubtractMilliseconds =
+  let sms (d1: String) (ms: Int64) : DateTime =
+    Stdlib.DateTime.subtractMilliseconds (d d1) ms
+
+  sms "2020-11-26T04:37:46Z" 0L = (d "2020-11-26T04:37:46Z")
+  (sms "2020-11-26T04:37:46Z" 500L) |> Stdlib.DateTime.millisecond = 500L
+  sms "2020-11-26T04:37:46Z" 1000L = (d "2020-11-26T04:37:45Z")
+  (sms "2020-11-26T04:37:46Z" -500L) |> Stdlib.DateTime.toString_v0 = "2020-11-26T04:37:46.500Z"
+
+
+module DifferenceMs =
+  let sMs (d1: String) (d2: String) : Int64 =
+    Stdlib.DateTime.subtractMs (d d1) (d d2)
+
+  sMs "2020-11-26T04:37:46Z" "2020-11-26T04:37:46Z" = 0L
+  sMs "2020-11-26T04:37:46Z" "2020-11-26T04:37:45Z" = 1000L
+  sMs "2020-11-26T04:37:46Z" "2020-11-26T04:37:56Z" = -10000L
+  sMs "2021-01-01T00:00:00Z" "2020-01-01T00:00:00Z" = 31622400000L

--- a/packages/darklang/stdlib/dateTime.dark
+++ b/packages/darklang/stdlib/dateTime.dark
@@ -104,3 +104,33 @@ let atStartOfDay (date: DateTime) : DateTime =
 /// Returns the difference of the two dates, in seconds
 let subtract (d1: DateTime) (d2: DateTime) : Int64 =
   Builtin.dateTimeSubtract d1 d2
+
+
+/// Converts <param date> to an <type Int64> representing milliseconds since the Unix epoch
+let toMilliseconds (date: DateTime) : Int64 =
+  Builtin.dateTimeToMilliseconds date
+
+
+/// Converts an <type Int64> representing milliseconds since the Unix epoch into a <type DateTime>
+let fromMilliseconds (milliseconds: Int64) : DateTime =
+  Builtin.dateTimeFromMilliseconds milliseconds
+
+
+/// Returns a <type DateTime> <param milliseconds> milliseconds after <param d>
+let addMilliseconds (d: DateTime) (milliseconds: Int64) : DateTime =
+  Builtin.dateTimeAddMilliseconds d milliseconds
+
+
+/// Returns a <type DateTime> <param milliseconds> milliseconds before <param d>
+let subtractMilliseconds (d: DateTime) (milliseconds: Int64) : DateTime =
+  Builtin.dateTimeSubtractMilliseconds d milliseconds
+
+
+/// Returns the millisecond portion of <param date> as an <type Int64> between {{0}} and {{999}}
+let millisecond (date: DateTime) : Int64 =
+  Builtin.dateTimeMillisecond date
+
+
+/// Returns the difference of the two dates, in milliseconds
+let subtractMs (d1: DateTime) (d2: DateTime) : Int64 =
+  Builtin.dateTimeSubtractMs d1 d2


### PR DESCRIPTION
- Add Builtin.timeNowMs (monotonic ms timer for perf measurement)
- Add DateTime.toMilliseconds/fromMilliseconds (Unix epoch ms)
- Add DateTime.addMilliseconds/subtractMilliseconds
- Add DateTime.millisecond (extract ms component 0-999)
- Add DateTime.subtractMs (difference in ms between two dates)
- Update parser to accept ISO 8601 with fractional seconds (.fffZ)
- Update toString to emit .fffZ when milliseconds are non-zero
- Update Prelude NodaTime extensions for .fff round-tripping