### PR TITLE
`dark apps` — a daemon / foreground / ui launch model

### DIFF
--- a/backend/testfiles/execution/cli/apps.dark
+++ b/backend/testfiles/execution/cli/apps.dark
@@ -1,0 +1,13 @@
+// `Darklang.Apps` — the pure helpers (kind tags + the install-string builders). The daemon lifecycle
+// + the install write step need a live env; these are testable here.
+
+// kindTag — the three launch kinds render to stable tags
+Darklang.Apps.kindTag Darklang.Apps.AppKind.Daemon = "daemon"
+Darklang.Apps.kindTag Darklang.Apps.AppKind.Foreground = "foreground"
+Darklang.Apps.kindTag Darklang.Apps.AppKind.Ui = "ui"
+
+// (findByName is exercised live via `dark apps list`; it reads the `all` package-VALUE registry,
+//  which the .dark testfile harness can't resolve — so it's covered at the CLI layer, not here.)
+
+// aliasPath — one dir on PATH, so uninstall is one file
+Darklang.Apps.aliasPath "ui-demo" = "~/.darklang/bin/ui-demo"

--- a/packages/darklang/apps-examples.dark
+++ b/packages/darklang/apps-examples.dark
@@ -1,0 +1,29 @@
+module Darklang.Apps.Examples
+
+// The reference DAEMON entrypoint — a self-contained heartbeat. `dark apps start heartbeat` launches
+// it detached; it claims its pidfile, then logs a line every interval until `apps stop` SIGTERMs it.
+// Proves the daemon management surface end to end.
+
+// One beat: log the time + pid, sleep the interval, recurse. `remaining` is a very large step count
+// (≈ forever); the daemon is meant to be ended by `apps stop` (SIGTERM), not by running out.
+let beat (name: String) (intervalMs: Int64) (remaining: Int64) : Int64 =
+  if remaining <= 0L then
+    0L
+  else
+    let pid = Stdlib.Cli.Sys.currentPid ()
+    Stdlib.printLine $"{name}: beat (pid {Stdlib.Int64.toString pid})"
+    Stdlib.Cli.Posix.sleep (Stdlib.Int64.toFloat intervalMs)
+    Darklang.Apps.Examples.beat name intervalMs (remaining - 1L)
+
+
+// The daemon entrypoint: claim the pidfile (recording THIS detached process's pid), then beat
+// forever. Invoked as `Darklang.Apps.Examples.heartbeat "heartbeat" 5000L` by `apps start`.
+let heartbeat (name: String) (intervalMs: Int64) : Int64 =
+  let _logged =
+    match Darklang.Cli.Daemons.claimPidfile name with
+    | Error e -> Stdlib.printLine $"{name}: could not write pidfile: {e}"
+    | Ok _ ->
+      Stdlib.printLine
+        $"{name}: started (pid {Stdlib.Int64.toString (Stdlib.Cli.Sys.currentPid ())}, interval {Stdlib.Int64.toString intervalMs}ms)"
+
+  Darklang.Apps.Examples.beat name intervalMs 1000000000L

