### PR TITLE
Suppress Unit output from CLI eval

### DIFF
--- a/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
+++ b/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
@@ -304,12 +304,20 @@ let fns () : List<BuiltInFn> =
             "allowHarmful"
             TBool
             "Opt out of Harmful-deprecation halting (see docs/deprecation)" ]
-      returnType = TypeReference.result TString (ExecutionError.typeRef ())
-      description = "Evaluates a Dark expression and returns the result as a String"
+      returnType =
+        TypeReference.result
+          (TypeReference.option TString)
+          (ExecutionError.typeRef ())
+      description =
+        "Evaluates a Dark expression. Returns Some(reprString) for a value, "
+        + "or None when the result is Unit (so callers can suppress empty echo)."
       fn =
         let errType = KTCustomType(ExecutionError.fqTypeName (), [])
-        let resultOk = Dval.resultOk KTString errType
-        let resultError = Dval.resultError KTString errType
+        let okKT = KTCustomType(Dval.optionType (), [ VT.known KTString ])
+        let resultOk = Dval.resultOk okKT errType
+        let resultError = Dval.resultError okKT errType
+        let okSome (s : string) = resultOk (Dval.optionSome KTString (DString s))
+        let okNone () = resultOk (Dval.optionNone KTString)
         (function
         | exeState,
           _,
@@ -340,10 +348,11 @@ let fns () : List<BuiltInFn> =
                 with
                 | Ok result ->
                   match result with
-                  | DString s -> return resultOk (DString s)
+                  | DUnit -> return okNone ()
+                  | DString s -> return okSome s
                   | _ ->
                     let! asString = Exe.dvalToRepr exeState result
-                    return resultOk (DString asString)
+                    return okSome asString
                 | Error(e, callStack) ->
                   let! csString = Exe.callStackString exeState callStack
                   print $"Error when executing expression. Call-stack:\n{csString}\n"

--- a/packages/darklang/cli/commands/traces.dark
+++ b/packages/darklang/cli/commands/traces.dark
@@ -1111,8 +1111,10 @@ let executeReplay (state: Cli.AppState) (traceID: String) : Cli.AppState =
       Builtin.cliEvaluateExpression
         state.accountID state.currentBranchId code false
     with
-    | Ok output ->
-      Stdlib.printLine output
+    | Ok outputOpt ->
+      match outputOpt with
+      | Some output -> Stdlib.printLine output
+      | None -> ()
       Stdlib.printLine ""
       Stdlib.printLine "Replay complete. A new trace was created for this execution."
       state

--- a/packages/darklang/cli/execution/eval.dark
+++ b/packages/darklang/cli/execution/eval.dark
@@ -21,9 +21,10 @@ let execute (state: AppState) (args: List<String>) : AppState =
         expr
         allowHarmful
     with
-    | Ok result ->
-      Stdlib.printLine result
+    | Ok (Some s) ->
+      Stdlib.printLine s
       state
+    | Ok None -> state
     | Error err ->
       let prettyError = PrettyPrinter.RuntimeTypes.RuntimeError.toString state.currentBranchId err
       Stdlib.printLine $"Error: {prettyError}"

--- a/packages/darklang/cli/packages/db.dark
+++ b/packages/darklang/cli/packages/db.dark
@@ -147,7 +147,8 @@ let viewDB (state: Cli.AppState) (dbName: String) : Cli.AppState =
       ++ nl ++ "|> Stdlib.String.join \"<<<ROW>>>\""
 
     match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
-    | Ok result ->
+    | Ok resultOpt ->
+      let result = resultOpt |> Stdlib.Option.withDefault ""
       Stdlib.printLine ""
 
       let colWidth = 15L
@@ -215,9 +216,10 @@ let getDBValue
   let expr = $"Stdlib.DB.get \"{key}\" {dbName}"
 
   match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
-  | Ok result ->
+  | Ok (Some result) ->
     Stdlib.printLine result
     state
+  | Ok None -> state
   | Error err ->
     let prettyError =
       PrettyPrinter.RuntimeTypes.RuntimeError.toString
@@ -285,9 +287,10 @@ let queryDB
   let expr = $"Stdlib.DB.query {dbName} ({filterExpr})"
 
   match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
-  | Ok result ->
+  | Ok (Some result) ->
     Stdlib.printLine result
     state
+  | Ok None -> state
   | Error err ->
     let prettyError =
       PrettyPrinter.RuntimeTypes.RuntimeError.toString

--- a/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
+++ b/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
@@ -9,7 +9,8 @@ let executeDarklang () : ModelContextProtocol.ServerBuilder.Tool =
     handler =
       fun code ->
         match Builtin.cliEvaluateExpression (Stdlib.Option.Option.None) SCM.Branch.mainBranchId code false with
-        | Ok result -> $"Result: {result}"
+        | Ok (Some result) -> $"Result: {result}"
+        | Ok None -> "Result: ()"
         | Error err ->
             let prettyError = PrettyPrinter.RuntimeTypes.RuntimeError.toString SCM.Branch.mainBranchId err
             $"Error: {prettyError}"


### PR DESCRIPTION
This PR suppresses `Unit` output from CLI eval.
```
dark eval 'someFnReturningUnit'
Old behavior printed:
()
```
`cliEvaluateExpression` now returns `Ok None` when the evaluated expression is actually `Unit`, and `Ok (Some rendered)` for real values. This preserves valid string results like `"()"` and `""` while letting CLI callers skip empty eval echoes.
