### PR TITLE
CLI views command

### DIFF
--- a/backend/src/BuiltinCli/Libs/Stdin.fs
+++ b/backend/src/BuiltinCli/Libs/Stdin.fs
@@ -12,6 +12,16 @@ module NR = LibExecution.RuntimeTypes.NameResolution
 
 open Builtin.Shortcuts
 
+/// Drain any buffered input characters that arrived in a burst
+/// (e.g. mouse wheel scroll generates many escape sequences at once).
+/// Returns the last ConsoleKeyInfo from the burst, or the original if no
+/// extra input was buffered.
+let private drainInputBurst (initial : ConsoleKeyInfo) : ConsoleKeyInfo =
+  let mutable last = initial
+  while Console.KeyAvailable do
+    last <- Console.ReadKey true
+  last
+
 let fns () : List<BuiltInFn> =
   [ { name = fn "stdinReadKey" 0
       typeParams = []
@@ -26,7 +36,7 @@ let fns () : List<BuiltInFn> =
         | _, _, _, [ DUnit ] ->
           // Treat Ctrl+C as input so the Dark code can handle it gracefully
           Console.TreatControlCAsInput <- true
-          let readKey = Console.ReadKey true
+          let readKey = Console.ReadKey true |> drainInputBurst
           Console.TreatControlCAsInput <- false
 
           let altHeld =

--- a/packages/darklang/cli/apps/views/ai-chats.dark
+++ b/packages/darklang/cli/apps/views/ai-chats.dark
@@ -1,0 +1,199 @@
+module Darklang.Cli.Apps.Views.AiChats
+
+/// Demo data: an AI coding thread
+type Thread =
+  { id: Int64
+    status: String
+    topic: String
+    branch: String
+    cost: String
+    tokens: String
+    time: String
+    detail: String }
+
+let demoThreads () : List<Thread> =
+  [ Thread
+      { id = 1L
+        status = "running"
+        topic = "Add binary serialization for sync"
+        branch = "ai/sync"
+        cost = "$4.82"
+        tokens = "128k"
+        time = "12m"
+        detail = "Currently editing packages/darklang/sync/serialize.dark  •  14 files changed" }
+    Thread
+      { id = 2L
+        status = "review"
+        topic = "Refactor HTTP handler error paths"
+        branch = "ai/errs"
+        cost = "$2.17"
+        tokens = "64k"
+        time = "8m"
+        detail = "⚠ Awaiting your review: 3 questions about error propagation strategy" }
+    Thread
+      { id = 3L
+        status = "running"
+        topic = "Write tests for package manager"
+        branch = "ai/test"
+        cost = "$1.53"
+        tokens = "41k"
+        time = "5m"
+        detail = "Running test suite (pass: 12, fail: 2, pending: 6)  •  4 files changed" }
+    Thread
+      { id = 4L
+        status = "review"
+        topic = "Design new DB migration system"
+        branch = "ai/db"
+        cost = "$6.31"
+        tokens = "187k"
+        time = "22m"
+        detail = "⚠ Awaiting your review: proposed 2 migration approaches, needs decision" }
+    Thread
+      { id = 5L
+        status = "running"
+        topic = "Fix canvas rendering perf regression"
+        branch = "ai/perf"
+        cost = "$0.89"
+        tokens = "22k"
+        time = "3m"
+        detail = "Profiling render loop, found bottleneck in tree diff  •  1 file changed" }
+    Thread
+      { id = 6L
+        status = "done"
+        topic = "Update stdlib List docs"
+        branch = "ai/docs"
+        cost = "$0.34"
+        tokens = "9k"
+        time = "1m"
+        detail = "Completed. PR #5601 ready to merge  •  8 files changed" } ]
+
+
+let statusBadge (status: String) : String =
+  match status with
+  | "running" -> Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgGreen ++ Darklang.Cli.Colors.black ++ Darklang.Cli.Colors.bold) " RUNNING "
+  | "review" -> Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgYellow ++ Darklang.Cli.Colors.black ++ Darklang.Cli.Colors.bold) " REVIEW  "
+  | "blocked" -> Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgRed ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold) " BLOCKED "
+  | "done" -> Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgBlue ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold) " DONE    "
+  | "paused" -> Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.grayBg ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold) " PAUSED  "
+  | "error" -> Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgRed ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold) " ERROR   "
+  | _ -> Darklang.Cli.Colors.dimText status
+
+let hr () : String =
+  let cols = Darklang.Cli.Terminal.getWidth ()
+  Darklang.Cli.Colors.dimText (Stdlib.String.repeat "─" cols)
+
+let thinHr () : String =
+  let cols = Darklang.Cli.Terminal.getWidth ()
+  Darklang.Cli.Colors.dimText (Stdlib.String.repeat "╌" cols)
+
+let padRight (s: String) (width: Int64) : String =
+  let len = Stdlib.String.length s
+  if len >= width then
+    Stdlib.String.slice s 0L width
+  else
+    s ++ (Stdlib.String.repeat " " (width - len))
+
+let renderThread (thread: Thread) : Unit =
+  let idStr = Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.cyan) ("#" ++ Stdlib.Int64.toString thread.id)
+  let badge = statusBadge thread.status
+  let topicStr =
+    if thread.status == "done" then
+      Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight thread.topic 40L)
+    else
+      Darklang.Cli.Colors.boldText (padRight thread.topic 40L)
+  let branchStr = Darklang.Cli.Colors.dimText (padRight thread.branch 10L)
+  let costColor =
+    match thread.status with
+    | "running" -> Darklang.Cli.Colors.green
+    | "review" -> Darklang.Cli.Colors.yellow
+    | _ -> Darklang.Cli.Colors.dim
+  let costStr = Darklang.Cli.Colors.colorize costColor (padRight thread.cost 10L)
+  let tokensStr = Darklang.Cli.Colors.dimText (padRight thread.tokens 10L)
+  let timeStr = Darklang.Cli.Colors.dimText (padRight thread.time 8L)
+
+  Stdlib.printLine ("  " ++ idStr ++ "    " ++ badge ++ "  " ++ topicStr ++ "  " ++ branchStr ++ "  " ++ costStr ++ "  " ++ tokensStr ++ "  " ++ timeStr)
+
+  let detailColor =
+    match thread.status with
+    | "review" -> Darklang.Cli.Colors.yellow
+    | _ -> Darklang.Cli.Colors.dim
+  Stdlib.printLine (Darklang.Cli.Colors.colorize detailColor ("       ╰─ " ++ thread.detail))
+
+
+let render () : Unit =
+  let threads = demoThreads ()
+
+  let runningCount =
+    threads
+    |> Stdlib.List.filter (fun t -> t.status == "running")
+    |> Stdlib.List.length
+
+  let reviewCount =
+    threads
+    |> Stdlib.List.filter (fun t -> t.status == "review")
+    |> Stdlib.List.length
+
+  let threadCount = Stdlib.List.length threads
+
+  // Header
+  Stdlib.printLine ""
+  Stdlib.printLine
+    ("  "
+     ++ Darklang.Cli.Colors.boldText "dark ai chats"
+     ++ "  "
+     ++ Darklang.Cli.Colors.dimText ("—  " ++ Stdlib.Int64.toString threadCount ++ " threads  •  " ++ Stdlib.Int64.toString runningCount ++ " running  •  " ++ Stdlib.Int64.toString reviewCount ++ " awaiting review"))
+  Stdlib.printLine ""
+  Stdlib.printLine (hr ())
+
+  // Column headers
+  let headerLine =
+    "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight "ID" 4L)
+    ++ "    "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight "STATUS" 10L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight "TOPIC" 40L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight "BRANCH" 10L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight "COST" 10L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight "TOKENS" 10L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim) (padRight "TIME" 8L)
+  Stdlib.printLine headerLine
+  Stdlib.printLine (hr ())
+
+  // Threads
+  threads
+  |> Stdlib.List.iter (fun thread ->
+    renderThread thread
+    Stdlib.printLine (thinHr ()))
+
+  Stdlib.printLine (hr ())
+
+  // Summary
+  Stdlib.printLine ""
+  Stdlib.printLine
+    ("  "
+     ++ Darklang.Cli.Colors.boldText "Session totals"
+     ++ "  "
+     ++ Darklang.Cli.Colors.dimText "│"
+     ++ "  Cost: " ++ Darklang.Cli.Colors.boldText "$16.06"
+     ++ "  " ++ Darklang.Cli.Colors.dimText "│"
+     ++ "  Tokens: " ++ Darklang.Cli.Colors.boldText "451k"
+     ++ "  " ++ Darklang.Cli.Colors.dimText "│"
+     ++ "  Uptime: " ++ Darklang.Cli.Colors.boldText "51m"
+     ++ "  " ++ Darklang.Cli.Colors.dimText "│"
+     ++ "  Files changed: " ++ Darklang.Cli.Colors.boldText "31")
+  Stdlib.printLine ""
+
+  // Keyboard hints
+  Stdlib.printLine
+    ("  "
+     ++ Darklang.Cli.Colors.dimText "[enter]" ++ " open thread   "
+     ++ Darklang.Cli.Colors.dimText "[r]" ++ " review flagged   "
+     ++ Darklang.Cli.Colors.dimText "[n]" ++ " new thread   "
+     ++ Darklang.Cli.Colors.dimText "[k]" ++ " kill thread   "
+     ++ Darklang.Cli.Colors.dimText "[q]" ++ " quit")
+  Stdlib.printLine ""

