### PR TITLE
Surface parse errors in match cases instead of silently dropping content

### DIFF
--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -125,12 +125,11 @@ let tEval (name : string) (input : string) (expected : RT.Dval) =
   }
 
 
-/// Asserts the ParseError case name returned by `parseForCli`. Uses
-/// `parseForCli` (the same parse path the CLI uses) because it surfaces
-/// `unparseableStuff` as `Result.Error` — `parsePTSourceFileWithOps` swallows
+/// Uses `parseForCli` (the same parse path the CLI uses) because it surfaces
+/// `unparseableStuff` as `Result.Error`; `parsePTSourceFileWithOps` swallows
 /// per-declaration parse failures into a side list and returns Ok overall.
-let tParseErrorVariant (name : string) (input : string) (expectedCaseName : string) =
-  testTask name {
+let parseForCliDval (input : string) =
+  task {
     let parseFnName =
       RT.FQFnName.fqPackage (
         PackageRefs.Fn.LanguageTools.Parser.CliScript.parseForCli ()
@@ -146,6 +145,14 @@ let tParseErrorVariant (name : string) (input : string) (expectedCaseName : stri
     let! parseResult =
       LibExecution.Execution.executeFunction parseExeState parseFnName [] args
     let! parseDval = unwrapExecutionResult parseExeState parseResult |> Ply.toTask
+    return parseDval
+  }
+
+
+let tParseErrorVariant (name : string) (input : string) (expectedCaseName : string) =
+  testTask name {
+    let! parseDval = parseForCliDval input
+
     match parseDval with
     | RT.DEnum(tn, _, _, "Error", [ RT.DEnum(_, _, _, caseName, _) ]) when
       tn = Dval.resultType ()
@@ -159,6 +166,27 @@ let tParseErrorVariant (name : string) (input : string) (expectedCaseName : stri
       return
         failtest
           $"Expected Result.Error containing a ParseError variant; got {parseDval}"
+  }
+
+
+/// Like `tParseErrorVariant`, but also asserts the exact `Unparseable` note.
+let tParseErrorNote (name : string) (input : string) (expectedNote : string) =
+  testTask name {
+    let! parseDval = parseForCliDval input
+
+    match parseDval with
+    | RT.DEnum(tn, _, _, "Error", [ errVariant ]) when tn = Dval.resultType () ->
+      match errVariant with
+      | RT.DEnum(_, _, _, "Unparseable", [ RT.DRecord(_, _, _, fields) ]) ->
+        match Map.tryFind "note" fields with
+        | Some(RT.DEnum(_, _, _, "Some", [ RT.DString note ])) ->
+          return Expect.equal note expectedNote $"wrong Unparseable note for {input}"
+        | other ->
+          return
+            failtest $"Expected an Unparseable with a Some note; got note = {other}"
+      | other -> return failtest $"Expected an Unparseable variant; got {other}"
+    | _ ->
+      return failtest $"Expected Result.Error (Unparseable ...); got {parseDval}"
   }
 
 
@@ -825,6 +853,28 @@ let exprs =
       "invalid escape in char match pattern"
       "match c with\n| '\\d' -> 1L\n| _ -> 0L"
       "Unparseable"
+    // A qualified enum-case pattern is unsupported (use the bare case name).
+    // tree-sitter keeps only the first path segment and error-recovers the
+    // rest; reject it instead of silently building a truncated pattern. The
+    // rejection holds across path lengths and whether or not fields are bound.
+    tParseErrorVariant
+      "qualified enum-case match pattern (fully qualified)"
+      "match x with\n| Stdlib.Result.Result.Ok n -> 1L\n| _ -> 0L"
+      "Unparseable"
+    tParseErrorVariant
+      "qualified enum-case match pattern (two segments)"
+      "match x with\n| Result.Ok n -> 1L\n| _ -> 0L"
+      "Unparseable"
+    tParseErrorVariant
+      "qualified enum-case match pattern (no field binding)"
+      "match x with\n| Stdlib.Result.Ok -> 1L\n| _ -> 0L"
+      "Unparseable"
+    // The diagnostic must name the actual problem (qualified path) so the user
+    // knows to use the bare case name, not just report a generic failure.
+    tParseErrorNote
+      "qualified enum-case match pattern suggests bare case name"
+      "match x with\n| Stdlib.Result.Result.Ok n -> 1L\n| _ -> 0L"
+      "Invalid match pattern. Enum patterns use the bare case name (e.g. `| Ok n`), not a qualified path like `| Stdlib.Result.Result.Ok n`."
     // Codepoints that tree-sitter accepts as well-formed escapes but that
     // are not valid Unicode scalars must be rejected by the decoder:
     //   - surrogate range (D800..DFFF)

--- a/packages/darklang/cli/packages/fn.dark
+++ b/packages/darklang/cli/packages/fn.dark
@@ -130,8 +130,15 @@ let createFnInline
             state
 
       | Error unparseable ->
-        Stdlib.printLine (Colors.error "Failed to parse function definition")
-        Stdlib.printLine $"Parse error at range: {unparseable.source.range}"
+        let r = unparseable.source.range
+        let detail =
+          match unparseable.note with
+          | Some note -> note
+          | None -> "Make sure your syntax is correct."
+        [ Colors.error "Failed to parse function definition"
+          $"  at line {Stdlib.Int64.toString (r.start.row + 1L)}, column {Stdlib.Int64.toString (r.start.column + 1L)}"
+          detail ]
+        |> Stdlib.printLines
         state
     | None ->
       [

--- a/packages/darklang/cli/packages/type.dark
+++ b/packages/darklang/cli/packages/type.dark
@@ -133,8 +133,15 @@ let createTypeInline
             state
 
       | Error unparseable ->
-        Stdlib.printLine (Colors.error "Failed to parse type definition")
-        Stdlib.printLine $"Parse error at range: {unparseable.source.range}"
+        let r = unparseable.source.range
+        let detail =
+          match unparseable.note with
+          | Some note -> note
+          | None -> "Make sure your syntax is correct."
+        [ Colors.error "Failed to parse type definition"
+          $"  at line {Stdlib.Int64.toString (r.start.row + 1L)}, column {Stdlib.Int64.toString (r.start.column + 1L)}"
+          detail ]
+        |> Stdlib.printLines
         state
     | None ->
       [

--- a/packages/darklang/cli/packages/value.dark
+++ b/packages/darklang/cli/packages/value.dark
@@ -133,8 +133,15 @@ let createValueInline
             state
 
       | Error unparseable ->
-        Stdlib.printLine (Colors.error "Failed to parse value expression")
-        Stdlib.printLine $"Parse error at range: {unparseable.source.range}"
+        let r = unparseable.source.range
+        let detail =
+          match unparseable.note with
+          | Some note -> note
+          | None -> "Make sure your syntax is correct."
+        [ Colors.error "Failed to parse value expression"
+          $"  at line {Stdlib.Int64.toString (r.start.row + 1L)}, column {Stdlib.Int64.toString (r.start.column + 1L)}"
+          detail ]
+        |> Stdlib.printLines
         state
     | None ->
       [

--- a/packages/darklang/languageTools/parser/core.dark
+++ b/packages/darklang/languageTools/parser/core.dark
@@ -65,6 +65,10 @@ let findNodeByFieldName
   | _ -> Stdlib.Option.Option.None // TODO: this should error, there are multiple matches
 
 
+let hasErrorChild (node: ParsedNode) : Bool =
+  node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
+
+
 let createUnparseableError
   (node: ParsedNode)
   : Stdlib.Result.Result<'a, WrittenTypes.Unparseable> =

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -151,12 +151,8 @@ let parseStringLiteral
     // tree-sitter classifies invalid escape sequences (e.g. "\d") as ERROR
     // children rather than `char_or_string_escape_sequence`. Surface them as
     // a parse failure instead of silently dropping content.
-    let hasErrorChild =
-      stringSegment.children
-      |> Stdlib.List.any (fun c -> c.typ == "ERROR")
-
     let contents =
-      if hasErrorChild then
+      if hasErrorChild stringSegment then
         createUnparseableErrorMsg
           stringSegment
           "Invalid escape sequence in string literal"
@@ -181,10 +177,7 @@ let parseStringLiteral
           | Some interpolationContent ->
             // ERROR children inside the interpolation content are the same
             // bug surface as the top-level case — refuse rather than drop.
-            let interpHasErrorChild =
-              interpolationContent.children
-              |> Stdlib.List.any (fun c -> c.typ == "ERROR")
-            if interpHasErrorChild then
+            if hasErrorChild interpolationContent then
               createUnparseableErrorMsg
                 interpolationContent
                 "Invalid escape sequence in interpolated string"
@@ -222,10 +215,7 @@ let parseCharLiteral
   // Invalid escapes in char literals (e.g. `'\d'`) make tree-sitter emit an
   // ERROR child at the char_literal level and a MISSING close-quote. Catch
   // this directly so the error message names the actual problem.
-  let hasErrorChild =
-    node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
-
-  if hasErrorChild then
+  if hasErrorChild node then
     createUnparseableErrorMsg node "Invalid escape sequence in char literal"
   else
     let openQuoteNode = findField node "symbol_open_single_quote"
@@ -682,15 +672,32 @@ let parseMatchCase
       (whenKeyword, guardExpr) |> Stdlib.Option.Option.Some
     | _ -> Stdlib.Option.Option.None
 
-  match pipeSym, pattern, arrowSym, rhs with
-  | Ok pipe, Ok pattern, Ok arrow, Ok rhs ->
-    (WrittenTypes.MatchCase
-      { pat = (pipe.range, pattern, arrow.range)
-        whenCondition = guardExpr
-        rhs = rhs })
-    |> Stdlib.Result.Result.Ok
+  // An ERROR child means tree-sitter couldn't parse the case and recovered by
+  // dropping content. Reject it rather than silently building a case from the
+  // surviving fragment (which then never matches at runtime, with no error).
+  let errorChild =
+    node.children |> Stdlib.List.findFirst (fun c -> c.typ == "ERROR")
 
-  | _ -> createUnparseableError node
+  match errorChild with
+  // Qualified enum-case patterns like `| Stdlib.Result.Result.Ok n ->` are
+  // unsupported (use the bare case name `| Ok n`). In this recovery shape,
+  // tree-sitter keeps the first path segment as the case name and puts the
+  // remaining dotted path in an ERROR child.
+  | Some err when Stdlib.String.contains err.text "." ->
+    createUnparseableErrorMsg
+      node
+      "Invalid match pattern. Enum patterns use the bare case name (e.g. `| Ok n`), not a qualified path like `| Stdlib.Result.Result.Ok n`."
+  | Some _ -> createUnparseableErrorMsg node "Invalid match case syntax."
+  | None ->
+    match pipeSym, pattern, arrowSym, rhs with
+    | Ok pipe, Ok pattern, Ok arrow, Ok rhs ->
+      (WrittenTypes.MatchCase
+        { pat = (pipe.range, pattern, arrow.range)
+          whenCondition = guardExpr
+          rhs = rhs })
+      |> Stdlib.Result.Result.Ok
+
+    | _ -> createUnparseableError node
 
 
 let parseMatchExpression
@@ -720,6 +727,9 @@ let parseMatchExpression
     ))
     |> Stdlib.Result.Result.Ok
 
+  // Propagate a case's own parse error (keeping its note and precise range)
+  // rather than discarding it behind a generic whole-match error.
+  | _, _, _, Error caseErr -> Stdlib.Result.Result.Error caseErr
   | _ -> createUnparseableError node
 
 

--- a/packages/darklang/languageTools/parser/functionDeclaration.dark
+++ b/packages/darklang/languageTools/parser/functionDeclaration.dark
@@ -155,6 +155,9 @@ let parse
           symbolEquals = equals.range })
       |> Stdlib.Result.Result.Ok
 
+    // Propagate the body's own parse error (note + precise range) instead of
+    // collapsing it into a generic whole-declaration error.
+    | _, _, _, _, Error bodyErr, _, _, _ -> Stdlib.Result.Result.Error bodyErr
     | _ -> createUnparseableError node
 
   else

--- a/packages/darklang/languageTools/parser/matchPattern.dark
+++ b/packages/darklang/languageTools/parser/matchPattern.dark
@@ -115,11 +115,8 @@ let parseMPString
   // tree-sitter classifies invalid escape sequences (e.g. "\d") as ERROR
   // children rather than `char_or_string_escape_sequence`. Surface them as
   // a parse failure instead of silently dropping content.
-  let hasErrorChild =
-    node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
-
   let contents =
-    if hasErrorChild then
+    if hasErrorChild node then
       createUnparseableErrorMsg
         node
         "Invalid escape sequence in string match pattern"
@@ -146,10 +143,7 @@ let parseMPString
 let parseMPChar
   (node: ParsedNode)
   : Stdlib.Result.Result<WrittenTypes.MatchPattern, WrittenTypes.Unparseable> =
-  let hasErrorChild =
-    node.children |> Stdlib.List.any (fun c -> c.typ == "ERROR")
-
-  if hasErrorChild then
+  if hasErrorChild node then
     createUnparseableErrorMsg node "Invalid escape sequence in char match pattern"
   else
     let openQuoteNode = findField node "symbol_open_single_quote"


### PR DESCRIPTION
When the parser hits a match case it can't understand, it now reports a clear error; before, it would quietly keep whatever fragment survived and build a broken case from it.
Example: enum pattern like `| Stdlib.Result.Result.Ok n ->...` the parser kept just the first piece as the case name, threw away the rest, and produced a match case that silently never matched at runtime, with no error anywhere. Now we get:
`Invalid match pattern. Enum patterns use the bare case name (e.g. | Ok n), not a qualified path like | Stdlib.Result.Result.Ok n.`