### PR TITLE
Fix trace storage for streams and ephemeral blobs

### DIFF
--- a/backend/src/LibDB/Tracing.fs
+++ b/backend/src/LibDB/Tracing.fs
@@ -9,6 +9,8 @@ module PT = LibExecution.ProgramTypes
 module RT = LibExecution.RuntimeTypes
 module AT = LibExecution.AnalysisTypes
 module Exe = LibExecution.Execution
+module Blob = LibExecution.Blob
+module RTToDT = LibExecution.RuntimeTypesToDarkTypes
 module BinarySer = LibSerialization.Binary.Serialization
 
 /// Tracing can go overboard, so use a per-handler feature flag to control it. If
@@ -417,35 +419,56 @@ module TraceStorage =
       ()
 
 
-/// Walk every captured Dval through `Blob.promote` so ephemeral blob refs
-/// resolve to persistent ones (writing the bytes into package_blobs in the
-/// process). Mutates `state.events` in place; returns the promoted input
-/// dval. Without this step, every trace would record blob UUIDs pointing
-/// at gone bytes.
-let private promoteBlobs
+/// Rewrite a Dval for the trace-storage boundary:
+///   - DStream → DStreamStub (the live pull fn closes over this VM's
+///     exeState; draining would consume the user's stream).
+///   - DBlob(Ephemeral _) → DBlob(Persistent _), promoting bytes
+///     into package_blobs so the trace survives the producing VM.
+/// Recursion and container rebuilding are handled by `Dval.rewriteWith`,
+/// so nested DStream values (inside lists, records, closures, ...) are
+/// stubbed just like top-level ones.
+let prepareDvalForStorage
+  (exeState : RT.ExecutionState)
+  (dv : RT.Dval)
+  : Ply.Ply<RT.Dval> =
+  let promoteBlob =
+    Blob.promoteEphemeralLeaf
+      exeState
+      exeState.blobs.persist
+      "Ephemeral blob not found in store during trace preparation"
+  dv
+  |> RT.Dval.rewriteWith (fun dv ->
+    uply {
+      match dv with
+      | RT.DStream(impl, _, _) -> return Some(RTToDT.Dval.streamStubDT impl)
+      | _ -> return! promoteBlob dv
+    })
+
+
+/// Walk every captured Dval through [prepareDvalForStorage]. Mutates
+/// `state.events` in place; returns the prepared input dval.
+let private prepareTraceForStorage
   (exeState : RT.ExecutionState)
   (inputDval : RT.Dval)
   (state : TracerState)
   : Ply.Ply<RT.Dval> =
   uply {
-    let persist = exeState.blobs.persist
-    let! promotedInput = LibExecution.Blob.promote exeState persist inputDval
+    let prep = prepareDvalForStorage exeState
+    let! preparedInput = prep inputDval
     for i in 0 .. state.events.Count - 1 do
       let ev = state.events[i]
-      let! promotedArgs =
-        ev.args
-        |> List.map (fun a -> LibExecution.Blob.promote exeState persist a)
-        |> Ply.List.flatten
-      let! promotedResult = LibExecution.Blob.promote exeState persist ev.result
-      state.events[i] <- { ev with args = promotedArgs; result = promotedResult }
+      let! preparedArgs = ev.args |> Ply.List.mapSequentially prep
+      let! preparedResult = prep ev.result
+      state.events[i] <- { ev with args = preparedArgs; result = preparedResult }
 
-    return promotedInput
+    return preparedInput
   }
 
 
-/// Shared helper: store a trace to SQLite with error handling. Promotes
-/// every Dval through `Blob.promote` first so blob bytes survive the
-/// per-request blob scope.
+/// Shared helper: store a trace to SQLite with error handling. Runs
+/// every captured Dval through [prepareTraceForStorage] first —
+/// stubs DStream values and promotes ephemeral blob bytes so the
+/// trace survives the producing VM.
 let private storeTrace
   (rootTLID : tlid)
   (traceID : AT.TraceID.T)
@@ -457,13 +480,13 @@ let private storeTrace
   : Ply.Ply<unit> =
   uply {
     try
-      let! promotedInput = promoteBlobs exeState inputDval state
+      let! preparedInput = prepareTraceForStorage exeState inputDval state
       TraceStorage.store
         rootTLID
         traceID
         handlerDesc
         inputVarName
-        promotedInput
+        preparedInput
         (Seq.toList state.events)
         exeState.accountID
     with ex ->

--- a/backend/src/LibExecution/Blob.fs
+++ b/backend/src/LibExecution/Blob.fs
@@ -3,15 +3,15 @@
 /// `Blob`s carry a `BlobRef` pointing at byte content held either
 /// in-process (Ephemeral) or in the content-addressed `package_blobs`
 /// table (Persistent). This module owns the byte-store mechanics
-/// (mint, read, scope-based reclaim) and the
-/// ephemeral-to-persistent promotion that runs at every persistence
-/// boundary.
+/// (mint, read, scope-based reclaim) and the leaf logic for
+/// ephemeral-to-persistent promotion ([promoteEphemeralLeaf]).
 ///
-/// The walk implementation (`promoteBlobs`) recurses through every
-/// Dval shape because a blob can be nested arbitrarily deep —
-/// rebuilding containers along the way. The traversal lives here
-/// rather than in `Dval.fs` because it's specifically a blob
-/// operation; Dval shape-walking is just the means.
+/// Promotion runs at every persistence boundary; structural recursion
+/// over the surrounding Dval shape is delegated to [Dval.rewriteWith] in
+/// `RuntimeTypes.fs`. `Blob.promote` wires the leaf handler into
+/// `rewriteWith` for the val-commit / User-DB-write path; the trace path
+/// (`LibDB.Tracing.prepareDvalForStorage`) reuses the same leaf
+/// handler alongside its own stream-stub rewrite.
 module LibExecution.Blob
 
 open Prelude
@@ -103,100 +103,60 @@ let readBytes (state : ExecutionState) (ref : BlobRef) : Ply.Ply<byte[]> =
   }
 
 