--- a/packages/darklang/cli/apps/views/app.dark
+++ b/packages/darklang/cli/apps/views/app.dark
@@ -1,0 +1,209 @@
+module Darklang.Cli.Apps.Views.App
+
+type Screen =
+  | ViewList of selected: Int64
+  | ViewDisplay of viewIndex: Int64
+
+type State =
+  { screen: Screen
+    views: List<ViewEntry> }
+
+
+// ── Rendering ──
+
+let renderViewList (state: State) (selected: Int64) : Unit =
+  let termWidth = Darklang.Cli.Terminal.getWidth ()
+
+  // Build entire output as a single string to avoid flicker
+  let header =
+    "\n"
+    ++ "  "
+    ++ Darklang.Cli.Colors.boldText "Views"
+    ++ "  "
+    ++ Darklang.Cli.Colors.dimText ("—  " ++ Stdlib.Int64.toString (Stdlib.List.length state.views) ++ " available")
+    ++ "\n\n"
+    ++ Darklang.Cli.Colors.dimText (Stdlib.String.repeat "─" termWidth)
+    ++ "\n\n"
+
+  let viewLines =
+    state.views
+    |> Stdlib.List.indexedMap (fun idx view -> (idx, view))
+    |> Stdlib.List.map (fun pair ->
+      let (idx, view) = pair
+      let isSelected = idx == selected
+      let pointer =
+        if isSelected then
+          Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.cyan) "▸ "
+        else
+          "  "
+      let nameStr =
+        if isSelected then
+          Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.cyan) view.name
+        else
+          Darklang.Cli.Colors.boldText view.name
+      let descStr = Darklang.Cli.Colors.dimText ("  " ++ view.description)
+
+      "  " ++ pointer ++ nameStr ++ "\n" ++ "      " ++ descStr ++ "\n")
+    |> Stdlib.String.join "\n"
+
+  let footer =
+    "\n"
+    ++ Darklang.Cli.Colors.dimText (Stdlib.String.repeat "─" termWidth)
+    ++ "\n\n"
+    ++ "  "
+    ++ Darklang.Cli.Colors.dimText "↑↓"
+    ++ " navigate   "
+    ++ Darklang.Cli.Colors.dimText "enter"
+    ++ " open view   "
+    ++ Darklang.Cli.Colors.dimText "esc"
+    ++ " exit"
+    ++ "\n"
+
+  // Single atomic write: hide cursor, clear, content, show cursor
+  Stdlib.print ("\u001b[?25l" ++ Darklang.Cli.Terminal.Display.clearScreen ++ header ++ viewLines ++ footer ++ "\u001b[?25h")
+
+
+let renderViewDisplay (state: State) (viewIndex: Int64) : Unit =
+  // Hide cursor + clear in one shot, then render view
+  Stdlib.print ("\u001b[?25l" ++ Darklang.Cli.Terminal.Display.clearScreen)
+
+  match Stdlib.List.getAt state.views viewIndex with
+  | Some view -> view.render ()
+  | None ->
+    Stdlib.printLine (Darklang.Cli.Colors.error "View not found")
+
+  // Back hint at bottom
+  Stdlib.printLine ""
+  Stdlib.printLine ("  " ++ Darklang.Cli.Colors.dimText "[esc] back to views list")
+  Stdlib.printLine ""
+  Stdlib.print "\u001b[?25h"
+
+
+let renderState (state: State) : Unit =
+  match state.screen with
+  | ViewList selected -> renderViewList state selected
+  | ViewDisplay viewIndex -> renderViewDisplay state viewIndex
+
+
+// ── Key handling ──
+
+type Action =
+  | Continue of State
+  | Exit of State
+
+let handleKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (_modifiers: Stdlib.Cli.Stdin.Modifiers.Modifiers)
+  (_keyChar: Stdlib.Option.Option<String>)
+  : Action =
+  match state.screen with
+  | ViewList selected ->
+    let viewCount = Stdlib.List.length state.views
+    match key with
+    | Escape -> Action.Exit state
+    | UpArrow ->
+      let newIdx = if selected > 0L then selected - 1L else selected
+      Action.Continue ({ state with screen = Screen.ViewList newIdx })
+    | DownArrow ->
+      let maxIdx = viewCount - 1L
+      let newIdx = if selected < maxIdx then selected + 1L else selected
+      Action.Continue ({ state with screen = Screen.ViewList newIdx })
+    | Enter ->
+      Action.Continue ({ state with screen = Screen.ViewDisplay selected })
+    | _ -> Action.Continue state
+
+  | ViewDisplay _viewIndex ->
+    match key with
+    | Escape -> Action.Continue ({ state with screen = Screen.ViewList 0L })
+    | _ -> Action.Continue state
+
+
+// ── SubApp adapter ──
+
+let rec makeSubApp (state: State) : Darklang.Cli.SubApp =
+  Darklang.Cli.SubApp
+    { onKey = fun key modifiers keyChar ->
+        match handleKey state key modifiers keyChar with
+        | Continue s -> (Darklang.Cli.SubAppAction.Continue, makeSubApp s)
+        | Exit s -> (Darklang.Cli.SubAppAction.Exit, makeSubApp s)
+      onDisplay = fun () -> renderState state
+      onSave = fun () -> () }
+
+
+// ── CLI command entry points ──
+
+let execute (cliState: Darklang.Cli.AppState) (args: List<String>) : Darklang.Cli.AppState =
+  let views = allViews ()
+
+  match args with
+  // Non-interactive: `views list` prints available views
+  | ["list"] ->
+    Stdlib.printLine (Darklang.Cli.Colors.boldText "Available views:")
+    Stdlib.printLine ""
+    views
+    |> Stdlib.List.iter (fun view ->
+      let slug = Stdlib.String.toLowercase (Stdlib.String.replaceAll view.name " " "-")
+      Stdlib.printLine ("  " ++ Darklang.Cli.Colors.boldText slug ++ "  " ++ Darklang.Cli.Colors.dimText view.description))
+    Stdlib.printLine ""
+    cliState
+
+  // Non-interactive: `views <name>` renders a specific view directly
+  | [viewName] ->
+    let slug = Stdlib.String.toLowercase viewName
+    let found =
+      views
+      |> Stdlib.List.findFirst (fun view ->
+        let viewSlug = Stdlib.String.toLowercase (Stdlib.String.replaceAll view.name " " "-")
+        viewSlug == slug)
+    match found with
+    | Some view ->
+      view.render ()
+      cliState
+    | None ->
+      Stdlib.printLine (Darklang.Cli.Colors.error ("Unknown view: " ++ viewName))
+      Stdlib.printLine "Use 'views list' to see available views."
+      cliState
+
+  // Interactive: `views` opens the browser
+  | _ ->
+    Stdlib.print "\u001b[?1049h"
+    match views with
+    | [] ->
+      Stdlib.print "\u001b[?1049l"
+      Stdlib.printLine (Darklang.Cli.Colors.dimText "No views available.")
+      cliState
+    | _ ->
+      let state = State { screen = Screen.ViewList 0L; views = views }
+      let app = makeSubApp state
+      { cliState with
+          currentPage = Darklang.Cli.Page.SubApp app
+          needsFullRedraw = true }
+
+
+let help (_state: Darklang.Cli.AppState) : Darklang.Cli.AppState =
+  [ "Usage: views [name|list]"
+    "Browse and preview available CLI views."
+    ""
+    "Views are interactive terminal dashboards and displays."
+    "Each view renders with demo data for quick previewing."
+    ""
+    "  views           Open interactive view browser"
+    "  views list      List available views"
+    "  views <name>    Render a specific view (e.g. views ai-chats)"
+    ""
+    "Interactive navigation:"
+    "  Up/Down    Select a view"
+    "  Enter      Open the selected view"
+    "  Escape     Back to list / exit"
+  ] |> Stdlib.printLines
+  _state
+
+
+let complete (_state: Darklang.Cli.AppState) (_args: List<String>) : List<Darklang.Cli.Completion.CompletionItem> =
+  let views = allViews ()
+  views
+  |> Stdlib.List.map (fun view ->
+    Darklang.Cli.Completion.CompletionItem
+      { value = Stdlib.String.toLowercase (Stdlib.String.replaceAll view.name " " "-")
+        display = Stdlib.String.toLowercase (Stdlib.String.replaceAll view.name " " "-") })

