### PR TITLE
Support nested function definitions

### DIFF
--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -658,6 +658,18 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
                     appLambda.closedRegisters
                     |> List.iter (fun (reg, value) -> r[reg] <- value)
 
+                    // Put the lambda itself in the self register so the body can
+                    // call itself. If it already has no applied args, reuse it
+                    // as-is.
+                    match foundLambda.selfRegister with
+                    | Some selfReg ->
+                      r[selfReg] <-
+                        if List.isEmpty appLambda.argsSoFar then
+                          DApplicable(AppLambda appLambda)
+                        else
+                          DApplicable(AppLambda { appLambda with argsSoFar = [] })
+                    | None -> ()
+
                     r
                   typeSymbolTable =
                     if Map.isEmpty appLambda.typeSymbolTable then

--- a/backend/src/LibExecution/ProgramTypesAst.fs
+++ b/backend/src/LibExecution/ProgramTypesAst.fs
@@ -108,3 +108,115 @@ and symbolsUsedInPipeExpr (pipeExpr : PipeExpr) : Set<string> =
   | EPipeFnCall(_, _, _, args) -> args |> List.map r |> Set.unionMany
   | EPipeEnum(_, _, _, fields) -> fields |> List.map r |> Set.unionMany
   | EPipeVariable(_, _, args) -> args |> List.map r |> Set.unionMany
+
+
+/// Finds unqualified names in an expr that resolved to package fns or values.
+/// Used to reject nested fn names that would be ambiguous with a package item.
+let rec unqualifiedResolvedNamesInExpr (expr : Expr) : Set<string> =
+  let r = unqualifiedResolvedNamesInExpr
+
+  match expr with
+  // simple values
+  | EUnit _
+  | EBool _
+  | EInt8 _
+  | EUInt8 _
+  | EInt16 _
+  | EUInt16 _
+  | EInt32 _
+  | EUInt32 _
+  | EInt64 _
+  | EUInt64 _
+  | EInt128 _
+  | EUInt128 _
+  | EFloat _
+  | EChar _ -> Set.empty
+
+  | EString(_, segments) ->
+    segments
+    |> List.map (fun s ->
+      match s with
+      | StringText _ -> Set.empty
+      | StringInterpolation e -> r e)
+    |> Set.unionMany
+
+  // simple structures
+  | ETuple(_, first, second, theRest) ->
+    [ r first; r second; theRest |> List.map r |> Set.unionMany ] |> Set.unionMany
+
+  | EList(_, exprs) -> exprs |> List.map r |> Set.unionMany
+
+  | EDict(_, pairs) -> pairs |> List.map (fun (_k, v) -> r v) |> Set.unionMany
+
+
+  // variables
+  | EVariable _ -> Set.empty
+  | EArg _ -> Set.empty
+
+  | ELet(_, _, rhs, next) -> Set.union (r rhs) (r next)
+
+
+  // flow control
+  | EIf(_, condExpr, ifExpr, elseExprMaybe) ->
+    match elseExprMaybe with
+    | None -> Set.union (r condExpr) (r ifExpr)
+    | Some elseExpr -> Set.unionMany [ r condExpr; r ifExpr; r elseExpr ]
+
+  | EMatch(_, target, cases) ->
+    let targetNames = r target
+    let whenNames =
+      cases
+      |> List.map (fun c ->
+        match c.whenCondition with
+        | None -> Set.empty
+        | Some w -> r w)
+      |> Set.unionMany
+    let rhsNames = cases |> List.map _.rhs |> List.map r |> Set.unionMany
+    Set.unionMany [ targetNames; whenNames; rhsNames ]
+
+  | EPipe(_, expr, parts) ->
+    Set.union
+      (r expr)
+      (parts |> List.map unqualifiedResolvedNamesInPipeExpr |> Set.unionMany)
+
+
+  // custom data
+  | EEnum(_, _, _, _, fields) -> fields |> List.map r |> Set.unionMany
+
+  | ERecord(_, _, _, fields) ->
+    fields |> List.map (fun (_, e) -> r e) |> Set.unionMany
+
+  | ERecordFieldAccess(_, expr, _) -> r expr
+
+  | ERecordUpdate(_, expr, updates) ->
+    Set.union
+      (r expr)
+      (updates |> NEList.toList |> List.map (fun (_, e) -> r e) |> Set.unionMany)
+
+  // the references we're collecting
+  | EValue(_, { originalName = [ name ]; resolved = Ok _ }) -> Set.singleton name
+  | EValue _ -> Set.empty
+  | EFnName(_, { originalName = [ name ]; resolved = Ok _ }) -> Set.singleton name
+  | EFnName _ -> Set.empty
+
+  // things that can be applied
+  | EInfix(_, _, left, right) -> Set.union (r left) (r right)
+  | ELambda(_, _, body) -> r body
+  | EApply(_, thingToApply, _, args) ->
+    Set.unionMany
+      [ r thingToApply; args |> NEList.toList |> List.map r |> Set.unionMany ]
+
+  | EStatement(_, expr, next) -> Set.union (r expr) (r next)
+  | ESelf _ -> Set.empty
+
+and unqualifiedResolvedNamesInPipeExpr (pipeExpr : PipeExpr) : Set<string> =
+  let r = unqualifiedResolvedNamesInExpr
+
+  match pipeExpr with
+  | EPipeLambda(_, _, body) -> r body
+  | EPipeInfix(_, _, expr) -> r expr
+  | EPipeFnCall(_, { originalName = [ name ]; resolved = Ok _ }, _, args) ->
+    Set.add name (args |> List.map r |> Set.unionMany)
+  | EPipeFnCall(_, _, _, args) -> args |> List.map r |> Set.unionMany
+  | EPipeEnum(_, _, _, fields) -> fields |> List.map r |> Set.unionMany
+  | EPipeVariable(_, _, args) -> args |> List.map r |> Set.unionMany

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -440,6 +440,145 @@ module Expr =
         instructions = [ RT.LoadVal(rc, dv) ]
         resultIn = rc }
 
