### PR TITLE
Tailscale bindings, CLI usage (towards sync)

### DIFF
--- a/backend/testfiles/execution/cli/tailscale.dark
+++ b/backend/testfiles/execution/cli/tailscale.dark
@@ -1,0 +1,12 @@
+// `Darklang.Tailscale` — minimal wrappers over the `tailscale` CLI (backs `dark devices`). The
+// shell-outs (`run`/`status`/`serve`/`ping`) need the daemon in the environment; the two PURE helpers
+// — the MagicDNS peer URL and the identity-header reader — are testable here.
+
+// peerUrl builds the MagicDNS URL a peer is reached at
+Darklang.Tailscale.peerUrl "major" "tail-scale" = "https://major.tail-scale.ts.net"
+Darklang.Tailscale.peerUrl "laptop" "example" = "https://laptop.example.ts.net"
+
+// loginHeader extracts the injected `Tailscale-User-Login` identity (present, missing, empty cases)
+Darklang.Tailscale.loginHeader [("Tailscale-User-Login", "user@example.com"); ("X-Other", "y")] = Stdlib.Option.Option.Some "user@example.com"
+Darklang.Tailscale.loginHeader [("X-Other", "y")] = Stdlib.Option.Option.None
+Darklang.Tailscale.loginHeader [] = Stdlib.Option.Option.None

--- a/packages/darklang/cli/commands/devices.dark
+++ b/packages/darklang/cli/commands/devices.dark
@@ -1,0 +1,66 @@
+module Darklang.Cli.Commands.Devices
+
+// `dark devices` — your tailnet at a glance, plus a couple of operations, over the real `tailscale`
+// CLI (backed by the `Darklang.Tailscale` wrappers). No sync coupling.
+
+// `devices` with no subcommand is the interactive landing: the device list, then the actions you can
+// take next. `devices status` is the clean, pipeable form (just the list).
+let private showStatus () : Unit =
+  match Darklang.Tailscale.status () with
+  | Ok out -> Stdlib.printLine out
+  | Error e -> Stdlib.printLine (Colors.error $"devices: status failed: {e}")
+
+let execute (state: AppState) (args: List<String>) : AppState =
+  match args with
+  | [] ->
+    // interactive landing — what's on the tailnet + what you can do
+    showStatus ()
+    Stdlib.printLine ""
+    Stdlib.printLine (Colors.hint "actions:  devices serve <port>    devices ping <peer>")
+    state
+
+  | [ "status" ] ->
+    showStatus ()  // explicit + clean (pipeable)
+    state
+
+  | [ "serve"; portStr ] ->
+    match Stdlib.Int64.parse portStr with
+    | Ok port ->
+      match Darklang.Tailscale.serve port with
+      | Ok() ->
+        Stdlib.printLine
+          (Colors.success $"serving local :{portStr} over the tailnet (TLS on 443)")
+      | Error e -> Stdlib.printLine (Colors.error $"devices: serve failed: {e}")
+    | Error _ -> Stdlib.printLine (Colors.error "Usage: devices serve <port>")
+    state
+
+  | [ "ping"; peer ] ->
+    match Darklang.Tailscale.ping peer with
+    | Ok out -> Stdlib.printLine out
+    | Error e -> Stdlib.printLine (Colors.error $"devices: ping failed: {e}")
+    state
+
+  | _ ->
+    Stdlib.printLine "Usage: devices [status] | serve <port> | ping <peer>"
+    state
+
+
+let help (state: AppState) : AppState =
+  [ "Usage: devices <command>"
+    "Your tailnet devices + a couple of operations (over the `tailscale` CLI)."
+    ""
+    "Commands:"
+    "  status            List your tailnet devices (default)"
+    "  serve <port>      Expose a local HTTP port over the tailnet via TLS (443)"
+    "  ping <peer>       Reachability check to a device by MagicDNS name" ]
+  |> Stdlib.printLines
+  state
+
+
+let complete
+  (state: AppState)
+  (args: List<String>)
+  : List<Completion.CompletionItem> =
+  match args with
+  | [] -> [ "status"; "serve"; "ping" ] |> Stdlib.List.map Completion.simple
+  | _ -> []

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -273,7 +273,8 @@ module Registry =
       ("review", "Review branch changesets", [], Darklang.Cli.Apps.Review.App.execute, Darklang.Cli.Apps.Review.App.help, Darklang.Cli.Apps.Review.App.complete)
       ("views", "Browse and preview CLI views", [], Darklang.Cli.Apps.Views.App.execute, Darklang.Cli.Apps.Views.App.help, Darklang.Cli.Apps.Views.App.complete)
       ("login", "Log in as a seeded account (required for commit / serve)", [], Commands.Login.execute, Commands.Login.help, Commands.Login.complete)