+/// [Dval.rewriteWith] leaf handler that promotes a `DBlob(Ephemeral _)`:
+/// look up bytes in `exeState.blobStore`, hash them, persist via
+/// [insert], and return `Some(DBlob(Persistent _))`. Returns `None`
+/// for anything else so the walker keeps descending. Raises with
+/// [errorContext] if the ephemeral UUID has no entry in the store —
+/// either the scope was popped early or the Dval is from a different
+/// VM.
+let promoteEphemeralLeaf
+  (exeState : ExecutionState)
+  (insert : string -> byte[] -> Ply.Ply<unit>)
+  (errorContext : string)
+  (dv : Dval)
+  : Ply.Ply<Dval option> =
+  uply {
+    match dv with
+    | DBlob(Ephemeral id) ->
+      let mutable bs : byte[] = null
+      if exeState.blobStore.TryGetValue(id, &bs) then
+        let h = sha256Hex bs
+        let n : int64 = System.Convert.ToInt64 bs.Length
+        do! insert h bs
+        return Some(DBlob(Persistent(h, n)))
+      else
+        return Exception.raiseInternal errorContext [ "id", id ]
+    | _ -> return None
+  }
+
+
 /// Promote any ephemeral blobs reachable from [dv] to persistent:
 /// hash the bytes (SHA-256), write them to the content-addressed
 /// store via [insert], and swap the ref. Idempotent by design — the
 /// insert path uses `INSERT OR IGNORE`, so promoting the same bytes
 /// twice writes to `package_blobs` once.
 ///
-/// Called before serializing a Dval through any persistence boundary
-/// (val commit, User DB write, trace capture). Plain `DBlob` writers
+/// Called before serializing a Dval through a non-trace persistence
+/// boundary (val commit, User DB write). Plain `DBlob` writers
 /// (binary, JSON) still raise on ephemeral — promote first, serialize
-/// second.
+/// second. The trace path has its own walker in
+/// `LibDB.Tracing.prepareDvalForStorage` that also stubs streams; it
+/// reuses [promoteEphemeralLeaf] but does not call this fn.
 ///
-/// `LibDB.Tracing.storeTrace` does call this (via `promoteBlobs`)
-/// before encoding each captured Dval — see that fn's docstring.
-/// Without it, a captured trace holding a `DBlob(Ephemeral _)` would
-/// deserialise in a fresh VM with the UUID intact but no bytes in that
-/// VM's blobStore, so the next `readBytes` would raise.
-///
-/// CLEANUP rebuilds container Dvals (Map.toList → walk → Map.ofList)
-/// even when no descendant blob promoted. Alloc-cheap in practice
-/// (~75KB regardless of input size), but a "did anything change"
-/// short-circuit would skip the round-trip in the common case.
+/// Structural recursion (including into DApplicable closures) is
+/// delegated to [Dval.rewriteWith] — we only describe the leaf substitution
+/// here. A lambda closing over an ephemeral blob has its capture
+/// environment promoted along with the rest of the value graph.
 let promote
   (exeState : ExecutionState)
   (insert : string -> byte[] -> Ply.Ply<unit>)
   (dv : Dval)
   : Ply.Ply<Dval> =