+    // Names bound to lambdas later in a let chain. Used to detect attempted
+    // mutual recursion between nested fns.
+    let rec laterNestedFnNames (e : PT.Expr) : Set<string> =
+      match e with
+      | PT.ELet(_, PT.LPVariable(_, n), PT.ELambda _, rest) ->
+        Set.add n (laterNestedFnNames rest)
+      | PT.ELet(_, _, _, rest) -> laterNestedFnNames rest
+      | _ -> Set.empty
+
+    // Compile a lambda. If `selfNameCandidate` is set and the body uses that
+    // name recursively, give it a self register instead of closing over it.
+    // Referencing a name in `laterFnNames` is attempted mutual recursion,
+    // which isn't supported - error clearly instead of "variable not found".
+    let compileLambda
+      (symbols : Map<string, RT.Register>)
+      (rc : int)
+      (id : id)
+      (pats : NEList<PT.LetPattern>)
+      (body : PT.Expr)
+      (selfNameCandidate : Option<string>)
+      (laterFnNames : Set<string>)
+      : RT.Instructions =
+      let symbolsUsedInBody = ProgramTypesAst.symbolsUsedInExpr body
+      let symbolsUsedInPats =
+        pats |> NEList.toList |> List.map PT.LetPattern.symbolsUsed |> Set.unionMany
+
+      // The lambda is self-recursive only if the body references the binding name,
+      // no param shadows it (in `let x = fun x -> x` the inner `x` is the param),
+      // and the name isn't an existing outer binding being rebound (in
+      // `let f = 1L
+      //  let f = fun x -> f + x`
+      // the lambda captures the outer `f`, it doesn't recurse).
+      let selfName =
+        selfNameCandidate
+        |> Option.filter (fun n ->
+          Set.contains n symbolsUsedInBody
+          && not (Set.contains n symbolsUsedInPats)
+          && not (Map.containsKey n symbols))
+
+      // Reject ambiguity when the body also resolves the same unqualified name to
+      // a package fn/value. In that case, require the user to rename instead of
+      // silently choosing recursion or the package item.
+      let collidingSelfName =
+        match selfNameCandidate with
+        | Some n when
+          Set.contains n (ProgramTypesAst.unqualifiedResolvedNamesInExpr body)
+          ->
+          Some n
+        | _ -> None
+
+      let selfSet =
+        match selfName with
+        | Some n -> Set.singleton n
+        | None -> Set.empty
+      let symbolsUsedInBodyNotDefinedInPats =
+        Set.difference (Set.difference symbolsUsedInBody symbolsUsedInPats) selfSet
+
+      let (rtPats, symbolsAfterPats, rcAfterPats)
+        : (List<RT.LetPattern> * Map<string, int> * int) =
+        pats
+        |> NEList.toList
+        |> List.fold
+          (fun (pats, symbols, rc) p ->
+            let (pat, newSymbols, rcAfterPat) = LetPattern.toRT symbols rc p
+            (pats @ [ pat ], Map.mergeFavoringRight symbols newSymbols, rcAfterPat))
+          ([], Map.empty, 0)
+
+      let (selfRegister, symbolsAfterSelf, rcAfterSelf) =
+        match selfName with
+        | Some n ->
+          (Some rcAfterPats, Map.add n rcAfterPats symbolsAfterPats, rcAfterPats + 1)
+        | None -> (None, symbolsAfterPats, rcAfterPats)
+
+      let (registersToCloseOver, symbolsFinal, rcFinal)
+        : (List<RT.Register * RT.Register> * Map<string, int> * int) =
+        symbolsUsedInBodyNotDefinedInPats
+        |> Set.toList
+        |> List.fold
+          (fun (regs, newSymbols, rc) name ->
+            match Map.tryFind name symbols with
+            | Some parentReg ->
+              (regs @ [ parentReg, rc ], Map.add name rc newSymbols, rc + 1)
+            | None -> (regs, newSymbols, rc))
+          ([], symbolsAfterSelf, rcAfterSelf)
+
+      match collidingSelfName with
+      | Some n ->
+        { registerCount = rc + 1
+          instructions =
+            [ RT.RaiseNRE(
+                [ $"Nested function name `{n}` (a function or value with this name already exists in scope)" ],
+                RT.NameResolutionError.InvalidName
+              ) ]
+          resultIn = rc }
+      | None ->
+        let bodyInstrs = toRT symbolsFinal rcFinal currentFnName body
+
+        // An unresolved reference to a nested fn defined later is attempted mutual
+        // recursion. Swap its VarNotFound for a clearer error - same place, same
+        // timing, better message. (Resolved/shadowed names never emit VarNotFound,
+        // so this can't fire on working code.)
+        let rec rewriteForwardRefs instrs =
+          instrs
+          |> List.map (fun instr ->
+            match instr with
+            | RT.VarNotFound(_, n) when Set.contains n laterFnNames ->
+              RT.RaiseNRE(
+                [ $"`{n}` (forward calls between nested functions aren't supported; use top-level functions instead)" ],
+                RT.NameResolutionError.NotFound
+              )
+            | RT.CreateLambda(reg, inner) ->
+              RT.CreateLambda(
+                reg,
+                { inner with
+                    instructions =
+                      { inner.instructions with
+                          instructions =
+                            rewriteForwardRefs inner.instructions.instructions } }
+              )
+            | instr -> instr)
+
+        let bodyInstrs =
+          if Set.isEmpty laterFnNames then
+            bodyInstrs
+          else
+            { bodyInstrs with
+                instructions = rewriteForwardRefs bodyInstrs.instructions }
+
+        let impl : RT.LambdaImpl =
+          { exprId = id
+            patterns = rtPats |> NEList.ofListUnsafe "" []
+            registersToCloseOver = registersToCloseOver
+            selfRegister = selfRegister
+            instructions = bodyInstrs }
+
+        { registerCount = rc + 1
+          instructions = [ RT.CreateLambda(rc, impl) ]
+          resultIn = rc }
+
     match e with
     | PT.EUnit _id -> justLoadDval RT.DUnit
 
@@ -554,6 +693,21 @@ module Expr =
           @ [ RT.CreateTuple(tupleReg, first.resultIn, second.resultIn, theRestRegs) ]
         resultIn = tupleReg }
 
+
+    // a lambda bound to a name: `let f = fun ... -> ... in body`
+    // (including a nested fn definition, which the parser desugars to this shape).
+    // Compile the lambda with `f` as its self-name candidate: compileLambda decides
+    // whether the body actually recurses on `f` (vs. shadowing by a param, or
+    // rebinding an outer `f`, which capture instead), then bind `f` for the
+    // continuation.
+    | PT.ELet(_id, PT.LPVariable(_, name), (PT.ELambda(lid, pats, lbody)), cont) ->
+      let lambdaInstrs =
+        compileLambda symbols rc lid pats lbody (Some name) (laterNestedFnNames cont)
+      let symbols = Map.add name lambdaInstrs.resultIn symbols
+      let contInstrs = toRT symbols lambdaInstrs.registerCount currentFnName cont
+      { registerCount = contInstrs.registerCount
+        instructions = lambdaInstrs.instructions @ contInstrs.instructions
+        resultIn = contInstrs.resultIn }
 
     // let x = 1
     | PT.ELet(_id, pat, expr, body) ->
@@ -1011,49 +1165,7 @@ module Expr =
 
 
     | PT.ELambda(id, pats, body) ->