--- a/packages/darklang/cli/apps/views/core.dark
+++ b/packages/darklang/cli/apps/views/core.dark
@@ -1,0 +1,24 @@
+module Darklang.Cli.Apps.Views
+
+/// A registered view that can be browsed and rendered from the CLI.
+type ViewEntry =
+  { name: String
+    description: String
+    render: Unit -> Unit }
+
+/// All available views. Add new views here.
+let allViews () : List<ViewEntry> =
+  [ ViewEntry
+      { name = "AI Chats"
+        description = "Monitor AI coding threads — status, cost, tokens"
+        render = fun () -> AiChats.render () }
+    ViewEntry
+      { name = "Package Stats"
+        description = "Package tree statistics — counts by kind and owner"
+        render = fun () -> PackageStats.render () }
+    ViewEntry
+      { name = "UI Components"
+        description = "Visual showcase of CLI UI components"
+        render = fun () ->
+          let _ = Darklang.CLI.UI.Demo.run ()
+          () } ]

--- a/packages/darklang/cli/apps/views/package-stats.dark
+++ b/packages/darklang/cli/apps/views/package-stats.dark
@@ -1,0 +1,126 @@
+module Darklang.Cli.Apps.Views.PackageStats
+
+/// Demo data for package statistics
+type ModuleStats =
+  { name: String
+    fnCount: Int64
+    typeCount: Int64
+    valueCount: Int64
+    submodules: Int64 }
+
+let demoStats () : List<ModuleStats> =
+  [ ModuleStats { name = "Darklang.Stdlib"; fnCount = 247L; typeCount = 42L; valueCount = 18L; submodules = 23L }
+    ModuleStats { name = "Darklang.Cli"; fnCount = 89L; typeCount = 31L; valueCount = 12L; submodules = 15L }
+    ModuleStats { name = "Darklang.LanguageTools"; fnCount = 156L; typeCount = 67L; valueCount = 8L; submodules = 19L }
+    ModuleStats { name = "Darklang.SCM"; fnCount = 43L; typeCount = 14L; valueCount = 5L; submodules = 7L }
+    ModuleStats { name = "Darklang.PrettyPrinter"; fnCount = 38L; typeCount = 9L; valueCount = 3L; submodules = 4L }
+    ModuleStats { name = "Darklang.LLM"; fnCount = 22L; typeCount = 11L; valueCount = 6L; submodules = 3L }
+    ModuleStats { name = "Darklang.Test"; fnCount = 34L; typeCount = 8L; valueCount = 2L; submodules = 5L } ]
+
+
+let padRight (s: String) (width: Int64) : String =
+  let len = Stdlib.String.length s
+  if len >= width then
+    Stdlib.String.slice s 0L width
+  else
+    s ++ (Stdlib.String.repeat " " (width - len))
+
+let padLeft (s: String) (width: Int64) : String =
+  let len = Stdlib.String.length s
+  if len >= width then
+    Stdlib.String.slice s 0L width
+  else
+    (Stdlib.String.repeat " " (width - len)) ++ s
+
+let bar (value: Int64) (maxVal: Int64) (width: Int64) (color: String) : String =
+  let barLen =
+    if maxVal == 0L then 0L
+    else Stdlib.Int64.divide (value * width) maxVal
+  let filled = Stdlib.String.repeat "█" barLen
+  let empty = Stdlib.String.repeat "░" (width - barLen)
+  (Darklang.Cli.Colors.colorize color filled) ++ (Darklang.Cli.Colors.dimText empty)
+
+
+let render () : Unit =
+  let stats = demoStats ()
+
+  let totalFns = Stdlib.List.fold stats 0L (fun acc s -> acc + s.fnCount)
+  let totalTypes = Stdlib.List.fold stats 0L (fun acc s -> acc + s.typeCount)
+  let totalValues = Stdlib.List.fold stats 0L (fun acc s -> acc + s.valueCount)
+  let totalModules = Stdlib.List.fold stats 0L (fun acc s -> acc + s.submodules)
+
+  // Header
+  Stdlib.printLine ""
+  Stdlib.printLine
+    ("  "
+     ++ Darklang.Cli.Colors.boldText "Package Statistics"
+     ++ "  "
+     ++ Darklang.Cli.Colors.dimText ("—  " ++ Stdlib.Int64.toString (Stdlib.List.length stats) ++ " top-level modules"))
+  Stdlib.printLine ""
+
+  // Summary cards
+  let summaryLine =
+    "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgGreen ++ Darklang.Cli.Colors.black ++ Darklang.Cli.Colors.bold) (" " ++ Stdlib.Int64.toString totalFns ++ " fns ")
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgBlue ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold) (" " ++ Stdlib.Int64.toString totalTypes ++ " types ")
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.bgMagenta ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold) (" " ++ Stdlib.Int64.toString totalValues ++ " values ")
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize (Darklang.Cli.Colors.grayBg ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold) (" " ++ Stdlib.Int64.toString totalModules ++ " modules ")
+  Stdlib.printLine summaryLine
+  Stdlib.printLine ""
+
+  // Table header
+  let termCols = Darklang.Cli.Terminal.getWidth ()
+  Stdlib.printLine (Darklang.Cli.Colors.dimText (Stdlib.String.repeat "─" termCols))
+
+  let boldDim = Darklang.Cli.Colors.bold ++ Darklang.Cli.Colors.dim
+  let headerLine =
+    "  "
+    ++ Darklang.Cli.Colors.colorize boldDim (padRight "MODULE" 30L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize boldDim (padLeft "FNS" 6L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize boldDim (padLeft "TYPES" 6L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize boldDim (padLeft "VALS" 6L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize boldDim (padLeft "MODS" 6L)
+    ++ "  "
+    ++ Darklang.Cli.Colors.colorize boldDim "FUNCTIONS"
+  Stdlib.printLine headerLine
+  Stdlib.printLine (Darklang.Cli.Colors.dimText (Stdlib.String.repeat "─" termCols))
+
+  let maxFns =
+    stats
+    |> Stdlib.List.map (fun s -> s.fnCount)
+    |> Stdlib.List.fold 0L (fun acc n -> if n > acc then n else acc)
+
+  // Rows
+  stats
+  |> Stdlib.List.iter (fun s ->
+    let total = s.fnCount + s.typeCount + s.valueCount
+    let nameStr =
+      if total > 100L then
+        Darklang.Cli.Colors.boldText (padRight s.name 30L)
+      else
+        padRight s.name 30L
+    let fnStr = Darklang.Cli.Colors.colorize Darklang.Cli.Colors.green (padLeft (Stdlib.Int64.toString s.fnCount) 6L)
+    let typeStr = Darklang.Cli.Colors.colorize Darklang.Cli.Colors.blue (padLeft (Stdlib.Int64.toString s.typeCount) 6L)
+    let valStr = Darklang.Cli.Colors.colorize Darklang.Cli.Colors.magenta (padLeft (Stdlib.Int64.toString s.valueCount) 6L)
+    let modStr = Darklang.Cli.Colors.dimText (padLeft (Stdlib.Int64.toString s.submodules) 6L)
+    let barStr = bar s.fnCount maxFns 20L Darklang.Cli.Colors.green
+
+    Stdlib.printLine ("  " ++ nameStr ++ "  " ++ fnStr ++ "  " ++ typeStr ++ "  " ++ valStr ++ "  " ++ modStr ++ "  " ++ barStr))
+
+  Stdlib.printLine (Darklang.Cli.Colors.dimText (Stdlib.String.repeat "─" termCols))
+  Stdlib.printLine ""
+
+  // Footer
+  Stdlib.printLine
+    ("  "
+     ++ Darklang.Cli.Colors.dimText "[q]" ++ " quit   "
+     ++ Darklang.Cli.Colors.dimText "[s]" ++ " sort by column   "
+     ++ Darklang.Cli.Colors.dimText "[/]" ++ " filter")
+  Stdlib.printLine ""

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -222,7 +222,8 @@ module Registry =
       ("outliner", "Interactive tree outliner", [ "tree-exp" ], Darklang.Cli.Apps.Outliner.App.execute, Darklang.Cli.Apps.Outliner.App.help, Darklang.Cli.Apps.Outliner.App.complete)
       ("export-seed", "Export minimal seed.db from current database", [], Commands.ExportSeed.execute, Commands.ExportSeed.help, Commands.ExportSeed.complete)
       ("traces", "List and view execution traces", [ "trace" ], Commands.Traces.execute, Commands.Traces.help, Commands.Traces.complete)
-      ("review", "Review branch changesets", [], Darklang.Cli.Apps.Review.App.execute, Darklang.Cli.Apps.Review.App.help, Darklang.Cli.Apps.Review.App.complete) ]
+      ("review", "Review branch changesets", [], Darklang.Cli.Apps.Review.App.execute, Darklang.Cli.Apps.Review.App.help, Darklang.Cli.Apps.Review.App.complete)
+      ("views", "Browse and preview CLI views", [], Darklang.Cli.Apps.Views.App.execute, Darklang.Cli.Apps.Views.App.help, Darklang.Cli.Apps.Views.App.complete) ]
     |> Stdlib.List.map(
       // CLEANUP nitpicky: swap help and complete
       fun (name, desc, aliases, execute, help, complete) ->
@@ -300,7 +301,7 @@ module Registry =
       ("Execution", [ "run"; "eval"; "scripts" ])
       ("Installation", [ "install"; "update"; "uninstall"; "version" ])
       ("AI", [ "agent" ])
-      ("Utilities", [ "clear"; "help"; "docs"; "quit"; "builtins"; "export-seed" ]) ]
+      ("Utilities", [ "clear"; "help"; "docs"; "quit"; "builtins"; "export-seed"; "views" ]) ]
 
   // Helper function to format a group of commands with details
   let formatCommandGroup (groupName: String) (commandNames: List<String>) (commands: List<CommandHandler>) : String =

--- a/packages/darklang/cli/docs/for-ai.dark
+++ b/packages/darklang/cli/docs/for-ai.dark
@@ -85,6 +85,8 @@ Rules:
 ## Critical Syntax
 - Whitespace-sensitive (like Python)
 - NO nested function definitions
+- NO binding modules to variables (`let c = Darklang.Cli.Colors` is invalid —
+  modules are not first-class values. Use the full path each time.)
 - Pipe needs parens: (complex expr) |> fn
 - Lists: [1L; 2L; 3L] (semicolons)
 - String concat: ++ (not @)


### PR DESCRIPTION
I had one 'demo view' locally in a .sh script, and wanted to get it off of my machine. separately, there's a broader unspecced `views` UI I'd like to work on. This resolves the first issue while laying up for the second.

- Add `views` command with interactive browser and direct rendering
- Views: AI Chats, Package Stats, UI Components
- Fix UI Demo module name resolution (CLI vs Cli casing)
- Buffer view list rendering to reduce flicker
- Document module-not-first-class syntax rule in for-ai docs