### PR TITLE
Fix concurrent ephemeral-blob loss

### DIFF
--- a/backend/src/Builtins/Builtins.Cli/Libs/File.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/File.fs
@@ -48,7 +48,7 @@ let fns () : List<BuiltInFn> =
         let resultOk = Dval.resultOk KTBlob errType
         let resultError = Dval.resultError KTBlob errType
         (function
-        | state, _, _, [ DString path ] ->
+        | _, _, _, [ DString path ] ->
           uply {
             try
               let path =
@@ -58,7 +58,7 @@ let fns () : List<BuiltInFn> =
                 )
 
               let! contents = System.IO.File.ReadAllBytesAsync path
-              return resultOk (Blob.newEphemeral state contents)
+              return resultOk (Blob.newEphemeral contents)
             with e ->
               return resultError (FileError.fromException e)
           }

--- a/backend/src/Builtins/Builtins.Cli/Libs/Posix.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Posix.fs
@@ -915,11 +915,11 @@ let fns () : List<BuiltInFn> =
         "Reads up to count bytes from a file descriptor into an ephemeral Blob."
       fn =
         (function
-        | state, _, _, [ DInt64 fd; DInt64 count ] ->
+        | _, _, _, [ DInt64 fd; DInt64 count ] ->
           let resultOk = Dval.resultOk KTBlob (posixErrorKT ())
           let resultError = Dval.resultError KTBlob (posixErrorKT ())
           match Libc.fdRead (int fd) (int count) with
-          | Ok bytes -> resultOk (Blob.newEphemeral state bytes) |> Ply
+          | Ok bytes -> resultOk (Blob.newEphemeral bytes) |> Ply
           | Error e -> resultError (dPosixError e) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
+++ b/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
@@ -737,7 +737,7 @@ let fns (config : Configuration) : List<BuiltInFn> =
                     let fields =
                       [ ("statusCode", DInt64(int64 response.statusCode))
                         ("headers", responseHeaders)
-                        ("body", Blob.newEphemeral state response.body) ]
+                        ("body", Blob.newEphemeral response.body) ]
 
                     return Ok(DRecord(typ, typ, [], Map fields) |> resultOk)
 

--- a/backend/src/Builtins/Builtins.Http.Server/Http.fs
+++ b/backend/src/Builtins/Builtins.Http.Server/Http.fs
@@ -24,7 +24,6 @@ module Request =
   let typ = RT.FQTypeName.fqPackage (PackageRefs.Type.Stdlib.Http.request ())
 
   let fromRequest
-    (state : RT.ExecutionState)
     (uri : string)
     (headers : List<string * string>)
     (body : byte array)
@@ -38,9 +37,7 @@ module Request =
       |> Dval.list headerType
 
     let fields =
-      [ "body", Blob.newEphemeral state body
-        "headers", headers
-        "url", RT.DString uri ]
+      [ "body", Blob.newEphemeral body; "headers", headers; "url", RT.DString uri ]
     RT.DRecord(typ, typ, [], Map fields)
 
 

--- a/backend/src/Builtins/Builtins.Http.Server/Libs/HttpServer.fs
+++ b/backend/src/Builtins/Builtins.Http.Server/Libs/HttpServer.fs
@@ -14,7 +14,6 @@ open LibExecution.Builtin.Shortcuts
 
 module Dval = LibExecution.Dval
 module Execution = LibExecution.Execution
-module Blob = LibExecution.Blob
 module Http = Builtins.Http.Server.Http
 module AT = LibExecution.AnalysisTypes
 module Tracing = LibDB.Tracing