-      let symbolsUsedInBody = ProgramTypesAst.symbolsUsedInExpr body
-      let symbolsUsedInPats =
-        pats |> NEList.toList |> List.map PT.LetPattern.symbolsUsed |> Set.unionMany
-      let symbolsUsedInBodyNotDefinedInPats =
-        Set.difference symbolsUsedInBody symbolsUsedInPats
-
-      let (pats, symbolsOfNewFrameAfterPats, rcOfNewFrameAfterPats)
-        : (List<RT.LetPattern> * Map<string, int> * int) =
-        pats
-        |> NEList.toList
-        |> List.fold
-          (fun (pats, symbols, rc) p ->
-            let (pat, newSymbols, rcAfterPat) = LetPattern.toRT symbols rc p
-            (pats @ [ pat ], Map.mergeFavoringRight symbols newSymbols, rcAfterPat))
-          ([], Map.empty, 0)
-
-      let (registersToCloseOver,
-           symbolsOfNewFrameAfterOnesOnlyUsedInBody,
-           rcOfNewFrame) : (List<RT.Register * RT.Register> * Map<string, int> * int) =
-        symbolsUsedInBodyNotDefinedInPats
-        |> Set.toList
-        |> List.fold
-          (fun (regs, newSymbols, rc) name ->
-            match Map.tryFind name symbols with
-            | Some parentReg ->
-              (regs @ [ parentReg, rc ], Map.add name rc newSymbols, rc + 1)
-            | None -> (regs, newSymbols, rc)) // should we raise an error here? or should we just ignore it, and let the runtime raise an error?
-          ([], symbolsOfNewFrameAfterPats, rcOfNewFrameAfterPats)
-
-      let impl : RT.LambdaImpl =
-        { exprId = id
-          patterns = pats |> NEList.ofListUnsafe "" []
-          registersToCloseOver = registersToCloseOver
-          instructions =
-            toRT
-              symbolsOfNewFrameAfterOnesOnlyUsedInBody
-              rcOfNewFrame
-              currentFnName
-              body }
-
-      { registerCount = rc + 1
-        instructions = [ RT.CreateLambda(rc, impl) ]
-        resultIn = rc }
+      compileLambda symbols rc id pats body None Set.empty
 
     | PT.EStatement(_id, expr, next) ->
       let firstExpr = toRT symbols rc currentFnName expr

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -567,6 +567,13 @@ and LambdaImpl =
     /// symtable for the evaluation of the expr on the RHS
     registersToCloseOver : List<Register * Register>
 
+    /// For a self-recursive nested function, the register in this frame that holds
+    /// the function value itself, so the body can call itself by name. Unlike
+    /// closed-over registers (captured by value when the lambda is created), this is
+    /// filled at call time with the lambda value - which doesn't exist yet at
+    /// creation. `None` for ordinary, non-recursive lambdas.
+    selfRegister : Option<Register>
+
     instructions : Instructions
   }
 

--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -180,6 +180,8 @@ module LetPattern =
 
     match pat with
     | SynPat.Paren(subPat, _) -> mapPat subPat
+    // `(x : Int64)` - we don't track the type annotation here, just the binding
+    | SynPat.Typed(subPat, _, _) -> mapPat subPat
     | SynPat.Wild(_) -> WT.LPWildcard(gid ())
     | SynPat.Named(SynIdent(name, _), _, _, _) -> WT.LPVariable(gid (), name.idText)
     | SynPat.Const(SynConst.Unit, _) -> WT.LPUnit(gid ())
@@ -659,6 +661,56 @@ module Expr =
     // if/else expressions
     | SynExpr.IfThenElse(cond, thenExpr, elseExpr, _, _, _, _) ->
       WT.EIf(id, c cond, c thenExpr, Option.map c elseExpr)
+
+
+    // nested function definitions, e.g. `let f (x: Int64) : Int64 = x + 1L`
+    // desugared to a lambda bound by a let. The return type and type params are
+    // not tracked at this level (lambdas are untyped at runtime); the binding is
+    // self-recursive (the function may call itself by name in its own body).
+    //
+    // The guard restricts this to the fully-annotated nested-fn form: lowercase
+    // fn name, parenthesized typed params (or unit), and a return type.
+    // Anything else (`let f x = ...`, `let Some x = ...`, `let (+) a b = ...`)
+    // falls through to the general let case and its loud "unsupported" error.
+    | SynExpr.LetOrUse(_,
+                       _,
+                       _,
+                       _,
+                       [ SynBinding(_,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    SynPat.LongIdent(SynLongIdent([ name ], _, _),
+                                                     _,
+                                                     _,
+                                                     SynArgPats.Pats(p1 :: pRest),
+                                                     _,
+                                                     _),
+                                    returnInfo,
+                                    rhs,
+                                    _,
+                                    _,
+                                    _) ],
+                       body,
+                       _,
+                       _) when
+      (let text = name.idText
+       text.Length > 0 && System.Char.IsLower text[0] && not (text.StartsWith "op_"))
+      && Option.isSome returnInfo
+      && (p1 :: pRest)
+         |> List.forall (fun p ->
+           match p with
+           | SynPat.Paren(SynPat.Typed _, _)
+           | SynPat.Paren(SynPat.Const(SynConst.Unit, _), _)
+           | SynPat.Const(SynConst.Unit, _) -> true
+           | _ -> false)
+      ->
+      let paramPats = NEList.ofList p1 pRest |> NEList.map LetPattern.fromSynPat
+      let lambda = WT.ELambda(gid (), paramPats, c rhs)
+      WT.ELet(id, WT.LPVariable(gid (), name.idText), lambda, c body)
 
 
     // `let` bindings

--- a/backend/src/LibParser/WrittenTypesToProgramTypes.fs
+++ b/backend/src/LibParser/WrittenTypesToProgramTypes.fs
@@ -478,7 +478,15 @@ module Expr =
             body
           )
       | WT.ELet(id, pat, rhs, body) ->
-        let! rhs = toPT context rhs
+        // If a let-bound lambda refers to its own name, treat that name as a
+        // local while converting the rhs so recursion becomes an `EVariable`.
+        // Resolved package names still stay resolved.
+        let rhsContext =
+          match pat, rhs with
+          | WT.LPVariable(_, name), WT.ELambda _ ->
+            { context with localBindings = Set.add name context.localBindings }
+          | _ -> context
+        let! rhs = toPT rhsContext rhs
         let (newContext, ptPat) = LetPattern.toPT context pat
         let! body = toPT newContext body
         return PT.ELet(id, ptPat, rhs, body)

--- a/backend/src/LibSerialization/Binary/Serializers/RT/Instructions.fs
+++ b/backend/src/LibSerialization/Binary/Serializers/RT/Instructions.fs
@@ -159,6 +159,7 @@ module LambdaImpl =
         w.Write(copyFrom : int)
         w.Write(copyTo : int))
       l.registersToCloseOver
+    Option.write w (fun w (reg : int) -> w.Write reg) l.selfRegister
     Instructions.write w l.instructions
 
 
@@ -170,11 +171,13 @@ module LambdaImpl =
         let copyFrom = r.ReadInt32()
         let copyTo = r.ReadInt32()
         (copyFrom, copyTo))
+    let selfRegister = Option.read r (fun r -> r.ReadInt32())
 
     let instructions = Instructions.read r
     { exprId = exprId
       patterns = patterns
       registersToCloseOver = registersToCloseOver
+      selfRegister = selfRegister
       instructions = instructions }
 
 

