### PR TITLE
Fix DB corruption on bulk grow and tidy trace telemetry

### DIFF
--- a/backend/src/LibDB/Seed.fs
+++ b/backend/src/LibDB/Seed.fs
@@ -162,12 +162,23 @@ let applyUnappliedOps () : Task<int64> =
         // PRAGMAs that affect transaction semantics must run *outside* a
         // transaction. foreign_keys=OFF in particular only takes effect
         // when not in a tx.
+        //
+        // synchronous=NORMAL (not OFF): OFF lets the writer skip syncing
+        // the change-counter update to disk, which poisons the page cache
+        // of any concurrent reader on a different connection — that
+        // reader then returns SQLITE_CORRUPT ("database disk image is
+        // malformed") even though PRAGMA integrity_check is clean. NORMAL
+        // keeps the WAL-mode coherence guarantee at the cost of one fsync
+        // per checkpoint; the bulk-grow win still comes from collapsing
+        // 9000+ commits into one transaction.
         do!
           runRaw
             "PRAGMA journal_mode=WAL; \
-             PRAGMA synchronous=OFF; \
+             PRAGMA synchronous=NORMAL; \
              PRAGMA busy_timeout=5000; \
              PRAGMA foreign_keys=OFF;"
+        let opCount = List.length unappliedOps
+        use _bulk = Telemetry.span "seed.applyOps.bulk" [ "ops", string opCount ]
         use tx = conn.BeginTransaction()
 
         for ((branchId, commitHash), ops) in groups do
@@ -222,7 +233,7 @@ let applyUnappliedOps () : Task<int64> =
               violation(s) after grow:\n{summary}"
             [ "first_violations", summary ]
 
-        return int64 (List.length unappliedOps)
+        return int64 opCount
   }
 
 

--- a/backend/src/LibDB/Tracing.fs
+++ b/backend/src/LibDB/Tracing.fs
@@ -479,6 +479,8 @@ let private storeTrace
   (exeState : RT.ExecutionState)
   : Ply.Ply<unit> =
   uply {
+    let traceIdStr = string traceID
+    use _span = Telemetry.span "trace.store" [ "traceId", traceIdStr ]
     try
       let! preparedInput = prepareTraceForStorage exeState inputDval state
       TraceStorage.store
@@ -490,10 +492,12 @@ let private storeTrace
         (Seq.toList state.events)
         exeState.accountID
     with ex ->
-      print $"[tracing] Failed to store trace: {ex.Message}"
+      System.Console.Error.WriteLine $"[tracing] Failed to store trace: {ex.Message}"
       Telemetry.event
         "trace.storeFailed"
-        [ "exception", ex.GetType().FullName; "message", ex.Message ]
+        [ "traceId", traceIdStr
+          "exception", ex.GetType().FullName
+          "message", ex.Message ]
   }
 
 


### PR DESCRIPTION
This PR:
- Fixes `SQLite Error 11: 'database disk image is malformed'`
The bulk-grow step was using `PRAGMA synchronous=OFF` to go faster. That setting skips a disk sync that WAL mode relies on, and it caused other readers to see:
SQLite Error 11: 'database disk image is malformed'
Switched it to `synchronous=NORMAL`. We still get the speedup, from batching everything into one transaction not from skipping the syncs.

- Sends trace-store error messages to stderr instead of stdout
When saving a trace failed, the error message was being printed to stdout the same place the CLI prints `eval` results. That mixed error text into normal command output, which broke any tooling that consumed stdout. Moved the error message to stderr so normal output stays clean.