--- a/packages/darklang/apps.dark
+++ b/packages/darklang/apps.dark
@@ -1,0 +1,103 @@
+module Darklang.Apps
+
+// An App — the thin manifest `dark apps` lists, installs, and (for daemons) manages. One surface
+// covers three launch kinds:
+//
+//   Daemon      a backgrounded long-runner, managed via a pidfile (start/stop/status/logs). Detached.
+//   Foreground  a normal `dark run <entrypoint>` that does its job and finishes (e.g. ui-demo).
+//   Ui          a full-screen TUI that runs ATTACHED until you quit (e.g. the outliner).
+//
+// An App is a package VALUE, so it's discoverable + shareable like any other value. This PR lists a
+// static `all` registry; value-index discovery is a follow-up.
+
+type AppKind =
+  | Daemon
+  | Foreground
+  | Ui
+
+type App =
+  { name: String
+    // The fn the app runs. Daemon: the loop entrypoint (invoked via `eval`, detached); Foreground:
+    // the `dark run` target; Ui: the interactive app fn.
+    entrypoint: String
+    description: String
+    kind: AppKind }
+
+
+let kindTag (kind: AppKind) : String =
+  match kind with
+  | Daemon -> "daemon"
+  | Foreground -> "foreground"
+  | Ui -> "ui"
+
+
+// ── the registry ── (static for now; a value-index is the follow-up)
+
+// heartbeat — a self-contained DAEMON: a detached process that logs a line every interval until
+// `apps stop`. The reference daemon — proves start/stop/status/logs end to end.
+let heartbeat : App =
+  App
+    { name = "heartbeat"
+      entrypoint = "Darklang.Apps.Examples.heartbeat"
+      description = "A demo daemon: log a heartbeat every interval until stopped"
+      kind = AppKind.Daemon }
+
+
+// outliner — the interactive tree-outliner TUI (runs attached).
+let outliner : App =
+  App
+    { name = "outliner"
+      entrypoint = "Darklang.Cli.Apps.Outliner.App.execute"
+      description = "Interactive tree outliner (full-screen TUI)"
+      kind = AppKind.Ui }
+
+
+// review — review a branch's changesets (TUI).
+let review : App =
+  App
+    { name = "review"
+      entrypoint = "Darklang.Cli.Apps.Review.App.execute"
+      description = "Review branch changesets"
+      kind = AppKind.Ui }
+
+
+// views — browse + preview the CLI's views (TUI).
+let views : App =
+  App
+    { name = "views"
+      entrypoint = "Darklang.Cli.Apps.Views.App.execute"
+      description = "Browse and preview CLI views"
+      kind = AppKind.Ui }
+
+
+// ui-demo — render the UI component gallery, then exit (a FOREGROUND `dark run`).
+let uiDemo : App =
+  App
+    { name = "ui-demo"
+      entrypoint = "Darklang.CLI.UI.Demo.run"
+      description = "Render the UI component gallery (a visual check)"
+      kind = AppKind.Foreground }
+
+
+// Every declared app. `dark apps list` iterates this.
+let all : List<App> =
+  [ Darklang.Apps.heartbeat
+    Darklang.Apps.outliner
+    Darklang.Apps.review
+    Darklang.Apps.views
+    Darklang.Apps.uiDemo ]
+
+
+let findByName (name: String) : Stdlib.Option.Option<App> =
+  Stdlib.List.findFirst Darklang.Apps.all (fun a -> a.name == name)
+
+
+// ── install ── the PATH shim `dark apps install` writes (the write step needs a live env).
+
+// the shim: typing `<app> …` runs the app's entrypoint via `dark run`.
+let aliasShim (entrypoint: String) : String =
+  "#!/bin/sh\nexec dark run " ++ entrypoint ++ " \"$@\"\n"
+
+// where the shim is written — one dir on PATH, so uninstall is one file.
+let aliasPath (appName: String) : String =
+  "~/.darklang/bin/" ++ appName

