### PR TITLE
Parser precedence fix

### DIFF
--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -770,7 +770,15 @@ let parseFunctionCall
       match c.fieldName with
       | Some fName -> fName == "args"
       | None -> false)
-    |> Stdlib.List.map Expr.parse
+    |> Stdlib.List.map (fun arg ->
+      // The grammar's `apply` rule has two arg shapes: single-line apply
+      // (`f 1L 2L`) yields bare `_atom` arg nodes, while multi-line/indented
+      // apply wraps each arg in `expression`. `parse` unwraps the latter;
+      // `parseCase` handles the bare atoms (and paren args) of the former.
+      if arg.typ == "expression" then
+        Expr.parse arg
+      else
+        Expr.parseCase arg)
     |> Stdlib.Result.collect
 
   match fnNameNode, args with

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -376,7 +376,13 @@ module.exports = grammar({
      */
 
     // TODO: reconsider having enum_literal as a simple_expression
-    simple_expression: $ =>
+    // an "atom": a self-delimiting expression usable as a function argument
+    // without parentheses. Hidden (leading `_`) so it inlines to its single
+    // child, leaving the CST shape unchanged. Deliberately excludes
+    // `infix_operation` and `apply` so that application binds tighter than
+    // infix (`f x ++ g y` is `(f x) ++ (g y)`) and apply args don't swallow
+    // operators (`f a + b` is `(f a) + b`).
+    _atom: $ =>
       choice(
         $.unit,
         $.bool_literal,
@@ -403,20 +409,28 @@ module.exports = grammar({
         $.record_update,
         $.qualified_val_or_fn_name,
         $.dbReference,
-        $.infix_operation,
         $.paren_expression,
+      ),
+
+    // operand/value tier: an atom, a function application, or an infix chain.
+    // `apply` is included so applications can be infix operands and values.
+    simple_expression: $ =>
+      choice(
+        $._atom,
+        $.apply,
+        $.infix_operation,
       ),
 
     expression: $ =>
       choice(
+        // `apply` is reachable via `simple_expression`; not listed separately
+        // here (that would make it derivable two ways → grammar conflict).
         $.simple_expression,
 
         $.if_expression,
         $.let_expression,
 
         $.match_expression,
-
-        $.apply,
 
         $.lambda_expression,
         $.pipe_expression,
@@ -889,7 +903,10 @@ module.exports = grammar({
           field("fn", $.qualified_fn_name),
           choice(
             seq(
-              field("args", repeat1($.simple_expression)),
+              // args are `_atom`s (not `simple_expression`) so application
+              // binds tighter than infix: `f a + b` is `(f a) + b`, and an
+              // operator stops arg collection so `f x ++ g y` is `(f x) ++ (g y)`.
+              field("args", repeat1($._atom)),
               optional($._function_boundary),
             ),
             seq(

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -1836,7 +1836,7 @@
         }
       }
     },
-    "simple_expression": {
+    "_atom": {
       "type": "CHOICE",
       "members": [
         {
@@ -1941,11 +1941,24 @@
         },
         {
           "type": "SYMBOL",
-          "name": "infix_operation"
+          "name": "paren_expression"
+        }
+      ]
+    },
+    "simple_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_atom"
         },
         {
           "type": "SYMBOL",
-          "name": "paren_expression"
+          "name": "apply"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "infix_operation"
         }
       ]
     },
@@ -1967,10 +1980,6 @@
         {
           "type": "SYMBOL",
           "name": "match_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "apply"
         },
         {
           "type": "SYMBOL",
@@ -5103,7 +5112,7 @@
                       "type": "REPEAT1",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "simple_expression"
+                        "name": "_atom"
                       }
                     }
                   },

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -8,11 +8,111 @@
         "required": true,
         "types": [
           {
+            "type": "bool_literal",
+            "named": true
+          },
+          {
+            "type": "char_literal",
+            "named": true
+          },
+          {
+            "type": "dbReference",
+            "named": true
+          },
+          {
+            "type": "dict_literal",
+            "named": true
+          },
+          {
+            "type": "enum_literal",
+            "named": true
+          },
+          {
             "type": "expression",
             "named": true
           },
           {
-            "type": "simple_expression",
+            "type": "field_access",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "int128_literal",
+            "named": true
+          },
+          {
+            "type": "int16_literal",
+            "named": true
+          },
+          {
+            "type": "int32_literal",
+            "named": true
+          },
+          {
+            "type": "int64_literal",
+            "named": true
+          },
+          {
+            "type": "int8_literal",
+            "named": true
+          },
+          {
+            "type": "list_literal",
+            "named": true
+          },
+          {
+            "type": "paren_expression",
+            "named": true
+          },
+          {
+            "type": "qualified_val_or_fn_name",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_update",
+            "named": true
+          },
+          {
+            "type": "string_segment",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "uint128_literal",
+            "named": true
+          },
+          {
+            "type": "uint16_literal",
+            "named": true
+          },
+          {
+            "type": "uint32_literal",
+            "named": true
+          },
+          {
+            "type": "uint64_literal",
+            "named": true
+          },
+          {
+            "type": "uint8_literal",
+            "named": true
+          },
+          {
+            "type": "unit",
+            "named": true
+          },
+          {
+            "type": "variable_identifier",
             "named": true
           }
         ]
@@ -586,10 +686,6 @@
       "multiple": false,
       "required": true,
       "types": [
-        {
-          "type": "apply",
-          "named": true
-        },
         {
           "type": "if_expression",
           "named": true
@@ -2956,6 +3052,10 @@
       "multiple": false,
       "required": true,
       "types": [
+        {
+          "type": "apply",
+          "named": true
+        },
         {
           "type": "bool_literal",
           "named": true

--- a/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/cli_scripts.txt
@@ -42,12 +42,12 @@ Builtin.printLine (myFn ())
             )
           )
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-              (simple_expression
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
                 (paren_expression
                   (symbol)
-                  (expression (apply (qualified_fn_name (fn_identifier)) (simple_expression (unit))))
+                  (expression (simple_expression (apply (qualified_fn_name (fn_identifier)) (unit))))
                   (symbol)
                 )
               )
@@ -85,9 +85,9 @@ helloworld ()
         (symbol)
         (indent)
         (expression
-          (apply
-            (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-            (simple_expression
+          (simple_expression
+            (apply
+              (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
               (paren_expression
                 (symbol)
                 (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
@@ -103,6 +103,6 @@ helloworld ()
   )
 
   (expression
-    (apply (qualified_fn_name (fn_identifier)) (simple_expression (unit)))
+    (simple_expression (apply (qualified_fn_name (fn_identifier)) (unit)))
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/Record.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/Record.txt
@@ -10,11 +10,11 @@ Person {name = "John"}
   (expression
     (simple_expression (record_literal
       (qualified_type_name (type_identifier))
-      (symbol)
-      (record_content
+        (symbol)
+        (record_content
         (record_pair (variable_identifier) (symbol) (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))))
       )
-      (symbol)
+                    (symbol)
     ))
   )
 )
@@ -32,13 +32,13 @@ Person {name = "John"; age = 30L}
   (expression
     (simple_expression (record_literal
       (qualified_type_name (type_identifier))
-      (symbol)
-      (record_content
-        (record_pair (variable_identifier) (symbol) (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))))
         (symbol)
+        (record_content
+        (record_pair (variable_identifier) (symbol) (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))))
+          (symbol)
         (record_pair (variable_identifier) (symbol) (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
       )
-      (symbol)
+            (symbol)
     ))
   )
 )
@@ -72,7 +72,7 @@ Person {name = "John"; age = 30L; hobbies = ["reading"; "swimming"]}
                     (symbol)
                     (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
                   )
-                  (symbol)
+                            (symbol)
                 )
               )
             )
@@ -134,7 +134,7 @@ Person {name = "John"; address = Address {city = "New York"; street = "5th Avenu
                       )
                     )
                   )
-                  (symbol)
+                              (symbol)
                 )
               )
             )
@@ -192,7 +192,7 @@ Person {
                     (symbol)
                     (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
                   )
-                  (symbol)
+                            (symbol)
                 )
               )
             )
