### PR TITLE
Interpreter: move lambda + package fn instruction caches onto ExecutionState

### DIFF
--- a/backend/src/BuiltinCloudExecution/Libs/DB.fs
+++ b/backend/src/BuiltinCloudExecution/Libs/DB.fs
@@ -70,30 +70,22 @@ let resolveLoadValues
   }
 
 
-/// Look up a lambda from the VM cache by its exprId
-let lookupLambdaImpl (vm : VMState) (exprId : id) : LambdaImpl =
-  match
-    Map.tryFind
-      (vm.callFrames[vm.currentFrameID].executionPoint, exprId)
-      vm.lambdaInstrCache
-  with
-  | Some impl -> impl
-  | None ->
-    match Map.tryFind (Source, exprId) vm.lambdaInstrCache with
-    | Some impl -> impl
-    | None ->
-      Exception.raiseInternal "Lambda not found in cache" [ "exprId", exprId ]
+/// Look up a lambda from the execution cache by its exprId
+let lookupLambdaImpl (exeState : ExecutionState) (exprId : id) : LambdaImpl =
+  match exeState.lambdaInstrCache.TryGetValue exprId with
+  | true, impl -> impl
+  | false, _ ->
+    Exception.raiseInternal "Lambda not found in cache" [ "exprId", exprId ]
 
 
 /// Compile a lambda to SQL for use in DB queries
 /// Raises RuntimeErrorException on error
 let compileQueryLambda
   (exeState : ExecutionState)
