### PR TITLE
Add capability-based restrictions to Builtin evaluation

### DIFF
--- a/backend/migrations/schema.sql
+++ b/backend/migrations/schema.sql
@@ -248,6 +248,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_package_dependencies_unique
     COALESCE(depends_on_name, '')
   );
 
+-- package_caps — content-addressed cache of a fn's effective capabilities (see PackageCaps.fs).
+-- `caps` = newline-joined sorted grant-specs; '' = pure.
+CREATE TABLE IF NOT EXISTS package_caps (
+  hash TEXT PRIMARY KEY,
+  caps TEXT NOT NULL
+);
+
 
 --------------------
 -- Traces

--- a/backend/src/Builtins/Builtins.Cli/Libs/Directory.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Directory.fs
@@ -28,6 +28,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileRead
       deprecated = NotDeprecated }
 
 
@@ -38,8 +39,10 @@ let fns () : List<BuiltInFn> =
       description = "Returns the directory at <param path>"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
           uply {
+            // precise check: this exact path must be covered (gate checked file presence).
+            LibExecution.CapabilityCheck.requireFileRead state.grantedCaps path
             // TODO make async
             let contents =
               try
@@ -52,6 +55,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileRead
       deprecated = NotDeprecated }
 
 
@@ -71,6 +75,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Cli/Libs/Environment.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Environment.fs
@@ -22,7 +22,9 @@ let fns () : List<BuiltInFn> =
         "Gets the value of the environment variable with the given <param varName> if it exists."
       fn =
         (function
-        | _, _, _, [ DString varName ] ->
+        | state, _, _, [ DString varName ] ->
+          // precise check: reading this exact env var must be covered (gate checked env presence).
+          LibExecution.CapabilityCheck.requireEnvRead state.grantedCaps varName
           let envValue = System.Environment.GetEnvironmentVariable(varName)
 
           if isNull envValue then
@@ -32,6 +34,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.envRead
       deprecated = NotDeprecated }
 
 
@@ -43,7 +46,9 @@ let fns () : List<BuiltInFn> =
         "Returns a list of tuples containing all the environment variables and their values."
       fn =
         (function
-        | _, _, _, [ DUnit ] ->
+        | state, _, _, [ DUnit ] ->
+          // precise check: reading the WHOLE environment needs an unscoped env-read grant.
+          LibExecution.CapabilityCheck.requireEnvReadAll state.grantedCaps
           let envVars = System.Environment.GetEnvironmentVariables()
 
           let envMap =
@@ -57,6 +62,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.envRead
       deprecated = NotDeprecated }
 
 
@@ -71,6 +77,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Cli/Libs/Execution.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Execution.fs
@@ -185,6 +185,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 
@@ -213,6 +214,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -258,6 +260,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 
@@ -364,6 +367,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 
@@ -417,6 +421,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 