@@ -231,7 +231,7 @@ MyRecord<String> { name = "test" }
             (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
           )
         )
-        (symbol)
+                    (symbol)
       )
     )
   )
@@ -266,9 +266,10 @@ MyRecord {
             (variable_identifier)
             (symbol)
             (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (int64_literal (digits (positive_digits)) (symbol)))
               )
             )
           )
@@ -322,12 +323,14 @@ MyRecord {
             (symbol)
             (indent)
             (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (indent)
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                (dedent)
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (indent)
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  (dedent)
+                )
               )
             )
             (dedent)
@@ -355,24 +358,26 @@ MyRecord {
                       (symbol)
                       (indent)
                       (expression
-                        (apply
-                          (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                          (indent)
-                          (expression
-                            (simple_expression
-                              (list_literal
-                                (symbol)
-                                (list_content
-                                  (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                        (simple_expression
+                          (apply
+                            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                            (indent)
+                            (expression
+                              (simple_expression
+                                (list_literal
                                   (symbol)
-                                  (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                                  (list_content
+                                    (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                                    (symbol)
+                                    (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                                  )
+                                  (symbol)
                                 )
-                                (symbol)
                               )
                             )
+                            (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+                            (dedent)
                           )
-                          (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
-                          (dedent)
                         )
                       )
                       (dedent)
@@ -423,12 +428,14 @@ MyRecord {
             (symbol)
             (indent)
             (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (indent)
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                (dedent)
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (indent)
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+                  (dedent)
+                )
               )
             )
             (dedent)
@@ -607,15 +614,16 @@ if node.typ == "val_decl" then
             (match_pattern (variable))
             (symbol)
             (expression
-              (apply
-                (qualified_fn_name (fn_identifier))
-                (simple_expression (variable_identifier))
+              (simple_expression
+                (apply
+                  (qualified_fn_name (fn_identifier))
+                  (variable_identifier))
               )
             )
           )
         )
       )
-    (dedent)
+      (dedent)
+      )
     )
   )
-)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/field_access.txt
@@ -95,7 +95,7 @@ field access fn_call
         (paren_expression
           (symbol)
           (expression
-            (apply (qualified_fn_name (fn_identifier)) (simple_expression (unit)))
+            (simple_expression (apply (qualified_fn_name (fn_identifier)) (unit)))
           )
           (symbol)
         )
@@ -122,7 +122,7 @@ field access fn_call - nested
         (field_access
           (paren_expression
             (symbol)
-            (expression (apply (qualified_fn_name (fn_identifier)) (simple_expression (unit))))
+            (expression (simple_expression (apply (qualified_fn_name (fn_identifier)) (unit))))
             (symbol)
           )
           (symbol)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/fn_calls.txt
@@ -281,10 +281,12 @@ Bool.and true false
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-      (simple_expression (bool_literal))
-      (simple_expression (bool_literal))
+    (simple_expression
+      (apply
+        (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+        (bool_literal)
+        (bool_literal)
+      )
     )
   )
 )
@@ -300,22 +302,24 @@ Bool.and (Bool.and true false) false
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-      (simple_expression
+    (simple_expression
+      (apply
+        (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
         (paren_expression
           (symbol)
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-              (simple_expression (bool_literal))
-              (simple_expression (bool_literal))
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+                (bool_literal)
+                (bool_literal)
+              )
             )
           )
           (symbol)
         )
+        (bool_literal)
       )
-      (simple_expression (bool_literal))
     )
   )
 )
@@ -335,15 +339,17 @@ Builtin.printLine (getTitle curiousGeorgeBookId)
   (expression
     (statement
       (expression
-        (apply
-          (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-          (simple_expression
+        (simple_expression
+          (apply
+            (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
             (paren_expression
               (symbol)
               (expression
-                (apply
-                  (qualified_fn_name (fn_identifier))
-                  (simple_expression (variable_identifier))
+                (simple_expression
+                  (apply
+                    (qualified_fn_name (fn_identifier))
+                    (variable_identifier)
+                  )
                 )
               )
               (symbol)
@@ -367,9 +373,9 @@ Builtin.printLine Person { name = "Alice" }
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-      (simple_expression
+    (simple_expression
+      (apply
+        (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
         (record_literal
           (qualified_type_name (type_identifier))
           (symbol)
@@ -377,7 +383,13 @@ Builtin.printLine Person { name = "Alice" }
             (record_pair
               (variable_identifier)
               (symbol)
-              (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+              (expression
+                (simple_expression
+                  (string_segment
+                    (string_literal (symbol) (string_content) (symbol))
+                  )
+                )
+              )
             )
           )
           (symbol)
@@ -400,9 +412,9 @@ Builtin.printLine Stdlib.Option.Option.Some 1L
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-      (simple_expression
+    (simple_expression
+      (apply
+        (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
         (enum_literal
           (qualified_type_name (module_identifier) (symbol) (module_identifier) (symbol) (type_identifier))
           (symbol)
@@ -427,9 +439,9 @@ Builtin.printLine Dict {a = 1L}
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-      (simple_expression
+    (simple_expression
+      (apply
+        (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
         (dict_literal
           (keyword)
           (symbol)
@@ -457,12 +469,14 @@ Builtin.jsonParse<Bool> "true"
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name
+    (simple_expression
+      (apply
+        (qualified_fn_name
         (module_identifier) (symbol) (fn_identifier)
         (type_args (symbol) (type_args_items (type_reference (builtin_type))) (symbol))
+        )
+        (string_segment (string_literal (symbol) (string_content) (symbol)))
       )
-      (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
     )
   )
 )
@@ -478,10 +492,12 @@ Darklang.Stdlib.Http.response request.body 200L
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-      (simple_expression (field_access (variable_identifier) (symbol) (variable_identifier)))
-      (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+    (simple_expression
+      (apply
+        (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+        (field_access (variable_identifier) (symbol) (variable_identifier))
+        (int64_literal (digits (positive_digits)) (symbol))
+      )
     )
   )
 )
@@ -501,91 +517,97 @@ Stdlib.Tuple3.mapAllThree
 
 (source_file
   (expression
-    (apply
-      (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-      (indent)
-      (expression
-        (simple_expression
-          (paren_expression
-            (symbol)
-            (expression
-              (lambda_expression
-                (keyword)
+    (simple_expression
+      (apply
+        (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+        (indent)
+        (expression
+          (simple_expression
+            (paren_expression
+              (symbol)
+              (expression
+                (lambda_expression
+                  (keyword)
                 (lambda_pats (let_pattern (variable_identifier)))
-                (symbol)
-                (expression
-                  (apply
-                    (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                    (simple_expression (variable_identifier))
-                  )
-                )
-              )
-            )
-            (symbol)
-          )
-        )
-      )
-      (expression
-        (simple_expression
-          (paren_expression
-            (symbol)
-            (expression
-              (lambda_expression
-                (keyword)
-                (lambda_pats (let_pattern (variable_identifier)))
-                (symbol)
-                (expression
-                  (simple_expression
-                    (infix_operation
-                      (simple_expression (variable_identifier))
-                      (operator)
-                      (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+                  (symbol)
+                  (expression
+                    (simple_expression
+                      (apply
+                        (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                        (variable_identifier)
+                      )
                     )
                   )
                 )
               )
+              (symbol)
             )
-            (symbol)
           )
         )
-      )
-      (expression
-        (simple_expression
-          (paren_expression
-            (symbol)
-            (expression
-              (lambda_expression
-                (keyword)
+        (expression
+          (simple_expression
+            (paren_expression
+              (symbol)
+              (expression
+                (lambda_expression
+                  (keyword)
                 (lambda_pats (let_pattern (variable_identifier)))
-                (symbol)
-                (expression
-                  (apply
-                    (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                    (simple_expression (variable_identifier))
+                  (symbol)
+                  (expression
+                    (simple_expression
+                      (infix_operation
+                        (simple_expression (variable_identifier))
+                        (operator)
+                      (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+                      )
+                    )
                   )
                 )
               )
+              (symbol)
             )
-            (symbol)
           )
         )
-      )
-      (expression
-        (simple_expression
-          (tuple_literal
-            (symbol)
-            (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
-            (symbol)
-            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-            (tuple_literal_the_rest
+        (expression
+          (simple_expression
+            (paren_expression
+              (symbol)
+              (expression
+                (lambda_expression
+                  (keyword)
+                (lambda_pats (let_pattern (variable_identifier)))
+                  (symbol)
+                  (expression
+                    (simple_expression
+                      (apply
+                        (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                        (variable_identifier)
+                      )
+                    )
+                  )
+                )
+              )
+              (symbol)
+            )
+          )
+        )
+        (expression
+          (simple_expression
+            (tuple_literal
               (symbol)
               (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+              (symbol)
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+              (tuple_literal_the_rest
+                (symbol)
+              (expression (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol)))))
+              )
+              (symbol)
             )
-            (symbol)
           )
         )
+        (dedent)
       )
-      (dedent)
     )
   )
 )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/if_else.txt
@@ -429,14 +429,17 @@ if a > b then
           (expression
             (statement
               (expression
-                (apply
-                  (qualified_fn_name (fn_identifier))
-                  (indent)
+                (simple_expression
+                  (apply
+                    (qualified_fn_name (fn_identifier))
+                    (indent)
                   (expression (simple_expression (variable_identifier)))
-                  (dedent)
+                    (dedent)
+                  )
                 )
               )
-              (expression (simple_expression (variable_identifier)))
+              (expression (simple_expression (variable_identifier))
+              )
             )
           )
         )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/lambda.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/lambda.txt
@@ -221,9 +221,11 @@ fun x ->
           (expression
             (statement
               (expression
-                (apply
-                  (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-                  (simple_expression (variable_identifier))
+                (simple_expression
+                  (apply
+                    (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+                    (variable_identifier)
+                  )
                 )
               )
               (expression (simple_expression (variable_identifier)))

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
@@ -227,10 +227,12 @@ x
     (let_expression
       (keyword) (let_pattern (variable_identifier)) (symbol)
       (expression
-        (apply
-          (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
-          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+        (simple_expression
+          (apply
+            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+            (int64_literal (digits (positive_digits)) (symbol))
+            (int64_literal (digits (positive_digits)) (symbol))
+          )
         )
       )
       (expression (simple_expression (variable_identifier)))
@@ -256,12 +258,14 @@ x
       (keyword) (let_pattern (variable_identifier)) (symbol)
       (indent)
       (expression
-        (apply
-          (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-          (indent)
-          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-          (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-          (dedent)
+        (simple_expression
+          (apply
+            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+            (indent)
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
+            (dedent)
+          )
         )
       )
       (dedent)
@@ -291,9 +295,12 @@ x
           (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
           (keyword)
           (expression
-            (apply (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
-              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                (int64_literal (digits (positive_digits)) (symbol))
+                (int64_literal (digits (positive_digits)) (symbol))
+              )
             )
           )
         )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/list.txt
@@ -491,9 +491,9 @@ List of fn calls
         (list_content
           (indent)
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-              (simple_expression
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
                 (tuple_literal
                   (symbol)
                   (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
@@ -506,17 +506,19 @@ List of fn calls
           )
           (newline)
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
-              (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                (int64_literal (digits (positive_digits)) (symbol))
+                (int64_literal (digits (positive_digits)) (symbol))
+              )
             )
           )
           (newline)
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-              (simple_expression
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
                 (list_literal
                   (symbol)
                   (list_content
@@ -560,12 +562,14 @@ List of fn calls
               (paren_expression
                 (symbol)
                 (expression
-                  (apply
-                    (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                    (indent)
+                  (simple_expression
+                    (apply
+                      (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                      (indent)
                     (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
                     (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                    (dedent)
+                      (dedent)
+                    )
                   )
                 )
                 (symbol)
@@ -574,9 +578,9 @@ List of fn calls
           )
           (newline)
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-              (simple_expression
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
                 (tuple_literal
                   (symbol)
                   (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
@@ -589,9 +593,9 @@ List of fn calls
           )
           (newline)
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-              (simple_expression
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
                 (list_literal
                   (symbol)
                   (list_content

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/match.txt
@@ -157,9 +157,11 @@ match [ true ] with
                 (paren_expression
                   (symbol)
                   (expression
-                    (apply
-                      (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                      (simple_expression (variable_identifier))
+                    (simple_expression
+                      (apply
+                        (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                        (variable_identifier)
+                      )
                     )
                   )
                   (symbol)
@@ -174,7 +176,7 @@ match [ true ] with
       (match_case
         (symbol)
         (match_pattern (list (symbol) (mp_list_content (match_pattern (bool))) (symbol)))
-        (symbol)
+            (symbol)
         (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
       )
       (match_case
@@ -720,10 +722,12 @@ match var with
         (match_pattern (int64 (digits (positive_digits)) (symbol)))
         (symbol)
         (expression
-          (apply
-            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-            (simple_expression (variable_identifier))
-            (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+          (simple_expression
+            (apply
+              (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+              (variable_identifier)
+              (int64_literal (digits (positive_digits)) (symbol))
+            )
           )
         )
       )
@@ -755,7 +759,7 @@ match var with
       (match_case
         (symbol)
         (match_pattern (int64 (digits (positive_digits)) (symbol)))
-        (symbol)
+            (symbol)
         (expression (simple_expression (variable_identifier)))
       )
     )

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/pipe.txt
@@ -390,10 +390,12 @@ Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L
   (expression
     (pipe_expression
       (expression
-        (apply
-          (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
-          (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+        (simple_expression
+          (apply
+            (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+            (int64_literal (digits (positive_digits)) (symbol))
+            (int64_literal (digits (positive_digits)) (symbol))
+          )
         )
       )
       (pipe_exprs

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/record_update.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/record_update.txt
@@ -279,41 +279,41 @@ record_update - apply
             (variable_identifier)
             (symbol)
             (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (simple_expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
                   (list_literal
                     (symbol)
                     (list_content (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
                     (symbol)
                   )
+                  (int64_literal (digits (positive_digits)) (symbol))
                 )
-                (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
               )
             )
           )
           (newline)
-
           (record_update_field
             (variable_identifier)
             (symbol)
             (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
-                (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (int64_literal (digits (positive_digits)) (symbol))
+                  (int64_literal (digits (positive_digits)) (symbol))
+                )
               )
             )
           )
           (newline)
-
           (record_update_field
             (variable_identifier)
             (symbol)
             (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (simple_expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
                   (tuple_literal
                     (symbol)
                     (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
@@ -371,24 +371,24 @@ record_update - mix
                     (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
                   )
                   (symbol))
-                )
-              )
-            )
-          (newline)
-
-          (record_update_field
-            (variable_identifier)
-            (symbol)
-            (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
-                (simple_expression (int64_literal (digits (positive_digits)) (symbol)))
               )
             )
           )
           (newline)
-
+          (record_update_field
+            (variable_identifier)
+            (symbol)
+            (expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (int64_literal (digits (positive_digits)) (symbol))
+                  (int64_literal (digits (positive_digits)) (symbol))
+                )
+              )
+            )
+          )
+          (newline)
           (record_update_field
             (variable_identifier)
             (symbol)
@@ -430,20 +430,22 @@ record_update - apply
             (symbol)
             (indent)
             (expression
-              (apply
-                (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
-                (indent)
-                (expression
-                  (simple_expression
-                    (list_literal
-                      (symbol)
+              (simple_expression
+                (apply
+                  (qualified_fn_name (module_identifier) (symbol) (module_identifier) (symbol) (module_identifier) (symbol) (fn_identifier))
+                  (indent)
+                  (expression
+                    (simple_expression
+                      (list_literal
+                        (symbol)
                       (list_content (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-                      (symbol)
+                        (symbol)
+                      )
                     )
                   )
-                )
                 (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
-                (dedent)
+                  (dedent)
+                )
               )
             )
             (dedent)

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/statement.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/statement.txt
@@ -11,9 +11,11 @@ Builtin.printline "hello"
   (expression
     (statement
       (expression
-        (apply
-          (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-          (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
+        (simple_expression
+          (apply
+            (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+            (string_segment (string_literal (symbol) (string_content) (symbol)))
+          )
         )
       )
       (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol))))
@@ -38,15 +40,19 @@ Builtin.printline "world"
       (expression
         (statement
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-              (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+                (string_segment (string_literal (symbol) (string_content) (symbol)))
+              )
             )
           )
           (expression
-            (apply
-              (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-              (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
+            (simple_expression
+              (apply
+                (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+                (string_segment (string_literal (symbol) (string_content) (symbol)))
+              )
             )
           )
         )

--- a/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/fn_decls.txt
@@ -72,10 +72,12 @@ let isHigher (a: Int64) (b: Int64): Bool =
     (symbol)
     (indent)
     (expression
-      (apply
-        (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-        (simple_expression (variable_identifier))
-        (simple_expression (variable_identifier))
+      (simple_expression
+        (apply
+          (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+          (variable_identifier)
+          (variable_identifier)
+        )
       )
     )
     (dedent)
@@ -174,14 +176,16 @@ let helloworld () : Int64 =
         (symbol)
         (indent)
         (expression
-          (apply
-            (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
-            (simple_expression (string_segment (string_literal (symbol) (string_content) (symbol))))
+          (simple_expression
+            (apply
+              (qualified_fn_name (module_identifier) (symbol) (fn_identifier))
+              (string_segment (string_literal (symbol) (string_content) (symbol)))
+            )
           )
         )
         (dedent)
         (expression (simple_expression (int64_literal (digits (positive_digits)) (symbol)))))
-      )
+    )
     (dedent)
   )
 )
@@ -251,9 +255,11 @@ let processItem (item: Item) : Result<Items.Item, Error.ProcessingError> =
                 (symbol)
                 (indent)
                 (expression
-                  (apply
-                    (qualified_fn_name (fn_identifier))
-                    (simple_expression (variable_identifier))
+                  (simple_expression
+                    (apply
+                      (qualified_fn_name (fn_identifier))
+                      (variable_identifier)
+                    )
                   )
                 )
                 (dedent)
@@ -263,9 +269,11 @@ let processItem (item: Item) : Result<Items.Item, Error.ProcessingError> =
                 (match_pattern (variable))
                 (symbol)
                 (expression
-                  (apply
-                    (qualified_fn_name (fn_identifier))
-                    (simple_expression (variable_identifier))
+                  (simple_expression
+                    (apply
+                      (qualified_fn_name (fn_identifier))
+                      (variable_identifier)
+                    )
                   )
                 )
               )
@@ -278,9 +286,11 @@ let processItem (item: Item) : Result<Items.Item, Error.ProcessingError> =
           (match_pattern (variable))
           (symbol)
           (expression
-            (apply
-              (qualified_fn_name (fn_identifier))
-              (simple_expression (variable_identifier))
+            (simple_expression
+              (apply
+                (qualified_fn_name (fn_identifier))
+                (variable_identifier)
+              )
             )
           )
         )


### PR DESCRIPTION
This PR fixes operator precedence between function application and infix operators. Function calls now bind tighter
so we no longer have to wrap function applications in parentheses.