### PR TITLE
Support committing a subset of WIP ops

### DIFF
--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/PackageOps.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/PackageOps.fs
@@ -55,7 +55,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
       description =
         "Add package ops to the database as WIP (uncommitted) on the given branch.
         Returns the number of inserted ops on success (duplicates are skipped), or an error message on failure.
-        Use scmCommit to commit WIP ops."
+        Use scmCommitWipOpsByIds to commit WIP ops."
       fn =
         let resultOk = Dval.resultOk KTInt64 KTString
         let resultError = Dval.resultError KTInt64 KTString
@@ -65,7 +65,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
             try
               let ops = ops |> List.choose PT2DT.PackageOp.fromDT
 
-              // All ops are added as WIP - use scmCommit to commit them
+              // All ops are added as WIP - use scmCommitWipOpsByIds to commit them
               let! insertedCount = LibDB.Inserts.insertAndApplyOpsAsWip branchId ops
 
               // Auto-refresh existing WIP items: re-resolve names and
@@ -73,7 +73,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
               let! _refreshed = LibDB.WipRefresh.refresh pm branchId
 
               // Populate `rt_dval` for any package_values rows still
-              // NULL after this insert+refresh — `applyAddValue` always
+              // NULL after this insert+refresh. `applyAddValue` always
               // inserts NULL and Phase-3 `evaluateAllValues` only runs
               // at startup when there are unapplied ops. Without this
               // step, a CLI-added value that references another value