--- a/backend/testfiles/execution/language/nested-fns.dark
+++ b/backend/testfiles/execution/language/nested-fns.dark
@@ -1,0 +1,76 @@
+// Nested function definitions: `let f (x: T) : R = ...` desugars to a lambda
+// bound by a let (see LibParser/FSharpToWrittenTypes.fs). The binding is
+// self-recursive - the function may call itself by name in its own body - via
+// the `selfRegister` mechanism in ProgramTypesToRuntimeTypes + Interpreter.
+
+// non-recursive nested fn with type annotations
+(let double (x: Int64) : Int64 = x * 2L
+ double 5L) = 10L
+
+// self-recursive nested fn
+(let fact (n: Int64) : Int64 =
+   if n <= 1L then 1L else n * (fact (n - 1L))
+ fact 5L) = 120L
+
+// the reverse/reverseHelper example, with the helper nested inside
+(let reverseHelper (list: List<Int64>) (acc: List<Int64>) : List<Int64> =
+   match list with
+   | [] -> acc
+   | head :: tail -> reverseHelper tail (Stdlib.List.push acc head)
+ reverseHelper [ 1L; 2L; 3L ] []) = [ 3L; 2L; 1L ]
+
+// generic type params in annotations are accepted (dropped at runtime)
+(let rev (list: List<'a>) (acc: List<'a>) : List<'a> =
+   match list with
+   | [] -> acc
+   | head :: tail -> rev tail (Stdlib.List.push acc head)
+ rev [ "a"; "b"; "c" ] []) = [ "c"; "b"; "a" ]
+
+// nested fn closes over an outer let binding AND recurses
+(let limit = 10L
+ let sumUpTo (i: Int64) : Int64 =
+   if i > limit then 0L else i + (sumUpTo (i + 1L))
+ sumUpTo 1L) = 55L
+
+// nested fn that closes over an outer binding without recursing
+(let multiplier = 3L
+ let scale (x: Int64) : Int64 = x * multiplier
+ scale 4L) = 12L
+
+// rebinding a name to a lambda that references the OUTER binding captures the
+// outer value - it is not self-recursion
+(let f = 1L
+ let f = (fun x -> f + x)
+ f 5L) = 6L
+
+// a lambda param that shadows the binding name is the param, not recursion
+(let x = (fun x -> x * 2L)
+ x 3L) = 6L
+
+// a nested fn whose name collides with a fn in scope is rejected - the
+// reference inside the body is ambiguous (recursion vs. the outer fn), so
+// it's an error rather than silently picking one
+let sumDown (x: Int64) : Int64 = x + 100L
+
+(let sumDown (n: Int64) : Int64 =
+   if n <= 0L then 0L else n + (sumDown (n - 1L))
+ sumDown 3L) = error="Nested function name `sumDown` (a function or value with this name already exists in scope) is not a valid name"
+
+// mutually recursive nested fns aren't supported - clear error, not "variable not found"
+(let isEven (n: Int64) : Bool =
+   if n == 0L then true else isOdd (n - 1L)
+ let isOdd (n: Int64) : Bool =
+   if n == 0L then false else isEven (n - 1L)
+ isEven 4L) = error="`isOdd` (forward calls between nested functions aren't supported; use top-level functions instead) not found"
+
+// but a nested fn CAN call one defined before it (plain closure capture)
+(let double (x: Int64) : Int64 = x * 2L
+ let quadruple (x: Int64) : Int64 = double (double x)
+ quadruple 3L) = 12L
+
+// an inner binding that shadows a later nested fn's name is fine - not mutual recursion
+(let f (n: Int64) : Int64 =
+   let foo = 5L
+   foo + n
+ let foo (x: Int64) : Int64 = x
+ f 1L) = 6L

--- a/backend/tests/Tests/LibParser.Tests.fs
+++ b/backend/tests/Tests/LibParser.Tests.fs
@@ -154,7 +154,7 @@ let exprRTs =
                     Ok
                       { name =
                           PT.FQFnName.fqPackage
-                            "6f980e08225c0f345c4887485a2785e7df0690293b1f2061bd4a5e048a441089"
+                            "e544bb61997193e298daa64917d67e38419df64b5dd321778ec191c18883fae8"
                         location = None } },
                 [],
                 [ PT.EInt64(id, 5L) ]

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -125,6 +125,72 @@ let tEval (name : string) (input : string) (expected : RT.Dval) =
   }
 
 
+/// Parses `input` as a Darklang source file declaring one fn (the same path the
+/// CLI and LSP use to create package fns), registers it, then executes it with
+/// `arg` and asserts the result. Execution catches resolution bugs inside the fn
+/// body that a pretty-print roundtrip can't.
+let tEvalSourceFileFn
+  (name : string)
+  (input : string)
+  (arg : RT.Dval)
+  (expected : RT.Dval)
+  =
+  let parseFnName =
+    RT.FQFnName.fqPackage (
+      PackageRefs.Fn.LanguageTools.Parser.parsePTSourceFileWithOps ()
+    )
+
+  testTask name {
+    let! parseExeState = executionStateFor pmPT false Map.empty
+
+    let args = NEList.singleton (RT.DString input)
+    let! parseResult =
+      LibExecution.Execution.executeFunction parseExeState parseFnName [] args
+    let! parseDval = unwrapExecutionResult parseExeState parseResult |> Ply.toTask
+
+    match parseDval with
+    | RT.DEnum(tn, _, _, "Ok", [ RT.DTuple(_, opsList, []) ]) when
+      tn = Dval.resultType ()
+      ->
+      // register the declared fn, as the CLI does
+      let packageOps =
+        match opsList with
+        | RT.DList(_vt, ops) ->
+          ops |> List.choose LibExecution.ProgramTypesToDarkTypes.PackageOp.fromDT
+        | _ -> []
+      let enhancedPM = LibDB.PackageManager.withExtraOps pmPT packageOps
+
+      let fnHashes =
+        packageOps
+        |> List.choose (fun op ->
+          match op with
+          | PT.AddFn fn ->
+            let (PT.Hash hashStr) = fn.hash
+            Some hashStr
+          | _ -> None)
+
+      match fnHashes with
+      | [ hashStr ] ->
+        let! exeState = executionStateFor enhancedPM false Map.empty
+        let! actual =
+          LibExecution.Execution.executeFunction
+            exeState
+            (RT.FQFnName.fqPackage hashStr)
+            []
+            (NEList.singleton arg)
+        match actual with
+        | Ok result ->
+          return Expect.RT.equalDval result expected "Unexpected execution result"
+        | Error(rte, _) -> return failtest $"Evaluation failed: {rte}"
+      | hashes ->
+        return failtest $"Expected exactly one declared fn; got {List.length hashes}"
+
+    | RT.DEnum(tn, _, _, "Error", [ RT.DString errMsg ]) when tn = Dval.resultType () ->
+      return failtest $"Parse error: {errMsg}"
+    | _ -> return failtest $"Unexpected parse result format: {parseDval}"
+  }
+
+
 /// Uses `parseForCli` (the same parse path the CLI uses) because it surfaces
 /// `unparseableStuff` as `Result.Error`; `parsePTSourceFileWithOps` swallows
 /// per-declaration parse failures into a side list and returns Ok overall.