--- a/packages/darklang/cli/commands/apps.dark
+++ b/packages/darklang/cli/commands/apps.dark
@@ -1,0 +1,150 @@
+module Darklang.Cli.Commands.Apps
+
+// `dark apps` — list + install the apps declared in `Darklang.Apps`, and start/stop/status/logs the
+// daemon ones via the generic pidfile manager (`Darklang.Cli.Daemons`). Foreground apps run with
+// `dark run`; UI apps run attached — the listing says which.
+
+let defaultIntervalMs = 5000L
+
+// One `apps list` row: name, [kind], description — and for daemons, the live running/stopped state.
+let listRow (app: Darklang.Apps.App) : String =
+  let tag = Darklang.Apps.kindTag app.kind
+  let state =
+    match app.kind with
+    | Daemon -> "  (" ++ (if Darklang.Cli.Daemons.isRunning app.name then "running" else "stopped") ++ ")"
+    | Foreground -> ""
+    | Ui -> ""
+
+  $"  {app.name}  [{tag}]  {app.description}{state}"
+
+
+let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
+  match args with
+  | [] | [ "list" ] ->
+    Stdlib.printLine "Apps:"
+    Darklang.Apps.all
+    |> Stdlib.List.map (fun app -> Commands.Apps.listRow app)
+    |> Stdlib.printLines
+
+    Stdlib.printLine ""
+    Stdlib.printLine
+      (Colors.dimText "  daemons: `apps start/stop/status/logs <name>`  ·  others: `dark run <entrypoint>`")
+    state
+
+  | [ "status" ] ->
+    let daemons = Darklang.Apps.all |> Stdlib.List.filter (fun a -> a.kind == Darklang.Apps.AppKind.Daemon)
+
+    if Stdlib.List.isEmpty daemons then
+      Stdlib.printLine (Colors.dimText "no daemon apps declared")
+    else
+      Stdlib.printLine "Daemon status:"
+      daemons
+      |> Stdlib.List.map (fun a -> "  " ++ Darklang.Cli.Daemons.statusLine a.name)
+      |> Stdlib.printLines
+
+    state
+
+  | [ "install"; name ] ->
+    match Darklang.Apps.findByName name with
+    | None -> Stdlib.printLine (Colors.error $"no app named '{name}' (see `apps list`)")
+    | Some app ->
+      Stdlib.printLine $"Install plan for '{app.name}' [{Darklang.Apps.kindTag app.kind}]:"
+      Stdlib.printLine $"  alias path:  {Darklang.Apps.aliasPath app.name}"
+      Stdlib.printLine $"  shim:        exec dark run {app.entrypoint} \"$@\""
+      Stdlib.printLine (Colors.dimText "  (preview; the write step needs a live env)")
+
+    state
+
+  | [ "start"; name ] -> Commands.Apps.startDaemon state name Commands.Apps.defaultIntervalMs
+
+  | [ "start"; name; intervalStr ] ->
+    match Stdlib.Int64.parse intervalStr with
+    | Ok ms -> Commands.Apps.startDaemon state name ms
+    | Error _ ->
+      Stdlib.printLine (Colors.error $"interval must be a number of ms, got '{intervalStr}'")
+      state
+
+  | [ "stop"; name ] ->
+    match Darklang.Cli.Daemons.stop name with
+    | Ok msg -> Stdlib.printLine (Colors.success msg)
+    | Error e -> Stdlib.printLine (Colors.error e)
+
+    state
+
+  | [ "logs"; name ] ->
+    let lines = Darklang.Cli.Daemons.tailLog name 20L
+
+    if Stdlib.List.isEmpty lines then
+      Stdlib.printLine (Colors.dimText $"no logs for '{name}' (has it run?)")
+    else
+      Stdlib.printLines lines
+
+    state
+
+  | _ ->
+    Stdlib.printLine
+      (Colors.error
+        "Usage: apps [list] | install <name> | status | start <name> [intervalMs] | stop <name> | logs <name>")
+    state
+
+
+// Start an app by name. Only DAEMON apps detach via the pidfile manager; foreground/UI apps are run
+// differently and `start` explains how rather than backgrounding a one-shot or a TUI.
+let startDaemon (state: Cli.AppState) (name: String) (intervalMs: Int64) : Cli.AppState =
+  match Darklang.Apps.findByName name with
+  | None -> Stdlib.printLine (Colors.error $"no app named '{name}' (see `apps list`)")
+  | Some app ->
+    match app.kind with
+    | Daemon ->
+      // build the detached entrypoint expression: `<entrypoint> "<name>" <intervalMs>L`
+      let q = "\""
+      let expr =
+        app.entrypoint ++ " " ++ q ++ name ++ q ++ " " ++ (Stdlib.Int64.toString intervalMs) ++ "L"
+
+      let okMsg =
+        $"{name} launching (interval {Stdlib.Int64.toString intervalMs}ms) — `apps status` to confirm"
+
+      match Darklang.Cli.Daemons.start name expr okMsg with
+      | Ok msg -> Stdlib.printLine (Colors.success msg)
+      | Error e -> Stdlib.printLine (Colors.error e)
+    | Foreground ->
+      Stdlib.printLine
+        (Colors.dimText $"'{name}' is a foreground app — run it with `dark run {app.entrypoint}`")
+    | Ui ->
+      Stdlib.printLine
+        (Colors.dimText $"'{name}' is a UI app — it runs attached; launch it from the CLI (e.g. `{name}`)")
+
+  state
+
+
+let complete
+  (_state: Cli.AppState)
+  (_args: List<String>)
+  : List<Cli.Completion.CompletionItem> =
+  [ Cli.Completion.simple "list"
+    Cli.Completion.simple "install"
+    Cli.Completion.simple "status"
+    Cli.Completion.simple "start"
+    Cli.Completion.simple "stop"
+    Cli.Completion.simple "logs" ]
+
+
+let help (state: Cli.AppState) : Cli.AppState =
+  [ "Usage: apps [list] | apps install <name> | apps status | apps start/stop/logs <name>"
+    ""
+    "List, install, and manage declared apps. Three kinds, one surface:"
+    "  daemon       backgrounded long-runner — start/stop/status/logs manage it via a pidfile"
+    "  foreground   a normal `dark run` that finishes (e.g. print-md)"
+    "  ui           an interactive full-screen TUI that runs attached (e.g. the outliner)"
+    ""
+    "  list                       Show every app: name, [kind], description (+ daemon state)"
+    "  install <name>             Preview the install plan (PATH shim)"
+    "  status                     Show each daemon's running/stopped/stale state"
+    "  start <name> [intervalMs]  Launch a daemon detached (pidfile-tracked)"
+    "  stop <name>                SIGTERM a daemon and clear its pidfile"
+    "  logs <name>                Show a daemon's last 20 log lines"
+    ""
+    "Foreground apps run with `dark run <entrypoint>`; UI apps run attached." ]
+  |> Stdlib.printLines
+
+  state

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -273,7 +273,8 @@ module Registry =
       ("review", "Review branch changesets", [], Darklang.Cli.Apps.Review.App.execute, Darklang.Cli.Apps.Review.App.help, Darklang.Cli.Apps.Review.App.complete)
       ("views", "Browse and preview CLI views", [], Darklang.Cli.Apps.Views.App.execute, Darklang.Cli.Apps.Views.App.help, Darklang.Cli.Apps.Views.App.complete)
       ("login", "Log in as a seeded account (required for commit / serve)", [], Commands.Login.execute, Commands.Login.help, Commands.Login.complete)
