### PR TITLE
CLI: support multi-line definitions via stdin

### DIFF
--- a/backend/src/BuiltinCli/Libs/Stdin.fs
+++ b/backend/src/BuiltinCli/Libs/Stdin.fs
@@ -287,6 +287,24 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "stdinReadAll" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TString
+      description =
+        "Reads all available input from standard input until EOF.
+        Blocks if stdin is an interactive TTY with no EOF signal."
+      fn =
+        (function
+        | _, _, _, [ DUnit ] ->
+          let input = System.Console.In.ReadToEnd()
+          Ply(DString input)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
       deprecated = NotDeprecated } ]
 
 

--- a/packages/darklang/cli/packages/fn.dark
+++ b/packages/darklang/cli/packages/fn.dark
@@ -13,8 +13,13 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
       | "=" :: rest -> rest
       | parts -> parts
 
-    // Join all remaining args as the inline definition
-    let inlineDefinition = Stdlib.String.join cleanedParts " "
+    // Join all remaining args as the inline definition.
+    // Special case: a single "-" arg means "read body from stdin" so callers
+    // can pipe multi-line bodies via heredoc without shell-quoting.
+    let inlineDefinition =
+      match cleanedParts with
+      | [ "-" ] -> Builtin.stdinReadAll ()
+      | parts -> Stdlib.String.join parts " "
 
     if Stdlib.String.isEmpty inlineDefinition then
       // No inline definition provided - show error
@@ -22,10 +27,18 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
         (Colors.error "Error: Inline function definition required")
         ""
         "Usage: fn <location> <parameters and body>"
+        "       fn <location> -    (read body from stdin, for multi-line input)"
         ""
         "Examples:"
         "  fn double (x: Int64): Int64 = Stdlib.Int64.multiply x 2L"
         "  fn greet (name: String): String = \"Hello, \" ++ name"
+        ""
+        "  # Multi-line body via stdin (run from shell, not the REPL):"
+        "  ./scripts/run-cli fn fib - <<'EOF'"
+        "  (n: Int64): Int64 ="
+        "    if n < 2L then n"
+        "    else fib (n - 1L) + fib (n - 2L)"
+        "  EOF"
         ""
       ] |> Stdlib.printLines
 
@@ -155,6 +168,13 @@ let help (state: Cli.AppState) : Cli.AppState =
     ""
     "  # Boolean function:"
     "  fn isPositive (x: Int64): Bool = x > 0L"
+    ""
+    "  # Multi-line body via stdin (run from shell, not the REPL — '-' reads stdin):"
+    "  ./scripts/run-cli fn fib - <<'EOF'"
+    "  (n: Int64): Int64 ="
+    "    if n < 2L then n"
+    "    else fib (n - 1L) + fib (n - 2L)"
+    "  EOF"
     ""
     "Location can be relative or absolute:"
     "  fn helper (x: Int64): Int64 = ...    # Relative to current location"

--- a/packages/darklang/cli/packages/type.dark
+++ b/packages/darklang/cli/packages/type.dark
@@ -13,8 +13,13 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
       | "=" :: rest -> rest
       | parts -> parts
 
-    // Join all remaining args as the inline definition
-    let inlineDefinition = Stdlib.String.join cleanedParts " "
+    // Join all remaining args as the inline definition.
+    // Special case: a single "-" arg means "read body from stdin" so callers
+    // can pipe multi-line definitions via heredoc without shell-quoting.
+    let inlineDefinition =
+      match cleanedParts with
+      | [ "-" ] -> Builtin.stdinReadAll ()
+      | parts -> Stdlib.String.join parts " "
 
     if Stdlib.String.isEmpty inlineDefinition then
       // No inline definition provided - show error
@@ -22,11 +27,21 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
         (Colors.error "Error: Inline type definition required")
         ""
         "Usage: type <location> <definition>"
+        "       type <location> -    (read definition from stdin, for multi-line input)"
         ""
         "Examples:"
         "  type Status = | Active | Inactive"
         "  type User = { name: String; age: Int64 }"
         "  type Result = | Ok of String | Error of String"
+        ""
+        "  # Multi-line definition via stdin (run from shell, not the REPL):"
+        "  ./scripts/run-cli type User - <<'EOF'"
+        "  {"
+        "    name: String"
+        "    age: Int64"
+        "    email: String"
+        "  }"
+        "  EOF"
         ""
       ] |> Stdlib.printLines
 
@@ -157,6 +172,15 @@ let help (state: Cli.AppState) : Cli.AppState =
     ""
     "  # Type alias:"
     "  type UserId = Uuid"
+    ""
+    "  # Multi-line definition via stdin (run from shell, not the REPL — '-' reads stdin):"
+    "  ./scripts/run-cli type User - <<'EOF'"
+    "  {"
+    "    name: String"
+    "    age: Int64"
+    "    email: String"
+    "  }"
+    "  EOF"
     ""
     "Location can be relative or absolute:"
     "  type Foo = ...              # Right here in this module"

--- a/packages/darklang/cli/packages/value.dark
+++ b/packages/darklang/cli/packages/value.dark
@@ -13,8 +13,13 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
       | "=" :: rest -> rest
       | parts -> parts
 
-    // Join all remaining args as the inline definition
-    let inlineDefinition = Stdlib.String.join cleanedParts " "
+    // Join all remaining args as the inline definition.
+    // Special case: a single "-" arg means "read body from stdin" so callers
+    // can pipe multi-line expressions via heredoc without shell-quoting.
+    let inlineDefinition =
+      match cleanedParts with
+      | [ "-" ] -> Builtin.stdinReadAll ()
+      | parts -> Stdlib.String.join parts " "
 
     if Stdlib.String.isEmpty inlineDefinition then
       // No inline definition provided - show error
@@ -22,11 +27,22 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
         (Colors.error "Error: Inline value expression required")
         ""
         "Usage: val <location> <expression>"
+        "       val <location> -    (read expression from stdin, for multi-line input)"
         ""
         "Examples:"
         "  val x = 42L"
         "  val myString = \"hello\""
         "  val myList = [1L; 2L; 3L]"
+        ""
+        "  # Multi-line expression via stdin (run from shell, not the REPL):"
+        "  ./scripts/run-cli val primes - <<'EOF'"
+        "  ["
+        "    2L"
+        "    3L"
+        "    5L"
+        "    7L"
+        "  ]"
+        "  EOF"
         ""
       ] |> Stdlib.printLines
 
@@ -155,6 +171,16 @@ let help (state: Cli.AppState) : Cli.AppState =
     ""
     "  # Type alias:"
     "  val userId = Uuid.parse \"123e4567-e89b-12d3-a456-426614174000\""
+    ""
+    "  # Multi-line expression via stdin (run from shell, not the REPL — '-' reads stdin):"
+    "  ./scripts/run-cli val primes - <<'EOF'"
+    "  ["
+    "    2L"
+    "    3L"
+    "    5L"
+    "    7L"
+    "  ]"
+    "  EOF"
     ""
     "Location can be relative or absolute:"
     "  val foo = 42L          # Relative to current location"


### PR DESCRIPTION
This PR lets `fn`, `type`, and `val` read their body from stdin when the definition arg is `-`. Multi-line definitions can then be supplied via heredoc instead of being collapsed onto one shell-quoted line
 
 example:
```
./scripts/run-cli fn Foo.fib - <<'EOF'                                                                                                                                                   
  (n: Int64): Int64 =                                                                                                                                                                        
    if n < 2L then n                                                                                                                                                                         
    else fib (n - 1L) + fib (n - 2L)                                                                                                                                                         
  EOF  
```          