@@ -111,24 +111,6 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "scmGetWipOps" 0
-      typeParams = []
-      parameters = [ Param.make "branchId" TUuid "Branch ID" ]
-      returnType = TList(TCustomType(NR.ok (packageOpTypeName ()), []))
-      description = "Get all WIP (uncommitted) package ops on a branch."
-      fn =
-        function
-        | _, _, _, [ DUuid branchId ] ->
-          uply {
-            let! ops = LibDB.Queries.getWipOps branchId
-            return Dval.list (packageOpKT ()) (ops |> List.map PT2DT.PackageOp.toDT)
-          }
-        | _ -> incorrectArgs ()
-      sqlSpec = NotQueryable
-      previewable = Impure
-      deprecated = NotDeprecated }
-
-
     { name = fn "scmGetWipSummary" 0
       typeParams = []
       parameters = [ Param.make "branchId" TUuid "Branch ID" ]
@@ -155,7 +137,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    // CLEANUP: these three builtins are performance workarounds — see Queries.fs
+    // CLEANUP: these three builtins are performance workarounds; see Queries.fs.
     { name = fn "scmGetWipItems" 0
       typeParams = []
       parameters = [ Param.make "branchId" TUuid "Branch ID" ]
@@ -220,28 +202,86 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
-    { name = fn "scmCommit" 0
+    { name = fn "scmGetWipOpsWithIds" 0
+      typeParams = []
+      parameters = [ Param.make "branchId" TUuid "Branch ID" ]
+      returnType =
+        TList(
+          TTuple(
+            TUuid,
+            TCustomType(NR.ok (packageOpTypeName ()), []),
+            [ TypeReference.option TUuid ]
+          )
+        )
+      description =
+        "Get all WIP ops on a branch with their DB row id and propagation_id
+        (None unless the op is part of a propagation batch). Use this when you
+        need to operate on individual ops (e.g. partial commit / discard)."
+      fn =
+        function
+        | _, vm, _, [ DUuid branchId ] ->
+          uply {
+            let! entries = LibDB.Queries.getWipOpsWithIds branchId
+            let optionUuidDval =
+              LibExecution.TypeChecker.DvalCreator.option vm.threadID VT.uuid
+            let optionUuidVT =
+              VT.known (KTCustomType(Dval.optionType (), [ VT.uuid ]))
+            return
+              entries
+              |> List.map (fun (id, op, propId) ->
+                let propDval = propId |> Option.map DUuid |> optionUuidDval
+                DTuple(DUuid id, PT2DT.PackageOp.toDT op, [ propDval ]))
+              |> Dval.list (
+                KTTuple(VT.uuid, VT.known (packageOpKT ()), [ optionUuidVT ])
+              )
+          }
+        | _ -> incorrectArgs ()
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "scmCommitWipOpsByIds" 0
       typeParams = []
       parameters =
         [ Param.make "accountId" TUuid "Author of the commit"
           Param.make "branchId" TUuid "Branch ID"
-          Param.make "message" TString "Commit message" ]
+          Param.make "message" TString "Commit message"
+          Param.make
+            "opIds"
+            (TList TUuid)
+            "WIP op IDs from scmGetWipOpsWithIds. Every id must belong to this
+            branch and still be WIP, or nothing is committed." ]
       returnType = TypeReference.result TString TString
       description =
-        "Commit all WIP ops on a branch with the given message + committer.
-        Returns the commit hash on success, or an error message on failure."
+        "Commit the named WIP ops and their derived projection rows. The caller
+        owns selection policy and dependency closure. Projection rows are matched
+        by content key until they can be tied directly to source op IDs. Returns
+        the commit hash, or an error message on failure."
       fn =
         let resultOk = Dval.resultOk KTString KTString
         let resultError = Dval.resultError KTString KTString
         (function
-        | _, _, _, [ DUuid accountId; DUuid branchId; DString message ] ->
+        | _,
+          _,
+          _,
+          [ DUuid accountId; DUuid branchId; DString message; DList(_, opIds) ] ->
           uply {
-            let! result = LibDB.Inserts.commitWipOps accountId branchId message
-            match result with
-            | Ok commitHash ->
-              let (PT.Hash h) = commitHash
-              return resultOk (Dval.string h)
-            | Error msg -> return resultError (Dval.string msg)
+            try
+              let ids =
+                opIds
+                |> List.map (function
+                  | DUuid u -> u
+                  | _ -> Exception.raiseInternal "opIds must be uuids" [])
+              let! result =
+                LibDB.Inserts.commitWipOpsByIds accountId branchId message ids
+              match result with
+              | Ok commitHash ->
+                let (PT.Hash h) = commitHash
+                return resultOk (Dval.string h)
+              | Error msg -> return resultError (Dval.string msg)
+            with ex ->
+              return resultError (Dval.string ex.Message)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
@@ -333,6 +373,55 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
             return Dval.list (packageOpKT ()) (ops |> List.map PT2DT.PackageOp.toDT)
           }
         | _ -> incorrectArgs ()
+      sqlSpec = NotQueryable
+      previewable = Impure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "scmGetDependencies" 0
+      typeParams = []
+      parameters =
+        [ Param.make "branchId" TUuid "Branch whose chain to resolve against"
+          Param.make
+            "itemHash"
+            (TCustomType(NR.ok (PT2DT.Hash.typeName ()), []))
+            "Content hash of the item whose forward dependencies to fetch" ]
+      returnType =
+        TList(
+          TTuple(
+            TCustomType(NR.ok (PT2DT.Hash.typeName ()), []),
+            TCustomType(NR.ok (PT2DT.ItemKind.typeName ()), []),
+            []
+          )
+        )
+      description =
+        "Get the items (content hash + kind) that the given item directly depends
+        on, resolved over the branch chain. Used by partial commit to warn when a
+        selected item references uncommitted items not in the selection."
+      fn =
+        (function
+        | _, _, _, [ DUuid branchId; hashDval ] ->
+          uply {
+            let itemHash = PT2DT.Hash.fromDT hashDval
+            let! chain = LibDB.Branches.getBranchChain branchId
+            let! deps = LibDB.Queries.getDependencies chain itemHash
+            return
+              deps
+              |> List.map (fun d ->
+                DTuple(
+                  PT2DT.Hash.toDT d.itemHash,
+                  PT2DT.ItemKind.toDT d.itemKind,
+                  []
+                ))
+              |> Dval.list (
+                KTTuple(
+                  VT.known (PT2DT.Hash.knownType ()),
+                  VT.known (PT2DT.ItemKind.knownType ()),
+                  []
+                )
+              )
+          }
+        | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
       deprecated = NotDeprecated } ]

--- a/backend/src/LibDB/Inserts.fs
+++ b/backend/src/LibDB/Inserts.fs
@@ -180,79 +180,265 @@ let insertAndApplyOpsAsWip
   insertAndApplyOps branchId None ops
 
 
+// A commit stamps package_ops plus the projection rows it publishes.
+// TODO: subset commits match projection rows by content key, so two WIP ops
+// that publish the same projection row cannot be committed or discarded
+// independently. The clearest case is re-deprecating an item with a changed
+// message/kind: same projection key (item_hash, kind, "deprecated"), different
+// op id, so committing one stamps the other's row too. (Also: should we even
+// allow deprecating an already-deprecated item?)
+
+/// Every requested id must currently be WIP on the branch. If any id is already
+/// committed, discarded, or from another branch, reject the whole commit.
+let private validateRequestedIds
+  (opIdSet : Set<uuid>)
+  (allWip : List<uuid * PT.PackageOp>)
+  : Result<unit, string> =
+  let wipIdSet = allWip |> List.map fst |> Set.ofList
+  let missing = opIdSet |> Set.filter (fun id -> not (Set.contains id wipIdSet))
+
+  if Set.isEmpty missing then
+    Ok()
+  else
+    Error(
+      $"{Set.count missing} of {Set.count opIdSet} requested op id(s) are not WIP "
+      + "on this branch (they may already be committed, discarded, or belong to "
+      + "another branch); nothing was committed."
+    )
+
+/// SQL to flip WIP rows for a commit. Full commits use branch-wide updates;
+/// subset commits only stamp projection rows derived from the selected ops.
+let private projectionStatements
+  (commitHashStr : string)
+  (branchId : PT.BranchId)
+  (allSelected : bool)
+  (selectedOps : List<uuid * PT.PackageOp>)
+  =
+  if allSelected then
+    [ ("""
+       UPDATE package_ops
+       SET commit_hash = @commit_hash
+       WHERE branch_id = @branch_id AND commit_hash IS NULL
+       """,
+       [ [ "commit_hash", Sql.string commitHashStr; "branch_id", Sql.uuid branchId ] ])
+
+      ("""
+       UPDATE locations
+       SET commit_hash = @commit_hash
+       WHERE branch_id = @branch_id AND commit_hash IS NULL
+       """,
+       [ [ "commit_hash", Sql.string commitHashStr; "branch_id", Sql.uuid branchId ] ])
+
+      ("""
+       UPDATE deprecations
+       SET commit_hash = @commit_hash
+       WHERE branch_id = @branch_id AND commit_hash IS NULL
+       """,
+       [ [ "commit_hash", Sql.string commitHashStr; "branch_id", Sql.uuid branchId ] ]) ]
+  else
+    let selectedOpIds = selectedOps |> List.map fst
+
+    // SetName stamps its location row, keyed by FQN and item_hash so a second
+    // SetName on the same FQN doesn't drag the prior (unlisted but still WIP)
+    // row in.
+    let selectedLocations : List<PT.PackageLocation * PT.ItemKind * Hash> =
+      selectedOps
+      |> List.choose (fun (_, op) ->
+        match op with
+        | PT.PackageOp.SetName(loc, target) -> Some(loc, target.kind, target.hash)
+        | _ -> None)
+      |> List.distinct
+
+    // Deprecate/Undeprecate stamps its deprecation row, keyed by (item_hash, kind,
+    // state) so committing a Deprecate doesn't drag in a still-WIP Undeprecate
+    // of the same item. The "deprecated"/"undeprecated" strings mirror the
+    // `state` column written by applyDeprecate / applyUndeprecate. (Two ops
+    // projecting the same state for one (hash, kind) are still
+    // indistinguishable; see the TODO above.)
+    let selectedDeps : List<Hash * PT.ItemKind * string> =
+      selectedOps
+      |> List.choose (fun (_, op) ->
+        match op with
+        | PT.PackageOp.Deprecate(target, _, _) ->
+          Some(target.hash, target.kind, "deprecated")
+        | PT.PackageOp.Undeprecate target ->
+          Some(target.hash, target.kind, "undeprecated")
+        | _ -> None)
+      |> List.distinct
+
+    let packageOpStmts =
+      selectedOpIds
+      |> List.map (fun opId ->
+        ("""
+         UPDATE package_ops
+         SET commit_hash = @commit_hash
+         WHERE id = @id AND branch_id = @branch_id AND commit_hash IS NULL
+         """,
+         [ [ "commit_hash", Sql.string commitHashStr
+             "id", Sql.uuid opId
+             "branch_id", Sql.uuid branchId ] ]))
+
+    let locationStmts =
+      selectedLocations
+      |> List.map (fun (loc, kind, hash) ->
+        let modulesStr = String.concat "." loc.modules
+        let itemTypeStr = kind.toString ()
+        let (Hash hashStr) = hash
+        ("""
+         UPDATE locations
+         SET commit_hash = @commit_hash
+         WHERE branch_id = @branch_id
+           AND commit_hash IS NULL
+           AND owner = @owner
+           AND modules = @modules
+           AND name = @name
+           AND item_type = @item_type
+           AND item_hash = @item_hash
+         """,
+         [ [ "commit_hash", Sql.string commitHashStr
+             "branch_id", Sql.uuid branchId
+             "owner", Sql.string loc.owner
+             "modules", Sql.string modulesStr
+             "name", Sql.string loc.name
+             "item_type", Sql.string itemTypeStr
+             "item_hash", Sql.string hashStr ] ]))
+
+    let deprecationStmts =
+      selectedDeps
+      |> List.map (fun (hash, kind, state) ->
+        let (Hash hashStr) = hash
+        let itemKindStr = kind.toString ()
+        ("""
+         UPDATE deprecations
+         SET commit_hash = @commit_hash
+         WHERE branch_id = @branch_id
+           AND commit_hash IS NULL
+           AND item_hash = @item_hash
+           AND item_kind = @item_kind
+           AND state = @state
+         """,
+         [ [ "commit_hash", Sql.string commitHashStr
+             "branch_id", Sql.uuid branchId
+             "item_hash", Sql.string hashStr
+             "item_kind", Sql.string itemKindStr
+             "state", Sql.string state ] ]))
+
+    packageOpStmts @ locationStmts @ deprecationStmts
+
+
 /// Commit all WIP ops on a branch by creating a new commit and assigning commit_hash.
 /// Commit hash is content-addressed: hash(parentHash + sorted opHashes).
 /// Returns the commit Hash on success.
-let commitWipOps
+let rec commitWipOps
   (accountId : AccountID)
   (branchId : PT.BranchId)
   (message : string)
   : Task<Result<Hash, string>> =
+  // Commit-all is just "commit every WIP op id": gather the ids and defer to
+  // commitWipOpsByIds, which takes a branch-wide bulk fast-path when handed
+  // the full set (see below). Keeps one commit-construction code path.
+  task {
+    let! ids =
+      Sql.query
+        """
+        SELECT id
+        FROM package_ops
+        WHERE branch_id = @branch_id AND commit_hash IS NULL
+        ORDER BY created_at ASC
+        """
+      |> Sql.parameters [ "branch_id", Sql.uuid branchId ]
+      |> Sql.executeAsync (fun read -> read.uuid "id")
+
+    if List.isEmpty ids then
+      return Error "Nothing to commit"
+    else
+      return! commitWipOpsByIds accountId branchId message ids
+  }
+
+
+/// Commit exactly the WIP ops with the given IDs.
+///
+/// The caller owns selection policy. This function validates that every
+/// requested id is still WIP, creates the commit, and stamps the selected ops
+/// plus their derived projection rows. If the requested ids cover the whole WIP
+/// set, it uses the commit-all projection path.
+///
+/// CLEANUP: if SCM becomes a shared multi-writer service, move validation,
+/// parent lookup, commit creation, and row stamping into one transaction
+/// on one connection.
+and commitWipOpsByIds
+  (accountId : AccountID)
+  (branchId : PT.BranchId)
+  (message : string)
+  (opIds : List<uuid>)
+  : Task<Result<Hash, string>> =
   task {
     try
-      // Get WIP ops with their hashes
-      let! wipOps =
-        Sql.query
-          """
-          SELECT id, op_blob
-          FROM package_ops
-          WHERE branch_id = @branch_id AND commit_hash IS NULL
-          ORDER BY created_at ASC
-          """
-        |> Sql.parameters [ "branch_id", Sql.uuid branchId ]
-        |> Sql.executeAsync (fun read ->
-          let opId = read.uuid "id"
-          let opBlob = read.bytes "op_blob"
-          let op = BS.PT.PackageOp.deserialize opId opBlob
-          (opId, op))
-
-      if List.isEmpty wipOps then
-        return Error "Nothing to commit"
+      if List.isEmpty opIds then
+        return Error "No ops selected"
       else
-        // Get parent commit hash (latest commit on this branch)
-        let! parentHash =
+        let opIdSet = Set.ofList opIds
+
+        let! allWip =
           Sql.query
             """
-            SELECT hash FROM commits
-            WHERE branch_id = @branch_id
-            ORDER BY created_at DESC
-            LIMIT 1
+            SELECT id, op_blob
+            FROM package_ops
+            WHERE branch_id = @branch_id AND commit_hash IS NULL
+            ORDER BY created_at ASC
             """
           |> Sql.parameters [ "branch_id", Sql.uuid branchId ]
-          |> Sql.executeRowOptionAsync (fun read -> Hash(read.string "hash"))
+          |> Sql.executeAsync (fun read ->
+            let opId = read.uuid "id"
+            let opBlob = read.bytes "op_blob"
+            let op = BS.PT.PackageOp.deserialize opId opBlob
+            (opId, op))
 
-        // Compute op hashes
-        let opHashes = wipOps |> List.map (fun (_, op) -> Hashing.computeOpHash op)
+        match validateRequestedIds opIdSet allWip with
+        | Error e -> return Error e
+        | Ok() ->
+          let selectedOps =
+            allWip |> List.filter (fun (id, _) -> Set.contains id opIdSet)
 
-        // Compute content-addressed commit hash
-        let commitHash =
-          Hashing.computeCommitHash accountId branchId parentHash opHashes
-        let (Hash commitHashStr) = commitHash
+          let! parentHash =
+            Sql.query
+              """
+              SELECT hash FROM commits
+              WHERE branch_id = @branch_id
+              ORDER BY created_at DESC
+              LIMIT 1
+              """
+            |> Sql.parameters [ "branch_id", Sql.uuid branchId ]
+            |> Sql.executeRowOptionAsync (fun read -> Hash(read.string "hash"))
 
-        // The whole flip from WIP → committed runs atomically: the
-        // BranchOp insert, the `commits` row, and the three column
-        // re-points all in one transaction. A crash mid-write used to
-        // leave a `commits` row whose `package_ops` were still WIP,
-        // which `getCommits` would surface but `getCommitOps` wouldn't.
-        let op =
-          PT.BranchOp.CreateCommit(
-            commitHash,
-            message,
-            accountId,
-            branchId,
-            opHashes
-          )
-        let opHash = Hashing.computeBranchOpHash op
-        let (Hash branchOpHashStr) = opHash
-        let opBlob = BS.PT.BranchOp.serialize branchOpHashStr op
+          let opHashes =
+            selectedOps |> List.map (fun (_, op) -> Hashing.computeOpHash op)
 
-        let statements =
-          [ ("""
+          let commitHash =
+            Hashing.computeCommitHash accountId branchId parentHash opHashes
+          let (Hash commitHashStr) = commitHash
+
+          let branchOp =
+            PT.BranchOp.CreateCommit(
+              commitHash,
+              message,
+              accountId,
+              branchId,
+              opHashes
+            )
+          let branchOpHash = Hashing.computeBranchOpHash branchOp
+          let (Hash branchOpHashStr) = branchOpHash
+          let branchOpBlob = BS.PT.BranchOp.serialize branchOpHashStr branchOp
+
+          let branchOpStmt =
+            ("""
              INSERT OR IGNORE INTO branch_ops (id, op_blob, applied, created_at)
              VALUES (@id, @op_blob, 1, datetime('now'))
              """,
-             [ [ "id", Sql.string branchOpHashStr; "op_blob", Sql.bytes opBlob ] ])
+             [ [ "id", Sql.string branchOpHashStr
+                 "op_blob", Sql.bytes branchOpBlob ] ])
 
+          let commitStmt =
             ("""
              INSERT OR IGNORE INTO commits
                  (hash, message, branch_id, account_id, created_at)
@@ -264,33 +450,18 @@ let commitWipOps
                  "branch_id", Sql.uuid branchId
                  "account_id", Sql.uuid accountId ] ])
 
-            ("""
-             UPDATE package_ops
-             SET commit_hash = @commit_hash
-             WHERE branch_id = @branch_id AND commit_hash IS NULL
-             """,
-             [ [ "commit_hash", Sql.string commitHashStr
-                 "branch_id", Sql.uuid branchId ] ])
+          // selectedOps is allWip filtered by the requested id set, so equal
+          // lengths means every WIP op was selected.
+          let allSelected = List.length selectedOps = List.length allWip
 
-            ("""
-             UPDATE locations
-             SET commit_hash = @commit_hash
-             WHERE branch_id = @branch_id AND commit_hash IS NULL
-             """,
-             [ [ "commit_hash", Sql.string commitHashStr
-                 "branch_id", Sql.uuid branchId ] ])
+          let projStmts =
+            projectionStatements commitHashStr branchId allSelected selectedOps
 
-            ("""
-             UPDATE deprecations
-             SET commit_hash = @commit_hash
-             WHERE branch_id = @branch_id AND commit_hash IS NULL
-             """,
-             [ [ "commit_hash", Sql.string commitHashStr
-                 "branch_id", Sql.uuid branchId ] ]) ]
+          let statements = [ branchOpStmt; commitStmt ] @ projStmts
 
-        let _ = Sql.executeTransactionSync statements
+          let _ = Sql.executeTransactionSync statements
 
-        return Ok commitHash
+          return Ok commitHash
     with ex ->
       return Error ex.Message
   }
@@ -408,7 +579,7 @@ let discardWipOps (branchId : PT.BranchId) : Task<Result<int64, string>> =
         // on retry, the consequence was orphan WIP rows or active rows
         // that should still have been hidden. WIP-deprecations: their
         // supersession set `unlisted_at` on prior rows; we don't restore
-        // those here — the op log is source of truth, so a re-run via
+        // those here. The op log is source of truth, so a re-run via
         // `commit` + reload would rebuild state.
         let branchParam = [ [ "branch_id", Sql.uuid branchId ] ]
         let discardStatements =

--- a/backend/src/LibDB/Queries.fs
+++ b/backend/src/LibDB/Queries.fs
@@ -311,6 +311,31 @@ let getWipOps (branchId : PT.BranchId) : Task<List<PT.PackageOp>> =
   }
 
 
+/// Get all WIP ops on a branch with their DB row id and propagation_id.
+/// Used by callers that need to operate on individual ops (e.g. partial
+/// commit / partial discard).
+let getWipOpsWithIds
+  (branchId : PT.BranchId)
+  : Task<List<uuid * PT.PackageOp * Option<uuid>>> =
+  task {
+    return!
+      Sql.query
+        """
+        SELECT id, op_blob, propagation_id
+        FROM package_ops
+        WHERE branch_id = @branch_id AND commit_hash IS NULL
+        ORDER BY created_at ASC
+        """
+      |> Sql.parameters [ "branch_id", Sql.uuid branchId ]
+      |> Sql.executeAsync (fun read ->
+        let opId = read.uuid "id"
+        let opBlob = read.bytes "op_blob"
+        let propId = read.uuidOrNone "propagation_id"
+        let op = BS.PT.PackageOp.deserialize opId opBlob
+        (opId, op, propId))
+  }
+
+
 /// Summary of WIP changes
 type WipSummary =
   { types : int64
@@ -383,7 +408,7 @@ let getWipSummary (branchId : PT.BranchId) : Task<WipSummary> =
 // CLEANUP: getWipItems, getWipOpCount, and getCommitCount exist as F# builtins
 // purely for performance — they avoid sending large op lists to the Dark runtime.
 // When Dark execution is fast enough, replace these with Dark implementations that
-// use the existing getWipOps/getCommits builtins directly.
+// use the existing scmGetWipOpsWithIds/scmGetCommits builtins directly.
 
 /// A WIP item on a branch (excludes auto-propagated ops)
 type WipItem =

--- a/backend/testfiles/execution/cli/scm-partial-commit.dark
+++ b/backend/testfiles/execution/cli/scm-partial-commit.dark
@@ -1,0 +1,259 @@
+// Tests for the pure `commit --include` planner (Darklang.SCM.PartialCommit),
+// extracted from the CLI so its selection/ambiguity logic is testable without
+// faking stdin. resolveSelection returns content-derived items, so these
+// assert on FQNs / error-vs-ok without needing op-id values.
+
+module PartialCommitPlanning =
+  let fnRef (h: String) : Darklang.LanguageTools.ProgramTypes.Reference =
+    Darklang.LanguageTools.ProgramTypes.Reference.PackageFn(
+      Darklang.LanguageTools.ProgramTypes.Hash.Hash h
+    )
+
+  let typeRef (h: String) : Darklang.LanguageTools.ProgramTypes.Reference =
+    Darklang.LanguageTools.ProgramTypes.Reference.PackageType(
+      Darklang.LanguageTools.ProgramTypes.Hash.Hash h
+    )
+
+  let setNameEntry
+    (uuid: String)
+    (name: String)
+    (target: Darklang.LanguageTools.ProgramTypes.Reference)
+    : Darklang.SCM.PackageOps.WipOpEntry =
+    Darklang.SCM.PackageOps.WipOpEntry
+      { id = Builtin.unwrap (Stdlib.Uuid.parse_v0 uuid)
+        op =
+          Darklang.LanguageTools.ProgramTypes.PackageOp.SetName(
+            Darklang.LanguageTools.ProgramTypes.PackageLocation
+              { owner = "Test"; modules = [ "M" ]; name = name },
+            target
+          )
+        propagationId = Stdlib.Option.Option.None }
+
+  // WIP set: fn "main", fn "helper", and a type *also* named "main" — so
+  // "Test.M.main" is cross-kind ambiguous, "Test.M.helper" is unique.
+  let wip () : List<Darklang.SCM.PackageOps.WipOpEntry> =
+    [ setNameEntry
+        "00000000-0000-0000-0000-000000000001"
+        "main"
+        (fnRef "1111111111111111111111111111111111111111111111111111111111111111")
+      setNameEntry
+        "00000000-0000-0000-0000-000000000002"
+        "helper"
+        (fnRef "2222222222222222222222222222222222222222222222222222222222222222")
+      setNameEntry
+        "00000000-0000-0000-0000-000000000003"
+        "main"
+        (typeRef "3333333333333333333333333333333333333333333333333333333333333333") ]
+
+  // A unique name resolves to its FQN.
+  (match Darklang.SCM.PartialCommit.resolveSelection (wip ()) [ "Test.M.helper" ] with
+   | Ok items -> items |> Stdlib.List.map (fun i -> i.fqn)
+   | Error _ -> []) = [ "Test.M.helper" ]
+
+  // A name matching more than one WIP item (here a fn and a type sharing an
+  // FQN) is rejected — names must be unique, so there's no kind-prefix to pick
+  // one. The error lists the conflicts.
+  (match Darklang.SCM.PartialCommit.resolveSelection (wip ()) [ "Test.M.main" ] with
+   | Ok _ -> false
+   | Error msg ->
+     (Stdlib.String.contains msg "matches more than one WIP item")
+     && (Stdlib.String.contains msg "fn  Test.M.main")
+     && (Stdlib.String.contains msg "type  Test.M.main")) = true
+
+  // A name not present in WIP is rejected.
+  (match Darklang.SCM.PartialCommit.resolveSelection (wip ()) [ "Test.M.nope" ] with
+   | Ok _ -> "ok"
+   | Error _ -> "error") = "error"
+
+
+  // The hash <-> location lookups underpinning the dependency closure must
+  // respect kind, since the fn "main" and the type "main" share an FQN.
+  let loc (name: String) : Darklang.LanguageTools.ProgramTypes.PackageLocation =
+    Darklang.LanguageTools.ProgramTypes.PackageLocation
+      { owner = "Test"; modules = [ "M" ]; name = name }
+
+  let fnHash = "1111111111111111111111111111111111111111111111111111111111111111"
+  let helperHash = "2222222222222222222222222222222222222222222222222222222222222222"
+  let typeHash = "3333333333333333333333333333333333333333333333333333333333333333"
+
+  // wipHashForLocation: (loc "main", Fn) -> the fn's hash, not the type's.
+  (Darklang.SCM.PartialCommit.wipHashForLocation
+    (wip ())
+    (loc "main")
+    Darklang.LanguageTools.ProgramTypes.ItemKind.Fn) = Stdlib.Option.Option.Some(
+    Darklang.LanguageTools.ProgramTypes.Hash.Hash fnHash)
+
+  // ...and (loc "main", Type) -> the type's hash.
+  (Darklang.SCM.PartialCommit.wipHashForLocation
+    (wip ())
+    (loc "main")
+    Darklang.LanguageTools.ProgramTypes.ItemKind.Type) = Stdlib.Option.Option.Some(
+    Darklang.LanguageTools.ProgramTypes.Hash.Hash typeHash)
+
+  // wipLocationForHash is the reverse: helper's hash -> helper's location.
+  (Darklang.SCM.PartialCommit.wipLocationForHash
+    (wip ())
+    (Darklang.LanguageTools.ProgramTypes.Hash.Hash helperHash)
+    Darklang.LanguageTools.ProgramTypes.ItemKind.Fn) = Stdlib.Option.Option.Some(
+    loc "helper")
+
+  // A hash bound at a different kind doesn't match (typeHash is a Type, not Fn).
+  (Darklang.SCM.PartialCommit.wipLocationForHash
+    (wip ())
+    (Darklang.LanguageTools.ProgramTypes.Hash.Hash typeHash)
+    Darklang.LanguageTools.ProgramTypes.ItemKind.Fn) = Stdlib.Option.Option.None
+
+  // seedDepItems carries each selected item's hash through for the walk.
+  (match Darklang.SCM.PartialCommit.resolveSelection (wip ()) [ "Test.M.helper" ] with
+   | Ok selection ->
+     let seeded = Darklang.SCM.PartialCommit.seedDepItems (wip ()) selection
+     seeded |> Stdlib.List.map (fun d -> (d.fqn, d.hash))
+   | Error _ -> []) = [ ("Test.M.helper",
+                         Darklang.LanguageTools.ProgramTypes.Hash.Hash helperHash) ]
+
+  // Two WIP fns at one FQN (a same-kind duplicate) also resolve to >1 item, so
+  // resolveSelection fails closed rather than committing an arbitrary one.
+  let dupA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  let dupB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+  let dupWip2 () : List<Darklang.SCM.PackageOps.WipOpEntry> =
+    [ setNameEntry "00000000-0000-0000-0000-0000000000a1" "dup" (fnRef dupA)
+      setNameEntry "00000000-0000-0000-0000-0000000000a2" "dup" (fnRef dupB) ]
+
+  (match
+    Darklang.SCM.PartialCommit.resolveSelection (dupWip2 ()) [ "Test.M.dup" ]
+   with
+   | Ok _ -> false
+   | Error msg ->
+     (Stdlib.String.contains msg "matches more than one WIP item")
+     && (Stdlib.String.contains msg "Test.M.dup")) = true
+
+  // A deprecation of a selected item shows in the partial-commit confirmation,
+  // by the item's FQN.
+  let deprecateEntry
+    (uuid: String)
+    (target: Darklang.LanguageTools.ProgramTypes.Reference)
+    : Darklang.SCM.PackageOps.WipOpEntry =
+    Darklang.SCM.PackageOps.WipOpEntry
+      { id = Builtin.unwrap (Stdlib.Uuid.parse_v0 uuid)
+        op =
+          Darklang.LanguageTools.ProgramTypes.PackageOp.Deprecate(
+            target,
+            Darklang.LanguageTools.ProgramTypes.DeprecationKind.Obsolete,
+            "old"
+          )
+        propagationId = Stdlib.Option.Option.None }
+
+  let depWip () : List<Darklang.SCM.PackageOps.WipOpEntry> =
+    [ setNameEntry "00000000-0000-0000-0000-0000000000b1" "foo" (fnRef fnHash)
+      deprecateEntry "00000000-0000-0000-0000-0000000000b2" (fnRef fnHash) ]
+
+  (Darklang.SCM.PartialCommit.deprecationLinesForSelection
+    (depWip ())
+    [ Darklang.SCM.PartialCommit.SelectedItem
+        { location = loc "foo"
+          kind = Darklang.LanguageTools.ProgramTypes.ItemKind.Fn
+          fqn = "Test.M.foo" } ]) = [ "  deprecations:"; "    deprecate fn Test.M.foo" ]
+
+  // A propagated SetName (propagation_id set) is NOT selectable by name — only
+  // its source is, so `--include=fn:Dependent` can't split a propagation batch.
+  let propagatedWip () : List<Darklang.SCM.PackageOps.WipOpEntry> =
+    [ Darklang.SCM.PackageOps.WipOpEntry
+        { id = Builtin.unwrap (Stdlib.Uuid.parse_v0 "00000000-0000-0000-0000-0000000000c1")
+          op =
+            Darklang.LanguageTools.ProgramTypes.PackageOp.SetName(
+              Darklang.LanguageTools.ProgramTypes.PackageLocation
+                { owner = "Test"; modules = [ "M" ]; name = "dependent" },
+              fnRef fnHash
+            )
+          propagationId =
+            Stdlib.Option.Option.Some(
+              Builtin.unwrap (Stdlib.Uuid.parse_v0 "00000000-0000-0000-0000-0000000000c9")
+            ) } ]
+
+  (match
+    Darklang.SCM.PartialCommit.resolveSelection
+      (propagatedWip ())
+      [ "Test.M.dependent" ]
+   with
+   | Ok _ -> "ok"
+   | Error _ -> "error") = "error"
+
+  // The dependency-closure lookups must likewise ignore propagated SetNames: a
+  // propagated repoint binds (loc, hash) too, but surfacing it here would let
+  // the closure pull it in and split it from its PropagateUpdate batch.
+  (Darklang.SCM.PartialCommit.wipLocationForHash
+    (propagatedWip ())
+    (Darklang.LanguageTools.ProgramTypes.Hash.Hash fnHash)
+    Darklang.LanguageTools.ProgramTypes.ItemKind.Fn) = Stdlib.Option.Option.None
+
+  (Darklang.SCM.PartialCommit.wipHashForLocation
+    (propagatedWip ())
+    (loc "dependent")
+    Darklang.LanguageTools.ProgramTypes.ItemKind.Fn) = Stdlib.Option.Option.None
+
+  // allWipNamedItems lists only authored items, so a propagated repoint isn't
+  // double-counted (once as a named item, once under "propagated repoints") in
+  // the full-commit confirmation.
+  (Darklang.SCM.PartialCommit.allWipNamedItems (propagatedWip ())) = []
+
+
+// Confirmation-display rendering: grouping and the propagation-collapse.
+module PartialCommitDisplay =
+  let mkItem (name: String) : Darklang.SCM.PartialCommit.SelectedItem =
+    Darklang.SCM.PartialCommit.SelectedItem
+      { location =
+          Darklang.LanguageTools.ProgramTypes.PackageLocation
+            { owner = "Test"; modules = [ "M" ]; name = name }
+        kind = Darklang.LanguageTools.ProgramTypes.ItemKind.Fn
+        fqn = $"Test.M.{name}" }
+
+  // groupLines: empty group renders nothing.
+  (Darklang.SCM.PartialCommit.groupLines "selected" []) = []
+
+  // groupLines: a "label:" header + one indented "kind fqn" row per item.
+  (Darklang.SCM.PartialCommit.groupLines "selected" [ mkItem "a"; mkItem "b" ]) =
+    [ "  selected:"; "    fn Test.M.a"; "    fn Test.M.b" ]
+
+  // propagationLines: empty renders nothing.
+  (Darklang.SCM.PartialCommit.propagationLines []) = []
+
+  // propagationLines: <= 5 items are all listed, no "... more".
+  (Darklang.SCM.PartialCommit.propagationLines [ mkItem "a"; mkItem "b" ]) =
+    [ "  propagated repoints (2):"; "    fn Test.M.a"; "    fn Test.M.b" ]
+
+  // propagationLines: > 5 collapses to the first 5 + an "... and N more" tail.
+  (Darklang.SCM.PartialCommit.propagationLines
+    [ mkItem "a"
+      mkItem "b"
+      mkItem "c"
+      mkItem "d"
+      mkItem "e"
+      mkItem "f"
+      mkItem "g" ]) =
+    [ "  propagated repoints (7):"
+      "    fn Test.M.a"
+      "    fn Test.M.b"
+      "    fn Test.M.c"
+      "    fn Test.M.d"
+      "    fn Test.M.e"
+      "    ... and 2 more" ]
+
+
+// `--include=` parsing: comma-lists and accumulation across repeated flags.
+module PartialCommitParseInclude =
+  // A single flag splits on commas.
+  (Darklang.Cli.SCM.Commit.parseInclude [ "--include=a,b,c"; "msg" ]) =
+    Stdlib.Option.Option.Some [ "a"; "b"; "c" ]
+
+  // Repeated flags accumulate (previously all but the first were dropped).
+  (Darklang.Cli.SCM.Commit.parseInclude [ "--include=a"; "--include=b,c" ]) =
+    Stdlib.Option.Option.Some [ "a"; "b"; "c" ]
+
+  // No --include= flag at all → None (a full commit).
+  (Darklang.Cli.SCM.Commit.parseInclude [ "just"; "a"; "message" ]) =
+    Stdlib.Option.Option.None
+
+  // A present-but-empty flag → Some [] (the caller turns this into an error).
+  (Darklang.Cli.SCM.Commit.parseInclude [ "--include=" ]) =
+    Stdlib.Option.Option.Some []

--- a/backend/tests/Tests/BranchOps.Tests.fs
+++ b/backend/tests/Tests/BranchOps.Tests.fs
@@ -200,10 +200,200 @@ let testGhostFunctionCrossBranch =
   }
 
 
+let testPartialCommit =
+  testTask "partial commit: only selected ops commit, the rest stay WIP" {
+    let! (branch : PT.Branch) = Branches.create "test-bo-partial" PT.mainBranchId
+
+    // Two independent fns (distinct bodies → distinct hashes), each added as
+    // AddFn + SetName: 4 WIP ops, 2 WIP locations.
+    let fnA = makeFn (eVar "x")
+    let fnB = makeFn (eInt64 1L)
+    let ops =
+      [ PT.PackageOp.AddFn fnA
+        PT.PackageOp.SetName(loc "partialA", PT.PackageFn fnA.hash)
+        PT.PackageOp.AddFn fnB
+        PT.PackageOp.SetName(loc "partialB", PT.PackageFn fnB.hash) ]
+    let! (_ : int64) = Inserts.insertAndApplyOpsAsWip branch.id ops
+
+    let wipLocCount () : Task<int64> =
+      Sql.query
+        """
+        SELECT COUNT(*) as cnt FROM locations
+        WHERE branch_id = @branch_id AND commit_hash IS NULL
+        """
+      |> Sql.parameters [ "branch_id", Sql.uuid branch.id ]
+      |> Sql.executeRowAsync (fun read -> read.int64 "cnt")
+
+    let! locsBefore = wipLocCount ()
+    Expect.equal locsBefore 2L "both fns' locations are WIP before commit"
+
+    // Select only fnA's two ops (its AddFn + SetName).
+    let! wip = LibDB.Queries.getWipOpsWithIds branch.id
+    let idsForFn (hash : PT.Hash) =
+      wip
+      |> List.choose (fun (id, op, _) ->
+        match op with
+        | PT.PackageOp.AddFn f when f.hash = hash -> Some id
+        | PT.PackageOp.SetName(_, target) when target.hash = hash -> Some id
+        | _ -> None)
+    let selectedIds = idsForFn fnA.hash
+    Expect.hasLength selectedIds 2 "should select fnA's AddFn + SetName"
+
+    let! (commitResult : Result<PT.Hash, string>) =
+      Inserts.commitWipOpsByIds
+        LibCloud.Account.IDs.darklang
+        branch.id
+        "partial commit: fnA only"
+        selectedIds
+    Expect.isOk commitResult "partial commit should succeed"
+
+    // fnA's ops + location are committed; fnB's stay WIP.
+    let mentions (hash : PT.Hash) (op : PT.PackageOp) : bool =
+      match op with
+      | PT.PackageOp.AddFn f -> f.hash = hash
+      | PT.PackageOp.SetName(_, target) -> target.hash = hash
+      | _ -> false
+
+    let! remainingWip = LibDB.Queries.getWipOps branch.id
+    Expect.hasLength remainingWip 2 "only fnB's two ops should remain WIP"
+    Expect.isFalse
+      (remainingWip |> List.exists (mentions fnA.hash))
+      "fnA's ops should be committed, not WIP"
+    Expect.isTrue
+      (remainingWip |> List.exists (mentions fnB.hash))
+      "fnB's ops should still be WIP"
+
+    let! locsAfter = wipLocCount ()
+    Expect.equal locsAfter 1L "only fnB's location should remain WIP"
+  }
+
+
+let testPartialCommitSameFqn =
+  testTask
+    "partial commit: same-FQN updates flip only the selected version's location" {
+    let! (branch : PT.Branch) = Branches.create "test-bo-partial-fqn" PT.mainBranchId
+
+    // Two versions of the SAME fqn (distinct bodies → distinct hashes), each
+    // AddFn + SetName at the same location. The second SetName unlists v1's
+    // WIP location row but leaves it commit_hash NULL, so two WIP location
+    // rows for one FQN coexist.
+    let v1 = makeFn (eVar "x")
+    let v2 = makeFn (eInt64 7L)
+    let ops =
+      [ PT.PackageOp.AddFn v1
+        PT.PackageOp.SetName(loc "samefqn", PT.PackageFn v1.hash)
+        PT.PackageOp.AddFn v2
+        PT.PackageOp.SetName(loc "samefqn", PT.PackageFn v2.hash) ]
+    let! (_ : int64) = Inserts.insertAndApplyOpsAsWip branch.id ops
+
+    let wipLocCount () : Task<int64> =
+      Sql.query
+        """
+        SELECT COUNT(*) as cnt FROM locations
+        WHERE branch_id = @branch_id AND commit_hash IS NULL
+        """
+      |> Sql.parameters [ "branch_id", Sql.uuid branch.id ]
+      |> Sql.executeRowAsync (fun read -> read.int64 "cnt")
+
+    let! locsBefore = wipLocCount ()
+    Expect.equal locsBefore 2L "both versions leave a WIP location row"
+
+    // Commit only v1's ops (AddFn v1 + its SetName). v2's SetName is not
+    // selected, so its location row must stay WIP — an FQN-only projection
+    // match would wrongly flip it too (this would read 0).
+    let! wip = LibDB.Queries.getWipOpsWithIds branch.id
+    let v1Ids =
+      wip
+      |> List.choose (fun (id, op, _) ->
+        match op with
+        | PT.PackageOp.AddFn f when f.hash = v1.hash -> Some id
+        | PT.PackageOp.SetName(_, target) when target.hash = v1.hash -> Some id
+        | _ -> None)
+    Expect.hasLength v1Ids 2 "should select v1's AddFn + SetName"
+
+    let! (commitResult : Result<PT.Hash, string>) =
+      Inserts.commitWipOpsByIds
+        LibCloud.Account.IDs.darklang
+        branch.id
+        "commit v1 only"
+        v1Ids
+    Expect.isOk commitResult "partial commit should succeed"
+
+    let! locsAfter = wipLocCount ()
+    Expect.equal locsAfter 1L "only v2's location row should remain WIP"
+  }
+
+
+let testPartialCommitDeprecationState =
+  testTask
+    "partial commit: Deprecate commits without flipping a still-WIP Undeprecate" {
+    let! (branch : PT.Branch) = Branches.create "test-bo-partial-dep" PT.mainBranchId
+
+    // Add a fn, deprecate it, then undeprecate it. The Undeprecate supersedes
+    // the WIP "deprecated" row (unlists it, still commit_hash NULL) and inserts
+    // an "undeprecated" row — two WIP deprecation rows for the same (hash, fn).
+    let fn1 = makeFn (eVar "x")
+    let ops =
+      [ PT.PackageOp.AddFn fn1
+        PT.PackageOp.SetName(loc "depper", PT.PackageFn fn1.hash)
+        PT.PackageOp.Deprecate(
+          PT.PackageFn fn1.hash,
+          PT.DeprecationKind.Obsolete,
+          "obsolete for test"
+        )
+        PT.PackageOp.Undeprecate(PT.PackageFn fn1.hash) ]
+    let! (_ : int64) = Inserts.insertAndApplyOpsAsWip branch.id ops
+
+    let wipDepCount () : Task<int64> =
+      Sql.query
+        """
+        SELECT COUNT(*) as cnt FROM deprecations
+        WHERE branch_id = @branch_id AND commit_hash IS NULL
+        """
+      |> Sql.parameters [ "branch_id", Sql.uuid branch.id ]
+      |> Sql.executeRowAsync (fun read -> read.int64 "cnt")
+
+    let! depsBefore = wipDepCount ()
+    Expect.equal
+      depsBefore
+      2L
+      "deprecate + undeprecate leave two WIP deprecation rows"
+
+    // Commit everything EXCEPT the Undeprecate op.
+    let! wip = LibDB.Queries.getWipOpsWithIds branch.id
+    let idsToCommit =
+      wip
+      |> List.choose (fun (id, op, _) ->
+        match op with
+        | PT.PackageOp.Undeprecate _ -> None
+        | _ -> Some id)
+    Expect.hasLength
+      idsToCommit
+      3
+      "commit AddFn + SetName + Deprecate, not Undeprecate"
+
+    let! (commitResult : Result<PT.Hash, string>) =
+      Inserts.commitWipOpsByIds
+        LibCloud.Account.IDs.darklang
+        branch.id
+        "commit deprecation only"
+        idsToCommit
+    Expect.isOk commitResult "partial commit should succeed"
+
+    // The Undeprecate op stays WIP, so its "undeprecated" projection row must
+    // too — a (hash, kind)-only match (no state) would flip it (reads 0).
+    let! depsAfter = wipDepCount ()
+    Expect.equal depsAfter 1L "only the undeprecated row should remain WIP"
+  }
+
+
 let tests =
   testList
     "BranchOps"
     [ testBranchOpsEmitted
       testBranchOpsSerialization
       testBranchOpsDeserialization
-      testGhostFunctionCrossBranch ]
+      testGhostFunctionCrossBranch
+      testPartialCommit
+      testPartialCommitSameFqn
+      testPartialCommitDeprecationState ]