@@ -1196,6 +1262,19 @@ let exprs =
       false
     // TODO: this is ugly
     t "simple let expr" "let x = 1L\n  x" "let x =\n  1L\nx" [] [] [] false
+    // A nested function definition desugars to a lambda bound by a let, so the
+    // roundtrip is intentionally lossy: the param/return types are dropped and the
+    // `let f (x) = ...` sugar prints as `let f = (fun x -> ...)`. (Top-level
+    // `let f (x): R = ...` is a fn_decl and keeps its types - this only applies to
+    // a `let` nested inside an expression.)
+    t
+      "nested function definition (desugars to lambda)"
+      "let result =\n  let double (x: Int64): Int64 = x * 2L\n  double 5L\nresult"
+      "let result =\n  let double =\n    (fun x ->\n      (x) * (2L))\n  double 5L\nresult"
+      []
+      []
+      []
+      false
     t "let expr with indent" "let x =\n  1L\nx" "let x =\n  1L\nx" [] [] [] false
 
     t
@@ -2220,7 +2299,27 @@ Builtin.printLine (getTitle curiousGeorgeBookId)
       []
       []
       []
-      false ]
+      false
+
+    // In the CLI/LSP path, a nested recursive fn should resolve its own name as
+    // a local variable while WT2PT converts the body, not as an unresolved fn
+    // name. This test executes the fn so we catch that case directly.
+    tEvalSourceFileFn
+      "fn decl containing a nested recursive fn (CLI/LSP path)"
+      "let myRev (list: List<Int64>): List<Int64> =
+  let helper (l: List<Int64>) (acc: List<Int64>): List<Int64> =
+    match l with
+    | [] -> acc
+    | head :: tail -> helper tail (Stdlib.List.push acc head)
+  helper list []"
+      (RT.DList(
+        LibExecution.ValueType.int64,
+        [ RT.DInt64 1L; RT.DInt64 2L; RT.DInt64 3L ]
+      ))
+      (RT.DList(
+        LibExecution.ValueType.int64,
+        [ RT.DInt64 3L; RT.DInt64 2L; RT.DInt64 1L ]
+      )) ]
   |> testList "cli scripts"
 
 let tests =

--- a/backend/tests/Tests/PT2RT.Tests.fs
+++ b/backend/tests/Tests/PT2RT.Tests.fs
@@ -608,6 +608,7 @@ module Expr =
              { exprId = E.Pipes.pipeID
                patterns = NEList.ofList (RT.LPVariable 0) []
                registersToCloseOver = []
+               selfRegister = None
                instructions = { registerCount = 1; instructions = []; resultIn = 0 } }
            )
            RT.Apply(2, 1, [], NEList.ofList 0 []) ],
@@ -657,12 +658,13 @@ module Expr =
       t
         "let myLambda = fun x -> x + 1\n1 |> myLambda"
         E.Pipes.variable
-        (4,
+        (3,
          [ RT.CreateLambda(
              0,
              { exprId = E.Pipes.lambdaID
                patterns = NEList.ofList (RT.LPVariable 0) []
                registersToCloseOver = []
+               selfRegister = None
                instructions =
                  { registerCount = 4
                    instructions =
@@ -680,21 +682,21 @@ module Expr =
                        RT.Apply(3, 2, [], NEList.ofList 0 [ 1 ]) ]
                    resultIn = 3 } }
            )
-           RT.CheckLetPatternAndExtractVars(0, RT.LPVariable 1)
-           RT.LoadVal(2, RT.DInt64 1L)
-           RT.Apply(3, 1, [], NEList.ofList 2 []) ],
-         3)
+           RT.LoadVal(1, RT.DInt64 1L)
+           RT.Apply(2, 0, [], NEList.ofList 1 []) ],
+         2)
 
     let multiple =
       t
         "let incr = fun x -> x + 1\n2 |> incr |> fun x -> x * 2 |> Builtin.int64Add 3 |> (+) 4"
         E.Pipes.multiple
-        (12,
+        (11,
          [ RT.CreateLambda(
              0,
              { exprId = E.Pipes.lambdaID
                patterns = NEList.ofList (RT.LPVariable 0) []
                registersToCloseOver = []
+               selfRegister = None
                instructions =
                  { registerCount = 4
                    instructions =
@@ -712,14 +714,14 @@ module Expr =
                        RT.Apply(3, 2, [], NEList.ofList 0 [ 1 ]) ]
                    resultIn = 3 } }
            )
-           RT.CheckLetPatternAndExtractVars(0, RT.LPVariable 1)
-           RT.LoadVal(2, RT.DInt64 2L)
-           RT.Apply(3, 1, [], NEList.ofList 2 [])
+           RT.LoadVal(1, RT.DInt64 2L)
+           RT.Apply(2, 0, [], NEList.ofList 1 [])
            RT.CreateLambda(
-             4,
+             3,
              { exprId = E.Pipes.pipeID
                patterns = NEList.ofList (RT.LPVariable 0) []
                registersToCloseOver = []
+               selfRegister = None
                instructions =
                  { registerCount = 4
                    instructions =
@@ -737,11 +739,11 @@ module Expr =
                        RT.Apply(3, 2, [], NEList.ofList 0 [ 1 ]) ]
                    resultIn = 3 } }
            )
-           RT.Apply(5, 4, [], NEList.ofList 3 [])
+           RT.Apply(4, 3, [], NEList.ofList 2 [])
 
-           RT.LoadVal(6, RT.DInt64 3L)
+           RT.LoadVal(5, RT.DInt64 3L)
            RT.LoadVal(
-             7,
+             6,
              RT.DApplicable(
                RT.AppNamedFn
                  { name = RT.FQFnName.fqBuiltin "int64Add" 0
@@ -751,10 +753,10 @@ module Expr =
              )
            )
 
-           RT.Apply(8, 7, [], NEList.ofList 5 [ 6 ])
-           RT.LoadVal(9, RT.DInt64 4L)
+           RT.Apply(7, 6, [], NEList.ofList 4 [ 5 ])
+           RT.LoadVal(8, RT.DInt64 4L)
            RT.LoadVal(
-             10,
+             9,
              RT.DApplicable(
                RT.AppNamedFn
                  { name = RT.FQFnName.fqBuiltin "int64Add" 0
@@ -763,8 +765,8 @@ module Expr =
                    argsSoFar = [] }
              )
            )
-           RT.Apply(11, 10, [], NEList.ofList 8 [ 9 ]) ],
-         11)
+           RT.Apply(10, 9, [], NEList.ofList 7 [ 8 ]) ],
+         10)
 
 
 
@@ -1041,6 +1043,7 @@ module Expr =
                { exprId = E.Lambdas.Identity.id
                  patterns = NEList.ofList (RT.LPVariable 0) []
                  registersToCloseOver = []
+                 selfRegister = None
                  instructions =
                    { registerCount = 1; instructions = []; resultIn = 0 } }
              ) ],
