### PR TITLE
Structured CLI errors and fixes to parser escape handling

### DIFF
--- a/backend/src/Builtins/Builtins.Cli/Libs/File.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/File.fs
@@ -9,19 +9,44 @@ open LibExecution.RuntimeTypes
 module Dval = LibExecution.Dval
 module Builtin = LibExecution.Builtin
 module Blob = LibExecution.Blob
+module PackageRefs = LibExecution.PackageRefs
+module NR = LibExecution.RuntimeTypes.NameResolution
 open Builtin.Shortcuts
+
+
+// Structured error for file I/O. Mirrors Stdlib.Cli.FileSystem.FileError so
+// callers can pattern-match instead of grepping .NET exception text.
+module FileError =
+  let fqTypeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.Stdlib.Cli.FileSystem.fileError ())
+
+  /// Classify a .NET exception into a FileError DEnum. NotFound covers both
+  /// missing files and missing parent directories (which present the same way
+  /// to a user). PermissionDenied covers UnauthorizedAccess. Anything else
+  /// becomes Other with the underlying message.
+  let fromException (e : exn) : Dval =
+    let typeName = fqTypeName ()
+    let (caseName, fields) =
+      match e with
+      | :? System.IO.FileNotFoundException
+      | :? System.IO.DirectoryNotFoundException -> "NotFound", []
+      | :? System.UnauthorizedAccessException -> "PermissionDenied", []
+      | _ -> "Other", [ DString e.Message ]
+    DEnum(typeName, typeName, [], caseName, fields)
 
 
 let fns () : List<BuiltInFn> =
   [ { name = fn "fileRead" 0
       typeParams = []
       parameters = [ Param.make "path" TString "" ]
-      returnType = TypeReference.result TBlob TString
+      returnType =
+        TypeReference.result TBlob (TCustomType(NR.ok (FileError.fqTypeName ()), []))
       description =
         "Reads the contents of a file at <param path> asynchronously into an ephemeral Blob, wrapped in a Result."
       fn =
-        let resultOk = Dval.resultOk KTBlob KTString
-        let resultError = Dval.resultError KTBlob KTString
+        let errType = KTCustomType(FileError.fqTypeName (), [])
+        let resultOk = Dval.resultOk KTBlob errType
+        let resultError = Dval.resultError KTBlob errType
         (function
         | state, _, _, [ DString path ] ->
           uply {
@@ -35,7 +60,7 @@ let fns () : List<BuiltInFn> =
               let! contents = System.IO.File.ReadAllBytesAsync path
               return resultOk (Blob.newEphemeral state contents)
             with e ->
-              return resultError (DString($"Error reading file: {e.Message}"))
+              return resultError (FileError.fromException e)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
+++ b/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
@@ -49,23 +49,67 @@ module CliTraceSource =
     | EvalExpression expr -> ("eval", "expression", RT.DString expr)
 
 
-// Create exception error from exn
-let createExceptionError (e : exn) : RuntimeError.Error =
-  RuntimeError.UncaughtException(
-    Exception.getMessages e |> String.concat "\n",
-    Exception.toMetadata e |> List.map (fun (k, v) -> (k, DString(string v)))
-  )
+module ParseError =
+  type Unparseable =
+    { text : string; line : int64; column : int64; note : Option<string> }
 
-// Parse CLI script code using the single-shot parseForCli function.
-// This keeps PM creation and parsing in the same execution context,
-// avoiding issues with lambda instructions crossing VM boundaries.
+  type ParseError =
+    | Unparseable of Unparseable
+    | Other of string
+
+  let fqTypeName () =
+    FQTypeName.fqPackage (
+      PackageRefs.Type.LanguageTools.Parser.CliScript.parseError ()
+    )
+
+  let unparseableTypeName () =
+    FQTypeName.fqPackage (
+      PackageRefs.Type.LanguageTools.Parser.CliScript.unparseable ()
+    )
+
+  let unparseableToDT (u : Unparseable) : Dval =
+    let typeName = unparseableTypeName ()
+    let fields =
+      [ "text", DString u.text
+        "line", DInt64 u.line
+        "column", DInt64 u.column
+        "note", C2DT.Option.toDT DString KTString u.note ]
+    DRecord(typeName, typeName, [], Map fields)
+
+  let unparseableFromDT (d : Dval) : Unparseable =
+    match d with
+    | DRecord(_, _, _, fields) ->
+      { text = fields |> D.field "text" |> D.string
+        line = fields |> D.field "line" |> D.int64
+        column = fields |> D.field "column" |> D.int64
+        note = C2DT.Option.fromDT D.string (fields |> D.field "note") }
+    | _ -> Exception.raiseInternal "Invalid Unparseable Dval" [ "dval", d ]
+
+  let toDT (err : ParseError) : Dval =
+    let typeName = fqTypeName ()
+    let (caseName, fields) =
+      match err with
+      | Unparseable u -> "Unparseable", [ unparseableToDT u ]
+      | Other msg -> "Other", [ DString msg ]
+    DEnum(typeName, typeName, [], caseName, fields)
+
+  let fromDT (d : Dval) : ParseError =
+    match d with
+    | DEnum(_, _, _, "Unparseable", [ uDval ]) ->
+      Unparseable(unparseableFromDT uDval)
+    | DEnum(_, _, _, "Other", [ DString msg ]) -> Other msg
+    | _ -> Exception.raiseInternal "Invalid ParseError Dval" [ "dval", d ]
+
+/// Parse CLI script code via the single-shot `parseForCli` Dark function.
+/// Keeping PM creation and parsing in the same execution context avoids
+/// lambda instructions crossing VM boundaries.
 let parseCliScript
   (exeState : RT.ExecutionState)
   (branchId : System.Guid)
   (owner : string)
   (scriptName : string)
   (code : string)
-  : Ply<Result<Utils.CliScript.PTCliScriptModule, RuntimeError.Error>> =
+  : Ply<Result<Utils.CliScript.PTCliScriptModule, ParseError.ParseError>> =
   uply {
     let args =
       NEList.ofList
@@ -84,13 +128,7 @@ let parseCliScript
       match C2DT.Result.fromDT identity dval identity with
       | Ok parsedModuleAndUnresolvedNames ->
         return (Utils.CliScript.fromDT parsedModuleAndUnresolvedNames) |> Ok
-      | Error(DString errMsg) ->
-        return Error(RuntimeError.UncaughtException(errMsg, []))
-      | Error _ ->
-        return
-          Exception.raiseInternal
-            "Invalid error format from parseCliScript"
-            [ "dval", dval ]
+      | Error parseErrorDval -> return Error(ParseError.fromDT parseErrorDval)
     | Error(rte, _cs) ->
       let! rteString = Exe.runtimeErrorToString exeState rte
       match rteString with
@@ -110,6 +148,42 @@ let parseCliScript
 module ExecutionError =
   let fqTypeName () = FQTypeName.fqPackage (PackageRefs.Type.Cli.executionError ())
   let typeRef () = TCustomType(NR.ok (fqTypeName ()), [])
+
+  let unhandledTypeName () = FQTypeName.fqPackage (PackageRefs.Type.Cli.unhandled ())
+
+  type Unhandled = { message : string; metadata : List<string * string> }
+
+  type ExecutionError =
+    | Parse of ParseError.ParseError
+    | Runtime of RT.RuntimeError.Error
+    | Unhandled of Unhandled
+
+  /// Capture an exception's message and metadata for the `Unhandled` case.
+  /// `Exception.toMetadata` only ever produces string-stringified values,
+  /// so `List<string * string>` faithfully represents what we have without
+  /// the Dval-wrapping machinery.
+  let unhandledFromExn (e : exn) : Unhandled =
+    { message = Exception.getMessages e |> String.concat "\n"
+      metadata = Exception.toMetadata e |> List.map (fun (k, v) -> (k, string v)) }
+
+  let private unhandledToDT (u : Unhandled) : Dval =
+    let typeName = unhandledTypeName ()
+    let pairKT = KTTuple(VT.string, VT.string, [])
+    let metadataDval =
+      u.metadata
+      |> List.map (fun (k, v) -> DTuple(DString k, DString v, []))
+      |> fun items -> DList(VT.known pairKT, items)
+    let fields = [ "message", DString u.message; "metadata", metadataDval ]
+    DRecord(typeName, typeName, [], Map fields)
+
+  let toDT (err : ExecutionError) : Dval =
+    let typeName = fqTypeName ()
+    let (caseName, fields) =
+      match err with
+      | Parse pe -> "Parse", [ ParseError.toDT pe ]
+      | Runtime rte -> "Runtime", [ RT2DT.RuntimeError.toDT rte ]
+      | Unhandled u -> "Unhandled", [ unhandledToDT u ]
+    DEnum(typeName, typeName, [], caseName, fields)
 
 
 let pmRT = LibDB.PackageManager.rt
@@ -255,10 +329,13 @@ let fns () : List<BuiltInFn> =
             let exeState = { exeState with accountID = accountID }
             // Use branch-specific state for parsing so name resolution uses the right branch
             let branchState = createBranchState exeState branchId allowHarmful
-            let! parsedScript =
-              parseCliScript branchState branchId "CliScript" filename code
 
             try
+              // parseCliScript itself can raise (e.g. deep VM failures); keep
+              // it inside the try so its exceptions hit the Unhandled net.
+              let! parsedScript =
+                parseCliScript branchState branchId "CliScript" filename code
+
               let! dbs = loadDBs ()
 
               match parsedScript with
@@ -275,18 +352,31 @@ let fns () : List<BuiltInFn> =
                 | Ok(DInt64 i) -> return resultOk (DInt64 i)
                 | Ok DUnit -> return resultOk (DInt64 0L)
                 | Ok result ->
+                  let rte =
+                    RuntimeError.CLIs.NonIntReturned result |> RuntimeError.CLI
                   return
-                    RuntimeError.CLIs.NonIntReturned result
-                    |> RuntimeError.CLI
-                    |> RT2DT.RuntimeError.toDT
-                    |> resultError
+                    resultError (ExecutionError.toDT (ExecutionError.Runtime rte))
                 | Error(e, callStack) ->
                   let! csString = Exe.callStackString exeState callStack
                   print $"Error when executing Script. Call-stack:\n{csString}\n"
-                  return e |> RT2DT.RuntimeError.toDT |> resultError
-              | Error e -> return e |> RT2DT.RuntimeError.toDT |> resultError
-            with e ->
-              return createExceptionError e |> RT2DT.RuntimeError.toDT |> resultError
+                  return resultError (ExecutionError.toDT (ExecutionError.Runtime e))
+              | Error pe ->
+                return resultError (ExecutionError.toDT (ExecutionError.Parse pe))
+            // Runtime errors raised via `raiseUntargetedRTE` (e.g.
+            // `NoExpressionsToExecute`) escape as `RuntimeErrorException`
+            // rather than returning through the normal `Error(rte, _)`
+            // channel. Catch them explicitly so they're classified as
+            // `Runtime`, not `Unhandled`.
+            with
+            | RuntimeErrorException(_, rte) ->
+              return resultError (ExecutionError.toDT (ExecutionError.Runtime rte))
+            | e ->
+              return
+                resultError (
+                  ExecutionError.toDT (
+                    ExecutionError.Unhandled(ExecutionError.unhandledFromExn e)
+                  )
+                )
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -322,15 +412,18 @@ let fns () : List<BuiltInFn> =
             let exeState = { exeState with accountID = accountID }
             // Use branch-specific state for parsing so name resolution uses the right branch
             let branchState = createBranchState exeState branchId allowHarmful
-            let! parsedScript =
-              parseCliScript
-                branchState
-                branchId
-                "CliScript"
-                "exprWrapper"
-                expression
 
             try
+              // parseCliScript itself can raise (e.g. deep VM failures); keep
+              // it inside the try so its exceptions hit the Unhandled net.
+              let! parsedScript =
+                parseCliScript
+                  branchState
+                  branchId
+                  "CliScript"
+                  "exprWrapper"
+                  expression
+
               let! dbs = loadDBs ()
 
               match parsedScript with
@@ -347,10 +440,19 @@ let fns () : List<BuiltInFn> =
                 | Error(e, callStack) ->
                   let! csString = Exe.callStackString exeState callStack
                   print $"Error when executing expression. Call-stack:\n{csString}\n"
-                  return e |> RT2DT.RuntimeError.toDT |> resultError
-              | Error e -> return e |> RT2DT.RuntimeError.toDT |> resultError
-            with e ->
-              return createExceptionError e |> RT2DT.RuntimeError.toDT |> resultError
+                  return resultError (ExecutionError.toDT (ExecutionError.Runtime e))
+              | Error pe ->
+                return resultError (ExecutionError.toDT (ExecutionError.Parse pe))
+            with
+            | RuntimeErrorException(_, rte) ->
+              return resultError (ExecutionError.toDT (ExecutionError.Runtime rte))
+            | e ->
+              return
+                resultError (
+                  ExecutionError.toDT (
+                    ExecutionError.Unhandled(ExecutionError.unhandledFromExn e)
+                  )
+                )
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/Builtins/Builtins.Pure/Libs/Char.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Char.fs
@@ -128,6 +128,28 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "charFromCodepoint" 0
+      typeParams = []
+      parameters = [ Param.make "codepoint" TInt64 "" ]
+      returnType = TypeReference.option TChar
+      description =
+        "Return {{Some <var c>}} for the Unicode codepoint <param codepoint>,
+        or {{None}} if the value is not a valid scalar codepoint
+        (i.e. negative, greater than 0x10FFFF, or a surrogate)."
+      fn =
+        function
+        | _, _, _, [ DInt64 cp ] ->
+          if cp < 0L || cp > 0x10FFFFL || (cp >= 0xD800L && cp <= 0xDFFFL) then
+            Dval.optionNone KTChar |> Ply
+          else
+            let s = System.Char.ConvertFromUtf32(int cp)
+            Dval.optionSome KTChar (DChar s) |> Ply
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplemented
+      previewable = Pure
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/LibExecution/PackageRefs.fs
+++ b/backend/src/LibExecution/PackageRefs.fs
@@ -143,6 +143,10 @@ module Type =
       let private p addl = p ("Cli" :: addl)
       let executionOutcome = p [] "ExecutionOutcome"
 
+      module FileSystem =
+        let private p addl = p ("FileSystem" :: addl)
+        let fileError = p [] "FileError"
+
       module Posix =
         let private p addl = p ("Posix" :: addl)
         let error = p [] "Error"

--- a/backend/src/LibExecution/PackageRefs.fs
+++ b/backend/src/LibExecution/PackageRefs.fs
@@ -178,6 +178,8 @@ module Type =
       module CliScript =
         let private p addl = p ("CliScript" :: addl)
         let pTCliScriptModule = p [] "PTCliScriptModule"
+        let parseError = p [] "ParseError"
+        let unparseable = p [] "Unparseable"
 
     module RuntimeTypes =
       let private p addl = p ("RuntimeTypes" :: addl)
@@ -331,6 +333,7 @@ module Type =
 
   module Cli =
     let executionError = p [ "Cli"; "ExecutionError" ] "ExecutionError"
+    let unhandled = p [ "Cli"; "ExecutionError" ] "Unhandled"
     let script = p [ "Cli"; "Scripts" ] "Script"
 
     module Commands =

--- a/backend/testfiles/execution/stdlib/char.dark
+++ b/backend/testfiles/execution/stdlib/char.dark
@@ -202,3 +202,23 @@ Stdlib.Char.toString 'Ł' = "Ł"
 Stdlib.Char.toString (hand ()) = "✋🏿"
 Stdlib.Char.toString 'Ჾ' = "Ჾ"
 Stdlib.Char.toString 'ჾ' = "ჾ"
+
+
+// Valid codepoints
+Stdlib.Char.fromCodepoint 65L = Stdlib.Option.Option.Some 'A'
+Stdlib.Char.fromCodepoint 233L = Stdlib.Option.Option.Some 'é'
+// Non-BMP: pins the surrogate-pair path through ConvertFromUtf32. 0x1F602 = 😂
+Stdlib.Char.fromCodepoint 128514L = Stdlib.Option.Option.Some (smiley ())
+
+// Invalid: surrogate range (D800..DFFF) — reserved for UTF-16 surrogate pairs
+Stdlib.Char.fromCodepoint 55296L = Stdlib.Option.Option.None
+Stdlib.Char.fromCodepoint 56319L = Stdlib.Option.Option.None
+Stdlib.Char.fromCodepoint 57343L = Stdlib.Option.Option.None
+
+// Invalid: above Unicode max (0x10FFFF)
+Stdlib.Char.fromCodepoint 1114112L = Stdlib.Option.Option.None
+Stdlib.Char.fromCodepoint 2147483647L = Stdlib.Option.Option.None
+
+// Invalid: negative — the F# test parser rejects `-NL`, so build via `0L - N`.
+Stdlib.Char.fromCodepoint (0L - 1L) = Stdlib.Option.Option.None
+Stdlib.Char.fromCodepoint (0L - 1000L) = Stdlib.Option.Option.None

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -125,14 +125,11 @@ let tEval (name : string) (input : string) (expected : RT.Dval) =
   }
 
 
-/// Asserts that the parser rejects the input. Used for inputs that should
-/// produce a parse error (e.g. invalid escape sequences) — symptomatic of
-/// the regression where invalid input was silently dropped.
-///
-/// Uses `parseForCli` (the same parse path the CLI uses) because it surfaces
+/// Asserts the ParseError case name returned by `parseForCli`. Uses
+/// `parseForCli` (the same parse path the CLI uses) because it surfaces
 /// `unparseableStuff` as `Result.Error` — `parsePTSourceFileWithOps` swallows
 /// per-declaration parse failures into a side list and returns Ok overall.
-let tFails (name : string) (input : string) =
+let tParseErrorVariant (name : string) (input : string) (expectedCaseName : string) =
   testTask name {
     let parseFnName =
       RT.FQFnName.fqPackage (
@@ -150,10 +147,18 @@ let tFails (name : string) (input : string) =
       LibExecution.Execution.executeFunction parseExeState parseFnName [] args
     let! parseDval = unwrapExecutionResult parseExeState parseResult |> Ply.toTask
     match parseDval with
-    | RT.DEnum(tn, _, _, "Error", _) when tn = Dval.resultType () -> return ()
-    | RT.DEnum(tn, _, _, "Ok", _) when tn = Dval.resultType () ->
-      return failtest $"Expected parse failure but got successful parse: {parseDval}"
-    | _ -> return failtest $"Unexpected parse result format: {parseDval}"
+    | RT.DEnum(tn, _, _, "Error", [ RT.DEnum(_, _, _, caseName, _) ]) when
+      tn = Dval.resultType ()
+      ->
+      return
+        Expect.equal
+          caseName
+          expectedCaseName
+          $"wrong ParseError variant for {input}"
+    | _ ->
+      return
+        failtest
+          $"Expected Result.Error containing a ParseError variant; got {parseDval}"
   }
 
 
@@ -808,24 +813,36 @@ let exprs =
       []
       false
     // Invalid escape sequences must be rejected (not silently dropped to "").
-    tFails "invalid escape in string literal" "\"\\d+\""
-    tFails "invalid escape in interpolation" "$\"a\\d+b\""
-    tFails "invalid escape in char literal" "'\\d'"
-    tFails
+    // Asserts both failure AND `Unparseable` variant
+    tParseErrorVariant "invalid escape in string literal" "\"\\d+\"" "Unparseable"
+    tParseErrorVariant "invalid escape in interpolation" "$\"a\\d+b\"" "Unparseable"
+    tParseErrorVariant "invalid escape in char literal" "'\\d'" "Unparseable"
+    tParseErrorVariant
       "invalid escape in string match pattern"
       "match s with\n| \"\\d+\" -> 1L\n| _ -> 0L"
-    tFails
+      "Unparseable"
+    tParseErrorVariant
       "invalid escape in char match pattern"
       "match c with\n| '\\d' -> 1L\n| _ -> 0L"
+      "Unparseable"
     // Codepoints that tree-sitter accepts as well-formed escapes but that
     // are not valid Unicode scalars must be rejected by the decoder:
     //   - surrogate range (D800..DFFF)
     //   - above the Unicode max (>0x10FFFF)
-    tFails "surrogate codepoint \\uD800" "\"\\uD800\""
-    tFails "surrogate codepoint \\U0000D800" "\"\\U0000D800\""
-    tFails "codepoint above max \\U00110000" "\"\\U00110000\""
-    tFails "surrogate codepoint in char" "'\\uD800'"
-    tFails "codepoint above max in char" "'\\U00110000'"
+    tParseErrorVariant "surrogate codepoint \\uD800" "\"\\uD800\"" "Unparseable"
+    tParseErrorVariant
+      "surrogate codepoint \\U0000D800"
+      "\"\\U0000D800\""
+      "Unparseable"
+    tParseErrorVariant
+      "codepoint above max \\U00110000"
+      "\"\\U00110000\""
+      "Unparseable"
+    tParseErrorVariant "surrogate codepoint in char" "'\\uD800'" "Unparseable"
+    tParseErrorVariant "codepoint above max in char" "'\\U00110000'" "Unparseable"
+    // Pure syntax-rejection cases (no escape involvement).
+    tParseErrorVariant "bang produces Unparseable" "!true" "Unparseable"
+    tParseErrorVariant "garbage tokens produce Unparseable" "@@@" "Unparseable"
     t
       "string interpolation - multiple expr to eval"
       "$\"Name: {name}, Age: {age}\""

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -90,6 +90,75 @@ let t
   }
 
 
+/// Parses `input` as a Darklang expression, evaluates it, and asserts the
+/// resulting runtime Dval equals `expected`. Distinct from `t` (which
+/// compares pretty-printed source) because round-trip tests can hide
+/// symmetric bugs between decode and re-encode — this catches a decode bug
+/// directly.
+let tEval (name : string) (input : string) (expected : RT.Dval) =
+  let parseFnName =
+    RT.FQFnName.fqPackage (PackageRefs.Fn.LanguageTools.Parser.parsePTExpr ())
+
+  testTask name {
+    let canvasID = System.Guid.NewGuid()
+    let! parseExeState = executionStateFor pmPT canvasID false false Map.empty
+
+    let args = NEList.singleton (RT.DString input)
+    let! parseResult =
+      LibExecution.Execution.executeFunction parseExeState parseFnName [] args
+    let! parseDval = unwrapExecutionResult parseExeState parseResult |> Ply.toTask
+
+    match parseDval with
+    | RT.DEnum(tn, _, _, "Ok", [ exprDT ]) when tn = Dval.resultType () ->
+      let ptExpr = LibExecution.ProgramTypesToDarkTypes.Expr.fromDT exprDT
+      let instructions =
+        ptExpr |> LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT Map.empty 0 None
+      let! exeState = executionStateFor pmPT canvasID false false Map.empty
+      let! actual = LibExecution.Execution.executeExpr exeState instructions
+      match actual with
+      | Ok result ->
+        return Expect.RT.equalDval result expected "Decoded runtime value mismatch"
+      | Error(rte, _) -> return failtest $"Evaluation failed: {rte}"
+
+    | RT.DEnum(tn, _, _, "Error", [ RT.DString msg ]) when tn = Dval.resultType () ->
+      return failtest $"Parse error: {msg}"
+    | _ -> return failtest $"Unexpected parse result format: {parseDval}"
+  }
+
+
+/// Asserts that the parser rejects the input. Used for inputs that should
+/// produce a parse error (e.g. invalid escape sequences) — symptomatic of
+/// the regression where invalid input was silently dropped.
+///
+/// Uses `parseForCli` (the same parse path the CLI uses) because it surfaces
+/// `unparseableStuff` as `Result.Error` — `parsePTSourceFileWithOps` swallows
+/// per-declaration parse failures into a side list and returns Ok overall.
+let tFails (name : string) (input : string) =
+  testTask name {
+    let parseFnName =
+      RT.FQFnName.fqPackage (
+        PackageRefs.Fn.LanguageTools.Parser.CliScript.parseForCli ()
+      )
+    let canvasID = System.Guid.NewGuid()
+    let! parseExeState = executionStateFor pmPT canvasID false false Map.empty
+    let args =
+      NEList.ofList
+        (RT.DUuid PT.mainBranchId)
+        [ RT.DString "Tests"
+          RT.DString "test"
+          RT.DString "test"
+          RT.DString input ]
+    let! parseResult =
+      LibExecution.Execution.executeFunction parseExeState parseFnName [] args
+    let! parseDval = unwrapExecutionResult parseExeState parseResult |> Ply.toTask
+    match parseDval with
+    | RT.DEnum(tn, _, _, "Error", _) when tn = Dval.resultType () -> return ()
+    | RT.DEnum(tn, _, _, "Ok", _) when tn = Dval.resultType () ->
+      return failtest $"Expected parse failure but got successful parse: {parseDval}"
+    | _ -> return failtest $"Unexpected parse result format: {parseDval}"
+  }
+
+
 let person : (PT.PackageType.PackageType * PT.PackageLocation) =
   let packageType : PT.PackageType.PackageType =
     { hash = PT.Hash ""
@@ -675,9 +744,90 @@ let exprs =
     t "empty string" "\"\"" "\"\"" [] [] [] false
     t "hello" "\"hello\"" "\"hello\"" [] [] [] false
     t "hello tab world" "\"hello\\tworld\"" "\"hello\\tworld\"" [] [] [] false
+    // string-escape round-trips: parser decodes, pretty-printer re-encodes.
+    t "string newline escape" "\"a\\nb\"" "\"a\\nb\"" [] [] [] false
+    t "string quote escape" "\"a\\\"b\"" "\"a\\\"b\"" [] [] [] false
+    t "string backslash escape" "\"a\\\\b\"" "\"a\\\\b\"" [] [] [] false
+    t "string bell escape" "\"\\a\"" "\"\\a\"" [] [] [] false
+    t "string backspace escape" "\"\\b\"" "\"\\b\"" [] [] [] false
+    t "string form-feed escape" "\"\\f\"" "\"\\f\"" [] [] [] false
+    t "string vertical-tab escape" "\"\\v\"" "\"\\v\"" [] [] [] false
+    t "string carriage-return escape" "\"\\r\"" "\"\\r\"" [] [] [] false
+    t "string hex escape \\xHH" "\"\\x41\"" "\"A\"" [] [] [] false
+    t "string hex escape \\XHHHH" "\"\\X0041\"" "\"A\"" [] [] [] false
+    t "string unicode escape \\uHHHH" "\"\\u00E9\"" "\"é\"" [] [] [] false
+    t "string unicode escape \\UHHHHHHHH" "\"\\U00000041\"" "\"A\"" [] [] [] false
+    t "string forward-slash escape" "\"\\/\"" "\"/\"" [] [] [] false
+    t "string single-quote escape in double quotes" "\"\\'\"" "\"'\"" [] [] [] false
+    // Decoded-value assertions: prove the byte/char actually decoded, not
+    // just that it survived a symmetric round-trip through the pretty-printer.
+    tEval "decoded \\r is CR" "\"\\r\"" (RT.DString "\r")
+    tEval "decoded \\x41 is A" "\"\\x41\"" (RT.DString "A")
+    tEval "decoded \\X0041 is A" "\"\\X0041\"" (RT.DString "A")
+    tEval "decoded \\u00E9 is é" "\"\\u00E9\"" (RT.DString "é")
+    tEval "decoded \\U00000041 is A" "\"\\U00000041\"" (RT.DString "A")
+    tEval "decoded \\/ is /" "\"\\/\"" (RT.DString "/")
+    tEval "decoded \\' in string is '" "\"\\'\"" (RT.DString "'")
+    tEval "decoded \\n is LF" "\"a\\nb\"" (RT.DString "a\nb")
+    tEval "decoded \\t is HT" "\"a\\tb\"" (RT.DString "a\tb")
+    tEval "decoded \\\\ is backslash" "\"a\\\\b\"" (RT.DString "a\\b")
+    tEval
+      "decoded \\u00E9 above-BMP \\U0001F600"
+      "\"\\U0001F600\""
+      (RT.DString "\U0001F600")
+    // Interpolation: bare-text segment must decode escapes correctly.
+    tEval
+      "decoded interpolation with escape"
+      "$\"a\\nb {\"x\"}\""
+      (RT.DString "a\nb x")
+    // Char literals: decode covers all the same shapes the string side does.
+    tEval "decoded '\\n' is LF" "'\\n'" (RT.DChar "\n")
+    tEval "decoded '\\r' is CR" "'\\r'" (RT.DChar "\r")
+    tEval "decoded '\\\\' is backslash" "'\\\\'" (RT.DChar "\\")
+    tEval "decoded '\\'' is single-quote" "'\\''" (RT.DChar "'")
+    tEval "decoded '\\x41' is A" "'\\x41'" (RT.DChar "A")
+    tEval "decoded '\\X0041' is A" "'\\X0041'" (RT.DChar "A")
+    tEval "decoded '\\u00E9' is é" "'\\u00E9'" (RT.DChar "é")
+    tEval "decoded '\\U00000041' is A" "'\\U00000041'" (RT.DChar "A")
+    tEval "decoded '\\/' is /" "'\\/'" (RT.DChar "/")
+    t
+      "string match pattern with escape"
+      "match s with\n| \"a\\nb\" -> 1L\n| _ -> 0L"
+      "match s with\n| \"a\\nb\" ->\n  1L\n| _ ->\n  0L"
+      []
+      []
+      []
+      true
     t "egc" "\"👩‍👩‍👧‍👦\"" "\"👩‍👩‍👧‍👦\"" [] [] [] false
     t "unicode" "\"żółw\"" "\"żółw\"" [] [] [] false
     t "string interpolation" "$\"hello {name}\"" "$\"hello {name}\"" [] [] [] false
+    t
+      "interpolation with escape"
+      "$\"a\\nb {name}\""
+      "$\"a\\nb {name}\""
+      []
+      []
+      []
+      false
+    // Invalid escape sequences must be rejected (not silently dropped to "").
+    tFails "invalid escape in string literal" "\"\\d+\""
+    tFails "invalid escape in interpolation" "$\"a\\d+b\""
+    tFails "invalid escape in char literal" "'\\d'"
+    tFails
+      "invalid escape in string match pattern"
+      "match s with\n| \"\\d+\" -> 1L\n| _ -> 0L"
+    tFails
+      "invalid escape in char match pattern"
+      "match c with\n| '\\d' -> 1L\n| _ -> 0L"
+    // Codepoints that tree-sitter accepts as well-formed escapes but that
+    // are not valid Unicode scalars must be rejected by the decoder:
+    //   - surrogate range (D800..DFFF)
+    //   - above the Unicode max (>0x10FFFF)
+    tFails "surrogate codepoint \\uD800" "\"\\uD800\""
+    tFails "surrogate codepoint \\U0000D800" "\"\\U0000D800\""
+    tFails "codepoint above max \\U00110000" "\"\\U00110000\""
+    tFails "surrogate codepoint in char" "'\\uD800'"
+    tFails "codepoint above max in char" "'\\U00110000'"
     t
       "string interpolation - multiple expr to eval"
       "$\"Name: {name}, Age: {age}\""
@@ -714,7 +864,7 @@ let exprs =
     // char literals
     t "the letter a" "'a'" "'a'" [] [] [] false
     t "a newline char" "'\\n'" "'\\n'" [] [] [] false
-    t "a tab char" "'\t'" "'\t'" [] [] [] false
+    t "a tab char" "'\t'" "'\\t'" [] [] [] false
 
     // list literal
     t "empty list" "[]" "[]" [] [] [] false

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -100,8 +100,7 @@ let tEval (name : string) (input : string) (expected : RT.Dval) =
     RT.FQFnName.fqPackage (PackageRefs.Fn.LanguageTools.Parser.parsePTExpr ())
 
   testTask name {
-    let canvasID = System.Guid.NewGuid()
-    let! parseExeState = executionStateFor pmPT canvasID false false Map.empty
+    let! parseExeState = executionStateFor pmPT false Map.empty
 
     let args = NEList.singleton (RT.DString input)
     let! parseResult =
@@ -113,7 +112,7 @@ let tEval (name : string) (input : string) (expected : RT.Dval) =
       let ptExpr = LibExecution.ProgramTypesToDarkTypes.Expr.fromDT exprDT
       let instructions =
         ptExpr |> LibExecution.ProgramTypesToRuntimeTypes.Expr.toRT Map.empty 0 None
-      let! exeState = executionStateFor pmPT canvasID false false Map.empty
+      let! exeState = executionStateFor pmPT false Map.empty
       let! actual = LibExecution.Execution.executeExpr exeState instructions
       match actual with
       | Ok result ->
@@ -139,8 +138,7 @@ let tFails (name : string) (input : string) =
       RT.FQFnName.fqPackage (
         PackageRefs.Fn.LanguageTools.Parser.CliScript.parseForCli ()
       )
-    let canvasID = System.Guid.NewGuid()
-    let! parseExeState = executionStateFor pmPT canvasID false false Map.empty
+    let! parseExeState = executionStateFor pmPT false Map.empty
     let args =
       NEList.ofList
         (RT.DUuid PT.mainBranchId)

--- a/packages/darklang/cli/apps/outliner/core.dark
+++ b/packages/darklang/cli/apps/outliner/core.dark
@@ -139,7 +139,7 @@ let swapAt (ids: List<Int64>) (i: Int64) (j: Int64) : List<Int64> =
 
 // --- Flatten ---
 
-let rec flattenVisibleHelper (outline: Outline) (ids: List<Int64>) (depth: Int64) : List<VisibleNode> =
+let flattenVisibleHelper (outline: Outline) (ids: List<Int64>) (depth: Int64) : List<VisibleNode> =
   ids
   |> Stdlib.List.fold [] (fun acc id ->
     let text = getNodeText outline id

--- a/packages/darklang/cli/apps/views/app.dark
+++ b/packages/darklang/cli/apps/views/app.dark
@@ -121,7 +121,7 @@ let handleKey
 
 // ── SubApp adapter ──
 
-let rec makeSubApp (state: State) : Darklang.Cli.SubApp =
+let makeSubApp (state: State) : Darklang.Cli.SubApp =
   Darklang.Cli.SubApp
     { onKey = fun key modifiers keyChar ->
         match handleKey state key modifiers keyChar with

--- a/packages/darklang/cli/commands/serve.dark
+++ b/packages/darklang/cli/commands/serve.dark
@@ -109,12 +109,8 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
          with
         | Ok _ -> state
         | Error err ->
-          let prettyError =
-            PrettyPrinter.RuntimeTypes.RuntimeError.toString
-              state.currentBranchId
-              err
-
-          Stdlib.printLine (Colors.error $"Server failed: {prettyError}")
+          let pretty = Cli.ExecutionError.toString state.currentBranchId err
+          Stdlib.printLine (Colors.error $"Server failed: {pretty}")
           state
 
 

--- a/packages/darklang/cli/commands/traces.dark
+++ b/packages/darklang/cli/commands/traces.dark
@@ -1117,8 +1117,7 @@ let executeReplay (state: Cli.AppState) (traceID: String) : Cli.AppState =
       Stdlib.printLine "Replay complete. A new trace was created for this execution."
       state
     | Error err ->
-      let pretty =
-        PrettyPrinter.RuntimeTypes.RuntimeError.toString state.currentBranchId err
+      let pretty = Cli.ExecutionError.toString state.currentBranchId err
       Stdlib.printLine (Colors.error $"Replay failed: {pretty}")
       state
 

--- a/packages/darklang/cli/commands/traces.dark
+++ b/packages/darklang/cli/commands/traces.dark
@@ -86,7 +86,7 @@ let resolveTraceID (input: String) : Stdlib.Option.Option<String> =
         Stdlib.Option.Option.None
 
 
-let rec parseViewOptions
+let parseViewOptions
   (opts: ViewOptions)
   (args: List<String>)
   : Stdlib.Result.Result<ViewOptions, String> =

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -119,17 +119,34 @@ type Msg =
 
 
 module ExecutionError =
-  // TODO migrate this to some ParseAndExecuteScript submodule
-  type ExecutionError =
-    { msg: String; metadata: Dict<String> }
+  /// Host-side exception that escaped the normal error path. `metadata` is
+  /// a string map; the F# host pre-stringifies values since `Exception.toMetadata`
+  /// only ever produces strings.
+  type Unhandled =
+    { message: String
+      metadata: List<(String * String)> }
 
-  let toString (err: ExecutionError) : String =
-    let metadataStr =
-      err.metadata
-      |> Stdlib.Dict.toList
-      |> Stdlib.List.map (fun (k, v) -> $"- {k}: {v}")
-      |> Stdlib.String.join "\n"
-    $"Error: {err.msg}\n{metadataStr}"
+  /// Boundary type for CLI command failures. Each variant carries its own
+  /// structured payload — no flattening to strings at the boundary.
+  type ExecutionError =
+    | Parse of LanguageTools.Parser.CliScript.ParseError
+    | Runtime of LanguageTools.RuntimeTypes.RuntimeError.Error
+    | Unhandled of Unhandled
+
+  let toString (branchId: Uuid) (err: ExecutionError) : String =
+    match err with
+    | Parse pe -> LanguageTools.Parser.CliScript.ParseError.toString pe
+    | Runtime rte ->
+      PrettyPrinter.RuntimeTypes.RuntimeError.toString branchId rte
+    | Unhandled u ->
+      match u.metadata with
+      | [] -> $"Internal error: {u.message}"
+      | _ ->
+        let lines =
+          u.metadata
+          |> Stdlib.List.map (fun (k, v) -> $"  {k}: {v}")
+          |> Stdlib.String.join "\n"
+        $"Internal error: {u.message}\n{lines}"
 
 
 module View =

--- a/packages/darklang/cli/docs/for-ai-internal.dark
+++ b/packages/darklang/cli/docs/for-ai-internal.dark
@@ -144,11 +144,13 @@ Dark parses pipes greedily; `Stdlib.List.length xs |> Stdlib.Int64.toString`
 raises "Pipe: LongIdent". Wrap the left side in parens:
   (Stdlib.List.length xs) |> Stdlib.Int64.toString
 
-## No nested functions (incl. no nested let rec)
-Dark rejects nested `let` (and `let rec`) that define functions. Move
-helpers to module scope instead. The common idiom is a top-level
-`let rec fooLoop acc xs = ...` that `let foo xs = fooLoop empty xs` wraps.
-Parser error reads: "Unsupported let or use expr pat type / pat: LongIdent".
+## No nested functions, no `rec` keyword
+Dark rejects nested `let` that defines a function — move helpers to module
+scope instead. Dark also has no `rec` keyword: a top-level `let` is
+automatically self-recursive. The common idiom is a top-level
+`let fooLoop acc xs = ...` that `let foo xs = fooLoop empty xs` wraps.
+Parser error for the nested-let case reads:
+"Unsupported let or use expr pat type / pat: LongIdent".
 
 ## Record update doesn't take a type-tag
 `{ state with field = v }` is correct. `MyType { state with field = v }`

--- a/packages/darklang/cli/docs/for-ai.dark
+++ b/packages/darklang/cli/docs/for-ai.dark
@@ -6,14 +6,14 @@ let content () : String =
 ## IMPORTANT: Darklang is Different
 Darklang is a LIVE PROGRAMMING ENVIRONMENT (like Smalltalk).
 You don't write scripts - you build a persistent package tree.
-- Use `fn` to CREATE functions in the tree (not eval)
-- Use `run` to TEST those functions
+- Use `fn` to CREATE functions in the tree
+- Use `eval` to TEST those functions
 - Use `commit` to SAVE your work
 - CLI state doesn't persist between calls - the PACKAGE TREE does
 
 ## Workflow
   1. fn myFn        # create function (stored in package tree)
-  2. run @myFn      # test it
+  2. eval myFn      # test it
   3. status         # see changes
   4. commit "msg"   # save to SCM
 
@@ -42,8 +42,8 @@ For multi-line bodies, use `-` and pipe via stdin (heredoc form):
   EOF
 
 ## Running/Testing
-  run @<fn> [args]  # run a function you created (with args)
-  eval <expr>       # quick test expressions (not for creating code)
+  eval <fn> [args]  # call a function / evaluate an expression
+  run <path>        # execute a .dark script file (not for calling fns)
 
 ## Navigation
   nav <path>        # go to module (cd)
@@ -63,7 +63,7 @@ For non-interactive use: `DARK_ACCOUNT=alice ./scripts/run-cli commit "msg" -y`
     kinds: superseded-by (requires --replacement), harmful, obsolete
   delete <fn|type|value> <name> [--force]     # sugar for --kind obsolete
   undo <fn|type|value> <name>                 # reverse a WIP deprecate
-  run --allow-harmful @<fn>                   # opt out of harmful halt
+  eval --allow-harmful <fn>                   # opt out of harmful halt
   (see: docs deprecation)
 
 ## Branches (use --branch flag!)

--- a/packages/darklang/cli/docs/for-ai.dark
+++ b/packages/darklang/cli/docs/for-ai.dark
@@ -34,6 +34,13 @@ Names need full paths (owner.module.name), e.g.:
   fn Darklang.Testing.fib (n: Int64): Int64 = ...
 Inside the body, use short names (e.g., `fib` for recursion).
 
+For multi-line bodies, use `-` and pipe via stdin (heredoc form):
+  ./scripts/run-cli fn Darklang.Foo.bar - <<'EOF'
+  (n: Int64): Int64 =
+    let x = n + 1L
+    x * 2L
+  EOF
+
 ## Running/Testing
   run @<fn> [args]  # run a function you created (with args)
   eval <expr>       # quick test expressions (not for creating code)
@@ -43,10 +50,13 @@ Inside the body, use short names (e.g., `fib` for recursion).
   ls / back         # list / go back
 
 ## SCM (version control)
-  status            # see current branch + uncommitted changes
-  commit <msg>      # commit changes
-  log               # history
-  discard           # undo uncommitted changes
+  status               # see current branch + uncommitted changes
+  commit <msg> [-y]    # commit changes; -y/--yes skips the y/n prompt
+  log                  # history
+  discard              # undo uncommitted changes
+
+`commit` requires the `DARK_ACCOUNT` env var to be set (your username).
+For non-interactive use: `DARK_ACCOUNT=alice ./scripts/run-cli commit "msg" -y`
 
 ## Deprecation (mark items as unused / dangerous / obsolete)
   deprecate <fn|type|value> <name> --kind <k> [options]
@@ -100,6 +110,7 @@ Rules:
 - Pipe needs parens: (complex expr) |> fn
 - Lists: [1L; 2L; 3L] (semicolons)
 - String concat: ++ (not @)
+- String interpolation: $"x = {expr}; total = {a ++ b}"
 - Int division: Stdlib.Int64.divide (not /)
 
 ## Records

--- a/packages/darklang/cli/execution/eval.dark
+++ b/packages/darklang/cli/execution/eval.dark
@@ -30,8 +30,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
       Stdlib.printLine result
       state
     | Error err ->
-      let prettyError = PrettyPrinter.RuntimeTypes.RuntimeError.toString state.currentBranchId err
-      Stdlib.printLine $"Error: {prettyError}"
+      Stdlib.printLine $"Error: {ExecutionError.toString state.currentBranchId err}"
       state
 
 

--- a/packages/darklang/cli/execution/eval.dark
+++ b/packages/darklang/cli/execution/eval.dark
@@ -13,7 +13,12 @@ let execute (state: AppState) (args: List<String>) : AppState =
     help state
     state
   | _ ->
-    let expr = Stdlib.String.join args " "
+    // Special case: a single "-" arg means "read expression from stdin" so
+    // callers can pipe multi-line expressions via heredoc without quoting.
+    let expr =
+      match args with
+      | [ "-" ] -> Builtin.stdinReadAll ()
+      | parts -> Stdlib.String.join parts " "
     match
       Builtin.cliEvaluateExpression
         state.accountID
@@ -38,6 +43,7 @@ let complete (_state: AppState) (_args: List<String>) : List<Completion.Completi
 let help (_state: AppState) : Unit =
   [
     "Usage: eval <expression>"
+    "       eval -    (read expression from stdin, for multi-line input)"
     "Evaluate a Dark expression and display the result."
     ""
     "Examples:"
@@ -45,4 +51,10 @@ let help (_state: AppState) : Unit =
     "  eval \"hello\" ++ \"world\"         - String concatenation"
     "  eval [1L; 2L; 3L] |> List.length  - List operations"
     "  eval Stdlib.String.length \"test\" - Function calls"
+    ""
+    "  # Multi-line expression via stdin (run from shell, not the REPL):"
+    "  ./scripts/run-cli eval - <<'EOF'"
+    "  let xs = [1L; 2L; 3L]"
+    "  Stdlib.List.length xs"
+    "  EOF"
   ] |> Stdlib.printLines

--- a/packages/darklang/cli/execution/run.dark
+++ b/packages/darklang/cli/execution/run.dark
@@ -50,8 +50,8 @@ let executeScript
         Stdlib.printLine $"Script exited with code {Stdlib.Int64.toString exitCode}"
         state
     | Error e ->
-      let prettyError = PrettyPrinter.RuntimeTypes.RuntimeError.toString state.currentBranchId e
-      Stdlib.printLine $"Script error: {prettyError}"
+      let pretty = ExecutionError.toString state.currentBranchId e
+      Stdlib.printLine $"Script error: {pretty}"
       state
 
 

--- a/packages/darklang/cli/execution/run.dark
+++ b/packages/darklang/cli/execution/run.dark
@@ -26,7 +26,10 @@ let executeScript
   : AppState =
   match Builtin.fileRead scriptPath with
   | Error e ->
-    Stdlib.printLine $"File error: {e}"
+    match e with
+    | NotFound -> Stdlib.printLine $"Script not found: {scriptPath}"
+    | PermissionDenied -> Stdlib.printLine $"Permission denied: {scriptPath}"
+    | Other msg -> Stdlib.printLine $"Could not read script {scriptPath}: {msg}"
     state
   | Ok script ->
     let scriptSourceCode = Stdlib.String.fromBlobWithReplacement script

--- a/packages/darklang/cli/packages/db.dark
+++ b/packages/darklang/cli/packages/db.dark
@@ -198,12 +198,7 @@ let viewDB (state: Cli.AppState) (dbName: String) : Cli.AppState =
       state
 
     | Error err ->
-      let prettyError =
-        PrettyPrinter.RuntimeTypes.RuntimeError.toString
-          state.currentBranchId
-          err
-
-      Stdlib.printLine (Colors.error $"Error: {prettyError}")
+      Stdlib.printLine (Colors.error (Cli.ExecutionError.toString state.currentBranchId err))
       state
 
 
@@ -219,12 +214,7 @@ let getDBValue
     Stdlib.printLine result
     state
   | Error err ->
-    let prettyError =
-      PrettyPrinter.RuntimeTypes.RuntimeError.toString
-        state.currentBranchId
-        err
-
-    Stdlib.printLine (Colors.error $"Error: {prettyError}")
+    Stdlib.printLine (Colors.error (Cli.ExecutionError.toString state.currentBranchId err))
     state
 
 
@@ -247,12 +237,7 @@ let setDBValue
       Stdlib.printLine (Colors.success $"Set {key} in {dbName}")
       state
     | Error err ->
-      let prettyError =
-        PrettyPrinter.RuntimeTypes.RuntimeError.toString
-          state.currentBranchId
-          err
-
-      Stdlib.printLine (Colors.error $"Error: {prettyError}")
+      Stdlib.printLine (Colors.error (Cli.ExecutionError.toString state.currentBranchId err))
       state
 
 
@@ -268,12 +253,7 @@ let deleteDBValue
     Stdlib.printLine (Colors.success $"Deleted {key} from {dbName}")
     state
   | Error err ->
-    let prettyError =
-      PrettyPrinter.RuntimeTypes.RuntimeError.toString
-        state.currentBranchId
-        err
-
-    Stdlib.printLine (Colors.error $"Error: {prettyError}")
+    Stdlib.printLine (Colors.error (Cli.ExecutionError.toString state.currentBranchId err))
     state
 
 
@@ -289,12 +269,7 @@ let queryDB
     Stdlib.printLine result
     state
   | Error err ->
-    let prettyError =
-      PrettyPrinter.RuntimeTypes.RuntimeError.toString
-        state.currentBranchId
-        err
-
-    Stdlib.printLine (Colors.error $"Error: {prettyError}")
+    Stdlib.printLine (Colors.error (Cli.ExecutionError.toString state.currentBranchId err))
     state
 
 

--- a/packages/darklang/cli/packages/delete.dark
+++ b/packages/darklang/cli/packages/delete.dark
@@ -26,7 +26,7 @@ let emptyArgs: ParsedArgs =
       dryRun = false }
 
 
-let rec parseArgsLoop (acc: ParsedArgs) (remaining: List<String>) : ParsedArgs =
+let parseArgsLoop (acc: ParsedArgs) (remaining: List<String>) : ParsedArgs =
   match remaining with
   | [] -> acc
   | "--yes" :: rest

--- a/packages/darklang/cli/packages/delete.dark
+++ b/packages/darklang/cli/packages/delete.dark
@@ -93,38 +93,43 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
 
   match (parsed.itemType, parsed.target) with
   | (None, _) -> help state
-  | (Some _, None) ->
-    Stdlib.printLine (Colors.error "Error: Missing target (location or hash)")
-    state
-  | (Some itemTypeStr, Some target) ->
+  | (Some itemTypeStr, targetOpt) ->
     match Propagate.itemKindFromString itemTypeStr with
     | None ->
-      Stdlib.printLine (Colors.error $"Error: Invalid item type '{itemTypeStr}'")
+      Stdlib.printLine
+        (Colors.error
+          $"Error: '{itemTypeStr}' is not a valid item kind. Expected fn, type, or value.")
+      Stdlib.printLine "Usage: delete <fn|type|value> <name-or-hash> [options]"
       state
     | Some itemKind ->
-      let currentLoc = state.packageData.currentLocation
-      match Location.parseRelativeTo currentLoc target with
-      | Error errMsg ->
-        Stdlib.printLine (Colors.error $"Could not resolve {itemTypeStr} {target}: {errMsg}")
+      match targetOpt with
+      | None ->
+        Stdlib.printLine (Colors.error "Error: Missing target (location or hash)")
         state
-      | Ok targetLoc ->
-        match Deprecate.resolveTarget branchId currentLoc itemKind target with
-        | None ->
-          Stdlib.printLine (Colors.error $"Could not resolve {itemTypeStr} {target}")
+      | Some target ->
+        let currentLoc = state.packageData.currentLocation
+        match Location.parseRelativeTo currentLoc target with
+        | Error errMsg ->
+          Stdlib.printLine (Colors.error $"Could not resolve {itemTypeStr} {target}: {errMsg}")
           state
-        | Some _targetRef ->
-          // Only gate `delete` adds over `deprecate --kind obsolete`: refuse
-          // when LIVE dependents exist. Deprecated-only callers don't block.
-          let depCount = countLiveDependents branchId targetLoc itemKind
-          if depCount > 0L && Stdlib.Bool.not parsed.force then
-            Stdlib.printLine
-              (Colors.error
-                $"{Stdlib.Int64.toString depCount} live dependent(s) still reference this item.")
-            Stdlib.printLine
-              "Use `deprecate` to give them time to migrate, or pass `--force`."
+        | Ok targetLoc ->
+          match Deprecate.resolveTarget branchId currentLoc itemKind target with
+          | None ->
+            Stdlib.printLine (Colors.error $"Could not resolve {itemTypeStr} {target}")
             state
-          else
-            Deprecate.execute state (toDeprecateArgs parsed itemTypeStr target)
+          | Some _targetRef ->
+            // Only gate `delete` adds over `deprecate --kind obsolete`: refuse
+            // when LIVE dependents exist. Deprecated-only callers don't block.
+            let depCount = countLiveDependents branchId targetLoc itemKind
+            if depCount > 0L && Stdlib.Bool.not parsed.force then
+              Stdlib.printLine
+                (Colors.error
+                  $"{Stdlib.Int64.toString depCount} live dependent(s) still reference this item.")
+              Stdlib.printLine
+                "Use `deprecate` to give them time to migrate, or pass `--force`."
+              state
+            else
+              Deprecate.execute state (toDeprecateArgs parsed itemTypeStr target)
 
 
 let help (state: Cli.AppState) : Cli.AppState =

--- a/packages/darklang/cli/packages/deprecate.dark
+++ b/packages/darklang/cli/packages/deprecate.dark
@@ -28,7 +28,7 @@ let emptyArgs: ParsedArgs =
       dryRun = false }
 
 
-let rec parseArgsLoop
+let parseArgsLoop
   (acc: ParsedArgs)
   (remaining: List<String>)
   : ParsedArgs =

--- a/packages/darklang/cli/packages/fn.dark
+++ b/packages/darklang/cli/packages/fn.dark
@@ -22,12 +22,13 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
       | parts -> Stdlib.String.join parts " "
 
     if Stdlib.String.isEmpty inlineDefinition then
-      // No inline definition provided - show error
+      // No body provided - show error
       [
-        (Colors.error "Error: Inline function definition required")
+        (Colors.error "Error: Function body required")
         ""
-        "Usage: fn <location> <parameters and body>"
-        "       fn <location> -    (read body from stdin, for multi-line input)"
+        "Pass the body inline, or `-` to read from stdin (for multi-line):"
+        "  fn <location> <parameters and body>"
+        "  fn <location> -    (read body from stdin)"
         ""
         "Examples:"
         "  fn double (x: Int64): Int64 = Stdlib.Int64.multiply x 2L"

--- a/packages/darklang/cli/scripts.dark
+++ b/packages/darklang/cli/scripts.dark
@@ -119,9 +119,9 @@ let execute (state: AppState) (args: List<String>) : AppState =
       | Ok exitCode ->
         Stdlib.printLine $"Script '{name}' exited with code {Stdlib.Int64.toString exitCode}"
         state
-      | Error runtimeError ->
-        let prettyError = PrettyPrinter.RuntimeTypes.RuntimeError.toString state.currentBranchId runtimeError
-        Stdlib.printLine $"Script error: {prettyError}"
+      | Error execErr ->
+        let pretty = ExecutionError.toString state.currentBranchId execErr
+        Stdlib.printLine $"Script error: {pretty}"
         state
     | None ->
       Stdlib.printLine $"Error: Script '{name}' not found"

--- a/packages/darklang/internal/darklang-internal-mcp-server/README.md
+++ b/packages/darklang/internal/darklang-internal-mcp-server/README.md
@@ -35,5 +35,5 @@ This is an MCP server that provides internal development tools, resources, and p
 To add this MCP server to Claude Code, run:
 
 ```bash
-claude mcp add darklang-internal ./scripts/run-cli run @Darklang.Internal.DarklangInternalMcpServer.main
+claude mcp add darklang-internal ./scripts/run-cli eval Darklang.Internal.DarklangInternalMcpServer.main
 ```

--- a/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
+++ b/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
@@ -11,8 +11,7 @@ let executeDarklang () : ModelContextProtocol.ServerBuilder.Tool =
         match Builtin.cliEvaluateExpression (Stdlib.Option.Option.None) SCM.Branch.mainBranchId code false with
         | Ok result -> $"Result: {result}"
         | Error err ->
-            let prettyError = PrettyPrinter.RuntimeTypes.RuntimeError.toString SCM.Branch.mainBranchId err
-            $"Error: {prettyError}"
+            $"Error: {Cli.ExecutionError.toString SCM.Branch.mainBranchId err}"
   }
 
 

--- a/packages/darklang/languageTools/lsp-server/docSync.dark
+++ b/packages/darklang/languageTools/lsp-server/docSync.dark
@@ -81,7 +81,7 @@ let parseAndReportDiagnostics
       match Parser.CliScript.parse nrCtx scriptName "fileName" requestText with
       | Ok ((_ptCliScriptModule, unresolvedNames)) -> unresolvedNames
       | Error err ->
-        log $"Parse error: {err}"
+        log $"Parse error: {Parser.CliScript.ParseError.toString err}"
         []
 
     Diagnostics.gatherAndReportDiagnostics

--- a/packages/darklang/languageTools/parser/cliScript.dark
+++ b/packages/darklang/languageTools/parser/cliScript.dark
@@ -1,6 +1,39 @@
 module Darklang.LanguageTools.Parser.CliScript
 
 
+/// Location of an unparseable subtree in the source.
+type Unparseable =
+  { text: String
+    line: Int64
+    column: Int64
+    note: Stdlib.Option.Option<String> }
+
+
+/// Why a parse attempt failed.
+type ParseError =
+  /// A token or subtree couldn't be matched to any grammar production
+  /// (e.g. `!true`).
+  | Unparseable of Unparseable
+
+  /// Lower-level parser failure (tree-sitter / AST conversion) that
+  /// produced a string error before declarations could be split out.
+  /// Rarer than `Unparseable` since tree-sitter usually recovers via
+  /// ERROR nodes that flow through `Unparseable` instead.
+  | Other of String
+
+
+module ParseError =
+  let toString (err: ParseError) : String =
+    match err with
+    | Unparseable u ->
+      let noteText =
+        match u.note with
+        | Some n -> $": {n}"
+        | None -> ""
+      $"Parse error at line {Stdlib.Int64.toString u.line}, column {Stdlib.Int64.toString u.column}: unexpected '{u.text}'{noteText}"
+    | Other msg -> msg
+
+
 type WTCliScriptModule =
   { owner: String
     name: String
@@ -24,23 +57,20 @@ let parseDecls
   (owner: String)
   (scriptName: String)
   (source: LanguageTools.WrittenTypes.ParsedFile)
-  : Stdlib.Result.Result<WTCliScriptModule, String> =
+  : Stdlib.Result.Result<WTCliScriptModule, ParseError> =
+  // `ParsedFile` is a single-case DU (`SourceFile of ...`). No `| _` fallback.
   match source with
   | SourceFile source ->
     // Check for unparseable content (e.g., invalid syntax like `!true`)
     match source.unparseableStuff with
     | first :: _ ->
-      let errorText = first.source.text
-      let errorRange = first.source.range
-      let lineNum = (Stdlib.Int64.add errorRange.start.row 1L) |> Stdlib.Int64.toString
-      let colNum = errorRange.start.column |> Stdlib.Int64.toString
-      let note =
-        match first.note with
-        | Some n -> $": {n}"
-        | None -> ""
-
-      Stdlib.Result.Result.Error
-        $"Parse error at line {lineNum}, column {colNum}: unexpected '{errorText}'{note}"
+      let u =
+        Unparseable
+          { text = first.source.text
+            line = Stdlib.Int64.add first.source.range.start.row 1L
+            column = first.source.range.start.column
+            note = first.note }
+      Stdlib.Result.Result.Error(ParseError.Unparseable u)
 
     | [] ->
       let types =
@@ -83,8 +113,6 @@ let parseDecls
             submodules = submodules
             exprs = exprs }
       )
-
-  | _ -> Stdlib.Result.Result.Error "Invalid source file"
 
 
 /// Helper to process a list of declarations and split results into separate lists (entities, ops, unresolved names)
@@ -229,9 +257,9 @@ let parse
   (scriptName: String)
   (filename: String)
   (source: String)
-  : Stdlib.Result.Result<(PTCliScriptModule * List<WrittenTypes.UnresolvedName>), String> =
+  : Stdlib.Result.Result<(PTCliScriptModule * List<WrittenTypes.UnresolvedName>), ParseError> =
   match source |> LanguageTools.Parser.TestParsing.initialParse with
-  | Error e -> Stdlib.Result.Result.Error e
+  | Error e -> Stdlib.Result.Result.Error(ParseError.Other e)
   | Ok parsedFile ->
     match parseDecls ctx.owner scriptName parsedFile with
     | Error e -> Stdlib.Result.Result.Error e
@@ -329,7 +357,7 @@ let parseForCli
   (scriptName: String)
   (filename: String)
   (source: String)
-  : Stdlib.Result.Result<(PTCliScriptModule * List<WrittenTypes.UnresolvedName>), String> =
+  : Stdlib.Result.Result<(PTCliScriptModule * List<WrittenTypes.UnresolvedName>), ParseError> =
   let pm = LanguageTools.PackageManager.pm ()
 
   let ctx =
@@ -348,9 +376,9 @@ let pmWithExtras
   (scriptName: String)
   (filename: String)
   (source: String)
-  : Stdlib.Result.Result<ProgramTypes.PackageManager.PackageManager, String> =
+  : Stdlib.Result.Result<ProgramTypes.PackageManager.PackageManager, ParseError> =
   match source |> LanguageTools.Parser.TestParsing.initialParse with
-  | Error e -> Stdlib.Result.Result.Error e
+  | Error e -> Stdlib.Result.Result.Error(ParseError.Other e)
   | Ok parsedFile ->
     match parseDecls ctx.owner scriptName parsedFile with
     | Error e -> Stdlib.Result.Result.Error e

--- a/packages/darklang/languageTools/parser/core.dark
+++ b/packages/darklang/languageTools/parser/core.dark
@@ -82,6 +82,150 @@ let createUnparseableErrorMsg
       note = Stdlib.Option.Option.Some msg })
   |> Stdlib.Result.Result.Error
 
+
+// Decodes one source-level escape sequence (e.g. `\n` or `é`) into its
+// runtime string value. Mirrors `char_or_string_escape_sequence` in
+// tree-sitter-darklang/grammar.js — keep these in sync.
+//
+// Tree-sitter already classifies these as escape tokens, so the input here
+// is guaranteed to start with `\` and be one of the documented shapes.
+// Anything else means the grammar and decoder have drifted.
+
+let hexDigitValue (c: Char) : Stdlib.Option.Option<Int64> =
+  if (Stdlib.Char.isGreaterThanOrEqualTo c '0') && (Stdlib.Char.isLessThanOrEqualTo c '9') then
+    Stdlib.Option.map (Stdlib.Char.toAsciiCode c) (fun code -> code - 48L)
+  else if (Stdlib.Char.isGreaterThanOrEqualTo c 'a') && (Stdlib.Char.isLessThanOrEqualTo c 'f') then
+    Stdlib.Option.map (Stdlib.Char.toAsciiCode c) (fun code -> code - 87L)
+  else if (Stdlib.Char.isGreaterThanOrEqualTo c 'A') && (Stdlib.Char.isLessThanOrEqualTo c 'F') then
+    Stdlib.Option.map (Stdlib.Char.toAsciiCode c) (fun code -> code - 55L)
+  else
+    Stdlib.Option.Option.None
+
+
+let hexDigitsValue (digits: List<Char>) : Stdlib.Option.Option<Int64> =
+  Stdlib.List.fold digits (Stdlib.Option.Option.Some 0L) (fun acc d ->
+    match acc, hexDigitValue d with
+    | Some acc, Some v -> Stdlib.Option.Option.Some ((acc * 16L) + v)
+    | _ -> Stdlib.Option.Option.None)
+
+
+let decodeHexCodepoint (digits: List<Char>) : Stdlib.Option.Option<String> =
+  match hexDigitsValue digits with
+  | Some cp ->
+    match Stdlib.Char.fromCodepoint cp with
+    | Some c -> Stdlib.Option.Option.Some(Stdlib.Char.toString c)
+    | None -> Stdlib.Option.Option.None
+  | None -> Stdlib.Option.Option.None
+
+
+/// Decode one escape token's text (e.g. `"\\n"`, `"\\u00E9"`) into its
+/// runtime value. Returns None for shapes outside the grammar — callers
+/// should turn that into a parse error against the originating node.
+let decodeSingleEscape (escapeText: String) : Stdlib.Option.Option<String> =
+  match Stdlib.String.toList escapeText with
+  | [ '\\'; 'n' ] -> Stdlib.Option.Option.Some "\n"
+  | [ '\\'; 't' ] -> Stdlib.Option.Option.Some "\t"
+  | [ '\\'; 'r' ] -> Stdlib.Option.Option.Some "\r"
+  | [ '\\'; '\\' ] -> Stdlib.Option.Option.Some "\\"
+  | [ '\\'; '"' ] -> Stdlib.Option.Option.Some "\""
+  | [ '\\'; '\'' ] -> Stdlib.Option.Option.Some "'"
+  | [ '\\'; '/' ] -> Stdlib.Option.Option.Some "/"
+  | [ '\\'; 'a' ] -> Stdlib.Option.Option.Some "\a"
+  | [ '\\'; 'b' ] -> Stdlib.Option.Option.Some "\b"
+  | [ '\\'; 'f' ] -> Stdlib.Option.Option.Some "\f"
+  | [ '\\'; 'v' ] -> Stdlib.Option.Option.Some "\v"
+  | [ '\\'; 'x'; a; b ] -> decodeHexCodepoint [ a; b ]
+  | [ '\\'; 'X'; a; b; c; d ] -> decodeHexCodepoint [ a; b; c; d ]
+  | [ '\\'; 'u'; a; b; c; d ] -> decodeHexCodepoint [ a; b; c; d ]
+  | [ '\\'; 'U'; a; b; c; d; e; f; g; h ] ->
+    decodeHexCodepoint [ a; b; c; d; e; f; g; h ]
+  | _ -> Stdlib.Option.Option.None
+
+
+/// Decode an escape sequence node (typ == `char_or_string_escape_sequence`).
+/// Produces a parse error on the node if its text doesn't match the grammar's
+/// escape shapes — which would indicate parser/grammar drift.
+let decodeEscapeNode
+  (node: ParsedNode)
+  : Stdlib.Result.Result<String, WrittenTypes.Unparseable> =
+  match decodeSingleEscape node.text with
+  | Some s -> Stdlib.Result.Result.Ok s
+  | None -> createUnparseableErrorMsg node "Invalid escape sequence"
+
+
+// Number of chars in the escape (including the leading `\`), based on the
+// char following `\`. Mirrors the shapes accepted by `decodeSingleEscape`.
+let escapeLength (afterBackslash: Char) : Int64 =
+  match afterBackslash with
+  | 'x' -> 4L      // \xHH
+  | 'X' -> 6L      // \XHHHH
+  | 'u' -> 6L      // \uHHHH
+  | 'U' -> 10L     // \UHHHHHHHH
+  | _ -> 2L        // \n \t \r \\ \" \' \/ \a \b \f \v
+
+
+let charsToString (chars: List<Char>) : String =
+  chars |> Stdlib.List.map Stdlib.Char.toString |> Stdlib.String.join ""
+
+
+/// Walks a string-content node character-by-character, dispatching to
+/// `decodeSingleEscape` on each `\`. Used for `string_content` and
+/// `multiline_string_content`, where tree-sitter doesn't expose raw text
+/// segments as named children — we have to scan the full text ourselves.
+///
+/// `acc` collects decoded chunks in reverse order; the caller reverses and
+/// joins once. This keeps the walk O(n) — repeated `++` would be O(n²).
+let rec decodeChars
+  (source: ParsedNode)
+  (chars: List<Char>)
+  (acc: List<String>)
+  : Stdlib.Result.Result<List<String>, WrittenTypes.Unparseable> =
+  match chars with
+  | [] -> Stdlib.Result.Result.Ok acc
+  | '\\' :: afterBackslash :: _ ->
+    let len = escapeLength afterBackslash
+    let escapeChars = Stdlib.List.take chars len
+    let remaining = Stdlib.List.drop chars len
+    if Stdlib.List.length escapeChars < len then
+      createUnparseableErrorMsg source "Incomplete escape sequence"
+    else
+      match decodeSingleEscape (charsToString escapeChars) with
+      | Some s -> decodeChars source remaining (Stdlib.List.push acc s)
+      | None -> createUnparseableErrorMsg source "Invalid escape sequence"
+  | '\\' :: [] ->
+    createUnparseableErrorMsg source "Trailing backslash in string"
+  | c :: rest ->
+    decodeChars source rest (Stdlib.List.push acc (Stdlib.Char.toString c))
+
+
+let decodeStringContent
+  (node: ParsedNode)
+  : Stdlib.Result.Result<String, WrittenTypes.Unparseable> =
+  Stdlib.Result.map (decodeChars node (Stdlib.String.toList node.text) []) (fun chunks ->
+    chunks |> Stdlib.List.reverse |> Stdlib.String.join "")
+
+
+/// Decode a `character` node (the `content` field of a char_literal /
+/// MPChar). The node has either one `char_or_string_escape_sequence` child,
+/// or no escape children — in which case `.text` is the raw single character.
+let decodeCharContent
+  (node: ParsedNode)
+  : Stdlib.Result.Result<(Range * String), WrittenTypes.Unparseable> =
+  let hasError =
+    node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
+  if hasError then
+    createUnparseableErrorMsg node "Invalid escape sequence in char literal"
+  else
+    let escape =
+      node.children
+      |> Stdlib.List.filter (fun c -> c.typ == "char_or_string_escape_sequence")
+      |> Stdlib.List.head
+
+    match escape with
+    | Some esc ->
+      Stdlib.Result.map (decodeEscapeNode esc) (fun s -> (node.range, s))
+    | None -> Stdlib.Result.Result.Ok((node.range, node.text))
+
 /// Used for fields that don't need to be parsed, i.e. symbols, keywords, etc
 let findField
   (node: ParsedNode)

--- a/packages/darklang/languageTools/parser/core.dark
+++ b/packages/darklang/languageTools/parser/core.dark
@@ -175,7 +175,7 @@ let charsToString (chars: List<Char>) : String =
 ///
 /// `acc` collects decoded chunks in reverse order; the caller reverses and
 /// joins once. This keeps the walk O(n) — repeated `++` would be O(n²).
-let rec decodeChars
+let decodeChars
   (source: ParsedNode)
   (chars: List<Char>)
   (acc: List<String>)

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -104,6 +104,40 @@ let parseFloatLiteral
   | Error _ -> createUnparseableError node
 
 
+// Parses one child of `string_interpolation_content`. `string_text` is raw
+// text (grammar excludes backslash), `char_or_string_escape_sequence` is
+// decoded, `string_to_eval` is `{expr}`.
+let parseInterpolationChild
+  (c: ParsedNode)
+  : Stdlib.Result.Result<WrittenTypes.StringSegment, WrittenTypes.Unparseable> =
+  match c.typ with
+  | "string_text" ->
+    Stdlib.Result.Result.Ok(WrittenTypes.StringSegment.StringText(c.range, c.text))
+
+  | "char_or_string_escape_sequence" ->
+    Stdlib.Result.map (decodeEscapeNode c) (fun s ->
+      WrittenTypes.StringSegment.StringText(c.range, s))
+
+  | "string_to_eval" ->
+    let openBrace = findField c "symbol_open_brace"
+    let closeBrace = findField c "symbol_close_brace"
+    let expr = findAndParseRequired c "expr" Expr.parse
+    match openBrace, closeBrace, expr with
+    | Ok openBrace, Ok closeBrace, Ok expr ->
+      Stdlib.Result.Result.Ok(
+        WrittenTypes.StringSegment.StringInterpolation(
+          c.range,
+          expr,
+          openBrace.range,
+          closeBrace.range
+        )
+      )
+    | _, _, Error e -> Stdlib.Result.Result.Error e
+    | _ -> createUnparseableError c
+
+  | _ -> createUnparseableError c
+
+
 let parseStringLiteral
   (node: ParsedNode)
   : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
@@ -114,63 +148,52 @@ let parseStringLiteral
     let closeQuoteNode = findField stringSegment "symbol_close_quote"
     let symbolDollarSign = findField stringSegment "symbol_dollar_sign"
 
+    // tree-sitter classifies invalid escape sequences (e.g. "\d") as ERROR
+    // children rather than `char_or_string_escape_sequence`. Surface them as
+    // a parse failure instead of silently dropping content.
+    let hasErrorChild =
+      stringSegment.children
+      |> Stdlib.List.any (fun c -> c.typ == "ERROR")
+
     let contents =
-      match stringSegment.typ with
-      | "string_literal" ->
-        let findContents =
-          findAndParseOptional stringSegment "content" (fun stringPart ->
-            (stringPart.range, stringPart.text) |> Stdlib.Result.Result.Ok)
+      if hasErrorChild then
+        createUnparseableErrorMsg
+          stringSegment
+          "Invalid escape sequence in string literal"
+      else
+        match stringSegment.typ with
+        | "string_literal" ->
+          match findNodeByFieldName stringSegment "content" with
+          | None ->
+            Stdlib.Result.Result.Ok
+              [ WrittenTypes.StringSegment.StringText(stringSegment.range, "") ]
+          | Some stringPart ->
+            Stdlib.Result.map (decodeStringContent stringPart) (fun decoded ->
+              [ WrittenTypes.StringSegment.StringText(stringPart.range, decoded) ])
 
-        let (range, contents) =
-          Stdlib.Option.withDefault findContents (stringSegment.range, "")
+        | "string_interpolation" ->
+          match
+            stringSegment.children
+            |> Stdlib.List.filter (fun c -> c.typ == "string_interpolation_content")
+            |> Stdlib.List.head
+          with
+          | None -> Stdlib.Result.Result.Ok []
+          | Some interpolationContent ->
+            // ERROR children inside the interpolation content are the same
+            // bug surface as the top-level case — refuse rather than drop.
+            let interpHasErrorChild =
+              interpolationContent.children
+              |> Stdlib.List.any (fun c -> c.typ == "ERROR")
+            if interpHasErrorChild then
+              createUnparseableErrorMsg
+                interpolationContent
+                "Invalid escape sequence in interpolated string"
+            else
+              interpolationContent.children
+              |> Stdlib.List.map parseInterpolationChild
+              |> Stdlib.Result.collect
 
-        [ WrittenTypes.StringSegment.StringText(range, contents) ]
-
-      | "string_interpolation" ->
-        let stringInterpolationContents =
-          stringSegment.children
-          |> Stdlib.List.filter (fun c ->
-            c.typ == "string_interpolation_content")
-          |> Stdlib.List.head
-
-        match stringInterpolationContents with
-        | Error _ -> []
-        | Some interpolationContent ->
-          interpolationContent.children
-          |> Stdlib.List.filterMap (fun c ->
-            match c.typ with
-            | "string_text" ->
-              [ (WrittenTypes.StringSegment.StringText(c.range, c.text)) ]
-              |> Stdlib.Option.Option.Some
-            | "string_to_eval" ->
-              let symbolOpenBrace = findField c "symbol_open_brace"
-              let symbolCloseBrace = findField c "symbol_close_brace"
-
-              c.children
-              |> Stdlib.List.filterMap (fun c ->
-                match symbolOpenBrace, symbolCloseBrace with
-                | Ok openBrace, Ok closeBrace ->
-                  match c.typ with
-                  | "expression" ->
-                    match Expr.parse c with
-                    | Ok expr ->
-                      Stdlib.Option.Option.Some(
-                        WrittenTypes.StringSegment.StringInterpolation(
-                          c.range,
-                          expr,
-                          openBrace.range,
-                          closeBrace.range
-                        )
-                      )
-                    | Error _ -> Stdlib.Option.Option.None
-                  | _ -> Stdlib.Option.Option.None
-                | _ -> Stdlib.Option.Option.None)
-              |> Stdlib.Option.Option.Some
-
-            | _ -> Stdlib.Option.Option.None)
-          |> Stdlib.List.flatten
-
-      | _ -> []
+        | _ -> createUnparseableError stringSegment
 
     let dollarSign =
       match symbolDollarSign with
@@ -178,8 +201,8 @@ let parseStringLiteral
         symbolDollarSign.range |> Stdlib.Option.Option.Some
       | _ -> Stdlib.Option.Option.None
 
-    match openQuoteNode, closeQuoteNode with
-    | Ok openQuote, Ok closeQuote ->
+    match openQuoteNode, closeQuoteNode, contents with
+    | Ok openQuote, Ok closeQuote, Ok contents ->
       (WrittenTypes.Expr.EString(
         node.range,
         dollarSign,
@@ -189,31 +212,42 @@ let parseStringLiteral
       ))
       |> Stdlib.Result.Result.Ok
 
+    | _, _, Error e -> Stdlib.Result.Result.Error e
     | _ -> createUnparseableError node
 
 
 let parseCharLiteral
   (node: ParsedNode)
   : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
-  let openQuoteNode = findField node "symbol_open_single_quote"
+  // Invalid escapes in char literals (e.g. `'\d'`) make tree-sitter emit an
+  // ERROR child at the char_literal level and a MISSING close-quote. Catch
+  // this directly so the error message names the actual problem.
+  let hasErrorChild =
+    node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
 
-  let charNode =
-    findAndParseOptional node "content" (fun charPart ->
-      (charPart.range, charPart.text) |> Stdlib.Result.Result.Ok)
+  if hasErrorChild then
+    createUnparseableErrorMsg node "Invalid escape sequence in char literal"
+  else
+    let openQuoteNode = findField node "symbol_open_single_quote"
+    let closeQuoteNode = findField node "symbol_close_single_quote"
 
-  let closeQuoteNode = findField node "symbol_close_single_quote"
+    let charContent =
+      match findNodeByFieldName node "content" with
+      | Some charPart -> decodeCharContent charPart
+      | None -> createUnparseableError node
 
-  match openQuoteNode, closeQuoteNode with
-  | Ok openQuote, Ok closeQuote ->
-    (WrittenTypes.Expr.EChar(
-      node.range,
-      charNode,
-      openQuote.range,
-      closeQuote.range
-    ))
-    |> Stdlib.Result.Result.Ok
+    match openQuoteNode, charContent, closeQuoteNode with
+    | Ok openQuote, Ok charContent, Ok closeQuote ->
+      (WrittenTypes.Expr.EChar(
+        node.range,
+        Stdlib.Option.Option.Some charContent,
+        openQuote.range,
+        closeQuote.range
+      ))
+      |> Stdlib.Result.Result.Ok
 
-  | _ -> createUnparseableError node
+    | _, Error e, _ -> Stdlib.Result.Result.Error e
+    | _ -> createUnparseableError node
 
 
 let parseListLiteral

--- a/packages/darklang/languageTools/parser/matchPattern.dark
+++ b/packages/darklang/languageTools/parser/matchPattern.dark
@@ -112,12 +112,26 @@ let parseMPString
   let openQuoteNode = findField node "symbol_open_quote"
   let closeQuoteNode = findField node "symbol_close_quote"
 
-  let contents =
-    findAndParseOptional node "content" (fun stringPart ->
-      (stringPart.range, stringPart.text) |> Stdlib.Result.Result.Ok)
+  // tree-sitter classifies invalid escape sequences (e.g. "\d") as ERROR
+  // children rather than `char_or_string_escape_sequence`. Surface them as
+  // a parse failure instead of silently dropping content.
+  let hasErrorChild =
+    node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
 
-  match (openQuoteNode, closeQuoteNode) with
-  | Ok openQuote, Ok closeQuote ->
+  let contents =
+    if hasErrorChild then
+      createUnparseableErrorMsg
+        node
+        "Invalid escape sequence in string match pattern"
+    else
+      match findNodeByFieldName node "content" with
+      | Some stringPart ->
+        Stdlib.Result.map (decodeStringContent stringPart) (fun decoded ->
+          Stdlib.Option.Option.Some((stringPart.range, decoded)))
+      | None -> Stdlib.Result.Result.Ok Stdlib.Option.Option.None
+
+  match (openQuoteNode, contents, closeQuoteNode) with
+  | Ok openQuote, Ok contents, Ok closeQuote ->
     (WrittenTypes.MatchPattern.MPString(
       node.range,
       contents,
@@ -125,31 +139,41 @@ let parseMPString
       closeQuote.range
     ))
     |> Stdlib.Result.Result.Ok
+  | _, Error e, _ -> Stdlib.Result.Result.Error e
   | _ -> createUnparseableError node
 
 
 let parseMPChar
   (node: ParsedNode)
   : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
-  let openQuoteNode = findField node "symbol_open_single_quote"
+  let hasErrorChild =
+    node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
 
-  let charNode =
-    findAndParseOptional node "content" (fun charPart ->
-      (charPart.range, charPart.text) |> Stdlib.Result.Result.Ok)
+  if hasErrorChild then
+    createUnparseableErrorMsg node "Invalid escape sequence in char match pattern"
+  else
+    let openQuoteNode = findField node "symbol_open_single_quote"
+    let closeQuoteNode = findField node "symbol_close_single_quote"
 
-  let closeQuoteNode = findField node "symbol_close_single_quote"
+    let charNode =
+      match findNodeByFieldName node "content" with
+      | Some charPart ->
+        Stdlib.Result.map (decodeCharContent charPart) (fun rs ->
+          Stdlib.Option.Option.Some rs)
+      | None -> createUnparseableError node
 
-  match (openQuoteNode, closeQuoteNode) with
-  | Ok openQuote, Ok closeQuote ->
-    (WrittenTypes.MatchPattern.MPChar(
-      node.range,
-      charNode,
-      openQuote.range,
-      closeQuote.range
-    ))
-    |> Stdlib.Result.Result.Ok
+    match (openQuoteNode, charNode, closeQuoteNode) with
+    | Ok openQuote, Ok charNode, Ok closeQuote ->
+      (WrittenTypes.MatchPattern.MPChar(
+        node.range,
+        charNode,
+        openQuote.range,
+        closeQuote.range
+      ))
+      |> Stdlib.Result.Result.Ok
 
-  | _ -> createUnparseableError node
+    | _, Error e, _ -> Stdlib.Result.Result.Error e
+    | _ -> createUnparseableError node
 
 
 let parseMPList

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -343,7 +343,7 @@ module Expr =
     /// `MPVariable` nodes. Used to add pattern-bound names to the
     /// match arm's `localBindings` so `EVariable` lookups don't try
     /// to resolve them as package references.
-    let rec bindings (p: WrittenTypes.MatchPattern) : List<String> =
+    let bindings (p: WrittenTypes.MatchPattern) : List<String> =
       match p with
       | MPVariable(_, name) -> [ name ]
       | MPList(_, contents, _, _) ->
@@ -1365,7 +1365,7 @@ module FunctionDeclaration =
   ///   `let f (x: List<'a>) : Stream<'a> = ...`
   /// may not declare `<'a>` explicitly but still need `'a` registered
   /// as a typeParam for callers that pass an explicit type arg.
-  let rec collectTVarsInTypeRef
+  let collectTVarsInTypeRef
     (acc: List<String>)
     (tr: ProgramTypes.TypeReference)
     : List<String> =

--- a/packages/darklang/llm/tools/file-system.dark
+++ b/packages/darklang/llm/tools/file-system.dark
@@ -175,7 +175,8 @@ let handleRead (input: Json) : Stdlib.Result.Result<ToolOutput, String> =
         | Ok bytes ->
           let content = Stdlib.String.fromBlobWithReplacement bytes
           Stdlib.Result.Result.Ok(ToolOutput.Text content)
-        | Error e -> Stdlib.Result.Result.Error e
+        | Error e ->
+          Stdlib.Result.Result.Error (Stdlib.Cli.FileSystem.FileError.toString e)
     | None -> Stdlib.Result.Result.Error "path required"
   | _ -> Stdlib.Result.Result.Error "invalid input"
 

--- a/packages/darklang/prettyPrinter/common.dark
+++ b/packages/darklang/prettyPrinter/common.dark
@@ -30,11 +30,48 @@ let sign (s: LanguageTools.Sign) : String =
   | Positive -> ""
   | Negative -> "-"
 
-let escapeSpecialCharacters (s: String) : String =
+// One-hex-digit (0-15) to its source character.
+let hexDigitChar (n: Int64) : String =
+  Stdlib.String.slice "0123456789ABCDEF" n (n + 1L)
+
+// Encode one Char to its source-form. ASCII control characters and the
+// backslash get an escape; everything else (printable ASCII, non-ASCII
+// graphemes) passes through unchanged.
+let encodeChar (c: Char) : String =
+  match Stdlib.Char.toAsciiCode c with
+  | None -> Stdlib.Char.toString c
+  | Some code ->
+    if code == 92L then "\\\\"
+    else if code == 7L then "\\a"
+    else if code == 8L then "\\b"
+    else if code == 9L then "\\t"
+    else if code == 10L then "\\n"
+    else if code == 11L then "\\v"
+    else if code == 12L then "\\f"
+    else if code == 13L then "\\r"
+    else if code < 32L || code == 127L then
+      let hi = Stdlib.Int64.divide code 16L
+      let lo = code % 16L
+      $"\\x{hexDigitChar hi}{hexDigitChar lo}"
+    else
+      Stdlib.Char.toString c
+
+// Encode special characters back to source-form. Symmetric with the parser's
+// `decodeStringContent`. Quote escapes are added per quote style — `"` for
+// string literals, `'` for char literals — so the common path skips them.
+let escapeCommon (s: String) : String =
   s
-  |> Stdlib.String.replaceAll "\n" "\\n"
-  |> Stdlib.String.replaceAll "\t" "\\t"
-  |> Stdlib.String.replaceAll "\r" "\\r"
+  |> Stdlib.String.toList
+  |> Stdlib.List.map encodeChar
+  |> Stdlib.String.join ""
+
+/// Escape for `"..."` string literals: common specials plus the closing `"`.
+let escapeSpecialCharacters (s: String) : String =
+  (escapeCommon s) |> Stdlib.String.replaceAll "\"" "\\\""
+
+/// Escape for `'...'` char literals: common specials plus the closing `'`.
+let escapeCharLiteral (s: String) : String =
+  (escapeCommon s) |> Stdlib.String.replaceAll "'" "\\'"
 
 let processRemainder (remainder: String) : String =
   match $".{remainder}" |> Stdlib.Float.parse with

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -427,7 +427,7 @@ let matchPattern (mp: LanguageTools.ProgramTypes.MatchPattern) : String =
     let remainderPart = PrettyPrinter.processRemainder remainder
     $"{PrettyPrinter.sign sign}{whole}.{remainderPart}"
 
-  | MPChar(_id, c) -> $"'{c}'"
+  | MPChar(_id, c) -> $"'{PrettyPrinter.escapeCharLiteral c}'"
   | MPString(_id, s) -> $"\"{PrettyPrinter.escapeSpecialCharacters s}\""
 
   | MPList(_id, items) ->
@@ -493,7 +493,7 @@ let infix (i: LanguageTools.ProgramTypes.Infix) : String =
 
 let stringSegment (ctx: Context) (s: LanguageTools.ProgramTypes.StringSegment) : String =
   match s with
-  | StringText text -> text
+  | StringText text -> PrettyPrinter.escapeSpecialCharacters text
   | StringInterpolation expr -> $"{{{expr ctx expr}}}"
 
 let pipeExpr (ctx: Context) (p: LanguageTools.ProgramTypes.PipeExpr) : String =
@@ -582,7 +582,7 @@ let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
     let remainderPart = PrettyPrinter.processRemainder remainder
     $"{signPart}{whole}.{remainderPart}"
 
-  | EChar(_id, c) -> "'" ++ c ++ "'"
+  | EChar(_id, c) -> "'" ++ (PrettyPrinter.escapeCharLiteral c) ++ "'"
 
   | EString(_id, segments) ->
     match segments with

--- a/packages/darklang/prettyPrinter/runtimeError.dark
+++ b/packages/darklang/prettyPrinter/runtimeError.dark
@@ -463,8 +463,11 @@ module RuntimeError =
 
     | CLI err ->
       match err with
-      | NoExpressionsToExecute -> [ ES.String "TODO NoExpressionsToExecute" ]
-      | NonIntReturned actuallyReturnedOfDval -> [ ES.String "TODO NonIntReturned" ]
+      | NoExpressionsToExecute ->
+        [ ES.String "Nothing to evaluate (empty input or no top-level expression)" ]
+      | NonIntReturned returnedValue ->
+        [ ES.String "Script must return an Int64 (exit code); got "
+          ES.FullValue returnedValue ]
 
     | SqlCompiler errMsg -> [ ES.String errMsg ]
 

--- a/packages/darklang/scm/unresolvedCheck.dark
+++ b/packages/darklang/scm/unresolvedCheck.dark
@@ -257,7 +257,9 @@ let findUnresolvedInOps
 
           (Stdlib.List.append results [item], Stdlib.Dict.remove pending key)
         | None -> (results, pending)
-      | PropagateUpdate _
-      | RevertPropagation _ -> (results, pending))
+      | Deprecate(_, _, _)
+      | Undeprecate _
+      | PropagateUpdate(_, _, _, _, _)
+      | RevertPropagation(_, _, _, _, _) -> (results, pending))
 
   results

--- a/packages/darklang/stdlib/char.dark
+++ b/packages/darklang/stdlib/char.dark
@@ -68,3 +68,9 @@ let isGreaterThanOrEqualTo (c1: Char) (c2: Char) : Bool =
 
 /// Stringify <param c>
 let toString (c: Char) : String = Builtin.charToString c
+
+
+/// Return {{Some <var c>}} for the Unicode codepoint <param codepoint>,
+/// or {{None}} if the value is not a valid scalar (negative, > 0x10FFFF, or a surrogate).
+let fromCodepoint (codepoint: Int64) : Stdlib.Option.Option<Char> =
+  Builtin.charFromCodepoint codepoint

--- a/packages/darklang/stdlib/cli/bash.dark
+++ b/packages/darklang/stdlib/cli/bash.dark
@@ -5,6 +5,7 @@ module Darklang.Stdlib.Cli.Bash
 let readBashrc () : Result.Result<String, String> =
   (Builtin.fileRead "$HOME/.bashrc")
   |> Result.map Stdlib.String.fromBlobWithReplacement
+  |> Result.mapError Stdlib.Cli.FileSystem.FileError.toString
 
 /// Apply changes to .bashrc
 let applyBashConfigChanges () : Result.Result<Unit, String> =

--- a/packages/darklang/stdlib/cli/fileSystem.dark
+++ b/packages/darklang/stdlib/cli/fileSystem.dark
@@ -1,6 +1,26 @@
 module Darklang.Stdlib.Cli.FileSystem
 
 
+/// Structured error from file I/O.
+type FileError =
+  /// File or directory at the given path doesn't exist.
+  | NotFound
+  /// Caller lacks permission to read/write the path.
+  | PermissionDenied
+  /// Any other I/O failure — carries the original message.
+  | Other of String
+
+
+module FileError =
+  /// Render a FileError for display or for callers that haven't migrated to
+  /// pattern-matching on the enum yet.
+  let toString (err: FileError) : String =
+    match err with
+    | NotFound -> "File not found"
+    | PermissionDenied -> "Permission denied"
+    | Other msg -> msg
+
+
 // Get files in a directory - returns just filenames
 let getDirectoryContents (path: String) : List<String> =
   let currentDir = Builtin.directoryCurrent ()
@@ -45,7 +65,7 @@ let isDirectoryAtPath (dirPath: String) (fileName: String) : Bool =
 
 
 /// Read an entire file as a Blob.
-let readFile (path: String) : Result.Result<Blob, String> =
+let readFile (path: String) : Result.Result<Blob, FileError> =
   Builtin.fileRead path
 
 

--- a/packages/darklang/stdlib/cli/fish.dark
+++ b/packages/darklang/stdlib/cli/fish.dark
@@ -5,6 +5,7 @@ module Darklang.Stdlib.Cli.Fish
 let readFishConfig () : Result.Result<String, String> =
   (Builtin.fileRead "$HOME/.config/fish/config.fish")
   |> Result.map Stdlib.String.fromBlobWithReplacement
+  |> Result.mapError Stdlib.Cli.FileSystem.FileError.toString
 
 /// Overwrite what's in the config.fish file
 let overwriteFishConfig (content: String) : Result.Result<Unit, String> =

--- a/packages/darklang/stdlib/cli/zsh.dark
+++ b/packages/darklang/stdlib/cli/zsh.dark
@@ -5,6 +5,7 @@ module Darklang.Stdlib.Cli.Zsh
 let readZshrc () : Result.Result<String, String> =
   (Builtin.fileRead "$HOME/.zshrc")
   |> Result.map Stdlib.String.fromBlobWithReplacement
+  |> Result.mapError Stdlib.Cli.FileSystem.FileError.toString
 
 /// Overwrite what's in the .zshrc file
 let overwriteZshrc (content: String) : Result.Result<Unit, String> =

--- a/packages/darklang/stdlib/diff.dark
+++ b/packages/darklang/stdlib/diff.dark
@@ -33,7 +33,7 @@ let buildTable (oldLines: List<String>) (newLines: List<String>) : List<List<Int
     Stdlib.List.append table [nextRow])
 
 /// Walk the table backwards to produce diff lines