--- a/packages/darklang/cli/scm/commit.dark
+++ b/packages/darklang/cli/scm/commit.dark
@@ -1,6 +1,61 @@
 module Darklang.Cli.SCM.Commit
 
 
+/// Parse repeated comma-separated `--include=` flags.
+/// None means full commit; Some [] means an empty include flag was provided.
+let parseInclude (args: List<String>) : Stdlib.Option.Option<List<String>> =
+  let prefix = "--include="
+
+  let flags =
+    args |> Stdlib.List.filter (fun a -> Stdlib.String.startsWith a prefix)
+
+  if Stdlib.List.isEmpty flags then
+    Stdlib.Option.Option.None
+  else
+    let names =
+      flags
+      |> Stdlib.List.map (fun a ->
+        let raw = Stdlib.String.dropFirst a (Stdlib.String.length prefix)
+
+        raw
+        |> Stdlib.String.split ","
+        |> Stdlib.List.map Stdlib.String.trim
+        |> Stdlib.List.filter (fun s ->
+          Stdlib.Bool.not (Stdlib.String.isEmpty s)))
+      |> Stdlib.List.flatten
+
+    Stdlib.Option.Option.Some names
+
+
+/// Ask a y/n question. `--yes` auto-confirms. An empty answer takes
+/// `defaultYes` (so a "(Y/n)" prompt defaults to yes, "(y/n)" to no).
+let promptYesNo (question: String) (autoConfirm: Bool) (defaultYes: Bool) : Bool =
+  if autoConfirm then
+    true
+  else
+    Stdlib.printLine question
+    let response = Builtin.stdinReadLine ()
+
+    if Stdlib.String.isEmpty (Stdlib.String.trim response) then
+      defaultYes
+    else
+      (response == "y") || (response == "Y")
+
+
+let printUnresolved (items: List<SCM.UnresolvedCheck.UnresolvedItem>) : Unit =
+  Stdlib.printLine (Colors.error "Cannot commit: unresolved references found:")
+
+  items
+  |> Stdlib.List.iter (fun item ->
+    Stdlib.printLine (Colors.error $"  {item.label}:")
+
+    item.names
+    |> Stdlib.List.iter (fun name ->
+      Stdlib.printLine (Colors.error $"    - {name}")))
+
+  Stdlib.printLine ""
+
+
 let execute (state: AppState) (args: List<String>) : AppState =
   match state.accountID with
   | None ->