-  (vm : VMState)
   (appLambda : ApplicableLambda)
   : Ply.Ply<LibExecution.RTQueryCompiler.CompiledQuery> =
   uply {
-    let lambdaImpl = lookupLambdaImpl vm appLambda.exprId
+    let lambdaImpl = lookupLambdaImpl exeState appLambda.exprId
     let! resolvedValues = resolveLoadValues exeState lambdaImpl
 
     match
@@ -411,7 +403,7 @@ let fns () : List<BuiltInFn> =
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
             let db = exeState.program.dbs[dbname]
-            let! compiled = compileQueryLambda exeState vm appLambda
+            let! compiled = compileQueryLambda exeState appLambda
             return!
               UserDB.executeCompiledQuery
                 exeState
@@ -438,7 +430,7 @@ let fns () : List<BuiltInFn> =
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
             let db = exeState.program.dbs[dbname]
-            let! compiled = compileQueryLambda exeState vm appLambda
+            let! compiled = compileQueryLambda exeState appLambda
             return!
               UserDB.executeCompiledQuery
                 exeState
@@ -465,7 +457,7 @@ let fns () : List<BuiltInFn> =
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
             let db = exeState.program.dbs[dbname]
-            let! compiled = compileQueryLambda exeState vm appLambda
+            let! compiled = compileQueryLambda exeState appLambda
             return!
               UserDB.executeCompiledQuery
                 exeState
@@ -492,7 +484,7 @@ let fns () : List<BuiltInFn> =
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
             let db = exeState.program.dbs[dbname]
-            let! compiled = compileQueryLambda exeState vm appLambda
+            let! compiled = compileQueryLambda exeState appLambda
             return!
               UserDB.executeCompiledQuery
                 exeState

--- a/backend/src/BuiltinExecution/Libs/StreamingHttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/StreamingHttpClient.fs
@@ -476,7 +476,6 @@ let private streamingRequestHandler
                 let! result =
                   Exe.executeApplicable
                     exeState
-                    vm
                     callbackApplicable
                     (NEList.singleton chunkDval)
                 match result with

--- a/backend/src/BuiltinHttpServer/Libs/HttpServer.fs
+++ b/backend/src/BuiltinHttpServer/Libs/HttpServer.fs
@@ -31,19 +31,16 @@ module Execution = LibExecution.Execution
 module Http = LibHttpMiddleware.Http
 
 
-/// Execute a named function with the given argument
-let private executeNamedFn
+/// Execute a handler (named fn or lambda) against the given request. Lambdas
+/// registered anywhere under this `exeState` (including the caller VM) are
+/// findable here since `lambdaInstrCache` lives on `exeState`.
+let private executeHandler
   (exeState : ExecutionState)
-  (namedFn : ApplicableNamedFn)
+  (handler : Applicable)
   (arg : Dval)
   : Task<Dval> =
   task {
-    let! result =
-      Execution.executeFunction
-        exeState
-        namedFn.name
-        namedFn.typeArgs
-        (NEList.singleton arg)
+    let! result = Execution.executeApplicable exeState handler (NEList.singleton arg)
     match result with
     | Ok dval -> return dval
     | Error(rte, _callStack) ->
@@ -67,7 +64,7 @@ let fns () : List<BuiltInFn> =
       description = "Start an HTTP server. Calls handler for each request."
       fn =
         (function
-        | exeState, _, _, [ DInt64 port; DApplicable(AppNamedFn handlerFn) ] ->
+        | exeState, _, _, [ DInt64 port; DApplicable handler ] ->
           uply {
             let builder = WebApplication.CreateBuilder()
             builder.WebHost.UseUrls($"http://*:{port}") |> ignore<IWebHostBuilder>
@@ -100,7 +97,7 @@ let fns () : List<BuiltInFn> =
                       Http.Request.fromRequest url reqHeaders reqBody
 
                     // Call the Darklang code
-                    let! result = executeNamedFn exeState handlerFn requestDval
+                    let! result = executeHandler exeState handler requestDval
 
                     // Convert result to HTTP response
                     let! response = Http.Response.toHttpResponse exeState result

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -38,6 +38,9 @@ let createState
     reportException = reportException
     notify = notify
 
+    lambdaInstrCache = System.Collections.Concurrent.ConcurrentDictionary()
+    packageFnInstrCache = System.Collections.Concurrent.ConcurrentDictionary()
+
     branchId = branchId
     program = program
 
@@ -117,12 +120,12 @@ let executeToplevel
   : Task<RT.ExecutionResult> =
   execute exeState (Some tlid, instrs)
 
-/// Execute an applicable (lambda or named fn) with given args,
-/// preserving the lambda instruction cache from the source VM.
+/// Execute an applicable (lambda or named fn) with given args in a fresh VM.
+/// Lambda + package fn instruction caches live on `exeState`, so lambdas
+/// created in the caller's VM remain findable here.
 /// Use this when calling a Darklang callback from within a builtin.
 let executeApplicable
   (exeState : RT.ExecutionState)
-  (sourceVM : RT.VMState)
   (applicable : RT.Applicable)
   (args : NEList<RT.Dval>)
   : Task<RT.ExecutionResult> =
@@ -149,17 +152,6 @@ let executeApplicable
 
   task {
     let vm = RT.VMState.create (None, instrs)
-    // Copy the lambda cache, and also re-key all entries under Source
-    // so that nested lambdas (e.g. match arms inside a callback) are
-    // findable from the new VM's root frame.
-    let reKeyed =
-      sourceVM.lambdaInstrCache
-      |> Map.fold
-        (fun acc ((_ep, exprId) : RT.ExecutionPoint * id) (v : RT.LambdaImpl) ->
-          acc |> Map.add (RT.Source, exprId) v)
-        sourceVM.lambdaInstrCache
-    vm.lambdaInstrCache <- reKeyed
-    vm.packageFnInstrCache <- sourceVM.packageFnInstrCache
     try
       try
         let! result = Interpreter.execute exeState vm

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -155,27 +155,22 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
         | Source -> Ply(snd vm.rootInstrData)
 
         | Lambda(parentContext, lambdaID) ->
-          let cacheKey = (parentContext, lambdaID)
-          match Map.tryFind cacheKey vm.lambdaInstrDataCache with
+          match Map.tryFind lambdaID vm.lambdaInstrDataCache with
           | Some cached -> Ply cached
           | None ->
             let lambda =
-              (match Map.tryFind cacheKey vm.lambdaInstrCache with
-               | Some l -> l
-               | None ->
-                 match Map.tryFind (Source, lambdaID) vm.lambdaInstrCache with
-                 | Some l -> l
-                 | None ->
-                   Exception.raiseInternal
-                     "lambda not found"
-                     [ "lambdaID", lambdaID; "parentContext", parentContext ])
-              |> _.instructions
+              match exeState.lambdaInstrCache.TryGetValue lambdaID with
+              | true, l -> l.instructions
+              | false, _ ->
+                Exception.raiseInternal
+                  "lambda not found"
+                  [ "lambdaID", lambdaID; "parentContext", parentContext ]
 
             let instrData =
               { instructions = List.toArray lambda.instructions
                 resultReg = lambda.resultIn }
             vm.lambdaInstrDataCache <-
-              Map.add cacheKey instrData vm.lambdaInstrDataCache
+              Map.add lambdaID instrData vm.lambdaInstrDataCache
             Ply instrData
 
         | Function(FQFnName.Builtin _) ->
@@ -185,16 +180,15 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
 
         | Function(FQFnName.Package fn) ->
           uply {
-            match Map.find fn vm.packageFnInstrCache with
-            | Some fn -> return fn
-            | None ->
+            match exeState.packageFnInstrCache.TryGetValue fn with
+            | true, cached -> return cached
+            | false, _ ->
               match! exeState.fns.package fn with
               | Some fn ->
                 let instrData =
                   { instructions = List.toArray fn.body.instructions
                     resultReg = fn.body.resultIn }
-                vm.packageFnInstrCache <-
-                  Map.add fn.hash instrData vm.packageFnInstrCache
+                exeState.packageFnInstrCache[fn.hash] <- instrData
                 return instrData
 
               | None -> return raiseRTE (RTE.FnNotFound(FQFnName.Package fn))
@@ -468,11 +462,7 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
 
 
         | CreateLambda(lambdaReg, impl) ->
-          vm.lambdaInstrCache <-
-            vm.lambdaInstrCache
-            |> Map.add (currentFrame.executionPoint, impl.exprId) impl
-            // CLEANUP why do we need this? ask Ocean for a reminder. I really feel like we shouldn't.
-            |> Map.add (Source, impl.exprId) impl
+          exeState.lambdaInstrCache[impl.exprId] <- impl
 
           registers[lambdaReg] <-
             { exprId = impl.exprId
@@ -512,15 +502,10 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
           | AppLambda appLambda ->
             let exprId = appLambda.exprId
             let foundLambda =
-              match
-                Map.tryFind (currentFrame.executionPoint, exprId) vm.lambdaInstrCache
-              with
-              | Some lambda -> lambda
-              | None ->
-                match Map.tryFind (Source, exprId) vm.lambdaInstrCache with
-                | Some lambda -> lambda
-                | None ->
-                  Exception.raiseInternal "lambda not found" [ "exprId", exprId ]
+              match exeState.lambdaInstrCache.TryGetValue exprId with
+              | true, lambda -> lambda
+              | false, _ ->
+                Exception.raiseInternal "lambda not found" [ "exprId", exprId ]
 
             let allArgs =
               match appLambda.argsSoFar with

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1379,9 +1379,8 @@ type VMState =
     // The inst data for each fn/lambda/etc. is stored here, so that
     // it doesn't have to be copied into each CallFrame.
     rootInstrData : Option<tlid> * InstrData
-    mutable lambdaInstrCache : Map<ExecutionPoint * id, LambdaImpl>
-    mutable lambdaInstrDataCache : Map<ExecutionPoint * id, InstrData>
-    mutable packageFnInstrCache : Map<FQFnName.Package, InstrData>
+    /// Per-VM memoization of InstrData derived from `exeState.lambdaInstrCache`.
+    mutable lambdaInstrDataCache : Map<id, InstrData>
 
     /// Performance counters — incremented during execution
     stats : InterpreterStats
@@ -1411,9 +1410,7 @@ type VMState =
           { instructions = List.toArray instrs.instructions
             resultReg = instrs.resultIn }
         (tlid, instrs)
-      lambdaInstrCache = Map.empty
       lambdaInstrDataCache = Map.empty
-      packageFnInstrCache = Map.empty
       stats = InterpreterStats.create () }
 
   static member createWithoutTLID(instrs : Instructions) : VMState =
@@ -1491,6 +1488,18 @@ and ExecutionState =
   { // -- Set consistently across a runtime --
     tracing : Tracing.Tracing
     test : TestContext
+
+    /// Lambda instructions registered by `CreateLambda`, looked up on `Apply`.
+    /// Shared across every VM spawned under this execution so that lambdas
+    /// created in one VM (e.g. an `eval` expression) remain findable when
+    /// invoked from another (e.g. an httpServerServe request handler VM).
+    lambdaInstrCache :
+      System.Collections.Concurrent.ConcurrentDictionary<id, LambdaImpl>
+
+    /// Memoization of `InstrData` derived from package function bodies.
+    /// Shared across VMs for the same reason as `lambdaInstrCache`.
+    packageFnInstrCache :
+      System.Collections.Concurrent.ConcurrentDictionary<FQFnName.Package, InstrData>
 
     /// Called to report exceptions
     reportException : ExceptionReporter

--- a/backend/tests/Tests/Interpreter.Tests.fs
+++ b/backend/tests/Tests/Interpreter.Tests.fs
@@ -16,7 +16,7 @@ let tCheckVM
   name
   ptExpr
   expectedInsts
-  (extraVmStateAssertions : RT.VMState -> unit)
+  (extraAssertions : RT.ExecutionState -> RT.VMState -> unit)
   =
   testTask name {
     let vmState =
@@ -28,11 +28,10 @@ let tCheckVM
     let! actual = LibExecution.Interpreter.execute exeState vmState |> Ply.toTask
     Expect.equal actual expectedInsts ""
 
-    extraVmStateAssertions vmState
+    extraAssertions exeState vmState
   }
 
-let t name ptExpr expectedInsts =
-  tCheckVM name ptExpr expectedInsts (ignore<RT.VMState>)
+let t name ptExpr expectedInsts = tCheckVM name ptExpr expectedInsts (fun _ _ -> ())
 
 
 
@@ -443,8 +442,8 @@ module Lambdas =
               argsSoFar = []
               typeSymbolTable = Map.empty }
         ))
-        (fun vm ->
-          Expect.isFalse (Map.isEmpty vm.lambdaInstrCache) "no lambdas in VMState")
+        (fun exeState _vm ->
+          Expect.isFalse exeState.lambdaInstrCache.IsEmpty "no lambdas registered")
 
     let applied = t "(fn x -> x) 1" E.Lambdas.Identity.applied (RT.DInt64 1L)
 
@@ -462,8 +461,8 @@ module Lambdas =
               argsSoFar = []
               typeSymbolTable = Map.empty }
         ))
-        (fun vm ->
-          Expect.isFalse (Map.isEmpty vm.lambdaInstrCache) "no lambdas in VMState")
+        (fun exeState _vm ->
+          Expect.isFalse exeState.lambdaInstrCache.IsEmpty "no lambdas registered")
 
     let partiallyApplied =
       t
@@ -495,8 +494,8 @@ module Lambdas =
               argsSoFar = []
               typeSymbolTable = Map.empty }
         ))