-  uply {
-    let rec go (dv : Dval) : Ply.Ply<Dval> =
-      uply {
-        match dv with
-        | DBlob(Ephemeral id) ->
-          let mutable bs : byte[] = null
-          if exeState.blobStore.TryGetValue(id, &bs) then
-            let h = sha256Hex bs
-            let n : int64 = System.Convert.ToInt64 bs.Length
-            do! insert h bs
-            return DBlob(Persistent(h, n))
-          else
-            return
-              Exception.raiseInternal
-                "Ephemeral blob not found in store during promotion"
-                [ "id", id ]
-        | DBlob(Persistent _)
-        | DUnit
-        | DBool _
-        | DInt8 _
-        | DUInt8 _
-        | DInt16 _
-        | DUInt16 _
-        | DInt32 _
-        | DUInt32 _
-        | DInt64 _
-        | DUInt64 _
-        | DInt128 _
-        | DUInt128 _
-        | DFloat _
-        | DChar _
-        | DString _
-        | DDateTime _
-        | DUuid _
-        | DApplicable _
-        | DDB _
-        | DStream _ -> return dv
-        | DList(vt, items) ->
-          let! items' = items |> Ply.List.mapSequentially go
-          return DList(vt, items')
-        | DDict(vt, entries) ->
-          let! entries' =
-            entries
-            |> Map.toList
-            |> Ply.List.mapSequentially (fun (k, v) ->
-              uply {
-                let! v' = go v
-                return (k, v')
-              })
-          return DDict(vt, Map.ofList entries')
-        | DTuple(a, b, rest) ->
-          let! a' = go a
-          let! b' = go b
-          let! rest' = rest |> Ply.List.mapSequentially go
-          return DTuple(a', b', rest')
-        | DRecord(src, rt, typeArgs, fields) ->
-          let! fields' =
-            fields
-            |> Map.toList
-            |> Ply.List.mapSequentially (fun (k, v) ->
-              uply {
-                let! v' = go v
-                return (k, v')
-              })
-          return DRecord(src, rt, typeArgs, Map.ofList fields')
-        | DEnum(src, rt, typeArgs, caseName, fields) ->
-          let! fields' = fields |> Ply.List.mapSequentially go
-          return DEnum(src, rt, typeArgs, caseName, fields')
-      }
-    return! go dv
-  }
+  dv
+  |> Dval.rewriteWith (
+    promoteEphemeralLeaf
+      exeState
+      insert
+      "Ephemeral blob not found in store during promotion"
+  )

--- a/backend/src/LibExecution/Dval.fs
+++ b/backend/src/LibExecution/Dval.fs
@@ -94,7 +94,9 @@ let result
 /// - `DStream` — the pull fn is a closure bound to this exeState.
 /// - `DBlob(Ephemeral _)` — the raw bytes live in exeState.blobStore;
 ///   promote to `Persistent` first. Most call paths already promote
-///   (see `promoteBlobs`); this branch is a safety net.
+///   (see `Blob.promote` for the val-commit / DB-write path and
+///   `LibDB.Tracing.prepareDvalForStorage` for the trace path); this
+///   branch is a safety net.
 ///
 /// Walks containers so one bad leaf anywhere in the tree disqualifies
 /// the whole value.

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1216,6 +1216,158 @@ module Dval =
     | DStream(impl, _, _) -> ValueType.Known(KTStream(StreamImpl.elemType impl))
 
 
+  /// Generic Dval-rewriting walker. At each node, asks `f`:
+  ///   - `Some dv'` → substitute, do not recurse further into the original
+  ///   - `None`     → recurse into containers and rebuild
+  ///
+  /// Recurses into DList/DTuple/DDict/DRecord/DEnum and into
+  /// DApplicable closures (closed registers + partially-applied args).
+  /// The closure recursion is required for persistence boundaries —
+  /// a lambda capturing an ephemeral blob or a stream must have its
+  /// environment rewritten alongside the rest of the value graph.
+  ///
+  /// Callers that only want to rewrite specific leaf shapes return
+  /// `None` everywhere else; the walker handles the structural
+  /// recursion and container rebuilds.
+  ///
+  /// Preserves structural sharing: when `f` returns `None` for every
+  /// reachable leaf, every container returns its original reference
+  /// (compared with `obj.ReferenceEquals`) rather than reconstructing.
+  /// Map containers in particular avoid the O(N log N) `Map.ofList`
+  /// rebuild path.
+  let rewriteWith (f : Dval -> Ply.Ply<Dval option>) (dv : Dval) : Ply.Ply<Dval> =
+    let inline same (a : obj) (b : obj) = obj.ReferenceEquals(a, b)
+
+    let rec go (dv : Dval) : Ply.Ply<Dval> =
+      uply {
+        let! substituted = f dv
+        match substituted with
+        | Some dv' -> return dv'
+        | None ->
+          match dv with
+          | DUnit
+          | DBool _
+          | DInt8 _
+          | DUInt8 _
+          | DInt16 _
+          | DUInt16 _
+          | DInt32 _
+          | DUInt32 _
+          | DInt64 _
+          | DUInt64 _
+          | DInt128 _
+          | DUInt128 _
+          | DFloat _
+          | DChar _
+          | DString _
+          | DDateTime _
+          | DUuid _
+          | DDB _
+          | DStream _
+          | DBlob _ -> return dv
+
+          | DList(vt, items) ->
+            let! items' = walkItems items
+            return (if same items' items then dv else DList(vt, items'))
+
+          | DTuple(a, b, rest) ->
+            let! a' = go a
+            let! b' = go b
+            let! rest' = walkItems rest
+            if same a' a && same b' b && same rest' rest then
+              return dv
+            else
+              return DTuple(a', b', rest')
+
+          | DDict(vt, entries) ->
+            let! entries' = walkMap entries
+            return (if same entries' entries then dv else DDict(vt, entries'))
+
+          | DRecord(src, rt, typeArgs, fields) ->
+            let! fields' = walkMap fields
+            return
+              (if same fields' fields then
+                 dv
+               else
+                 DRecord(src, rt, typeArgs, fields'))
+
+          | DEnum(src, rt, typeArgs, caseName, fields) ->
+            let! fields' = walkItems fields
+            return
+              (if same fields' fields then
+                 dv
+               else
+                 DEnum(src, rt, typeArgs, caseName, fields'))
+
+          | DApplicable(AppLambda lambda) ->
+            let! cr' = walkRegisters lambda.closedRegisters
+            let! args' = walkItems lambda.argsSoFar
+            if same cr' lambda.closedRegisters && same args' lambda.argsSoFar then
+              return dv
+            else
+              return
+                DApplicable(
+                  AppLambda { lambda with closedRegisters = cr'; argsSoFar = args' }
+                )
+
+          | DApplicable(AppNamedFn namedFn) ->
+            let! args' = walkItems namedFn.argsSoFar
+            if same args' namedFn.argsSoFar then
+              return dv
+            else
+              return DApplicable(AppNamedFn { namedFn with argsSoFar = args' })
+      }
+
+    /// Walk a `List<Dval>` element by element; return the original list
+    /// reference if every child walked to itself, else build a new list
+    /// with the walked results.
+    and walkItems (xs : List<Dval>) : Ply.Ply<List<Dval>> =
+      uply {
+        match xs with
+        | [] -> return xs
+        | _ ->
+          let arr = List.toArray xs
+          let mutable changed = false
+          for i in 0 .. arr.Length - 1 do
+            let! y = go arr[i]
+            if not (same y arr[i]) then
+              changed <- true
+              arr[i] <- y
+          return (if changed then List.ofArray arr else xs)
+      }
+
+    /// Walk a `List<Register * Dval>` (lambda closed registers); only
+    /// the Dval can change.
+    and walkRegisters (rs : List<Register * Dval>) : Ply.Ply<List<Register * Dval>> =
+      uply {
+        match rs with
+        | [] -> return rs
+        | _ ->
+          let arr = List.toArray rs
+          let mutable changed = false
+          for i in 0 .. arr.Length - 1 do
+            let r, v = arr[i]
+            let! v' = go v
+            if not (same v' v) then
+              changed <- true
+              arr[i] <- (r, v')
+          return (if changed then List.ofArray arr else rs)
+      }
+
+    /// Walk a `Map<string, Dval>`; return the original Map reference
+    /// when nothing changes, otherwise reuse the original map and
+    /// replace only the changed entries.
+    and walkMap (m : Map<string, Dval>) : Ply.Ply<Map<string, Dval>> =
+      uply {
+        let mutable acc = m
+        for KeyValue(k, v) in m do
+          let! v' = go v
+          if not (same v' v) then acc <- Map.add k v' acc
+        return acc
+      }
+
+    go dv
+
 
 
 // ------------

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -648,77 +648,88 @@ module Dval =
     FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.RuntimeTypes.dval ())
   let knownType () = KTCustomType(typeName (), [])
 
-  let rec toDT (dv : Dval) : Dval =
-    let (caseName, fields) =
-      match dv with
-      | DUnit -> "DUnit", []
-      | DBool b -> "DBool", [ DBool b ]
-      | DInt8 i -> "DInt8", [ DInt8 i ]
-      | DUInt8 i -> "DUInt8", [ DUInt8 i ]
-      | DInt16 i -> "DInt16", [ DInt16 i ]
-      | DUInt16 i -> "DUInt16", [ DUInt16 i ]
-      | DInt32 i -> "DInt32", [ DInt32 i ]
-      | DUInt32 i -> "DUInt32", [ DUInt32 i ]
-      | DInt64 i -> "DInt64", [ DInt64 i ]
-      | DUInt64 i -> "DUInt64", [ DUInt64 i ]
-      | DInt128 i -> "DInt128", [ DInt128 i ]
-      | DUInt128 i -> "DUInt128", [ DUInt128 i ]
-      | DFloat f -> "DFloat", [ DFloat f ]
-      | DChar c -> "DChar", [ DChar c ]
-      | DString s -> "DString", [ DString s ]
-      | DUuid u -> "DUuid", [ DUuid u ]
-      | DDateTime d -> "DDateTime", [ DDateTime d ]
+  /// Build the DStreamStub DEnum for a stream of the given impl. Streams
+  /// can't round-trip through the dark-type bridge (the live pull fn
+  /// doesn't survive serialization), so reflection and the trace-storage
+  /// boundary substitute this stub. [StreamImpl.elemType] walks
+  /// transform nodes (Mapped/Filtered/Take/Concat) to report the
+  /// emitted element type.
+  let streamStubDT (impl : StreamImpl) : Dval =
+    let tn = typeName ()
+    DEnum(tn, tn, [], "DStreamStub", [ ValueType.toDT (StreamImpl.elemType impl) ])
 
-      | DTuple(first, second, theRest) ->
-        "DTuple",
+  let rec toDT (dv : Dval) : Dval =
+    let tn = typeName ()
+    let mk caseName fields = DEnum(tn, tn, [], caseName, fields)
+    match dv with
+    | DUnit -> mk "DUnit" []
+    | DBool b -> mk "DBool" [ DBool b ]
+    | DInt8 i -> mk "DInt8" [ DInt8 i ]
+    | DUInt8 i -> mk "DUInt8" [ DUInt8 i ]
+    | DInt16 i -> mk "DInt16" [ DInt16 i ]
+    | DUInt16 i -> mk "DUInt16" [ DUInt16 i ]
+    | DInt32 i -> mk "DInt32" [ DInt32 i ]
+    | DUInt32 i -> mk "DUInt32" [ DUInt32 i ]
+    | DInt64 i -> mk "DInt64" [ DInt64 i ]
+    | DUInt64 i -> mk "DUInt64" [ DUInt64 i ]
+    | DInt128 i -> mk "DInt128" [ DInt128 i ]
+    | DUInt128 i -> mk "DUInt128" [ DUInt128 i ]
+    | DFloat f -> mk "DFloat" [ DFloat f ]
+    | DChar c -> mk "DChar" [ DChar c ]
+    | DString s -> mk "DString" [ DString s ]
+    | DUuid u -> mk "DUuid" [ DUuid u ]
+    | DDateTime d -> mk "DDateTime" [ DDateTime d ]
+
+    | DTuple(first, second, theRest) ->
+      mk
+        "DTuple"
         [ toDT first
           toDT second
           DList(VT.known (knownType ()), List.map toDT theRest) ]
 
-      | DList(vt, items) ->
-        "DList",
+    | DList(vt, items) ->
+      mk
+        "DList"
         [ ValueType.toDT vt; DList(VT.known (knownType ()), List.map toDT items) ]
 
-      | DDict(vt, entries) ->
-        "DDict",
+    | DDict(vt, entries) ->
+      mk
+        "DDict"
         [ ValueType.toDT vt; DDict(VT.known (knownType ()), Map.map toDT entries) ]
 
-      | DRecord(runtimeTypeName, sourceTypeName, typeArgs, fields) ->
-        "DRecord",
+    | DRecord(runtimeTypeName, sourceTypeName, typeArgs, fields) ->
+      mk
+        "DRecord"
         [ FQTypeName.toDT runtimeTypeName
           FQTypeName.toDT sourceTypeName
           DList(VT.known (ValueType.knownType ()), List.map ValueType.toDT typeArgs)
           DDict(VT.known (knownType ()), Map.map toDT fields) ]
 
-      | DEnum(runtimeTypeName, sourceTypeName, typeArgs, caseName, fields) ->
-        "DEnum",
+    | DEnum(runtimeTypeName, sourceTypeName, typeArgs, caseName, fields) ->
+      mk
+        "DEnum"
         [ FQTypeName.toDT runtimeTypeName
           FQTypeName.toDT sourceTypeName
           DList(VT.known (ValueType.knownType ()), List.map ValueType.toDT typeArgs)
           DString caseName
           DList(VT.known (knownType ()), List.map toDT fields) ]
 
-      | DApplicable applicable -> "DApplicable", [ Applicable.toDT applicable ]
+    | DApplicable applicable -> mk "DApplicable" [ Applicable.toDT applicable ]
 
-      | DDB name -> "DDB", [ DString name ]
+    | DDB name -> mk "DDB" [ DString name ]
 
-      | DBlob(Ephemeral id) -> "DBlobEphemeral", [ DUuid id ]
-      | DBlob(Persistent(hash, length)) ->
-        "DBlobPersistent", [ DString hash; DInt64 length ]
+    | DBlob(Ephemeral id) -> mk "DBlobEphemeral" [ DUuid id ]
+    | DBlob(Persistent(hash, length)) ->
+      mk "DBlobPersistent" [ DString hash; DInt64 length ]
 
-      // Streams render as a stub tag for LSP/reflection only — they
-      // can't round-trip (no live pull fn on the other side).
-      // [StreamImpl.elemType] walks transform nodes (Mapped/Filtered/
-      // Take/Concat) to report the emitted element type.
-      // TODO this is a one-way bridge — `fromDT` raises on DStreamStub.
-      // Any user code that introspects a Dval and rebuilds it (custom
-      // pretty-printer, trace viewer) silently breaks for streams. The
-      // asymmetry isn't documented in the public API. Document it or
-      // add a "rehydrate as a no-op stub stream" path.
-      | DStream(impl, _, _) ->
-        "DStreamStub", [ ValueType.toDT (StreamImpl.elemType impl) ]
-
-    DEnum(typeName (), typeName (), [], caseName, fields)
+    // Streams render as a stub tag for LSP/reflection only — they
+    // can't round-trip (no live pull fn on the other side).
+    // TODO this is a one-way bridge — `fromDT` raises on DStreamStub.
+    // Any user code that introspects a Dval and rebuilds it (custom
+    // pretty-printer, trace viewer) silently breaks for streams. The
+    // asymmetry isn't documented in the public API. Document it or
+    // add a "rehydrate as a no-op stub stream" path.
+    | DStream(impl, _, _) -> streamStubDT impl
 
 
   let fromDT (d : Dval) : Dval =

--- a/backend/tests/Tests/Blob.Tests.fs
+++ b/backend/tests/Tests/Blob.Tests.fs
@@ -24,6 +24,7 @@ module BS = LibSerialization.Binary.Serialization
 module PT2DT = LibExecution.ProgramTypesToDarkTypes
 module RT2DT = LibExecution.RuntimeTypesToDarkTypes
 module PMBlob = LibDB.RuntimeTypes.Blob
+module Tracing = LibDB.Tracing
 module QueryableJson = LibSerialization.DvalReprInternalQueryable
 module Equals = Builtins.Pure.Libs.NoModule
 
@@ -657,6 +658,245 @@ let equalsEphemeralDifferentBytes =
   }
 
 
+// ─────────────────────────────────────────────────────────────────────
+// Dval.rewriteWith structural sharing
+// ─────────────────────────────────────────────────────────────────────
+//
+// The walker promises that when `f` returns `None` for every reachable
+// leaf, no container is reconstructed — the input Dval reference is
+// returned unchanged. These tests lock that in: every test here passes
+// behaviorally even without sharing, so the only way they catch
+// regressions is via `obj.ReferenceEquals`.
+
+let private noopRewriteWith (dv : RT.Dval) : Task<RT.Dval> =
+  RT.Dval.rewriteWith (fun _ -> Ply None) dv |> Ply.toTask
+
+let rewriteWithNoOpPreservesOuterRef =
+  testTask "Dval.rewriteWith: no-op f returns the input reference (DList)" {
+    let dv = RT.DList(RT.ValueType.Known RT.KTInt64, [ RT.DInt64 1L; RT.DInt64 2L ])
+    let! result = noopRewriteWith dv
+    Expect.isTrue
+      (obj.ReferenceEquals(result, dv))
+      "outer DList ref must be preserved"
+  }
+
+let rewriteWithNoOpPreservesNestedRefs =
+  testTask "Dval.rewriteWith: no-op f preserves every nested container ref" {
+    let inner = RT.DList(RT.ValueType.Known RT.KTInt64, [ RT.DInt64 7L ])
+    let middle = RT.DTuple(RT.DString "k", inner, [])
+    let outer =
+      RT.DDict(RT.ValueType.Unknown, Map [ "a", middle; "b", RT.DBool true ])
+    let! result = noopRewriteWith outer
+    Expect.isTrue (obj.ReferenceEquals(result, outer)) "outer DDict ref preserved"
+    // Reach into the result and verify the inner refs survived too.
+    match result with
+    | RT.DDict(_, m) ->
+      Expect.isTrue
+        (obj.ReferenceEquals(m["a"], middle))
+        "nested DTuple ref preserved"
+      match m["a"] with
+      | RT.DTuple(_, innerResult, _) ->
+        Expect.isTrue
+          (obj.ReferenceEquals(innerResult, inner))
+          "innermost DList ref preserved"
+      | _ -> failtest "expected DTuple at key 'a'"
+    | _ -> failtest "expected DDict"
+  }
+
+let rewriteWithSingleChangePreservesSiblings =
+  testTask "Dval.rewriteWith: rewriting one element keeps unchanged sibling refs" {
+    let sibling1 = RT.DInt64 1L
+    let sibling2 = RT.DInt64 2L
+    let target = RT.DString "rewrite-me"
+    let dv = RT.DList(RT.ValueType.Known RT.KTInt64, [ sibling1; target; sibling2 ])
+    let! result =
+      RT.Dval.rewriteWith
+        (fun d ->
+          uply {
+            match d with
+            | RT.DString "rewrite-me" -> return Some(RT.DInt64 99L)
+            | _ -> return None
+          })
+        dv
+      |> Ply.toTask
+    match result with
+    | RT.DList(_, [ a; b; c ]) ->
+      Expect.isTrue (obj.ReferenceEquals(a, sibling1)) "left sibling ref preserved"
+      Expect.isTrue (obj.ReferenceEquals(c, sibling2)) "right sibling ref preserved"
+      Expect.equal b (RT.DInt64 99L) "target replaced"
+    | _ -> failtest $"expected DList of 3, got {result}"
+  }
+
+let rewriteWithNoOpOnPrimitivePreservesRef =
+  testTask "Dval.rewriteWith: no-op on a primitive returns the input reference" {
+    let dv = RT.DInt64 42L
+    let! result = noopRewriteWith dv
+    Expect.isTrue
+      (obj.ReferenceEquals(result, dv))
+      "primitive Dval ref must be preserved"
+  }
+
+
+// ─────────────────────────────────────────────────────────────────────
+// Blob.promote recurses into DApplicable closures
+// ─────────────────────────────────────────────────────────────────────
+//
+// `Dval.rewriteWith` walks into AppLambda.closedRegisters /
+// AppLambda.argsSoFar / AppNamedFn.argsSoFar. A lambda closing over an
+// ephemeral blob must have its capture environment promoted along
+// with the rest of the value graph — otherwise the persisted closure
+// carries a DBlob(Ephemeral _) ref pointing at bytes that died with
+// the producing VM.
+
+let private fakeAppLambda
+  (closedRegisters : List<RT.Register * RT.Dval>)
+  (argsSoFar : List<RT.Dval>)
+  : RT.Dval =
+  RT.DApplicable(
+    RT.AppLambda
+      { exprId = 0UL
+        closedRegisters = closedRegisters
+        typeSymbolTable = Map.empty
+        argsSoFar = argsSoFar }
+  )
+
+let private fakeAppNamedFn (argsSoFar : List<RT.Dval>) : RT.Dval =
+  let name = RT.FQFnName.fqBuiltin "intAdd" 0
+  RT.DApplicable(
+    RT.AppNamedFn
+      { name = name
+        typeSymbolTable = Map.empty
+        typeArgs = []
+        argsSoFar = argsSoFar }
+  )
+
+let promoteRewritesInsideClosedRegisters =
+  testTask "Blob.promote: ephemeral inside AppLambda.closedRegisters is promoted" {
+    let state = freshState ()
+    let payload = uniquePayload "promote-closure"
+    let ephemeral = Blob.newEphemeral state payload
+    let dv = fakeAppLambda [ (1, ephemeral) ] []
+    let! promoted = Blob.promote state PMBlob.insert dv |> Ply.toTask
+    match promoted with
+    | RT.DApplicable(RT.AppLambda lambda) ->
+      match lambda.closedRegisters with
+      | [ (_, RT.DBlob(RT.Persistent(h, n))) ] ->
+        Expect.equal h (Blob.sha256Hex payload) "captured blob hash"
+        Expect.equal n (int64 payload.Length) "captured blob length"
+      | _ -> failtest $"expected promoted ephemeral, got {lambda.closedRegisters}"
+    | _ -> failtest $"expected DApplicable, got {promoted}"
+  }
+
+let promoteRewritesInsideAppLambdaArgs =
+  testTask "Blob.promote: ephemeral inside AppLambda.argsSoFar is promoted" {
+    let state = freshState ()
+    let payload = uniquePayload "promote-applambda-args"
+    let ephemeral = Blob.newEphemeral state payload
+    let dv = fakeAppLambda [] [ ephemeral ]
+    let! promoted = Blob.promote state PMBlob.insert dv |> Ply.toTask
+    match promoted with
+    | RT.DApplicable(RT.AppLambda lambda) ->
+      match lambda.argsSoFar with
+      | [ RT.DBlob(RT.Persistent(h, _)) ] ->
+        Expect.equal h (Blob.sha256Hex payload) "argsSoFar blob promoted"
+      | _ -> failtest $"expected promoted ephemeral, got {lambda.argsSoFar}"
+    | _ -> failtest $"expected DApplicable, got {promoted}"
+  }
+
+let promoteRewritesInsideAppNamedFnArgs =
+  testTask "Blob.promote: ephemeral inside AppNamedFn.argsSoFar is promoted" {
+    let state = freshState ()
+    let payload = uniquePayload "promote-namedfn-args"
+    let ephemeral = Blob.newEphemeral state payload
+    let dv = fakeAppNamedFn [ ephemeral ]
+    let! promoted = Blob.promote state PMBlob.insert dv |> Ply.toTask
+    match promoted with
+    | RT.DApplicable(RT.AppNamedFn fn) ->
+      match fn.argsSoFar with
+      | [ RT.DBlob(RT.Persistent(h, _)) ] ->
+        Expect.equal h (Blob.sha256Hex payload) "argsSoFar blob promoted"
+      | _ -> failtest $"expected promoted ephemeral, got {fn.argsSoFar}"
+    | _ -> failtest $"expected DApplicable, got {promoted}"
+  }
+
+
+// ─────────────────────────────────────────────────────────────────────
+// Trace storage stubs nested DStream values
+// ─────────────────────────────────────────────────────────────────────
+//
+// `LibDB.Tracing.prepareDvalForStorage` walks each captured Dval
+// through `Dval.rewriteWith`. A stream anywhere in the graph (top
+// level, list element, record field, captured by a closure) becomes
+// the shared `DStreamStub` DEnum from `RTToDT.Dval.streamStubDT`.
+
+let private freshStream () : RT.Dval =
+  let next () : Ply<Option<RT.Dval>> = uply { return None }
+  Stream.newFromIO LibExecution.ValueType.int64 next None
+
+let private isStubInt64 (dv : RT.Dval) : bool =
+  match dv with
+  | RT.DEnum(_, _, [], "DStreamStub", [ _ ]) -> true
+  | _ -> false
+
+let prepareStubsTopLevelStream =
+  testTask "prepareDvalForStorage: top-level DStream becomes DStreamStub" {
+    let state = freshState ()
+    let! result = Tracing.prepareDvalForStorage state (freshStream ()) |> Ply.toTask
+    Expect.isTrue (isStubInt64 result) $"expected stub, got {result}"
+  }
+
+let prepareStubsStreamInsideList =
+  testTask "prepareDvalForStorage: DStream nested inside DList is stubbed" {
+    let state = freshState ()
+    let dv =
+      RT.DList(RT.ValueType.Unknown, [ RT.DInt64 1L; freshStream (); RT.DInt64 2L ])
+    let! result = Tracing.prepareDvalForStorage state dv |> Ply.toTask
+    match result with
+    | RT.DList(_, [ a; b; c ]) ->
+      Expect.equal a (RT.DInt64 1L) "leading sibling preserved"
+      Expect.isTrue (isStubInt64 b) $"middle stream stubbed, got {b}"
+      Expect.equal c (RT.DInt64 2L) "trailing sibling preserved"
+    | _ -> failtest $"expected DList of 3, got {result}"
+  }
+
+let prepareStubsStreamInsideRecord =
+  testTask "prepareDvalForStorage: DStream nested inside DRecord field is stubbed" {
+    let state = freshState ()
+    let typeName =
+      RT.FQTypeName.fqPackage (LibExecution.PackageRefs.Type.Stdlib.option ())
+    let dv =
+      RT.DRecord(
+        typeName,
+        typeName,
+        [],
+        Map.ofList [ ("body", freshStream ()); ("count", RT.DInt64 5L) ]
+      )
+    let! result = Tracing.prepareDvalForStorage state dv |> Ply.toTask
+    match result with
+    | RT.DRecord(_, _, _, fields) ->
+      let body = fields["body"]
+      Expect.isTrue (isStubInt64 body) $"stream field stubbed, got {body}"
+      Expect.equal fields["count"] (RT.DInt64 5L) "sibling field preserved"
+    | _ -> failtest $"expected DRecord, got {result}"
+  }
+
+let prepareStubsStreamInsideClosure =
+  testTask "prepareDvalForStorage: DStream captured by AppLambda is stubbed" {
+    let state = freshState ()
+    let dv = fakeAppLambda [ (1, freshStream ()) ] []
+    let! result = Tracing.prepareDvalForStorage state dv |> Ply.toTask
+    match result with
+    | RT.DApplicable(RT.AppLambda lambda) ->
+      match lambda.closedRegisters with
+      | [ (_, captured) ] ->
+        Expect.isTrue
+          (isStubInt64 captured)
+          $"captured stream stubbed, got {captured}"
+      | _ -> failtest $"expected one closed register, got {lambda.closedRegisters}"
+    | _ -> failtest $"expected DApplicable, got {result}"
+  }
+
+
 // `sweepOrphans` deletes any `package_blobs` row not referenced
 // by `package_values.rt_dval`. Without sequencing, the sweep test
 // can run concurrently with `packageBlobDedupesOnSameHash` (which
@@ -706,4 +946,15 @@ let tests =
       equalsEphemeralPersistentSameBytesIsFalse
       equalsPersistentPersistentSameHash
       equalsPersistentPersistentDifferentHashes
-      equalsEphemeralDifferentBytes ]
+      equalsEphemeralDifferentBytes
+      rewriteWithNoOpPreservesOuterRef
+      rewriteWithNoOpPreservesNestedRefs
+      rewriteWithSingleChangePreservesSiblings
+      rewriteWithNoOpOnPrimitivePreservesRef
+      promoteRewritesInsideClosedRegisters
+      promoteRewritesInsideAppLambdaArgs
+      promoteRewritesInsideAppNamedFnArgs
+      prepareStubsTopLevelStream
+      prepareStubsStreamInsideList
+      prepareStubsStreamInsideRecord
+      prepareStubsStreamInsideClosure ]


### PR DESCRIPTION
When you run Dark code, the tracing system records function calls: its arguments, its return value, how long it took so you can later look at exactly what your program did. For most values (numbers, strings, lists, records, etc.) this is simple: the runtime takes a snapshot of the value and writes it to disk.
Streams are different. If a function returns a stream, or takes one as an argument, the trace stores a placeholder such as `Stream<Int64>` instead of trying to read and save the stream's contents.

A stream is a cursor over a sequence of elements that haven't been produced yet. It might be:
- An iterator over an in-memory list that hasn't been walked.
- A live HTTP response body, streaming bytes in over the network as the remote server sends them.
- A computation that lazily generates each next element on demand from some seed (`Stream.unfold`).

the stream's "value" at any given moment isn't a collection, it's a recipe plus a position. Asking "what is this stream?" doesn't have a useful answer until somebody actually reads from it

Why we can't just write the stream to the trace

- The runtime can't tell pure streams apart from impure ones
The runtime has no way to look inside and see whether that function reads from memory, from a network socket, or from a file. They all look the same

- Reading from a stream changes it
A stream is a cursor. Reading the next element advances the position. If the trace machinery drains a stream to record its contents, the program's later reads from that same stream see fewer elements or none at all
(maybe we could work around this by draining the stream and then putting a fresh stream back into the program that replays the captured values?)

- Streams can be infinite
`Stream.unfold` and `Stream.fromList` over huge lists can describe sequences that are arbitrarily long, on the assumption that the consumer will only pull what it needs. The whole point of streams is that you can talk about a 100GB log file or a never-ending event source without holding all of it in memory at once


What we do instead:
When tracing serializes a value that contains a stream at the top level, or nested inside a list, tuple, dict, record, enum, or closure we replace the stream with a `DStreamStub` enum value that carries the stream's element type, but no values. A trace viewer rendering this stub knows it stood in for a stream of `Int64`s. The rewrite happens once, at the trace-storage boundary

This PR also fixes ephemeral blobs at persistence boundaries.
Ephemeral blobs store their bytes in the producing VM's in-memory blob store. If a trace persisted only the ephemeral UUID, reading the trace later would point at bytes that no longer exist. Before writing a trace, we now promote ephemeral blobs to persistent blob refs by hashing the bytes and inserting them into `package_blobs`.

The same rewrite machinery is also used by `Blob.promote`, so blobs captured inside function values are promoted too.