@@ -14,6 +69,8 @@ let execute (state: AppState) (args: List<String>) : AppState =
 
   let autoConfirm =
     (Stdlib.List.member_v0 args "--yes") || (Stdlib.List.member_v0 args "-y")
+
+  let includeNames = parseInclude args
 
   // Get message from args (everything that's not a flag)
   let messageParts =
@@ -29,65 +86,106 @@ let execute (state: AppState) (args: List<String>) : AppState =
     Stdlib.printLine "Usage: commit \"Your commit message\""
     state
   else
-    // Show what will be committed
-    let summary = SCM.PackageOps.getWipSummary branchId
+    let wipOps = SCM.PackageOps.getWipWithIds branchId
 
-    if summary.total == 0L then
+    if Stdlib.List.isEmpty wipOps then
       Stdlib.printLine "Nothing to commit."
       state
     else
-      Stdlib.printLine "Will commit:"
+      // Pick op IDs to commit + display lines for the confirm prompt.
+      let plan =
+        match includeNames with
+        | Some names when Stdlib.List.isEmpty names ->
+          Stdlib.Result.Result.Error
+            "`--include=` requires at least one item name."
 
-      if summary.types > 0L then
-        Stdlib.printLine $"  {Stdlib.Int64.toString summary.types} type(s)"
+        | Some names ->
+          match SCM.PartialCommit.resolveSelection wipOps names with
+          | Error msg -> Stdlib.Result.Result.Error msg
 