-let rec trace
+let trace
   (oldLines: List<String>)
   (newLines: List<String>)
   (table: List<List<Int64>>)

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -266,7 +266,7 @@ module Sse =
   /// Pull bytes from the underlying stream until a complete event
   /// terminator (blank line) arrives, then emit. Returns None once
   /// the stream is exhausted and no buffered data remains.
-  let rec pullNextEvent
+  let pullNextEvent
     (bytes: Stream<UInt8>)
     (state: ParseState)
     : Stdlib.Option.Option<(Event * ParseState)> =

--- a/packages/feriel/modelContextProtocol/push-notification/README.md
+++ b/packages/feriel/modelContextProtocol/push-notification/README.md
@@ -14,7 +14,7 @@ This is an MCP server that provides push notification capabilities through multi
 To add this MCP server run:
 
 ```bash
-claude mcp add push-notifications ./scripts/run-cli run @Feriel.ModelContextProtocol.PushNotification.Server.main --env PUSHOVER_USER_KEY=your_pushover_user_key --env PUSHOVER_APP_TOKEN=your_pushover_app_token
+claude mcp add push-notifications ./scripts/run-cli eval Feriel.ModelContextProtocol.PushNotification.Server.main --env PUSHOVER_USER_KEY=your_pushover_user_key --env PUSHOVER_APP_TOKEN=your_pushover_app_token
 ```
 
 ### Environment Variables

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/char.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/char.txt
@@ -22,3 +22,130 @@ escape sequence
 (source_file
   (expression
     (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+escape sequence - carriage return
+==================
+
+'\r'
+
+---
+
+(source_file
+  (expression
+    (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+escape sequence - hex \xHH
+==================
+
+'\x41'
+
+---
+
+(source_file
+  (expression
+    (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+escape sequence - hex \XHHHH
+==================
+
+'\X0041'
+
+---
+
+(source_file
+  (expression
+    (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+escape sequence - unicode \UHHHHHHHH
+==================
+
+'\U0001F600'
+
+---
+
+(source_file
+  (expression
+    (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+escape sequence - forward-slash
+==================
+
+'\/'
+
+---
+
+(source_file
+  (expression
+    (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+escape sequence - unicode \uHHHH
+==================
+
+'\u00E9'
+
+---
+
+(source_file
+  (expression
+    (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+escape sequence - escaped single quote
+==================
+
+'\''
+
+---
+
+(source_file
+  (expression
+    (simple_expression (char_literal (symbol) (character (char_or_string_escape_sequence)) (symbol)))))
+
+
+==================
+char - invalid escape produces ERROR
+==================
+
+'\d'
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (char_literal
+        (symbol)
+        (ERROR (UNEXPECTED 'd'))
+        (character)
+        (MISSING symbol)))))
+
+
+==================
+char - partial-hex \u escape produces ERROR
+==================
+
+'\u00E'
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (char_literal
+        (symbol)
+        (ERROR (UNEXPECTED '''))
+        (character)
+        (MISSING symbol)))))

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/strings.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/strings.txt
@@ -267,3 +267,179 @@ string - escaped single quote
     )
   )
 )
+
+
+==================
+string - carriage-return escape
+==================
+
+"\r"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (string_content (char_or_string_escape_sequence))
+          (symbol)
+        )
+      )
+    )
+  )
+)
+
+
+==================
+string - hex escape \xHH
+==================
+
+"\x41"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (string_content (char_or_string_escape_sequence))
+          (symbol)
+        )
+      )
+    )
+  )
+)
+
+
+==================
+string - hex escape \XHHHH
+==================
+
+"\X0041"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (string_content (char_or_string_escape_sequence))
+          (symbol)
+        )
+      )
+    )
+  )
+)
+
+
+==================
+string - unicode escape \uHHHH
+==================
+
+"\u00E9"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (string_content (char_or_string_escape_sequence))
+          (symbol)
+        )
+      )
+    )
+  )
+)
+
+
+==================
+string - unicode escape \UHHHHHHHH
+==================
+
+"\U0001F600"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (string_content (char_or_string_escape_sequence))
+          (symbol)
+        )
+      )
+    )
+  )
+)
+
+
+==================
+string - forward-slash escape
+==================
+
+"\/"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (string_content (char_or_string_escape_sequence))
+          (symbol)
+        )
+      )
+    )
+  )
+)
+
+
+==================
+string - invalid escape produces ERROR
+==================
+
+"\d"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (ERROR (UNEXPECTED 'd'))
+          (symbol)))))
+)
+
+
+==================
+string - partial-hex \u escape produces ERROR
+==================
+
+"\u00E"
+
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (string_segment
+        (string_literal
+          (symbol)
+          (ERROR (UNEXPECTED '"'))
+          (symbol)))))
+)


### PR DESCRIPTION
This PR 
- fixes delete command
- makes the decoder produce actual runtime string values and reject invalid escapes as parse errors. The parser was taking the raw text of escape tokens, so "\n" stayed as literal backslash+n at runtime, and invalid escapes like "\d+" were silently dropped to ""
- replaces fileRead's stringified .NET exception with a structured `FileError`
- replaces the CLI's stringly-typed error slot (which rendered as raw AST) with a typed `ExecutionError`
- `eval -` reads the expression from stdin for multi-line input
- misc docs fixes
