### PR TITLE
Fix package op merge deduplication across branches

### DIFF
--- a/backend/migrations/incremental/20260519_133237_package_ops_composite_pk.sql
+++ b/backend/migrations/incremental/20260519_133237_package_ops_composite_pk.sql
@@ -1,0 +1,27 @@
+-- Ghost-function fix: PK was bare `id` (op content hash), so an
+-- identical op on two branches hashed equal and the second INSERT was
+-- dropped by `INSERT OR IGNORE` — fn invisible everywhere though `fn`
+-- printed `✓ Created`. PK becomes (id, branch_id), so IGNORE only
+-- catches true within-branch repeats.
+
+DROP TABLE package_ops;
+
+CREATE TABLE package_ops (
+  id TEXT NOT NULL,
+  op_blob BLOB NOT NULL,
+  branch_id TEXT NOT NULL REFERENCES branches(id),
+  commit_hash TEXT REFERENCES commits(hash),
+  applied INTEGER NOT NULL DEFAULT 0,
+  propagation_id TEXT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (id, branch_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_package_ops_wip
+  ON package_ops(branch_id) WHERE commit_hash IS NULL;
+CREATE INDEX IF NOT EXISTS idx_package_ops_created ON package_ops(created_at);
+CREATE INDEX IF NOT EXISTS idx_package_ops_applied
+  ON package_ops(applied) WHERE applied = 0;
+CREATE INDEX IF NOT EXISTS idx_package_ops_commit_hash ON package_ops(commit_hash);
+CREATE INDEX IF NOT EXISTS idx_package_ops_propagation_id
+  ON package_ops(propagation_id) WHERE propagation_id IS NOT NULL;

--- a/backend/src/LibDB/BranchOpPlayback.fs
+++ b/backend/src/LibDB/BranchOpPlayback.fs
@@ -90,6 +90,23 @@ let applyOp (op : PT.BranchOp) : Task<unit> =
           ("UPDATE commits SET branch_id = @parent_id WHERE branch_id = @branch_id",
            [ parentParams ])
 
+          // Drop duplicate child ops before moving the remaining rows to the
+          // parent; otherwise the (id, branch_id) PK rejects the UPDATE below.
+          // This preserves program state because the duplicate op content is
+          // identical.
+          //
+          // History caveat: deleting the child row can make getCommitOps miss
+          // that child's commit attribution. The proper fix is to store
+          // commit-to-op attribution separately from package_ops.
+          ("""
+           DELETE FROM package_ops
+           WHERE branch_id = @branch_id
+             AND id IN (
+               SELECT id FROM package_ops WHERE branch_id = @parent_id
+             )
+           """,
+           [ parentParams ])
+
           ("UPDATE package_ops SET branch_id = @parent_id WHERE branch_id = @branch_id",
            [ parentParams ])
 

--- a/backend/src/LibDB/Inserts.fs
+++ b/backend/src/LibDB/Inserts.fs
@@ -112,8 +112,13 @@ let insertAndApplyOps
           let updateStatements =
             insertedOpIds
             |> List.map (fun opId ->
-              let sql = "UPDATE package_ops SET applied = @applied WHERE id = @id"
-              let parameters = [ "applied", Sql.bool true; "id", Sql.uuid opId ]
+              let sql =
+                "UPDATE package_ops SET applied = @applied \
+                 WHERE id = @id AND branch_id = @branch_id"
+              let parameters =
+                [ "applied", Sql.bool true
+                  "id", Sql.uuid opId
+                  "branch_id", Sql.uuid branchId ]
               (sql, [ parameters ]))
 
           let _ = updateStatements |> Sql.executeTransactionSync

--- a/backend/tests/Tests/BranchOps.Tests.fs
+++ b/backend/tests/Tests/BranchOps.Tests.fs
@@ -157,9 +157,53 @@ let testBranchOpsDeserialization =
   }
 
 
+/// Regression: same FQN + same body on two branches used to ghost the
+/// second one. The SetName op is content-addressed, and with a bare
+/// `id` PK on package_ops, the second branch's identical SetName
+/// collided on insert (INSERT OR IGNORE silently dropped it). Result:
+/// no `locations` row on branch B, so view/search/tree/eval all act
+/// like the fn doesn't exist while `fn` still claimed `✓ Created`.
+let testGhostFunctionCrossBranch =
+  testTask "package ops: same fn on two branches is visible on both" {
+    let fn = makeFn (eVar "x")
+    let location = loc "ghost-cross-branch"
+    let ops =
+      [ PT.PackageOp.AddFn fn; PT.PackageOp.SetName(location, PT.PackageFn fn.hash) ]
+
+    let! (branchA : PT.Branch) = Branches.create "ghost-test-A" PT.mainBranchId
+    let! (_ : int64) = Inserts.insertAndApplyOpsAsWip branchA.id ops
+
+    let! (branchB : PT.Branch) = Branches.create "ghost-test-B" PT.mainBranchId
+    let! (_ : int64) = Inserts.insertAndApplyOpsAsWip branchB.id ops
+
+    let countLocationsFor (branchId : PT.BranchId) : Task<int64> =
+      Sql.query
+        """
+        SELECT COUNT(*) as cnt FROM locations
+        WHERE branch_id = @branch_id
+          AND owner = @owner AND modules = @modules AND name = @name
+        """
+      |> Sql.parameters
+        [ "branch_id", Sql.uuid branchId
+          "owner", Sql.string location.owner
+          "modules", Sql.string (String.concat "." location.modules)
+          "name", Sql.string location.name ]
+      |> Sql.executeRowAsync (fun read -> read.int64 "cnt")
+
+    let! locA = countLocationsFor branchA.id
+    let! locB = countLocationsFor branchB.id
+    Expect.equal locA 1L "branch A should have 1 location row"
+    Expect.equal
+      locB
+      1L
+      "branch B should have 1 location row (ghost-function regression)"
+  }
+
+
 let tests =
   testList
     "BranchOps"
     [ testBranchOpsEmitted
       testBranchOpsSerialization
-      testBranchOpsDeserialization ]
+      testBranchOpsDeserialization
+      testGhostFunctionCrossBranch ]


### PR DESCRIPTION
This PR Fixes branch isolation for identical package ops. 

`package_ops.id` is a content hash, so two branches can create the same op id. The old primary key only used `id`, which meant the second branch's `INSERT OR IGNORE` could be skipped even though it was a different branch.

This changes the primary key to `(id, branch_id)`, so duplicate ops are only ignored within the same branch. On merge, duplicate child ops are dropped before moving the rest to the parent branch, preserving the final program state.

TODO
After a merge, the final package state is correct, but the history can still be incomplete. If we delete a duplicate op row from the child branch, we can also lose the record that says the child commit included that op.
The proper fix is to track commit history separately from `package_ops`.