-      if summary.values > 0L then
-        Stdlib.printLine $"  {Stdlib.Int64.toString summary.values} value(s)"
+          | Ok selection ->
+            // Offer to include WIP-only dependencies of the selected items.
+            let depClosure =
+              SCM.PartialCommit.uncommittedDepClosure branchId wipOps selection
 
-      if summary.fns > 0L then
-        Stdlib.printLine $"  {Stdlib.Int64.toString summary.fns} function(s)"
+            // Keep pulled-in dependencies separate for the confirmation summary.
+            let (finalSelection, pulledIn) =
+              if Stdlib.List.isEmpty depClosure then
+                (selection, [])
+              else
+                Stdlib.printLine
+                  (Colors.warning
+                    "Selected item(s) reference uncommitted item(s) not in the selection:")
 
-      Stdlib.printLine ""
+                depClosure
+                |> Stdlib.List.iter (fun item ->
+                  Stdlib.printLine
+                    $"  {SCM.PartialCommit.itemKindLabel item.kind} {item.fqn}")
 
-      let proceed =
-        if autoConfirm then
-          true
-        else
-          Stdlib.printLine "Proceed? (y/n): "
-          let response = Builtin.stdinReadLine ()
-          (response == "y") || (response == "Y")
+                if
+                  promptYesNo "Include them in this commit? (Y/n): " autoConfirm true
+                then
+                  (Stdlib.List.append selection depClosure, depClosure)
+                else
+                  (selection, [])
 
-      if proceed then
-        // Check for unresolved references before committing
-        let ops = SCM.PackageOps.getWip branchId
-        let unresolvedItems = SCM.UnresolvedCheck.findUnresolvedInOps ops
+            let opIds =
+              SCM.PartialCommit.planForSelection wipOps finalSelection true
 
-        if (Stdlib.List.isEmpty unresolvedItems) |> Stdlib.Bool.not then
-          Stdlib.printLine
-            (Colors.error "Cannot commit: unresolved references found:")
+            let summary =
+              SCM.PartialCommit.displayLinesForSelection
+                wipOps
+                selection
+                pulledIn
+                finalSelection
 
-          unresolvedItems
-          |> Stdlib.List.iter (fun item ->
-            Stdlib.printLine (Colors.error $"  {item.label}:")
+            Stdlib.Result.Result.Ok((opIds, summary))
 
-            item.names
-            |> Stdlib.List.iter (fun name ->
-              Stdlib.printLine (Colors.error $"    - {name}")))
+        | None ->
+          // Full commit: every WIP op id.
+          let opIds = wipOps |> Stdlib.List.map (fun e -> e.id)
+          let summary = SCM.PartialCommit.displayLinesForFull wipOps
+          Stdlib.Result.Result.Ok((opIds, summary))
 
-          Stdlib.printLine ""
+      match plan with
+      | Error msg ->
+        Stdlib.printLine (Colors.error msg)
+        state
+
+      | Ok((opIds, summaryLines)) ->
+        if Stdlib.List.isEmpty opIds then
+          Stdlib.printLine "Nothing to commit."
           state
         else