-        (fun vm ->
-          Expect.isFalse (Map.isEmpty vm.lambdaInstrCache) "no lambdas in VMState")
+        (fun exeState _vm ->
+          Expect.isFalse exeState.lambdaInstrCache.IsEmpty "no lambdas registered")
 
     let applied =
       t "(fn (x, y) -> x + y) (1, 2)" E.Lambdas.AddTuple.applied (RT.DInt64 3L)
@@ -517,8 +516,8 @@ module Lambdas =
               argsSoFar = []
               typeSymbolTable = Map.empty }
         ))
-        (fun vm ->
-          Expect.isFalse (Map.isEmpty vm.lambdaInstrCache) "no lambdas in VMState")
+        (fun exeState _vm ->
+          Expect.isFalse exeState.lambdaInstrCache.IsEmpty "no lambdas registered")
 
     let applied =
       t

--- a/backend/tests/Tests/Interpreter.Tests.fs
+++ b/backend/tests/Tests/Interpreter.Tests.fs
@@ -549,8 +549,7 @@ module Lambdas =
         E.Lambdas.Identity.unapplied
         |> PT2RT.Expr.toRT Map.empty 0 None
         |> RT.VMState.createWithoutTLID
-      let! lambdaDval =
-        LibExecution.Interpreter.execute exeState vmA |> Ply.toTask
+      let! lambdaDval = LibExecution.Interpreter.execute exeState vmA |> Ply.toTask
 
       let applicable =
         match lambdaDval with

