### PR TITLE
CLI telemetry and performance caching; instructions for testing interactive CLI

### DIFF
--- a/backend/src/BuiltinCli/Libs/Terminal.fs
+++ b/backend/src/BuiltinCli/Libs/Terminal.fs
@@ -8,6 +8,80 @@ open LibExecution.RuntimeTypes
 open LibExecution.Builtin.Shortcuts
 
 
+// Cache terminal dimensions — refreshed at most every 500ms
+let mutable private cachedWidth : int64 = 0L
+let mutable private cachedHeight : int64 = 0L
+let mutable private lastDimensionCheck : int64 = 0L
+let private dimensionCacheMs = 500L
+
+let private shouldRefreshDimensions () =
+  let now =
+    System.Diagnostics.Stopwatch.GetTimestamp() * 1000L
+    / System.Diagnostics.Stopwatch.Frequency
+  if now - lastDimensionCheck > dimensionCacheMs then
+    lastDimensionCheck <- now
+    true
+  else
+    false
+
+let private isUnix () =
+  System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+    System.Runtime.InteropServices.OSPlatform.Linux
+  )
+  || System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+    System.Runtime.InteropServices.OSPlatform.OSX
+  )
+
+/// Try to get a terminal dimension via tput, falling back to the given default.
+let private tputDimension (tputArg : string) (fallback : int) : int =
+  try
+    let p = new System.Diagnostics.Process()
+    p.StartInfo.FileName <- "/bin/sh"
+    p.StartInfo.Arguments <- $"-c \"tput {tputArg} 2>/dev/null || echo {fallback}\""
+    p.StartInfo.UseShellExecute <- false
+    p.StartInfo.RedirectStandardOutput <- true
+    p.StartInfo.CreateNoWindow <- true
+    if p.Start() then
+      let output = p.StandardOutput.ReadToEnd().Trim()
+      p.WaitForExit()
+      match System.Int32.TryParse(output) with
+      | true, v when v > 0 -> v
+      | _ -> fallback
+    else
+      fallback
+  with _ ->
+    fallback
+
+/// Get a terminal dimension with caching: check env var, then Console, then tput.
+let private getDimension
+  (envVar : string)
+  (consoleFn : unit -> int)
+  (tputArg : string)
+  (defaultVal : int)
+  (cached : byref<int64>)
+  : int64 =
+  if not (shouldRefreshDimensions ()) && cached > 0L then
+    cached
+  else
+    let result =
+      try
+        match System.Environment.GetEnvironmentVariable(envVar) with
+        | null ->
+          let consoleVal = consoleFn ()
+          if consoleVal = defaultVal && isUnix () then
+            tputDimension tputArg defaultVal |> int64
+          else
+            int64 consoleVal
+        | envVal ->
+          match System.Int32.TryParse(envVal) with
+          | true, v when v > 0 -> int64 v
+          | _ -> int64 defaultVal
+      with _ ->
+        int64 defaultVal
+    cached <- result
+    result
+
+
 let fns () : List<BuiltInFn> =
   [ { name = fn "cliGetTerminalHeight" 0
       typeParams = []
@@ -17,56 +91,15 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | _, _, [], [ DUnit ] ->
-          uply {
-            try
-              // First try environment variable (most reliable across different terminals)
-              match System.Environment.GetEnvironmentVariable("LINES") with
-              | null ->
-                // Try Console.WindowHeight
-                let height = System.Console.WindowHeight
-
-                // If we get exactly 24, it might be a default value
-                // Let's try alternative methods
-                if height = 24 then
-                  // On Unix systems, try tput command
-                  if
-                    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                      System.Runtime.InteropServices.OSPlatform.Linux
-                    )
-                    || System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                      System.Runtime.InteropServices.OSPlatform.OSX
-                    )
-                  then
-                    try
-                      let p = new System.Diagnostics.Process()
-                      p.StartInfo.FileName <- "/bin/sh"
-                      p.StartInfo.Arguments <-
-                        "-c \"tput lines 2>/dev/null || echo 24\""
-                      p.StartInfo.UseShellExecute <- false
-                      p.StartInfo.RedirectStandardOutput <- true
-                      p.StartInfo.CreateNoWindow <- true
-                      if p.Start() then
-                        let output = p.StandardOutput.ReadToEnd().Trim()
-                        p.WaitForExit()
-                        match System.Int32.TryParse(output) with
-                        | true, h when h > 0 -> return DInt64(int64 h)
-                        | _ -> return DInt64(int64 height)
-                      else
-                        return DInt64(int64 height)
-                    with _ ->
-                      return DInt64(int64 height)
-                  else
-                    return DInt64(int64 height)
-                else
-                  return DInt64(int64 height)
-              | lines ->
-                match System.Int32.TryParse(lines) with
-                | true, h when h > 0 -> return DInt64(int64 h)
-                | _ -> return DInt64 24L
-            with _ ->
-              // Fallback if unable to detect terminal size
-              return DInt64 24L
-          }
+          DInt64(
+            getDimension
+              "LINES"
+              (fun () -> System.Console.WindowHeight)
+              "lines"
+              24
+              &cachedHeight
+          )
+          |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
@@ -81,56 +114,29 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | _, _, [], [ DUnit ] ->
-          uply {
-            try
-              // First try environment variable (most reliable across different terminals)
-              match System.Environment.GetEnvironmentVariable("COLUMNS") with
-              | null ->
-                // Try Console.WindowWidth
-                let width = System.Console.WindowWidth
+          DInt64(
+            getDimension
+              "COLUMNS"
+              (fun () -> System.Console.WindowWidth)
+              "cols"
+              80
+              &cachedWidth
+          )
+          |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
 
-                // If we get exactly 80, it might be a default value
-                // Let's try alternative methods
-                if width = 80 then
-                  // On Unix systems, try tput command
-                  if
-                    System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                      System.Runtime.InteropServices.OSPlatform.Linux
-                    )
-                    || System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-                      System.Runtime.InteropServices.OSPlatform.OSX
-                    )
-                  then
-                    try
-                      let p = new System.Diagnostics.Process()
-                      p.StartInfo.FileName <- "/bin/sh"
-                      p.StartInfo.Arguments <-
-                        "-c \"tput cols 2>/dev/null || echo 80\""
-                      p.StartInfo.UseShellExecute <- false
-                      p.StartInfo.RedirectStandardOutput <- true
-                      p.StartInfo.CreateNoWindow <- true
-                      if p.Start() then
-                        let output = p.StandardOutput.ReadToEnd().Trim()
-                        p.WaitForExit()
-                        match System.Int32.TryParse(output) with
-                        | true, w when w > 0 -> return DInt64(int64 w)
-                        | _ -> return DInt64(int64 width)
-                      else
-                        return DInt64(int64 width)
-                    with _ ->
-                      return DInt64(int64 width)
-                  else
-                    return DInt64(int64 width)
-                else
-                  return DInt64(int64 width)
-              | columns ->
-                match System.Int32.TryParse(columns) with
-                | true, w when w > 0 -> return DInt64(int64 w)
-                | _ -> return DInt64 80L
-            with _ ->
-              // Fallback if unable to detect terminal size
-              return DInt64 80L
-          }
+
+    { name = fn "cliGetLogDir" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TString
+      description = "Returns the absolute path to the CLI log directory"
+      fn =
+        (function
+        | _, _, [], [ DUnit ] -> DString(LibConfig.Config.logDir) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure

--- a/backend/src/BuiltinCli/Libs/Time.fs
+++ b/backend/src/BuiltinCli/Libs/Time.fs
@@ -46,6 +46,102 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      deprecated = NotDeprecated }
+
+    { name = fn "interpreterStatsReset" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TUnit
+      description = "Resets interpreter performance counters to zero."
+      fn =
+        (function
+        | _, vm, _, [ DUnit ] ->
+          vm.stats.reset ()
+          vm.stats.enabled <- true
+          DUnit |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+    { name = fn "interpreterStatsGet" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TString
+      description =
+        "Returns interpreter performance counters as a JSON string. "
+        + "Includes instruction count, builtin/package call counts, frame pushes. "
+        + "When detailed timing is enabled, also includes per-builtin and per-package-fn "
+        + "cumulative microseconds and call counts."
+      fn =
+        (function
+        | _, vm, _, [ DUnit ] ->
+          let s = vm.stats
+          let sb = System.Text.StringBuilder()
+          sb.Append("{") |> ignore<System.Text.StringBuilder>
+          sb.Append($"\"instructions\":{s.instructionCount}")
+          |> ignore<System.Text.StringBuilder>
+          sb.Append($",\"builtinCalls\":{s.builtinCallCount}")
+          |> ignore<System.Text.StringBuilder>
+          sb.Append($",\"packageCalls\":{s.packageCallCount}")
+          |> ignore<System.Text.StringBuilder>
+          sb.Append($",\"framePushes\":{s.framePushCount}")
+          |> ignore<System.Text.StringBuilder>
+          let dtStr = if s.detailedTiming then "true" else "false"
+          sb.Append($",\"detailedTiming\":{dtStr}")
+          |> ignore<System.Text.StringBuilder>
+
+          if s.detailedTiming && s.builtinTiming.Count > 0 then
+            sb.Append(",\"builtinTiming\":{") |> ignore<System.Text.StringBuilder>
+            let mutable first = true
+            for kv in s.builtinTiming do
+              if not first then sb.Append(",") |> ignore<System.Text.StringBuilder>
+              let count =
+                match s.builtinCounts.TryGetValue(kv.Key) with
+                | true, c -> c
+                | _ -> 0L
+              sb.Append($"\"{kv.Key}\":{{\"us\":{kv.Value},\"n\":{count}}}")
+              |> ignore<System.Text.StringBuilder>
+              first <- false
+            sb.Append("}") |> ignore<System.Text.StringBuilder>
+
+          if s.detailedTiming && s.packageFnTiming.Count > 0 then
+            sb.Append(",\"packageFnTiming\":{") |> ignore<System.Text.StringBuilder>
+            let mutable first = true
+            for kv in s.packageFnTiming do
+              if not first then sb.Append(",") |> ignore<System.Text.StringBuilder>
+              let count =
+                match s.packageFnCounts.TryGetValue(kv.Key) with
+                | true, c -> c
+                | _ -> 0L
+              sb.Append($"\"{kv.Key}\":{{\"us\":{kv.Value},\"n\":{count}}}")
+              |> ignore<System.Text.StringBuilder>
+              first <- false
+            sb.Append("}") |> ignore<System.Text.StringBuilder>
+
+          sb.Append("}") |> ignore<System.Text.StringBuilder>
+          DString(sb.ToString()) |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+    { name = fn "interpreterStatsEnableDetailedTiming" 0
+      typeParams = []
+      parameters = [ Param.make "enabled" TBool "" ]
+      returnType = TUnit
+      description =
+        "Enables or disables per-builtin and per-package-fn timing collection. "
+        + "When enabled, adds ~1 Stopwatch call per builtin invocation."
+      fn =
+        (function
+        | _, vm, _, [ DBool enabled ] ->
+          vm.stats.enabled <- true
+          vm.stats.detailedTiming <- enabled
+          DUnit |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Impure
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -127,9 +127,16 @@ let initSerializers () = ()
 [<EntryPoint>]
 let main (args : string[]) =
   try
+    // Extract embedded resources FIRST — this sets DARK_CONFIG_RUNDIR
+    // which LibConfig.Config needs to resolve paths correctly.
     EmbeddedResources.extract ()
     initSerializers ()
 
+    // Now safe to access LibConfig paths
+    let telemetryPath =
+      System.IO.Path.Combine(LibConfig.Config.logDir, "telemetry.jsonl")
+    Telemetry.init telemetryPath
+    use _totalSpan = Telemetry.span "cli.total" []
 
     // If data.db is missing but seed.db exists, copy seed as data.db
     let dbPath = LibConfig.Config.dbPath
@@ -139,20 +146,24 @@ let main (args : string[]) =
       System.IO.File.Copy(seedPath, dbPath)
 
     // Grow the database: apply any unapplied ops and evaluate values.
-    // This handles first-run from an embedded seed (all ops unapplied)
-    // and incremental updates (new ops fetched from a seed).
-    // On a warm DB with nothing to do, this is a single fast SELECT COUNT.
-    let cliPackageManager = LibPackageManager.PackageManager.rt
-    (LibPackageManager.Seed.growIfNeeded
-      (fun () -> builtins)
-      cliPackageManager
-      (fun msg -> System.Console.Error.WriteLine msg))
-      .Result
-    |> ignore<bool>
-    cliPackageManager.init.Result
+    let cliPackageManager =
+      Telemetry.time "cli.createPM" [] (fun () ->
+        LibPackageManager.PackageManager.rt)
 
-    let result = execute cliPackageManager (Array.toList args)
-    let result = result.Result
+    Telemetry.time "cli.growIfNeeded" [] (fun () ->
+      (LibPackageManager.Seed.growIfNeeded
+        (fun () -> builtins)
+        cliPackageManager
+        (fun msg -> System.Console.Error.WriteLine msg))
+        .Result
+      |> ignore<bool>)
+
+    Telemetry.time "cli.pmInit" [] (fun () -> cliPackageManager.init.Result)
+
+    let result =
+      Telemetry.time "cli.execute" [] (fun () ->
+        let result = execute cliPackageManager (Array.toList args)
+        result.Result)
 
     NonBlockingConsole.wait ()
 

--- a/backend/src/LibCloud/Tracing.fs
+++ b/backend/src/LibCloud/Tracing.fs
@@ -316,16 +316,28 @@ let createCliTracer
   let results = TraceResults.empty ()
   let fnCalls = System.Collections.Generic.List<StoredFnCall>()
 
+  // Skip per-fn-call tracing: makeStoreFnResult uses reflection-based JSON
+  // (DvalReprInternalRoundtrippable) which is stripped by the .NET trimmer in
+  // release/AOT builds. Top-level trace input uses DvalReprDeveloper (string
+  // repr, no reflection) as a trim-safe fallback.
+  // TODO: use binary serialization or Darklang-native JSON for full trace support.
   { enabled = true
     results = results
     executionTracing =
       { Exe.noTracing with
+#if DEBUG
           storeFnResult = makeStoreFnResult fnCalls
+#endif
           skipTracing = false }
     storeTraceInput = fun _ _ _ -> ()
     storeTraceResults =
       fun () ->
+#if DEBUG
         let inputJson = DvalReprInternalRoundtrippable.toJsonV0 inputDval
+#else
+        ignore<RT.Dval> inputDval
+        let inputJson = "(release: trace serialization unavailable)"
+#endif
         storeTrace canvasID 0UL traceID description inputVarName inputJson fnCalls }
 
 

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -136,11 +136,9 @@ let rec checkAndExtractMatchPattern
 
 
 
-let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
+let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
   uply {
     let raiseRTE rte = raiseRTE vm.threadID rte
-
-    // Track args for package fn calls so we can trace them at frame return
     let pendingCallArgs = System.Collections.Generic.Dictionary<uuid, Dval list>()
 
     let mutable finalResult : Dval option = None
@@ -206,6 +204,8 @@ let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
       let mutable frameToPush = None
 
       while counter < instrData.instructions.Length && frameToPush = None do
+        if vm.stats.enabled then
+          vm.stats.instructionCount <- vm.stats.instructionCount + 1L
 
         let inst = instrData.instructions[counter]
         match inst with
@@ -569,6 +569,8 @@ let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
                         currentFrame.typeSymbolTable
                   executionPoint = Lambda(currentFrame.executionPoint, exprId) }
 
+              if vm.stats.enabled then
+                vm.stats.framePushCount <- vm.stats.framePushCount + 1L
               frameToPush <- Some newFrame
 
             else if argCount > paramCount then
@@ -683,7 +685,20 @@ let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
                       // Builtin.jsonParse<'a>, the 'a needs to resolve to Int64.
                       let resolvedTypeArgs =
                         typeArgs |> List.map (TypeReference.resolveTypeVariables tst)
+                      let sw =
+                        if vm.stats.enabled then
+                          vm.stats.builtinCallCount <- vm.stats.builtinCallCount + 1L
+                          if vm.stats.detailedTiming then
+                            System.Diagnostics.Stopwatch.GetTimestamp()
+                          else
+                            0L
+                        else
+                          0L
                       let! result = fn.fn (exeState, vm, resolvedTypeArgs, allArgs)
+                      if vm.stats.enabled && vm.stats.detailedTiming then
+                        let elapsed =
+                          System.Diagnostics.Stopwatch.GetTimestamp() - sw
+                        vm.stats.recordBuiltin (fn.name.name, elapsed)
 
                       let expectedReturnType = fn.returnType
                       match!
@@ -775,6 +790,12 @@ let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
                   let newFrameId = guuid ()
                   if not exeState.tracing.skipTracing then
                     pendingCallArgs[newFrameId] <- allArgs
+                  if vm.stats.enabled then
+                    vm.stats.packageCallCount <- vm.stats.packageCallCount + 1L
+                    vm.stats.framePushCount <- vm.stats.framePushCount + 1L
+                    if vm.stats.detailedTiming then
+                      vm.stats.framePushTimestamps[newFrameId] <-
+                        System.Diagnostics.Stopwatch.GetTimestamp()
                   frameToPush <-
                     { id = newFrameId
                       parent = Some(vm.currentFrameID, putResultIn, counter + 1)
@@ -865,6 +886,18 @@ let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
                 |> RuntimeError.Apply
                 |> raiseRTE
 
+          // Record per-package-fn timing on frame return
+          if vm.stats.enabled && vm.stats.detailedTiming then
+            match vm.stats.framePushTimestamps.TryGetValue(vm.currentFrameID) with
+            | true, pushTs ->
+              let elapsed = System.Diagnostics.Stopwatch.GetTimestamp() - pushTs
+              match currentFrame.executionPoint with
+              | Function(FQFnName.Package(Hash h)) ->
+                vm.stats.recordPackageFn (h, elapsed)
+              | _ -> ()
+              vm.stats.framePushTimestamps.Remove(vm.currentFrameID) |> ignore<bool>
+            | false, _ -> ()
+
           vm.callFrames.Remove(vm.currentFrameID) |> ignore<bool>
 
           vm.currentFrameID <- parentID
@@ -899,3 +932,6 @@ let execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
     | Some dv -> return dv
     | None -> return Exception.raiseInternal "No finalResult found" []
   }
+
+and execute (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
+  executeInner exeState vm

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1280,8 +1280,83 @@ type InstrData =
     resultReg : Register
   }
 
+/// Lightweight interpreter performance counters.
+/// Incremented during execution, read/reset via builtins.
+/// Per-builtin timing uses a dictionary keyed by name; overhead is ~1 Stopwatch
+/// call per builtin invocation, only when detailedTiming is true.
+type InterpreterStats =
+  {
+    /// When false, all counting is skipped (zero overhead in hot loop)
+    mutable enabled : bool
+    mutable instructionCount : int64
+    mutable builtinCallCount : int64
+    mutable packageCallCount : int64
+    mutable framePushCount : int64
+    mutable packageFnLoadCount : int64
+
+    /// When true, per-builtin cumulative timing is collected (requires enabled)
+    mutable detailedTiming : bool
+    /// Cumulative microseconds per builtin name
+    builtinTiming : System.Collections.Generic.Dictionary<string, int64>
+    /// Call count per builtin name
+    builtinCounts : System.Collections.Generic.Dictionary<string, int64>
+    /// Cumulative microseconds per package fn hash
+    packageFnTiming : System.Collections.Generic.Dictionary<string, int64>
+    /// Call count per package fn hash
+    packageFnCounts : System.Collections.Generic.Dictionary<string, int64>
+    /// Timestamp when each frame was pushed (for measuring total fn time)
+    framePushTimestamps : System.Collections.Generic.Dictionary<uuid, int64>
+  }
+
+  static member create() =
+    { enabled = false
+      instructionCount = 0L
+      builtinCallCount = 0L
+      packageCallCount = 0L
+      framePushCount = 0L
+      packageFnLoadCount = 0L
+      detailedTiming = false
+      builtinTiming = System.Collections.Generic.Dictionary()
+      builtinCounts = System.Collections.Generic.Dictionary()
+      packageFnTiming = System.Collections.Generic.Dictionary()
+      packageFnCounts = System.Collections.Generic.Dictionary()
+      framePushTimestamps = System.Collections.Generic.Dictionary() }
+
+  member this.reset() =
+    this.instructionCount <- 0L
+    this.builtinCallCount <- 0L
+    this.packageCallCount <- 0L
+    this.framePushCount <- 0L
+    this.packageFnLoadCount <- 0L
+    this.builtinTiming.Clear()
+    this.builtinCounts.Clear()
+    this.packageFnTiming.Clear()
+    this.packageFnCounts.Clear()
+    this.framePushTimestamps.Clear()
+
+  member private this.addTiming
+    (timingDict : System.Collections.Generic.Dictionary<string, int64>)
+    (countDict : System.Collections.Generic.Dictionary<string, int64>)
+    (name : string)
+    (elapsedTicks : int64)
+    =
+    let usec = elapsedTicks * 1000000L / System.Diagnostics.Stopwatch.Frequency
+    match timingDict.TryGetValue(name) with
+    | true, v -> timingDict[name] <- v + usec
+    | false, _ -> timingDict[name] <- usec
+    match countDict.TryGetValue(name) with
+    | true, v -> countDict[name] <- v + 1L
+    | false, _ -> countDict[name] <- 1L
+
+  member this.recordBuiltin(name : string, elapsedTicks : int64) =
+    this.addTiming this.builtinTiming this.builtinCounts name elapsedTicks
+
+  member this.recordPackageFn(hash : string, elapsedTicks : int64) =
+    this.addTiming this.packageFnTiming this.packageFnCounts hash elapsedTicks
+
 type VMState =
-  { mutable threadID : uuid
+  {
+    mutable threadID : uuid
 
     callFrames : System.Collections.Generic.Dictionary<uuid, CallFrame>
     mutable currentFrameID : uuid
@@ -1291,7 +1366,11 @@ type VMState =
     rootInstrData : Option<tlid> * InstrData
     mutable lambdaInstrCache : Map<ExecutionPoint * id, LambdaImpl>
     mutable lambdaInstrDataCache : Map<ExecutionPoint * id, InstrData>
-    mutable packageFnInstrCache : Map<FQFnName.Package, InstrData> }
+    mutable packageFnInstrCache : Map<FQFnName.Package, InstrData>
+
+    /// Performance counters — incremented during execution
+    stats : InterpreterStats
+  }
 
   static member create(instrs : Option<tlid> * Instructions) : VMState =
     let tlid, instrs = instrs
@@ -1319,7 +1398,8 @@ type VMState =
         (tlid, instrs)
       lambdaInstrCache = Map.empty
       lambdaInstrDataCache = Map.empty
-      packageFnInstrCache = Map.empty }
+      packageFnInstrCache = Map.empty
+      stats = InterpreterStats.create () }
 
   static member createWithoutTLID(instrs : Instructions) : VMState =
     VMState.create (None, instrs)

--- a/backend/src/LibPackageManager/Seed.fs
+++ b/backend/src/LibPackageManager/Seed.fs
@@ -96,44 +96,54 @@ let export (outputPath : string) : Task<unit> =
 /// Returns the count of ops applied.
 let applyUnappliedOps () : Task<int64> =
   task {
-    let! unappliedOps =
-      Sql.query
-        """
+    // Fast check: are there any unapplied ops? Avoids loading blobs when count is 0.
+    let! count =
+      Sql.query "SELECT COUNT(*) as n FROM package_ops WHERE applied = 0"
+      |> Sql.executeRowAsync (fun read -> read.int64 "n")
+
+    if count = 0L then
+      return 0L
+    else
+
+      let! unappliedOps =
+        Sql.query
+          """
         SELECT id, op_blob, branch_id, commit_hash
         FROM package_ops
         WHERE applied = 0
         ORDER BY created_at ASC
         """
-      |> Sql.executeAsync (fun read ->
-        let opId = read.uuid "id"
-        let opBlob = read.bytes "op_blob"
-        let branchId : PT.BranchId = read.uuid "branch_id"
-        let commitHash = read.stringOrNone "commit_hash"
-        let op = BS.PT.PackageOp.deserialize opId opBlob
-        (opId, op, branchId, commitHash))
+        |> Sql.executeAsync (fun read ->
+          let opId = read.uuid "id"
+          let opBlob = read.bytes "op_blob"
+          let branchId : PT.BranchId = read.uuid "branch_id"
+          let commitHash = read.stringOrNone "commit_hash"
+          let op = BS.PT.PackageOp.deserialize opId opBlob
+          (opId, op, branchId, commitHash))
 
-    if List.isEmpty unappliedOps then
-      return 0L
-    else
-      let groups =
-        unappliedOps
-        |> List.groupBy (fun (_, _, branchId, commitHash) -> (branchId, commitHash))
-        |> Map.toList
+      if List.isEmpty unappliedOps then
+        return 0L
+      else
+        let groups =
+          unappliedOps
+          |> List.groupBy (fun (_, _, branchId, commitHash) ->
+            (branchId, commitHash))
+          |> Map.toList
 
-      for ((branchId, commitHash), ops) in groups do
-        let opsOnly = ops |> List.map (fun (_, op, _, _) -> op)
-        do! PackageOpPlayback.applyOps branchId commitHash opsOnly
+        for ((branchId, commitHash), ops) in groups do
+          let opsOnly = ops |> List.map (fun (_, op, _, _) -> op)
+          do! PackageOpPlayback.applyOps branchId commitHash opsOnly
 
-      let opIds = unappliedOps |> List.map (fun (opId, _, _, _) -> opId)
-      let updateStatements =
-        opIds
-        |> List.map (fun opId ->
-          let sql = "UPDATE package_ops SET applied = 1 WHERE id = @id"
-          let parameters = [ "applied", Sql.bool true; "id", Sql.uuid opId ]
-          (sql, [ parameters ]))
-      let _ = Sql.executeTransactionSync updateStatements
+        let opIds = unappliedOps |> List.map (fun (opId, _, _, _) -> opId)
+        let updateStatements =
+          opIds
+          |> List.map (fun opId ->
+            let sql = "UPDATE package_ops SET applied = 1 WHERE id = @id"
+            let parameters = [ "applied", Sql.bool true; "id", Sql.uuid opId ]
+            (sql, [ parameters ]))
+        let _ = Sql.executeTransactionSync updateStatements
 
-      return int64 (List.length unappliedOps)
+        return int64 (List.length unappliedOps)
   }
 
 
@@ -263,13 +273,24 @@ let growIfNeeded
   (log : string -> unit)
   : Task<bool> =
   task {
-    let! appliedCount = applyUnappliedOps ()
+    use _span = Telemetry.span "seed.growIfNeeded" []
+    let! appliedCount =
+      Telemetry.timeTask "seed.applyOps" [] (fun () -> applyUnappliedOps ())
     if appliedCount > 0L then
       log $"Growing package DB from ops ({appliedCount} ops to apply)..."
-      do! PackageRefsGenerator.generate ()
-      LibExecution.PackageRefs.reloadHashes ()
-      let! _evalResult = evaluateAllValues (getBuiltins ()) pm
-      do! Sql.query "PRAGMA wal_checkpoint(TRUNCATE);" |> Sql.executeStatementAsync
+      Telemetry.event "seed.applyOps.count" [ ("count", string appliedCount) ]
+      do!
+        Telemetry.timeTask "seed.generateRefs" [] (fun () ->
+          task {
+            do! PackageRefsGenerator.generate ()
+            LibExecution.PackageRefs.reloadHashes ()
+          })
+      let! _evalResult =
+        Telemetry.timeTask "seed.evaluateValues" [] (fun () ->
+          evaluateAllValues (getBuiltins ()) pm)
+      do!
+        Telemetry.timeTask "seed.walCheckpoint" [] (fun () ->
+          Sql.query "PRAGMA wal_checkpoint(TRUNCATE);" |> Sql.executeStatementAsync)
       log "Package DB ready"
       return true
     else

--- a/backend/src/LibSerialization/Hashing/Canonical.fs
+++ b/backend/src/LibSerialization/Hashing/Canonical.fs
@@ -185,6 +185,7 @@ let writeLetPattern (w : BinaryWriter) (pattern : PT.LetPattern) =
     writeLetPattern w first
     writeLetPattern w second
     Common.List.write w writeLetPattern rest
+  | PT.LPWildcard _id -> w.Write 3uy
 
 
 let writeMatchPattern (w : BinaryWriter) (pattern : PT.MatchPattern) =

--- a/backend/src/Prelude/Prelude.fsproj
+++ b/backend/src/Prelude/Prelude.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="NonBlockingConsole.fs" />
     <Compile Include="Prelude.fs" />
     <Compile Include="Json.fs" />
+    <Compile Include="Telemetry.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/backend/src/Prelude/Telemetry.fs
+++ b/backend/src/Prelude/Telemetry.fs
@@ -1,0 +1,104 @@
+/// Lightweight telemetry for profiling CLI startup and runtime.
+/// Writes JSON-lines to a log file. Each line is one span or event.
+///
+/// Usage:
+///   use _span = Telemetry.span "phase" [("key", "value")]
+///   // ... work ...
+///   // span is closed and logged on Dispose
+///
+///   Telemetry.event "marker" [("key", "value")]
+///
+/// The output format matches the Dark-side Telemetry module so both
+/// F# and Dark traces appear in the same file and can be analyzed together.
+module Telemetry
+
+open System.Diagnostics
+
+/// Global mutable log path. Set early in startup.
+/// Empty string = telemetry disabled.
+let mutable private logPath : string = ""
+
+/// Set the telemetry output file path. Call once at startup.
+let init (path : string) : unit =
+  logPath <- path
+  // Ensure directory exists
+  let dir = System.IO.Path.GetDirectoryName(path)
+  if dir <> "" && not (System.IO.Directory.Exists(dir)) then
+    System.IO.Directory.CreateDirectory(dir) |> ignore<System.IO.DirectoryInfo>
+
+let isEnabled () : bool = logPath <> ""
+
+/// Write a raw JSON line to the telemetry log (thread-safe via lock).
+let private writeLock = obj ()
+
+let private writeLine (line : string) : unit =
+  if logPath <> "" then
+    lock writeLock (fun () ->
+      try
+        System.IO.File.AppendAllText(logPath, line + "\n")
+      with _ ->
+        ())
+
+/// Get monotonic timestamp in microseconds.
+let private nowUs () : int64 =
+  Stopwatch.GetTimestamp() * 1_000_000L / Stopwatch.Frequency
+
+/// Get wall-clock ISO 8601 timestamp.
+let private wallClock () : string =
+  System.DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+
+/// Escape a string for JSON.
+let private jsonEscape (s : string) : string =
+  s.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n")
+
+/// Format context pairs as JSON object string.
+let private formatCtx (ctx : (string * string) list) : string =
+  match ctx with
+  | [] -> "{}"
+  | pairs ->
+    pairs
+    |> List.map (fun (k, v) -> $"\"{jsonEscape k}\":\"{jsonEscape v}\"")
+    |> String.concat ","
+    |> fun s -> "{" + s + "}"
+
+/// Log a point-in-time event (no duration).
+let event (name : string) (ctx : (string * string) list) : unit =
+  if logPath <> "" then
+    let wall = wallClock ()
+    let ctxJson = formatCtx ctx
+    writeLine
+      $"{{\"event\":\"{jsonEscape name}\",\"wall\":\"{wall}\",\"ctx\":{ctxJson}}}"
+
+/// A span that measures elapsed time and logs on Dispose.
+type Span(name : string, ctx : (string * string) list) =
+  let startUs = nowUs ()
+  let wall = wallClock ()
+
+  interface System.IDisposable with
+    member _.Dispose() =
+      if logPath <> "" then
+        let elapsedUs = nowUs () - startUs
+        let ms = elapsedUs / 1000L
+        let ctxJson = formatCtx ctx
+        writeLine
+          $"{{\"event\":\"{jsonEscape name}\",\"ms\":{ms},\"us\":{elapsedUs},\"wall\":\"{wall}\",\"ctx\":{ctxJson}}}"
+
+/// Create a span that logs its duration when disposed.
+/// Use with `use`: `use _s = Telemetry.span "name" []`
+let span (name : string) (ctx : (string * string) list) : Span = new Span(name, ctx)
+
+/// Convenience: time a synchronous function and log the result.
+let time (name : string) (ctx : (string * string) list) (f : unit -> 'a) : 'a =
+  use _s = span name ctx
+  f ()
+
+/// Convenience: time an async task and log the result.
+let timeTask
+  (name : string)
+  (ctx : (string * string) list)
+  (f : unit -> System.Threading.Tasks.Task<'a>)
+  : System.Threading.Tasks.Task<'a> =
+  task {
+    use _s = span name ctx
+    return! f ()
+  }

--- a/packages/darklang/cli/commands/docs.dark
+++ b/packages/darklang/cli/commands/docs.dark
@@ -146,6 +146,14 @@ module Topics =
           aliases = [ "git"; "vcs"; "commits" ]
           context = "cli"
           content = Docs.SCM.content
+          subtopics = [] }
+
+      DocTopic
+        { name = "interactive-testing"
+          description = "Interactive CLI testing & telemetry"
+          aliases = [ "testing"; "telemetry"; "expect"; "perf" ]
+          context = "internal"
+          content = Docs.InteractiveTesting.content
           subtopics = [] } ]
 
   let findTopic (name: String) : Stdlib.Option.Option<DocTopic> =

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -28,7 +28,18 @@ type AppState =
     /// How many terminal rows the prompt used last frame
     previousRenderedRows: Int64
     /// True when invoked from the command line (not the interactive REPL)
-    nonInteractive: Bool }
+    nonInteractive: Bool
+    /// Cached completion hint — skip recompute when prompt text unchanged
+    cachedHintInput: String
+    cachedHintValue: String
+    /// Cached command list and option strings — built once at startup
+    allCommandsCache: List<Registry.CommandHandler>
+    commandOptionsCache: List<String>
+    /// Cached status bar string — skip re-render when branch unchanged
+    cachedStatusBar: String
+    cachedStatusBarBranch: Uuid
+    /// When true, write telemetry to rundir/logs/telemetry.jsonl
+    telemetryEnabled: Bool }
 
 let locationStr (state: AppState) : String =
   Packages.formatLocation state.packageData.currentLocation
@@ -63,7 +74,14 @@ let initState () : AppState =
       accountID = accountID
       accountName = accountName
       previousRenderedRows = 0L
-      nonInteractive = false }
+      nonInteractive = false
+      cachedHintInput = ""
+      cachedHintValue = ""
+      allCommandsCache = Registry.allCommands ()
+      commandOptionsCache = commandOptions ()
+      cachedStatusBar = ""
+      cachedStatusBarBranch = Builtin.unwrap (Stdlib.Uuid.parse_v0 "00000000-0000-0000-0000-000000000000")
+      telemetryEnabled = (Builtin.environmentGet "DARK_TELEMETRY") == Stdlib.Option.Option.Some "1" }
 
 type Msg =
   | ProcessInput of String
@@ -106,14 +124,11 @@ module StatusBar =
     // Set scroll region to all rows except the last one
     Stdlib.print (Colors.setScrollRegion 1L (terminalHeight - 1L))
 
-  /// Render the status bar at the bottom of the terminal
-  let render (state: AppState) : Unit =
-    let terminalHeight = Terminal.getHeight ()
+  /// Build the status bar string for the given state
+  let build (state: AppState) : String =
     let terminalWidth = Terminal.getWidth ()
 
     let leftText = " Darklang "
-
-    // Use Darklang brand colors (purple/magenta)
     let leftPart =
       Colors.colorize (Colors.purpleBg ++ Colors.white ++ Colors.bold) leftText
 
@@ -121,7 +136,6 @@ module StatusBar =
     let branchPart =
       Colors.colorize (Colors.grayBg ++ Colors.white) branchText
 
-    // Calculate padding
     let leftLen = Stdlib.String.length leftText + Stdlib.String.length branchText
     let paddingLen = terminalWidth - leftLen
 
@@ -131,9 +145,11 @@ module StatusBar =
       else
         ""
 
-    let statusLine = leftPart ++ branchPart ++ padding
+    leftPart ++ branchPart ++ padding
 
-    // Save cursor, move to bottom, render, restore cursor
+  /// Render the status bar at the bottom of the terminal
+  let render (statusLine: String) : Unit =
+    let terminalHeight = Terminal.getHeight ()
     Stdlib.print
       (Colors.saveCursor
        ++ Colors.moveCursorTo terminalHeight 1L
@@ -220,8 +236,7 @@ module Registry =
       )
 
 
-  let findCommand (name: String) : CommandHandler =
-    let commands = allCommands ()
+  let findCommandIn (commands: List<CommandHandler>) (name: String) : CommandHandler =
 
     let allMatches = // CLEANUP use a Set?
       let nameMatches =
@@ -253,12 +268,19 @@ module Registry =
           complete = fun _state _args -> [] }
 
   let executeCommand (name: String) (state: AppState) (args: List<String>) : AppState =
-    let handler = findCommand name
-    let ex = handler.execute
-    ex state args
+    let handler = findCommandIn state.allCommandsCache name
+
+    let hasHelpFlag =
+      (Stdlib.List.member_v0 args "--help") || (Stdlib.List.member_v0 args "-h")
+
+    if hasHelpFlag then
+      executeCommandHelp name state
+    else
+      let ex = handler.execute
+      ex state args
 
   let executeCommandHelp (name: String) (state: AppState) : AppState =
-    let handler = findCommand name
+    let handler = findCommandIn state.allCommandsCache name
     let help = handler.help
     let _ = help state
 
@@ -373,7 +395,7 @@ module Registry =
       // Completing command name
       let partial = Completion.getPartialCompletion parsed
 
-      let options = commandOptions ()
+      let options = state.commandOptionsCache
 
       let filtered =
         if Stdlib.String.isEmpty partial then
@@ -384,7 +406,7 @@ module Registry =
       filtered |> Stdlib.List.map Completion.simple
     else
       // Completing command arguments
-      let handler = findCommand parsed.commandName
+      let handler = findCommandIn state.allCommandsCache parsed.commandName
       let completeFunc = handler.complete
 
       // Split args into completed args and partial (last arg)
@@ -466,7 +488,9 @@ let handleKeyInput (state: AppState) (key: Stdlib.Cli.Stdin.Key.Key) (modifiers:
       else
         Stdlib.printLine ""
         let commandToExecute = Stdlib.String.trim state.prompt.text
+        let tCmd = Telemetry.now ()
         let newState = Commands.parseAndExecute state commandToExecute
+        Telemetry.logWithContext "commandExec" tCmd [("cmd", commandToExecute)]
         let clearedPrompt = Prompt.Editing.clear newState.prompt
         let promptWithHistory = Prompt.History.addCommand clearedPrompt commandToExecute
         { newState with
@@ -485,7 +509,9 @@ let handleKeyInput (state: AppState) (key: Stdlib.Cli.Stdin.Key.Key) (modifiers:
 
     | Tab ->
       // Handle tab completion
+      let tTab = Telemetry.now ()
       let completions = Registry.getCompletions state state.prompt.text
+      Telemetry.logWithContext "tabComplete" tTab [("resultCount", Stdlib.Int64.toString (Stdlib.List.length completions)); ("input", state.prompt.text)]
 
       // CLEANUP: When there are multiple completions with a common prefix (e.g. "filter" and "filterMap"),
       // Tab should complete up to the common part ("filter") rather than just showing options
@@ -614,12 +640,26 @@ let runInteractiveLoop (state: AppState) : Int64 =
     Stdlib.print (Colors.moveCursorToColumn 1L ++ "\u001b[2K" ++ "\n")
     0L
   else
+    let tLoopStart = if state.telemetryEnabled then Telemetry.now () else 0L
+    if state.telemetryEnabled then
+      let _ = Builtin.interpreterStatsReset ()
+      ()
+
     // TODO: handle terminal resize and Unicode display width
-    // Compute prompt output and line metrics once
     let location = locationStr state
+
+    let tHint = if state.telemetryEnabled then Telemetry.now () else 0L
     let inputStartColumn =
       Prompt.Display.calculateInputStartColumn location
-    let hint = Registry.getCompletionHint state state.prompt.text
+    let hintCached = state.cachedHintInput == state.prompt.text
+    let hint =
+      if hintCached then
+        state.cachedHintValue
+      else
+        Registry.getCompletionHint state state.prompt.text
+    if state.telemetryEnabled then
+      Telemetry.logWithContext "completionHint" tHint [("inputLen", Stdlib.Int64.toString (Stdlib.String.length state.prompt.text)); ("cached", Stdlib.Bool.toString hintCached)]
+
     let promptOutput =
       Prompt.Display.formatPromptWithInput location state.prompt.text hint
     let terminalWidth = Terminal.getWidth ()
@@ -631,6 +671,8 @@ let runInteractiveLoop (state: AppState) : Int64 =
       else (Stdlib.Int64.divide (visualLength - 1L) terminalWidth) + 1L
 
     // Display current page
+    let tRender = if state.telemetryEnabled then Telemetry.now () else 0L
+
     match state.currentPage with
     | MainPrompt ->
       Stdlib.print "\u001b[?25l" // Hide cursor
@@ -671,14 +713,41 @@ let runInteractiveLoop (state: AppState) : Int64 =
     | SubApp app ->
       app.onDisplay ()
 
-    // Render status bar at bottom of terminal
-    StatusBar.render state
+    // Render status bar — cache and skip when branch unchanged
+    let statusBar =
+      if state.cachedStatusBarBranch == state.currentBranchId && state.cachedStatusBar != "" then
+        state.cachedStatusBar
+      else
+        StatusBar.build state
+    StatusBar.render statusBar
+
+    if state.telemetryEnabled then
+      let pageName =
+        match state.currentPage with
+        | MainPrompt -> "MainPrompt"
+        | InteractiveNav _ -> "InteractiveNav"
+        | CompletionPicker _ -> "CompletionPicker"
+        | SubApp _ -> "SubApp"
+      Telemetry.logWithContext "render" tRender [("page", pageName); ("fullRedraw", Stdlib.Bool.toString state.needsFullRedraw)]
+      Telemetry.log "preInput" tLoopStart
 
     // Read keystroke input
+    let tReadKey = if state.telemetryEnabled then Telemetry.now () else 0L
     let keyInput = Stdlib.Cli.Stdin.readKey ()
+
+    // Process the key
     let keyPressedMsg = Msg.KeyPressed (keyInput.key, keyInput.modifiers, Stdlib.Option.Option.Some keyInput.keyChar)
     let newState = Update.updateAppState state keyPressedMsg
-    runInteractiveLoop { newState with previousRenderedRows = renderedRows }
+
+    if state.telemetryEnabled then
+      Telemetry.logWithContext "readKey" tReadKey [("char", keyInput.keyChar)]
+      let tUpdate = Telemetry.now ()
+      Telemetry.logWithContext "update" tUpdate [("char", keyInput.keyChar)]
+      let loopWorkMs = (Telemetry.elapsedMs tLoopStart) - (Telemetry.elapsedMs tReadKey)
+      let interpStats = Builtin.interpreterStatsGet ()
+      Telemetry.logWithContext "loopWork" tLoopStart [("workMs", Stdlib.Int64.toString loopWorkMs); ("interp", interpStats)]
+
+    runInteractiveLoop { newState with previousRenderedRows = renderedRows; cachedHintInput = state.prompt.text; cachedHintValue = hint; cachedStatusBar = statusBar; cachedStatusBarBranch = state.currentBranchId }
 
 
 /// Extract --branch <name> from args, returning (branchId, remainingArgs).
@@ -731,6 +800,11 @@ let executeCliCommand (args: List<String>) : Int64 =
   match remainingArgs with
   // If someone runs `dark` without args, start the interactive loop
   | [] ->
+    if initialState.telemetryEnabled then
+      Telemetry.logSessionStart ()
+      let _ = Builtin.interpreterStatsReset ()
+      ()
+
     // Clear screen so leftover output from a previous session doesn't show through
     Stdlib.print Terminal.Display.clearScreen
 

--- a/packages/darklang/cli/docs/for-ai-internal.dark
+++ b/packages/darklang/cli/docs/for-ai-internal.dark
@@ -74,6 +74,13 @@ so Darklang.* names need full qualification or Stdlib.* shortcut:
 Impl: backend/src/LibParser/NameResolver.fs (F#)
       packages/darklang/languageTools/nameResolver.dark (Dark)
 
+## Interactive CLI Testing
+The interactive CLI (run-cli with no args) needs a real TTY.
+Use `expect` via run-in-docker for automated interactive testing:
+  ./scripts/run-in-docker expect scripts/testing/test-interactive.expect
+Telemetry data lands in rundir/logs/telemetry.jsonl.
+Full guide: `docs interactive-testing`
+
 ## Debug
   Builtin.debug "label" value   # prints DEBUG: label: <repr> to stdout
   eval <expr>                   # test small pieces (uses tree-sitter parser, not F# parser)

--- a/packages/darklang/cli/docs/interactive-testing.dark
+++ b/packages/darklang/cli/docs/interactive-testing.dark
@@ -1,0 +1,82 @@
+module Darklang.Cli.Docs.InteractiveTesting
+
+let content () : String =
+  """# Interactive CLI Testing & Telemetry
+
+## The Problem
+The CLI interactive mode uses Console.ReadKey() which needs a real TTY.
+You can't pipe stdin — it crashes with "Cannot read keys when console
+input has been redirected."
+
+## Solution: expect via run-in-docker
+The devcontainer has `expect` installed. It spawns the CLI with a
+pseudo-TTY and sends keystrokes programmatically.
+
+### Quick one-off test
+  ./scripts/run-in-docker expect -c '
+    spawn ./scripts/run-cli
+    sleep 3
+    send "help\r"
+    sleep 3
+    send "quit\r"
+    sleep 2
+    expect eof
+  '
+
+### Reusable expect script
+  ./scripts/run-in-docker expect scripts/testing/test-interactive.expect
+
+Customize sleeps and sends for different scenarios.
+
+### Writing expect scripts
+  #!/usr/bin/expect -f
+  set timeout 30
+  spawn ./scripts/run-cli
+  sleep 3                  # Wait for startup + package load
+  send "tree\r"            # Command + Enter
+  sleep 5
+  send "\t"                # Tab completion
+  sleep 1
+  send "quit\r"
+  sleep 2
+  expect eof
+
+Key points:
+  - sleep 3 after spawn (CLI needs time to load packages)
+  - send "\r" for Enter, send "\t" for Tab
+  - send "x" sends individual characters (CLI reads one at a time)
+  - sleep 0.5 between chars for realistic typing speed
+  - Runs inside devcontainer via run-in-docker
+
+## Telemetry
+When packages/darklang/cli/telemetry.dark is loaded, the interactive
+loop writes JSON-lines to rundir/logs/telemetry.jsonl:
+
+  {"event":"completionHint","ms":126,"ctx":{"inputLen":"0"}}
+  {"event":"render","ms":33,"ctx":{"page":"MainPrompt"}}
+  {"event":"preInput","ms":169,"ctx":{}}
+  {"event":"readKey","ms":2014,"ctx":{"char":"h"}}
+
+### Events per loop iteration
+  completionHint   getCompletionHint (ghosted suggestion text)
+  render           Page display (MainPrompt, InteractiveNav, etc.)
+  preInput         Total work before blocking on keystroke
+  readKey          Time waiting for user input (idle time)
+  update           updateAppState after keystroke
+  loopWork         Total non-idle work (preInput + update)
+  commandExec      Command execution (on Enter)
+  tabComplete      Tab completion lookup
+  session_start    Session marker
+
+### Analyzing telemetry
+  # preInput times (the "lag" the user feels):
+  jq -r 'select(.event=="preInput") | .ms' rundir/logs/telemetry.jsonl
+
+  # Average completionHint time:
+  jq -r 'select(.event=="completionHint") | .ms' \
+    rundir/logs/telemetry.jsonl | awk '{s+=$1;n++} END{print s/n"ms"}'
+
+## Testing across modes
+  1. Debug:   ./scripts/run-in-docker expect scripts/testing/test-interactive.expect
+  2. Release: Build with build-release-cli-exes.sh, run binary directly
+  3. Remote:  Copy release binary to rM2/etc, run there"""

--- a/packages/darklang/cli/telemetry.dark
+++ b/packages/darklang/cli/telemetry.dark
@@ -1,0 +1,70 @@
+module Darklang.Cli.Telemetry
+
+/// Simple file-based telemetry for measuring interactive loop performance.
+/// Writes JSON-lines to a log file. Each line is one timing event.
+///
+/// Usage:
+///   let t0 = Telemetry.now ()
+///   // ... do work ...
+///   Telemetry.log "render" t0
+///
+///   // Or for spans with extra context:
+///   Telemetry.logWithContext "completionHint" t0 [("input", promptText)]
+
+let logFilePath: String =
+  (Builtin.cliGetLogDir ()) ++ "/telemetry.jsonl"
+
+/// Returns monotonic millisecond timestamp (only differences are meaningful)
+let now () : Int64 = Builtin.timeNowMs ()
+
+/// Compute elapsed ms between a start timestamp and now
+let elapsedMs (startMs: Int64) : Int64 =
+  (now ()) - startMs
+
+/// Write a single telemetry event line to the log file.
+/// Format: {"event":"<label>","ms":<elapsed>,"wall":"<ISO8601>","ctx":{...}}
+let logWithContext
+  (label: String)
+  (startMs: Int64)
+  (context: List<(String * String)>)
+  : Unit =
+  let elapsed = elapsedMs startMs
+
+  let ctxPairs =
+    context
+    |> Stdlib.List.map (fun (k, v) ->
+      // Escape any quotes in values for safety
+      let escaped = Stdlib.String.replaceAll v "\"" "\\\""
+      $"\"{k}\":\"{escaped}\"")
+
+  let ctxJson =
+    match ctxPairs with
+    | [] -> "{}"
+    | pairs -> "{" ++ (Stdlib.String.join pairs ",") ++ "}"
+
+  let wall = Stdlib.DateTime.toString (Stdlib.DateTime.now ())
+  let line = $"{{\"event\":\"{label}\",\"ms\":{Stdlib.Int64.toString elapsed},\"wall\":\"{wall}\",\"ctx\":{ctxJson}}}"
+
+  let _ = Builtin.fileAppendText logFilePath (line ++ "\n")
+  ()
+
+/// Shorthand: log a timing event with no extra context
+let log (label: String) (startMs: Int64) : Unit =
+  logWithContext label startMs []
+
+/// Log a raw message (not a timing span) — useful for one-off markers
+let logMessage (label: String) (message: String) : Unit =
+  let wall = Stdlib.DateTime.toString (Stdlib.DateTime.now ())
+  let escaped = Stdlib.String.replaceAll message "\"" "\\\""
+  let line = $"{{\"event\":\"{label}\",\"msg\":\"{escaped}\",\"wall\":\"{wall}\"}}"
+
+  let _ = Builtin.fileAppendText logFilePath (line ++ "\n")
+  ()
+
+/// Log the start of a session so we can separate runs in the log
+let logSessionStart () : Unit =
+  let wall = Stdlib.DateTime.toString (Stdlib.DateTime.now ())
+  let line = $"{{\"event\":\"session_start\",\"wall\":\"{wall}\"}}"
+
+  let _ = Builtin.fileAppendText logFilePath (line ++ "\n")
+  ()

--- a/scripts/testing/test-interactive.expect
+++ b/scripts/testing/test-interactive.expect
@@ -1,0 +1,31 @@
+#!/usr/bin/expect -f
+set timeout 30
+
+spawn ./scripts/run-cli
+sleep 3
+
+# Type "help" and Enter
+send "h"
+sleep 0.5
+send "e"
+sleep 0.5
+send "l"
+sleep 0.5
+send "p"
+sleep 0.5
+send "\r"
+sleep 3
+
+# Type "quit" and Enter
+send "q"
+sleep 0.5
+send "u"
+sleep 0.5
+send "i"
+sleep 0.5
+send "t"
+sleep 0.5
+send "\r"
+sleep 2
+
+expect eof

--- a/scripts/testing/test-interactive.py
+++ b/scripts/testing/test-interactive.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Interactive CLI test using pty module (no pexpect dependency).
+Works on both host (with pexpect) and rM2 (pty fallback).
+"""
+import sys, os, time, select, signal
+
+try:
+    import pexpect
+    USE_PEXPECT = True
+except ImportError:
+    import pty, subprocess
+    USE_PEXPECT = False
+
+BINARY = sys.argv[1] if len(sys.argv) > 1 else "./clis/darklang-alpha-2c6d956fc3-linux-x64"
+STARTUP_WAIT = float(sys.argv[2]) if len(sys.argv) > 2 else 3.0
+CHAR_DELAY = float(sys.argv[3]) if len(sys.argv) > 3 else 0.2
+
+def run_pexpect():
+    child = pexpect.spawn(BINARY, timeout=30)
+    time.sleep(STARTUP_WAIT)
+    for c in "help":
+        child.send(c)
+        time.sleep(CHAR_DELAY)
+    child.send("\r")
+    time.sleep(STARTUP_WAIT)
+    for c in "quit":
+        child.send(c)
+        time.sleep(CHAR_DELAY)
+    child.send("\r")
+    time.sleep(2)
+    child.close()
+
+def run_pty():
+    master, slave = pty.openpty()
+    proc = subprocess.Popen(
+        [BINARY],
+        stdin=slave, stdout=slave, stderr=slave,
+        close_fds=True
+    )
+    os.close(slave)
+    time.sleep(STARTUP_WAIT)
+
+    def send(text):
+        os.write(master, text.encode())
+
+    def drain():
+        """Read any available output to prevent buffer blocking"""
+        while select.select([master], [], [], 0.1)[0]:
+            try:
+                os.read(master, 4096)
+            except OSError:
+                break
+
+    for c in "help":
+        send(c)
+        time.sleep(CHAR_DELAY)
+        drain()
+    send("\r")
+    time.sleep(STARTUP_WAIT)
+    drain()
+
+    for c in "quit":
+        send(c)
+        time.sleep(CHAR_DELAY)
+        drain()
+    send("\r")
+    time.sleep(2)
+    drain()
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    os.close(master)
+
+if __name__ == "__main__":
+    if USE_PEXPECT:
+        run_pexpect()
+    else:
+        run_pty()
+    print("done")

--- a/scripts/testing/view-telemetry.py
+++ b/scripts/testing/view-telemetry.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Telemetry viewer for Darklang CLI traces.
+Reads telemetry.jsonl and shows a breakdown of where time went.
+
+Usage:
+  ./scripts/view-telemetry.py [path/to/telemetry.jsonl]
+  ssh rm2 cat /path/to/telemetry.jsonl | ./scripts/view-telemetry.py -
+"""
+import json, sys, os
+from collections import defaultdict
+
+def load(path):
+    if path == "-":
+        return [json.loads(l) for l in sys.stdin if l.strip()]
+    with open(path) as f:
+        return [json.loads(l) for l in f if l.strip()]
+
+def format_ms(ms):
+    if ms < 1: return f"{ms*1000:.0f}us"
+    if ms < 1000: return f"{ms:.0f}ms"
+    return f"{ms/1000:.2f}s"
+
+def bar(ms, max_ms, width=40):
+    if max_ms == 0: return ""
+    filled = int(ms / max_ms * width)
+    return "█" * filled + "░" * (width - filled)
+
+def show_startup(events):
+    """Show F#-level startup phases."""
+    phases = [e for e in events if e["event"].startswith("cli.") or e["event"].startswith("seed.")]
+    if not phases:
+        return
+    print("\n╔══════════════════════════════════════════════════════════════╗")
+    print("║  STARTUP BREAKDOWN                                         ║")
+    print("╚══════════════════════════════════════════════════════════════╝\n")
+    max_ms = max((e.get("ms", 0) for e in phases), default=1)
+    for e in phases:
+        ms = e.get("ms", 0)
+        name = e["event"]
+        ctx = e.get("ctx", {})
+        ctx_str = " ".join(f"{k}={v}" for k, v in ctx.items()) if ctx and ctx != {} else ""
+        print(f"  {name:<30s} {format_ms(ms):>8s}  {bar(ms, max_ms, 30)}  {ctx_str}")
+    print()
+
+def show_interactive(events):
+    """Show per-keystroke interactive loop breakdown."""
+    loops = [e for e in events if e["event"] == "loopWork"]
+    if not loops:
+        return
+    print("╔══════════════════════════════════════════════════════════════╗")
+    print("║  INTERACTIVE LOOP (per keystroke)                           ║")
+    print("╚══════════════════════════════════════════════════════════════╝\n")
+
+    hints = [e for e in events if e["event"] == "completionHint"]
+    renders = [e for e in events if e["event"] == "render"]
+    pre = [e for e in events if e["event"] == "preInput"]
+    updates = [e for e in events if e["event"] == "update"]
+
+    def stats(entries):
+        ms_list = [e["ms"] for e in entries]
+        if not ms_list: return "n/a"
+        return f"min={min(ms_list)} avg={sum(ms_list)//len(ms_list)} max={max(ms_list)} ms"
+
+    print(f"  {'Metric':<25s} {'Stats':}")
+    print(f"  {'─'*25} {'─'*40}")
+    print(f"  {'completionHint':<25s} {stats(hints)}")
+    print(f"  {'render':<25s} {stats(renders)}")
+    print(f"  {'preInput (total)':<25s} {stats(pre)}")
+    print(f"  {'update':<25s} {stats(updates)}")
+    print(f"  {'loopWork':<25s} {stats(loops)}")
+    print()
+
+    # Show interpreter stats if available
+    interp_data = []
+    for l in loops:
+        ctx = l.get("ctx", {})
+        if "interp" in ctx:
+            try:
+                interp_data.append(json.loads(ctx["interp"]))
+            except:
+                pass
+
+    if interp_data:
+        avg_instrs = sum(d["instructions"] for d in interp_data) // len(interp_data)
+        avg_frames = sum(d["framePushes"] for d in interp_data) // len(interp_data)
+        avg_builtin = sum(d["builtinCalls"] for d in interp_data) // len(interp_data)
+        avg_pkg = sum(d["packageCalls"] for d in interp_data) // len(interp_data)
+
+        print(f"  Interpreter (avg per keystroke):")
+        print(f"    Instructions: {avg_instrs:,}")
+        print(f"    Frames:       {avg_frames:,}")
+        print(f"    Builtin calls:{avg_builtin:,}")
+        print(f"    Package calls:{avg_pkg:,}")
+        print()
+
+        # Per-builtin timing
+        if any("builtinTiming" in d for d in interp_data):
+            agg = defaultdict(lambda: {"us": 0, "n": 0})
+            count = 0
+            for d in interp_data:
+                bt = d.get("builtinTiming", {})
+                if bt:
+                    count += 1
+                    for name, stats in bt.items():
+                        agg[name]["us"] += stats["us"]
+                        agg[name]["n"] += stats["n"]
+
+            if count > 0:
+                print(f"  Top builtins by cumulative time:")
+                top = sorted(agg.items(), key=lambda x: x[1]["us"], reverse=True)[:10]
+                for name, s in top:
+                    avg_us = s["us"] // count
+                    avg_n = s["n"] // count
+                    print(f"    {name:<30s} {avg_us:>7,}us  ({avg_n:>4}x)")
+                print()
+
+def show_commands(events):
+    """Show command execution times."""
+    cmds = [e for e in events if e["event"] == "commandExec"]
+    if not cmds:
+        return
+    print(f"  Commands executed:")
+    for c in cmds:
+        print(f"    {c['ctx'].get('cmd', '?'):<20s} {format_ms(c['ms'])}")
+    print()
+
+def main():
+    # Find telemetry file
+    if len(sys.argv) > 1:
+        path = sys.argv[1]
+    else:
+        candidates = [
+            "rundir/logs/telemetry.jsonl",
+            os.path.expanduser("~/.darklang/logs/telemetry.jsonl"),
+        ]
+        path = next((p for p in candidates if os.path.exists(p)), None)
+        if not path:
+            print("No telemetry file found. Specify path as argument.")
+            sys.exit(1)
+
+    events = load(path)
+    if not events:
+        print("No telemetry events found.")
+        sys.exit(0)
+
+    print(f"\n  Telemetry: {path} ({len(events)} events)")
+    print(f"  Time range: {events[0].get('wall', '?')} -> {events[-1].get('wall', '?')}")
+
+    show_startup(events)
+    show_interactive(events)
+    show_commands(events)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Telemetry:
- Telemetry.fs: span-based F# tracing with JSON-lines output
- telemetry.dark: Dark-side interactive loop instrumentation
- InterpreterStats on VMState: instruction/call/frame counters with optional per-builtin timing (disabled by default, zero overhead)
- Builtins: interpreterStatsReset/Get/EnableDetailedTiming, cliGetLogDir
- scripts/testing/: expect-based interactive test and telemetry viewer
- docs interactive-testing topic

Performance caching:
- Cache allCommands() and commandOptions() at init
- Cache completionHint by prompt text (skip recompute when unchanged)
- Cache terminal width/height with 500ms TTL (avoids tput subprocesses)
- Deduplicate Terminal.fs width/height into shared getDimension helper
- Fast-path COUNT(*) in applyUnappliedOps
- Fix release binary resource extraction timing

Results (debug, expect test):
- First frame preInput: ~169ms -> ~39ms
- Subsequent preInput: 42-124ms -> 24-45ms
- completionHint cached: ~4ms (vs 17-34ms uncached)