-          match SCM.PackageOps.commit accountId branchId message with
-          | Ok commitHash ->
-            let shortId = Stdlib.String.first commitHash 8L
-            Stdlib.printLine (Colors.success $"Created commit {shortId}")
+          Stdlib.printLine "Will commit:"
+          summaryLines |> Stdlib.List.iter Stdlib.printLine
+          Stdlib.printLine ""
+
+          if promptYesNo "Proceed? (y/n): " autoConfirm false then
+            // Only selected ops should block this commit on unresolved names.
+            let selectedOps =
+              wipOps
+              |> Stdlib.List.filter (fun e -> Stdlib.List.member_v0 opIds e.id)
+              |> Stdlib.List.map (fun e -> e.op)
+            let unresolved = SCM.UnresolvedCheck.findUnresolvedInOps selectedOps
+
+            if (Stdlib.List.isEmpty unresolved) |> Stdlib.Bool.not then
+              printUnresolved unresolved
+              state
+            else
+              match
+                SCM.PackageOps.commitOpIds accountId branchId message opIds
+                with
+              | Ok commitHash ->
+                let shortId = Stdlib.String.first commitHash 8L
+                Stdlib.printLine (Colors.success $"Created commit {shortId}")
+                state
+              | Error e ->
+                Stdlib.printLine (Colors.error $"Commit failed: {e}")
+                state
+          else
+            Stdlib.printLine "Commit cancelled."
             state
-          | Error e ->
-            Stdlib.printLine (Colors.error $"Commit failed: {e}")
-            state
-      else
-        Stdlib.printLine "Commit cancelled."
-        state
 
 
 let complete (_state: AppState) (_args: List<String>) : List<Completion.CompletionItem> =
@@ -95,12 +193,19 @@ let complete (_state: AppState) (_args: List<String>) : List<Completion.Completi
 
 
 let help (_state: AppState) : Unit =
-  [ "Usage: commit \"message\" [--yes|-y]"
-    "Commit all uncommitted (WIP) changes on the current branch."
+  [ "Usage: commit \"message\" [--include=name1,name2] [--yes|-y]"
+    "Commit uncommitted (WIP) changes on the current branch."
     ""
     "Arguments:"
     "  message   Commit message describing the changes"
     ""
     "Flags:"
-    "  --yes, -y   Skip confirmation prompt" ]
+    "  --include=<names>   Only commit the named items (comma-separated FQNs)."
+    "                      Names must match WIP items as listed by `status`."
+    "                      Auto-propagated repoints to dependents are always"
+    "                      committed with their source item. If a selected item"
+    "                      references other uncommitted items, you'll be asked"
+    "                      whether to pull them into the commit."
+    "  --yes, -y           Skip confirmation prompts (includes referenced"
+    "                      uncommitted items)" ]
   |> Stdlib.printLines

--- a/packages/darklang/scm/packageOps.dark
+++ b/packages/darklang/scm/packageOps.dark
@@ -33,7 +33,34 @@ let getRecent (limit: Int64) : List<LanguageTools.ProgramTypes.PackageOp> =
 
 /// Get all WIP (uncommitted) ops on a branch
 let getWip (branchId: Uuid) : List<LanguageTools.ProgramTypes.PackageOp> =
-  Builtin.scmGetWipOps branchId
+  branchId |> getWipWithIds |> Stdlib.List.map (fun e -> e.op)
+
+
+/// A WIP package op with its DB row id and optional propagation batch id.
+type WipOpEntry =
+  { id: Uuid
+    op: LanguageTools.ProgramTypes.PackageOp
+    propagationId: Stdlib.Option.Option<Uuid> }
+
+
+/// Get all WIP ops on a branch as `WipOpEntry` records (op + DB id + batch).
+let getWipWithIds (branchId: Uuid) : List<WipOpEntry> =
+  branchId
+  |> Builtin.scmGetWipOpsWithIds
+  |> Stdlib.List.map (fun tuple ->
+    let (id, op, propId) = tuple
+    WipOpEntry { id = id; op = op; propagationId = propId })
+
+
+/// Render a PackageLocation as its dotted FQN string. Mirrors
+/// `LibDB.PackageLocation.toFQN` on the F# side so CLI-side name matching
+/// agrees with what `getWipItems` returns.
+let locationToFqn (loc: LanguageTools.ProgramTypes.PackageLocation) : String =
+  if Stdlib.List.isEmpty loc.modules then
+    $"{loc.owner}.{loc.name}"
+  else
+    let modStr = Stdlib.String.join loc.modules "."
+    $"{loc.owner}.{modStr}.{loc.name}"
 
 
 /// Summary of WIP (uncommitted) changes on a branch
@@ -83,7 +110,24 @@ let commit
   (branchId: Uuid)
   (message: String)
   : Stdlib.Result.Result<String, String> =
-  Builtin.scmCommit accountId branchId message
+  // Full commit means committing every WIP op id.
+  let opIds =
+    branchId |> getWipWithIds |> Stdlib.List.map (fun e -> e.id)
+
+  if Stdlib.List.isEmpty opIds then
+    Stdlib.Result.Result.Error "Nothing to commit"
+  else
+    commitOpIds accountId branchId message opIds
+
+
+/// Commit the selected WIP op IDs. Caller owns selection policy.
+let commitOpIds
+  (accountId: Uuid)
+  (branchId: Uuid)
+  (message: String)
+  (opIds: List<Uuid>)
+  : Stdlib.Result.Result<String, String> =
+  Builtin.scmCommitWipOpsByIds accountId branchId message opIds
 
 
 /// Discard all WIP ops on a branch