--- a/backend/tests/Tests/Interpreter.Tests.fs
+++ b/backend/tests/Tests/Interpreter.Tests.fs
@@ -527,10 +527,59 @@ module Lambdas =
 
     let tests = testList "AddToClosedVars" [ unapplied; applied ]
 
+  module Nested =
+    let fullyApplied =
+      t "(fn x -> fn y -> x + y) 3 4" E.Lambdas.Nested.fullyApplied (RT.DInt64 7L)
+
+    let tests = testList "Nested" [ fullyApplied ]
+
+  /// Two VMs, one `ExecutionState`. VM-A (built here) runs `fn x -> x` and
+  /// registers the lambda in `exeState.lambdaInstrCache`. `executeApplicable`
+  /// internally spins up VM-B to invoke the `DApplicable`; VM-B must find
+  /// the lambda in the shared exeState cache, not its own empty one.
+  /// Regression guard for moving `lambdaInstrCache` off VMState.
+  let crossVM =
+    testTask "cross-VM lambda invocation" {
+      let! exeState =
+        executionStateFor TestValues.pm (System.Guid.NewGuid()) false false Map.empty
+
+      // VM-A: evaluate `fn x -> x`, producing a DApplicable whose instructions
+      // live in exeState.lambdaInstrCache after this call.
+      let vmA =
+        E.Lambdas.Identity.unapplied
+        |> PT2RT.Expr.toRT Map.empty 0 None
+        |> RT.VMState.createWithoutTLID
+      let! lambdaDval =
+        LibExecution.Interpreter.execute exeState vmA |> Ply.toTask
+
+      let applicable =
+        match lambdaDval with
+        | RT.DApplicable app -> app
+        | other -> failtestf "expected DApplicable from VM-A, got %A" other
+
+      // VM-B lives inside executeApplicable — a fresh VMState is created there
+      // to run the Apply. If lambdaInstrCache were still per-VM, VM-B's cache
+      // would be empty and this call would raise "lambda not found".
+      let! result =
+        LibExecution.Execution.executeApplicable
+          exeState
+          applicable
+          (NEList.singleton (RT.DInt64 42L))
+
+      match result with
+      | Ok dval -> Expect.equal dval (RT.DInt64 42L) "identity lambda across VMs"
+      | Error(rte, _) -> failtestf "executeApplicable errored: %A" rte
+    }
+
   let tests =
     testList
       "Lambdas"