@@ -1057,6 +1060,7 @@ module Expr =
                { exprId = E.Lambdas.Identity.id
                  patterns = NEList.ofList (RT.LPVariable 0) []
                  registersToCloseOver = []
+                 selfRegister = None
                  instructions =
                    { registerCount = 1; instructions = []; resultIn = 0 } }
              )
@@ -1076,6 +1080,7 @@ module Expr =
                { exprId = E.Lambdas.Add.id
                  patterns = NEList.ofList (RT.LPVariable 0) [ RT.LPVariable 1 ]
                  registersToCloseOver = []
+                 selfRegister = None
                  instructions =
                    { registerCount = 4
                      instructions =
@@ -1105,6 +1110,7 @@ module Expr =
                { exprId = E.Lambdas.Add.id
                  patterns = NEList.ofList (RT.LPVariable 0) [ RT.LPVariable 1 ]
                  registersToCloseOver = []
+                 selfRegister = None
                  instructions =
                    { registerCount = 4
                      instructions =
@@ -1137,6 +1143,7 @@ module Expr =
                { exprId = E.Lambdas.Add.id
                  patterns = NEList.ofList (RT.LPVariable 0) [ RT.LPVariable 1 ]
                  registersToCloseOver = []
+                 selfRegister = None
                  instructions =
                    { registerCount = 4
                      instructions =
@@ -1174,6 +1181,7 @@ module Expr =
                      (RT.LPTuple(RT.LPVariable 0, RT.LPVariable 1, []))
                      []
                  registersToCloseOver = []
+                 selfRegister = None
                  instructions =
                    { registerCount = 4
                      instructions =
@@ -1208,6 +1216,7 @@ module Expr =
                      (RT.LPTuple(RT.LPVariable 0, RT.LPVariable 1, []))
                      []
                  registersToCloseOver = []
+                 selfRegister = None
                  instructions =
                    { registerCount = 4
                      instructions =
@@ -1253,6 +1262,7 @@ module Expr =
                { exprId = E.Lambdas.AddToClosedVars.id
                  patterns = NEList.ofList (RT.LPVariable 0) []
                  registersToCloseOver = [ (1, 1); (3, 2) ]
+                 selfRegister = None
                  instructions =
                    { registerCount = 7
                      instructions =
@@ -1298,6 +1308,7 @@ module Expr =
                { exprId = E.Lambdas.AddToClosedVars.id
                  patterns = NEList.ofList (RT.LPVariable 0) []
                  registersToCloseOver = [ (1, 1); (3, 2) ]
+                 selfRegister = None
                  instructions =
                    { registerCount = 7
                      instructions =
@@ -1502,6 +1513,7 @@ module Expr =
                  { exprId = E.Fns.Package.MyFnThatTakesALambda.lambdaID
                    patterns = { head = RT.LPVariable 0; tail = [] }
                    registersToCloseOver = []
+                   selfRegister = None
                    instructions =
                      { registerCount = 4
                        instructions =

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -430,29 +430,86 @@ let parseEnumLiteral
       |> Stdlib.Result.Result.Ok)
 
 
+/// Converts a function-declaration parameter (`(x: Int64)` or `()`) into a
+/// LetPattern, dropping the type annotation. Used to desugar a nested function
+/// definition into a lambda.
+let letPatternFromFnParam
+  (node: ParsedNode)
+  : Stdlib.Result.Result<WrittenTypes.LetPattern, WrittenTypes.Unparseable> =
+  if node.typ == "unit" then
+    (WrittenTypes.LetPattern.LPUnit(node.range)) |> Stdlib.Result.Result.Ok
+  elif node.typ == "fn_decl_param" then
+    match findField node "identifier" with
+    | Ok ident ->
+      (WrittenTypes.LetPattern.LPVariable(ident.range, getText ident))
+      |> Stdlib.Result.Result.Ok
+    | Error _ -> createUnparseableError node
+  else
+    createUnparseableError node
+
+
 let parseLetExpr
   (node: ParsedNode)
   : Stdlib.Result.Result<WrittenTypes.Expr, WrittenTypes.Unparseable> =
   let keywordLetNode = findField node "keyword_let"
-  let patternNode = findField node "pattern"
   let symbolEqualsNode = findField node "symbol_equals"
   let expr = findAndParseRequired node "expr" Expr.parse
   let body = findAndParseRequired node "body" Expr.parse
 
-  match keywordLetNode, patternNode, symbolEqualsNode, expr, body with
-  | Ok keywordLet, Ok pattern, Ok symbolEquals, Ok expr, Ok body ->
-    match parseLetPattern pattern with
-    | Ok pattern ->
+  match keywordLetNode, symbolEqualsNode, expr, body with
+  | Ok keywordLet, Ok symbolEquals, Ok expr, Ok body ->
+    // a nested function definition (`let f (x: Int64) : Int64 = ...`) carries a
+    // `fn_name` + `params` instead of a `pattern` (the grammar restricts a fn name
+    // to a plain variable). Desugar it to a lambda bound by the let; the recursion
+    // and type-dropping then match the F# parser + PT2RT path. A plain let carries
+    // a `pattern` and binds the expr as-is.
+    let patternAndRhs =
+      match findField node "fn_name" with
+      | Ok fnName ->
+        let paramPats =
+          match findField node "params" with
+          | Ok paramsNode ->
+            paramsNode.children
+            |> Stdlib.List.map letPatternFromFnParam
+            |> Stdlib.Result.collect
+          | Error _ -> createUnparseableError node
+
+        match paramPats with
+        | Ok paramPats ->
+          let pattern =
+            WrittenTypes.LetPattern.LPVariable(fnName.range, getText fnName)
+
+          let lambda =
+            WrittenTypes.Expr.ELambda(
+              node.range,
+              paramPats,
+              expr,
+              keywordLet.range,
+              symbolEquals.range
+            )
+
+          (pattern, lambda) |> Stdlib.Result.Result.Ok
+        | Error _ -> createUnparseableError node
+
+      | Error _ ->
+        match findField node "pattern" with
+        | Ok patternNode ->
+          match parseLetPattern patternNode with
+          | Ok pattern -> (pattern, expr) |> Stdlib.Result.Result.Ok
+          | Error _ -> createUnparseableError node
+        | Error _ -> createUnparseableError node
+
+    match patternAndRhs with
+    | Ok((pattern, rhs)) ->
       (WrittenTypes.Expr.ELet(
         node.range,
         pattern,
-        expr,
+        rhs,
         body,
         keywordLet.range,
         symbolEquals.range
       ))
       |> Stdlib.Result.Result.Ok
-
     | Error _ -> createUnparseableError node
 
   | _ -> createUnparseableError node

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -705,7 +705,19 @@ module Expr =
 
     // declaring and accessing variables
     | ELet(_, pat, rhs, body, _, _) ->
-      let (rhs, rhsUnresolvedNames) = toPT ctx context rhs
+      // If a let-bound lambda refers to its own name, treat that name as a
+      // local while converting the rhs so recursion becomes an `EVariable`.
+      // Resolved package names still stay resolved.
+      let rhsContext =
+        match (pat, rhs) with
+        | (LPVariable(_, name), ELambda(_, _, _, _, _)) ->
+          Context
+            { currentFnName = context.currentFnName
+              argMap = context.argMap
+              localBindings = Stdlib.List.push context.localBindings name }
+        | _ -> context
+
+      let (rhs, rhsUnresolvedNames) = toPT ctx rhsContext rhs
 
       // Get the new context from LetPattern processing
       let (bodyContext, ptPattern) = LetPattern.toPT context pat

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -51,14 +51,14 @@ let last (list: List<'a>) : Option.Option<'a> =
     | _ -> last tail
 
 
-// Todo: inline as a nested helper fn once Dark supports local function definitions
-let reverseHelper (list: List<'a>) (acc: List<'a>) : List<'a> =
-  match list with
-  | [] -> acc
-  | head :: tail -> reverseHelper tail (push acc head)
-
 /// Returns a reversed copy of <param list>
-let reverse (list: List<'a>) : List<'a> = reverseHelper list []
+let reverse (list: List<'a>) : List<'a> =
+  let reverseHelper (list: List<'a>) (acc: List<'a>) : List<'a> =
+    match list with
+    | [] -> acc
+    | head :: tail -> reverseHelper tail (push acc head)
+
+  reverseHelper list []
 
 
 /// Returns {{Some firstMatch}} where <var firstMatch> is the first value of the

--- a/tree-sitter-darklang/grammar.js
+++ b/tree-sitter-darklang/grammar.js
@@ -857,7 +857,21 @@ module.exports = grammar({
     let_expression: $ =>
       seq(
         field("keyword_let", alias("let", $.keyword)),
-        field("pattern", $.let_pattern),
+        choice(
+          // a nested function definition: `let f (x: Int64) : Int64 = ...`. Only
+          // a plain variable can name a fn (not unit or a tuple pattern). The
+          // params/return-type are parsed but dropped when desugaring to a lambda
+          // (lambdas are untyped); see parser/expr.dark.
+          seq(
+            field("fn_name", $.variable_identifier),
+            optional(field("type_params", $.type_params)),
+            field("params", $.fn_decl_params),
+            field("symbol_colon", alias(":", $.symbol)),
+            field("return_type", $.type_reference),
+          ),
+          // a plain let binding: `let <pattern> = ...`
+          field("pattern", $.let_pattern),
+        ),
         field("symbol_equals", alias("=", $.symbol)),
         choice(
           seq(field("expr", $.expression), "\n"),

--- a/tree-sitter-darklang/src/grammar.json
+++ b/tree-sitter-darklang/src/grammar.json
@@ -4839,12 +4839,75 @@
           }
         },
         {
-          "type": "FIELD",
-          "name": "pattern",
-          "content": {
-            "type": "SYMBOL",
-            "name": "let_pattern"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "fn_name",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "variable_identifier"
+                  }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "FIELD",
+                      "name": "type_params",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "type_params"
+                      }
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "FIELD",
+                  "name": "params",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "fn_decl_params"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "symbol_colon",
+                  "content": {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "STRING",
+                      "value": ":"
+                    },
+                    "named": true,
+                    "value": "symbol"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "return_type",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "type_reference"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "pattern",
+              "content": {
+                "type": "SYMBOL",
+                "name": "let_pattern"
+              }
+            }
+          ]
         },
         {
           "type": "FIELD",

--- a/tree-sitter-darklang/src/node-types.json
+++ b/tree-sitter-darklang/src/node-types.json
@@ -1481,6 +1481,16 @@
           }
         ]
       },
+      "fn_name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "variable_identifier",
+            "named": true
+          }
+        ]
+      },
       "keyword_let": {
         "multiple": false,
         "required": true,
@@ -1491,12 +1501,42 @@
           }
         ]
       },
+      "params": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "fn_decl_params",
+            "named": true
+          }
+        ]
+      },
       "pattern": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "let_pattern",
+            "named": true
+          }
+        ]
+      },
+      "return_type": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_reference",
+            "named": true
+          }
+        ]
+      },
+      "symbol_colon": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "symbol",
             "named": true
           }
         ]