--- a/packages/darklang/scm/partialCommit.dark
+++ b/packages/darklang/scm/partialCommit.dark
@@ -1,0 +1,747 @@
+module Darklang.SCM.PartialCommit
+
+// Pure planning for `commit --include=…`: resolve the requested names against
+// the WIP set, detect ambiguity, and turn a resolved selection into the op-id
+// set + display summary the CLI commits. No I/O — the CLI shell owns prompts,
+// printing, and the actual commit call. Kept separate so this logic is testable
+// without faking stdin.
+
+
+/// A resolved item: PackageLocation + ItemKind + display name (FQN).
+type SelectedItem =
+  { location: LanguageTools.ProgramTypes.PackageLocation
+    kind: LanguageTools.ProgramTypes.ItemKind
+    fqn: String }
+
+
+/// A WIP SetName match for a requested name: which item, what kind, its hash.
+type Candidate =
+  { location: LanguageTools.ProgramTypes.PackageLocation
+    kind: LanguageTools.ProgramTypes.ItemKind
+    hash: LanguageTools.ProgramTypes.Hash }
+
+
+/// Every *authored* WIP SetName op binding `fqn`, as candidates (one per op).
+///
+/// Only authored SetNames (`propagationId == None`) are selectable by name —
+/// propagated repoints carry the batch's `propagation_id` and are excluded, so
+/// `--include` can't pick a dependent's rebind out of its batch (which would
+/// commit the rebind while leaving its PropagateUpdate WIP). This also makes
+/// `--include` match what `status` shows, since `getWipItems` excludes
+/// propagated ops too. A repoint still rides along when its *source* is
+/// selected (handled by `collectIncludedPropIds`, not here).
+let candidatesFor
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (fqn: String)
+  : List<Candidate> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | SetName(loc, target) ->
+      if
+        (entry.propagationId == Stdlib.Option.Option.None)
+        && ((SCM.PackageOps.locationToFqn loc) == fqn)
+      then
+        Stdlib.Option.Option.Some(
+          Candidate
+            { location = loc
+              kind = LanguageTools.ProgramTypes.Reference.kind target
+              hash = LanguageTools.ProgramTypes.Reference.hash target }
+        )
+      else
+        Stdlib.Option.Option.None
+    | _ -> Stdlib.Option.Option.None)
+
+
+/// Outcome of resolving one requested --include token.
+type TokenResolution =
+  | Resolved of SelectedItem
+  | NotFound of String
+  // The name matches more than one WIP item. Names are meant to be unique, so
+  // rather than guess (or pick by kind) we fail closed and list the conflicts.
+  | NonUnique of
+    String *
+      List<(LanguageTools.ProgramTypes.ItemKind *
+        LanguageTools.ProgramTypes.Hash)>
+
+
+/// Resolve one requested token (a plain FQN) to a single WIP item. Names are
+/// unique, so a hit is exactly one item; more than one is NonUnique.
+let resolveToken
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (raw: String)
+  : TokenResolution =
+  match candidatesFor wipOps raw with
+  | [] -> TokenResolution.NotFound raw
+  | [ c ] ->
+    TokenResolution.Resolved(
+      SelectedItem { location = c.location; kind = c.kind; fqn = raw }
+    )
+  | cands ->
+    let pairs = cands |> Stdlib.List.map (fun c -> (c.kind, c.hash))
+    TokenResolution.NonUnique(raw, pairs)
+
+
+/// Resolve every requested token. Ok of resolved items, or Error with a
+/// ready-to-print message: non-unique names first, then missing tokens.
+let resolveSelection
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (requestedNames: List<String>)
+  : Stdlib.Result.Result<List<SelectedItem>, String> =
+  let resolutions =
+    requestedNames |> Stdlib.List.map (fun raw -> resolveToken wipOps raw)
+
+  let nonUnique =
+    resolutions
+    |> Stdlib.List.filterMap (fun r ->
+      match r with
+      | NonUnique(fqn, cands) -> Stdlib.Option.Option.Some((fqn, cands))
+      | _ -> Stdlib.Option.Option.None)
+
+  let notFound =
+    resolutions
+    |> Stdlib.List.filterMap (fun r ->
+      match r with
+      | NotFound raw -> Stdlib.Option.Option.Some raw
+      | _ -> Stdlib.Option.Option.None)
+
+  if Stdlib.Bool.not (Stdlib.List.isEmpty nonUnique) then
+    // A name resolving to >1 WIP item — fail closed rather than guess.
+    let blocks =
+      nonUnique
+      |> Stdlib.List.map (fun pair ->
+        let (fqn, cands) = pair
+
+        let rows =
+          cands
+          |> Stdlib.List.map (fun kh ->
+            let (kind, hash) = kh
+            let short = LanguageTools.ProgramTypes.hashToShort hash
+            $"    {itemKindLabel kind}  {fqn}  {short}")
+
+        let head = $"  \"{fqn}\" matches more than one WIP item:"
+        Stdlib.String.join (Stdlib.List.append [ head ] rows) "\n")
+
+    let header =
+      [ "Some --include items match more than one WIP item (names must be"
+        "unique). Nothing was committed:"
+        "" ]
+
+    Stdlib.Result.Result.Error(
+      Stdlib.String.join (Stdlib.List.append header blocks) "\n"
+    )
+  else if Stdlib.Bool.not (Stdlib.List.isEmpty notFound) then
+    let lines = notFound |> Stdlib.List.map (fun n -> $"  - {n}")
+    let header = [ "Some --include items are not in the WIP list:" ]
+    let body = Stdlib.String.join (Stdlib.List.append header lines) "\n"
+
+    Stdlib.Result.Result.Error $"{body}\n\nRun `status` to see WIP items."
+  else
+    let resolved =
+      resolutions
+      |> Stdlib.List.filterMap (fun r ->
+        match r with
+        | Resolved item -> Stdlib.Option.Option.Some item
+        | _ -> Stdlib.Option.Option.None)
+
+    Stdlib.Result.Result.Ok resolved
+
+
+let itemKindLabel (kind: LanguageTools.ProgramTypes.ItemKind) : String =
+  match kind with
+  | Fn -> "fn"
+  | Type -> "type"
+  | Value -> "value"
+
+
+let selectionContains
+  (selection: List<SelectedItem>)
+  (loc: LanguageTools.ProgramTypes.PackageLocation)
+  (kind: LanguageTools.ProgramTypes.ItemKind)
+  : Bool =
+  selection
+  |> Stdlib.List.any (fun item -> item.location == loc && item.kind == kind)
+
+
+// ---------------------------------------------------------------------------
+// Op-selection policy.
+//
+// Given a resolved selection (location + kind), decide exactly which WIP op ids
+// the commit should stamp. This is the item-local op closure — the Add/SetName
+// ops for selected items, the deprecations targeting them, and (optionally) the
+// propagation batches they source. Dependency closure across items is the
+// caller's job (see `uncommittedDepClosure`). Kept here, not in PackageOps, so
+// PackageOps stays a thin DB/builtin wrapper and all commit-selection policy
+// lives in one place.
+// ---------------------------------------------------------------------------
+
+
+/// True iff (loc, kind) appears in `selection`.
+let isSelected
+  (selection:
+    List<(LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  (loc: LanguageTools.ProgramTypes.PackageLocation)
+  (kind: LanguageTools.ProgramTypes.ItemKind)
+  : Bool =
+  Stdlib.List.member_v0 selection (loc, kind)
+
+
+/// Pick the propagation IDs of batches whose source is in the selection.
+let collectIncludedPropIds
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection:
+    List<(LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  : List<Uuid> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | PropagateUpdate(pid, sloc, _, toRef, _) ->
+      let kind = LanguageTools.ProgramTypes.Reference.kind toRef
+
+      if isSelected selection sloc kind then
+        Stdlib.Option.Option.Some pid
+      else
+        Stdlib.Option.Option.None
+    | RevertPropagation(rid, _, sloc, restored, _) ->
+      let kind = LanguageTools.ProgramTypes.Reference.kind restored
+
+      if isSelected selection sloc kind then
+        Stdlib.Option.Option.Some rid
+      else
+        Stdlib.Option.Option.None
+    | _ -> Stdlib.Option.Option.None)
+
+
+let inPropBatch
+  (includedPropIds: List<Uuid>)
+  (propId: Stdlib.Option.Option<Uuid>)
+  : Bool =
+  match propId with
+  | Some p -> Stdlib.List.member_v0 includedPropIds p
+  | None -> false
+
+
+/// Hashes bound by SetName ops that will be in the commit. AddX /
+/// Deprecate / Undeprecate get pulled in when they reference one of these.
+let collectReferencedHashes
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection:
+    List<(LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  (includedPropIds: List<Uuid>)
+  : List<(LanguageTools.ProgramTypes.Hash *
+    LanguageTools.ProgramTypes.ItemKind)> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | SetName(loc, target) ->
+      let kind = LanguageTools.ProgramTypes.Reference.kind target
+
+      if
+        (isSelected selection loc kind)
+        || (inPropBatch includedPropIds entry.propagationId)
+      then
+        let hash = LanguageTools.ProgramTypes.Reference.hash target
+        Stdlib.Option.Option.Some((hash, kind))
+      else
+        Stdlib.Option.Option.None
+    | _ -> Stdlib.Option.Option.None)
+
+
+let referencedHashContains
+  (referencedHashes:
+    List<(LanguageTools.ProgramTypes.Hash *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  (target: LanguageTools.ProgramTypes.Reference)
+  : Bool =
+  let h = LanguageTools.ProgramTypes.Reference.hash target
+  let k = LanguageTools.ProgramTypes.Reference.kind target
+  Stdlib.List.member_v0 referencedHashes (h, k)
+
+
+/// Decide whether one WIP op should be in the partial commit.
+let shouldInclude
+  (selection:
+    List<(LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  (referencedHashes:
+    List<(LanguageTools.ProgramTypes.Hash *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  (includedPropIds: List<Uuid>)
+  (entry: SCM.PackageOps.WipOpEntry)
+  : Bool =
+  if inPropBatch includedPropIds entry.propagationId then
+    true
+  else
+    match entry.op with
+    | AddType t ->
+      Stdlib.List.member_v0
+        referencedHashes
+        (t.hash, LanguageTools.ProgramTypes.ItemKind.Type)
+    | AddValue v ->
+      Stdlib.List.member_v0
+        referencedHashes
+        (v.hash, LanguageTools.ProgramTypes.ItemKind.Value)
+    | AddFn f ->
+      Stdlib.List.member_v0
+        referencedHashes
+        (f.hash, LanguageTools.ProgramTypes.ItemKind.Fn)
+    | SetName(loc, target) ->
+      let k = LanguageTools.ProgramTypes.Reference.kind target
+      isSelected selection loc k
+    | Deprecate(target, _, _) -> referencedHashContains referencedHashes target
+    | Undeprecate target -> referencedHashContains referencedHashes target
+    | PropagateUpdate(_, _, _, _, _) -> false
+    | RevertPropagation(_, _, _, _, _) -> false
+
+
+/// Pick the WIP op IDs for selected items. This includes item-local Add/SetName
+/// ops, matching deprecations, and optional propagation batches. Dependency
+/// closure is handled by the caller.
+let selectOpIdsForItems
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection:
+    List<(LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  (includePropagations: Bool)
+  : List<Uuid> =
+  let includedPropIds =
+    if Stdlib.Bool.not includePropagations then
+      []
+    else
+      collectIncludedPropIds wipOps selection
+
+  let referencedHashes =
+    collectReferencedHashes wipOps selection includedPropIds
+
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    if shouldInclude selection referencedHashes includedPropIds entry then
+      Stdlib.Option.Option.Some entry.id
+    else
+      Stdlib.Option.Option.None)
+
+
+/// Turn a resolved --include selection into the op-id set to commit.
+/// `includePropagations` is the (already-made) decision about whether to pull in
+/// dependent repoint batches.
+let planForSelection
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection: List<SelectedItem>)
+  (includePropagations: Bool)
+  : List<Uuid> =
+  let selectionForBuiltin =
+    selection |> Stdlib.List.map (fun item -> (item.location, item.kind))
+
+  selectOpIdsForItems wipOps selectionForBuiltin includePropagations
+
+
+// ---------------------------------------------------------------------------
+// Downward dependency closure.
+//
+// A `commit --include=…` of item A that references a still-WIP item B publishes
+// a name whose meaning depends on something unpublished. The content resolves
+// (references are by hash), so it's not *broken* — but the committed namespace
+// is incoherent until B is committed too. So before committing we compute the
+// transitive set of WIP-only items the selection references but doesn't include,
+// and let the user pull them in (one prompt, default yes). Declining is allowed
+// — the CLI shell owns that prompt.
+// ---------------------------------------------------------------------------
+
+
+/// An uncommitted item discovered as a dependency of the selection. Carries the
+/// hash so the closure walk can expand it to *its* dependencies in turn.
+type DepItem =
+  { hash: LanguageTools.ProgramTypes.Hash
+    kind: LanguageTools.ProgramTypes.ItemKind
+    location: LanguageTools.ProgramTypes.PackageLocation
+    fqn: String }
+
+
+/// The hash bound by the WIP SetName op for (loc, kind), if any. None means the
+/// item isn't WIP at that kind (e.g. it's already committed).
+///
+/// Only authored SetNames (`propagationId == None`) count — a propagated repoint
+/// must never be surfaced as a standalone dependency, or the closure could
+/// commit it apart from its propagation batch (see `oneLevelDeps`).
+let wipHashForLocation
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (loc: LanguageTools.ProgramTypes.PackageLocation)
+  (kind: LanguageTools.ProgramTypes.ItemKind)
+  : Stdlib.Option.Option<LanguageTools.ProgramTypes.Hash> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | SetName(l, target) ->
+      if
+        (entry.propagationId == Stdlib.Option.Option.None)
+        && (l == loc)
+        && (LanguageTools.ProgramTypes.Reference.kind target == kind)
+      then
+        Stdlib.Option.Option.Some(LanguageTools.ProgramTypes.Reference.hash target)
+      else
+        Stdlib.Option.Option.None
+    | _ -> Stdlib.Option.Option.None)
+  |> Stdlib.List.head
+
+
+/// The location bound by the WIP SetName op for (hash, kind), if any. A match
+/// means that exact version is uncommitted (bound only in the WIP set).
+///
+/// Authored SetNames only (`propagationId == None`): a propagated repoint binds
+/// its hash too, but pulling it in here as a dependency would split it from its
+/// PropagateUpdate batch, leaving a half-committed propagation.
+let wipLocationForHash
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (hash: LanguageTools.ProgramTypes.Hash)
+  (kind: LanguageTools.ProgramTypes.ItemKind)
+  : Stdlib.Option.Option<LanguageTools.ProgramTypes.PackageLocation> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | SetName(loc, target) ->
+      if
+        (entry.propagationId == Stdlib.Option.Option.None)
+        && (LanguageTools.ProgramTypes.Reference.hash target == hash)
+        && (LanguageTools.ProgramTypes.Reference.kind target == kind)
+      then
+        Stdlib.Option.Option.Some loc
+      else
+        Stdlib.Option.Option.None
+    | _ -> Stdlib.Option.Option.None)
+  |> Stdlib.List.head
+
+
+/// The selection itself, as DepItems (the starting frontier for the walk).
+let seedDepItems
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection: List<SelectedItem>)
+  : List<DepItem> =
+  selection
+  |> Stdlib.List.filterMap (fun item ->
+    match wipHashForLocation wipOps item.location item.kind with
+    | Some h ->
+      Stdlib.Option.Option.Some(
+        DepItem
+          { hash = h
+            kind = item.kind
+            location = item.location
+            fqn = item.fqn }
+      )
+    | None -> Stdlib.Option.Option.None)
+
+
+/// One BFS step: the WIP-only items the frontier depends on, excluding anything
+/// already in the selection or already discovered (`seenKeys`).
+let oneLevelDeps
+  (branchId: Uuid)
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection: List<SelectedItem>)
+  (seenKeys:
+    List<(LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  (frontier: List<DepItem>)
+  : List<DepItem> =
+  frontier
+  |> Stdlib.List.map (fun item -> Builtin.scmGetDependencies branchId item.hash)
+  |> Stdlib.List.flatten
+  |> Stdlib.List.unique
+  |> Stdlib.List.filterMap (fun dep ->
+    let (dHash, dKind) = dep
+
+    match wipLocationForHash wipOps dHash dKind with
+    | Some loc ->
+      if
+        (selectionContains selection loc dKind)
+        || (Stdlib.List.member_v0 seenKeys (loc, dKind))
+      then
+        Stdlib.Option.Option.None
+      else
+        Stdlib.Option.Option.Some(
+          DepItem
+            { hash = dHash
+              kind = dKind
+              location = loc
+              fqn = SCM.PackageOps.locationToFqn loc }
+        )
+    | None -> Stdlib.Option.Option.None)
+
+
+/// Walk dependency edges breadth-first, accumulating WIP-only items not in the
+/// selection. Terminates: the WIP set is finite and a key is never revisited.
+let depClosureLoop
+  (branchId: Uuid)
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection: List<SelectedItem>)
+  (frontier: List<DepItem>)
+  (acc: List<DepItem>)
+  : List<DepItem> =
+  match frontier with
+  | [] -> acc
+  | _ ->
+    let accKeys = acc |> Stdlib.List.map (fun d -> (d.location, d.kind))
+    let next = oneLevelDeps branchId wipOps selection accKeys frontier
+
+    if Stdlib.List.isEmpty next then
+      acc
+    else
+      depClosureLoop branchId wipOps selection next (Stdlib.List.append acc next)
+
+
+/// The transitive set of WIP-only items the selection references but does not
+/// include. Empty when the selection is already self-contained.
+let uncommittedDepClosure
+  (branchId: Uuid)
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection: List<SelectedItem>)
+  : List<SelectedItem> =
+  let seed = seedDepItems wipOps selection
+  let deps = depClosureLoop branchId wipOps selection seed []
+
+  deps
+  |> Stdlib.List.map (fun d ->
+    SelectedItem { location = d.location; kind = d.kind; fqn = d.fqn })
+
+
+// ---------------------------------------------------------------------------
+// Commit-contents display.
+//
+// The confirmation shows what will actually be committed, at item granularity,
+// grouped by why each item is included: what you named, what dependency closure
+// pulled in, and the propagated repoints that ride along. Long propagation
+// lists collapse to a count + a few examples so a big ripple isn't a wall of
+// mechanical entries.
+// ---------------------------------------------------------------------------
+
+
+/// An indented "label:" header + one "kind fqn" row per item. [] when empty.
+let groupLines (label: String) (items: List<SelectedItem>) : List<String> =
+  if Stdlib.List.isEmpty items then
+    []
+  else
+    let header = $"  {label}:"
+
+    let rows =
+      items |> Stdlib.List.map (fun i -> $"    {itemKindLabel i.kind} {i.fqn}")
+
+    Stdlib.List.append [ header ] rows
+
+
+/// The propagated-repoint group, collapsed to a count + first few when long.
+let propagationLines (items: List<SelectedItem>) : List<String> =
+  let n = Stdlib.List.length items
+
+  if n == 0L then
+    []
+  else
+    let header = $"  propagated repoints ({Stdlib.Int64.toString n}):"
+    let shown = Stdlib.List.take items 5L
+
+    let rows =
+      shown |> Stdlib.List.map (fun i -> $"    {itemKindLabel i.kind} {i.fqn}")
+
+    let more = n - (Stdlib.List.length shown)
+
+    let tail =
+      if more > 0L then
+        [ $"    ... and {Stdlib.Int64.toString more} more" ]
+      else
+        []
+
+    Stdlib.List.append (Stdlib.List.append [ header ] rows) tail
+
+
+/// A PropagateRepoint rendered as a display item (the repointed dependent).
+let repointToItem
+  (rp: LanguageTools.ProgramTypes.PropagateRepoint)
+  : SelectedItem =
+  SelectedItem
+    { location = rp.location
+      kind = LanguageTools.ProgramTypes.Reference.kind rp.toRef
+      fqn = SCM.PackageOps.locationToFqn rp.location }
+
+
+/// Dependents repointed by propagation batches whose source is in `selection`.
+let propagatedItemsForSelection
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selection: List<SelectedItem>)
+  : List<SelectedItem> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | PropagateUpdate(_, sloc, _, toRef, repoints) ->
+      if
+        selectionContains
+          selection
+          sloc
+          (LanguageTools.ProgramTypes.Reference.kind toRef)
+      then
+        Stdlib.Option.Option.Some repoints
+      else
+        Stdlib.Option.Option.None
+    | RevertPropagation(_, _, sloc, restored, reverted) ->
+      if
+        selectionContains
+          selection
+          sloc
+          (LanguageTools.ProgramTypes.Reference.kind restored)
+      then
+        Stdlib.Option.Option.Some reverted
+      else
+        Stdlib.Option.Option.None
+    | _ -> Stdlib.Option.Option.None)
+  |> Stdlib.List.flatten
+  |> Stdlib.List.map repointToItem
+  |> Stdlib.List.unique
+
+
+/// Every dependent repointed by any propagation batch — for full commits, where
+/// every source is committed so every batch applies.
+let allPropagatedItems
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  : List<SelectedItem> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | PropagateUpdate(_, _, _, _, repoints) -> Stdlib.Option.Option.Some repoints
+    | RevertPropagation(_, _, _, _, reverted) ->
+      Stdlib.Option.Option.Some reverted
+    | _ -> Stdlib.Option.Option.None)
+  |> Stdlib.List.flatten
+  |> Stdlib.List.map repointToItem
+  |> Stdlib.List.unique
+
+
+/// Every authored (SetName) item in the WIP set, as display items.
+///
+/// Authored SetNames only (`propagationId == None`). Propagated repoints are
+/// also SetName ops, but they're shown by `allPropagatedItems` under the
+/// "propagated repoints" group — including them here too would list every
+/// dependent twice in the full-commit confirmation.
+let allWipNamedItems
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  : List<SelectedItem> =
+  wipOps
+  |> Stdlib.List.filterMap (fun entry ->
+    match entry.op with
+    | SetName(loc, target) ->
+      if entry.propagationId == Stdlib.Option.Option.None then
+        Stdlib.Option.Option.Some(
+          SelectedItem
+            { location = loc
+              kind = LanguageTools.ProgramTypes.Reference.kind target
+              fqn = SCM.PackageOps.locationToFqn loc }
+        )
+      else
+        Stdlib.Option.Option.None
+    | _ -> Stdlib.Option.Option.None)
+  |> Stdlib.List.unique
+
+
+/// Deprecate / undeprecate ops as display lines. A standalone deprecation has
+/// no SetName (and no resolvable name yet — see the deferred select-by-name
+/// work), so it's shown by kind + short hash rather than dropped silently.
+let deprecationLines
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  : List<String> =
+  let entries =
+    wipOps
+    |> Stdlib.List.filterMap (fun entry ->
+      match entry.op with
+      | Deprecate(target, _, _) -> Stdlib.Option.Option.Some(("deprecate", target))
+      | Undeprecate target -> Stdlib.Option.Option.Some(("undeprecate", target))
+      | _ -> Stdlib.Option.Option.None)
+
+  if Stdlib.List.isEmpty entries then
+    []
+  else
+    let rows =
+      entries
+      |> Stdlib.List.map (fun pair ->
+        let (verb, target) = pair
+        let short =
+          LanguageTools.ProgramTypes.hashToShort
+            (LanguageTools.ProgramTypes.Reference.hash target)
+        let kind =
+          itemKindLabel (LanguageTools.ProgramTypes.Reference.kind target)
+
+        $"    {verb} {kind} {short}")
+
+    Stdlib.List.append [ "  deprecations:" ] rows
+
+
+/// Confirmation lines for a full commit (no --include): every authored item,
+/// any deprecations, plus the propagated repoints (collapsed).
+let displayLinesForFull
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  : List<String> =
+  let named = allWipNamedItems wipOps
+
+  let itemLines =
+    named |> Stdlib.List.map (fun i -> $"  {itemKindLabel i.kind} {i.fqn}")
+
+  Stdlib.List.append
+    itemLines
+    (Stdlib.List.append
+      (deprecationLines wipOps)
+      (propagationLines (allPropagatedItems wipOps)))
+
+
+/// Deprecate / undeprecate ops pulled into a partial commit because their
+/// target hash belongs to a selected item (`shouldInclude` does this). Shown by
+/// the item's FQN — since these target selected items, the name is known.
+let deprecationLinesForSelection
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (finalSelection: List<SelectedItem>)
+  : List<String> =
+  let selItems = seedDepItems wipOps finalSelection
+
+  let rows =
+    wipOps
+    |> Stdlib.List.filterMap (fun entry ->
+      let verbAndTarget =
+        match entry.op with
+        | Deprecate(target, _, _) -> Stdlib.Option.Option.Some(("deprecate", target))
+        | Undeprecate target ->
+          Stdlib.Option.Option.Some(("undeprecate", target))
+        | _ -> Stdlib.Option.Option.None
+
+      match verbAndTarget with
+      | Some pair ->
+        let (verb, target) = pair
+        let h = LanguageTools.ProgramTypes.Reference.hash target
+        let k = LanguageTools.ProgramTypes.Reference.kind target
+
+        match
+          selItems |> Stdlib.List.findFirst (fun d -> d.hash == h && d.kind == k)
+          with
+        | Some d -> Stdlib.Option.Option.Some $"    {verb} {itemKindLabel k} {d.fqn}"
+        | None -> Stdlib.Option.Option.None
+      | None -> Stdlib.Option.Option.None)
+
+  if Stdlib.List.isEmpty rows then
+    []
+  else
+    Stdlib.List.append [ "  deprecations:" ] rows
+
+
+/// Confirmation lines for a partial commit, grouped by why each item is in:
+/// what you named (`selected`), what closure pulled in (`pulledIn`), the
+/// deprecations carried with selected items, and the propagated repoints.
+let displayLinesForSelection
+  (wipOps: List<SCM.PackageOps.WipOpEntry>)
+  (selected: List<SelectedItem>)
+  (pulledIn: List<SelectedItem>)
+  (finalSelection: List<SelectedItem>)
+  : List<String> =
+  let propagated = propagatedItemsForSelection wipOps finalSelection
+
+  Stdlib.List.append
+    (groupLines "selected" selected)
+    (Stdlib.List.append
+      (groupLines "dependencies (pulled in)" pulledIn)
+      (Stdlib.List.append
+        (deprecationLinesForSelection wipOps finalSelection)
+        (propagationLines propagated)))


### PR DESCRIPTION
This PR 
- Adds the ability to commit a subset of WIP package items by name, instead of committing all WIP at once.
- `commit "msg" --include=Owner.Mod.name[,name2,…]` commits only the named items.
- Resolves names against the WIP set and fails on ambiguous or unknown names.
- Pulls in the ops that belong to each selected item — its Add + SetName, plus any deprecations targeting it
- If a selected item refers to other items that are still WIP, asks whether to include those in the commit too
- Auto-propagated repoints to dependents are always committed with their source item, so a propagation batch stays atomic.

Side finding: re-deprecating an already-deprecated item
When you commit a subset, the package_ops rows are marked by op id, but the rows they derive (locations, deprecations) are marked by content instead, those tables don't track which op created each row. So if two WIP ops produce the same content, you can't commit or discard one without the other.

Example: deprecating the same item twice with a different message or kind: both Deprecate ops share the key (item_hash, kind, "deprecated"), so committing one also stamps the other's row. (Re-deprecating with identical content is harmless, those ops dedup on op id.)

We probably shouldn't allow re-deprecating an already-deprecated item in the first place, but that's separate from this PR and will be handled in a follow-up. It's left as a TODO in Inserts.fs.