-      [ Identity.tests; Add.tests; AddTuple.tests; AddToClosedVars.tests ]
+      [ Identity.tests
+        Add.tests
+        AddTuple.tests
+        AddToClosedVars.tests
+        Nested.tests
+        crossVM ]
 
 
 module Fns =

--- a/backend/tests/Tests/TestValues.fs
+++ b/backend/tests/Tests/TestValues.fs
@@ -517,7 +517,6 @@ module Expressions =
 
 
 
-  // TODO: test nested lambdas
   module Lambdas =
     module Identity =
       let id = gid ()
@@ -574,6 +573,24 @@ module Expressions =
           (lpVar "addFifteen")
           unapplied
           (eApply (eVar "addFifteen") [] [ eInt64 25 ])
+
+    ///```fsharp
+    /// (fun x -> fun y -> x + y) 3 4
+    /// ```
+    /// Exercises an inner lambda defined inside another lambda — the inner
+    /// body's `CreateLambda` runs inside the outer's call frame.
+    module Nested =
+      let outerId = gid ()
+      let innerId = gid ()
+      let unapplied =
+        eLambda
+          outerId
+          [ lpVar "x" ]
+          (eLambda
+            innerId
+            [ lpVar "y" ]
+            (eApply (eBuiltinFn "int64Add" 0) [] [ eVar "x"; eVar "y" ]))
+      let fullyApplied = eApply (eApply unapplied [] [ eInt64 3 ]) [] [ eInt64 4 ]
 
 
   module Fns =

--- a/packages/darklang/cli/docs/for-ai-internal.dark
+++ b/packages/darklang/cli/docs/for-ai-internal.dark
@@ -109,10 +109,6 @@ Full guide: `docs interactive-testing`
   http-server <port> <router>   # serve a Darklang router function
 Use ports 9090-9099 for demos (forwarded from devcontainer to host).
 Kill anything already on the port if needed.
-Known limitation: httpServerServe runs handlers in a fresh execution
-context without lambda instruction caches, so handlers that use
-lambdas (List.map, routeRequest, etc.) will fail at runtime.
-Workaround: avoid lambdas in handler call chains, or pre-compute results.
 
 ## Debug
   Builtin.debug "label" value   # prints DEBUG: label: <repr> to stdout


### PR DESCRIPTION
Passing an inline lambda as an `httpServerServe` handler failed before the server even started with `Uncaught exception: IncorrectArgs`. 
                                                                                                                                                                                                                                     
- Root cause: httpServerServe's pattern match only accepted `AppNamedFn`. Even if it hadn't, `lambdaInstrCache` lived on `VMState`, so every cross-VM invocation (e.g. HTTP handler) had to copy the caller's lambdas into each new VM by hand (O(N) per call)
- Moved `lambdaInstrCache` and `packageFnInstrCache` off `VMState` onto `ExecutionState`. Every VM spawned under a single execution now shares the caches, so lambda lookup just works across VMs without any copying.  
-  Inline-lambda handlers now work:                                                                                                                                                                                                   
    `./scripts/run-cli eval 'Stdlib.HttpServer.serve 9099L (fun req -> ...)'`. 