--- a/backend/src/Builtins/Builtins.Cli/Libs/File.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/File.fs
@@ -48,8 +48,10 @@ let fns () : List<BuiltInFn> =
         let resultOk = Dval.resultOk KTBlob errType
         let resultError = Dval.resultError KTBlob errType
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
           uply {
+            // precise check: this exact path must be covered (gate checked file presence).
+            LibExecution.CapabilityCheck.requireFileRead state.grantedCaps path
             try
               let path =
                 path.Replace(
@@ -65,6 +67,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileRead
       deprecated = NotDeprecated }
 
 
@@ -80,6 +83,8 @@ let fns () : List<BuiltInFn> =
         (function
         | state, _, _, [ DBlob ref; DString path ] ->
           uply {
+            // precise check: this exact path must be covered (gate checked file presence).
+            LibExecution.CapabilityCheck.requireFileWrite state.grantedCaps path
             try
               let path =
                 path.Replace(
@@ -96,6 +101,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileWrite
       deprecated = NotDeprecated }
 
 
@@ -106,8 +112,10 @@ let fns () : List<BuiltInFn> =
       description = "Deletes the file specified by <param path>"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
           uply {
+            // precise check: this exact path must be covered (gate checked file presence).
+            LibExecution.CapabilityCheck.requireFileWrite state.grantedCaps path
             try
               System.IO.File.Delete path
               return Dval.resultOk KTUnit KTString DUnit
@@ -121,6 +129,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileWrite
       deprecated = NotDeprecated }
 
 
@@ -134,8 +143,10 @@ let fns () : List<BuiltInFn> =
         let resultOk = Dval.resultOk KTUnit KTString
         let resultError = Dval.resultError KTUnit KTString
         (function
-        | _, _, _, [ DString path; DString content ] ->
+        | state, _, _, [ DString path; DString content ] ->
           uply {
+            // precise check: this exact path must be covered (gate checked file presence).
+            LibExecution.CapabilityCheck.requireFileWrite state.grantedCaps path
             try
               do! System.IO.File.AppendAllTextAsync(path, content)
               return resultOk DUnit
@@ -145,6 +156,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileWrite
       deprecated = NotDeprecated }
 
 
@@ -156,8 +168,10 @@ let fns () : List<BuiltInFn> =
         "Returns true if the file specified by <param path> is a directory, or false if it is a file or does not exist"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
           uply {
+            // precise check: this exact path must be covered (gate checked file presence).
+            LibExecution.CapabilityCheck.requireFileRead state.grantedCaps path
             try
               let attrs = System.IO.File.GetAttributes(path)
               let isDir = attrs.HasFlag(System.IO.FileAttributes.Directory)
@@ -168,6 +182,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileRead
       deprecated = NotDeprecated }
 
 
@@ -179,8 +194,10 @@ let fns () : List<BuiltInFn> =
         "Returns true if a file or directory exists at the specified <param path>, or false otherwise"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
           uply {
+            // precise check: this exact path must be covered (gate checked file presence).
+            LibExecution.CapabilityCheck.requireFileRead state.grantedCaps path
             try
               let exists =
                 System.IO.File.Exists(path) || System.IO.Directory.Exists(path)
@@ -191,6 +208,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileRead
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Cli/Libs/Output.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Output.fs
@@ -29,6 +29,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdout
       deprecated = NotDeprecated }
 
 
@@ -45,6 +46,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdout
       deprecated = NotDeprecated }
 
 
@@ -64,6 +66,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdout
       deprecated = NotDeprecated }
 
 
@@ -85,6 +88,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdout
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Cli/Libs/Posix.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Posix.fs
@@ -495,6 +495,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -513,6 +514,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 
@@ -525,7 +527,8 @@ let fns () : List<BuiltInFn> =
       description = "Sets an environment variable via libc setenv()"
       fn =
         (function
-        | _, _, _, [ DString name; DString value ] ->
+        | state, _, _, [ DString name; DString value ] ->
+          LibExecution.CapabilityCheck.requireEnvWrite state.grantedCaps name
           match Libc.setenv name value with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -533,6 +536,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.envWrite
       deprecated = NotDeprecated }
 
 
@@ -543,7 +547,8 @@ let fns () : List<BuiltInFn> =
       description = "Removes an environment variable via libc unsetenv()"
       fn =
         (function
-        | _, _, _, [ DString name ] ->
+        | state, _, _, [ DString name ] ->
+          LibExecution.CapabilityCheck.requireEnvWrite state.grantedCaps name
           match Libc.unsetenv name with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -551,6 +556,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.envWrite
       deprecated = NotDeprecated }
 
 
@@ -563,7 +569,8 @@ let fns () : List<BuiltInFn> =
       description = "Creates a directory via libc mkdir()"
       fn =
         (function
-        | _, _, _, [ DString path; DInt64 mode ] ->
+        | state, _, _, [ DString path; DInt64 mode ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           match Libc.mkdir path (int mode) with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -571,6 +578,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -581,7 +589,8 @@ let fns () : List<BuiltInFn> =
       description = "Removes an empty directory via libc rmdir()"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           match Libc.rmdir path with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -589,6 +598,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -599,7 +609,8 @@ let fns () : List<BuiltInFn> =
       description = "Removes a file via libc unlink()"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           match Libc.unlink path with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -607,6 +618,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -619,7 +631,8 @@ let fns () : List<BuiltInFn> =
       description = "Renames/moves a file or directory via libc rename()"
       fn =
         (function
-        | _, _, _, [ DString oldpath; DString newpath ] ->
+        | state, _, _, [ DString oldpath; DString newpath ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps oldpath
           match Libc.rename oldpath newpath with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -627,6 +640,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -639,7 +653,8 @@ let fns () : List<BuiltInFn> =
       description = "Changes file permissions via libc chmod()"
       fn =
         (function
-        | _, _, _, [ DString path; DInt64 mode ] ->
+        | state, _, _, [ DString path; DInt64 mode ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           match Libc.chmod path (int mode) with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -647,6 +662,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -657,7 +673,8 @@ let fns () : List<BuiltInFn> =
       description = "Updates atime and mtime to now via libc utimes(path, NULL)"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           match Libc.utimesNow path with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -665,6 +682,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -677,7 +695,8 @@ let fns () : List<BuiltInFn> =
       description = "Creates a symbolic link via libc symlink()"
       fn =
         (function
-        | _, _, _, [ DString target; DString linkpath ] ->
+        | state, _, _, [ DString target; DString linkpath ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps target
           match Libc.symlink target linkpath with
           | Ok() -> Dval.resultOk KTUnit (posixErrorKT ()) DUnit |> Ply
           | Error e ->
@@ -685,6 +704,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -695,7 +715,8 @@ let fns () : List<BuiltInFn> =
       description = "Reads the target of a symbolic link via libc readlink()"
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           match Libc.readlink path with
           | Ok target ->
             Dval.resultOk KTString (posixErrorKT ()) (DString target) |> Ply
@@ -704,6 +725,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -720,7 +742,8 @@ let fns () : List<BuiltInFn> =
         "Creates a unique temp file via libc mkstemp(). Returns (fd, path)."
       fn =
         (function
-        | _, _, _, [ DString prefix ] ->
+        | state, _, _, [ DString prefix ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps prefix
           let resultOk =
             Dval.resultOk (KTTuple(VT.int64, VT.string, [])) (posixErrorKT ())
           let resultError =
@@ -732,6 +755,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -747,7 +771,8 @@ let fns () : List<BuiltInFn> =
         "Creates a unique temp directory via libc mkdtemp(). Returns the path."
       fn =
         (function
-        | _, _, _, [ DString prefix ] ->
+        | state, _, _, [ DString prefix ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps prefix
           match Libc.mkdtemp prefix with
           | Ok path -> Dval.resultOk KTString (posixErrorKT ()) (DString path) |> Ply
           | Error e ->
@@ -755,6 +780,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -766,7 +792,8 @@ let fns () : List<BuiltInFn> =
         "Lists entries in a directory via libc opendir/readdir/closedir. Excludes '.' and '..'."
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           let resultOk =
             Dval.resultOk (KTList(ValueType.Known KTString)) (posixErrorKT ())
           let resultError =
@@ -779,6 +806,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -789,13 +817,15 @@ let fns () : List<BuiltInFn> =
       description = "Gets an environment variable via libc getenv()"
       fn =
         (function
-        | _, _, _, [ DString name ] ->
+        | state, _, _, [ DString name ] ->
+          LibExecution.CapabilityCheck.requireEnvRead state.grantedCaps name
           match Libc.getenv name with
           | Some v -> Dval.optionSome KTString (DString v) |> Ply
           | None -> Dval.optionNone KTString |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.envRead
       deprecated = NotDeprecated }
 
 
@@ -812,7 +842,7 @@ let fns () : List<BuiltInFn> =
         "Spawns a child process, waits for it to finish, returns (exitCode, stdout, stderr)."
       fn =
         (function
-        | _, _, _, [ DString program; DList(_, args) ] ->
+        | state, _, _, [ DString program; DList(_, args) ] ->
           let resultOk =
             Dval.resultOk
               (KTTuple(VT.int64, VT.string, [ VT.string ]))
@@ -827,6 +857,8 @@ let fns () : List<BuiltInFn> =
               match d with
               | DString s -> s
               | _ -> incorrectArgs ())
+          // precise check: this exact program + args must be covered (gate only checked exec presence).
+          LibExecution.CapabilityCheck.requireExec state.grantedCaps program argStrs
           match Libc.spawnAndWait program argStrs with
           | Ok(exitCode, stdout, stderr) ->
             resultOk (
@@ -837,6 +869,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 
@@ -854,7 +887,7 @@ let fns () : List<BuiltInFn> =
         "Spawns a child process with a timeout. Returns (exitCode, stdout, stderr) or Error on timeout."
       fn =
         (function
-        | _, _, _, [ DString program; DList(_, args); DInt64 timeoutMs ] ->
+        | state, _, _, [ DString program; DList(_, args); DInt64 timeoutMs ] ->
           let resultOk =
             Dval.resultOk
               (KTTuple(VT.int64, VT.string, [ VT.string ]))
@@ -869,6 +902,8 @@ let fns () : List<BuiltInFn> =
               match d with
               | DString s -> s
               | _ -> incorrectArgs ())
+          // precise check: this exact program + args must be covered (gate only checked exec presence).
+          LibExecution.CapabilityCheck.requireExec state.grantedCaps program argStrs
           match Libc.spawnAndWaitWithTimeout program argStrs (int timeoutMs) with
           | Ok(exitCode, stdout, stderr) ->
             resultOk (
@@ -879,6 +914,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 
@@ -902,6 +938,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
       deprecated = NotDeprecated }
 
 
@@ -924,6 +961,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -948,6 +986,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -966,6 +1005,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -982,7 +1022,8 @@ let fns () : List<BuiltInFn> =
       description = "Opens a file via libc open(). Returns a file descriptor."
       fn =
         (function
-        | _, _, _, [ DString path; DInt64 flags; DInt64 mode ] ->
+        | state, _, _, [ DString path; DInt64 flags; DInt64 mode ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           match Libc.openFile path (int flags) (int mode) with
           | Ok fd ->
             Dval.resultOk KTInt64 (posixErrorKT ()) (DInt64(int64 fd)) |> Ply
@@ -991,6 +1032,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -1005,6 +1047,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1019,6 +1062,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1033,6 +1077,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1047,6 +1092,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1061,6 +1107,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1075,6 +1122,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1088,7 +1136,8 @@ let fns () : List<BuiltInFn> =
       description = "Stats a file via libc stat(). Returns (mode, size, mtimeSec)."
       fn =
         (function
-        | _, _, _, [ DString path ] ->
+        | state, _, _, [ DString path ] ->
+          LibExecution.CapabilityCheck.requireFileReadWrite state.grantedCaps path
           let resultOk =
             Dval.resultOk
               (KTTuple(VT.int64, VT.int64, [ VT.int64 ]))
@@ -1105,6 +1154,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -1135,6 +1185,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1149,6 +1200,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1163,6 +1215,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1182,6 +1235,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1196,6 +1250,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1214,6 +1269,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1233,6 +1289,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -1254,6 +1311,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.fileReadWrite
       deprecated = NotDeprecated }
 
 
@@ -1272,6 +1330,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Cli/Libs/Stdin.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Stdin.fs
@@ -233,6 +233,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdin
       deprecated = NotDeprecated }
 
 
@@ -249,6 +250,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdin
       deprecated = NotDeprecated }
 
 
@@ -266,6 +268,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -287,6 +290,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdin
       deprecated = NotDeprecated }
 
 
@@ -305,6 +309,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.stdin
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Cli/Libs/Terminal.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Terminal.fs
@@ -103,6 +103,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -126,6 +127,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -140,6 +142,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
+++ b/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
@@ -303,7 +303,11 @@ let fns () : List<BuiltInFn> =
           Param.make
             "allowHarmful"
             TBool
-            "Opt out of Harmful-deprecation halting (see docs/deprecation)" ]
+            "Opt out of Harmful-deprecation halting (see docs/deprecation)"
+          Param.make
+            "applyHostCaps"
+            TBool
+            "Run the script with the host's granted capabilities instead of none (`dark run` is secure-by-default: no caps)" ]
       returnType = TypeReference.result TInt64 (ExecutionError.typeRef ())
       description =
         "Parses Dark code as a script, and and executes it, returning an exit code"
@@ -320,14 +324,18 @@ let fns () : List<BuiltInFn> =
             DString filename
             DString code
             DList(_vtTODO, scriptArgs)
-            DBool allowHarmful ] ->
+            DBool allowHarmful
+            DBool applyHostCaps ] ->
           uply {
             // Attribute the run to the calling account so the trace
             // insert can stamp `traces.account_id`. None passes through
             // (anonymous runs, tests).
             let accountID = C2DT.Option.fromDT D.uuid accountIDDval
             let exeState = { exeState with accountID = accountID }
-            // Use branch-specific state for parsing so name resolution uses the right branch
+            // Use branch-specific state for parsing so name resolution uses the right branch.
+            // Parsing keeps the host's caps — name resolution / package loading needs
+            // cli-host effects to boot (the noCaps-breaks-bootstrap case). Only the script
+            // *body* is sandboxed below (`runState`).
             let branchState = createBranchState exeState branchId allowHarmful
 
             try
@@ -340,6 +348,16 @@ let fns () : List<BuiltInFn> =
 
               match parsedScript with
               | Ok mod' ->
+                // `dark run` is the secure-by-default SANDBOX: the script body gets NO capabilities, so
+                // an effectful builtin (http, fs, time, …) raises unless the run opts into the host's
+                // capabilities via `--apply-host-caps` (`hostCaps`: allCaps until an instance grant is
+                // configured, then that grant).
+                let runCaps =
+                  if applyHostCaps then
+                    LibDB.CapabilityGrants.hostCaps ()
+                  else
+                    LibExecution.Capabilities.noCaps
+                let exeState = { exeState with grantedCaps = runCaps }
                 match!
                   execute
                     exeState
@@ -381,6 +399,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -417,7 +436,12 @@ let fns () : List<BuiltInFn> =
             // Attribute the run to the calling account so the trace
             // insert can stamp `traces.account_id`.
             let accountID = C2DT.Option.fromDT D.uuid accountIDDval
-            let exeState = { exeState with accountID = accountID }
+            // `eval` runs the expression under the HOST's capabilities — `allCaps` until an instance
+            // grant is configured, then whatever that grant allows (the gate denies uncovered builtins).
+            let exeState =
+              { exeState with
+                  accountID = accountID
+                  grantedCaps = LibDB.CapabilityGrants.hostCaps () }
             // Use branch-specific state for parsing so name resolution uses the right branch
             let branchState = createBranchState exeState branchId allowHarmful
 
@@ -466,6 +490,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 

--- a/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
+++ b/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
@@ -305,9 +305,9 @@ let fns () : List<BuiltInFn> =
             TBool
             "Opt out of Harmful-deprecation halting (see docs/deprecation)"
           Param.make
-            "applyHostCaps"
+            "sandbox"
             TBool
-            "Run the script with the host's granted capabilities instead of none (`dark run` is secure-by-default: no caps)" ]
+            "Run the script body with NO capabilities (a deny-all sandbox for untrusted scripts), instead of the host's configured grant" ]
       returnType = TypeReference.result TInt64 (ExecutionError.typeRef ())
       description =
         "Parses Dark code as a script, and and executes it, returning an exit code"
@@ -325,7 +325,7 @@ let fns () : List<BuiltInFn> =
             DString code
             DList(_vtTODO, scriptArgs)
             DBool allowHarmful
-            DBool applyHostCaps ] ->
+            DBool sandbox ] ->
           uply {
             // Attribute the run to the calling account so the trace
             // insert can stamp `traces.account_id`. None passes through
@@ -348,15 +348,19 @@ let fns () : List<BuiltInFn> =
 
               match parsedScript with
               | Ok mod' ->
-                // `dark run` is the secure-by-default SANDBOX: the script body gets NO capabilities, so
-                // an effectful builtin (http, fs, time, …) raises unless the run opts into the host's
-                // capabilities via `--apply-host-caps` (`hostCaps`: allCaps until an instance grant is
-                // configured, then that grant).
+                // `dark run` RESPECTS the host's configured grant by default (`hostCaps`: allCaps until
+                // an instance grant is configured, then that grant) — the same posture as `eval`, so the
+                // grant you set is the grant scripts obey. `--sandbox` drops to NO capabilities for
+                // running untrusted scripts (any effectful builtin then raises).
+                // TODO product decision, revisit: this favors "run my own script" over "run an untrusted
+                // script" (sandbox is opt-IN). If `dark run <url>` / piping untrusted code becomes common,
+                // a deny-all default + `--trust`/`--apply-host-caps` opt-in may be safer. See also the
+                // trust-boundary TODO in `LanguageTools.Capabilities.all`.
                 let runCaps =
-                  if applyHostCaps then
-                    LibDB.CapabilityGrants.hostCaps ()
-                  else
+                  if sandbox then
                     LibExecution.Capabilities.noCaps
+                  else
+                    LibDB.CapabilityGrants.hostCaps ()
                 let exeState = { exeState with grantedCaps = runCaps }
                 match!
                   execute

--- a/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
+++ b/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
@@ -667,6 +667,8 @@ let fns (config : Configuration) : List<BuiltInFn> =
           _,
           [ DString method; DString uri; DList(_, reqHeaders); DBlob bodyRef ] ->
           uply {
+            // precise check: this exact method+URL must be covered (the gate only checked http presence).
+            LibExecution.CapabilityCheck.requireHttp state.grantedCaps method uri
             let! reqBodyBytes = Blob.readBytes state bodyRef
             let! (reqHeaders : Result<List<string * string>, BadHeader.BadHeader>) =
               reqHeaders
@@ -755,6 +757,7 @@ let fns (config : Configuration) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.http
       deprecated = NotDeprecated }
 
 
@@ -797,8 +800,10 @@ let fns (config : Configuration) : List<BuiltInFn> =
         let resultOk = Dval.resultOk streamTypeOk streamTypeErr
         let resultError = Dval.resultError streamTypeOk streamTypeErr
         (function
-        | _, vm, _, [ DString method; DString uri; DList(_, reqHeaders) ] ->
+        | state, vm, _, [ DString method; DString uri; DList(_, reqHeaders) ] ->
           uply {
+            // precise check: this exact method+URL must be covered (the gate only checked http presence).
+            LibExecution.CapabilityCheck.requireHttp state.grantedCaps method uri
             let! (reqHeaders : Result<List<string * string>, BadHeader.BadHeader>) =
               reqHeaders
               |> Ply.List.mapSequentially (fun item ->
@@ -905,6 +910,7 @@ let fns (config : Configuration) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.http
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Http.Server/Libs/HttpServer.fs
+++ b/backend/src/Builtins/Builtins.Http.Server/Libs/HttpServer.fs
@@ -393,6 +393,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.httpServer
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Language/Libs/LanguageTools.fs
+++ b/backend/src/Builtins/Builtins.Language/Libs/LanguageTools.fs
@@ -55,6 +55,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -93,6 +94,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Language/Libs/Parser.fs
+++ b/backend/src/Builtins/Builtins.Language/Libs/Parser.fs
@@ -104,6 +104,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Language/Libs/Reflection.fs
+++ b/backend/src/Builtins/Builtins.Language/Libs/Reflection.fs
@@ -23,6 +23,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
     // { name = fn "reflect" 0

--- a/backend/src/Builtins/Builtins.Matter/Builtin.fs
+++ b/backend/src/Builtins/Builtins.Matter/Builtin.fs
@@ -24,6 +24,7 @@ let builtins (pm : PT.PackageManager) : Builtins =
       Libs.PM.Scripts.builtins ()
       Libs.PM.Dependencies.builtins ()
       Libs.PM.Seed.builtins
+      Libs.PM.Caps.builtins
 
       // Traces (reader surface)
       Libs.Traces.builtins ()

--- a/backend/src/Builtins/Builtins.Matter/Builtins.Matter.fsproj
+++ b/backend/src/Builtins/Builtins.Matter/Builtins.Matter.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Libs/PM/Scripts.fs" />
     <Compile Include="Libs/PM/Dependencies.fs" />
     <Compile Include="Libs/PM/Seed.fs" />
+    <Compile Include="Libs/PM/Caps.fs" />
 
     <!-- Tracing (reader) -->
     <Compile Include="Libs/Traces.fs" />

--- a/backend/src/Builtins/Builtins.Matter/Libs/Account.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/Account.fs
@@ -36,6 +36,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -61,6 +62,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -85,6 +87,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Matter/Libs/DB.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/DB.fs
@@ -124,9 +124,11 @@ let fns () : List<BuiltInFn> =
       description = "Creates a new database"
       fn =
         (function
-        | _, _, _, [ DString dbName; typeHashDval ] ->
+        | exeState, _, _, [ DString dbName; typeHashDval ] ->
           let typeHash = PT2DT.Hash.fromDT typeHashDval
           uply {
+            // precise check: creating this datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbWrite exeState.grantedCaps dbName
             let! existing =
               Sql.query
                 "SELECT COUNT(*) as cnt FROM toplevels_v0
@@ -164,6 +166,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbWrite
       deprecated = NotDeprecated }
 
 
@@ -201,6 +204,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -211,8 +215,10 @@ let fns () : List<BuiltInFn> =
       description = "Drops (deletes) all databases with the given name"
       fn =
         (function
-        | _, _, _, [ DString dbName ] ->
+        | exeState, _, _, [ DString dbName ] ->
           uply {
+            // precise check: dropping this datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbWrite exeState.grantedCaps dbName
             let! matchingTlids =
               Sql.query
                 "SELECT tlid FROM toplevels_v0
@@ -245,6 +251,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbWrite
       deprecated = NotDeprecated }
 
 
@@ -261,6 +268,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ value; DString key; DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbWrite exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
 
             let! id = UserDB.set exeState vm.threadID true db key value
@@ -272,6 +281,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbWrite
       deprecated = NotDeprecated }
 
 
@@ -284,6 +294,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DString key; DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let! result = UserDB.getOption exeState vm.threadID db key
             return TypeChecker.DvalCreator.option vm.threadID VT.unknownDbTODO result
@@ -291,6 +303,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -306,6 +319,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DList(_, keys); DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
 
             let tst = Map.empty // TODO idk if this is reasonable
@@ -328,6 +343,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -341,6 +357,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DList(_, keys); DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
 
             let tst = Map.empty // TODO idk if this is reasonable
@@ -357,6 +375,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -370,6 +389,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DList(_, keys); DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
 
             let tst = Map.empty // TODO idk if this is reasonable
@@ -385,6 +406,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -397,6 +419,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, _, _, [ DString key; DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbWrite exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             do! UserDB.delete exeState db key
             return DUnit
@@ -404,6 +428,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbWrite
       deprecated = NotDeprecated }
 
 
@@ -416,6 +441,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, _, _, [ DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbWrite exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             do! UserDB.deleteAll exeState db
             return DUnit
@@ -423,6 +450,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbWrite
       deprecated = NotDeprecated }
 
 
@@ -435,6 +463,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let tst = Map.empty // TODO idk if this is reasonable
             let! results = UserDB.getAll exeState vm.threadID tst db
@@ -446,6 +476,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -459,6 +490,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let tst = Map.empty // TODO idk if this is reasonable
             let! result = UserDB.getAll exeState vm.threadID tst db
@@ -467,6 +500,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -479,6 +513,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, _, _, [ DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let! (count : int) = UserDB.count exeState db
             return count |> int64 |> DInt64
@@ -486,6 +522,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -500,6 +537,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbWrite
       deprecated = NotDeprecated }
 
 
@@ -513,6 +551,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, _, _, [ DDB dbname ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let! results = UserDB.getAllKeys exeState db
             return results |> List.map DString |> Dval.list KTString
@@ -520,6 +560,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -535,6 +576,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let! compiled = compileQueryLambda exeState appLambda
             return!
@@ -549,6 +592,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = QueryFunction
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -562,6 +606,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let! compiled = compileQueryLambda exeState appLambda
             return!
@@ -576,6 +622,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = QueryFunction
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -589,6 +636,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let! compiled = compileQueryLambda exeState appLambda
             return!
@@ -603,6 +652,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = QueryFunction
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated }
 
 
@@ -616,6 +666,8 @@ let fns () : List<BuiltInFn> =
         (function
         | exeState, vm, _, [ DDB dbname; DApplicable(AppLambda appLambda) ] ->
           uply {
+            // precise check: this exact datastore must be covered (gate checked db presence).
+            LibExecution.CapabilityCheck.requireDbRead exeState.grantedCaps dbname
             let db = exeState.program.dbs[dbname]
             let! compiled = compileQueryLambda exeState appLambda
             return!
@@ -630,6 +682,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = QueryFunction
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.dbRead
       deprecated = NotDeprecated } ]
 
 let builtins () = Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Branches.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Branches.fs
@@ -32,6 +32,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -53,6 +54,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -74,6 +76,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -95,6 +98,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -116,6 +120,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -140,6 +145,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -162,6 +168,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -184,6 +191,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -206,6 +214,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Caps.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Caps.fs
@@ -1,0 +1,103 @@
+/// Builtins behind `dark caps` — the MINIMAL core for viewing + controlling this instance's grant.
+///
+/// The grant is a structured `Capabilities` record stored LOCALLY in `~/.darklang/capabilities.bin`
+/// (never synced), default NONE. These builtins exchange the STRUCTURED value across the F#/Dark
+/// boundary (via `CapabilitiesToDarkTypes`) — F# never parses or renders the grant-spec language; that
+/// all lives in `.dark` (`LanguageTools.Capabilities.parse`/`render`). `pmCapsGet` reads the grant,
+/// `pmCapsSet` REPLACES it; `pmFnEffectiveCaps` is the static analyzer behind `dark caps needed-for
+/// <fn>`. The runtime gate that ENFORCES the grant lives in the interpreter (`Capabilities.covers`).
+module Builtins.Matter.Libs.PM.Caps
+
+open Prelude
+open LibExecution.RuntimeTypes
+
+module Dval = LibExecution.Dval
+module VT = LibExecution.ValueType
+module Builtin = LibExecution.Builtin
+module C2DT = LibExecution.CapabilitiesToDarkTypes
+module NR = LibExecution.RuntimeTypes.NameResolution
+
+open Builtin.Shortcuts
+
+
+/// The structured `Capabilities` Dark type, as a TypeReference (builtin param/return).
+let private capsType : TypeReference =
+  TCustomType(NR.ok (C2DT.Capabilities.typeName ()), [])
+
+
+let fns : List<BuiltInFn> =
+  [ { name = fn "pmCapsGet" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = capsType
+      description =
+        "This instance's current capability grant, as a structured <type Capabilities> value (NONE — the
+         strict default — is the all-empty grant). The CORE read primitive: `.dark` renders it and
+         composes adjustments over it."
+      fn =
+        (function
+        | _, _, _, [ DUnit ] ->
+          uply {
+            return LibDB.CapabilityGrants.getGrant () |> C2DT.Capabilities.toDT
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "pmCapsSet" 0
+      typeParams = []
+      parameters = [ Param.make "caps" capsType "The full grant to replace with" ]
+      returnType = TUnit
+      description =
+        "REPLACE the whole grant with exactly this <type Capabilities> — the CORE write primitive. The
+         all-empty grant sets NONE. `.dark` parses/validates spec strings into the structure and builds
+         grant/revoke/clear/profile on top of get+set."
+      fn =
+        (function
+        | _, _, _, [ caps ] ->
+          uply {
+            C2DT.Capabilities.fromDT caps |> LibDB.CapabilityGrants.setGrant
+            return DUnit
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "pmFnEffectiveCaps" 0
+      typeParams = []
+      parameters = [ Param.make "hash" TString "The package-fn hash to analyze" ]
+      returnType = capsType
+      description =
+        "The capabilities a package fn (transitively) needs, as a structured <type Capabilities> value
+         (behind `dark caps needed-for <fn>`). See `LibDB.PackageCaps`."
+      fn =
+        (function
+        | exeState, _, _, [ DString hashStr ] ->
+          uply {
+            // a builtin's declared caps, by flat name — built from the runtime's builtin map (no name
+            // magic; the need lives on each `BuiltInFn`).
+            let capsByName =
+              exeState.fns.builtIn
+              |> Map.toList
+              |> List.map (fun (k, b) -> k.name, b.capabilities)
+              |> Map.ofList
+            let capsFor (name : string) : LibExecution.Capabilities.Capabilities =
+              Map.tryFind name capsByName
+              |> Option.defaultValue LibExecution.Capabilities.noCaps
+            let! caps = LibDB.PackageCaps.effectiveCaps capsFor hashStr
+            return C2DT.Capabilities.toDT caps
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated } ]
+
+
+let builtins = LibExecution.Builtin.make [] fns

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Dependencies.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Dependencies.fs
@@ -72,6 +72,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -119,6 +120,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -159,6 +161,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Merge.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Merge.fs
@@ -36,6 +36,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -61,6 +62,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/PackageOps.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/PackageOps.fs
@@ -43,6 +43,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -90,6 +91,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -108,6 +110,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -134,6 +137,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -163,6 +167,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -181,6 +186,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -199,6 +205,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -238,6 +245,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -286,6 +294,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -310,6 +319,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -333,6 +343,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -357,6 +368,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -375,6 +387,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -424,6 +437,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Packages.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Packages.fs
@@ -68,6 +68,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -101,6 +102,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -123,6 +125,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -154,6 +157,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -180,6 +184,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -210,6 +215,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -247,6 +253,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -278,6 +285,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -302,6 +310,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -327,6 +336,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -352,6 +362,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -376,6 +387,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -400,6 +412,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -442,6 +455,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -529,6 +543,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -634,6 +649,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -669,6 +685,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -722,6 +739,7 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Rebase.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Rebase.fs
@@ -41,6 +41,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -63,6 +64,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Scripts.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Scripts.fs
@@ -43,6 +43,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -64,6 +65,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +88,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -108,6 +111,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -130,6 +134,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Seed.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Seed.fs
@@ -30,6 +30,7 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins = LibExecution.Builtin.make [] fns

--- a/backend/src/Builtins/Builtins.Matter/Libs/Traces.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/Traces.fs
@@ -158,6 +158,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -212,6 +213,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -266,6 +268,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -319,6 +322,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -373,6 +377,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -488,6 +493,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -545,6 +551,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -579,6 +586,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -625,6 +633,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -651,6 +660,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -684,6 +694,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -741,6 +752,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/AltJson.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/AltJson.fs
@@ -195,6 +195,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -214,6 +215,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Base64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Base64.fs
@@ -50,6 +50,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -71,6 +72,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -98,6 +100,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Blob.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Blob.fs
@@ -29,6 +29,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -45,6 +46,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -70,6 +72,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -90,6 +93,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -112,6 +116,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -131,6 +136,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -161,6 +167,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -190,6 +197,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -222,6 +230,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -241,6 +250,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -258,6 +268,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 // TODO `blobEmpty` is the only BuiltInValue we ship. The pattern is

--- a/backend/src/Builtins/Builtins.Pure/Libs/Bool.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Bool.fs
@@ -23,6 +23,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "not"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Char.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Char.fs
@@ -22,6 +22,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -38,6 +39,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -58,6 +60,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -72,6 +75,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +90,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -100,6 +105,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -114,6 +120,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -128,6 +135,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -150,6 +158,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Crypto.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Crypto.fs
@@ -33,6 +33,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -52,6 +53,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -72,6 +74,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = ImpurePreviewable
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -94,6 +97,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = ImpurePreviewable
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -116,6 +120,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = ImpurePreviewable
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/DateTime.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/DateTime.fs
@@ -50,6 +50,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -77,6 +78,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -95,6 +97,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -110,6 +113,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -126,6 +130,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "+"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -147,6 +152,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "-"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -161,6 +167,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -175,6 +182,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -189,6 +197,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -203,6 +212,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -219,6 +229,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -239,6 +250,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -253,6 +265,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'year'" ])
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -268,6 +281,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'month'" ])
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -282,6 +296,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'day'" ])
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -298,6 +313,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -312,6 +328,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'hour'" ])
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -326,6 +343,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'minute'" ])
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -340,6 +358,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_part", [ "'second'" ])
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -355,6 +374,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunctionWithPrefixArgs("date_trunc", [ "'day'" ])
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -377,6 +397,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -393,6 +414,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -413,6 +435,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -430,6 +453,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -447,6 +471,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -462,6 +487,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -480,6 +506,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Dict.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Dict.fs
@@ -26,6 +26,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -43,6 +44,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -59,6 +61,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -79,6 +82,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -119,6 +123,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -160,6 +165,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -179,6 +185,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -195,6 +202,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -222,6 +230,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -249,6 +258,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -276,6 +286,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -291,6 +302,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Float.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Float.fs
@@ -33,6 +33,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -47,6 +48,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -66,6 +68,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +89,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -100,6 +104,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -116,6 +121,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -130,6 +136,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -144,6 +151,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "POWER"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -158,6 +166,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "/"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -172,6 +181,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "+"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -186,6 +196,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "*"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -200,6 +211,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "-"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -214,6 +226,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -228,6 +241,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -242,6 +256,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -256,6 +271,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -272,6 +288,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -303,6 +320,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -332,6 +350,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -346,6 +365,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int128.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int128.fs
@@ -51,6 +51,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -85,6 +86,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -104,6 +106,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -123,6 +126,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -143,6 +147,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -168,6 +173,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -187,6 +193,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -201,6 +208,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -216,6 +224,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -230,6 +239,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -245,6 +255,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -259,6 +270,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -273,6 +285,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -287,6 +300,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -322,6 +336,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -336,6 +351,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -350,6 +366,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -364,6 +381,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -378,6 +396,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -392,6 +411,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -406,6 +426,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -420,6 +441,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -434,6 +456,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -448,6 +471,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -462,6 +486,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -476,6 +501,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -490,6 +516,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -504,6 +531,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -518,6 +546,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int16.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int16.fs
@@ -52,6 +52,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +87,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -105,6 +107,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -124,6 +127,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -143,6 +147,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -167,6 +172,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -192,6 +198,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -212,6 +219,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -226,6 +234,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -241,6 +250,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -255,6 +265,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -270,6 +281,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -284,6 +296,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -298,6 +311,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -328,6 +342,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -342,6 +357,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -356,6 +372,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -375,6 +392,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -394,6 +412,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -413,6 +432,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -432,6 +452,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -451,6 +472,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -473,6 +495,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -492,6 +515,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -506,6 +530,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -520,6 +545,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -534,6 +560,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -548,6 +575,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -562,6 +590,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -576,6 +605,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int32.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int32.fs
@@ -52,6 +52,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +87,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -100,6 +102,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -114,6 +117,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -128,6 +132,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -152,6 +157,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -170,6 +176,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -184,6 +191,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -198,6 +206,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -213,6 +222,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -227,6 +237,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -242,6 +253,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -256,6 +268,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -270,6 +283,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -299,6 +313,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -313,6 +328,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -327,6 +343,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -341,6 +358,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -355,6 +373,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -369,6 +388,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -388,6 +408,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -409,6 +430,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -428,6 +450,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -450,6 +473,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -469,6 +493,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -483,6 +508,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -497,6 +523,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -511,6 +538,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -525,6 +553,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -539,6 +568,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -553,6 +583,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int64.fs
@@ -53,6 +53,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "%"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       // TODO: Deprecate this when we can version infix operators
       //  and when infix operators support Result return types
       //  (https://github.com/darklang/dark/issues/4267)
@@ -128,6 +129,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -142,6 +144,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "+"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -156,6 +159,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "-"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -170,6 +174,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "*"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -194,6 +199,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "POWER"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -212,6 +218,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "/"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -226,6 +233,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -240,6 +248,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -255,6 +264,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -269,6 +279,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -284,6 +295,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -298,6 +310,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -312,6 +325,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -340,6 +354,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -354,6 +369,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -368,6 +384,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -382,6 +399,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -396,6 +414,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -410,6 +429,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -424,6 +444,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -438,6 +459,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -457,6 +479,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -479,6 +502,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -498,6 +522,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -512,6 +537,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -526,6 +552,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -540,6 +567,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -554,6 +582,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -568,6 +597,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -582,6 +612,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int8.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int8.fs
@@ -52,6 +52,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +87,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -104,6 +106,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -122,6 +125,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -140,6 +144,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -164,6 +169,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -186,6 +192,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -205,6 +212,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -219,6 +227,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -234,6 +243,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -248,6 +258,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -263,6 +274,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -277,6 +289,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -291,6 +304,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -307,6 +321,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -335,6 +350,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -354,6 +370,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -373,6 +390,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -392,6 +410,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -411,6 +430,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -430,6 +450,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -449,6 +470,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -468,6 +490,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -487,6 +510,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -506,6 +530,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -520,6 +545,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -534,6 +560,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -548,6 +575,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -562,6 +590,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -576,6 +605,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -590,6 +620,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Json.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Json.fs
@@ -735,6 +735,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -766,6 +767,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/List.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/List.fs
@@ -294,6 +294,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -315,6 +316,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -339,6 +341,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -359,6 +362,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Math.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Math.fs
@@ -27,6 +27,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -45,6 +46,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -64,6 +66,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -91,6 +94,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -118,6 +122,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -137,6 +142,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -158,6 +164,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -172,6 +179,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -186,6 +194,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -200,6 +209,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
@@ -185,6 +185,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -199,6 +200,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<>"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -256,6 +258,7 @@ let fns () : List<BuiltInFn> =
 
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Regex.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Regex.fs
@@ -32,6 +32,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -59,6 +60,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -88,6 +90,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -124,6 +127,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -159,6 +163,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -184,6 +189,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Stream.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Stream.fs
@@ -91,6 +91,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -144,6 +145,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -164,6 +166,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -197,6 +200,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -228,6 +232,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -257,6 +262,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -297,6 +303,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -333,6 +340,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -356,6 +364,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -383,6 +392,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/String.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/String.fs
@@ -32,6 +32,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -72,6 +73,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "replace"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +88,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "upper"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -100,6 +103,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "lower"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -115,6 +119,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented // CLEANUP: Sqlite has "LENGTH" but that counts characters; if we can get it to count EGCs, great
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -133,6 +138,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -166,6 +172,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -181,6 +188,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "reverse"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -225,6 +233,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -251,6 +260,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -299,6 +309,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -317,6 +328,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "trim"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -334,6 +346,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "ltrim"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -351,6 +364,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "rtrim"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -367,6 +381,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -386,6 +401,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -407,6 +423,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -430,6 +447,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -465,6 +483,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlCallback2(fun str search -> $"(INSTR({str}, {search}) - 1)")
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -523,6 +542,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -548,6 +568,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -601,6 +622,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt128.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt128.fs
@@ -50,6 +50,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -69,6 +70,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -88,6 +90,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -108,6 +111,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -133,6 +137,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -147,6 +152,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -162,6 +168,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -176,6 +183,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -191,6 +199,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -205,6 +214,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -219,6 +229,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -233,6 +244,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -268,6 +280,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -282,6 +295,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -296,6 +310,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -310,6 +325,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -324,6 +340,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -338,6 +355,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -352,6 +370,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -366,6 +385,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -381,6 +401,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -395,6 +416,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -409,6 +431,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt16.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt16.fs
@@ -51,6 +51,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -71,6 +72,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -91,6 +93,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -111,6 +114,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -132,6 +136,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -157,6 +162,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -171,6 +177,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -186,6 +193,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -200,6 +208,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -215,6 +224,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -229,6 +239,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -243,6 +254,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -257,6 +269,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -287,6 +300,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -306,6 +320,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -320,6 +335,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -339,6 +355,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -360,6 +377,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -379,6 +397,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -400,6 +419,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -419,6 +439,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -441,6 +462,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -460,6 +482,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -474,6 +497,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -488,6 +512,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -502,6 +527,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -516,6 +542,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -530,6 +557,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -544,6 +572,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt32.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt32.fs
@@ -51,6 +51,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -70,6 +71,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -89,6 +91,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -108,6 +111,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -129,6 +133,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -154,6 +159,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -168,6 +174,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -183,6 +190,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -197,6 +205,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -212,6 +221,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -226,6 +236,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -240,6 +251,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -254,6 +266,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -284,6 +297,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -304,6 +318,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -318,6 +333,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -338,6 +354,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -352,6 +369,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -372,6 +390,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -394,6 +413,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -414,6 +434,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -436,6 +457,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -456,6 +478,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -470,6 +493,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -484,6 +508,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -498,6 +523,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -512,6 +538,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -526,6 +553,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -540,6 +568,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt64.fs
@@ -50,6 +50,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -68,6 +69,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -86,6 +88,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -104,6 +107,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -125,6 +129,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -149,6 +154,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -163,6 +169,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -178,6 +185,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -192,6 +200,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -207,6 +216,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -223,6 +233,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -237,6 +248,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -272,6 +284,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -286,6 +299,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -305,6 +319,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -319,6 +334,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -338,6 +354,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -352,6 +369,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -371,6 +389,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -385,6 +404,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -404,6 +424,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -426,6 +447,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -445,6 +467,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -459,6 +482,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -473,6 +497,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -487,6 +512,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -501,6 +527,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -515,6 +542,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -529,6 +557,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt8.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt8.fs
@@ -51,6 +51,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -69,6 +70,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -87,6 +89,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -105,6 +108,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -126,6 +130,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -148,6 +153,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -162,6 +168,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -177,6 +184,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -191,6 +199,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -206,6 +215,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -220,6 +230,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -234,6 +245,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -250,6 +262,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -278,6 +291,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -297,6 +311,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -316,6 +331,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -335,6 +351,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -354,6 +371,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -373,6 +391,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -392,6 +411,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -411,6 +431,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -430,6 +451,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -449,6 +471,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -463,6 +486,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -477,6 +501,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -491,6 +516,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -505,6 +531,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -519,6 +546,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -533,6 +561,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/Uuid.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Uuid.fs
@@ -48,6 +48,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -63,6 +64,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/X509.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/X509.fs
@@ -53,6 +53,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Random/Libs/Random.fs
+++ b/backend/src/Builtins/Builtins.Random/Libs/Random.fs
@@ -30,6 +30,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -52,6 +53,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -73,6 +75,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -96,6 +99,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -114,6 +118,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -137,6 +142,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -158,6 +164,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -181,6 +188,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated }
 
 
@@ -208,6 +216,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/Builtins/Builtins.Random/Libs/Uuid.fs
+++ b/backend/src/Builtins/Builtins.Random/Libs/Uuid.fs
@@ -22,6 +22,7 @@ let fns () : List<BuiltInFn> =
         // Similarly to DateTime.now, it's not particularly fun for this to change
         // when live programming, so let's keep this as Impure rather than ImpurePreviewable
         Impure
+      capabilities = LibExecution.Capabilities.Needs.random
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Time/Libs/DateTime.fs
+++ b/backend/src/Builtins/Builtins.Time/Libs/DateTime.fs
@@ -24,6 +24,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.clock
       deprecated = NotDeprecated }
 
 
@@ -40,6 +41,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.clock
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make [] (fns ())

--- a/backend/src/Builtins/Builtins.Time/Libs/Time.fs
+++ b/backend/src/Builtins/Builtins.Time/Libs/Time.fs
@@ -27,6 +27,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.clock
       deprecated = NotDeprecated }
 
     { name = fn "timeNowMs" 0
@@ -46,6 +47,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.clock
       deprecated = NotDeprecated }
 
     { name = fn "interpreterStatsReset" 0
@@ -62,6 +64,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
     { name = fn "interpreterStatsGet" 0
@@ -124,6 +127,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 

--- a/backend/src/LibDB/CapabilityGrants.fs
+++ b/backend/src/LibDB/CapabilityGrants.fs
@@ -1,0 +1,60 @@
+/// CapabilityGrants — the per-instance capability GRANT, stored as a local file.
+///
+/// "This instance may do GET to any host, and use random." A LOCAL setting, never synced and not
+/// package data — so it lives in `~/.darklang/capabilities.bin`, NOT a SQL table. It's a binary blob of
+/// the `Capabilities` record (via the reflection-free `LibSerialization` format — the release CLI is
+/// AOT-trimmed). Default is NONE: a missing file ⇒ `Capabilities.noCaps`. View/edit it through
+/// `dark caps`; the CLI grant grammar talks spec strings, which `pmCapsGet`/`pmCapsSet` map to/from the
+/// record.
+module LibDB.CapabilityGrants
+
+open Prelude
+
+module Cap = LibExecution.Capabilities
+module CapBin = LibSerialization.Binary.Serializers.Capabilities
+
+let private filePath () : string =
+  let home =
+    match System.Environment.GetEnvironmentVariable "HOME" with
+    | null
+    | "" -> "/tmp"
+    | h -> h
+  System.IO.Path.Combine(home, ".darklang", "capabilities.bin")
+
+let toBytes (caps : Cap.Capabilities) : byte[] =
+  use ms = new System.IO.MemoryStream()
+  use w = new System.IO.BinaryWriter(ms)
+  CapBin.write w caps
+  w.Flush()
+  ms.ToArray()
+
+let fromBytes (bytes : byte[]) : Cap.Capabilities =
+  use ms = new System.IO.MemoryStream(bytes)
+  use r = new System.IO.BinaryReader(ms)
+  CapBin.read r
+
+/// The current grant, read from the binary file. Missing/unreadable ⇒ NONE.
+let getGrant () : Cap.Capabilities =
+  try
+    let path = filePath ()
+    if System.IO.File.Exists path then
+      fromBytes (System.IO.File.ReadAllBytes path)
+    else
+      Cap.noCaps
+  with _ ->
+    Cap.noCaps
+
+/// The HOST's effective capabilities — what `eval` (and the interactive instance) runs under. Permissive
+/// by DEFAULT (no config file ⇒ `allCaps`, so a fresh install is unrestricted), but once you configure a
+/// grant the host RESPECTS it. Distinct from `getGrant` (NONE-default), the secure-by-default sandbox
+/// grant `dark run` uses.
+let hostCaps () : Cap.Capabilities =
+  if System.IO.File.Exists(filePath ()) then getGrant () else Cap.allCaps
+
+/// Overwrite the grant (written as the binary blob). The grant-spec language is parsed/validated in
+/// `.dark` (`LanguageTools.Capabilities.parse`); F# only stores the already-structured record.
+let setGrant (caps : Cap.Capabilities) : unit =
+  let path = filePath ()
+  System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName path)
+  |> ignore<System.IO.DirectoryInfo>
+  System.IO.File.WriteAllBytes(path, toBytes caps)

--- a/backend/src/LibDB/LibDB.fsproj
+++ b/backend/src/LibDB/LibDB.fsproj
@@ -42,6 +42,8 @@
     <Compile Include="Scripts.fs" />
     <Compile Include="PackageRefsGenerator.fs" />
     <Compile Include="Seed.fs" />
+    <Compile Include="CapabilityGrants.fs" />
+    <Compile Include="PackageCaps.fs" />
 
     <!-- ex-LibCloud SQLite-bound modules /-->
     <Compile Include="Tracing.fs" />

--- a/backend/src/LibDB/PackageCaps.fs
+++ b/backend/src/LibDB/PackageCaps.fs
@@ -1,0 +1,118 @@
+/// PackageCaps — content-addressed cache of a package fn's effective capabilities.
+///
+/// A fn's effective caps are a pure function of its content hash, so we compute once and store forever
+/// (the CLI runs cold per command, so an in-memory memo wouldn't survive). `effectiveSpecs` is the
+/// read-through entry point: cache hit ⇒ one lookup; miss ⇒ walk the call graph, fold, store. Specs are
+/// newline-joined (`''` = pure); the `package_caps` table lives in `schema.sql`.
+module LibDB.PackageCaps
+
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+
+open Prelude
+
+open Fumble
+open LibDB.Sqlite
+
+module PT = LibExecution.ProgramTypes
+module Cap = LibExecution.Capabilities
+module Analysis = LibExecution.CapabilityAnalysis
+module PMPT = LibDB.ProgramTypes
+module CapBin = LibSerialization.Binary.Serializers.Capabilities
+
+
+// The cache stores the STRUCTURED caps (the reflection-free binary form, base64'd into the text column)
+// — F# never renders the grant-spec language. The `package_caps` row is a pure function of the hash, so
+// kill-and-fill is safe (a stale/old-format row just gets recomputed).
+let private toB64 (caps : Cap.Capabilities) : string =
+  use ms = new System.IO.MemoryStream()
+  use w = new System.IO.BinaryWriter(ms)
+  CapBin.write w caps
+  w.Flush()
+  System.Convert.ToBase64String(ms.ToArray())
+
+let private fromB64 (s : string) : Cap.Capabilities =
+  use ms = new System.IO.MemoryStream(System.Convert.FromBase64String s)
+  use r = new System.IO.BinaryReader(ms)
+  CapBin.read r
+
+
+/// The cached effective caps for a fn hash, or None if not computed yet.
+let get (hash : string) : Task<Option<Cap.Capabilities>> =
+  task {
+    let! rows =
+      Sql.query "SELECT caps FROM package_caps WHERE hash = @h"
+      |> Sql.parameters [ "h", Sql.string hash ]
+      |> Sql.executeAsync (fun read -> read.string "caps")
+
+    match rows with
+    | caps :: _ -> return Some(fromB64 caps)
+    | [] -> return None
+  }
+
+
+/// Cache a fn's computed caps. Write-once (re-inserting the same hash is a no-op).
+let put (hash : string) (caps : Cap.Capabilities) : Task<unit> =
+  Sql.query
+    "INSERT INTO package_caps (hash, caps) VALUES (@h, @c) ON CONFLICT(hash) DO NOTHING"
+  |> Sql.parameters [ "h", Sql.string hash; "c", Sql.string (toB64 caps) ]
+  |> Sql.executeStatementAsync
+
+
+/// Pre-load every package fn reachable from `root` (the async part), returning a lookup for them — so
+/// the capability fold over the call graph can then run synchronously.
+let private loadClosure
+  (root : PT.Hash)
+  : Ply<PT.Hash -> Option<PT.PackageFn.PackageFn>> =
+  uply {
+    let loaded =
+      System.Collections.Generic.Dictionary<PT.Hash, PT.PackageFn.PackageFn>()
+    let visited = System.Collections.Generic.HashSet<PT.Hash>()
+
+    let rec load (h : PT.Hash) : Ply<unit> =
+      uply {
+        if not (visited.Contains h) then
+          visited.Add h |> ignore<bool>
+
+          match! PMPT.Fn.get h with
+          | None -> ()
+          | Some fn ->
+            loaded[h] <- fn
+
+            let callees =
+              Analysis.fnRefs fn.body
+              |> List.choose (fun fqfn ->
+                match fqfn with
+                | PT.FQFnName.Package p -> Some p
+                | PT.FQFnName.Builtin _ -> None)
+
+            for callee in callees do
+              do! load callee
+      }
+
+    do! load root
+
+    return
+      fun h ->
+        match loaded.TryGetValue h with
+        | true, fn -> Some fn
+        | false, _ -> None
+  }
+
+
+/// The effective (transitive) caps of a package fn — read-through the cache. `capsFor` looks up a
+/// builtin's declared caps by flat name (the caller builds it from the runtime's builtin map).
+let effectiveCaps
+  (capsFor : string -> Cap.Capabilities)
+  (hashStr : string)
+  : Ply<Cap.Capabilities> =
+  uply {
+    match! get hashStr with
+    | Some caps -> return caps
+    | None ->
+      let root = PT.Hash hashStr
+      let! getFn = loadClosure root
+      let caps = Analysis.effectiveCapsOfFn capsFor getFn root
+      do! put hashStr caps
+      return caps
+  }

--- a/backend/src/LibExecution/Capabilities.fs
+++ b/backend/src/LibExecution/Capabilities.fs
@@ -1,0 +1,315 @@
+/// Capabilities — the resource-domain axis used to GATE effectful builtins.
+///
+/// "This code may do exactly these effects." Both a GRANT (the instance's configured allowances) and a
+/// NEED (what a fn requires) are ONE `Capabilities` record — a field per domain, each holding that
+/// domain's nuance (the http method/host scopes, the file read-scope × write-scope, …). A grant covers
+/// a need iff it covers it field-by-field. Modelling it as a record (not a list of cases) means: a
+/// single well-defined configured state, natural JSON, and per-direction scopes for free — "read
+/// anywhere, write only in ~/.darklang" is just `file = { read = Any; write = Only {…} }`.
+///
+/// This is the resource-domain axis (for gating) — ORTHOGONAL to the concurrency-character axis (a
+/// separate `effects` field: Pure / AsyncRead / …, used for scheduling).
+///
+/// RT-independent (only Prelude) so it compiles before RuntimeTypes.fs.
+///
+/// TODO: `Capabilities` is arguably a LANGUAGE-LEVEL type — low-level, defined in the context of
+/// builtins, and meant to be stable — so it should probably live in ProgramTypes (or RuntimeTypes)
+/// rather than its own module here. Moving it would let it share the PT/RT binary-serialization +
+/// hashing machinery (its disk serializer in `LibSerialization/Binary/Serializers/Capabilities.fs`
+/// would move under the matching PT/RT folder). Deferred — revisit when shuffling these namespaces.
+module LibExecution.Capabilities
+
+open Prelude
+
+/// A scope over targets: `Any` (the ⊤ — "anywhere") or a specific allow-list. `Only Set.empty` is the
+/// bottom (nothing). A GRANT field says what's allowed; a NEED field says what's required.
+type Scope<'a when 'a : comparison> =
+  | Any
+  | Only of Set<'a>
+
+/// A read-scope and a write-scope for one domain (files, env, db) — they can differ.
+type RW<'a when 'a : comparison> = { read : Scope<'a>; write : Scope<'a> }
+
+/// A structured host matcher — deliberately NOT regex (auditability + no host-bypass/ReDoS footguns).
+type HostMatch =
+  | AnyHost
+  | ExactHost of string // "api.github.com"
+  | Subdomain of string // "github.com" matches "github.com" and any "*.github.com"
+
+/// A URL capability: every dimension scoped INDEPENDENTLY and EXPLICITLY. There is no "empty implies
+/// any" — an undetermined dimension is a deliberate value (`Any` / `[ AnyHost ]`), never an accident.
+type UrlScope =
+  { schemes : Scope<string> // Only {"https"} | Any
+    hosts : List<HostMatch> // OR-list; [ AnyHost ] = any host; [] = no host (bottom)
+    ports : Scope<int64> // Only {443L} | Any
+    paths : Scope<string> } // prefix-matched (pathUnder); Any = any path
+
+/// One http-client rule: these methods to this URL scope. The http grant/need is a LIST of rules, so
+/// method and URL COUPLE per rule — "any method to localhost AND GET to everywhere else" is two rules.
+/// A request (method, scheme, host, port, path) is allowed iff some rule covers it.
+type HttpRule = { methods : Scope<string>; url : UrlScope }
+
+/// One exec rule: these programs with these args. Like httpClient, exec is a LIST of rules so program
+/// and args COUPLE per rule — "git with any args, but rm only with --dry-run" is two rules. A launch
+/// (program, args) is allowed iff some rule covers it: the program is in scope AND every arg is in scope.
+type ExecRule = { programs : Scope<string>; args : Scope<string> }
+
+/// The full per-instance capability shape — a field per domain.
+type Capabilities =
+  { httpClient : List<HttpRule>
+    httpServer : Scope<int64> // which ports may bind
+    file : RW<string> // read paths × write paths (prefix-scoped)
+    env : RW<string> // read vars × write vars
+    db : RW<string> // read tables × write tables
+    exec : List<ExecRule> // (program × args) rules — a launch matching SOME rule is allowed
+    stdout : bool
+    stdin : bool
+    random : bool
+    clock : bool
+    llm : bool } // the AI opt-in — denied by default
+
+
+// ───────────────────────────────────────────────────────────────────────────
+// Construction
+// ───────────────────────────────────────────────────────────────────────────
+
+let private noneScope<'a when 'a : comparison> : Scope<'a> = Only Set.empty
+let private noRW<'a when 'a : comparison> : RW<'a> =
+  { read = noneScope; write = noneScope }
+
+/// The fully-permissive URL scope (any scheme/host/port/path) — used by `allCaps` and as the maximal
+/// NEED for a name-based http need (only an unrestricted http grant covers it).
+let anyUrl : UrlScope =
+  { schemes = Any; hosts = [ AnyHost ]; ports = Any; paths = Any }
+
+/// The strict default — grants nothing. Pure code (a need that's all-empty) always passes.
+let noCaps : Capabilities =
+  { httpClient = [] // no rules ⇒ no http allowed
+    httpServer = noneScope
+    file = noRW
+    env = noRW
+    db = noRW
+    exec = [] // no rules ⇒ no external programs may run
+    stdout = false
+    stdin = false
+    random = false
+    clock = false
+    llm = false }
+
+/// A permissive grant — everything, unscoped. The rollout default, so wiring the gate changes no
+/// existing behavior; a real instance narrows it.
+let allCaps : Capabilities =
+  { httpClient = [ { methods = Any; url = anyUrl } ]
+    httpServer = Any
+    file = { read = Any; write = Any }
+    env = { read = Any; write = Any }
+    db = { read = Any; write = Any }
+    exec = [ { programs = Any; args = Any } ]
+    stdout = true
+    stdin = true
+    random = true
+    clock = true
+    llm = true }
+
+/// Builtin need constructors — what a builtin declares as its `capabilities` (pure ⇒ `noCaps`). The
+/// rich-domain needs (http/file/exec/…) are coarse: the gate checks presence, the builtin body narrows.
+module Needs =
+  let http : Capabilities =
+    { noCaps with httpClient = [ { methods = Any; url = anyUrl } ] }
+  let httpServer : Capabilities = { noCaps with httpServer = Any }
+  let fileRead : Capabilities =
+    { noCaps with file = { read = Any; write = Only Set.empty } }
+  let fileWrite : Capabilities =
+    { noCaps with file = { read = Only Set.empty; write = Any } }
+  let fileReadWrite : Capabilities =
+    { noCaps with file = { read = Any; write = Any } }
+  let envRead : Capabilities =
+    { noCaps with env = { read = Any; write = Only Set.empty } }
+  let envWrite : Capabilities =
+    { noCaps with env = { read = Only Set.empty; write = Any } }
+  let dbRead : Capabilities =
+    { noCaps with db = { read = Any; write = Only Set.empty } }
+  let dbWrite : Capabilities =
+    { noCaps with db = { read = Only Set.empty; write = Any } }
+  let exec : Capabilities = { noCaps with exec = [ { programs = Any; args = Any } ] }
+  let clock : Capabilities = { noCaps with clock = true }
+  let random : Capabilities = { noCaps with random = true }
+  let stdout : Capabilities = { noCaps with stdout = true }
+  let stdin : Capabilities = { noCaps with stdin = true }
+  let llm : Capabilities = { noCaps with llm = true }
+
+
+// ───────────────────────────────────────────────────────────────────────────
+// Matchers
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Does a granted host matcher cover a needed one? Needs from the gate are always concrete
+/// (`ExactHost`); `AnyHost` on the need side (an undetermined host) is covered only by an `AnyHost`
+/// grant — fail-closed, but EXPLICIT (never an empty-string accident).
+let hostMatchCovers (grant : HostMatch) (need : HostMatch) : bool =
+  match grant, need with
+  | AnyHost, _ -> true
+  | _, AnyHost -> false // needing "any host" requires an AnyHost grant
+  | ExactHost g, ExactHost n -> g = n
+  | Subdomain g, ExactHost n -> n = g || n.EndsWith("." + g)
+  | Subdomain g, Subdomain n -> n = g || n.EndsWith("." + g)
+  | ExactHost _, Subdomain _ -> false
+
+/// Every needed host matched by SOME granted matcher.
+let hostsCover (grant : List<HostMatch>) (need : List<HostMatch>) : bool =
+  need
+  |> List.forall (fun n -> grant |> List.exists (fun g -> hostMatchCovers g n))
+
+/// Path scope match: a grant prefix covers a path only at or BELOW a directory boundary — `/a` covers
+/// `/a` and `/a/b`, but NOT the sibling `/ab` or `/a-evil`. A trailing `/` on the grant is fine
+/// (`~/.darklang/` covers `~/.darklang/x`).
+let pathUnder (prefix : string) (path : string) : bool =
+  if path = prefix then
+    true
+  else
+    let boundary = if prefix.EndsWith "/" then prefix else prefix + "/"
+    path.StartsWith boundary
+
+let private exact (a : 'a) (b : 'a) : bool = a = b
+
+
+// ───────────────────────────────────────────────────────────────────────────
+// Subsumption — does the grant cover the need?
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Scope subsumption (`need ⊑ grant`) under a per-element matcher.
+let scopeCovers
+  (matcher : 'a -> 'a -> bool)
+  (grant : Scope<'a>)
+  (need : Scope<'a>)
+  : bool =
+  match grant, need with
+  | Any, _ -> true
+  | Only _, Any -> false // "needs any" is covered only by "grants any"
+  | Only g, Only n ->
+    n |> Set.forall (fun x -> g |> Set.exists (fun p -> matcher p x))
+
+/// The gate verdict. `Denied` names the first unmet aspect so the error is actionable.
+type CapDecision =
+  | Allowed
+  | Denied of string
+
+/// Does a granted URL scope cover a needed one, dimension by dimension (scheme AND host AND port AND
+/// path)? Needs from the gate carry concrete singletons.
+let urlCovers (grant : UrlScope) (need : UrlScope) : bool =
+  scopeCovers exact grant.schemes need.schemes
+  && hostsCover grant.hosts need.hosts
+  && scopeCovers exact grant.ports need.ports
+  && scopeCovers pathUnder grant.paths need.paths
+
+/// http: every NEEDED rule must be covered by SOME granted rule (method AND the whole URL scope). This
+/// is the "list of rules, OR'd" coupling — so "any method to localhost" + "GET everywhere" composes.
+let private httpCovers (grant : List<HttpRule>) (need : List<HttpRule>) : bool =
+  need
+  |> List.forall (fun n ->
+    grant
+    |> List.exists (fun g ->
+      scopeCovers exact g.methods n.methods && urlCovers g.url n.url))
+
+/// exec: same coupling as http — every NEEDED rule must be covered by SOME granted rule (program AND
+/// args both covered). So "git any-args" + "rm --dry-run-only" composes as two rules.
+let private execCovers (grant : List<ExecRule>) (need : List<ExecRule>) : bool =
+  need
+  |> List.forall (fun n ->
+    grant
+    |> List.exists (fun g ->
+      scopeCovers exact g.programs n.programs && scopeCovers exact g.args n.args))
+
+/// Does `grant` cover `need`, field by field? Returns the first unmet aspect as `Denied "<desc>"`.
+let covers (grant : Capabilities) (need : Capabilities) : CapDecision =
+  let rw matcher (g : RW<'a>) (n : RW<'a>) =
+    scopeCovers matcher g.read n.read && scopeCovers matcher g.write n.write
+  let needsBool g n = (not n) || g // if needed, must be granted
+  if not (httpCovers grant.httpClient need.httpClient) then
+    Denied "http-client (a method/scheme/host/port/path it doesn't allow)"
+  elif not (scopeCovers exact grant.httpServer need.httpServer) then
+    Denied "http-server (a port)"
+  elif not (rw pathUnder grant.file need.file) then
+    Denied "file (a path/access it doesn't allow)"
+  elif not (rw exact grant.env need.env) then
+    Denied "env"
+  elif not (rw exact grant.db need.db) then
+    Denied "db"
+  elif not (execCovers grant.exec need.exec) then
+    Denied "exec (a program/args it doesn't allow)"
+  elif not (needsBool grant.stdout need.stdout) then
+    Denied "stdout"
+  elif not (needsBool grant.stdin need.stdin) then
+    Denied "stdin"
+  elif not (needsBool grant.random need.random) then
+    Denied "random"
+  elif not (needsBool grant.clock need.clock) then
+    Denied "clock"
+  elif not (needsBool grant.llm need.llm) then
+    Denied "llm"
+  else
+    Allowed
+
+
+/// The GATE check: does the grant allow this builtin's domain AT ALL? Presence-only for the rich domains
+/// (http/file/env/db/exec) — the builtin's body then enforces the specific URL/path/args via `covers`.
+/// Bools are exact. So a scoped grant (e.g. "http GET api.x") passes the gate and the body decides the
+/// concrete call, while a grant with no http at all is denied here before the body runs.
+let coversStructurally (grant : Capabilities) (need : Capabilities) : CapDecision =
+  let present (s : Scope<'a>) =
+    match s with
+    | Any -> true
+    | Only xs -> not (Set.isEmpty xs)
+  // (does the need touch this domain?, does the grant provide any presence?, label)
+  let checks : List<bool * bool * string> =
+    [ not (List.isEmpty need.httpClient),
+      not (List.isEmpty grant.httpClient),
+      "http-client"
+      present need.httpServer, present grant.httpServer, "http-server"
+      present need.file.read, present grant.file.read, "file (read)"
+      present need.file.write, present grant.file.write, "file (write)"
+      present need.env.read, present grant.env.read, "env (read)"
+      present need.env.write, present grant.env.write, "env (write)"
+      present need.db.read, present grant.db.read, "db (read)"
+      present need.db.write, present grant.db.write, "db (write)"
+      not (List.isEmpty need.exec), not (List.isEmpty grant.exec), "exec"
+      need.stdout, grant.stdout, "stdout"
+      need.stdin, grant.stdin, "stdin"
+      need.random, grant.random, "random"
+      need.clock, grant.clock, "clock"
+      need.llm, grant.llm, "llm" ]
+  match checks |> List.tryFind (fun (n, g, _) -> n && not g) with
+  | Some(_, _, label) -> Denied label
+  | None -> Allowed
+
+
+// ───────────────────────────────────────────────────────────────────────────
+// Join — union two capability records field-wise (for the analysis fold)
+// ───────────────────────────────────────────────────────────────────────────
+
+let joinScope (a : Scope<'x>) (b : Scope<'x>) : Scope<'x> =
+  match a, b with
+  | Any, _
+  | _, Any -> Any
+  | Only x, Only y -> Only(Set.union x y)
+
+let private joinRW (a : RW<'x>) (b : RW<'x>) : RW<'x> =
+  { read = joinScope a.read b.read; write = joinScope a.write b.write }
+
+/// Field-wise union of two capability records (used to fold a fn's effective needs over its call graph).
+let join (a : Capabilities) (b : Capabilities) : Capabilities =
+  { httpClient = List.append a.httpClient b.httpClient |> List.distinct
+    httpServer = joinScope a.httpServer b.httpServer
+    file = joinRW a.file b.file
+    env = joinRW a.env b.env
+    db = joinRW a.db b.db
+    exec = List.append a.exec b.exec |> List.distinct
+    stdout = a.stdout || b.stdout
+    stdin = a.stdin || b.stdin
+    random = a.random || b.random
+    clock = a.clock || b.clock
+    llm = a.llm || b.llm }
+
+// The grant-spec LANGUAGE (parse/render of `http-client GET`, `file write ~/x`, …) lives entirely in
+// `.dark` (`LanguageTools.Capabilities`) — F# only ever deals with this structured model. The F#/Dark
+// boundary is `CapabilitiesToDarkTypes`.

--- a/backend/src/LibExecution/CapabilitiesToDarkTypes.fs
+++ b/backend/src/LibExecution/CapabilitiesToDarkTypes.fs
@@ -1,0 +1,206 @@
+/// C2DT for the capability model — converts F# `LibExecution.Capabilities` values to/from their Dark
+/// mirror (`Darklang.LanguageTools.Capabilities`). This is the STRUCTURED F#/Dark boundary: the caps
+/// builtins hand the grant across as this value, and ALL spec-string parsing/rendering lives in Dark.
+/// Mirrors the style of `ProgramTypesToDarkTypes`.
+module LibExecution.CapabilitiesToDarkTypes
+
+open Prelude
+open RuntimeTypes
+
+module Cap = LibExecution.Capabilities
+module VT = ValueType
+module D = LibExecution.DvalDecoder
+
+
+module Scope =
+  let typeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.Capabilities.scope ())
+
+  /// Generic over the element's value-type + converter, so it serves `Scope<String>` and `Scope<Int64>`.
+  let toDT (elemVT : ValueType) (elemToDT : 'a -> Dval) (s : Cap.Scope<'a>) : Dval =
+    let typeArgs = [ elemVT ]
+    match s with
+    | Cap.Any -> DEnum(typeName (), typeName (), typeArgs, "Any", [])
+    | Cap.Only xs ->
+      DEnum(
+        typeName (),
+        typeName (),
+        typeArgs,
+        "Only",
+        [ DList(elemVT, xs |> Set.toList |> List.map elemToDT) ]
+      )
+
+  let fromDT (elemFromDT : Dval -> 'a) (d : Dval) : Cap.Scope<'a> =
+    match d with
+    | DEnum(_, _, _, "Any", []) -> Cap.Any
+    | DEnum(_, _, _, "Only", [ items ]) ->
+      Cap.Only(D.list elemFromDT items |> Set.ofList)
+    | _ -> Exception.raiseInternal "Invalid Capabilities.Scope" [ "dval", d ]
+
+  // the two concrete element kinds the model uses
+  let strToDT (s : Cap.Scope<string>) : Dval = toDT VT.string DString s
+  let strFromDT (d : Dval) : Cap.Scope<string> = fromDT D.string d
+  let portToDT (s : Cap.Scope<int64>) : Dval = toDT VT.int64 (fun n -> DInt64 n) s
+  let portFromDT (d : Dval) : Cap.Scope<int64> = fromDT D.int64 d
+
+
+module HostMatch =
+  let typeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.Capabilities.hostMatch ())
+  let knownType () = KTCustomType(typeName (), [])
+
+  let toDT (h : Cap.HostMatch) : Dval =
+    let (caseName, fields) =
+      match h with
+      | Cap.AnyHost -> "AnyHost", []
+      | Cap.ExactHost s -> "ExactHost", [ DString s ]
+      | Cap.Subdomain s -> "Subdomain", [ DString s ]
+    DEnum(typeName (), typeName (), [], caseName, fields)
+
+  let fromDT (d : Dval) : Cap.HostMatch =
+    match d with
+    | DEnum(_, _, _, "AnyHost", []) -> Cap.AnyHost
+    | DEnum(_, _, _, "ExactHost", [ DString s ]) -> Cap.ExactHost s
+    | DEnum(_, _, _, "Subdomain", [ DString s ]) -> Cap.Subdomain s
+    | _ -> Exception.raiseInternal "Invalid Capabilities.HostMatch" [ "dval", d ]
+
+
+module UrlScope =
+  let typeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.Capabilities.urlScope ())
+  let knownType () = KTCustomType(typeName (), [])
+
+  let toDT (u : Cap.UrlScope) : Dval =
+    DRecord(
+      typeName (),
+      typeName (),
+      [],
+      Map
+        [ "schemes", Scope.strToDT u.schemes
+          "hosts",
+          DList(
+            VT.known (HostMatch.knownType ()),
+            u.hosts |> List.map HostMatch.toDT
+          )
+          "ports", Scope.portToDT u.ports
+          "paths", Scope.strToDT u.paths ]
+    )
+
+  let fromDT (d : Dval) : Cap.UrlScope =
+    match d with
+    | DRecord(_, _, _, f) ->
+      { schemes = Scope.strFromDT (D.field "schemes" f)
+        hosts = D.list HostMatch.fromDT (D.field "hosts" f)
+        ports = Scope.portFromDT (D.field "ports" f)
+        paths = Scope.strFromDT (D.field "paths" f) }
+    | _ -> Exception.raiseInternal "Invalid Capabilities.UrlScope" [ "dval", d ]
+
+
+module HttpRule =
+  let typeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.Capabilities.httpRule ())
+  let knownType () = KTCustomType(typeName (), [])
+
+  let toDT (r : Cap.HttpRule) : Dval =
+    DRecord(
+      typeName (),
+      typeName (),
+      [],
+      Map [ "methods", Scope.strToDT r.methods; "url", UrlScope.toDT r.url ]
+    )
+
+  let fromDT (d : Dval) : Cap.HttpRule =
+    match d with
+    | DRecord(_, _, _, f) ->
+      { methods = Scope.strFromDT (D.field "methods" f)
+        url = UrlScope.fromDT (D.field "url" f) }
+    | _ -> Exception.raiseInternal "Invalid Capabilities.HttpRule" [ "dval", d ]
+
+
+module ExecRule =
+  let typeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.Capabilities.execRule ())
+  let knownType () = KTCustomType(typeName (), [])
+
+  let toDT (r : Cap.ExecRule) : Dval =
+    DRecord(
+      typeName (),
+      typeName (),
+      [],
+      Map [ "programs", Scope.strToDT r.programs; "args", Scope.strToDT r.args ]
+    )
+
+  let fromDT (d : Dval) : Cap.ExecRule =
+    match d with
+    | DRecord(_, _, _, f) ->
+      { programs = Scope.strFromDT (D.field "programs" f)
+        args = Scope.strFromDT (D.field "args" f) }
+    | _ -> Exception.raiseInternal "Invalid Capabilities.ExecRule" [ "dval", d ]
+
+
+module RW =
+  let typeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.Capabilities.rw ())
+
+  let toDT (rw : Cap.RW<string>) : Dval =
+    DRecord(
+      typeName (),
+      typeName (),
+      [ VT.string ],
+      Map [ "read", Scope.strToDT rw.read; "write", Scope.strToDT rw.write ]
+    )
+
+  let fromDT (d : Dval) : Cap.RW<string> =
+    match d with
+    | DRecord(_, _, _, f) ->
+      { read = Scope.strFromDT (D.field "read" f)
+        write = Scope.strFromDT (D.field "write" f) }
+    | _ -> Exception.raiseInternal "Invalid Capabilities.RW" [ "dval", d ]
+
+
+module Capabilities =
+  let typeName () =
+    FQTypeName.fqPackage (
+      PackageRefs.Type.LanguageTools.Capabilities.capabilities ()
+    )
+  let knownType () = KTCustomType(typeName (), [])
+
+  let toDT (c : Cap.Capabilities) : Dval =
+    DRecord(
+      typeName (),
+      typeName (),
+      [],
+      Map
+        [ "httpClient",
+          DList(
+            VT.known (HttpRule.knownType ()),
+            c.httpClient |> List.map HttpRule.toDT
+          )
+          "httpServer", Scope.portToDT c.httpServer
+          "file", RW.toDT c.file
+          "env", RW.toDT c.env
+          "db", RW.toDT c.db
+          "exec",
+          DList(VT.known (ExecRule.knownType ()), c.exec |> List.map ExecRule.toDT)
+          "stdout", DBool c.stdout
+          "stdin", DBool c.stdin
+          "random", DBool c.random
+          "clock", DBool c.clock
+          "llm", DBool c.llm ]
+    )
+
+  let fromDT (d : Dval) : Cap.Capabilities =
+    match d with
+    | DRecord(_, _, _, f) ->
+      { httpClient = D.list HttpRule.fromDT (D.field "httpClient" f)
+        httpServer = Scope.portFromDT (D.field "httpServer" f)
+        file = RW.fromDT (D.field "file" f)
+        env = RW.fromDT (D.field "env" f)
+        db = RW.fromDT (D.field "db" f)
+        exec = D.list ExecRule.fromDT (D.field "exec" f)
+        stdout = D.bool (D.field "stdout" f)
+        stdin = D.bool (D.field "stdin" f)
+        random = D.bool (D.field "random" f)
+        clock = D.bool (D.field "clock" f)
+        llm = D.bool (D.field "llm" f) }
+    | _ -> Exception.raiseInternal "Invalid Capabilities" [ "dval", d ]

--- a/backend/src/LibExecution/CapabilityAnalysis.fs
+++ b/backend/src/LibExecution/CapabilityAnalysis.fs
@@ -1,0 +1,109 @@
+/// Static per-fn capability analysis, on ProgramTypes (the source AST), not the RT instruction stream.
+/// Walk a fn's PT body for the fns it calls — a builtin contributes its declared caps
+/// (`fn.capabilities`, looked up by the caller), a package fn is a node to recurse into. The transitive,
+/// cycle-safe fold is `Capabilities.effectiveCaps`. PURE: the caller pre-loads the reachable PT fns
+/// (the async load of that closure stays out of the fold).
+module LibExecution.CapabilityAnalysis
+
+open Prelude
+
+module PT = LibExecution.ProgramTypes
+module Caps = LibExecution.Capabilities
+
+/// A resolved fn name, or nothing if it didn't resolve.
+let private nameRef
+  (nr : PT.NameResolution<PT.FQFnName.FQFnName>)
+  : List<PT.FQFnName.FQFnName> =
+  match nr.resolved with
+  | Ok resolved -> [ resolved.name ]
+  | Error _ -> []
+
+/// Every fn-name an expression references — `EFnName` and the piped `EPipeFnCall` — recursing all
+/// subexpressions. Mirrors `DependencyExtractor.extractFromExpr`, but collects fn names not deps.
+let rec fnRefs (expr : PT.Expr) : List<PT.FQFnName.FQFnName> =
+  let r = fnRefs
+  match expr with
+  | PT.EUnit _
+  | PT.EBool _
+  | PT.EInt8 _
+  | PT.EUInt8 _
+  | PT.EInt16 _
+  | PT.EUInt16 _
+  | PT.EInt32 _
+  | PT.EUInt32 _
+  | PT.EInt64 _
+  | PT.EUInt64 _
+  | PT.EInt128 _
+  | PT.EUInt128 _
+  | PT.EFloat _
+  | PT.EChar _
+  | PT.EVariable _
+  | PT.EArg _
+  | PT.ESelf _
+  | PT.EValue _ -> []
+
+  | PT.EFnName(_, nr) -> nameRef nr
+
+  | PT.EString(_, segments) -> segments |> List.collect segRefs
+  | PT.EIf(_, c, t, e) ->
+    List.concat [ r c; r t; e |> Option.map r |> Option.defaultValue [] ]
+  | PT.EPipe(_, lhs, parts) -> List.concat [ r lhs; parts |> List.collect pipeRefs ]
+  | PT.EMatch(_, arg, cases) -> List.concat [ r arg; cases |> List.collect caseRefs ]
+  | PT.ELet(_, _, value, body) -> List.concat [ r value; r body ]
+  | PT.EList(_, items) -> items |> List.collect r
+  | PT.EDict(_, pairs) -> pairs |> List.collect (snd >> r)
+  | PT.ETuple(_, first, second, rest) ->
+    List.concat [ r first; r second; rest |> List.collect r ]
+  | PT.EApply(_, fnExpr, _, args) ->
+    List.concat [ r fnExpr; args |> NEList.toList |> List.collect r ]
+  | PT.ELambda(_, _, body) -> r body
+  | PT.EInfix(_, _, lhs, rhs) -> List.concat [ r lhs; r rhs ]
+  | PT.ERecord(_, _, _, fields) -> fields |> List.collect (snd >> r)
+  | PT.ERecordFieldAccess(_, record, _) -> r record
+  | PT.ERecordUpdate(_, record, updates) ->
+    List.concat [ r record; updates |> NEList.toList |> List.collect (snd >> r) ]
+  | PT.EEnum(_, _, _, _, fields) -> fields |> List.collect r
+  | PT.EStatement(_, first, next) -> List.concat [ r first; r next ]
+
+and private segRefs (segment : PT.StringSegment) : List<PT.FQFnName.FQFnName> =
+  match segment with
+  | PT.StringText _ -> []
+  | PT.StringInterpolation expr -> fnRefs expr
+
+and private caseRefs (case : PT.MatchCase) : List<PT.FQFnName.FQFnName> =
+  List.concat
+    [ case.whenCondition |> Option.map fnRefs |> Option.defaultValue []
+      fnRefs case.rhs ]
+
+and private pipeRefs (pe : PT.PipeExpr) : List<PT.FQFnName.FQFnName> =
+  match pe with
+  | PT.EPipeLambda(_, _, body) -> fnRefs body
+  | PT.EPipeInfix(_, _, rhs) -> fnRefs rhs
+  | PT.EPipeFnCall(_, nr, _, args) ->
+    List.concat [ nameRef nr; args |> List.collect fnRefs ]
+  | PT.EPipeEnum(_, _, _, fields) -> fields |> List.collect fnRefs
+  | PT.EPipeVariable(_, _, args) -> args |> List.collect fnRefs
+
+
+/// Effective needs of a package fn = the field-wise JOIN of the needs of every builtin reachable
+/// through its PT call graph. `capsFor` looks up a builtin's declared `fn.capabilities`; `getFn`
+/// resolves a package-fn name to its pre-loaded PT body; cycles terminate via a visited set.
+let effectiveCapsOfFn
+  (capsFor : string -> Caps.Capabilities)
+  (getFn : PT.FQFnName.Package -> Option<PT.PackageFn.PackageFn>)
+  (root : PT.FQFnName.Package)
+  : Caps.Capabilities =
+  let mutable visited = Set.empty
+  let mutable acc = Caps.noCaps
+  let rec go (p : PT.FQFnName.Package) : unit =
+    if not (Set.contains p visited) then
+      visited <- Set.add p visited
+      match getFn p with
+      | Some fn ->
+        for fqfn in fnRefs fn.body do
+          match fqfn with
+          | PT.FQFnName.Builtin b -> acc <- Caps.join acc (capsFor b.name)
+          | PT.FQFnName.Package q -> go q
+      | None -> ()
+  go root
+  acc

--- a/backend/src/LibExecution/CapabilityCheck.fs
+++ b/backend/src/LibExecution/CapabilityCheck.fs
@@ -1,0 +1,104 @@
+/// CapabilityCheck — the PRECISE, per-call capability check that a nuanced builtin runs in its own body.
+///
+/// The call-site gate (Interpreter) already did the BROAD check — `coversStructurally grant fn.capabilities`
+/// — so the instance allows this builtin's domain at all. But a scoped grant (`file read ~/x`,
+/// `http-client GET api.x`) only means something if the SPECIFIC target is enforced, and only the builtin
+/// knows its own target (the path is fileRead's first arg, the URL is httpClient's). So each such builtin
+/// calls the matching `require*` here with the concrete value it holds — no name-matching, no central
+/// side-table. On denial we name the resource and the exact `dark caps grant …` command that would allow it.
+module LibExecution.CapabilityCheck
+
+open Prelude
+open LibExecution.RuntimeTypes
+module Cap = LibExecution.Capabilities
+
+/// Enforce a precise need against the grant; raise a denial (resource + grant hint) if uncovered.
+let private check
+  (grant : Cap.Capabilities)
+  (need : Cap.Capabilities)
+  (resource : string)
+  : unit =
+  match Cap.covers grant need with
+  | Cap.Allowed -> ()
+  | Cap.Denied what ->
+    RuntimeError.UncaughtException(
+      $"capability denied: {resource} needs {what}, which this instance doesn't grant. Grant it with `dark caps`.",
+      []
+    )
+    |> raiseUntargetedRTE
+
+let private only1 (x : string) : Cap.Scope<string> = Cap.Only(Set.singleton x)
+let private noScope : Cap.Scope<string> = Cap.Only Set.empty
+
+// ── http ────────────────────────────────────────────────────────────────────
+
+/// Decompose the request URL into the structured need and enforce it. An unparseable URL ⇒ the MAXIMAL
+/// `anyUrl` need (only an unrestricted http grant covers it) — fail-closed, never a silent "empty ⇒ any".
+let requireHttp (grant : Cap.Capabilities) (method : string) (uri : string) : unit =
+  let urlNeed : Cap.UrlScope =
+    try
+      let u = System.Uri uri
+      { schemes = only1 (u.Scheme.ToLowerInvariant())
+        hosts = [ Cap.ExactHost(u.Host.ToLowerInvariant()) ]
+        ports = Cap.Only(Set.singleton (int64 u.Port))
+        paths = only1 u.AbsolutePath }
+    with _ ->
+      Cap.anyUrl
+  let need =
+    { Cap.noCaps with
+        httpClient =
+          [ { methods = only1 (method.ToUpperInvariant()); url = urlNeed } ] }
+  check grant need $"{method.ToUpperInvariant()} {uri}"
+
+// ── exec ──────────────────────────────────────────────────────────────────────
+
+/// Enforce the CONCRETE program + arg tokens at a spawn call site.
+let requireExec
+  (grant : Cap.Capabilities)
+  (program : string)
+  (args : List<string>)
+  : unit =
+  let need =
+    { Cap.noCaps with
+        exec = [ { programs = only1 program; args = Cap.Only(Set.ofList args) } ] }
+  check grant need $"running `{program}`"
+
+// ── filesystem ────────────────────────────────────────────────────────────────
+
+let private fileNeed (r, w) : Cap.Capabilities =
+  { Cap.noCaps with file = { read = r; write = w } }
+
+let requireFileRead (grant : Cap.Capabilities) (path : string) : unit =
+  check grant (fileNeed (only1 path, noScope)) $"reading `{path}`"
+
+let requireFileWrite (grant : Cap.Capabilities) (path : string) : unit =
+  check grant (fileNeed (noScope, only1 path)) $"writing `{path}`"
+
+let requireFileReadWrite (grant : Cap.Capabilities) (path : string) : unit =
+  check grant (fileNeed (only1 path, only1 path)) $"accessing `{path}`"
+
+// ── environment ───────────────────────────────────────────────────────────────
+
+let private envNeed (r, w) : Cap.Capabilities =
+  { Cap.noCaps with env = { read = r; write = w } }
+
+let requireEnvRead (grant : Cap.Capabilities) (var : string) : unit =
+  check grant (envNeed (only1 var, noScope)) $"reading env `{var}`"
+
+/// Reading ALL of the environment (no single var) — needs an unscoped env-read grant.
+let requireEnvReadAll (grant : Cap.Capabilities) : unit =
+  check grant (envNeed (Cap.Any, noScope)) "reading the environment"
+
+let requireEnvWrite (grant : Cap.Capabilities) (var : string) : unit =
+  check grant (envNeed (noScope, only1 var)) $"setting env `{var}`"
+
+// ── datastore ─────────────────────────────────────────────────────────────────
+
+let private dbNeed (r, w) : Cap.Capabilities =
+  { Cap.noCaps with db = { read = r; write = w } }
+
+let requireDbRead (grant : Cap.Capabilities) (table : string) : unit =
+  check grant (dbNeed (only1 table, noScope)) $"reading datastore `{table}`"
+
+let requireDbWrite (grant : Cap.Capabilities) (table : string) : unit =
+  check grant (dbNeed (noScope, only1 table)) $"writing datastore `{table}`"

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -54,6 +54,11 @@ let createState
 
     allowHarmful = false
 
+    // The base default is permissive — `createState` is RT-level and can't read the on-disk grant, so
+    // the gate is a no-op here. The CLI host narrows it per entry point (`eval`/host → the configured
+    // grant; `dark run` → NONE) before executing user code; tests run permissive.
+    grantedCaps = LibExecution.Capabilities.allCaps
+
     accountID = None }
 
 

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -843,19 +843,30 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
                       // matching. Nuanced builtins (http/file/exec/…) additionally enforce the SPECIFIC
                       // target (URL/path/args) in their own body via `CapabilityCheck`. Default grant is
                       // allCaps (no behavior change); a real instance narrows it (default NONE for `dark run`).
-                      match
-                        Capabilities.coversStructurally
-                          exeState.grantedCaps
-                          fn.capabilities
-                      with
-                      | Capabilities.Denied what ->
-                        raiseRTE (
-                          RTE.UncaughtException(
-                            $"capability denied: `{fn.name.name}` needs {what}, which this instance doesn't grant. Grant it with `dark caps`.",
-                            []
+                      // fast-path: pure builtins (the vast majority) all share the one `noCaps` instance,
+                      // so a reference check skips the structural scan entirely in the hot path. A false
+                      // negative (an all-empty need built fresh) just runs the full check — still correct.
+                      if
+                        not (
+                          System.Object.ReferenceEquals(
+                            fn.capabilities,
+                            Capabilities.noCaps
                           )
                         )
-                      | Capabilities.Allowed -> ()
+                      then
+                        match
+                          Capabilities.coversStructurally
+                            exeState.grantedCaps
+                            fn.capabilities
+                        with
+                        | Capabilities.Denied what ->
+                          raiseRTE (
+                            RTE.UncaughtException(
+                              $"capability denied: `{fn.name.name}` needs {what}, which this instance doesn't grant. Grant it with `dark caps`.",
+                              []
+                            )
+                          )
+                        | Capabilities.Allowed -> ()
                       let! result = fn.fn (exeState, vm, resolvedTypeArgs, allArgs)
                       if vm.stats.enabled && vm.stats.detailedTiming then
                         let elapsed =

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -838,6 +838,24 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
                             0L
                         else
                           0L
+                      // capabilities gate: a builtin runs only if the instance's grant covers the DOMAIN
+                      // it declares it needs (`fn.capabilities`) — a structural PRESENCE check, no name
+                      // matching. Nuanced builtins (http/file/exec/…) additionally enforce the SPECIFIC
+                      // target (URL/path/args) in their own body via `CapabilityCheck`. Default grant is
+                      // allCaps (no behavior change); a real instance narrows it (default NONE for `dark run`).
+                      match
+                        Capabilities.coversStructurally
+                          exeState.grantedCaps
+                          fn.capabilities
+                      with
+                      | Capabilities.Denied what ->
+                        raiseRTE (
+                          RTE.UncaughtException(
+                            $"capability denied: `{fn.name.name}` needs {what}, which this instance doesn't grant. Grant it with `dark caps`.",
+                            []
+                          )
+                        )
+                      | Capabilities.Allowed -> ()
                       let! result = fn.fn (exeState, vm, resolvedTypeArgs, allArgs)
                       if vm.stats.enabled && vm.stats.detailedTiming then
                         let elapsed =

--- a/backend/src/LibExecution/LibExecution.fsproj
+++ b/backend/src/LibExecution/LibExecution.fsproj
@@ -23,8 +23,11 @@
   <ItemGroup>
     <Compile Include="DarkDateTime.fs" />
     <Compile Include="PackageRefs.fs" />
+    <!-- Capabilities (resource-domain gating model — RT-independent) /-->
+    <Compile Include="Capabilities.fs" />
     <!-- Runtime /-->
     <Compile Include="RuntimeTypes.fs" />
+    <Compile Include="CapabilityCheck.fs" />
     <Compile Include="ValueType.fs" />
     <Compile Include="Blob.fs" />
     <Compile Include="Stream.fs" />
@@ -35,12 +38,14 @@
     <Compile Include="AnalysisTypes.fs" />
     <!-- Dev-time, Language Design, Mental Model /-->
     <Compile Include="ProgramTypes.fs" />
+    <Compile Include="CapabilityAnalysis.fs" />
     <Compile Include="ProgramTypesAst.fs" />
     <Compile Include="RTQueryCompiler.fs" />
     <Compile Include="ProgramTypesToRuntimeTypes.fs" />
     <!-- User+Runtime I/O /-->
     <Compile Include="DvalDecoder.fs" />
     <Compile Include="CommonToDarkTypes.fs" />
+    <Compile Include="CapabilitiesToDarkTypes.fs" />
     <Compile Include="RuntimeTypesToDarkTypes.fs" />
     <Compile Include="ProgramTypesToDarkTypes.fs" />
     <!-- Expose the runtime to the outside world /-->

--- a/backend/src/LibExecution/PackageRefs.fs
+++ b/backend/src/LibExecution/PackageRefs.fs
@@ -169,6 +169,17 @@ module Type =
     let builtinFn = p [] "BuiltinFunction"
     let builtinFnPurity = p [] "BuiltinFunctionPurity"
 
+    /// The structured capability model — the F#/Dark wire form (see `CapabilitiesToDarkTypes`).
+    module Capabilities =
+      let private p addl = p ("Capabilities" :: addl)
+      let scope = p [] "Scope"
+      let hostMatch = p [] "HostMatch"
+      let urlScope = p [] "UrlScope"
+      let httpRule = p [] "HttpRule"
+      let execRule = p [] "ExecRule"
+      let rw = p [] "RW"
+      let capabilities = p [] "Capabilities"
+
     module Parser =
       let private p addl = p ("Parser" :: addl)
       let point = p [] "Point"

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1791,7 +1791,8 @@ type BuiltInValue =
 /// (Generally shouldn't be accessed directly,
 /// except by a single stdlib Package fn that wraps it)
 type BuiltInFn =
-  { name : FQFnName.Builtin
+  {
+    name : FQFnName.Builtin
     typeParams : List<string>
     parameters : List<BuiltInParam> // TODO: should be NEList but there's so much to change!
     returnType : TypeReference
@@ -1799,7 +1800,12 @@ type BuiltInFn =
     previewable : Previewable
     deprecated : Deprecation<FQFnName.FQFnName>
     sqlSpec : SqlSpec
-    fn : BuiltInFnSig }
+    /// The capabilities this builtin needs — pure (`noCaps`) by default; effectful builtins declare
+    /// their need. The call-site gate checks PRESENCE against this; nuanced builtins (http/file/exec)
+    /// additionally enforce the specific scope (URL/path/args) in their own body.
+    capabilities : Capabilities.Capabilities
+    fn : BuiltInFnSig
+  }
 
 and BuiltInFnSig =
   // (exeState * vmState * typeArgs * fnArgs) -> result
@@ -1871,6 +1877,11 @@ and ExecutionState =
     types : Types
     fns : Functions
     values : Values
+
+    /// The capabilities the running code is allowed — read by the call-site gate (an uncovered builtin
+    /// call is denied). Callers set it: `eval`/host use the configured grant (allCaps by default), `dark
+    /// run` uses NONE.
+    grantedCaps : Capabilities.Capabilities
 
     /// Content-addressed persistent blob store (`package_blobs`).
     /// Ephemeral blobs carry their bytes inline and need no store;

--- a/backend/src/LibSerialization/Binary/Serializers/Capabilities.fs
+++ b/backend/src/LibSerialization/Binary/Serializers/Capabilities.fs
@@ -1,0 +1,131 @@
+/// Binary serializer for the on-disk capability grant.
+///
+/// TODO: when `Capabilities` moves to the language level (see `LibExecution.Capabilities`), this should
+/// move under the matching `PT`/`RT` folder and adopt its versioning conventions.
+module LibSerialization.Binary.Serializers.Capabilities
+
+open System.IO
+open Prelude
+
+module Cap = LibExecution.Capabilities
+
+open LibSerialization.Binary.BaseFormat
+open LibSerialization.Binary.Serializers.Common
+
+// A Scope is a tag (Any vs Only) + the allow-list when Only.
+let private writeScopeStr (w : BinaryWriter) (s : Cap.Scope<string>) : unit =
+  match s with
+  | Cap.Any -> Bool.write w true
+  | Cap.Only xs ->
+    Bool.write w false
+    List.write w String.write (Set.toList xs)
+
+let private readScopeStr (r : BinaryReader) : Cap.Scope<string> =
+  if Bool.read r then Cap.Any else Cap.Only(List.read r String.read |> Set.ofList)
+
+let private writeScopeInt (w : BinaryWriter) (s : Cap.Scope<int64>) : unit =
+  match s with
+  | Cap.Any -> Bool.write w true
+  | Cap.Only xs ->
+    Bool.write w false
+    List.write w Int64.writeInt64 (Set.toList xs)
+
+let private readScopeInt (r : BinaryReader) : Cap.Scope<int64> =
+  if Bool.read r then
+    Cap.Any
+  else
+    Cap.Only(List.read r Int64.readInt64 |> Set.ofList)
+
+let private writeRW (w : BinaryWriter) (rw : Cap.RW<string>) : unit =
+  writeScopeStr w rw.read
+  writeScopeStr w rw.write
+
+let private readRW (r : BinaryReader) : Cap.RW<string> =
+  let read = readScopeStr r
+  let write = readScopeStr r
+  { read = read; write = write }
+
+let private writeHost (w : BinaryWriter) (h : Cap.HostMatch) : unit =
+  match h with
+  | Cap.AnyHost -> w.Write(0uy)
+  | Cap.ExactHost s ->
+    w.Write(1uy)
+    String.write w s
+  | Cap.Subdomain d ->
+    w.Write(2uy)
+    String.write w d
+
+let private readHost (r : BinaryReader) : Cap.HostMatch =
+  match r.ReadByte() with
+  | 0uy -> Cap.AnyHost
+  | 1uy -> Cap.ExactHost(String.read r)
+  | 2uy -> Cap.Subdomain(String.read r)
+  | b -> raise (BinaryFormatException(CorruptedData $"Invalid HostMatch tag: {b}"))
+
+let private writeUrl (w : BinaryWriter) (u : Cap.UrlScope) : unit =
+  writeScopeStr w u.schemes
+  List.write w writeHost u.hosts
+  writeScopeInt w u.ports
+  writeScopeStr w u.paths
+
+let private readUrl (r : BinaryReader) : Cap.UrlScope =
+  let schemes = readScopeStr r
+  let hosts = List.read r readHost
+  let ports = readScopeInt r
+  let paths = readScopeStr r
+  { schemes = schemes; hosts = hosts; ports = ports; paths = paths }
+
+let private writeHttpRule (w : BinaryWriter) (rule : Cap.HttpRule) : unit =
+  writeScopeStr w rule.methods
+  writeUrl w rule.url
+
+let private readHttpRule (r : BinaryReader) : Cap.HttpRule =
+  let methods = readScopeStr r
+  let url = readUrl r
+  { methods = methods; url = url }
+
+let private writeExecRule (w : BinaryWriter) (rule : Cap.ExecRule) : unit =
+  writeScopeStr w rule.programs
+  writeScopeStr w rule.args
+
+let private readExecRule (r : BinaryReader) : Cap.ExecRule =
+  let programs = readScopeStr r
+  let args = readScopeStr r
+  { programs = programs; args = args }
+
+let write (w : BinaryWriter) (c : Cap.Capabilities) : unit =
+  List.write w writeHttpRule c.httpClient
+  writeScopeInt w c.httpServer
+  writeRW w c.file
+  writeRW w c.env
+  writeRW w c.db
+  List.write w writeExecRule c.exec
+  Bool.write w c.stdout
+  Bool.write w c.stdin
+  Bool.write w c.random
+  Bool.write w c.clock
+  Bool.write w c.llm
+
+let read (r : BinaryReader) : Cap.Capabilities =
+  let httpClient = List.read r readHttpRule
+  let httpServer = readScopeInt r
+  let file = readRW r
+  let env = readRW r
+  let db = readRW r
+  let exec = List.read r readExecRule
+  let stdout = Bool.read r
+  let stdin = Bool.read r
+  let random = Bool.read r
+  let clock = Bool.read r
+  let llm = Bool.read r
+  { httpClient = httpClient
+    httpServer = httpServer
+    file = file
+    env = env
+    db = db
+    exec = exec
+    stdout = stdout
+    stdin = stdin
+    random = random
+    clock = clock
+    llm = llm }

--- a/backend/src/LibSerialization/LibSerialization.fsproj
+++ b/backend/src/LibSerialization/LibSerialization.fsproj
@@ -18,6 +18,8 @@
 
     <Compile Include="Binary/Serializers/Common.fs" />
 
+    <Compile Include="Binary/Serializers/Capabilities.fs" />
+
     <Compile Include="Binary/Serializers/PT/Common.fs" />
     <Compile Include="Binary/Serializers/PT/TypeReference.fs" />
     <Compile Include="Binary/Serializers/PT/PackageType.fs" />

--- a/backend/tests/TestUtils/LibTest.fs
+++ b/backend/tests/TestUtils/LibTest.fs
@@ -56,6 +56,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
     { name = fn "testToChar" 0
@@ -80,6 +81,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -98,6 +100,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -112,6 +115,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -128,6 +132,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -151,6 +156,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -165,6 +171,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -183,6 +190,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated } ]
 
 let builtins () = LibExecution.Builtin.make values (fns ())

--- a/backend/tests/Tests/Capabilities.Tests.fs
+++ b/backend/tests/Tests/Capabilities.Tests.fs
@@ -1,0 +1,530 @@
+/// Tests for the nuanced capability model.
+///
+/// Pure — no ExecutionState. Covers the field-wise `covers` gate (subsumption), the structural presence
+/// gate (`coversStructurally`), the host/path matchers + scope subsumption, the `join` fold, the binary
+/// blob round-trip, and the `fnRefs` PT-walk. (The grant-spec LANGUAGE — parse/render — now lives in
+/// `.dark`'s `LanguageTools.Capabilities`, tested there.)
+module Tests.Capabilities
+
+open Expecto
+
+open Prelude
+
+module Cap = LibExecution.Capabilities
+module PT = LibExecution.ProgramTypes
+module Analysis = LibExecution.CapabilityAnalysis
+module Grants = LibDB.CapabilityGrants
+
+let private only (xs : string list) : Cap.Scope<string> = Cap.Only(Set.ofList xs)
+let private isAllowed (g : Cap.Capabilities) (n : Cap.Capabilities) =
+  Cap.covers g n = Cap.Allowed
+
+let private isDenied (g : Cap.Capabilities) (n : Cap.Capabilities) =
+  match Cap.covers g n with
+  | Cap.Denied _ -> true
+  | _ -> false
+
+/// A concrete http-request NEED: `METHOD scheme://host:port/path` (what the gate builds from a call).
+let private req
+  (method : string)
+  (scheme : string)
+  (host : string)
+  (port : int64)
+  (path : string)
+  : Cap.Capabilities =
+  { Cap.noCaps with
+      httpClient =
+        [ { methods = Cap.Only(Set.singleton method)
+            url =
+              { schemes = Cap.Only(Set.singleton scheme)
+                hosts = [ Cap.ExactHost host ]
+                ports = Cap.Only(Set.singleton port)
+                paths = Cap.Only(Set.singleton path) } } ] }
+
+/// Build grants STRUCTURALLY — the grant-spec LANGUAGE now lives in `.dark`
+/// (`LanguageTools.Capabilities.parse`), so F# tests construct the model directly.
+let private port (n : int64) : Cap.Scope<int64> = Cap.Only(Set.singleton n)
+
+let private urlS
+  (schemes : Cap.Scope<string>)
+  (hosts : List<Cap.HostMatch>)
+  (ports : Cap.Scope<int64>)
+  (paths : Cap.Scope<string>)
+  : Cap.UrlScope =
+  { schemes = schemes; hosts = hosts; ports = ports; paths = paths }
+
+let private httpGrant
+  (methods : Cap.Scope<string>)
+  (url : Cap.UrlScope)
+  : Cap.Capabilities =
+  { Cap.noCaps with httpClient = [ { methods = methods; url = url } ] }
+
+/// Build a exec grant/need from an explicit list of (programs, args) rules.
+let private execRules
+  (rules : List<Cap.Scope<string> * Cap.Scope<string>>)
+  : Cap.Capabilities =
+  { Cap.noCaps with
+      exec = rules |> List.map (fun (p, a) -> { programs = p; args = a }) }
+
+/// A exec NEED for one concrete launch: program `p` with args `argv`.
+let private needExec (p : string) (argv : List<string>) : Cap.Capabilities =
+  execRules [ (only [ p ], Cap.Only(Set.ofList argv)) ]
+
+
+// ─────────────────────────────────────────────────────────────────────
+// covers — field-wise subsumption (the gate)
+// ─────────────────────────────────────────────────────────────────────
+
+let noCapsDeniesEffectful =
+  test "covers: noCaps denies any effectful need (the strict default blocks)" {
+    Expect.isTrue
+      (isDenied Cap.noCaps { Cap.noCaps with clock = true })
+      "clock denied under noCaps"
+    Expect.equal
+      (Cap.covers Cap.noCaps Cap.noCaps)
+      Cap.Allowed
+      "a pure need (noCaps) always passes — the fast-path"
+  }
+
+let allCapsGrantsEverything =
+  test "covers: allCaps grants every need" {
+    Expect.isTrue
+      (isAllowed Cap.allCaps (req "POST" "https" "api.x" 443L "/"))
+      "http allowed"
+    Expect.isTrue
+      (isAllowed Cap.allCaps { Cap.noCaps with random = true })
+      "random allowed"
+  }
+
+let getOnlyCoversGetDeniesPost =
+  test "covers: a `GET-only` grant covers a GET need but denies a POST" {
+    let grant = httpGrant (only [ "GET" ]) Cap.anyUrl // any URL, GET only
+    Expect.isTrue
+      (isAllowed grant (req "GET" "https" "api.github.com" 443L "/x"))
+      "GET passes"
+    Expect.isTrue
+      (isDenied grant (req "POST" "https" "api.x" 443L "/"))
+      "POST denied"
+  }
+
+let hostScopedGrant =
+  test "covers: a host-scoped grant covers that host, denies others" {
+    let grant =
+      httpGrant
+        Cap.Any
+        (urlS
+          (only [ "https" ])
+          [ Cap.ExactHost "api.github.com" ]
+          (port 443L)
+          Cap.Any)
+    Expect.isTrue
+      (isAllowed grant (req "GET" "https" "api.github.com" 443L "/x"))
+      "in-scope host"
+    Expect.isTrue
+      (isDenied grant (req "GET" "https" "evil.com" 443L "/"))
+      "out-of-scope host"
+  }
+
+let schemePortPathScoping =
+  test "covers: scheme/port/path are each enforced" {
+    // https://api.x/v3  (omitted scheme ⇒ https, omitted port ⇒ 443, path-prefix /v3)
+    let grant =
+      httpGrant
+        (only [ "GET" ])
+        (urlS
+          (only [ "https" ])
+          [ Cap.ExactHost "api.x" ]
+          (port 443L)
+          (only [ "/v3" ]))
+    Expect.isTrue
+      (isAllowed grant (req "GET" "https" "api.x" 443L "/v3/users"))
+      "in-scope path ok"
+    Expect.isTrue
+      (isDenied grant (req "GET" "https" "api.x" 443L "/admin"))
+      "out-of-scope path denied"
+    Expect.isTrue
+      (isDenied grant (req "GET" "http" "api.x" 80L "/v3"))
+      "plain http denied (https only)"
+    Expect.isTrue
+      (isDenied grant (req "GET" "https" "api.x" 8443L "/v3"))
+      "non-default port denied"
+    // explicit any-scheme + any-port
+    let loose =
+      httpGrant
+        (only [ "GET" ])
+        (urlS Cap.Any [ Cap.ExactHost "api.x" ] Cap.Any Cap.Any)
+    Expect.isTrue
+      (isAllowed loose (req "GET" "http" "api.x" 8080L "/"))
+      "any scheme + any port ok"
+  }
+
+let subdomainScoping =
+  test
+    "covers: a `*.github.com` grant covers subdomains + the bare domain, not look-alikes" {
+    let grant =
+      httpGrant
+        (only [ "GET" ])
+        (urlS (only [ "https" ]) [ Cap.Subdomain "github.com" ] (port 443L) Cap.Any)
+    Expect.isTrue
+      (isAllowed grant (req "GET" "https" "api.github.com" 443L "/"))
+      "subdomain ok"
+    Expect.isTrue
+      (isAllowed grant (req "GET" "https" "github.com" 443L "/"))
+      "bare domain ok"
+    Expect.isTrue
+      (isDenied grant (req "GET" "https" "github.com.evil.com" 443L "/"))
+      "look-alike suffix denied"
+  }
+
+let perHostCoupling =
+  // the headline for the rule LIST: "any method to localhost, AND GET-only everywhere else".
+  // method and URL couple per-rule, and the request must match SOME rule.
+  test
+    "covers: coupled rules — any-method@localhost + GET-anywhere passes/denies correctly" {
+    let grant =
+      Cap.join
+        (httpGrant
+          Cap.Any
+          (urlS (only [ "https" ]) [ Cap.ExactHost "localhost" ] (port 443L) Cap.Any)) // any method, https://localhost
+        (httpGrant (only [ "GET" ]) Cap.anyUrl) // GET anywhere
+    // POST to localhost — covered by rule 1
+    Expect.isTrue
+      (isAllowed grant (req "POST" "https" "localhost" 443L "/"))
+      "POST→localhost ok"
+    // GET to an external host — covered by rule 2
+    Expect.isTrue
+      (isAllowed grant (req "GET" "https" "api.github.com" 443L "/x"))
+      "GET→external ok"
+    // POST to an external host — covered by NEITHER rule
+    Expect.isTrue
+      (isDenied grant (req "POST" "https" "api.github.com" 443L "/"))
+      "POST→external denied"
+  }
+
+let execCoupling =
+  // the same coupled-rule pattern for exec: "git with any args, but rm only with --dry-run".
+  test "covers: coupled exec rules — program × args couple per rule" {
+    let grant =
+      execRules
+        [ (only [ "git" ], Cap.Any) // git with any args
+          (only [ "rm" ], only [ "--dry-run" ]) ] // rm only with --dry-run
+    Expect.isTrue
+      (isAllowed grant (needExec "git" [ "commit"; "-m"; "x" ]))
+      "git any-args ok"
+    Expect.isTrue (isAllowed grant (needExec "rm" [ "--dry-run" ])) "rm --dry-run ok"
+    Expect.isTrue
+      (isAllowed grant (needExec "rm" []))
+      "rm no-args ok (empty ⊑ allowlist)"
+    Expect.isTrue
+      (isDenied grant (needExec "rm" [ "-rf"; "/" ]))
+      "rm -rf denied (arg not in allowlist)"
+    Expect.isTrue
+      (isDenied grant (needExec "curl" []))
+      "an ungranted program is denied"
+  }
+
+let fileReadAnyWriteHere =
+  // the headline: read anywhere, write only inside ~/.darklang  — one record, two scopes
+  test
+    "covers: file read=any, write=only-dir — reads pass anywhere, writes only inside the dir" {
+    let grant =
+      { Cap.noCaps with file = { read = Cap.Any; write = only [ "~/.darklang/" ] } }
+    let needReadAnywhere =
+      { Cap.noCaps with file = { read = Cap.Any; write = Cap.Only Set.empty } }
+    let needWriteInside =
+      { Cap.noCaps with
+          file = { read = Cap.Only Set.empty; write = only [ "~/.darklang/x" ] } }
+    let needWriteOutside =
+      { Cap.noCaps with
+          file = { read = Cap.Only Set.empty; write = only [ "/etc/passwd" ] } }
+    Expect.isTrue (isAllowed grant needReadAnywhere) "read anywhere allowed"
+    Expect.isTrue
+      (isAllowed grant needWriteInside)
+      "write inside the dir allowed (prefix)"
+    Expect.isTrue (isDenied grant needWriteOutside) "write outside the dir denied"
+  }
+
+
+// ─────────────────────────────────────────────────────────────────────
+// matchers + scope subsumption
+// ─────────────────────────────────────────────────────────────────────
+
+let hostMatching =
+  test "hostMatchCovers: AnyHost, ExactHost, Subdomain (subdomain + bare)" {
+    let exact = Cap.ExactHost "api.github.com"
+    Expect.isTrue
+      (Cap.hostMatchCovers exact (Cap.ExactHost "api.github.com"))
+      "exact match"
+    Expect.isFalse
+      (Cap.hostMatchCovers exact (Cap.ExactHost "evil.com"))
+      "exact non-match"
+    let sub = Cap.Subdomain "github.com"
+    Expect.isTrue
+      (Cap.hostMatchCovers sub (Cap.ExactHost "api.github.com"))
+      "subdomain covered"
+    Expect.isTrue
+      (Cap.hostMatchCovers sub (Cap.ExactHost "github.com"))
+      "bare domain covered"
+    Expect.isFalse
+      (Cap.hostMatchCovers sub (Cap.ExactHost "github.com.evil.com"))
+      "look-alike suffix not covered"
+    Expect.isTrue
+      (Cap.hostMatchCovers Cap.AnyHost (Cap.ExactHost "anything.example"))
+      "AnyHost covers all"
+    Expect.isFalse
+      (Cap.hostMatchCovers exact Cap.AnyHost)
+      "needing AnyHost requires AnyHost grant"
+  }
+
+let pathMatching =
+  test "pathUnder: a grant prefix covers paths at/under it, on a directory boundary" {
+    Expect.isTrue (Cap.pathUnder "/a" "/a") "exact prefix"
+    Expect.isTrue (Cap.pathUnder "/a" "/a/b/c") "under the prefix"
+    Expect.isFalse (Cap.pathUnder "/a" "/b") "outside the prefix"
+    // boundary: a prefix must NOT cover a sibling that merely shares the string prefix
+    Expect.isFalse
+      (Cap.pathUnder "/a" "/ab")
+      "sibling sharing the string prefix is NOT covered"
+    Expect.isFalse
+      (Cap.pathUnder "/home/safe" "/home/safe-evil/x")
+      "no partial-segment match"
+    // a trailing slash on the grant is fine
+    Expect.isTrue
+      (Cap.pathUnder "~/.darklang/" "~/.darklang/x")
+      "trailing-slash prefix covers under it"
+  }
+
+let scopeSubsumption =
+  test "scopeCovers: Any ⊒ anything; Only ⊒ subset; needing Any needs Any" {
+    let m = (=)
+    Expect.isTrue (Cap.scopeCovers m Cap.Any (only [ "x" ])) "Any covers a specific"
+    Expect.isTrue
+      (Cap.scopeCovers m (only [ "x"; "y" ]) (only [ "x" ]))
+      "superset covers subset"
+    Expect.isFalse
+      (Cap.scopeCovers m (only [ "x" ]) (only [ "y" ]))
+      "missing element denied"
+    Expect.isFalse
+      (Cap.scopeCovers m (only [ "x" ]) Cap.Any)
+      "needing Any is only covered by Any"
+  }
+
+
+// ─────────────────────────────────────────────────────────────────────
+// join — the analysis fold's field-wise union
+// ─────────────────────────────────────────────────────────────────────
+
+let joinUnions =
+  test "join: unions scopes + ORs the flags, field by field" {
+    let a = { httpGrant (only [ "GET" ]) Cap.anyUrl with random = true }
+    let b = { httpGrant (only [ "POST" ]) Cap.anyUrl with clock = true }
+    let j = Cap.join a b
+    Expect.isTrue j.random "random kept"
+    Expect.isTrue j.clock "clock added"
+    // both a GET need and a POST need are now covered (the two rules are appended)
+    Expect.isTrue (isAllowed j (req "GET" "https" "api.x" 443L "/")) "GET covered"
+    Expect.isTrue (isAllowed j (req "POST" "https" "api.x" 443L "/")) "POST covered"
+  }
+
+
+// ─────────────────────────────────────────────────────────────────────
+// binary blob — toBytes / fromBytes round-trip (the on-disk grant store)
+// (the grant-spec LANGUAGE round-trip lives in `.dark`'s `LanguageTools.Capabilities` tests now)
+// ─────────────────────────────────────────────────────────────────────
+
+let binaryRoundTrip =
+  test "toBytes ↔ fromBytes round-trips the grant (the on-disk binary blob)" {
+    let caps =
+      { Cap.noCaps with
+          httpClient =
+            [ { methods = only [ "GET" ]
+                url =
+                  urlS
+                    (only [ "https" ])
+                    [ Cap.Subdomain "github.com" ]
+                    (port 443L)
+                    (only [ "/api" ]) }
+              { methods = Cap.Any
+                url = urlS Cap.Any [ Cap.ExactHost "localhost" ] Cap.Any Cap.Any } ]
+          httpServer = Cap.Any
+          file = { read = Cap.Any; write = only [ "~/.darklang/" ] }
+          env = { read = only [ "PATH" ]; write = Cap.Only Set.empty }
+          db = { read = only [ "users" ]; write = only [ "users" ] }
+          exec =
+            [ { programs = only [ "git" ]; args = Cap.Any }
+              { programs = only [ "rm" ]; args = only [ "--dry-run" ] } ]
+          random = true
+          clock = true
+          stdout = true }
+    Expect.equal
+      (Grants.fromBytes (Grants.toBytes caps))
+      caps
+      "binary blob round-trips the record"
+    Expect.equal
+      (Grants.fromBytes (Grants.toBytes Cap.noCaps))
+      Cap.noCaps
+      "noCaps round-trips"
+  }
+
+
+// ─────────────────────────────────────────────────────────────────────
+// gate — the structural PRESENCE check (`coversStructurally`)
+// ─────────────────────────────────────────────────────────────────────
+
+let private isPresent (g : Cap.Capabilities) (n : Cap.Capabilities) =
+  Cap.coversStructurally g n = Cap.Allowed
+
+let private isAbsent (g : Cap.Capabilities) (n : Cap.Capabilities) =
+  match Cap.coversStructurally g n with
+  | Cap.Denied _ -> true
+  | _ -> false
+
+let structuralGatePresence =
+  // the gate is presence-only for rich domains: a SCOPED grant passes (the body refines the specifics),
+  // but a grant with NO http at all is denied here before the body runs. Bools are exact.
+  test "coversStructurally: presence for rich domains, exact for bools" {
+    // a GET-only grant passes the http presence gate for any http need (body enforces the method/host)
+    let getOnly = httpGrant (only [ "GET" ]) Cap.anyUrl
+    Expect.isTrue
+      (isPresent getOnly (req "POST" "https" "api.x" 443L "/"))
+      "a POST need passes the http presence gate under a GET grant (body decides the method)"
+    Expect.isTrue
+      (isAbsent Cap.noCaps (Cap.Needs.http))
+      "no http grant ⇒ http need denied at the gate"
+    // file read presence is per-direction: a write-only grant doesn't satisfy a read need
+    Expect.isTrue
+      (isAbsent Cap.Needs.fileWrite Cap.Needs.fileRead)
+      "a write-only grant doesn't satisfy a read need at the gate"
+    Expect.isTrue
+      (isPresent Cap.Needs.fileRead Cap.Needs.fileRead)
+      "a read grant satisfies a read need"
+    // bools are exact
+    Expect.isTrue
+      (isAbsent Cap.noCaps Cap.Needs.clock)
+      "clock need denied without grant"
+    Expect.isTrue
+      (isPresent Cap.Needs.clock Cap.Needs.clock)
+      "clock granted ⇒ allowed"
+  }
+
+let scopedGrantsEnforced =
+  // the headline: `file write ~/.darklang/` must enforce at runtime. The builtin body builds the PRECISE
+  // need (a singleton path) and `covers` decides — exactly what `CapabilityCheck.requireFileWrite` does.
+  test "covers: a scoped file/db grant covers in-scope targets and denies others" {
+    let fileGrant =
+      { Cap.noCaps with
+          file = { read = Cap.Only Set.empty; write = only [ "~/.darklang/" ] } }
+    let writeNeed (p : string) : Cap.Capabilities =
+      { Cap.noCaps with
+          file = { read = Cap.Only Set.empty; write = Cap.Only(Set.singleton p) } }
+    Expect.isTrue
+      (isAllowed fileGrant (writeNeed "~/.darklang/x"))
+      "write inside ~/.darklang/ allowed"
+    Expect.isTrue
+      (isDenied fileGrant (writeNeed "/etc/passwd"))
+      "write outside the dir denied"
+    // an unscoped `file write` (Any) still covers any concrete path
+    Expect.isTrue
+      (isAllowed
+        ({ Cap.noCaps with file = { read = Cap.Only Set.empty; write = Cap.Any } })
+        (writeNeed "/etc/passwd"))
+      "an unscoped write grant covers any path"
+    // db: the table is the concrete reference the body holds
+    let dbGrant =
+      { Cap.noCaps with
+          db = { read = only [ "users" ]; write = Cap.Only Set.empty } }
+    let dbReadNeed (t : string) : Cap.Capabilities =
+      { Cap.noCaps with
+          db = { read = Cap.Only(Set.singleton t); write = Cap.Only Set.empty } }
+    Expect.isTrue
+      (isAllowed dbGrant (dbReadNeed "users"))
+      "db read of the granted table allowed"
+    Expect.isTrue
+      (isDenied dbGrant (dbReadNeed "secrets"))
+      "db read of a different table denied"
+  }
+
+// revoke + clear now live in `.dark` as spec-list filtering over get/set (no F# domain-clear).
+
+
+// ─────────────────────────────────────────────────────────────────────
+// fnRefs — the PT-walk that feeds the analysis
+// ─────────────────────────────────────────────────────────────────────
+
+let private bi (name : string) : PT.FQFnName.FQFnName =
+  PT.FQFnName.Builtin { name = name; version = 0 }
+
+let private fnName (fq : PT.FQFnName.FQFnName) : PT.Expr =
+  PT.EFnName(0UL, PT.NameResolution.ok fq)
+
+let fnRefsDirectName =
+  test "fnRefs: an EFnName yields its resolved name" {
+    Expect.equal
+      (Analysis.fnRefs (fnName (bi "httpClientRequest")))
+      [ bi "httpClientRequest" ]
+      "the single referenced builtin"
+  }
+
+let fnRefsRecursesSubexprs =
+  test "fnRefs: recurses into every subexpression (both sides of a let)" {
+    let e =
+      PT.ELet(
+        0UL,
+        PT.LPWildcard 0UL,
+        fnName (bi "httpClientRequest"),
+        fnName (bi "randomUuid")
+      )
+    Expect.equal
+      (Set.ofList (Analysis.fnRefs e))
+      (Set.ofList [ bi "httpClientRequest"; bi "randomUuid" ])
+      "names collected from value AND body"
+  }
+
+let fnRefsSkipsUnresolved =
+  test "fnRefs: an unresolved name contributes nothing" {
+    let e =
+      PT.EFnName(
+        0UL,
+        { originalName = [ "Nope" ]
+          resolved = Error PT.NameResolutionError.NotFound }
+      )
+    Expect.equal (Analysis.fnRefs e) [] "an Error resolution yields no fn ref"
+  }
+
+let fnRefsCollectsPipedCalls =
+  test "fnRefs: a piped fn-call (EPipeFnCall) contributes its name" {
+    let pipe = PT.EPipeFnCall(0UL, PT.NameResolution.ok (bi "jsonSerialize"), [], [])
+    let e = PT.EPipe(0UL, PT.EVariable(0UL, "x"), [ pipe ])
+    Expect.equal (Analysis.fnRefs e) [ bi "jsonSerialize" ] "the piped fn name"
+  }
+
+let fnRefsLiteralsAreEmpty =
+  test "fnRefs: a literal references no fns (the pure leaf)" {
+    Expect.equal (Analysis.fnRefs (PT.EInt64(0UL, 5L))) [] "no fn refs in a literal"
+  }
+
+
+let tests =
+  testList
+    "capabilities"
+    [ noCapsDeniesEffectful
+      allCapsGrantsEverything
+      getOnlyCoversGetDeniesPost
+      hostScopedGrant
+      schemePortPathScoping
+      subdomainScoping
+      perHostCoupling
+      execCoupling
+      fileReadAnyWriteHere
+      hostMatching
+      pathMatching
+      scopeSubsumption
+      joinUnions
+      binaryRoundTrip
+      structuralGatePresence
+      scopedGrantsEnforced
+      fnRefsDirectName
+      fnRefsRecursesSubexprs
+      fnRefsSkipsUnresolved
+      fnRefsCollectsPipedCalls
+      fnRefsLiteralsAreEmpty ]

--- a/backend/tests/Tests/Interpreter.Tests.fs
+++ b/backend/tests/Tests/Interpreter.Tests.fs
@@ -3,8 +3,10 @@ module Tests.Interpreter
 open Expecto
 open Prelude
 open TestUtils.TestUtils
+open TestUtils.PTShortcuts
 
 module RT = LibExecution.RuntimeTypes
+module Cap = LibExecution.Capabilities
 module VT = LibExecution.ValueType
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module RTE = RT.RuntimeError
@@ -728,10 +730,61 @@ module Statement =
   let tests = testList "Statement" [ simple; nested; shouldError ]
 
 
+module CapsGate =
+  // the call-site gate ENFORCES — a builtin whose capability isn't granted raises at runtime.
+  // `timeNowMs` needs `clock`; under noCaps it's denied, under allCaps (the default) it runs. Proves
+  // "blockers work" end-to-end through the interpreter.
+  let clockCall () =
+    eApply (eBuiltinFn "timeNowMs" 0) [] [ eUnit () ]
+    |> PT2RT.Expr.toRT Map.empty 0 None
+
+  let denied =
+    testTask "an effectful builtin is DENIED when its capability isn't granted" {
+      let! exeState = executionStateFor TestValues.pm false Map.empty
+      let restricted : RT.ExecutionState = { exeState with grantedCaps = Cap.noCaps }
+      let! actual = LibExecution.Execution.executeExpr restricted (clockCall ())
+      match actual with
+      | Ok _ -> Expect.equal 1 2 "expected a capability-denied RTE, got success"
+      | Error(RTE.Error.UncaughtException(msg, _), _) ->
+        Expect.stringContains
+          msg
+          "capability denied"
+          "the gate denied the ungranted builtin"
+        Expect.stringContains msg "clock" "the error names the missing domain"
+      | Error(other, _) ->
+        Expect.equal
+          1
+          2
+          $"expected UncaughtException(capability denied), got {other}"
+    }
+
+  let allowed =
+    testTask
+      "the gate does NOT deny when the capability IS granted (allCaps default)" {
+      let! exeState = executionStateFor TestValues.pm false Map.empty // allCaps
+      let! actual = LibExecution.Execution.executeExpr exeState (clockCall ())
+      // We only assert the GATE was transparent — the builtin reaches `fn.fn`. (Its result may not
+      // typecheck headless without the OS package type; that's downstream of the gate, not a denial.)
+      match actual with
+      | Ok _ -> ()
+      | Error(RTE.Error.UncaughtException(msg, _), _) ->
+        Expect.isFalse
+          (msg.Contains "capability denied")
+          "under allCaps the gate must NOT deny — it got past the gate"
+      | Error _ -> () // any other RTE means it ran past the gate — fine
+    }
+
+  // NOTE: the path-scoped file/env/db enforcement (gate refines the need to the concrete target) is
+  // covered at the unit level by `scopedGrantsEnforcedByRefine` in Capabilities.Tests — the Cli file
+  // builtins aren't registered in this test execution state, so it can't be exercised end-to-end here.
+  let tests = testList "CapsGate" [ denied; allowed ]
+
+
 let tests =
   testList
     "Interpreter"
     [ Basic.tests
+      CapsGate.tests
       List.tests
       Let.tests
       String.tests

--- a/backend/tests/Tests/Tests.fs
+++ b/backend/tests/Tests/Tests.fs
@@ -59,7 +59,8 @@ let main (args : string array) : int =
         Tests.LibExecution.tests.Force()
 
         Tests.Blob.tests
-        Tests.Stream.tests ]
+        Tests.Stream.tests
+        Tests.Capabilities.tests ]
 
     let cancelationTokenSource = new System.Threading.CancellationTokenSource()
     let httpClientTestsTask = Tests.HttpClient.init cancelationTokenSource.Token

--- a/backend/tests/Tests/Tests.fsproj
+++ b/backend/tests/Tests/Tests.fsproj
@@ -53,6 +53,7 @@
 
     <Compile Include="Blob.Tests.fs" />
     <Compile Include="Stream.Tests.fs" />
+    <Compile Include="Capabilities.Tests.fs" />
 
     <Compile Include="Tests.fs" />
   </ItemGroup>

--- a/packages/darklang/cli/apps/caps/accessEditor.dark
+++ b/packages/darklang/cli/apps/caps/accessEditor.dark
@@ -1,0 +1,139 @@
+module Darklang.Cli.Apps.Caps.AccessEditor
+
+// A composable editor for ONE file/env/db access rule: an access mode (read / write / read+write)
+// coupled with a path/var/table scope. Emits a grant-spec like `file write ~/.darklang/`. The domain
+// (`file`/`env`/`db`) is fixed when the editor is opened. Empty scope ⇒ anywhere.
+
+type Field =
+  | AccessField
+  | ScopeField
+
+type State =
+  { domain: String
+    accessIdx: Int64
+    scope: Darklang.Cli.Apps.Caps.LineInput.State
+    field: Field }
+
+type EditResult =
+  | Editing of State
+  | Finished of String
+  | Cancelled
+
+let accesses : List<String> = [ "read"; "write"; "read+write" ]
+
+let forDomain (domain: String) : State =
+  State
+    { domain = domain
+      accessIdx = 0L
+      scope = Darklang.Cli.Apps.Caps.LineInput.empty
+      field = Field.AccessField }
+
+let indexOfAccess (a: String) : Int64 =
+  let indexed = Stdlib.List.indexedMap accesses (fun i x -> (i, x))
+  Stdlib.List.fold indexed 0L (fun acc pair ->
+    let (i, x) = pair
+    if x == a then i else acc)
+
+let fromSpec (spec: String) : State =
+  let parts =
+    (Stdlib.String.split spec " ") |> Stdlib.List.filter (fun s -> s != "")
+  match parts with
+  | domain :: access :: rest ->
+    // `rest` may contain spaces (e.g. a path with a space) — rejoin it as the scope
+    let scope = Stdlib.String.join rest " "
+    State
+      { domain = domain
+        accessIdx = indexOfAccess access
+        scope =
+          if scope == "" then Darklang.Cli.Apps.Caps.LineInput.empty
+          else Darklang.Cli.Apps.Caps.LineInput.make scope
+        field = Field.AccessField }
+  | _ -> forDomain "file"
+
+let currentAccess (state: State) : String =
+  accesses |> Stdlib.List.getAt state.accessIdx |> Stdlib.Option.withDefault "read"
+
+let toSpec (state: State) : String =
+  let access = currentAccess state
+  let scopeState = state.scope
+  let scope = Stdlib.String.trim scopeState.text
+  if scope == "" then $"{state.domain} {access}"
+  else $"{state.domain} {access} {scope}"
+
+let cycleAccess (state: State) (delta: Int64) : State =
+  let count = Stdlib.List.length accesses
+  let raw = state.accessIdx + delta
+  let next =
+    if raw < 0L then count - 1L
+    else if raw >= count then 0L
+    else raw
+  { state with accessIdx = next }
+
+let toggleField (state: State) : State =
+  let next =
+    match state.field with
+    | AccessField -> Field.ScopeField
+    | ScopeField -> Field.AccessField
+  { state with field = next }
+
+let applyScopeKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (keyChar: Stdlib.Option.Option<String>)
+  : State =
+  if state.field == Field.ScopeField then
+    match Darklang.Cli.Apps.Caps.LineInput.handleKey state.scope key keyChar with
+    | Some s -> { state with scope = s }
+    | None -> state
+  else
+    state
+
+let handleKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (_modifiers: Stdlib.Cli.Stdin.Modifiers.Modifiers)
+  (keyChar: Stdlib.Option.Option<String>)
+  : EditResult =
+  let onAccess = state.field == Field.AccessField
+  match key with
+  | Enter -> EditResult.Finished (toSpec state)
+  | Escape -> EditResult.Cancelled
+  | Tab -> EditResult.Editing (toggleField state)
+  | UpArrow -> EditResult.Editing ({ state with field = Field.AccessField })
+  | DownArrow -> EditResult.Editing ({ state with field = Field.ScopeField })
+  | LeftArrow ->
+    if onAccess then EditResult.Editing (cycleAccess state (0L - 1L))
+    else EditResult.Editing (applyScopeKey state key keyChar)
+  | RightArrow ->
+    if onAccess then EditResult.Editing (cycleAccess state 1L)
+    else EditResult.Editing (applyScopeKey state key keyChar)
+  | Spacebar ->
+    if onAccess then EditResult.Editing (cycleAccess state 1L)
+    else EditResult.Editing (applyScopeKey state key keyChar)
+  | _ -> EditResult.Editing (applyScopeKey state key keyChar)
+
+let render (state: State) : List<String> =
+  let accessFocused = state.field == Field.AccessField
+  let scopeFocused = state.field == Field.ScopeField
+  let access = currentAccess state
+  let accessVal =
+    if accessFocused then
+      Darklang.Cli.Colors.colorize Darklang.Cli.Colors.selection $" {access} "
+    else
+      $"[{access}]"
+  let scopePlaceholder =
+    if state.domain == "file" then "anywhere"
+    else if state.domain == "env" then "any var"
+    else "any table"
+  let scopeVal =
+    Darklang.Cli.Apps.Caps.LineInput.render state.scope scopeFocused scopePlaceholder
+  let hint =
+    Darklang.Cli.Colors.dimText
+      "  (left/right cycle access, Tab switch field, Enter save, Esc cancel)"
+  let specLabel = Darklang.Cli.Colors.dimText "spec:"
+  [ $"  Edit {state.domain} rule:"
+    $"    access:  {accessVal}"
+    $"    scope:   {scopeVal}"
+    hint
+    ""
+    $"    {specLabel} {toSpec state}" ]

--- a/packages/darklang/cli/apps/caps/app.dark
+++ b/packages/darklang/cli/apps/caps/app.dark
@@ -1,0 +1,47 @@
+module Darklang.Cli.Apps.Caps.App
+
+// The interactive capability editor, wrapped as a CLI SubApp. Composes the http/exec/access rule
+// editors + flag toggles + profile picker over a working copy of the grant, written via `pmCapsSet`.
+
+let makeSubApp (state: Main.State) : Darklang.Cli.SubApp =
+  Darklang.Cli.SubApp
+    { onKey =
+        fun key modifiers keyChar ->
+          match Main.handleKey state key modifiers keyChar with
+          | Continue s -> (Darklang.Cli.SubAppAction.Continue, makeSubApp s)
+          | Save s -> (Darklang.Cli.SubAppAction.Save, makeSubApp s)
+          | Exit s -> (Darklang.Cli.SubAppAction.Exit, makeSubApp s)
+      onDisplay = fun () -> Main.render state
+      onSave = fun () -> Main.save state }
+
+let execute (cliState: Darklang.Cli.AppState) (_args: List<String>) : Darklang.Cli.AppState =
+  Stdlib.print "\u001b[?1049h"
+  let state = Main.load ()
+  let app = makeSubApp state
+  { cliState with
+      currentPage = Darklang.Cli.Page.SubApp app
+      needsFullRedraw = true }
+
+let help (state: Darklang.Cli.AppState) : Darklang.Cli.AppState =
+  [ "Usage: caps-edit"
+    "Interactive editor for this instance's capability grant."
+    ""
+    "  Up/Down      Move between rows"
+    "  Space        Toggle a flag capability (random, clock, …)"
+    "  Enter        Edit the selected rule (or toggle a flag)"
+    "  a            Add a rule (http-client / file / env / db / exec)"
+    "  d            Delete the selected rule"
+    "  p            Apply a profile (replaces the grant)"
+    "  w            Write the grant to ~/.darklang/capabilities.bin"
+    "  Esc          Exit (discards unsaved edits)"
+    ""
+    "Inside a rule editor: Tab switches field, arrows cycle/move, Enter saves, Esc cancels." ]
+  |> Stdlib.printLines
+
+  state
+
+let complete
+  (_state: Darklang.Cli.AppState)
+  (_args: List<String>)
+  : List<Darklang.Cli.Completion.CompletionItem> =
+  []

--- a/packages/darklang/cli/apps/caps/execRuleEditor.dark
+++ b/packages/darklang/cli/apps/caps/execRuleEditor.dark
@@ -1,0 +1,98 @@
+module Darklang.Cli.Apps.Caps.ExecRuleEditor
+
+// A composable editor for ONE exec rule: a program coupled with an arg-allowlist. Emits a grant-spec
+// like `exec rm --dry-run`. Standalone or embedded. Empty program ⇒ `exec` (any program); empty args
+// ⇒ any args.
+
+type Field =
+  | ProgramField
+  | ArgsField
+
+type State =
+  { program: Darklang.Cli.Apps.Caps.LineInput.State
+    args: Darklang.Cli.Apps.Caps.LineInput.State
+    field: Field }
+
+type EditResult =
+  | Editing of State
+  | Finished of String
+  | Cancelled
+
+let empty : State =
+  State
+    { program = Darklang.Cli.Apps.Caps.LineInput.empty
+      args = Darklang.Cli.Apps.Caps.LineInput.empty
+      field = Field.ProgramField }
+
+let fromSpec (spec: String) : State =
+  let parts =
+    (Stdlib.String.split spec " ") |> Stdlib.List.filter (fun s -> s != "")
+  match parts with
+  | "exec" :: prog :: argv ->
+    State
+      { program = Darklang.Cli.Apps.Caps.LineInput.make prog
+        args = Darklang.Cli.Apps.Caps.LineInput.make (Stdlib.String.join argv " ")
+        field = Field.ProgramField }
+  | _ -> empty
+
+let toSpec (state: State) : String =
+  let progState = state.program
+  let argsState = state.args
+  let prog = Stdlib.String.trim progState.text
+  let args = Stdlib.String.trim argsState.text
+  if prog == "" then "exec"
+  else if args == "" then $"exec {prog}"
+  else $"exec {prog} {args}"
+
+let toggleField (state: State) : State =
+  let next =
+    match state.field with
+    | ProgramField -> Field.ArgsField
+    | ArgsField -> Field.ProgramField
+  { state with field = next }
+
+let applyKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (keyChar: Stdlib.Option.Option<String>)
+  : State =
+  match state.field with
+  | ProgramField ->
+    match Darklang.Cli.Apps.Caps.LineInput.handleKey state.program key keyChar with
+    | Some p -> { state with program = p }
+    | None -> state
+  | ArgsField ->
+    match Darklang.Cli.Apps.Caps.LineInput.handleKey state.args key keyChar with
+    | Some a -> { state with args = a }
+    | None -> state
+
+let handleKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (_modifiers: Stdlib.Cli.Stdin.Modifiers.Modifiers)
+  (keyChar: Stdlib.Option.Option<String>)
+  : EditResult =
+  match key with
+  | Enter -> EditResult.Finished (toSpec state)
+  | Escape -> EditResult.Cancelled
+  | Tab -> EditResult.Editing (toggleField state)
+  | UpArrow -> EditResult.Editing ({ state with field = Field.ProgramField })
+  | DownArrow -> EditResult.Editing ({ state with field = Field.ArgsField })
+  | _ -> EditResult.Editing (applyKey state key keyChar)
+
+let render (state: State) : List<String> =
+  let progFocused = state.field == Field.ProgramField
+  let argsFocused = state.field == Field.ArgsField
+  let progVal =
+    Darklang.Cli.Apps.Caps.LineInput.render state.program progFocused "any program"
+  let argsVal =
+    Darklang.Cli.Apps.Caps.LineInput.render state.args argsFocused "any args"
+  let hint =
+    Darklang.Cli.Colors.dimText "  (Tab switch field, Enter save, Esc cancel)"
+  let specLabel = Darklang.Cli.Colors.dimText "spec:"
+  [ "  Edit exec rule:"
+    $"    program:  {progVal}"
+    $"    args:     {argsVal}"
+    hint
+    ""
+    $"    {specLabel} {toSpec state}" ]

--- a/packages/darklang/cli/apps/caps/httpRuleEditor.dark
+++ b/packages/darklang/cli/apps/caps/httpRuleEditor.dark
@@ -1,0 +1,138 @@
+module Darklang.Cli.Apps.Caps.HttpRuleEditor
+
+// A composable editor for ONE http-client rule: a method (cycled) coupled with a URL pattern (typed).
+// Emits a grant-spec like `http-client GET https://*.github.com/api`. Standalone or embedded. An empty
+// URL means "anywhere"; the pattern is `[scheme://]host[:port][/path]` with `*` as the per-part wildcard.
+
+type Field =
+  | MethodField
+  | UrlField
+
+type State =
+  { methodIdx: Int64
+    url: Darklang.Cli.Apps.Caps.LineInput.State
+    field: Field }
+
+type EditResult =
+  | Editing of State
+  | Finished of String
+  | Cancelled
+
+let methods : List<String> =
+  [ "*"; "GET"; "POST"; "PUT"; "PATCH"; "DELETE"; "HEAD"; "OPTIONS" ]
+
+let empty : State =
+  State
+    { methodIdx = 1L
+      url = Darklang.Cli.Apps.Caps.LineInput.empty
+      field = Field.MethodField }
+
+// find a method's index (default 0 = `*`)
+let indexOfMethod (m: String) : Int64 =
+  let indexed = Stdlib.List.indexedMap methods (fun i x -> (i, x))
+  Stdlib.List.fold indexed 0L (fun acc pair ->
+    let (i, x) = pair
+    if x == m then i else acc)
+
+/// Pre-fill from an existing spec (`http-client [METHOD [URL]]`) so a row can be edited in place.
+let fromSpec (spec: String) : State =
+  let parts =
+    (Stdlib.String.split spec " ") |> Stdlib.List.filter (fun s -> s != "")
+  match parts with
+  | [ "http-client"; m; url ] ->
+    State
+      { methodIdx = indexOfMethod m
+        url = Darklang.Cli.Apps.Caps.LineInput.make url
+        field = Field.MethodField }
+  | [ "http-client"; m ] ->
+    State
+      { methodIdx = indexOfMethod m
+        url = Darklang.Cli.Apps.Caps.LineInput.empty
+        field = Field.MethodField }
+  | _ -> empty
+
+let currentMethod (state: State) : String =
+  methods |> Stdlib.List.getAt state.methodIdx |> Stdlib.Option.withDefault "*"
+
+let toSpec (state: State) : String =
+  let m = currentMethod state
+  let urlState = state.url
+  let u = Stdlib.String.trim urlState.text
+  if u == "" then $"http-client {m}" else $"http-client {m} {u}"
+
+let cycleMethod (state: State) (delta: Int64) : State =
+  let count = Stdlib.List.length methods
+  let raw = state.methodIdx + delta
+  let next =
+    if raw < 0L then count - 1L
+    else if raw >= count then 0L
+    else raw
+  { state with methodIdx = next }
+
+let toggleField (state: State) : State =
+  let next =
+    match state.field with
+    | MethodField -> Field.UrlField
+    | UrlField -> Field.MethodField
+  { state with field = next }
+
+// apply a key to the URL text field (only when it's focused)
+let applyUrlKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (keyChar: Stdlib.Option.Option<String>)
+  : State =
+  if state.field == Field.UrlField then
+    match Darklang.Cli.Apps.Caps.LineInput.handleKey state.url key keyChar with
+    | Some u -> { state with url = u }
+    | None -> state
+  else
+    state
+
+let handleKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (_modifiers: Stdlib.Cli.Stdin.Modifiers.Modifiers)
+  (keyChar: Stdlib.Option.Option<String>)
+  : EditResult =
+  let onMethod = state.field == Field.MethodField
+  match key with
+  | Enter -> EditResult.Finished (toSpec state)
+  | Escape -> EditResult.Cancelled
+  | Tab -> EditResult.Editing (toggleField state)
+  | UpArrow -> EditResult.Editing ({ state with field = Field.MethodField })
+  | DownArrow -> EditResult.Editing ({ state with field = Field.UrlField })
+  | LeftArrow ->
+    if onMethod then EditResult.Editing (cycleMethod state (0L - 1L))
+    else EditResult.Editing (applyUrlKey state key keyChar)
+  | RightArrow ->
+    if onMethod then EditResult.Editing (cycleMethod state 1L)
+    else EditResult.Editing (applyUrlKey state key keyChar)
+  | Spacebar ->
+    if onMethod then EditResult.Editing (cycleMethod state 1L)
+    else EditResult.Editing (applyUrlKey state key keyChar)
+  | _ -> EditResult.Editing (applyUrlKey state key keyChar)
+
+/// Render the editor as lines (caller positions them).
+let render (state: State) : List<String> =
+  let methodFocused = state.field == Field.MethodField
+  let urlFocused = state.field == Field.UrlField
+  let m = currentMethod state
+  let mLabel = if m == "*" then "any method" else m
+  let methodVal =
+    if methodFocused then
+      Darklang.Cli.Colors.colorize Darklang.Cli.Colors.selection $" {mLabel} "
+    else
+      $"[{mLabel}]"
+  let urlVal =
+    Darklang.Cli.Apps.Caps.LineInput.render state.url urlFocused "anywhere (e.g. https://*.github.com/api)"
+  let hint =
+    Darklang.Cli.Colors.dimText
+      "  (left/right cycle method, Tab switch field, Enter save, Esc cancel)"
+  let specLabel = Darklang.Cli.Colors.dimText "spec:"
+  [ "  Edit http-client rule:"
+    $"    method:  {methodVal}"
+    $"    url:     {urlVal}"
+    hint
+    ""
+    $"    {specLabel} {toSpec state}" ]

--- a/packages/darklang/cli/apps/caps/lineInput.dark
+++ b/packages/darklang/cli/apps/caps/lineInput.dark
@@ -1,0 +1,70 @@
+module Darklang.Cli.Apps.Caps.LineInput
+
+// A tiny composable single-line text field. Standalone (no app state) so any caps editor — or any other
+// app — can embed it: hold a `State`, feed it keys via `handleKey`, and `render` it focused or not.
+
+type State = { text: String; cursor: Int64 }
+
+let make (text: String) : State =
+  State { text = text; cursor = Stdlib.String.length text }
+
+let empty : State = State { text = ""; cursor = 0L }
+
+let insert (state: State) (ch: String) : State =
+  let before = Stdlib.String.slice state.text 0L state.cursor
+  let after = Stdlib.String.dropFirst state.text state.cursor
+  State { text = before ++ ch ++ after; cursor = state.cursor + Stdlib.String.length ch }
+
+let backspace (state: State) : State =
+  if state.cursor == 0L then
+    state
+  else
+    let before = Stdlib.String.slice state.text 0L (state.cursor - 1L)
+    let after = Stdlib.String.dropFirst state.text state.cursor
+    State { text = before ++ after; cursor = state.cursor - 1L }
+
+let left (state: State) : State =
+  if state.cursor > 0L then { state with cursor = state.cursor - 1L } else state
+
+let right (state: State) : State =
+  if state.cursor < Stdlib.String.length state.text then
+    { state with cursor = state.cursor + 1L }
+  else
+    state
+
+/// Feed a key to a focused field. Returns Some newState if the key was a text edit, None if it's not
+/// ours (so the embedding editor can handle Tab/Enter/Esc/etc.).
+let handleKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (keyChar: Stdlib.Option.Option<String>)
+  : Stdlib.Option.Option<State> =
+  match key with
+  | Backspace -> Stdlib.Option.Option.Some(backspace state)
+  | LeftArrow -> Stdlib.Option.Option.Some(left state)
+  | RightArrow -> Stdlib.Option.Option.Some(right state)
+  | _ ->
+    match keyChar with
+    | Some ch -> Stdlib.Option.Option.Some(insert state ch)
+    | None -> Stdlib.Option.Option.None
+
+/// Render the field. When focused, shows a reverse-video cursor; unfocused + empty shows `placeholder`.
+let render (state: State) (focused: Bool) (placeholder: String) : String =
+  if focused then
+    let before = Stdlib.String.slice state.text 0L state.cursor
+    let cursorChar =
+      if state.cursor < Stdlib.String.length state.text then
+        Stdlib.String.slice state.text state.cursor (state.cursor + 1L)
+      else
+        " "
+    let cursorDisplay = Darklang.Cli.Colors.colorize Darklang.Cli.Colors.reverse cursorChar
+    let after =
+      if state.cursor < Stdlib.String.length state.text then
+        Stdlib.String.dropFirst state.text (state.cursor + 1L)
+      else
+        ""
+    before ++ cursorDisplay ++ after
+  else if state.text == "" then
+    Darklang.Cli.Colors.dimText placeholder
+  else
+    state.text

--- a/packages/darklang/cli/apps/caps/main.dark
+++ b/packages/darklang/cli/apps/caps/main.dark
@@ -15,6 +15,9 @@ let ruleDomains : List<String> =
 type Row =
   | FlagRow of String * Bool
   | RuleRow of String
+  // a selectable "+ Add rule…" affordance at the end of the scoped-rules section — `enter` on it opens
+  // the same domain picker as the `a` shortcut, so the add flow is discoverable without knowing the key.
+  | AddRuleRow
 
 // each Edit* carries the ORIGINAL spec being edited ("" when adding a new rule), so saving the edit
 // removes the original before adding the new one (otherwise editing a rule would duplicate it).
@@ -61,7 +64,7 @@ let rows (state: State) : List<Row> =
       let d = Darklang.PrettyPrinter.Capabilities.domainOf s
       Stdlib.Bool.not (isFlag d))
     |> Stdlib.List.map (fun s -> Row.RuleRow s)
-  Stdlib.List.append flagRows ruleRows
+  Stdlib.List.append flagRows (Stdlib.List.append ruleRows [ Row.AddRuleRow ])
 
 let rowCount (state: State) : Int64 = Stdlib.List.length (rows state)
 
@@ -148,6 +151,8 @@ let handleBrowsing
     match Stdlib.List.getAt (rows state) state.cursor with
     | Some(FlagRow(d, _)) -> KeyResult.Continue (toggleFlag state d)
     | Some(RuleRow spec) -> KeyResult.Continue (editSpec state spec)
+    | Some AddRuleRow ->
+      KeyResult.Continue ({ state with screen = Screen.AddPickDomain 0L })
     | None -> KeyResult.Continue state
   | _ ->
     match keyChar with
@@ -238,18 +243,31 @@ let private rowText (row: Row) : String =
     let box = if granted then "[x]" else "[ ]"
     $"{box} {d}"
   | RuleRow spec -> Darklang.PrettyPrinter.Capabilities.line spec
+  | AddRuleRow -> "+ Add rule…"
 
+let private printOneRow (state: State) (pair: (Int64 * Row)) : Unit =
+  let (i, r) = pair
+  let selected = i == state.cursor
+  let prefix = if selected then "›" else " "
+  let line = $"  {prefix} {rowText r}"
+  let styled =
+    if selected then Darklang.Cli.Colors.colorize Darklang.Cli.Colors.selection line
+    else line
+  Stdlib.printLine styled
+
+// flag checklist on top, then a labelled "Scoped rules" section (existing rules + the "+ Add rule…"
+// affordance). The cursor index maps into `rows`; the section label is printed between, not selectable.
 let private printRows (state: State) : Unit =
+  let flagCount = Stdlib.List.length flagDomains
   let indexed = Stdlib.List.indexedMap (rows state) (fun i r -> (i, r))
-  Stdlib.List.iter indexed (fun pair ->
-    let (i, r) = pair
-    let selected = i == state.cursor
-    let prefix = if selected then "›" else " "
-    let line = $"  {prefix} {rowText r}"
-    let styled =
-      if selected then Darklang.Cli.Colors.colorize Darklang.Cli.Colors.selection line
-      else line
-    Stdlib.printLine styled)
+  indexed
+  |> Stdlib.List.filter (fun pair -> Stdlib.Tuple2.first pair < flagCount)
+  |> Stdlib.List.iter (fun pair -> printOneRow state pair)
+  Stdlib.printLine ""
+  Stdlib.printLine (Darklang.Cli.Colors.dimText "  Scoped rules")
+  indexed
+  |> Stdlib.List.filter (fun pair -> Stdlib.Tuple2.first pair >= flagCount)
+  |> Stdlib.List.iter (fun pair -> printOneRow state pair)
 
 let private printMenu (title: String) (items: List<String>) (cursor: Int64) : Unit =
   Stdlib.printLine title
@@ -282,7 +300,7 @@ let render (state: State) : Unit =
     Stdlib.printLine ""
     Stdlib.printLine
       (Darklang.Cli.Colors.dimText
-        "  ↑↓ move · space toggle · enter edit · a add · d delete · p profile · w write · esc exit")
+        "  ↑↓ move · space toggle · enter edit/add · a add rule · d delete · p profile · w write · esc exit")
   | AddPickDomain cursor ->
     printMenu "  Add a rule for which domain?" ruleDomains cursor
     Stdlib.printLine ""

--- a/packages/darklang/cli/apps/caps/main.dark
+++ b/packages/darklang/cli/apps/caps/main.dark
@@ -1,0 +1,306 @@
+module Darklang.Cli.Apps.Caps.Main
+
+// The interactive caps editor. A working copy of the grant (spec strings) that you navigate and mutate;
+// `w` writes it through `pmCapsSet`. Flag domains (random/clock/…) toggle in place; scoped/coupled
+// rules (http-client/file/env/db/exec) open the matching composable editor. Profiles replace the set.
+
+// the toggle-only domains (no scope/coupling) — shown as a checklist at the top
+let flagDomains : List<String> =
+  [ "random"; "clock"; "stdout"; "stdin"; "llm"; "http-server" ]
+
+// the domains that need a rule editor (and which one)
+let ruleDomains : List<String> =
+  [ "http-client"; "file"; "env"; "db"; "exec" ]
+
+type Row =
+  | FlagRow of String * Bool
+  | RuleRow of String
+
+// each Edit* carries the ORIGINAL spec being edited ("" when adding a new rule), so saving the edit
+// removes the original before adding the new one (otherwise editing a rule would duplicate it).
+type Screen =
+  | Browsing
+  | AddPickDomain of Int64
+  | EditHttp of String * Darklang.Cli.Apps.Caps.HttpRuleEditor.State
+  | EditExec of String * Darklang.Cli.Apps.Caps.ExecRuleEditor.State
+  | EditAccess of String * Darklang.Cli.Apps.Caps.AccessEditor.State
+  | PickProfile of Int64
+
+type State =
+  { specs: List<String>
+    saved: List<String>
+    cursor: Int64
+    dirty: Bool
+    screen: Screen }
+
+type KeyResult =
+  | Continue of State
+  | Save of State
+  | Exit of State
+
+let load () : State =
+  let specs = Commands.Caps.currentSpecs ()
+  State
+    { specs = specs
+      saved = specs
+      cursor = 0L
+      dirty = false
+      screen = Screen.Browsing }
+
+let isFlag (domain: String) : Bool = Stdlib.List.member_v0 flagDomains domain
+
+// the visible rows: the flag checklist, then one row per scoped/coupled rule spec
+let rows (state: State) : List<Row> =
+  let flagRows =
+    Stdlib.List.map flagDomains (fun d ->
+      let granted = Stdlib.List.member_v0 state.specs d
+      Row.FlagRow(d, granted))
+  let ruleRows =
+    state.specs
+    |> Stdlib.List.filter (fun s ->
+      let d = Darklang.PrettyPrinter.Capabilities.domainOf s
+      Stdlib.Bool.not (isFlag d))
+    |> Stdlib.List.map (fun s -> Row.RuleRow s)
+  Stdlib.List.append flagRows ruleRows
+
+let rowCount (state: State) : Int64 = Stdlib.List.length (rows state)
+
+let toggleFlag (state: State) (domain: String) : State =
+  if Stdlib.List.member_v0 state.specs domain then
+    let next = Stdlib.List.filter state.specs (fun s -> s != domain)
+    { state with specs = next; dirty = true }
+  else
+    { state with specs = Stdlib.List.append state.specs [ domain ]; dirty = true }
+
+let removeSpec (state: State) (spec: String) : State =
+  { state with
+      specs = Stdlib.List.filter state.specs (fun s -> s != spec)
+      dirty = true }
+
+// add a spec produced by an editor (replace any identical, then append) and return to Browsing
+let addSpec (state: State) (spec: String) : State =
+  let without = Stdlib.List.filter state.specs (fun s -> s != spec)
+  { state with
+      specs = Stdlib.List.append without [ spec ]
+      dirty = true
+      screen = Screen.Browsing }
+
+// replace the original spec (if any) with a freshly-edited one, then return to Browsing
+let replaceSpec (state: State) (orig: String) (newSpec: String) : State =
+  let cleared =
+    if orig == "" then state else removeSpec state orig
+  addSpec cleared newSpec
+
+// open the right editor for an existing rule spec (carrying the original so the edit replaces it)
+let editSpec (state: State) (spec: String) : State =
+  let domain = Darklang.PrettyPrinter.Capabilities.domainOf spec
+  if domain == "http-client" then
+    { state with screen = Screen.EditHttp(spec, Darklang.Cli.Apps.Caps.HttpRuleEditor.fromSpec spec) }
+  else if domain == "exec" then
+    { state with screen = Screen.EditExec(spec, Darklang.Cli.Apps.Caps.ExecRuleEditor.fromSpec spec) }
+  else
+    { state with screen = Screen.EditAccess(spec, Darklang.Cli.Apps.Caps.AccessEditor.fromSpec spec) }
+
+// open a fresh editor for a chosen domain (no original spec to replace)
+let editNew (state: State) (domain: String) : State =
+  if domain == "http-client" then
+    { state with screen = Screen.EditHttp("", Darklang.Cli.Apps.Caps.HttpRuleEditor.empty) }
+  else if domain == "exec" then
+    { state with screen = Screen.EditExec("", Darklang.Cli.Apps.Caps.ExecRuleEditor.empty) }
+  else
+    { state with screen = Screen.EditAccess("", Darklang.Cli.Apps.Caps.AccessEditor.forDomain domain) }
+
+
+// ─────────────────────────────────────────────────────────────────────
+// key handling
+// ─────────────────────────────────────────────────────────────────────
+
+let private clampCursor (state: State) : State =
+  let count = rowCount state
+  let c =
+    if count == 0L then 0L
+    else if state.cursor >= count then count - 1L
+    else if state.cursor < 0L then 0L
+    else state.cursor
+  { state with cursor = c }
+
+let handleBrowsing
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (keyChar: Stdlib.Option.Option<String>)
+  : KeyResult =
+  match key with
+  | Escape ->
+    // discard unsaved edits: restore the last-saved set so onSave writes it unchanged
+    KeyResult.Exit ({ state with specs = state.saved })
+  | UpArrow ->
+    let c = if state.cursor > 0L then state.cursor - 1L else 0L
+    KeyResult.Continue ({ state with cursor = c })
+  | DownArrow ->
+    let maxIdx = rowCount state - 1L
+    let c = if state.cursor < maxIdx then state.cursor + 1L else maxIdx
+    KeyResult.Continue ({ state with cursor = c })
+  | Spacebar ->
+    match Stdlib.List.getAt (rows state) state.cursor with
+    | Some(FlagRow(d, _)) -> KeyResult.Continue (toggleFlag state d)
+    | _ -> KeyResult.Continue state
+  | Enter ->
+    match Stdlib.List.getAt (rows state) state.cursor with
+    | Some(FlagRow(d, _)) -> KeyResult.Continue (toggleFlag state d)
+    | Some(RuleRow spec) -> KeyResult.Continue (editSpec state spec)
+    | None -> KeyResult.Continue state
+  | _ ->
+    match keyChar with
+    | Some "a" -> KeyResult.Continue ({ state with screen = Screen.AddPickDomain 0L })
+    | Some "p" -> KeyResult.Continue ({ state with screen = Screen.PickProfile 0L })
+    | Some "d" ->
+      match Stdlib.List.getAt (rows state) state.cursor with
+      | Some(RuleRow spec) -> KeyResult.Continue (clampCursor (removeSpec state spec))
+      | _ -> KeyResult.Continue state
+    | Some "w" ->
+      KeyResult.Save ({ state with saved = state.specs; dirty = false })
+    | Some "q" -> KeyResult.Exit ({ state with specs = state.saved })
+    | _ -> KeyResult.Continue state
+
+let handleMenu
+  (cursor: Int64)
+  (count: Int64)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  : Stdlib.Option.Option<Int64> =
+  // returns Some newCursor while browsing; None signals Enter/Escape handled by caller via key match
+  match key with
+  | UpArrow ->
+    let c = if cursor > 0L then cursor - 1L else 0L
+    Stdlib.Option.Option.Some c
+  | DownArrow ->
+    let c = if cursor < count - 1L then cursor + 1L else count - 1L
+    Stdlib.Option.Option.Some c
+  | _ -> Stdlib.Option.Option.None
+
+let handleKey
+  (state: State)
+  (key: Stdlib.Cli.Stdin.Key.Key)
+  (modifiers: Stdlib.Cli.Stdin.Modifiers.Modifiers)
+  (keyChar: Stdlib.Option.Option<String>)
+  : KeyResult =
+  match state.screen with
+  | Browsing -> handleBrowsing state key keyChar
+  | AddPickDomain cursor ->
+    match key with
+    | Escape -> KeyResult.Continue ({ state with screen = Screen.Browsing })
+    | Enter ->
+      match Stdlib.List.getAt ruleDomains cursor with
+      | Some d -> KeyResult.Continue (editNew state d)
+      | None -> KeyResult.Continue ({ state with screen = Screen.Browsing })
+    | _ ->
+      match handleMenu cursor (Stdlib.List.length ruleDomains) key with
+      | Some c -> KeyResult.Continue ({ state with screen = Screen.AddPickDomain c })
+      | None -> KeyResult.Continue state
+  | PickProfile cursor ->
+    match key with
+    | Escape -> KeyResult.Continue ({ state with screen = Screen.Browsing })
+    | Enter ->
+      match Stdlib.List.getAt Commands.Caps.profiles cursor with
+      | Some((_, specs)) ->
+        // a profile can have fewer rows than the current grant — clamp the cursor back in range
+        KeyResult.Continue
+          (clampCursor
+            ({ state with specs = specs; dirty = true; screen = Screen.Browsing }))
+      | None -> KeyResult.Continue ({ state with screen = Screen.Browsing })
+    | _ ->
+      match handleMenu cursor (Stdlib.List.length Commands.Caps.profiles) key with
+      | Some c -> KeyResult.Continue ({ state with screen = Screen.PickProfile c })
+      | None -> KeyResult.Continue state
+  | EditHttp(orig, editor) ->
+    match Darklang.Cli.Apps.Caps.HttpRuleEditor.handleKey editor key modifiers keyChar with
+    | Editing e -> KeyResult.Continue ({ state with screen = Screen.EditHttp(orig, e) })
+    | Finished spec -> KeyResult.Continue (clampCursor (replaceSpec state orig spec))
+    | Cancelled -> KeyResult.Continue ({ state with screen = Screen.Browsing })
+  | EditExec(orig, editor) ->
+    match Darklang.Cli.Apps.Caps.ExecRuleEditor.handleKey editor key modifiers keyChar with
+    | Editing e -> KeyResult.Continue ({ state with screen = Screen.EditExec(orig, e) })
+    | Finished spec -> KeyResult.Continue (clampCursor (replaceSpec state orig spec))
+    | Cancelled -> KeyResult.Continue ({ state with screen = Screen.Browsing })
+  | EditAccess(orig, editor) ->
+    match Darklang.Cli.Apps.Caps.AccessEditor.handleKey editor key modifiers keyChar with
+    | Editing e -> KeyResult.Continue ({ state with screen = Screen.EditAccess(orig, e) })
+    | Finished spec -> KeyResult.Continue (clampCursor (replaceSpec state orig spec))
+    | Cancelled -> KeyResult.Continue ({ state with screen = Screen.Browsing })
+
+
+// ─────────────────────────────────────────────────────────────────────
+// rendering
+// ─────────────────────────────────────────────────────────────────────
+
+let private rowText (row: Row) : String =
+  match row with
+  | FlagRow(d, granted) ->
+    let box = if granted then "[x]" else "[ ]"
+    $"{box} {d}"
+  | RuleRow spec -> Darklang.PrettyPrinter.Capabilities.line spec
+
+let private printRows (state: State) : Unit =
+  let indexed = Stdlib.List.indexedMap (rows state) (fun i r -> (i, r))
+  Stdlib.List.iter indexed (fun pair ->
+    let (i, r) = pair
+    let selected = i == state.cursor
+    let prefix = if selected then "›" else " "
+    let line = $"  {prefix} {rowText r}"
+    let styled =
+      if selected then Darklang.Cli.Colors.colorize Darklang.Cli.Colors.selection line
+      else line
+    Stdlib.printLine styled)
+
+let private printMenu (title: String) (items: List<String>) (cursor: Int64) : Unit =
+  Stdlib.printLine title
+  Stdlib.printLine ""
+  let indexed = Stdlib.List.indexedMap items (fun i x -> (i, x))
+  Stdlib.List.iter indexed (fun pair ->
+    let (i, x) = pair
+    let selected = i == cursor
+    let prefix = if selected then "›" else " "
+    let line = $"  {prefix} {x}"
+    let styled =
+      if selected then Darklang.Cli.Colors.colorize Darklang.Cli.Colors.selection line
+      else line
+    Stdlib.printLine styled)
+
+let render (state: State) : Unit =
+  Stdlib.print "\u001b[?25l\u001b[2J\u001b[H"
+  let dirtyTag =
+    if state.dirty then Darklang.Cli.Colors.colorize Darklang.Cli.Colors.yellow "  ● unsaved"
+    else ""
+  let title =
+    Darklang.Cli.Colors.colorize
+      (Darklang.Cli.Colors.purpleBg ++ Darklang.Cli.Colors.white ++ Darklang.Cli.Colors.bold)
+      " capabilities "
+  Stdlib.printLine $"{title}{dirtyTag}"
+  Stdlib.printLine ""
+  match state.screen with
+  | Browsing ->
+    printRows state
+    Stdlib.printLine ""
+    Stdlib.printLine
+      (Darklang.Cli.Colors.dimText
+        "  ↑↓ move · space toggle · enter edit · a add · d delete · p profile · w write · esc exit")
+  | AddPickDomain cursor ->
+    printMenu "  Add a rule for which domain?" ruleDomains cursor
+    Stdlib.printLine ""
+    Stdlib.printLine
+      (Darklang.Cli.Colors.dimText "  ↑↓ move · enter choose · esc cancel")
+  | PickProfile cursor ->
+    let names = Stdlib.List.map Commands.Caps.profiles (fun pair -> Stdlib.Tuple2.first pair)
+    printMenu "  Apply a profile (REPLACES the grant):" names cursor
+    Stdlib.printLine ""
+    Stdlib.printLine
+      (Darklang.Cli.Colors.dimText "  ↑↓ move · enter apply · esc cancel")
+  | EditHttp(_, editor) ->
+    Stdlib.printLines (Darklang.Cli.Apps.Caps.HttpRuleEditor.render editor)
+  | EditExec(_, editor) ->
+    Stdlib.printLines (Darklang.Cli.Apps.Caps.ExecRuleEditor.render editor)
+  | EditAccess(_, editor) ->
+    Stdlib.printLines (Darklang.Cli.Apps.Caps.AccessEditor.render editor)
+
+let save (state: State) : Unit =
+  let _ = Commands.Caps.writeSpecs state.specs
+  ()

--- a/packages/darklang/cli/commands/caps.dark
+++ b/packages/darklang/cli/commands/caps.dark
@@ -6,10 +6,11 @@ module Darklang.Cli.Commands.Caps
 // in `~/.darklang/capabilities.bin`, default NONE — effectful code is blocked until granted. The
 // runtime gate ENFORCES it (a builtin call whose need isn't covered is denied).
 //
-// Only TWO builtins back this: `pmCapsGet` (the grant, as spec strings) and `pmCapsSet` (replace from
-// spec strings). Every adjustment below — grant one, revoke a domain, clear, apply a profile — is a
-// get-modify-set composed here in `.dark`. Rendering is shared via `Darklang.PrettyPrinter.Capabilities`
-// so `caps list`, `caps needed-for <fn>`, the app, and any other command render identically.
+// The builtins (`pmCapsGet` / `pmCapsSet`) exchange the STRUCTURED `Capabilities` value; the grant-spec
+// LANGUAGE (parse/render) lives in `.dark` (`LanguageTools.Capabilities`) and is applied at the boundary
+// wrappers below, so the rest of this command works on spec strings. Every adjustment — grant one,
+// revoke a domain, clear, grant-all, apply a profile — is a get-modify-set composed here. Rendering is
+// shared via `Darklang.PrettyPrinter.Capabilities` so every caps surface renders identically.
 
 // Named PRESET grants — common bundles you apply in one go (`caps profile local-dev`). The http-client
 // grant is a LIST of (method × URL) rules that couple per-rule, so a preset CAN say "any method to
@@ -48,10 +49,13 @@ let profiles : List<(String * List<String>)> =
 let currentSpecs () : List<String> =
   (Builtin.pmCapsGet ()) |> LanguageTools.Capabilities.render
 
+// the single `pmCapsSet` call site (keeps the builtin to one wrapper); takes the already-structured grant.
+let writeCaps (caps: LanguageTools.Capabilities.Capabilities) : Unit = Builtin.pmCapsSet caps
+
 let writeSpecs (specs: List<String>) : Stdlib.Option.Option<String> =
   match LanguageTools.Capabilities.parse specs with
   | Ok caps ->
-    let _ = Builtin.pmCapsSet caps
+    Commands.Caps.writeCaps caps
     Stdlib.Option.Option.None
   | Error bad -> Stdlib.Option.Option.Some bad
 
@@ -195,6 +199,15 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     Stdlib.printLine (Colors.success "✓ cleared — all capabilities revoked (NONE)")
     state
 
+  // `caps grant-all` — REPLACE the grant with everything (unrestricted). The one-command "let it all
+  // through" for when capability prompts are getting in the way (common for agents / trusted local work).
+  // TODO this hands back the full unrestricted grant — see the trust-boundary TODO in
+  // `LanguageTools.Capabilities.all`. It's a convenience, not a security control.
+  | [ "grant-all" ] | [ "allow-all" ] ->
+    Commands.Caps.writeCaps (LanguageTools.Capabilities.all ())
+    Stdlib.printLine (Colors.success "✓ granted ALL capabilities — this instance is now unrestricted")
+    Commands.Caps.show state
+
   | [ "revoke"; domain ] ->
     if Commands.Caps.revokeDomain domain then
       Stdlib.printLine (Colors.success $"✓ revoked  {domain}")
@@ -240,7 +253,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
 
   | _ ->
     Stdlib.printLine
-      (Colors.error "Usage: caps [list] | grant <spec> | set <spec>… | clear | revoke <domain> | grant-for-fn <fn> | needed-for <fn>")
+      (Colors.error "Usage: caps [list] | grant <spec> | set <spec>… | clear | grant-all | revoke <domain> | grant-for-fn <fn> | needed-for <fn>")
     state
 
 
@@ -252,6 +265,7 @@ let complete
     Cli.Completion.simple "grant"
     Cli.Completion.simple "set"
     Cli.Completion.simple "clear"
+    Cli.Completion.simple "grant-all"
     Cli.Completion.simple "revoke"
     Cli.Completion.simple "grant-for-fn"
     Cli.Completion.simple "needed-for"
@@ -259,7 +273,7 @@ let complete
 
 
 let help (state: Cli.AppState) : Cli.AppState =
-  [ "Usage: caps [list] | grant <spec> | set <spec>… | clear | revoke <domain> | grant-for-fn <fn> | needed-for <fn>"
+  [ "Usage: caps [list] | grant <spec> | set <spec>… | clear | grant-all | revoke <domain> | grant-for-fn <fn> | needed-for <fn>"
     ""
     "View + control the capabilities this instance grants to the code it runs. LOCAL (never synced),"
     "stored in ~/.darklang/capabilities.bin, default NONE. The runtime gate enforces it."
@@ -276,6 +290,7 @@ let help (state: Cli.AppState) : Cli.AppState =
     "  Replace the whole grant (direct control):"
     "    set <spec>; <spec>; …    Set caps to EXACTLY these specs (semicolon-separated)"
     "    clear                    Set NONE — revoke everything"
+    "    grant-all                Set ALL — unrestricted (convenience; not a security boundary)"
     "    profile [name]           List, or apply, a preset posture — applying REPLACES the grant"
     "                               (read-only · local-dev · trusted; layer extras with `grant` after)"
     "    (`caps edit` opens an interactive editor; the file itself is a binary blob)"

--- a/packages/darklang/cli/commands/caps.dark
+++ b/packages/darklang/cli/commands/caps.dark
@@ -1,0 +1,298 @@
+module Darklang.Cli.Commands.Caps
+
+// `dark caps` — view + control the CAPABILITIES this instance grants to the code it runs. A grant is
+// nuanced: a domain (http-client, file, exec, …) with an access/scope (e.g. `http-client GET` = GET
+// to any host; `file write ~/.darklang/` = write only inside that dir). LOCAL (never synced), stored
+// in `~/.darklang/capabilities.bin`, default NONE — effectful code is blocked until granted. The
+// runtime gate ENFORCES it (a builtin call whose need isn't covered is denied).
+//
+// Only TWO builtins back this: `pmCapsGet` (the grant, as spec strings) and `pmCapsSet` (replace from
+// spec strings). Every adjustment below — grant one, revoke a domain, clear, apply a profile — is a
+// get-modify-set composed here in `.dark`. Rendering is shared via `Darklang.PrettyPrinter.Capabilities`
+// so `caps list`, `caps needed-for <fn>`, the app, and any other command render identically.
+
+// Named PRESET grants — common bundles you apply in one go (`caps profile local-dev`). The http-client
+// grant is a LIST of (method × URL) rules that couple per-rule, so a preset CAN say "any method to
+// localhost, but GET-only externally": `http-client * *://localhost:*` + `http-client GET`.
+let profiles : List<(String * List<String>)> =
+  [ ("read-only",
+     [ "http-client GET"; "file read"; "db read"; "env read"; "clock"; "random"; "stdin"; "stdout" ])
+    ("local-dev",
+     [ "http-server"
+       "http-client * *://localhost:*" // any method/scheme/port to your own local services
+       "http-client GET" // but only GET (https) to the outside world
+       "file read"
+       "file write ~/.darklang/"
+       "stdout"
+       "stdin"
+       "clock"
+       "random" ])
+    ("trusted",
+     [ "http-client"
+       "http-server"
+       "file read+write"
+       "exec"
+       "env read+write"
+       "db read+write"
+       "stdout"
+       "stdin"
+       "clock"
+       "random"
+       "llm" ]) ]
+
+
+// The three caps builtins, each behind a single wrapper so callers (this command, the app) go through
+// one call site. The builtins exchange the STRUCTURED `Capabilities` value; the grant-spec LANGUAGE
+// (parse/render) is applied HERE at the boundary, so the rest of this command + the pretty-printer keep
+// working on spec strings.
+let currentSpecs () : List<String> =
+  (Builtin.pmCapsGet ()) |> LanguageTools.Capabilities.render
+
+let writeSpecs (specs: List<String>) : Stdlib.Option.Option<String> =
+  match LanguageTools.Capabilities.parse specs with
+  | Ok caps ->
+    let _ = Builtin.pmCapsSet caps
+    Stdlib.Option.Option.None
+  | Error bad -> Stdlib.Option.Option.Some bad
+
+let effectiveCapsForHash (hash: String) : List<String> =
+  (Builtin.pmFnEffectiveCaps hash) |> LanguageTools.Capabilities.render
+
+
+// Rendering of caps lives in the shared pretty-printer (`Darklang.PrettyPrinter.Capabilities`), so
+// `caps list`, `caps needed-for <fn>`, the caps app, and any other command render identically.
+
+// The compact caps badge for a package fn (by hash): "pure" or e.g. "http-client, file". Other
+// commands/apps that list fns can call this to show what each fn would be allowed to do.
+let badgeForHash (hash: String) : String =
+  PrettyPrinter.Capabilities.badge (Commands.Caps.effectiveCapsForHash hash)
+
+
+// ───────────────────────────────────────────────────────────────────────────
+// Adjustments — get-modify-set over the two primitives (pmCapsGet / pmCapsSet)
+// ───────────────────────────────────────────────────────────────────────────
+
+// add one spec to the grant. Ok () on success; Error badSpec if it didn't parse (grant unchanged).
+let grantSpec (spec: String) : Stdlib.Result.Result<Unit, String> =
+  let next = Stdlib.List.append (currentSpecs ()) [ spec ]
+  match writeSpecs next with
+  | None -> Stdlib.Result.Result.Ok()
+  | Some bad -> Stdlib.Result.Result.Error bad
+
+// drop every spec belonging to a domain. Returns whether anything was removed.
+let revokeDomain (domain: String) : Bool =
+  let before = currentSpecs ()
+  let after =
+    before
+    |> Stdlib.List.filter (fun s -> PrettyPrinter.Capabilities.domainOf s != domain)
+  if Stdlib.List.length after == Stdlib.List.length before then
+    false
+  else
+    let _ = writeSpecs after
+    true
+
+
+// ───────────────────────────────────────────────────────────────────────────
+
+let show (state: Cli.AppState) : Cli.AppState =
+  let specs = currentSpecs ()
+  Stdlib.printLine "Capabilities (this instance grants):"
+  if Stdlib.List.isEmpty specs then
+    Stdlib.printLine (Colors.dimText "  (none — NONE is the default)")
+  else
+    Stdlib.printLines
+      ((PrettyPrinter.Capabilities.lines specs) |> Stdlib.List.map (fun l -> "  " ++ l))
+  Stdlib.printLine ""
+  Stdlib.printLine
+    (Colors.dimText "  adjust: `caps grant http-client GET` · `caps revoke <domain>` · `caps grant-for-fn <fn>`")
+  Stdlib.printLine
+    (Colors.dimText "  replace: `caps set <spec>; <spec>…` · `caps clear` · `caps edit` (TUI)")
+  state
+
+
+// Show what a fn (transitively) needs — the shared nice rendering (used by `caps needed-for <fn>`).
+let showFnNeeds (state: Cli.AppState) (fnName: String) : Unit =
+  match Cli.Packages.Location.parseRelativeTo state.packageData.currentLocation fnName with
+  | Error e -> Stdlib.printLine (Colors.error e)
+  | Ok location ->
+    match LanguageTools.PackageManager.findAny state.currentBranchId location with
+    | Some((hash, Fn)) ->
+      let specs =
+        effectiveCapsForHash (LanguageTools.ProgramTypes.hashToString hash)
+      if Stdlib.List.isEmpty specs then
+        Stdlib.printLine (Colors.success $"{fnName}  ✓ pure — needs no capabilities")
+      else
+        Stdlib.printLine $"{fnName} needs:"
+        Stdlib.printLines
+          ((PrettyPrinter.Capabilities.lines specs) |> Stdlib.List.map (fun l -> "  " ++ l))
+        Stdlib.printLine
+          (Colors.dimText $"  grant them all with `caps grant-for-fn {fnName}`")
+    | Some((_, _)) -> Stdlib.printLine (Colors.error "caps analysis is for functions")
+    | None -> Stdlib.printLine (Colors.error $"'{fnName}' not found at this location")
+
+
+// `caps grant-for-fn <fn>` — grant exactly the capabilities a fn (transitively) needs.
+let grantForFn (state: Cli.AppState) (fnName: String) : Cli.AppState =
+  match Cli.Packages.Location.parseRelativeTo state.packageData.currentLocation fnName with
+  | Error e -> Stdlib.printLine (Colors.error e)
+  | Ok location ->
+    match LanguageTools.PackageManager.findAny state.currentBranchId location with
+    | Some((hash, Fn)) ->
+      let specs = effectiveCapsForHash (LanguageTools.ProgramTypes.hashToString hash)
+      if Stdlib.List.isEmpty specs then
+        Stdlib.printLine (Colors.dimText $"{fnName} needs no capabilities (pure) — nothing to grant")
+      else
+        Stdlib.List.iter specs (fun spec ->
+          match Commands.Caps.grantSpec spec with
+          | Ok() -> Stdlib.printLine (Colors.success $"✓ granted  {spec}")
+          | Error bad -> Stdlib.printLine (Colors.error $"couldn't grant '{bad}'"))
+    | Some((_, _)) -> Stdlib.printLine (Colors.error "caps analysis is for functions")
+    | None -> Stdlib.printLine (Colors.error $"'{fnName}' not found at this location")
+  state
+
+
+let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
+  match args with
+  | [] | [ "list" ] | [ "status" ] -> Commands.Caps.show state
+
+  // `caps edit` — launch the interactive TUI editor
+  | [ "edit" ] | [ "ui" ] -> Darklang.Cli.Apps.Caps.App.execute state []
+
+  // `caps grant <spec…>` — e.g. `grant http-client GET`, `grant file write ~/x`, `grant random`
+  | "grant" :: specWords ->
+    let spec = Stdlib.String.join specWords " "
+    match Commands.Caps.grantSpec spec with
+    | Ok() -> Stdlib.printLine (Colors.success $"✓ granted  {spec}")
+    | Error bad ->
+      Stdlib.printLine
+        (Colors.error $"couldn't parse '{bad}' — see `caps help` for the grammar")
+    state
+
+  // `caps set <spec>[; <spec>…]` — REPLACE the whole grant with exactly these specs (direct control).
+  | "set" :: rest ->
+    let joined = Stdlib.String.join rest " "
+    let specs =
+      (Stdlib.String.split joined ";")
+      |> Stdlib.List.map (fun s -> Stdlib.String.trim s)
+      |> Stdlib.List.filter (fun s -> s != "")
+    if Stdlib.List.isEmpty specs then
+      // an empty set would silently wipe the grant — make the user say `caps clear` for that
+      Stdlib.printLine (Colors.error "usage: caps set <spec>; <spec>… — to revoke everything use `caps clear`")
+      state
+    else
+      match writeSpecs specs with
+      | None ->
+        Stdlib.printLine (Colors.success "✓ capabilities set")
+        Commands.Caps.show state
+      | Some badSpec ->
+        Stdlib.printLine
+          (Colors.error $"couldn't parse '{badSpec}' — nothing changed. See `caps help` for the grammar.")
+        state
+
+  // `caps clear` — REPLACE the grant with NONE (revoke everything).
+  | [ "clear" ] | [ "none" ] ->
+    let _ = writeSpecs []
+    Stdlib.printLine (Colors.success "✓ cleared — all capabilities revoked (NONE)")
+    state
+
+  | [ "revoke"; domain ] ->
+    if Commands.Caps.revokeDomain domain then
+      Stdlib.printLine (Colors.success $"✓ revoked  {domain}")
+    else
+      Stdlib.printLine (Colors.dimText $"'{domain}' was not granted (nothing to revoke)")
+    state
+
+  | [ "grant-for-fn"; fnName ] -> Commands.Caps.grantForFn state fnName
+
+  | [ "profile" ] ->
+    Stdlib.printLine
+      "Capability profiles — `caps profile <name>` REPLACES the grant with that posture:"
+    Stdlib.List.iter Commands.Caps.profiles (fun (name, specs) ->
+      let label =
+        match Stdlib.String.padEnd name " " 12L with
+        | Ok r -> r
+        | Error _ -> name
+      Stdlib.printLine $"  {label}{Colors.dimText (PrettyPrinter.Capabilities.compact specs)}")
+    Stdlib.printLine
+      (Colors.dimText "  (to layer one on top of your grant, apply it then `caps grant …` the extras)")
+    state
+
+  // A profile is a complete posture, so applying one REPLACES the grant (set, not adjust).
+  | [ "profile"; name ] ->
+    match Stdlib.List.findFirst Commands.Caps.profiles (fun (n, _) -> n == name) with
+    | None ->
+      Stdlib.printLine (Colors.error $"no profile '{name}' — see `caps profile`")
+      state
+    | Some((_, specs)) ->
+      match writeSpecs specs with
+      | None ->
+        Stdlib.printLine (Colors.success $"✓ capabilities set to profile '{name}'")
+        Commands.Caps.show state
+      | Some badSpec ->
+        Stdlib.printLine
+          (Colors.error $"profile '{name}' has a spec that didn't parse ('{badSpec}') — nothing changed")
+        state
+
+  // `caps needed-for <fn>` — the capabilities a function (transitively) needs.
+  | [ "needed-for"; fnName ] ->
+    Commands.Caps.showFnNeeds state fnName
+    state
+
+  | _ ->
+    Stdlib.printLine
+      (Colors.error "Usage: caps [list] | grant <spec> | set <spec>… | clear | revoke <domain> | grant-for-fn <fn> | needed-for <fn>")
+    state
+
+
+let complete
+  (_state: Cli.AppState)
+  (_args: List<String>)
+  : List<Cli.Completion.CompletionItem> =
+  [ Cli.Completion.simple "list"
+    Cli.Completion.simple "grant"
+    Cli.Completion.simple "set"
+    Cli.Completion.simple "clear"
+    Cli.Completion.simple "revoke"
+    Cli.Completion.simple "grant-for-fn"
+    Cli.Completion.simple "needed-for"
+    Cli.Completion.simple "profile" ]
+
+
+let help (state: Cli.AppState) : Cli.AppState =
+  [ "Usage: caps [list] | grant <spec> | set <spec>… | clear | revoke <domain> | grant-for-fn <fn> | needed-for <fn>"
+    ""
+    "View + control the capabilities this instance grants to the code it runs. LOCAL (never synced),"
+    "stored in ~/.darklang/capabilities.bin, default NONE. The runtime gate enforces it."
+    ""
+    "  list                       Show the current grant"
+    "  edit                       Open the interactive editor (TUI)"
+    "  needed-for <fn>            Show what a fn (transitively) needs"
+    "  grant-for-fn <fn>          Grant exactly what a fn needs (adjusts)"
+    ""
+    "  Adjust the current grant:"
+    "    grant <spec>             Add one capability"
+    "    revoke <domain>          Clear a domain (http-client, file, random, …)"
+    ""
+    "  Replace the whole grant (direct control):"
+    "    set <spec>; <spec>; …    Set caps to EXACTLY these specs (semicolon-separated)"
+    "    clear                    Set NONE — revoke everything"
+    "    profile [name]           List, or apply, a preset posture — applying REPLACES the grant"
+    "                               (read-only · local-dev · trusted; layer extras with `grant` after)"
+    "    (`caps edit` opens an interactive editor; the file itself is a binary blob)"
+    ""
+    "  <spec> grammar:"
+    "    http-client [METHOD [URL]]    METHOD: GET/POST/… or `*` = any."
+    "                                  URL pattern: [scheme://]host[:port][/path], where omitted scheme = https,"
+    "                                  omitted port = the scheme's default, omitted path = any; `*` is the wildcard"
+    "                                  per part (`*://` any scheme, `:*` any port, `*.github.com` = subdomains)."
+    "                                  e.g. `http-client GET` (GET anywhere) · `http-client GET https://*.github.com/api`"
+    "                                       `http-client * *://localhost:*` (any method/scheme/port to localhost)."
+    "                                  Repeat to couple rules: a request must match SOME rule."
+    "    exec [PROG [ARG…]]           e.g. `exec git` = git any-args; `exec rm --dry-run` = rm only with --dry-run;"
+    "                                  PROG `*` = any program. Repeat to couple per-program arg allowlists."
+    "    file read|write [PATH]        e.g. `file write ~/.darklang/` = write only inside that dir"
+    "    env read|write [VAR]   ·  db read|write [TABLE]   ·  http-server"
+    "    random  ·  clock  ·  stdout  ·  stdin  ·  llm" ]
+  |> Stdlib.printLines
+
+  state

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -273,7 +273,8 @@ module Registry =
       ("review", "Review branch changesets", [], Darklang.Cli.Apps.Review.App.execute, Darklang.Cli.Apps.Review.App.help, Darklang.Cli.Apps.Review.App.complete)
       ("views", "Browse and preview CLI views", [], Darklang.Cli.Apps.Views.App.execute, Darklang.Cli.Apps.Views.App.help, Darklang.Cli.Apps.Views.App.complete)
       ("login", "Log in as a seeded account (required for commit / serve)", [], Commands.Login.execute, Commands.Login.help, Commands.Login.complete)
-      ("logout", "Clear the active account", [], Commands.Logout.execute, Commands.Logout.help, Commands.Logout.complete) ]
+      ("logout", "Clear the active account", [], Commands.Logout.execute, Commands.Logout.help, Commands.Logout.complete)
+      ("caps", "View + control this instance's capability grant (default NONE)", [ "capabilities" ], Commands.Caps.execute, Commands.Caps.help, Commands.Caps.complete) ]
     |> Stdlib.List.map(
       // CLEANUP nitpicky: swap help and complete
       fun (name, desc, aliases, execute, help, complete) ->
@@ -351,6 +352,7 @@ module Registry =
       ("Execution", [ "run"; "eval"; "scripts" ])
       ("Installation", [ "install"; "update"; "uninstall"; "version" ])
       ("AI", [ "agent" ])
+      ("Security", [ "caps" ])
       ("Utilities", [ "clear"; "help"; "docs"; "quit"; "builtins"; "export-seed"; "views" ]) ]
 
   // Helper function to format a group of commands with details

--- a/packages/darklang/cli/docs/for-ai.dark
+++ b/packages/darklang/cli/docs/for-ai.dark
@@ -44,6 +44,22 @@ For multi-line bodies, use `-` and pipe via stdin (heredoc form):
 ## Running/Testing
   eval <fn> [args]  # call a function / evaluate an expression
   run <path>        # execute a .dark script file (not for calling fns)
+  run <path> --sandbox   # ...with NO capabilities (deny-all, for untrusted scripts)
+
+## Capabilities (effectful operations may be gated)
+Effectful builtins — http, filesystem, subprocess, env vars, datastores, clock, randomness, llm — run
+under a per-instance capability GRANT. A call the grant doesn't cover fails with `capability denied: …`.
+Pure code never needs a grant. A fresh instance is permissive; once you configure a grant, both `eval`
+and `run` obey it.
+
+  caps                    # show the current grant
+  caps needed-for <fn>    # what a fn (transitively) needs to run
+  caps grant <spec>       # allow one — e.g. `caps grant http-client GET`, `caps grant file read`, `caps grant llm`
+  caps grant-for-fn <fn>  # grant exactly what a fn needs
+  caps grant-all          # remove ALL restrictions
+  caps clear              # revoke everything (NONE)
+
+If a capability denial is blocking you and you trust this environment, run `caps grant-all` to proceed.
 
 ## Navigation
   nav <path>        # go to module (cd)

--- a/packages/darklang/cli/execution/run.dark
+++ b/packages/darklang/cli/execution/run.dark
@@ -7,21 +7,21 @@ module Darklang.Cli.Run
 let execute (state: AppState) (args: List<String>) : AppState =
   let allowHarmful =
     Stdlib.List.member_v0 args "--allow-harmful"
-  // `dark run` is secure-by-default: the script body gets NO capabilities.
-  // `--apply-host-caps` opts into inheriting the host shell's granted caps.
-  let applyHostCaps =
-    Stdlib.List.member_v0 args "--apply-host-caps"
+  // `dark run` respects the host's configured grant by default (same as `eval`).
+  // `--sandbox` drops to NO capabilities, for running untrusted scripts.
+  let sandbox =
+    Stdlib.List.member_v0 args "--sandbox"
   let args =
     args
     |> Stdlib.List.filter (fun a ->
-      (a != "--allow-harmful") && (a != "--apply-host-caps"))
+      (a != "--allow-harmful") && (a != "--sandbox"))
 
   match args with
   | [] ->
     help state
     state
   | scriptPath :: scriptArgs ->
-    executeScript state scriptPath scriptArgs allowHarmful applyHostCaps
+    executeScript state scriptPath scriptArgs allowHarmful sandbox
 
 
 let executeScript
@@ -29,7 +29,7 @@ let executeScript
   (scriptPath: String)
   (args: List<String>)
   (allowHarmful: Bool)
-  (applyHostCaps: Bool)
+  (sandbox: Bool)
   : AppState =
   match Builtin.fileRead scriptPath with
   | Error e ->
@@ -48,7 +48,7 @@ let executeScript
         scriptSourceCode
         args
         allowHarmful
-        applyHostCaps
+        sandbox
 
     match result with
     | Ok exitCode ->
@@ -93,6 +93,11 @@ let help (state: AppState) : Unit =
     "Examples:"
     "  run-script script.dark            - Run a script"
     "  run-script script.dark a b c      - Run with args"
+    ""
+    "Flags:"
+    "  --sandbox          - Run with NO capabilities (deny-all) for untrusted scripts."
+    "                       By default a script runs under your configured grant (see `caps`)."
+    "  --allow-harmful    - Opt out of Harmful-deprecation halting."
     ""
     "To call a package function, use 'eval' instead:"
     "  eval Stdlib.Int64.add 5L 3L" ]

--- a/packages/darklang/cli/execution/run.dark
+++ b/packages/darklang/cli/execution/run.dark
@@ -7,15 +7,21 @@ module Darklang.Cli.Run
 let execute (state: AppState) (args: List<String>) : AppState =
   let allowHarmful =
     Stdlib.List.member_v0 args "--allow-harmful"
+  // `dark run` is secure-by-default: the script body gets NO capabilities.
+  // `--apply-host-caps` opts into inheriting the host shell's granted caps.
+  let applyHostCaps =
+    Stdlib.List.member_v0 args "--apply-host-caps"
   let args =
-    args |> Stdlib.List.filter (fun a -> a != "--allow-harmful")
+    args
+    |> Stdlib.List.filter (fun a ->
+      (a != "--allow-harmful") && (a != "--apply-host-caps"))
 
   match args with
   | [] ->
     help state
     state
   | scriptPath :: scriptArgs ->
-    executeScript state scriptPath scriptArgs allowHarmful
+    executeScript state scriptPath scriptArgs allowHarmful applyHostCaps
 
 
 let executeScript
@@ -23,6 +29,7 @@ let executeScript
   (scriptPath: String)
   (args: List<String>)
   (allowHarmful: Bool)
+  (applyHostCaps: Bool)
   : AppState =
   match Builtin.fileRead scriptPath with
   | Error e ->
@@ -41,6 +48,7 @@ let executeScript
         scriptSourceCode
         args
         allowHarmful
+        applyHostCaps
 
     match result with
     | Ok exitCode ->

--- a/packages/darklang/cli/packages/view.dark
+++ b/packages/darklang/cli/packages/view.dark
@@ -146,6 +146,11 @@ let viewEntity (branchId: Uuid) (location: PackageLocation) : Unit =
       let prettyPrinted = PrettyPrinter.ProgramTypes.packageFn ctx item.entity
       let highlighted = SyntaxHighlighting.highlightCode prettyPrinted
       Stdlib.printLine highlighted
+      // the capabilities this fn (transitively) needs — what it would be allowed to do if run
+      let capsBadge =
+        Commands.Caps.badgeForHash
+          (LanguageTools.ProgramTypes.hashToString item.entity.hash)
+      Stdlib.printLine (Colors.dimText $"capabilities: {capsBadge}")
 
   | Value name ->
     // Find and display the specific value

--- a/packages/darklang/cli/scripts.dark
+++ b/packages/darklang/cli/scripts.dark
@@ -113,7 +113,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
   | ["run"; name] ->
     match Builtin.pmScriptsGet name with
     | Some script ->
-      let result = Builtin.cliParseAndExecuteScript state.accountID state.currentBranchId $"script:{name}" script.text [] false
+      let result = Builtin.cliParseAndExecuteScript state.accountID state.currentBranchId $"script:{name}" script.text [] false false
       match result with
       | Ok 0L -> state
       | Ok exitCode ->

--- a/packages/darklang/languageTools/capabilities.dark
+++ b/packages/darklang/languageTools/capabilities.dark
@@ -1,0 +1,444 @@
+/// The capability model, mirrored from F# `LibExecution.Capabilities`. This is the STRUCTURED form that
+/// crosses the F#/Dark boundary (via `CapabilitiesToDarkTypes`): `pmCapsGet` returns it (the instance's
+/// grant), `pmCapsSet` takes it (replace the grant), `pmFnEffectiveCaps` returns it (what a fn needs).
+/// All grant-spec PARSING and RENDERING lives in Dark (the CLI) — F# only ever sees this structure.
+module Darklang.LanguageTools.Capabilities
+
+/// A set-or-everything scope over some token (method, host, path, port, program, …).
+type Scope<'a> =
+  | Any
+  | Only of List<'a>
+
+/// How a granted host matches a request host.
+type HostMatch =
+  | AnyHost
+  | ExactHost of String
+  | Subdomain of String
+
+/// A URL pattern, dimension by dimension.
+type UrlScope =
+  { schemes: Capabilities.Scope<String>
+    hosts: List<Capabilities.HostMatch>
+    ports: Capabilities.Scope<Int64>
+    paths: Capabilities.Scope<String> }
+
+/// One http-client rule: a set of methods coupled to a URL scope.
+type HttpRule =
+  { methods: Capabilities.Scope<String>
+    url: Capabilities.UrlScope }
+
+/// One exec rule: a set of programs coupled to an allowed-args scope.
+type ExecRule =
+  { programs: Capabilities.Scope<String>
+    args: Capabilities.Scope<String> }
+
+/// A read/write split for a path-like domain (file, env, db).
+type RW<'a> =
+  { read: Capabilities.Scope<'a>
+    write: Capabilities.Scope<'a> }
+
+/// The whole grant/need — one field per impurity. All-empty (`Only []` everywhere, all bools false) is
+/// pure / NONE.
+type Capabilities =
+  { httpClient: List<Capabilities.HttpRule>
+    httpServer: Capabilities.Scope<Int64>
+    file: Capabilities.RW<String>
+    env: Capabilities.RW<String>
+    db: Capabilities.RW<String>
+    exec: List<Capabilities.ExecRule>
+    stdout: Bool
+    stdin: Bool
+    random: Bool
+    clock: Bool
+    llm: Bool }
+
+
+// ───────────────────────────────────────────────────────────────────────────
+// Grammar — the CLI grant language (spec string ⇄ structured). All PARSING + RENDERING live HERE in
+// Dark; F# only ever sees the structured `Capabilities` (via CapabilitiesToDarkTypes). Mirrors the
+// retired F# `LibExecution.Capabilities.Grammar`.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// The empty grant / NONE (pure): every scope empty, every flag false.
+let empty () : LanguageTools.Capabilities.Capabilities =
+  let noScope = LanguageTools.Capabilities.Scope.Only []
+  LanguageTools.Capabilities.Capabilities
+    { httpClient = []
+      httpServer = LanguageTools.Capabilities.Scope.Only []
+      file = LanguageTools.Capabilities.RW { read = noScope; write = noScope }
+      env = LanguageTools.Capabilities.RW { read = noScope; write = noScope }
+      db = LanguageTools.Capabilities.RW { read = noScope; write = noScope }
+      exec = []
+      stdout = false
+      stdin = false
+      random = false
+      clock = false
+      llm = false }
+
+let joinScope
+  (a: LanguageTools.Capabilities.Scope<'a>)
+  (b: LanguageTools.Capabilities.Scope<'a>)
+  : LanguageTools.Capabilities.Scope<'a> =
+  match (a, b) with
+  | (Any, _) -> LanguageTools.Capabilities.Scope.Any
+  | (_, Any) -> LanguageTools.Capabilities.Scope.Any
+  | (Only x, Only y) ->
+    LanguageTools.Capabilities.Scope.Only(Stdlib.List.unique (Stdlib.List.append x y))
+
+let joinRW
+  (a: LanguageTools.Capabilities.RW<'a>)
+  (b: LanguageTools.Capabilities.RW<'a>)
+  : LanguageTools.Capabilities.RW<'a> =
+  LanguageTools.Capabilities.RW
+    { read = LanguageTools.Capabilities.joinScope a.read b.read
+      write = LanguageTools.Capabilities.joinScope a.write b.write }
+
+let join
+  (a: LanguageTools.Capabilities.Capabilities)
+  (b: LanguageTools.Capabilities.Capabilities)
+  : LanguageTools.Capabilities.Capabilities =
+  LanguageTools.Capabilities.Capabilities
+    { httpClient = Stdlib.List.unique (Stdlib.List.append a.httpClient b.httpClient)
+      httpServer = LanguageTools.Capabilities.joinScope a.httpServer b.httpServer
+      file = LanguageTools.Capabilities.joinRW a.file b.file
+      env = LanguageTools.Capabilities.joinRW a.env b.env
+      db = LanguageTools.Capabilities.joinRW a.db b.db
+      exec = Stdlib.List.unique (Stdlib.List.append a.exec b.exec)
+      stdout = a.stdout || b.stdout
+      stdin = a.stdin || b.stdin
+      random = a.random || b.random
+      clock = a.clock || b.clock
+      llm = a.llm || b.llm }
+
+/// The fully-permissive URL pattern (any scheme/host/port/path).
+let anyUrl () : LanguageTools.Capabilities.UrlScope =
+  LanguageTools.Capabilities.UrlScope
+    { schemes = LanguageTools.Capabilities.Scope.Any
+      hosts = [ LanguageTools.Capabilities.HostMatch.AnyHost ]
+      ports = LanguageTools.Capabilities.Scope.Any
+      paths = LanguageTools.Capabilities.Scope.Any }
+
+/// The standard port for a single concrete scheme (so an omitted port narrows to it, not to Any).
+let defaultPortFor
+  (schemes: LanguageTools.Capabilities.Scope<String>)
+  : LanguageTools.Capabilities.Scope<Int64> =
+  match schemes with
+  | Only [ scheme ] ->
+    (match scheme with
+     | "https" -> LanguageTools.Capabilities.Scope.Only [ 443L ]
+     | "wss" -> LanguageTools.Capabilities.Scope.Only [ 443L ]
+     | "http" -> LanguageTools.Capabilities.Scope.Only [ 80L ]
+     | "ws" -> LanguageTools.Capabilities.Scope.Only [ 80L ]
+     | _ -> LanguageTools.Capabilities.Scope.Any)
+  | _ -> LanguageTools.Capabilities.Scope.Any
+
+/// Parse a URL PATTERN (`[scheme://]host[:port][/path]`) into a structured `UrlScope`.
+let parseUrl (pattern: String) : LanguageTools.Capabilities.UrlScope =
+  let (schemeStr, afterScheme) =
+    match Stdlib.String.splitFirst pattern "://" with
+    | Some((s, rest)) -> (s, rest)
+    | None -> ("https", pattern)
+  let schemes =
+    if schemeStr == "*" then
+      LanguageTools.Capabilities.Scope.Any
+    else
+      LanguageTools.Capabilities.Scope.Only [ Stdlib.String.toLowercase schemeStr ]
+  let (hostPort, pathStr) =
+    match Stdlib.String.splitFirst afterScheme "/" with
+    | Some((hp, rest)) -> (hp, Stdlib.Option.Option.Some $"/{rest}")
+    | None -> (afterScheme, Stdlib.Option.Option.None)
+  let (hostStr, portStr) =
+    match Stdlib.String.splitFirst hostPort ":" with
+    | Some((h, p)) -> (h, Stdlib.Option.Option.Some p)
+    | None -> (hostPort, Stdlib.Option.Option.None)
+  let hosts =
+    if hostStr == "*" then
+      [ LanguageTools.Capabilities.HostMatch.AnyHost ]
+    else if Stdlib.String.startsWith hostStr "*." then
+      [ LanguageTools.Capabilities.HostMatch.Subdomain(
+          Stdlib.String.toLowercase (Stdlib.String.dropFirst hostStr 2L)) ]
+    else
+      [ LanguageTools.Capabilities.HostMatch.ExactHost(Stdlib.String.toLowercase hostStr) ]
+  let ports =
+    match portStr with
+    | Some "*" -> LanguageTools.Capabilities.Scope.Any
+    | Some p ->
+      (match Stdlib.Int64.parse p with
+       | Ok n -> LanguageTools.Capabilities.Scope.Only [ n ]
+       | Error _ -> LanguageTools.Capabilities.Scope.Any)
+    | None -> LanguageTools.Capabilities.defaultPortFor schemes
+  let paths =
+    match pathStr with
+    | Some pp -> LanguageTools.Capabilities.Scope.Only [ pp ]
+    | None -> LanguageTools.Capabilities.Scope.Any
+  LanguageTools.Capabilities.UrlScope
+    { schemes = schemes; hosts = hosts; ports = ports; paths = paths }
+
+/// read/write split from an access token.
+let rwFor
+  (access: String)
+  (scope: LanguageTools.Capabilities.Scope<String>)
+  : Stdlib.Option.Option<LanguageTools.Capabilities.RW<String>> =
+  let none = LanguageTools.Capabilities.Scope.Only []
+  match Stdlib.String.toLowercase access with
+  | "read" ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.RW { read = scope; write = none })
+  | "write" ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.RW { read = none; write = scope })
+  | "read+write" ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.RW { read = scope; write = scope })
+  | "readwrite" ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.RW { read = scope; write = scope })
+  | "rw" ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.RW { read = scope; write = scope })
+  | _ -> Stdlib.Option.Option.None
+
+/// `*` ⇒ any method, else the upper-cased literal.
+let methodScope (m: String) : LanguageTools.Capabilities.Scope<String> =
+  if m == "*" then
+    LanguageTools.Capabilities.Scope.Any
+  else
+    LanguageTools.Capabilities.Scope.Only [ Stdlib.String.toUppercase m ]
+
+/// `*` ⇒ any program, else the literal.
+let programScope (p: String) : LanguageTools.Capabilities.Scope<String> =
+  if p == "*" then
+    LanguageTools.Capabilities.Scope.Any
+  else
+    LanguageTools.Capabilities.Scope.Only [ p ]
+
+let capHttp
+  (m: LanguageTools.Capabilities.Scope<String>)
+  (url: LanguageTools.Capabilities.UrlScope)
+  : LanguageTools.Capabilities.Capabilities =
+  let e = LanguageTools.Capabilities.empty ()
+  { e with
+      httpClient = [ LanguageTools.Capabilities.HttpRule { methods = m; url = url } ] }
+
+let capExec
+  (p: LanguageTools.Capabilities.Scope<String>)
+  (a: LanguageTools.Capabilities.Scope<String>)
+  : LanguageTools.Capabilities.Capabilities =
+  let e = LanguageTools.Capabilities.empty ()
+  { e with exec = [ LanguageTools.Capabilities.ExecRule { programs = p; args = a } ] }
+
+/// Parse one already-tokenized `dark caps grant …` spec into a sparse Capabilities.
+let parseGrant
+  (args: List<String>)
+  : Stdlib.Option.Option<LanguageTools.Capabilities.Capabilities> =
+  let e = LanguageTools.Capabilities.empty ()
+  match args with
+  | [ "http-client" ] ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.capHttp
+        LanguageTools.Capabilities.Scope.Any
+        (LanguageTools.Capabilities.anyUrl ()))
+  | [ "http-client"; m ] ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.capHttp
+        (LanguageTools.Capabilities.methodScope m)
+        (LanguageTools.Capabilities.anyUrl ()))
+  | [ "http-client"; m; url ] ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.capHttp
+        (LanguageTools.Capabilities.methodScope m)
+        (LanguageTools.Capabilities.parseUrl url))
+  | [ "http-server" ] ->
+    Stdlib.Option.Option.Some({ e with httpServer = LanguageTools.Capabilities.Scope.Any })
+  | [ "exec" ] ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.capExec
+        LanguageTools.Capabilities.Scope.Any
+        LanguageTools.Capabilities.Scope.Any)
+  | [ "exec"; p ] ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.capExec
+        (LanguageTools.Capabilities.programScope p)
+        LanguageTools.Capabilities.Scope.Any)
+  | "exec" :: p :: argv ->
+    Stdlib.Option.Option.Some(
+      LanguageTools.Capabilities.capExec
+        (LanguageTools.Capabilities.programScope p)
+        (LanguageTools.Capabilities.Scope.Only argv))
+  | [ "file"; a ] ->
+    (match LanguageTools.Capabilities.rwFor a LanguageTools.Capabilities.Scope.Any with
+     | Some rw -> Stdlib.Option.Option.Some({ e with file = rw })
+     | None -> Stdlib.Option.Option.None)
+  | [ "file"; a; p ] ->
+    (match LanguageTools.Capabilities.rwFor a (LanguageTools.Capabilities.Scope.Only [ p ]) with
+     | Some rw -> Stdlib.Option.Option.Some({ e with file = rw })
+     | None -> Stdlib.Option.Option.None)
+  | [ "env"; a ] ->
+    (match LanguageTools.Capabilities.rwFor a LanguageTools.Capabilities.Scope.Any with
+     | Some rw -> Stdlib.Option.Option.Some({ e with env = rw })
+     | None -> Stdlib.Option.Option.None)
+  | [ "env"; a; v ] ->
+    (match LanguageTools.Capabilities.rwFor a (LanguageTools.Capabilities.Scope.Only [ v ]) with
+     | Some rw -> Stdlib.Option.Option.Some({ e with env = rw })
+     | None -> Stdlib.Option.Option.None)
+  | [ "db"; a ] ->
+    (match LanguageTools.Capabilities.rwFor a LanguageTools.Capabilities.Scope.Any with
+     | Some rw -> Stdlib.Option.Option.Some({ e with db = rw })
+     | None -> Stdlib.Option.Option.None)
+  | [ "db"; a; t ] ->
+    (match LanguageTools.Capabilities.rwFor a (LanguageTools.Capabilities.Scope.Only [ t ]) with
+     | Some rw -> Stdlib.Option.Option.Some({ e with db = rw })
+     | None -> Stdlib.Option.Option.None)
+  | [ "stdout" ] -> Stdlib.Option.Option.Some({ e with stdout = true })
+  | [ "stdin" ] -> Stdlib.Option.Option.Some({ e with stdin = true })
+  | [ "random" ] -> Stdlib.Option.Option.Some({ e with random = true })
+  | [ "clock" ] -> Stdlib.Option.Option.Some({ e with clock = true })
+  | [ "llm" ] -> Stdlib.Option.Option.Some({ e with llm = true })
+  | _ -> Stdlib.Option.Option.None
+
+/// Parse one spec string (tokenizes, then `parseGrant`).
+let parseSpec
+  (spec: String)
+  : Stdlib.Option.Option<LanguageTools.Capabilities.Capabilities> =
+  let toks = (Stdlib.String.split spec " ") |> Stdlib.List.filter (fun w -> w != "")
+  LanguageTools.Capabilities.parseGrant toks
+
+/// Parse a full spec list into one grant (folded from empty), or `Error badSpec` naming the first spec
+/// that doesn't parse.
+let parse
+  (specs: List<String>)
+  : Stdlib.Result.Result<LanguageTools.Capabilities.Capabilities, String> =
+  let cleaned =
+    specs
+    |> Stdlib.List.map (fun s -> Stdlib.String.trim s)
+    |> Stdlib.List.filter (fun s -> s != "")
+  Stdlib.List.fold
+    cleaned
+    (Stdlib.Result.Result.Ok(LanguageTools.Capabilities.empty ()))
+    (fun acc spec ->
+      match acc with
+      | Error e -> Stdlib.Result.Result.Error e
+      | Ok cur ->
+        match LanguageTools.Capabilities.parseSpec spec with
+        | Some c -> Stdlib.Result.Result.Ok(LanguageTools.Capabilities.join cur c)
+        | None -> Stdlib.Result.Result.Error spec)
+
+let defaultPortValue (schemeTok: String) : Int64 =
+  match schemeTok with
+  | "https" -> 443L
+  | "wss" -> 443L
+  | "http" -> 80L
+  | "ws" -> 80L
+  | _ -> -1L
+
+/// Inverse of `parseUrl` for the single-valued scopes `parseGrant` produces.
+let urlToPattern (url: LanguageTools.Capabilities.UrlScope) : String =
+  let schemeTok =
+    match url.schemes with
+    | Any -> "*"
+    | Only [ s ] -> s
+    | _ -> "*"
+  let hostTok =
+    match url.hosts with
+    | [ AnyHost ] -> "*"
+    | [ ExactHost h ] -> h
+    | [ Subdomain d ] -> $"*.{d}"
+    | _ -> "*"
+  let schemePrefix = if schemeTok == "https" then "" else $"{schemeTok}://"
+  let portTok =
+    match url.ports with
+    | Any -> ":*"
+    | Only [ n ] ->
+      if n == LanguageTools.Capabilities.defaultPortValue schemeTok then "" else $":{n}"
+    | _ -> ""
+  let pathTok =
+    match url.paths with
+    | Only [ p ] -> p
+    | _ -> ""
+  $"{schemePrefix}{hostTok}{portTok}{pathTok}"
+
+let scopeArgs (s: LanguageTools.Capabilities.Scope<String>) : List<List<String>> =
+  match s with
+  | Any -> [ [] ]
+  | Only xs -> if Stdlib.List.isEmpty xs then [] else Stdlib.List.map xs (fun x -> [ x ])
+
+/// `prefix` tokens (e.g. ["file"; "read"]) joined with the scope arg into one spec line.
+let specLine (prefix: List<String>) (a: List<String>) : String =
+  Stdlib.String.join (Stdlib.List.append prefix a) " "
+
+/// Render a grant as parse-compatible spec strings (the inverse of `parse`).
+let render (c: LanguageTools.Capabilities.Capabilities) : List<String> =
+  let httpSpecs =
+    c.httpClient
+    |> Stdlib.List.map (fun rule ->
+      let ms =
+        match rule.methods with
+        | Any -> [ "*" ]
+        | Only m -> m
+      let hasHost =
+        match rule.url.hosts with
+        | [] -> false
+        | _ -> true
+      let isAnyUrl = rule.url == LanguageTools.Capabilities.anyUrl ()
+      ms
+      |> Stdlib.List.filterMap (fun m ->
+        if hasHost then
+          (if isAnyUrl then
+             (if m == "*" then
+                Stdlib.Option.Option.Some "http-client"
+              else
+                Stdlib.Option.Option.Some $"http-client {m}")
+           else
+             Stdlib.Option.Option.Some
+               $"http-client {m} {LanguageTools.Capabilities.urlToPattern rule.url}")
+        else
+          Stdlib.Option.Option.None))
+    |> Stdlib.List.flatten
+  let serverSpecs =
+    match c.httpServer with
+    | Only [] -> []
+    | _ -> [ "http-server" ]
+  let fileSpecs =
+    Stdlib.List.append
+      ((LanguageTools.Capabilities.scopeArgs c.file.read)
+       |> Stdlib.List.map (fun a -> LanguageTools.Capabilities.specLine [ "file"; "read" ] a))
+      ((LanguageTools.Capabilities.scopeArgs c.file.write)
+       |> Stdlib.List.map (fun a -> LanguageTools.Capabilities.specLine [ "file"; "write" ] a))
+  let execSpecs =
+    c.exec
+    |> Stdlib.List.map (fun rule ->
+      let progs =
+        match rule.programs with
+        | Any -> [ "*" ]
+        | Only p -> p
+      let argToks =
+        match rule.args with
+        | Any -> []
+        | Only a -> a
+      progs
+      |> Stdlib.List.map (fun p ->
+        match (p, argToks) with
+        | ("*", []) -> "exec"
+        | _ -> Stdlib.String.join (Stdlib.List.append [ "exec"; p ] argToks) " "))
+    |> Stdlib.List.flatten
+  let envSpecs =
+    Stdlib.List.append
+      ((LanguageTools.Capabilities.scopeArgs c.env.read)
+       |> Stdlib.List.map (fun a -> LanguageTools.Capabilities.specLine [ "env"; "read" ] a))
+      ((LanguageTools.Capabilities.scopeArgs c.env.write)
+       |> Stdlib.List.map (fun a -> LanguageTools.Capabilities.specLine [ "env"; "write" ] a))
+  let dbSpecs =
+    Stdlib.List.append
+      ((LanguageTools.Capabilities.scopeArgs c.db.read)
+       |> Stdlib.List.map (fun a -> LanguageTools.Capabilities.specLine [ "db"; "read" ] a))
+      ((LanguageTools.Capabilities.scopeArgs c.db.write)
+       |> Stdlib.List.map (fun a -> LanguageTools.Capabilities.specLine [ "db"; "write" ] a))
+  let flagSpecs =
+    Stdlib.List.flatten
+      [ (if c.stdout then [ "stdout" ] else [])
+        (if c.stdin then [ "stdin" ] else [])
+        (if c.random then [ "random" ] else [])
+        (if c.clock then [ "clock" ] else [])
+        (if c.llm then [ "llm" ] else []) ]
+  Stdlib.List.flatten
+    [ httpSpecs; serverSpecs; fileSpecs; execSpecs; envSpecs; dbSpecs; flagSpecs ]

--- a/packages/darklang/languageTools/capabilities.dark
+++ b/packages/darklang/languageTools/capabilities.dark
@@ -75,6 +75,39 @@ let empty () : LanguageTools.Capabilities.Capabilities =
       clock = false
       llm = false }
 
+// TODO the sandbox intent is undercut by `all ()` + `caps grant-all`: any code (or agent) that can run
+// a command can also lift every restriction. Until there's a real trust boundary (signed/locked grants,
+// an out-of-band approval, a read-only enforcement layer), "allow all" is a convenience, not a control.
+/// The fully-permissive grant — every domain unscoped, every flag on (`caps grant-all`).
+let all () : LanguageTools.Capabilities.Capabilities =
+  LanguageTools.Capabilities.Capabilities
+    { httpClient =
+        [ LanguageTools.Capabilities.HttpRule
+            { methods = LanguageTools.Capabilities.Scope.Any
+              url = LanguageTools.Capabilities.anyUrl () } ]
+      httpServer = LanguageTools.Capabilities.Scope.Any
+      file =
+        LanguageTools.Capabilities.RW
+          { read = LanguageTools.Capabilities.Scope.Any
+            write = LanguageTools.Capabilities.Scope.Any }
+      env =
+        LanguageTools.Capabilities.RW
+          { read = LanguageTools.Capabilities.Scope.Any
+            write = LanguageTools.Capabilities.Scope.Any }
+      db =
+        LanguageTools.Capabilities.RW
+          { read = LanguageTools.Capabilities.Scope.Any
+            write = LanguageTools.Capabilities.Scope.Any }
+      exec =
+        [ LanguageTools.Capabilities.ExecRule
+            { programs = LanguageTools.Capabilities.Scope.Any
+              args = LanguageTools.Capabilities.Scope.Any } ]
+      stdout = true
+      stdin = true
+      random = true
+      clock = true
+      llm = true }
+
 let joinScope
   (a: LanguageTools.Capabilities.Scope<'a>)
   (b: LanguageTools.Capabilities.Scope<'a>)

--- a/packages/darklang/prettyPrinter/capabilities.dark
+++ b/packages/darklang/prettyPrinter/capabilities.dark
@@ -1,0 +1,71 @@
+module Darklang.PrettyPrinter.Capabilities
+
+// Pretty-print a Darklang capability GRANT or NEED for display. Capabilities cross the F#/Dark boundary
+// as grant-spec strings — the stable wire form produced by `pmCapsGet` (the instance's grant) and
+// `pmFnEffectiveCaps` (what a fn transitively needs), e.g. "http-client GET", "file write ~/x", "random".
+// This is the ONE place that turns those specs into readable output, so `dark caps`, the caps app, and
+// any command that shows "what is this fn allowed to do?" all render identically.
+
+let methodLabel (m: String) : String = if m == "*" then "any" else m
+
+let pad (s: String) (goal: Int64) : String =
+  match Stdlib.String.padEnd s " " goal with
+  | Ok r -> r
+  | Error _ -> s
+
+/// The domain token of a spec — its first word. "http-client GET" → "http-client".
+let domainOf (spec: String) : String =
+  match Stdlib.String.split spec " " with
+  | head :: _ -> head
+  | [] -> ""
+
+/// The human-readable detail of one spec (everything after the domain), per-domain semantics. "" for
+/// the flag domains (random / clock / stdout / stdin / llm) — the domain name says it all.
+let detail (spec: String) : String =
+  let parts =
+    (Stdlib.String.split spec " ")
+    |> Stdlib.List.filter (fun s -> s != "")
+  match parts with
+  | [ "http-client" ] -> "any method → anywhere"
+  | [ "http-client"; m ] -> $"{PrettyPrinter.Capabilities.methodLabel m} → anywhere"
+  | [ "http-client"; m; url ] -> $"{PrettyPrinter.Capabilities.methodLabel m} → {url}"
+  | [ "http-server" ] -> "bind any port"
+  | [ "file"; rw ] -> $"{rw} → anywhere"
+  | [ "file"; rw; p ] -> $"{rw} → {p}"
+  | [ "env"; rw ] -> $"{rw} → any var"
+  | [ "env"; rw; v ] -> $"{rw} → {v}"
+  | [ "db"; rw ] -> $"{rw} → any table"
+  | [ "db"; rw; t ] -> $"{rw} → {t}"
+  | [ "exec" ] -> "any program"
+  | [ "exec"; prog ] -> prog
+  | "exec" :: prog :: progArgs -> $"""{prog}  ({Stdlib.String.join progArgs " "})"""
+  | [ _ ] -> "" // flag domains
+  | _ -> Stdlib.String.join (Stdlib.List.drop parts 1L) " "
+
+/// One aligned "domain   detail" line for a single spec — the single source of truth for a caps row
+/// (used by `caps list`, `caps <fn>`, and the interactive editor's rows).
+let line (spec: String) : String =
+  let det = PrettyPrinter.Capabilities.detail spec
+  if det == "" then
+    PrettyPrinter.Capabilities.domainOf spec
+  else
+    $"{PrettyPrinter.Capabilities.pad (PrettyPrinter.Capabilities.domainOf spec) 14L}{det}"
+
+/// The multi-line view: one aligned line per spec.
+let lines (specs: List<String>) : List<String> =
+  Stdlib.List.map specs (fun s -> PrettyPrinter.Capabilities.line s)
+
+/// A one-line summary: the distinct domains, e.g. "http-client, file, random".
+let compact (specs: List<String>) : String =
+  let domains =
+    specs
+    |> Stdlib.List.map (fun s -> PrettyPrinter.Capabilities.domainOf s)
+    |> Stdlib.List.unique
+  Stdlib.String.join domains ", "
+
+/// An inline badge: "pure" when there are no caps, else the compact domain summary.
+let badge (specs: List<String>) : String =
+  if Stdlib.List.isEmpty specs then
+    "pure"
+  else
+    PrettyPrinter.Capabilities.compact specs


### PR DESCRIPTION
## What this does

Darklang code performs every impurity through a Builtin — http, the filesystem, subprocesses, env vars,
datastores, the clock, randomness, the LLM. This PR adds a per-instance **capability grant**: an explicit
allow-list of which of those impurities are permitted, **enforced at the Builtin call site** — a call
whose need the grant doesn't cover is denied at runtime, before the impurity happens.

The grant is **local** to the instance (never synced, it's not package data), **nuanced** (not just
"http on/off" but "GET over https to `*.github.com`"), and **managed** through `dark caps`. The
interactive instance is permissive until you configure a grant, then it respects it; `dark run` scripts
are deny-all and opt in. The same per-domain need data also powers static "what can this function do?"
analysis. Default behaviour is unchanged until you start restricting.

## The model

A grant (what the instance allows) and a need (what a call requires) are the **same** type — one
`Capabilities` record, a field per impurity. A grant covers a need field-by-field.

```fsharp
type Capabilities =
  { // simple on/off impurities
    stdout : bool
    stdin  : bool
    random : bool
    clock  : bool
    llm    : bool                  // the AI opt-in — denied by default

    // scoped / coupled impurities
    httpClient : List<HttpRule>    // (method × URL) rules — coupled, OR'd
    httpServer : Scope<int64>      // which ports may bind
    file : RW<string>              // read paths × write paths (prefix-scoped)
    env  : RW<string>              // read vars × write vars
    db   : RW<string>              // read tables × write tables
    exec : List<ExecRule> }        // run external programs — (program × args) rules
```

The pieces:

```fsharp
type Scope<'a> = Any | Only of Set<'a>                   // ⊤ "anywhere"  |  an allow-list (Only {} = nothing)
type RW<'a>    = { read: Scope<'a>; write: Scope<'a> }   // read-scope and write-scope can differ

type HttpRule = { methods: Scope<string>; url: UrlScope }
type ExecRule = { programs: Scope<string>; args: Scope<string> }

type HostMatch = AnyHost | ExactHost of string | Subdomain of string   // structured, NOT regex
type UrlScope  = { schemes : Scope<string>     // Only {"https"} | Any
                   hosts   : List<HostMatch>    // OR-list; [AnyHost] = any host
                   ports   : Scope<int64>
                   paths   : Scope<string> }    // path-prefix matched
```

**Coupled rule-lists.** Some domains must constrain dimensions *together*. `httpClient` couples
method × URL; `exec` couples program × args. Each is a list of rules — a request is allowed iff it
matches **some** rule (OR across rules, AND within one):

```
http-client * *://localhost:*    ┐  any method/scheme/port to your own services,
http-client GET                  ┘  but GET-only (https) to the outside world

exec git                         ┐  git with any args,
exec rm --dry-run                ┘  rm only with --dry-run
```

**Structured URLs.** The URL is decomposed into scheme / host / port / path, each its own `Scope`.
Host matching is structured rather than regex (auditable, no host-bypass or ReDoS footguns). The grant
grammar is a URL pattern `[scheme://]host[:port][/path]` with safe defaults — omitted scheme ⇒ `https`,
omitted port ⇒ the scheme's default, omitted path ⇒ any — and `*` as the explicit per-part wildcard:

```
http-client GET  https://*.github.com/api    # https + subdomains + path-prefix, GET only
http-client GET  api.x                        # = GET https://api.x:443, any path
http-client *    *://localhost:*              # any method/scheme/port to localhost
```

Every dimension is explicit — there is no "empty implies any". An undeterminable value (e.g. a URL the
gate can't parse) becomes the *maximal* need, denied unless the grant is unrestricted: fail-closed and
deliberate, never a silent `Any`.

## Implementation

Three structural choices keep this honest — no name-string magic, no central side-table, no parsing in F#:

**Builtins declare their own needs.** Every `BuiltInFn` carries a `capabilities : Capabilities` field —
the need lives *on the builtin*, set at its definition site by what it actually does (mostly `Caps.pure`;
the ~70 effectful ones their real need). There is no `name.StartsWith "httpClient"` registry deciding
needs by string-matching. (Marking needs by behaviour rather than name also fixed a latent bug: the
`*Random`/`uuidGenerate` builtins never matched the old `"random"` prefix and so declared *no* need.)

**Two-tier enforcement, no name dispatch in the interpreter.** The call-site gate is one structural
presence check — `coversStructurally grant fn.capabilities` — that asks only "may this instance touch
this domain at all?". The nuanced per-call check (this URL, this path, these args) lives in the
**builtin's own body**, which calls `CapabilityCheck.requireHttp`/`requireFile`/`requireExec`/… with the
concrete target it already holds. The interpreter no longer pattern-matches `fn.name.name` against
`"httpClientRequest"` to special-case URL parsing — it knows nothing about URLs, paths, or args.

**The grant LANGUAGE lives in Dark.** All spec-string parsing and rendering (`http-client GET api.x` ⇄
the structured record) is `.dark` code (`Darklang.LanguageTools.Capabilities.parse` / `render`). F# only
ever deals with the structured model. The boundary is a `CapabilitiesToDarkTypes` (C2DT) converter
mirroring `ProgramTypesToDarkTypes`, against a Dark mirror type `LanguageTools.Capabilities`; the caps
builtins hand the structured value across, and the CLI parses/renders at the edge.

## Builtins & CLI

### Static analysis — "what can this function do?"

A function's **effective capabilities** are the union of its Builtins' needs, folded over its entire
(transitive) call graph. Because that's a pure function of the fn's content hash, it's computed once and
cached, so repeat lookups (and an always-on caps badge) cost an indexed read, not a graph walk. It's
exposed by the `pmFnEffectiveCaps` Builtin and surfaced as:

```
$ caps needed-for Darklang.Stdlib.HttpClient.get
Darklang.Stdlib.HttpClient.get needs:
  http-client   any method → anywhere

$ view Darklang.Stdlib.HttpClient.get
let get (uri: String) … = Stdlib.HttpClient.request "GET" uri headers Stdlib.Blob.empty
capabilities: http-client          ← dim badge
```

### `eval` — runs under the host's capabilities

`dark eval <expr>` evaluates the expression under the instance's capabilities. With no grant configured
the host is permissive (`allCaps`), so eval is unrestricted by default; once you configure a grant, eval
respects it — an uncovered Builtin is denied. This is the common path and where the restriction matters
day-to-day.

### `dark run` — secure-by-default sandbox

`dark run <script>` runs the script body with **no** capabilities, so any impurity raises unless you opt
into the host's grant with `--apply-host-caps`. Untrusted scripts stay sandboxed; you grant deliberately.

### the grant itself

Three Builtins back the whole feature: `pmCapsGet` (the grant), `pmCapsSet` (replace it), and
`pmFnEffectiveCaps` (the analyzer) — each exchanging the **structured `Capabilities` value** across the
F#/Dark boundary, never spec strings. Every adjustment — grant one, revoke a domain, clear, apply a
profile — is a get-modify-set composed on top. The `caps` command:

```
caps                         Show the current grant
caps needed-for <fn>         What a fn (transitively) needs
caps grant-for-fn <fn>       Grant exactly what a fn needs
caps edit                    Interactive editor (TUI)

Adjust:  grant <spec> · revoke <domain>
Replace: set <spec>; <spec>… · clear · profile [name]
```

`caps edit` is a small TUI over a working copy of the grant — toggle flag impurities, edit coupled rules
through per-domain editors, apply a profile, `w` to write:

```
 capabilities   ● unsaved

   [x] random
   [ ] http-server
 › http-client   GET → *.github.com/api
   file          write → ~/.darklang/
   exec          rm  (--dry-run)

  ↑↓ move · space toggle · enter edit · a add · d delete · p profile · w write · esc exit
```

## When a grant is missing

A denied call raises a structural error naming the resource and pointing at `dark caps` — the denial
fires **before** the impurity runs:

```
$ dark eval 'Stdlib.HttpClient.post "https://api.stripe.com/v1/charges" headers body'
capability denied: POST https://api.stripe.com/v1/charges needs http-client (a method/scheme/host/port/
path it doesn't allow), which this instance doesn't grant. Grant it with `dark caps`.

$ dark caps grant http-client POST api.stripe.com/v1
✓ granted  http-client POST api.stripe.com/v1
```

(The runtime message stays structural rather than printing a `dark caps grant …` spec, because F# never
renders the grant language — see *Implementation* below. The CLI is the place to surface a one-shot
grant suggestion, rendered from the structured need on the Dark side.)

## Adjusting grants

```sh
# simple on/off impurities
caps grant random
caps grant llm                          # the AI opt-in, denied by default

# http — coarse → nuanced
caps grant http-client                  # any method, anywhere
caps grant http-client GET              # GET anywhere (https)
caps grant http-client GET api.github.com           # GET https://api.github.com:443, any path
caps grant http-client POST https://api.stripe.com/v1   # POST, https, that host, under /v1 only
caps grant http-client GET *.github.com             # GET to github.com + any subdomain
caps grant http-client * *://localhost:*            # any method/scheme/port to localhost

# filesystem / env / db — direction × scope
caps grant file read                    # read anywhere
caps grant file write ~/.darklang/      # write only inside that dir
caps grant file read+write /tmp/work/
caps grant env read PATH
caps grant db read+write users

# run external programs — program × arg-allowlist
caps grant exec git                     # git with any args
caps grant exec rm --dry-run            # rm, only with --dry-run

# exactly what a function needs (walks its call graph)
caps grant-for-fn Darklang.Stdlib.HttpClient.get
```

Removing / replacing:

```sh
caps revoke http-client                 # drop every http-client rule
caps revoke file                        # drop file read AND write
caps clear                              # NONE — revoke everything

caps set 'http-client GET; file read ~/proj/; exec git; random'   # replace the whole posture at once
caps profile read-only                  # or a named posture: read-only · local-dev · trusted
```

Coupled rules just accumulate — "anything to localhost, but only GET-with-https outside" is two grants:

```sh
caps grant http-client * *://localhost:*
caps grant http-client GET
```

### On disk

The grant lives in `~/.darklang/capabilities.bin` — the `Capabilities` record serialized through the
repo's reflection-free binary format (the release CLI is AOT-trimmed, so reflection-based serializers
like System.Text.Json are out). You manage it through `dark caps`, not by editing the file. A realistic
local posture — read the web, POST to one API + anything to localhost, write only a couple of dirs, run
a couple of tools — set in one go and viewed back:

```sh
$ caps set 'http-client GET; http-client POST api.openai.com/v1; http-client * *://localhost:*;
           file read; file write /tmp/; file write ~/.darklang/; exec git; exec rm --dry-run;
           env read PATH; stdout; stdin; random; clock'

$ caps
  http-client   GET → anywhere
  http-client   POST → api.openai.com/v1
  http-client   any → *://localhost:*
  file          read → anywhere
  file          write → /tmp/
  file          write → ~/.darklang/
  exec          git
  exec          rm  (--dry-run)
  env           read → PATH
  stdout
  stdin
  random
  clock
```

(One small future note: the F# `Capabilities` type currently lives in its own `LibExecution.Capabilities`
module with a hand-rolled binary serializer and a `CapabilitiesToDarkTypes` converter. It's a low-level,
builtin-adjacent, should-be-stable shape, so it likely wants to live at the language level — PT or RT —
and share their serialization/hashing and DarkTypes conversion, rather than carrying its own.)