-      ("logout", "Clear the active account", [], Commands.Logout.execute, Commands.Logout.help, Commands.Logout.complete) ]
+      ("logout", "Clear the active account", [], Commands.Logout.execute, Commands.Logout.help, Commands.Logout.complete)
+      ("apps", "List, install, and manage apps (daemons, foreground, UI)", [], Commands.Apps.execute, Commands.Apps.help, Commands.Apps.complete) ]
     |> Stdlib.List.map(
       // CLEANUP nitpicky: swap help and complete
       fun (name, desc, aliases, execute, help, complete) ->
@@ -351,6 +352,7 @@ module Registry =
       ("Execution", [ "run"; "eval"; "scripts" ])
       ("Installation", [ "install"; "update"; "uninstall"; "version" ])
       ("AI", [ "agent" ])
+      ("Apps", [ "apps" ])
       ("Utilities", [ "clear"; "help"; "docs"; "quit"; "builtins"; "export-seed"; "views" ]) ]
 
   // Helper function to format a group of commands with details

--- a/packages/darklang/cli/daemons.dark
+++ b/packages/darklang/cli/daemons.dark
@@ -1,0 +1,130 @@
+module Darklang.Cli.Daemons
+
+// Background-daemon process management for the Dark CLI. A daemon is a DETACHED `dark` process
+// tracked by a pidfile, so the launching CLI can exit and the daemon keeps running. Built on the
+// POSIX stdlib: pidfile via `Stdlib.Cli.File`, signal-0 liveness via `Posix.isProcessRunning`,
+// detached launch + SIGTERM via `Process`/`Posix`. Generic — it manages ANY named daemon; the
+// caller supplies the entrypoint expression.
+
+// ── pidfile + log location ──  ~/.darklang/run/<name>.{pid,log}
+let runDir () : String =
+  let home = Stdlib.Option.withDefault (Stdlib.Cli.Env.home ()) "/tmp"
+  home ++ "/.darklang/run"
+
+let pidfilePath (name: String) : String =
+  (runDir ()) ++ "/" ++ name ++ ".pid"
+
+// A detached daemon has no terminal, so its output + startup errors append here; `logs` reads it.
+let logPath (name: String) : String =
+  (runDir ()) ++ "/" ++ name ++ ".log"
+
+// The daemon's last `n` log lines (newest at the bottom); empty if it never logged.
+let tailLog (name: String) (n: Int64) : List<String> =
+  match Stdlib.Cli.File.readLines (logPath name) with
+  | Ok lines ->
+    let total = Stdlib.List.length lines
+    if total <= n then lines else Stdlib.List.drop lines (total - n)
+  | Error _ -> []
+
+
+// Record THIS process as the named daemon. The entrypoint calls this on startup, so the pidfile
+// holds the real detached-worker pid, not a transient launcher.
+let claimPidfile (name: String) : Stdlib.Result.Result<Unit, String> =
+  match Stdlib.Cli.Posix.mkdirRecursive (runDir ()) with
+  | Error e -> Stdlib.Result.Result.Error e.message
+  | Ok _ ->
+    let pid = Stdlib.Cli.Sys.currentPid ()
+
+    match Stdlib.Cli.File.writeText (pidfilePath name) (Stdlib.Int64.toString pid) with
+    | Error e -> Stdlib.Result.Result.Error e.message
+    | Ok _ -> Stdlib.Result.Result.Ok()
+
+
+// The pid recorded for a daemon, if its pidfile exists and parses.
+let recordedPid (name: String) : Stdlib.Option.Option<Int64> =
+  let path = pidfilePath name
+
+  if Stdlib.Cli.File.exists path then
+    match Stdlib.Cli.File.readText path with
+    | Ok content -> Stdlib.Result.toOption (Stdlib.Int64.parse (Stdlib.String.trim content))
+    | Error _ -> Stdlib.Option.Option.None
+  else
+    Stdlib.Option.Option.None
+
+
+// Alive? pidfile present AND that pid is a running process (signal-0) — so a stale pidfile (daemon
+// killed without cleanup) correctly reads as not running.
+let isRunning (name: String) : Bool =
+  match recordedPid name with
+  | Some pid -> Stdlib.Cli.Posix.isProcessRunning pid
+  | None -> false
+
+
+// One status line: running / stopped / stale (pidfile present but its pid is dead).
+let statusLine (name: String) : String =
+  match recordedPid name with
+  | Some pid ->
+    if Stdlib.Cli.Posix.isProcessRunning pid then
+      $"{name}: running (pid {Stdlib.Int64.toString pid})"
+    else
+      $"{name}: stale (pid {Stdlib.Int64.toString pid} not running — `stop` clears it)"
+  | None -> $"{name}: stopped"
+
+
+// Stop the named daemon: SIGTERM the recorded pid (if alive), then remove the pidfile. Idempotent.
+let stop (name: String) : Stdlib.Result.Result<String, String> =
+  match recordedPid name with
+  | None -> Stdlib.Result.Result.Ok $"{name}: not running"
+  | Some pid ->
+    let wasRunning = Stdlib.Cli.Posix.isProcessRunning pid
+
+    let _killed =
+      if wasRunning then
+        Stdlib.Cli.Posix.kill pid Stdlib.Cli.Posix.sigterm
+      else
+        Stdlib.Result.Result.Ok()
+
+    let _removed = Stdlib.Cli.File.delete (pidfilePath name)
+
+    if wasRunning then
+      Stdlib.Result.Result.Ok $"{name}: stopped (pid {Stdlib.Int64.toString pid})"
+    else
+      Stdlib.Result.Result.Ok
+        $"{name}: cleared stale pidfile (pid {Stdlib.Int64.toString pid} was not running)"
+
+
+// ── launch ──
+
+// The `dark` launcher to re-invoke for the detached child: `dark` is on PATH in production; in a
+// dev container the built Cli exe isn't named `dark`, so DARK_CLI overrides the launcher path.
+let launcher () : String =
+  match Stdlib.Cli.Posix.getenv "DARK_CLI" with
+  | Some path -> path
+  | None -> "dark"
+
+
+// Spawn `expr` DETACHED so it survives this CLI exiting: `nohup … &` backgrounds it + shields it
+// from hangups, the launching `sh -c` returns immediately, and the child reparents to init. Output
+// appends to the daemon's logfile. The entrypoint must `claimPidfile name` first.
+let launchDetached
+  (name: String)
+  (expr: String)
+  (okMsg: String)
+  : Stdlib.Result.Result<String, String> =
+  let cmd = $"nohup {launcher ()} eval '{expr}' >> {logPath name} 2>&1 &"
+
+  match Stdlib.Cli.Process.exec "/bin/sh" [ "-c"; cmd ] with
+  | Ok _ -> Stdlib.Result.Result.Ok okMsg
+  | Error e -> Stdlib.Result.Result.Error $"failed to launch {name}: {e}"
+
+
+// Launch a named daemon detached, running `entrypointExpr`. Refuses if it's already running.
+let start
+  (name: String)
+  (entrypointExpr: String)
+  (okMsg: String)
+  : Stdlib.Result.Result<String, String> =
+  if isRunning name then
+    Stdlib.Result.Result.Error $"{name} is already running (see `status`)"
+  else
+    Darklang.Cli.Daemons.launchDetached name entrypointExpr okMsg