@@ -1507,6 +1547,16 @@
         "types": [
           {
             "type": "symbol",
+            "named": true
+          }
+        ]
+      },
+      "type_params": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_params",
             "named": true
           }
         ]

--- a/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
+++ b/tree-sitter-darklang/test/corpus/exhaustive/exprs/let_expr.txt
@@ -309,3 +309,407 @@ x
     )
   )
 )
+
+==================
+let expression with nested function definition
+==================
+
+(let double (x: Int64) : Int64 = x * 2L
+ double 5L)
+---
+
+(source_file
+  (expression
+    (simple_expression
+      (paren_expression
+        (symbol)
+        (expression
+          (let_expression
+            (keyword)
+            (variable_identifier)
+            (fn_decl_params
+              (fn_decl_param
+                (symbol) (variable_identifier) (symbol)
+                (type_reference (builtin_type))
+                (symbol)))
+            (symbol)
+            (type_reference (builtin_type))
+            (symbol)
+            (expression
+              (simple_expression
+                (infix_operation
+                  (simple_expression (variable_identifier))
+                  (operator)
+                  (simple_expression
+                    (int64_literal (digits (positive_digits)) (symbol))))))
+            (expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name (fn_identifier))
+                  (int64_literal (digits (positive_digits)) (symbol)))))))
+        (symbol)))))
+
+================================================================================
+nested function definition - multiple params
+================================================================================
+
+(let combine (x: Int64) (y: Int64) : Int64 =
+   x + y
+ combine 1L 2L)
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression
+    (simple_expression
+      (paren_expression
+        (symbol)
+        (expression
+          (let_expression
+            (keyword)
+            (variable_identifier)
+            (fn_decl_params
+              (fn_decl_param
+                (symbol)
+                (variable_identifier)
+                (symbol)
+                (type_reference
+                  (builtin_type))
+                (symbol))
+              (fn_decl_param
+                (symbol)
+                (variable_identifier)
+                (symbol)
+                (type_reference
+                  (builtin_type))
+                (symbol)))
+            (symbol)
+            (type_reference
+              (builtin_type))
+            (symbol)
+            (indent)
+            (expression
+              (simple_expression
+                (infix_operation
+                  (simple_expression
+                    (variable_identifier))
+                  (operator)
+                  (simple_expression
+                    (variable_identifier)))))
+            (dedent)
+            (expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name
+                    (fn_identifier))
+                  (int64_literal
+                    (digits
+                      (positive_digits))
+                    (symbol))
+                  (int64_literal
+                    (digits
+                      (positive_digits))
+                    (symbol)))))))
+        (symbol)))))
+
+================================================================================
+nested function definition - unit param
+================================================================================
+
+(let getFive () : Int64 = 5L
+ getFive ())
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression
+    (simple_expression
+      (paren_expression
+        (symbol)
+        (expression
+          (let_expression
+            (keyword)
+            (variable_identifier)
+            (fn_decl_params
+              (unit))
+            (symbol)
+            (type_reference
+              (builtin_type))
+            (symbol)
+            (expression
+              (simple_expression
+                (int64_literal
+                  (digits
+                    (positive_digits))
+                  (symbol))))
+            (expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name
+                    (fn_identifier))
+                  (unit))))))
+        (symbol)))))
+
+================================================================================
+nested function definition - generic type annotations
+================================================================================
+
+(let rev (list: List<'a>) (acc: List<'a>) : List<'a> =
+   acc
+ rev [ 1L ] [])
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression
+    (simple_expression
+      (paren_expression
+        (symbol)
+        (expression
+          (let_expression
+            (keyword)
+            (variable_identifier)
+            (fn_decl_params
+              (fn_decl_param
+                (symbol)
+                (variable_identifier)
+                (symbol)
+                (type_reference
+                  (builtin_type
+                    (list_type_reference
+                      (keyword)
+                      (symbol)
+                      (type_reference
+                        (builtin_type
+                          (variable_type_reference
+                            (symbol)
+                            (variable_identifier))))
+                      (symbol))))
+                (symbol))
+              (fn_decl_param
+                (symbol)
+                (variable_identifier)
+                (symbol)
+                (type_reference
+                  (builtin_type
+                    (list_type_reference
+                      (keyword)
+                      (symbol)
+                      (type_reference
+                        (builtin_type
+                          (variable_type_reference
+                            (symbol)
+                            (variable_identifier))))
+                      (symbol))))
+                (symbol)))
+            (symbol)
+            (type_reference
+              (builtin_type
+                (list_type_reference
+                  (keyword)
+                  (symbol)
+                  (type_reference
+                    (builtin_type
+                      (variable_type_reference
+                        (symbol)
+                        (variable_identifier))))
+                  (symbol))))
+            (symbol)
+            (indent)
+            (expression
+              (simple_expression
+                (variable_identifier)))
+            (dedent)
+            (expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name
+                    (fn_identifier))
+                  (list_literal
+                    (symbol)
+                    (list_content
+                      (expression
+                        (simple_expression
+                          (int64_literal
+                            (digits
+                              (positive_digits))
+                            (symbol)))))
+                    (symbol))
+                  (list_literal
+                    (symbol)
+                    (symbol)))))))
+        (symbol)))))
+
+================================================================================
+nested function definition - indented recursive body
+================================================================================
+
+(let fact (n: Int64) : Int64 =
+   if n <= 1L then 1L else fact (n - 1L)
+ fact 5L)
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression
+    (simple_expression
+      (paren_expression
+        (symbol)
+        (expression
+          (let_expression
+            (keyword)
+            (variable_identifier)
+            (fn_decl_params
+              (fn_decl_param
+                (symbol)
+                (variable_identifier)
+                (symbol)
+                (type_reference
+                  (builtin_type))
+                (symbol)))
+            (symbol)
+            (type_reference
+              (builtin_type))
+            (symbol)
+            (indent)
+            (expression
+              (if_expression
+                (keyword)
+                (expression
+                  (simple_expression
+                    (infix_operation
+                      (simple_expression
+                        (variable_identifier))
+                      (operator)
+                      (simple_expression
+                        (int64_literal
+                          (digits
+                            (positive_digits))
+                          (symbol))))))
+                (keyword)
+                (expression
+                  (simple_expression
+                    (int64_literal
+                      (digits
+                        (positive_digits))
+                      (symbol))))
+                (keyword)
+                (expression
+                  (simple_expression
+                    (apply
+                      (qualified_fn_name
+                        (fn_identifier))
+                      (paren_expression
+                        (symbol)
+                        (expression
+                          (simple_expression
+                            (infix_operation
+                              (simple_expression
+                                (variable_identifier))
+                              (operator)
+                              (simple_expression
+                                (int64_literal
+                                  (digits
+                                    (positive_digits))
+                                  (symbol))))))
+                        (symbol)))))))
+            (dedent)
+            (expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name
+                    (fn_identifier))
+                  (int64_literal
+                    (digits
+                      (positive_digits))
+                    (symbol)))))))
+        (symbol)))))
+
+================================================================================
+nested function sugar on a non-variable pattern is invalid
+================================================================================
+
+(let () (x: Int64) : Int64 = x
+ 5L)
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression
+    (simple_expression
+      (paren_expression
+        (symbol)
+        (ERROR
+          (keyword)
+          (ERROR
+            (let_pattern
+              (unit)))
+          (symbol)
+          (let_pattern
+            (variable_identifier))
+          (symbol)
+          (symbol)
+          (symbol)
+          (symbol)
+          (UNEXPECTED 'x'))
+        (expression
+          (simple_expression
+            (int64_literal
+              (digits
+                (positive_digits))
+              (symbol))))
+        (symbol)))))
+
+================================================================================
+nested function definition - explicit type params
+================================================================================
+
+(let identity<'a> (x: 'a) : 'a =
+   x
+ identity 5L)
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression
+    (simple_expression
+      (paren_expression
+        (symbol)
+        (expression
+          (let_expression
+            (keyword)
+            (variable_identifier)
+            (type_params
+              (symbol)
+              (type_params_items
+                (variable_type_reference
+                  (symbol)
+                  (variable_identifier)))
+              (symbol))
+            (fn_decl_params
+              (fn_decl_param
+                (symbol)
+                (variable_identifier)
+                (symbol)
+                (type_reference
+                  (builtin_type
+                    (variable_type_reference
+                      (symbol)
+                      (variable_identifier))))
+                (symbol)))
+            (symbol)
+            (type_reference
+              (builtin_type
+                (variable_type_reference
+                  (symbol)
+                  (variable_identifier))))
+            (symbol)
+            (indent)
+            (expression
+              (simple_expression
+                (variable_identifier)))
+            (dedent)
+            (expression
+              (simple_expression
+                (apply
+                  (qualified_fn_name
+                    (fn_identifier))
+                  (int64_literal
+                    (digits
+                      (positive_digits))
+                    (symbol)))))))
+        (symbol)))))


### PR DESCRIPTION
This PR adds support for nested function definitions.
You can now define a helper function inside a function body, instead of only at the package top level:

```fsharp
let reverse (list: List<'a>) : List<'a> =
  let reverseHelper (list: List<'a>) (acc: List<'a>) : List<'a> =
    match list with
    | [] -> acc
    | head :: tail -> reverseHelper tail (push acc head)

  reverseHelper list []
```

The `let f (x: T) : R = ...` form is now a variant of the regular let expression, so it works anywhere a let can appear (function bodies, match arms, lambda bodies, etc.).

How it works
- Desugars to a let-bound lambda; type annotations are parsed but dropped at runtime (lambdas are untyped)
- Self-recursion is supported - a nested fn can call itself by name

Limitations
- A nested fn whose name collides with a fn/value already in scope is rejected 
- Mutual recursion between nested fns isn't supported - calling a nested fn defined later gives a "forward calls between nested functions aren't supported" error 