@@ -169,10 +168,8 @@ let private handleRequest
   : Task<unit> =
   task {
     let started = System.DateTime.UtcNow
-    // Per-request blob scope: ephemeral blobs minted by the handler get
-    // reclaimed when the response is sent. Prevents long-lived servers from
-    // leaking blobStore entries.
-    Blob.pushScope exeState
+    // Ephemeral blobs carry their bytes inline (lifetime is GC), so there's no
+    // shared blob store for concurrent requests to race over.
     try
       try
         let! bodyResult = readRequestBodyWithLimit ctx.Request maxBodyBytes
@@ -191,7 +188,7 @@ let private handleRequest
             else
               rawUrl
 
-          let requestDval = Http.Request.fromRequest exeState url reqHeaders reqBody
+          let requestDval = Http.Request.fromRequest url reqHeaders reqBody
 
           // Per-request tracer — same shape as `eval`/`run` so HTTP traces
           // appear alongside CLI traces with no consumer-side changes.
@@ -232,7 +229,6 @@ let private handleRequest
         ctx.Response.ContentLength64 <- int64 errorBytes.Length
         do! ctx.Response.OutputStream.WriteAsync(errorBytes, 0, errorBytes.Length)
     finally
-      Blob.popScope exeState
       if logRequests then
         try
           logRequest ctx ctx.Response.StatusCode started

--- a/backend/src/Builtins/Builtins.Pure/Libs/Base64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Base64.fs
@@ -26,7 +26,7 @@ let fns () : List<BuiltInFn> =
         let resultOk r = Dval.resultOk KTBlob KTString r |> Ply
         let resultError r = Dval.resultError KTBlob KTString r |> Ply
         (function
-        | state, _, _, [ DString s ] ->
+        | _, _, _, [ DString s ] ->
           let base64FromUrlEncoded (str : string) : string =
             let initial = str.Replace('-', '+').Replace('_', '/')
             let length = initial.Length
@@ -36,7 +36,7 @@ let fns () : List<BuiltInFn> =
             else initial
 
           if s = "" then
-            resultOk (Blob.newEphemeral state [||])
+            resultOk (Blob.newEphemeral [||])
           elif Regex.IsMatch(s, @"\s") then
             // dotnet ignores whitespace but we don't allow it
             resultError (DString "Not a valid base64 string")
@@ -44,7 +44,7 @@ let fns () : List<BuiltInFn> =
             try
               let bytes =
                 s |> base64FromUrlEncoded |> System.Convert.FromBase64String
-              resultOk (Blob.newEphemeral state bytes)
+              resultOk (Blob.newEphemeral bytes)
             with _ ->
               resultError (DString "Not a valid base64 string")
         | _ -> incorrectArgs ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Blob.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Blob.fs
@@ -39,9 +39,9 @@ let fns () : List<BuiltInFn> =
       description = "Encodes <param s> as UTF-8 bytes in a fresh ephemeral Blob."
       fn =
         (function
-        | state, _, _, [ DString s ] ->
+        | _, _, _, [ DString s ] ->
           let bs = System.Text.Encoding.UTF8.GetBytes(s)
-          Blob.newEphemeral state bs |> Ply
+          Blob.newEphemeral bs |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -103,10 +103,10 @@ let fns () : List<BuiltInFn> =
         let ok b = Dval.resultOk KTBlob KTString b
         let err s = Dval.resultError KTBlob KTString (DString s)
         (function
-        | state, _, _, [ DString s ] ->
+        | _, _, _, [ DString s ] ->
           try
             let bs = System.Convert.FromHexString(s)
-            ok (Blob.newEphemeral state bs) |> Ply
+            ok (Blob.newEphemeral bs) |> Ply
           with e ->
             err $"Invalid hex string: {e.Message}" |> Ply
         | _ -> incorrectArgs ())
@@ -144,7 +144,7 @@ let fns () : List<BuiltInFn> =
         let ok b = Dval.resultOk KTBlob KTString b
         let err s = Dval.resultError KTBlob KTString (DString s)
         (function
-        | state, _, _, [ DString s ] ->
+        | _, _, _, [ DString s ] ->
           let normalized =
             // Accept URL-safe alphabet + optional padding — matches
             // the old base64Decode behaviour.
@@ -155,7 +155,7 @@ let fns () : List<BuiltInFn> =
             | _ -> base0
           try
             let bs = System.Convert.FromBase64String(normalized)
-            ok (Blob.newEphemeral state bs) |> Ply
+            ok (Blob.newEphemeral bs) |> Ply
           with e ->
             err $"Invalid base64 string: {e.Message}" |> Ply
         | _ -> incorrectArgs ())
@@ -185,7 +185,7 @@ let fns () : List<BuiltInFn> =
                   Exception.raiseInternal
                     "blobConcat: expected DBlob"
                     [ "item", item ]
-            return Blob.newEphemeral state (collected.ToArray())
+            return Blob.newEphemeral (collected.ToArray())
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -217,7 +217,7 @@ let fns () : List<BuiltInFn> =
             let slice = Array.zeroCreate<byte> (int safeLen)
             if safeLen > 0L then
               System.Array.Copy(bs, int safeStart, slice, 0, int safeLen)
-            return Blob.newEphemeral state slice
+            return Blob.newEphemeral slice
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -252,9 +252,9 @@ let fns () : List<BuiltInFn> =
         "Collects a List<UInt8> into a fresh ephemeral Blob. Escape hatch for bridging old and new code."
       fn =
         (function
-        | state, _, _, [ DList(_, items) ] ->
+        | _, _, _, [ DList(_, items) ] ->
           let bs = Dval.dlistToByteArray items
-          Blob.newEphemeral state bs |> Ply
+          Blob.newEphemeral bs |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/Builtins/Builtins.Pure/Libs/Crypto.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Crypto.fs
@@ -28,7 +28,7 @@ let fns () : List<BuiltInFn> =
           uply {
             let! data = Blob.readBytes state ref
             let hash = SHA256.HashData(System.ReadOnlySpan(data))
-            return Blob.newEphemeral state hash
+            return Blob.newEphemeral hash
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -47,7 +47,7 @@ let fns () : List<BuiltInFn> =
           uply {
             let! data = Blob.readBytes state ref
             let hash = SHA384.HashData(System.ReadOnlySpan data)
-            return Blob.newEphemeral state hash
+            return Blob.newEphemeral hash
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -67,7 +67,7 @@ let fns () : List<BuiltInFn> =
           uply {
             let! data = Blob.readBytes state ref
             let hash = MD5.HashData(System.ReadOnlySpan data)
-            return Blob.newEphemeral state hash
+            return Blob.newEphemeral hash
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -89,7 +89,7 @@ let fns () : List<BuiltInFn> =
             let! data = Blob.readBytes state dataRef
             use hmac = new HMACSHA256(key)
             let hash = hmac.ComputeHash(data)
-            return Blob.newEphemeral state hash
+            return Blob.newEphemeral hash
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -111,7 +111,7 @@ let fns () : List<BuiltInFn> =
             let! data = Blob.readBytes state dataRef
             use hmac = new HMACSHA1(key)
             let hash = hmac.ComputeHash(data)
-            return Blob.newEphemeral state hash
+            return Blob.newEphemeral hash
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented

--- a/backend/src/Builtins/Builtins.Pure/Libs/List.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/List.fs
@@ -95,7 +95,7 @@ module DvalComparator =
       // persistent refs, UUID for ephemeral, to keep sort stable.
       match a, b with
       | Persistent(h1, _), Persistent(h2, _) -> order h1 h2
-      | Ephemeral id1, Ephemeral id2 -> order id1 id2
+      | Ephemeral e1, Ephemeral e2 -> order e1.id e2.id
       | Persistent _, Ephemeral _ -> Less
       | Ephemeral _, Persistent _ -> Greater
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
@@ -121,7 +121,7 @@ let rec equals (a : Dval) (b : Dval) : bool =
     // want byte-equality.
     match refA, refB with
     | Persistent(h1, l1), Persistent(h2, l2) -> h1 = h2 && l1 = l2
-    | Ephemeral id1, Ephemeral id2 -> id1 = id2
+    | Ephemeral e1, Ephemeral e2 -> e1.id = e2.id
     | _ -> false
 
   | DStream(_, _, lockA), DStream(_, _, lockB) ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Stream.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Stream.fs
@@ -208,7 +208,7 @@ let fns () : List<BuiltInFn> =
         "Drains a byte stream into a single ephemeral Blob, consuming <param stream>."
       fn =
         (function
-        | state, _, _, [ s ] ->
+        | _, _, _, [ s ] ->
           uply {
             // Drain via `readStreamChunk` so IO-backed byte streams
             // (HttpClient.stream) hand back a whole buffer per pull
@@ -223,7 +223,7 @@ let fns () : List<BuiltInFn> =
               match chunk with
               | Some buf -> collected.Write(buf, 0, buf.Length)
               | None -> keepGoing <- false
-            return Blob.newEphemeral state (collected.ToArray())
+            return Blob.newEphemeral (collected.ToArray())
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented

--- a/backend/src/Builtins/Builtins.Pure/Libs/String.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/String.fs
@@ -361,9 +361,9 @@ let fns () : List<BuiltInFn> =
       description = "Converts the given unicode string to a UTF8-encoded Blob."
       fn =
         (function
-        | state, _, _, [ DString str ] ->
+        | _, _, _, [ DString str ] ->
           let theBytes = System.Text.Encoding.UTF8.GetBytes str
-          Blob.newEphemeral state theBytes |> Ply
+          Blob.newEphemeral theBytes |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/LibDB/Seed.fs
+++ b/backend/src/LibDB/Seed.fs
@@ -318,7 +318,7 @@ let evaluateAllValues
               // persistent so we can serialize. Streams remain
               // non-persistable and trip the [isPersistable] guard
               // below with a clear error.
-              let! dval = LibExecution.Blob.promote exeState pm.persistBlob dval
+              let! dval = LibExecution.Blob.promote pm.persistBlob dval
 
               if not (LibExecution.Dval.isPersistable dval) then
                 let reason =

--- a/backend/src/LibDB/Tracing.fs
+++ b/backend/src/LibDB/Tracing.fs
@@ -431,11 +431,7 @@ let prepareDvalForStorage
   (exeState : RT.ExecutionState)
   (dv : RT.Dval)
   : Ply.Ply<RT.Dval> =
-  let promoteBlob =
-    Blob.promoteEphemeralLeaf
-      exeState
-      exeState.blobs.persist
-      "Ephemeral blob not found in store during trace preparation"
+  let promoteBlob = Blob.promoteEphemeralLeaf exeState.blobs.persist
   dv
   |> RT.Dval.rewriteWith (fun dv ->
     uply {

--- a/backend/src/LibExecution/Blob.fs
+++ b/backend/src/LibExecution/Blob.fs
@@ -1,10 +1,10 @@
 /// Runtime helpers for the `Blob` Dval type.
 ///
-/// `Blob`s carry a `BlobRef` pointing at byte content held either
-/// in-process (Ephemeral) or in the content-addressed `package_blobs`
-/// table (Persistent). This module owns the byte-store mechanics
-/// (mint, read, scope-based reclaim) and the leaf logic for
-/// ephemeral-to-persistent promotion ([promoteEphemeralLeaf]).
+/// `Blob`s carry a `BlobRef`: ephemeral blobs hold their bytes inline
+/// (lifetime is GC), persistent blobs hold a content hash backed by the
+/// content-addressed `package_blobs` table. This module owns minting,
+/// reading, and the leaf logic for ephemeral-to-persistent promotion
+/// ([promoteEphemeralLeaf]).
 ///
 /// Promotion runs at every persistence boundary; structural recursion
 /// over the surrounding Dval shape is delegated to [Dval.rewriteWith] in
@@ -38,58 +38,28 @@ let sha256Hex (bytes : byte[]) : string =
   System.Convert.ToHexStringLower(digest)
 
 
-/// Mint a fresh ephemeral blob: register the bytes in the exeState's
-/// blob store and return a DBlob that references them. Caller retains
-/// no direct handle on the byte[] past this point.
+/// Mint a fresh ephemeral blob holding [bytes] inline. Each mint gets a
+/// fresh identity (`id`), so two ephemerals with the same bytes are
+/// distinct values; the bytes are reachable only through the returned
+/// Dval, so GC reclaims them when it's collected. No store, no scope,
+/// and so no ExecutionState — minting needs no execution context.
 ///
-/// If a blob-scope is active (see [pushScope]), the new UUID is
-/// recorded in the top scope so [popScope] can reclaim the bytes
-/// when the scope exits. Runs without an active scope (CLI, tests)
-/// leave the bytes in the ExecutionState for its full lifetime.
-let newEphemeral (exeState : ExecutionState) (bytes : byte[]) : Dval =
-  let id = System.Guid.NewGuid()
-  exeState.blobStore[id] <- bytes
-  if exeState.blobScopes.Count > 0 then
-    exeState.blobScopes.Peek().Add(id) |> ignore<bool>
-  DBlob(Ephemeral id)
+/// Takes ownership of [bytes]: the array is stored as-is (not copied),
+/// so the caller must not mutate it afterwards.
+let newEphemeral (bytes : byte[]) : Dval =
+  DBlob(Ephemeral { id = System.Guid.NewGuid(); bytes = bytes })
 
 
-/// Push a fresh, empty blob-scope onto the stack. Each subsequent
-/// [newEphemeral] records its UUID in this scope until it's popped.
-/// Used by long-lived VMs (http-server) around per-handler work so
-/// ephemeral blobs don't accumulate across requests.
-let pushScope (exeState : ExecutionState) : unit =
-  exeState.blobScopes.Push(System.Collections.Generic.HashSet<System.Guid>())
-
-
-/// Pop the top blob-scope: drop every UUID it tracked from
-/// `blobStore`. Safe to call without a push (no-op on empty stack).
-/// Caller should wrap `pushScope` / `popScope` in a `try/finally` so
-/// failures don't leak blob bytes.
-///
-/// Blobs promoted to `Persistent` inside this scope are unaffected —
-/// promotion writes to `package_blobs` (a separate durable table)
-/// and the DBlob reference swaps to `Persistent`. We only drop the
-/// in-memory ephemeral byte cache.
-let popScope (exeState : ExecutionState) : unit =
-  if exeState.blobScopes.Count > 0 then
-    let scope = exeState.blobScopes.Pop()
-    for id in scope do
-      exeState.blobStore.TryRemove(id) |> ignore<bool * byte[]>
-
-
-/// Resolve a BlobRef to its bytes. Ephemerals read from the VM store;
+/// Resolve a BlobRef to its bytes. Ephemerals carry their bytes inline;
 /// persistent refs hit package_blobs via the ExecutionState's blob
 /// accessor. Shared by every builtin that dereferences a DBlob.
+///
+/// For ephemerals this returns the blob's own array, not a copy — treat
+/// the result as read-only; mutating it mutates the blob.
 let readBytes (state : ExecutionState) (ref : BlobRef) : Ply.Ply<byte[]> =
   uply {
     match ref with
-    | Ephemeral id ->
-      let mutable bs : byte[] = null
-      if state.blobStore.TryGetValue(id, &bs) then
-        return bs
-      else
-        return Exception.raiseInternal "ephemeral blob not found" [ "id", id ]
+    | Ephemeral eph -> return eph.bytes
     | Persistent(hash, _length) when hash = emptyHash -> return [||]
     | Persistent(hash, _length) ->
       let! got = state.blobs.get hash
@@ -104,29 +74,22 @@ let readBytes (state : ExecutionState) (ref : BlobRef) : Ply.Ply<byte[]> =
 
 
 /// [Dval.rewriteWith] leaf handler that promotes a `DBlob(Ephemeral _)`:
-/// look up bytes in `exeState.blobStore`, hash them, persist via
-/// [insert], and return `Some(DBlob(Persistent _))`. Returns `None`
-/// for anything else so the walker keeps descending. Raises with
-/// [errorContext] if the ephemeral UUID has no entry in the store —
-/// either the scope was popped early or the Dval is from a different
-/// VM.
+/// hash the inline bytes, persist them via [insert], and return
+/// `Some(DBlob(Persistent _))`. Returns `None` for anything else so the
+/// walker keeps descending. Can't fail to find bytes — they travel with
+/// the value.
 let promoteEphemeralLeaf
-  (exeState : ExecutionState)
   (insert : string -> byte[] -> Ply.Ply<unit>)
-  (errorContext : string)
   (dv : Dval)
   : Ply.Ply<Dval option> =
   uply {
     match dv with
-    | DBlob(Ephemeral id) ->
-      let mutable bs : byte[] = null
-      if exeState.blobStore.TryGetValue(id, &bs) then
-        let h = sha256Hex bs
-        let n : int64 = System.Convert.ToInt64 bs.Length
-        do! insert h bs
-        return Some(DBlob(Persistent(h, n)))
-      else
-        return Exception.raiseInternal errorContext [ "id", id ]
+    | DBlob(Ephemeral eph) ->
+      let bs = eph.bytes
+      let h = sha256Hex bs
+      let n : int64 = System.Convert.ToInt64 bs.Length
+      do! insert h bs
+      return Some(DBlob(Persistent(h, n)))
     | _ -> return None
   }
 
@@ -149,14 +112,7 @@ let promoteEphemeralLeaf
 /// here. A lambda closing over an ephemeral blob has its capture
 /// environment promoted along with the rest of the value graph.
 let promote
-  (exeState : ExecutionState)
   (insert : string -> byte[] -> Ply.Ply<unit>)
   (dv : Dval)
   : Ply.Ply<Dval> =
-  dv
-  |> Dval.rewriteWith (
-    promoteEphemeralLeaf
-      exeState
-      insert
-      "Ephemeral blob not found in store during promotion"
-  )
+  dv |> Dval.rewriteWith (promoteEphemeralLeaf insert)

--- a/backend/src/LibExecution/Dval.fs
+++ b/backend/src/LibExecution/Dval.fs
@@ -92,7 +92,7 @@ let result
 ///
 /// Rejected:
 /// - `DStream` — the pull fn is a closure bound to this exeState.
-/// - `DBlob(Ephemeral _)` — the raw bytes live in exeState.blobStore;
+/// - `DBlob(Ephemeral _)` — the bytes are VM-local (inline, GC-bound);
 ///   promote to `Persistent` first. Most call paths already promote
 ///   (see `Blob.promote` for the val-commit / DB-write path and
 ///   `LibDB.Tracing.prepareDvalForStorage` for the trace path); this

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -54,15 +54,6 @@ let createState
 
     allowHarmful = false
 
-    blobStore =
-      new System.Collections.Concurrent.ConcurrentDictionary<System.Guid, byte[]>()
-
-    // No active scope by default. HttpServer (and anything else with a
-    // request/handler lifecycle) pushes one per invocation so ephemeral
-    // blob bytes don't leak across requests.
-    blobScopes =
-      new System.Collections.Generic.Stack<System.Collections.Generic.HashSet<System.Guid>>()
-
     accountID = None }
 
 

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -365,13 +365,26 @@ type StringSegment =
 /// not byte equality. `Blob.newEphemeral` mints a fresh id and takes
 /// ownership of the byte array, which callers must treat as immutable.
 ///
-/// CLEANUP: this is a plain public record, so those invariants are by
-/// convention: callers can construct records directly, F# record equality
-/// still compares `bytes`, and `bytes` can be mutated if a caller keeps
-/// or receives the array. For example, hand-built blobs can reuse an `id`,
-/// F# `=` can disagree with Dark equality by comparing bytes, and a caller
-/// can mutate the array after `Blob.newEphemeral` stores it.
-type EphemeralBlob = { id : uuid; bytes : byte[] }
+/// Custom `Equals`/`GetHashCode` key on `id`, so F# `=` (reachable on any
+/// Dval containing a blob) agrees with Dark equality and hashing never
+/// scans the byte array. `NoComparison` is required alongside
+/// `CustomEquality`; it costs nothing here, since F# structural comparison
+/// of blobs is never used — Dark ordering is hand-coded in `List.compareDval`
+/// (by `id`) and Dval itself is already `NoComparison`.
+///
+/// CLEANUP: `bytes` can still be mutated if a caller keeps or receives the
+/// array, and a hand-built record can reuse an `id`. Both are by
+/// convention — not reachable from Dark, only from future internal code.
+[<CustomEquality; NoComparison>]
+type EphemeralBlob =
+  { id : uuid
+    bytes : byte[] }
+
+  override this.Equals(o : obj) : bool =
+    match o with
+    | :? EphemeralBlob as other -> this.id = other.id
+    | _ -> false
+  override this.GetHashCode() : int = this.id.GetHashCode()
 
 /// Where the bytes of a DBlob live. Ephemeral refs carry their bytes
 /// inline ([EphemeralBlob]); persistent refs hold a content hash and

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -354,9 +354,29 @@ type StringSegment =
   | Interpolated of Register
 
 
-/// Where the bytes of a DBlob actually live. Ephemeral refs resolve
-/// via [ExecutionState.blobStore]; persistent refs resolve via the
-/// package manager's `blobs` lookup.
+/// In-process blob whose bytes live directly on the Dval.
+///
+/// This deliberately avoids any current-scope or external ephemeral-blob
+/// store lookup: if the Dval is reachable, the bytes are reachable; when
+/// the Dval is collected, the bytes can be collected too.
+///
+/// `id` is the blob's runtime identity. Dark equality and ordering for
+/// ephemeral blobs use this id (`NoModule.equals`, `List.compareDval`),
+/// not byte equality. `Blob.newEphemeral` mints a fresh id and takes
+/// ownership of the byte array, which callers must treat as immutable.
+///
+/// CLEANUP: this is a plain public record, so those invariants are by
+/// convention: callers can construct records directly, F# record equality
+/// still compares `bytes`, and `bytes` can be mutated if a caller keeps
+/// or receives the array. For example, hand-built blobs can reuse an `id`,
+/// F# `=` can disagree with Dark equality by comparing bytes, and a caller
+/// can mutate the array after `Blob.newEphemeral` stores it.
+type EphemeralBlob = { id : uuid; bytes : byte[] }
+
+/// Where the bytes of a DBlob live. Ephemeral refs carry their bytes
+/// inline ([EphemeralBlob]); persistent refs hold a content hash and
+/// resolve via the package manager's `blobs` lookup against
+/// `package_blobs`.
 ///
 /// TODO BEAM-style sub-blob sharing: add
 ///   `| Subblob of parent: BlobRef * offset: int64 * length: int64`
@@ -365,7 +385,7 @@ type StringSegment =
 /// (default) or the parent. Skip until a profile shows slice-copy is
 /// hot — neither phase-1 nor phase-2 measurements flagged it.
 type BlobRef =
-  | Ephemeral of uuid
+  | Ephemeral of EphemeralBlob
   | Persistent of hash : string * length : int64
 
 
@@ -644,9 +664,10 @@ and [<NoComparison>] Dval =
   // References
   | DDB of name : string
 
-  /// Immutable byte sequence. The Dval holds a small reference (UUID
-  /// or hash); the bytes live in the per-ExecutionState ephemeral
-  /// store or in `package_blobs`.
+  /// Byte sequence, immutable by convention. Ephemeral blobs carry their
+  /// bytes inline (lifetime is GC); `Blob.readBytes` returns the array to
+  /// in-engine consumers, which treat it as read-only. Persistent blobs
+  /// hold a content hash and resolve via `package_blobs`. See [BlobRef].
   | DBlob of BlobRef
 
   /// Lazy, single-consumer, non-persistable sequence. The inner
@@ -1837,46 +1858,12 @@ and ExecutionState =
     types : Types
     fns : Functions
     values : Values
-    blobs : Blobs
 
-    /// Escape hatch for `Harmful`-marked fns: when true, the interpreter
-    /// still sees `fns.isHarmful` return true, but proceeds anyway (and
-    /// can still `notify` for observability). Tests, sandboxes, security
-    /// research set this; `run --allow-harmful` / `eval --allow-harmful`
-    /// toggle it for one-offs.
-    allowHarmful : bool
-
-    /// Per-execution ephemeral byte-store for `DBlob(Ephemeral _)`
-    /// references. Populated by IO builtins (fileRead, HttpClient.body,
-    /// etc.). Bytes live until the ExecutionState is discarded or
-    /// until the enclosing blob-scope pops (see [blobScopes] below).
-    blobStore :
-      System.Collections.Concurrent.ConcurrentDictionary<System.Guid, byte[]>
-
-    /// Stack of blob-scopes. Each scope tracks the set of ephemeral
-    /// blob UUIDs minted inside it so they can be dropped from
-    /// [blobStore] when the scope pops. Long-lived VMs (http-server)
-    /// push a fresh scope per handler invocation so blob bytes are
-    /// reclaimed promptly rather than accumulating for the life of
-    /// the VM. CLI runs typically don't push a scope — blobs live
-    /// for the length of the process, which is fine.
+    /// Content-addressed persistent blob store (`package_blobs`).
+    /// Ephemeral blobs carry their bytes inline and need no store;
+    /// promotion (see `Blob.promote`) writes them here.
     ///
-    /// Blobs promoted to `Persistent` before a scope pops remain
-    /// resolvable via `package_blobs` — we only drop the in-memory
-    /// byte-store entry, never the content-addressed row.
-    ///
-    /// Known limits not addressed here:
-    ///   - Within a single scope, ephemeral bytes accumulate until
-    ///     pop. A handler that pulls many large files or HTTP bodies
-    ///     can still balloon one request's footprint; no per-scope
-    ///     byte budget or backpressure enforces a ceiling.
-    ///     TODO config-driven byte-budget on `newEphemeralBlob`, raise
-    ///     on overflow. Eviction breaks identity once a UUID is gone,
-    ///     so raise-on-overflow is the only safe option.
-    ///   - No explicit eviction for ephemerals that outlive their
-    ///     usefulness within a scope (e.g. a byte[] built, read once,
-    ///     then logically dead): they sit in `blobStore` until the
-    ///     scope pops.
+    /// Orphan reclaim TODOs (persistent blobs only):
     ///   - `package_blobs` orphan reclaim runs via the `pm-sweep-blobs`
     ///     CLI command, which scans `package_values.rt_dval` only —
     ///     `trace_data` and User DB rows don't hold blob refs today,
@@ -1887,7 +1874,14 @@ and ExecutionState =
     ///   - No reverse-index table (`package_blob_refs`) — the sweep
     ///     is O(N+M). Fine at current scale; revisit at higher
     ///     package counts.
-    blobScopes : Stack<HashSet<System.Guid>>
+    blobs : Blobs
+
+    /// Escape hatch for `Harmful`-marked fns: when true, the interpreter
+    /// still sees `fns.isHarmful` return true, but proceeds anyway (and
+    /// can still `notify` for observability). Tests, sandboxes, security
+    /// research set this; `run --allow-harmful` / `eval --allow-harmful`
+    /// toggle it for one-offs.
+    allowHarmful : bool
 
     /// The account this run is attributed to (the developer behind a
     /// commit / script run / handler invocation). `None` means

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -718,7 +718,11 @@ module Dval =
 
     | DDB name -> mk "DDB" [ DString name ]
 
-    | DBlob(Ephemeral id) -> mk "DBlobEphemeral" [ DUuid id ]
+    // Inspectable but not round-trippable. The DT form carries only the
+    // runtime id; the inline bytes stay on the original DBlob value.
+    // `fromDT` raises on this case rather than rebuilding a blob that
+    // cannot be read.
+    | DBlob(Ephemeral eph) -> mk "DBlobEphemeral" [ DUuid eph.id ]
     | DBlob(Persistent(hash, length)) ->
       mk "DBlobPersistent" [ DString hash; DInt64 length ]
 
@@ -791,7 +795,15 @@ module Dval =
 
     | DEnum(_, _, [], "DDB", [ DString name ]) -> DDB name
 
-    | DEnum(_, _, [], "DBlobEphemeral", [ DUuid id ]) -> DBlob(Ephemeral id)
+    | DEnum(_, _, [], "DBlobEphemeral", [ DUuid _ ]) ->
+      // Reflected ephemeral blobs are inspectable but not round-trippable.
+      // The DT form carries only the runtime id; the inline bytes remain on
+      // the original DBlob value. Rebuilding from this would create a blob
+      // that cannot be read, so callers must promote to Persistent before
+      // any DT round-trip.
+      Exception.raiseInternal
+        "Cannot rebuild an ephemeral blob from its reflected form; it contains only the blob id, not the bytes. Values that need to round-trip through DT must be promoted to Persistent first."
+        []
     | DEnum(_, _, [], "DBlobPersistent", [ DString hash; DInt64 length ]) ->
       DBlob(Persistent(hash, length))
 

--- a/backend/src/LibSerialization/Binary/Serializers/RT/Dval.fs
+++ b/backend/src/LibSerialization/Binary/Serializers/RT/Dval.fs
@@ -189,14 +189,12 @@ and writeDvalImpl (w : BinaryWriter) (dval : Dval) =
     w.Write 24uy
     String.write w hash
     w.Write length
-  | DBlob(Ephemeral id) ->
-    // Ephemeral blobs aren't serialisable — the bytes live in the
-    // producing VM's blob store and won't resolve across VM
-    // boundaries. Callers must promote to Persistent first (see
-    // `Blob.promote`); we raise here rather than silently
-    // write a dangling handle.
+  | DBlob(Ephemeral eph) ->
+    // The binary format only serializes persistent blob refs. Ephemeral
+    // bytes live inline on the runtime DBlob and are not addressable after
+    // serialization, so callers must promote to Persistent first.
     raiseFormatError
-      $"Cannot serialize ephemeral blob {id} — promote to persistent first"
+      $"Cannot serialize ephemeral blob {eph.id}; promote to Persistent first"
   | DStream _ ->
     // Streams are not persistable by design — lifetime is bounded by
     // the VM that produced them. Caller should drain to Blob first.

--- a/backend/src/LocalExec/BenchmarkScenarios.fs
+++ b/backend/src/LocalExec/BenchmarkScenarios.fs
@@ -69,23 +69,9 @@ let private randomBytes (seed : int) (size : int) : byte[] =
   buf
 
 
-/// Fresh ExecutionState for measurement runs. Uses TestUtils' canonical
-/// PMs (benchmarks share that wiring with the test infra).
-let freshState () : RT.ExecutionState =
-  let builtins = TestUtils.TestUtils.localBuiltIns TestUtils.TestUtils.pmPT
-  LibExecution.Execution.createState
-    builtins
-    TestUtils.TestUtils.pmRT
-    LibExecution.Execution.noTracing
-    (fun _ _ _ _ -> uply { return () })
-    (fun _ _ _ _ -> uply { return () })
-    LibExecution.ProgramTypes.mainBranchId
-    { dbs = Map.empty }
-
-
 // ─── Scenarios ───────────────────────────────────────────────────
 
-let private fileRead (state : RT.ExecutionState) : List<Result> =
+let private fileRead () : List<Result> =
   let tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "dark-bench")
   System.IO.Directory.CreateDirectory(tempDir) |> ignore<System.IO.DirectoryInfo>
   let rng = System.Random(0)
@@ -99,14 +85,13 @@ let private fileRead (state : RT.ExecutionState) : List<Result> =
       System.IO.File.WriteAllBytes(path, buf)
     try
       let dv, sample =
-        measure (fun () ->
-          Blob.newEphemeral state (System.IO.File.ReadAllBytes(path)))
+        measure (fun () -> Blob.newEphemeral (System.IO.File.ReadAllBytes(path)))
       mkResult "fileRead" size (countDvalNodes dv) "ok" sample
     with :? System.OutOfMemoryException ->
       mkResult "fileRead" size -1 "oom" { allocBytes = -1L; elapsedMs = -1L })
 
 
-let private httpBody (state : RT.ExecutionState) : List<Result> =
+let private httpBody () : List<Result> =
   [ 100_000; 1_000_000; 10_000_000 ]
   |> List.map (fun size ->
     let payload = randomBytes 0 size
@@ -123,27 +108,27 @@ let private httpBody (state : RT.ExecutionState) : List<Result> =
         let resp =
           client.GetAsync("http://fake.local/body").GetAwaiter().GetResult()
         let bytes = resp.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
-        Blob.newEphemeral state bytes)
+        Blob.newEphemeral bytes)
     mkResult "httpBody" size (countDvalNodes dv) "simulated-handler" sample)
 
 
-let private hexEncode (state : RT.ExecutionState) : List<Result> =
+let private hexEncode () : List<Result> =
   // Mirror Builtin.blobToHex: mint blob, deref bytes, hex-encode.
   let size = 1_000_000
   let raw = randomBytes 0 size
   let _, sample =
     measure (fun () ->
-      let _ = Blob.newEphemeral state raw
+      let _ = Blob.newEphemeral raw
       System.Convert.ToHexString(raw))
   [ mkResult "hexEncode" size 1 "ok" sample ]
 
 
-let private base64Encode (state : RT.ExecutionState) : List<Result> =
+let private base64Encode () : List<Result> =
   let size = 1_000_000
   let raw = randomBytes 0 size
   let _, sample =
     measure (fun () ->
-      let _ = Blob.newEphemeral state raw
+      let _ = Blob.newEphemeral raw
       System.Convert.ToBase64String(raw))
   [ mkResult "base64Encode" size 1 "ok" sample ]
 
@@ -151,7 +136,7 @@ let private base64Encode (state : RT.ExecutionState) : List<Result> =
 /// Many small ephemeral blobs in one scope, each with distinct bytes.
 /// Stresses the ConcurrentDictionary/GUID-gen/Dval-wrapper hot path
 /// that fileRead amortises away.
-let private manyBlobs (state : RT.ExecutionState) : List<Result> =
+let private manyBlobs () : List<Result> =
   let rng = System.Random(1)
   [ 100, 1_024; 1_000, 1_024; 10_000, 256 ]
   |> List.map (fun (count, perBlobBytes) ->
@@ -163,7 +148,7 @@ let private manyBlobs (state : RT.ExecutionState) : List<Result> =
     let _, sample =
       measure (fun () ->
         for i in 0 .. count - 1 do
-          ignore<RT.Dval> (Blob.newEphemeral state payloads[i]))
+          ignore<RT.Dval> (Blob.newEphemeral payloads[i]))
     mkResult
       $"manyBlobs/{count}x{perBlobBytes}B"
       (count * perBlobBytes)
@@ -174,7 +159,7 @@ let private manyBlobs (state : RT.ExecutionState) : List<Result> =
 
 /// Drain a Stream<UInt8> into a Blob via the chunked path — the bulk
 /// path that pulls 64 KB buffers instead of boxing one DUInt8 per byte.
-let private streamToBlob (state : RT.ExecutionState) : List<Result> =
+let private streamToBlob () : List<Result> =
   [ 100_000; 1_000_000; 10_000_000 ]
   |> List.map (fun size ->
     let payload = randomBytes 0 size
@@ -201,14 +186,14 @@ let private streamToBlob (state : RT.ExecutionState) : List<Result> =
             | None -> return ()
           }
         drain () |> Ply.toTask |> _.Wait()
-        ignore<RT.Dval> (Blob.newEphemeral state (collected.ToArray())))
+        ignore<RT.Dval> (Blob.newEphemeral (collected.ToArray())))
     mkResult "streamToBlob" size 1 "chunked-drain" sample)
 
 
 /// Multipart-style body construction: build a Blob by concatenating
 /// many text/binary parts. Mirrors the openai/audio.dark
 /// MultipartRequest pattern.
-let private multipart (state : RT.ExecutionState) : List<Result> =
+let private multipart () : List<Result> =
   [ 10, 1_024; 100, 10_240; 50, 100_000 ]
   |> List.map (fun (parts, perPartBytes) ->
     let part = randomBytes 0 perPartBytes
@@ -216,9 +201,9 @@ let private multipart (state : RT.ExecutionState) : List<Result> =
       measure (fun () ->
         use buf = new System.IO.MemoryStream()
         for _ in 1..parts do
-          let _ = Blob.newEphemeral state part
+          let _ = Blob.newEphemeral part
           buf.Write(part, 0, part.Length)
-        ignore<RT.Dval> (Blob.newEphemeral state (buf.ToArray())))
+        ignore<RT.Dval> (Blob.newEphemeral (buf.ToArray())))
     mkResult
       $"multipart/{parts}x{perPartBytes}B"
       (parts * perPartBytes)
@@ -228,11 +213,11 @@ let private multipart (state : RT.ExecutionState) : List<Result> =
 
 
 /// Run every scenario; concatenate their Result rows.
-let run (state : RT.ExecutionState) : List<Result> =
-  [ yield! fileRead state
-    yield! httpBody state
-    yield! hexEncode state
-    yield! base64Encode state
-    yield! manyBlobs state
-    yield! streamToBlob state
-    yield! multipart state ]
+let run () : List<Result> =
+  [ yield! fileRead ()
+    yield! httpBody ()
+    yield! hexEncode ()
+    yield! base64Encode ()
+    yield! manyBlobs ()
+    yield! streamToBlob ()
+    yield! multipart () ]

--- a/backend/src/LocalExec/Benchmarks.fs
+++ b/backend/src/LocalExec/Benchmarks.fs
@@ -115,7 +115,7 @@ let private printSummary (results : List<Scenarios.Result>) : unit =
 
 let runAll () : Ply<Result<unit, string>> =
   uply {
-    let results = Scenarios.run (Scenarios.freshState ())
+    let results = Scenarios.run ()
     let timestamp = System.DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
     let json = serializeSnapshot timestamp (gitCommit ()) results
 

--- a/backend/tests/Tests/Blob.Tests.fs
+++ b/backend/tests/Tests/Blob.Tests.fs
@@ -1,9 +1,8 @@
 /// Tests for the Blob Dval.
 ///
-/// Covers the ephemeral-blob byte-store on ExecutionState,
-/// serialization roundtrips, promotion, memory-bound assertions,
-/// scope-based lifetime, the val-persistability guard, the orphan
-/// sweeper, and the blob-equality semantics.
+/// Covers inline ephemeral-blob bytes, serialization roundtrips,
+/// promotion, memory-bound assertions, the val-persistability guard,
+/// the orphan sweeper, and the blob-equality semantics.
 module Tests.Blob
 
 open Expecto
@@ -56,13 +55,10 @@ let private dblobRef (dv : RT.Dval) : RT.BlobRef =
 
 let private ephemeralId (dv : RT.Dval) : System.Guid =
   match dv with
-  | RT.DBlob(RT.Ephemeral id) -> id
+  | RT.DBlob(RT.Ephemeral eph) -> eph.id
   | _ -> failtest $"expected DBlob(Ephemeral _), got {dv}"
 
-let private persistentHash (dv : RT.Dval) : string =
-  match dv with
-  | RT.DBlob(RT.Persistent(h, _)) -> h
-  | _ -> failtest $"expected DBlob(Persistent _), got {dv}"
+let private mkEphemeral (bytes : byte[]) : RT.Dval = Blob.newEphemeral bytes
 
 let private noopInsert : string -> byte[] -> Ply<unit> =
   fun _ _ -> uply { return () }
@@ -96,14 +92,14 @@ let private expectThrows (label : string) (f : unit -> Task<'a>) : Task<unit> =
 
 
 // ─────────────────────────────────────────────────────────────────────
-// Ephemeral byte-store
+// Ephemeral blobs — inline bytes
 // ─────────────────────────────────────────────────────────────────────
 
 let ephemeralRoundtrip =
-  testTask "ephemeral blob roundtrips bytes through the store" {
+  testTask "ephemeral blob roundtrips its inline bytes" {
     let state = freshState ()
     let payload = [| 1uy; 2uy; 3uy; 4uy; 5uy |]
-    let dv = Blob.newEphemeral state payload
+    let dv = Blob.newEphemeral payload
     match dv with
     | RT.DBlob(RT.Ephemeral _) -> ()
     | _ -> failtest $"expected DBlob(Ephemeral _), got {dv}"
@@ -115,22 +111,13 @@ let twoEphemeralsAreDistinct =
   testTask "two ephemeral blobs with same bytes have distinct handles" {
     let state = freshState ()
     let payload = [| 7uy; 7uy; 7uy |]
-    let dv1 = Blob.newEphemeral state payload
-    let dv2 = Blob.newEphemeral state payload
+    let dv1 = Blob.newEphemeral payload
+    let dv2 = Blob.newEphemeral payload
     Expect.notEqual (ephemeralId dv1) (ephemeralId dv2) "each mint gets a fresh uuid"
     let! b1 = Blob.readBytes state (dblobRef dv1) |> Ply.toTask
     let! b2 = Blob.readBytes state (dblobRef dv2) |> Ply.toTask
     Expect.equal b1 payload "first blob reads its bytes"
     Expect.equal b2 payload "second blob reads its bytes"
-  }
-
-let missingEphemeralRaises =
-  testTask "reading an unknown ephemeral id raises" {
-    let state = freshState ()
-    let bogusRef = RT.Ephemeral(System.Guid.NewGuid())
-    do!
-      expectThrows "expected an exception on missing ephemeral id" (fun () ->
-        Blob.readBytes state bogusRef |> Ply.toTask :> Task<_>)
   }
 
 
@@ -154,7 +141,7 @@ let persistentBlobBinaryRoundtrip =
 
 let ephemeralBlobBinaryRaises =
   test "DBlob(Ephemeral _) serialization raises; promote to persistent first" {
-    let dv = RT.DBlob(RT.Ephemeral(System.Guid.NewGuid()))
+    let dv = mkEphemeral [| 1uy; 2uy; 3uy |]
     Expect.throws
       (fun () -> BS.RT.Dval.serialize "dval" dv |> ignore<byte[]>)
       "ephemeral blob must raise on serialize — promote via `Blob.promote` first"
@@ -225,13 +212,20 @@ let dblobPersistentDarkBridge =
   }
 
 let dblobEphemeralDarkBridge =
-  // The ephemeral branch could force promotion, but LSP/reflection
-  // needs to render ephemeral blobs without a side effect. The current
-  // encoding preserves both variants distinctly.
-  test "DBlob(Ephemeral _) survives rt<->dark dval bridge without promotion" {
-    let original = RT.DBlob(RT.Ephemeral(System.Guid.NewGuid()))
-    let restored = RT2DT.Dval.fromDT (RT2DT.Dval.toDT original)
-    Expect.equal restored original "DBlob(Ephemeral) survives dval bridge"
+  // Ephemeral blobs render via `toDT` for LSP/reflection without a
+  // promotion side effect, but they don't round-trip: the inline bytes
+  // can't be rebuilt from the reflected id-only form, so `fromDT` raises
+  // (a one-way bridge, like DStreamStub). Promote to Persistent first if
+  // you need a value that survives the bridge.
+  test "DBlob(Ephemeral _) renders via toDT but fromDT raises (one-way)" {
+    let original = mkEphemeral [| 0xAAuy; 0xBBuy |]
+    let dt = RT2DT.Dval.toDT original
+    match dt with
+    | RT.DEnum(_, _, _, "DBlobEphemeral", _) -> ()
+    | _ -> failtest $"expected DBlobEphemeral DEnum, got {dt}"
+    Expect.throws
+      (fun () -> RT2DT.Dval.fromDT dt |> ignore<RT.Dval>)
+      "ephemeral blob must not round-trip through the dark-type bridge"
   }
 
 
@@ -272,10 +266,9 @@ let packageBlobMissingHashReturnsNone =
 
 let promotePersistsAndSwaps =
   testTask "promoteBlobs: ephemeral -> persistent + row in package_blobs" {
-    let state = freshState ()
     let payload = uniquePayload "promote-test"
-    let ephemeral = Blob.newEphemeral state payload
-    let! promoted = Blob.promote state PMBlob.insert ephemeral |> Ply.toTask
+    let ephemeral = Blob.newEphemeral payload
+    let! promoted = Blob.promote PMBlob.insert ephemeral |> Ply.toTask
     let expectedHash = Blob.sha256Hex payload
     match promoted with
     | RT.DBlob(RT.Persistent(h, n)) ->
@@ -288,10 +281,9 @@ let promotePersistsAndSwaps =
 
 let promoteThenSerializeRoundtrips =
   testTask "promoteBlobs then binary serialize roundtrips cleanly" {
-    let state = freshState ()
     let payload = uniquePayload "promote-serialize"
-    let ephemeral = Blob.newEphemeral state payload
-    let! promoted = Blob.promote state PMBlob.insert ephemeral |> Ply.toTask
+    let ephemeral = Blob.newEphemeral payload
+    let! promoted = Blob.promote PMBlob.insert ephemeral |> Ply.toTask
     let restored =
       BS.RT.Dval.deserialize "dval" (BS.RT.Dval.serialize "dval" promoted)
     Expect.equal
@@ -302,12 +294,11 @@ let promoteThenSerializeRoundtrips =
 
 let promoteSameBytesTwiceDedups =
   testTask "promoteBlobs: two ephemerals with identical bytes hit package_blobs once" {
-    let state = freshState ()
     let payload = uniquePayload "dedup-test"
-    let eph1 = Blob.newEphemeral state payload
-    let eph2 = Blob.newEphemeral state payload
-    let! p1 = Blob.promote state PMBlob.insert eph1 |> Ply.toTask
-    let! p2 = Blob.promote state PMBlob.insert eph2 |> Ply.toTask
+    let eph1 = Blob.newEphemeral payload
+    let eph2 = Blob.newEphemeral payload
+    let! p1 = Blob.promote PMBlob.insert eph1 |> Ply.toTask
+    let! p2 = Blob.promote PMBlob.insert eph2 |> Ply.toTask
     Expect.equal p1 p2 "two promotions of identical bytes share the hash"
     let! row = PMBlob.get (Blob.sha256Hex payload) |> Ply.toTask
     Expect.equal row (Some payload) "row still contains original bytes"
@@ -317,8 +308,8 @@ let promotedBlobResolvesViaReadBlobBytes =
   testTask "readBlobBytes on a promoted blob reads from package_blobs" {
     let state = freshState ()
     let payload = uniquePayload "resolve-test"
-    let ephemeral = Blob.newEphemeral state payload
-    let! promoted = Blob.promote state PMBlob.insert ephemeral |> Ply.toTask
+    let ephemeral = Blob.newEphemeral payload
+    let! promoted = Blob.promote PMBlob.insert ephemeral |> Ply.toTask
     let! bytes = Blob.readBytes state (dblobRef promoted) |> Ply.toTask
     Expect.equal bytes payload "persistent blob resolves back to its bytes"
   }
@@ -336,13 +327,12 @@ let fileReadMemoryBound =
       let buf = Array.zeroCreate<byte> 10_000_000
       System.Random(0).NextBytes(buf)
       System.IO.File.WriteAllBytes(path, buf)
-    let state = freshState ()
     System.GC.Collect()
     System.GC.WaitForPendingFinalizers()
     System.GC.Collect()
     let before = System.GC.GetTotalAllocatedBytes(precise = false)
     let! bytes = System.IO.File.ReadAllBytesAsync path
-    let _dv = Blob.newEphemeral state bytes
+    let _dv = Blob.newEphemeral bytes
     let delta = System.GC.GetTotalAllocatedBytes(precise = false) - before
     // Old List<UInt8> path allocated ~200× file size (10 MB → ~2 GB). Blob
     // path drops by ~100×; the bound is generous so any list-boxing
@@ -386,81 +376,14 @@ let queryableJsonRoundtrip =
 
 let queryableJsonEphemeralRaises =
   testTask "User-DB queryable JSON raises on ephemeral blob (promotion needed)" {
-    let state = freshState ()
     let types = { RT.Types.empty with package = pmRT.getType }
     let threadID = System.Guid.NewGuid()
-    let ephemeral = Blob.newEphemeral state [| 1uy; 2uy; 3uy |]
+    let ephemeral = Blob.newEphemeral [| 1uy; 2uy; 3uy |]
     do!
       expectThrows
         "ephemeral blob in queryable JSON should raise (promote first)"
         (fun () ->
           QueryableJson.toJsonStringV0 types threadID ephemeral |> Ply.toTask)
-  }
-
-
-// ─────────────────────────────────────────────────────────────────────
-// Scope-based ephemeral-blob lifetime
-// ─────────────────────────────────────────────────────────────────────
-
-let pushPopReclaimsScopedBlobs =
-  test "scope: popBlobScope drops blobs created inside the scope" {
-    let state = freshState ()
-    // Pre-scope blob (no scope: leaks for VM lifetime).
-    let preId = ephemeralId (Blob.newEphemeral state [| 0xAAuy |])
-    Blob.pushScope state
-    let aId = ephemeralId (Blob.newEphemeral state [| 0x01uy; 0x02uy |])
-    let bId = ephemeralId (Blob.newEphemeral state [| 0x03uy |])
-    Expect.isTrue (state.blobStore.ContainsKey aId) "a is in store pre-pop"
-    Expect.isTrue (state.blobStore.ContainsKey bId) "b is in store pre-pop"
-    Blob.popScope state
-    Expect.isFalse (state.blobStore.ContainsKey aId) "a dropped on pop"
-    Expect.isFalse (state.blobStore.ContainsKey bId) "b dropped on pop"
-    Expect.isTrue
-      (state.blobStore.ContainsKey preId)
-      "pre-scope blob survives the pop"
-  }
-
-let scopeNestsLikeAStack =
-  test "scope: nested scopes each clean up only their own blobs" {
-    let state = freshState ()
-    Blob.pushScope state
-    let outerId = ephemeralId (Blob.newEphemeral state [| 0x10uy |])
-    Blob.pushScope state
-    let innerId = ephemeralId (Blob.newEphemeral state [| 0x20uy |])
-    Blob.popScope state
-    Expect.isFalse
-      (state.blobStore.ContainsKey innerId)
-      "inner blob dropped on inner pop"
-    Expect.isTrue
-      (state.blobStore.ContainsKey outerId)
-      "outer blob survives inner pop"
-    Blob.popScope state
-    Expect.isFalse
-      (state.blobStore.ContainsKey outerId)
-      "outer blob drops on outer pop"
-  }
-
-let popWithoutPushIsNoOp =
-  test "scope: popBlobScope on an empty stack is a no-op" {
-    let state = freshState ()
-    Blob.popScope state
-    Blob.popScope state
-    Expect.equal state.blobScopes.Count 0 "stack still empty"
-  }
-
-let promotedBlobsSurviveScopePop =
-  testTask "scope: a blob promoted inside the scope stays resolvable via PM" {
-    let state = freshState ()
-    let payload = [| 0xDEuy; 0xADuy; 0xBEuy; 0xEFuy |]
-    Blob.pushScope state
-    let eph = Blob.newEphemeral state payload
-    let! promoted = Blob.promote state pmRT.persistBlob eph |> Ply.toTask
-    let hash = persistentHash promoted
-    Blob.popScope state
-    // Ephemeral bytes gone; persistent bytes survive in package_blobs.
-    let! bytes =
-      Blob.readBytes state (RT.Persistent(hash, int64 payload.Length)) |> Ply.toTask
-    Expect.equal bytes payload "persistent bytes survive the pop"
   }
 
 
@@ -492,7 +415,7 @@ let persistableAcceptsPlainShapes =
 
 let persistableRejectsEphemeralBlob =
   test "isPersistable: ephemeral blob is not persistable (must promote)" {
-    let dv = RT.DBlob(RT.Ephemeral(System.Guid.NewGuid()))
+    let dv = mkEphemeral [| 1uy; 2uy; 3uy |]
     Expect.isFalse (Dval.isPersistable dv) "ephemeral blob rejected"
     match Dval.nonPersistableReason dv with
     | Some reason ->
@@ -522,8 +445,7 @@ let persistableRejectsNestedBadShapes =
     let list =
       RT.DList(
         RT.ValueType.Known RT.KTBlob,
-        [ RT.DBlob(RT.Persistent("x", 1L))
-          RT.DBlob(RT.Ephemeral(System.Guid.NewGuid())) ]
+        [ RT.DBlob(RT.Persistent("x", 1L)); mkEphemeral [| 9uy |] ]
       )
     Expect.isFalse (Dval.isPersistable list) "list with ephemeral blob rejected"
 
@@ -610,26 +532,23 @@ let sweepDeletesOrphansButKeepsReferenced =
 
 let equalsEphemeralEphemeralSameUuid =
   test "blob equality: two refs to the same ephemeral UUID are equal" {
-    let state = freshState ()
-    let dv = Blob.newEphemeral state [| 0x01uy; 0x02uy |]
+    let dv = Blob.newEphemeral [| 0x01uy; 0x02uy |]
     Expect.isTrue (Equals.equals dv dv) "same ephemeral handle compares equal"
   }
 
 let equalsEphemeralEphemeralSameBytesIsFalse =
   test "blob equality: two distinct ephemerals with same bytes are unequal" {
-    let state = freshState ()
     let payload = [| 0x11uy; 0x22uy; 0x33uy |]
-    let a = Blob.newEphemeral state payload
-    let b = Blob.newEphemeral state payload
+    let a = Blob.newEphemeral payload
+    let b = Blob.newEphemeral payload
     Expect.notEqual (ephemeralId a) (ephemeralId b) "distinct UUIDs"
     Expect.isFalse (Equals.equals a b) "ephemeral identity is by UUID, not by bytes"
   }
 
 let equalsEphemeralPersistentSameBytesIsFalse =
   test "blob equality: ephemeral vs persistent with same bytes are unequal" {
-    let state = freshState ()
     let payload = [| 0xDEuy; 0xADuy |]
-    let eph = Blob.newEphemeral state payload
+    let eph = Blob.newEphemeral payload
     let per = RT.DBlob(RT.Persistent(Blob.sha256Hex payload, int64 payload.Length))
     Expect.isFalse
       (Equals.equals eph per)
@@ -651,9 +570,8 @@ let equalsPersistentPersistentDifferentHashes =
 
 let equalsEphemeralDifferentBytes =
   test "blob equality: two ephemerals with different bytes are unequal" {
-    let state = freshState ()
-    let a = Blob.newEphemeral state [| 0x00uy |]
-    let b = Blob.newEphemeral state [| 0xFFuy |]
+    let a = Blob.newEphemeral [| 0x00uy |]
+    let b = Blob.newEphemeral [| 0xFFuy |]
     Expect.isFalse (Equals.equals a b) "distinct UUIDs = unequal"
   }
 
@@ -772,11 +690,10 @@ let private fakeAppNamedFn (argsSoFar : List<RT.Dval>) : RT.Dval =
 
 let promoteRewritesInsideClosedRegisters =
   testTask "Blob.promote: ephemeral inside AppLambda.closedRegisters is promoted" {
-    let state = freshState ()
     let payload = uniquePayload "promote-closure"
-    let ephemeral = Blob.newEphemeral state payload
+    let ephemeral = Blob.newEphemeral payload
     let dv = fakeAppLambda [ (1, ephemeral) ] []
-    let! promoted = Blob.promote state PMBlob.insert dv |> Ply.toTask
+    let! promoted = Blob.promote PMBlob.insert dv |> Ply.toTask
     match promoted with
     | RT.DApplicable(RT.AppLambda lambda) ->
       match lambda.closedRegisters with
@@ -789,11 +706,10 @@ let promoteRewritesInsideClosedRegisters =
 
 let promoteRewritesInsideAppLambdaArgs =
   testTask "Blob.promote: ephemeral inside AppLambda.argsSoFar is promoted" {
-    let state = freshState ()
     let payload = uniquePayload "promote-applambda-args"
-    let ephemeral = Blob.newEphemeral state payload
+    let ephemeral = Blob.newEphemeral payload
     let dv = fakeAppLambda [] [ ephemeral ]
-    let! promoted = Blob.promote state PMBlob.insert dv |> Ply.toTask
+    let! promoted = Blob.promote PMBlob.insert dv |> Ply.toTask
     match promoted with
     | RT.DApplicable(RT.AppLambda lambda) ->
       match lambda.argsSoFar with
@@ -805,11 +721,10 @@ let promoteRewritesInsideAppLambdaArgs =
 
 let promoteRewritesInsideAppNamedFnArgs =
   testTask "Blob.promote: ephemeral inside AppNamedFn.argsSoFar is promoted" {
-    let state = freshState ()
     let payload = uniquePayload "promote-namedfn-args"
-    let ephemeral = Blob.newEphemeral state payload
+    let ephemeral = Blob.newEphemeral payload
     let dv = fakeAppNamedFn [ ephemeral ]
-    let! promoted = Blob.promote state PMBlob.insert dv |> Ply.toTask
+    let! promoted = Blob.promote PMBlob.insert dv |> Ply.toTask
     match promoted with
     | RT.DApplicable(RT.AppNamedFn fn) ->
       match fn.argsSoFar with
@@ -911,7 +826,6 @@ let tests =
     "blob"
     [ ephemeralRoundtrip
       twoEphemeralsAreDistinct
-      missingEphemeralRaises
       persistentBlobBinaryRoundtrip
       ephemeralBlobBinaryRaises
       tblobBinaryRoundtrip
@@ -931,10 +845,6 @@ let tests =
       fileReadMemoryBound
       queryableJsonRoundtrip
       queryableJsonEphemeralRaises
-      pushPopReclaimsScopedBlobs
-      scopeNestsLikeAStack
-      popWithoutPushIsNoOp
-      promotedBlobsSurviveScopePop
       persistableAcceptsPlainShapes
       persistableRejectsEphemeralBlob
       persistableRejectsStream

--- a/backend/tests/Tests/HttpClient.Tests.fs
+++ b/backend/tests/Tests/HttpClient.Tests.fs
@@ -243,7 +243,7 @@ let makeTest versionName filename =
         task {
           match r with
           | Ok dv ->
-            let! p = LibExecution.Blob.promote exeState noopInsert dv |> Ply.toTask
+            let! p = LibExecution.Blob.promote noopInsert dv |> Ply.toTask
             return Ok p
           | Error _ -> return r
         }

--- a/backend/tests/Tests/HttpServer.Tests.fs
+++ b/backend/tests/Tests/HttpServer.Tests.fs
@@ -444,6 +444,95 @@ let private runFixture (test : Test) : Task<unit> =
   }
 
 
+/// Regression test for the ephemeral-blob HTTP race. The request body
+/// becomes an ephemeral blob (`Http.Request.fromRequest`), which the handler reads
+/// back and the tracer promotes. Under the old shared blob store + scope
+/// stack, concurrent requests deleted each other's blobs — surfacing as
+/// "Ephemeral blob not found during trace preparation" (→ 500s) or
+/// cross-wired bodies. With bytes inline there's no shared state to race
+/// over: this fires many overlapping body-echo requests and asserts each
+/// one gets ITS OWN body back, with status 200.
+let private concurrentEphemeralBlobRequests =
+  testTask "concurrent requests don't lose or cross ephemeral blob bodies" {
+    let! exeState = executionStateFor pmPT true Map.empty
+    let test =
+      { handlers =
+          [ { version = Http
+              route = "/"
+              method = "POST"
+              code = "Darklang.Stdlib.Http.response request.body 200L" } ]
+        request = [||]
+        expectedResponse = [||] }
+    let! handler = buildRouterForTest exeState test
+    let port = allocateFreePort ()
+    let cts = new CancellationTokenSource()
+
+    let listenerTask =
+      HttpServer.runListener
+        exeState
+        (int64 port)
+        handler
+        HttpServer.defaultMaxBodyBytes
+        false // injectStandardHeaders
+        false // canonicalizeFromForwardedProto
+        false // logRequests
+        cts.Token
+
+    // Distinct, non-trivial body per request so a lost/mis-tagged blob
+    // shows up as a wrong or empty echo, not a coincidental match.
+    let bodyFor (i : int) : byte[] = UTF8.toBytes (String.replicate 64 $"req{i:D4}-")
+
+    let oneRequest (i : int) : Task<string * byte[]> =
+      task {
+        let body = bodyFor i
+        let header =
+          UTF8.toBytes
+            $"POST / HTTP/1.1\r\nHost: localhost:{port}\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n"
+        let reqBytes = Array.append header body
+        use client = new TcpClient()
+        do! client.ConnectAsync("127.0.0.1", port)
+        use stream = client.GetStream()
+        do! stream.WriteAsync(reqBytes, 0, reqBytes.Length)
+        do! stream.FlushAsync()
+        // Read until the server closes (Connection: close); 10s cancel
+        // guards against a hang if a connection is ever kept alive.
+        use ms = new System.IO.MemoryStream()
+        let buf = Array.zeroCreate 8192
+        use readCts = new CancellationTokenSource(10_000)
+        let mutable reading = true
+        try
+          while reading do
+            let! n = stream.ReadAsync(buf, 0, buf.Length, readCts.Token)
+            if n = 0 then reading <- false else ms.Write(buf, 0, n)
+        with :? System.OperationCanceledException ->
+          ()
+        let parsed = Http.split (ms.ToArray())
+        return (parsed.status, parsed.body)
+      }
+
+    try
+      // `task { }` is hot, so mapping starts all requests concurrently.
+      let! results = [ 1..64 ] |> List.map oneRequest |> Task.WhenAll
+      results
+      |> Array.iteri (fun idx (status, body) ->
+        let i = idx + 1
+        Expect.stringContains
+          status
+          "200"
+          $"request {i}: status 200 (lost blob => 500)"
+        Expect.equal
+          body
+          (bodyFor i)
+          $"request {i}: body echoed intact (no cross-request blob)")
+    finally
+      cts.Cancel()
+      try
+        listenerTask.Wait 2000 |> ignore<bool>
+      with _ ->
+        ()
+  }
+
+
 let tests =
   let t rootDir (filename : string) =
     testTask $"Http files: {filename}" {
@@ -463,12 +552,13 @@ let tests =
         do! runFixture test
     }
 
-  [ ($"{basePath}", "http") ]
-  |> List.map (fun (dir, testListName) ->
-    let tests =
-      System.IO.Directory.GetFiles(dir, "*.test")
-      |> Array.map (System.IO.Path.GetFileName)
-      |> Array.toList
-      |> List.map (t dir)
-    testList testListName tests)
-  |> testList "HttpServer"
+  let fileTestLists =
+    [ ($"{basePath}", "http") ]
+    |> List.map (fun (dir, testListName) ->
+      let tests =
+        System.IO.Directory.GetFiles(dir, "*.test")
+        |> Array.map (System.IO.Path.GetFileName)
+        |> Array.toList
+        |> List.map (t dir)
+      testList testListName tests)
+  testList "HttpServer" (concurrentEphemeralBlobRequests :: fileTestLists)

--- a/backend/tests/Tests/LibExecution.Tests.fs
+++ b/backend/tests/Tests/LibExecution.Tests.fs
@@ -215,19 +215,18 @@ let t
       // a follow-up PR). Drop the dump until the new tracer lands.
       ignore<unit> ()
 
-      // Promote any ephemeral blobs to content-addressed Persistent
-      // refs so two expressions that construct the same bytes via
-      // different `newEphemeralBlob` calls compare equal under the
-      // test framework's structural `dvalEquality`. The no-op insert
-      // means we don't persist to `package_blobs` — we only need the
-      // hash to dedupe UUID identity.
+      // Promote ephemeral blobs before comparing test results. Runtime
+      // ephemerals use per-mint identity, so two expressions that build the
+      // same bytes produce different ephemeral ids and compare unequal.
+      // Promotion turns both into content-addressed Persistent refs, which
+      // compare by hash. The insert is a no-op because this test only needs
+      // the promoted identity; it does not read the persisted bytes later.
       let noopInsert _ _ = uply { return () }
       let promoteIfOk (r : RT.ExecutionResult) : Task<RT.ExecutionResult> =
         task {
           match r with
           | Ok dv ->
-            let! promoted =
-              LibExecution.Blob.promote state noopInsert dv |> Ply.toTask
+            let! promoted = LibExecution.Blob.promote noopInsert dv |> Ply.toTask
             return Ok promoted
           | Error _ -> return r
         }


### PR DESCRIPTION
Example of the old bug:
1. Request A starts. It does: `Blob.pushScope exeState`
Stack:
[ scopeA ]   <- top

2. Request B starts before A finishes. It also does: `Blob.pushScope exeState`
Stack:
[ scopeB ]   <- top
[ scopeA ]

3. Request A creates an ephemeral blob.
The old code did not remember "the scope that belongs to Request A." Instead, it always attached new blobs to whatever scope was currently on top of the shared stack. But Request B had already started, so B's scope was now on top. That means A's blob was accidentally registered under B’s scope.
scopeB tracks idA  // wrong
scopeA tracks nothing

4. Request B finishes first.
`Blob.popScope exeState` This pops scopeB and deletes every blob ID tracked by it. That deletes idA, even though Request A is still running. blobStore no longer has idA

5. Request A later tries to read or promote its blob. But idA was deleted when B finished, so it fails with: `ephemeral blob not found`

The core issue was that concurrent requests shared one ExecutionState.blobScopes stack. A stack only works if scopes exit in exact last-in-first-out order.
Concurrent HTTP requests don't guarantee that, so one request could accidentally put its blob into another request's top scope.

After:
`DBlob(Ephemeral { id; bytes })` carries the bytes directly inside the value. So as long as the Dval exists, the bytes exist. There is no shared ephemeral store and no UUID lookup that can go stale.