### PR DESCRIPTION
The one surface that lists, installs, and runs Apps — covering **both** background daemons **and** interactive UI apps, so the same `dark apps` manages the sync daemon, a print-md run, and the outliner TUI alike. An App is a package VALUE, so the manifest syncs like any other value.

## The thin manifest + the three kinds

```fsharp
type AppKind = | Daemon | Foreground | Ui
type App =
  { name: String
    entrypoint: String          // Daemon: the loop fn (detached); Foreground: `dark run` target; Ui: the TUI fn
    description: String
    kind: AppKind
    spawnAllowList: List<String> }   // executables `apps install` grants as a Cli(spawn:…) capability
```

- **Daemon** — backgrounded long-runner; `start/stop/status/logs` manage it via a pidfile (sync daemon, heartbeat). Detached, survives CLI exit.
- **Foreground** — a normal `dark run` that finishes (print-md).
- **Ui** — a full-screen MVU TUI, attached until you quit (the outliner).

```
$ dark apps                          # the registry, at a glance
print-md   foreground   Render a markdown file to PDF and print it
heartbeat  daemon       A demo daemon: log a heartbeat every interval
outliner   ui           Interactive tree outliner (full-screen TUI)

$ dark apps start heartbeat          # detached; managed by pidfile
heartbeat running (pid 48213)
$ dark apps status heartbeat
heartbeat: running (pid 48213)
```

## Install surface

`apps install` writes a one-line shell shim (`~/.darklang/bin/<app>` → `dark run <entrypoint>`) and grants the app's `spawnAllowList` as `Cli(spawn: …)`. One dir on PATH, so uninstall is one file.

## Tests

`testfiles/execution/pre-s-and-s/apps.dark` — **6/6**: `kindTag` (×3), `aliasPath`, `spawnGrantSummary` (empty / non-empty). (`findByName` reads the `all` package-VALUE registry, which the `.dark` test harness can't resolve, so it's exercised via `dark apps list` at the CLI.) Build + reload clean.

## Deferred

Type-discovery of Apps via the synced value index (this PR lists a static `all`); `dark apps fork` (later). Files: `apps.dark`, `apps-daemon.dark`, `apps-examples.dark`, `…/cli/commands/apps.dark`, `core.dark`, the testfile.