-      ("logout", "Clear the active account", [], Commands.Logout.execute, Commands.Logout.help, Commands.Logout.complete) ]
+      ("logout", "Clear the active account", [], Commands.Logout.execute, Commands.Logout.help, Commands.Logout.complete)
+      ("devices", "Your tailnet devices (status / serve / ping), over the `tailscale` CLI", [], Commands.Devices.execute, Commands.Devices.help, Commands.Devices.complete) ]
     |> Stdlib.List.map(
       // CLEANUP nitpicky: swap help and complete
       fun (name, desc, aliases, execute, help, complete) ->
@@ -351,6 +352,7 @@ module Registry =
       ("Execution", [ "run"; "eval"; "scripts" ])
       ("Installation", [ "install"; "update"; "uninstall"; "version" ])
       ("AI", [ "agent" ])
+      ("Network", [ "devices" ])
       ("Utilities", [ "clear"; "help"; "docs"; "quit"; "builtins"; "export-seed"; "views" ]) ]
 
   // Helper function to format a group of commands with details

--- a/packages/darklang/tailscale.dark
+++ b/packages/darklang/tailscale.dark
@@ -1,0 +1,42 @@
+module Darklang.Tailscale
+
+// Minimal wrappers over the real `tailscale` CLI (via `Stdlib.Cli.execute` — you hand it a command
+// string, no process plumbing) plus the pure addressing/auth helpers. Backs the `dark devices`
+// command; general tailnet operations, no coupling to anything else.
+
+// ─── addressing (pure) ───
+
+// The MagicDNS URL a tailnet peer is reached at — 443, no explicit port, fronted by `tailscale serve`.
+let peerUrl (name: String) (tailnet: String) : String =
+  "https://" ++ name ++ "." ++ tailnet ++ ".ts.net"
+
+
+// ─── CLI wrappers (shell out to the `tailscale` binary) ───
+
+// Run a `tailscale` subcommand: stdout on success, stderr as the error. The one shell-out seam.
+let run (subcommand: String) : Stdlib.Result.Result<String, String> =
+  Stdlib.Cli.executeWithStdOutOrStdErr ("tailscale " ++ subcommand)
+
+// Your tailnet at a glance — the peer/device list (`tailscale status`).
+let status () : Stdlib.Result.Result<String, String> =
+  run "status"
+
+// Expose this instance's local HTTP server over TLS on the tailnet (`tailscale serve --https=443`).
+let serve (localPort: Int64) : Stdlib.Result.Result<Unit, String> =
+  Stdlib.Cli.executeWithUnitOrStdErr
+    ("tailscale serve --https=443 " ++ Stdlib.Int64.toString localPort)
+
+// Reachability check to a peer by MagicDNS name (`tailscale ping <peer>`).
+let ping (peer: String) : Stdlib.Result.Result<String, String> =
+  run ("ping " ++ peer)
+
+
+// ─── auth (read on the inbound HTTP path) ───
+
+// Tailscale injects `Tailscale-User-Login` after terminating TLS; a receiver reads it as the
+// request's identity (e.g. → account attribution).
+let loginHeader
+  (headers: List<(String * String)>)
+  : Stdlib.Option.Option<String> =
+  let found = Stdlib.List.findFirst headers (fun (k, _) -> k == "Tailscale-User-Login")
+  Stdlib.Option.map found (fun (_, v) -> v)


### PR DESCRIPTION
Efforts towards sync+stable: a thin `Darklang.Tailscale` module over the real `tailscale` CLI, plus a `dark tailscale` command. One sync strategy rests on a tailscale network.


```fsharp
module Darklang.Tailscale
let peerUrl (name: String) (tailnet: String) : String          // MagicDNS: https://{name}.{tailnet}.ts.net
let run    (subcommand: String) : Result<String, String>       // the ONE seam: Cli.executeWithStdOutOrStdErr ("tailscale " ++ …)
let status () : Result<String, String> = run "status"          // the peer/device list, raw
let serve  (localPort: Int64) : Result<Unit, String>           // tailscale serve --https=443 <port>
let ping   (peer: String) : Result<String, String> = run ("ping " ++ peer)
let loginHeader (headers: List<String * String>) : Option<String>   // Tailscale-User-Login → identity
```

```
$ dark devices status                      # your tailnet at a glance
major    major.tail-scale.ts.net    online   (self)
laptop   laptop.tail-scale.ts.net   online

$ dark devices ping major                  # the whole stance, one round-trip
← 200 "pong"  (as stachu@stachu.net, 14ms)
```

`dark devices status | serve <port> | ping <peer>` + help + completion, under a new `Network` group.