### PR TITLE
Share one flag parser across CLI package commands

### DIFF
--- a/packages/darklang/cli/commands/signatures.dark
+++ b/packages/darklang/cli/commands/signatures.dark
@@ -150,32 +150,37 @@ let renderModule
   $"{header}\n{body}"
 
 
-// Returns (rootModulePath, includeTypes, includeDeprecated, filterText, all)
-let parseArgsLoop
-  (remaining: List<String>)
-  (root: List<String>)
-  (types: Bool)
-  (dep: Bool)
-  (filter: Stdlib.Option.Option<String>)
-  (all: Bool)
-  : (List<String> * Bool * Bool * Stdlib.Option.Option<String> * Bool) =
-  match remaining with
-  | [] -> (root, types, dep, filter, all)
-  | "--types" :: rest -> parseArgsLoop rest root true dep filter all
-  | "--include-deprecated" :: rest -> parseArgsLoop rest root types true filter all
-  | "--all" :: rest -> parseArgsLoop rest root types dep filter true
-  | "--module" :: path :: rest ->
-    parseArgsLoop rest (Stdlib.String.split path ".") types dep filter all
-  | arg :: rest ->
-    match filter with
-    | None -> parseArgsLoop rest root types dep (Stdlib.Option.Option.Some arg) all
-    | Some _ -> parseArgsLoop rest root types dep filter all
+type ParsedArgs =
+  { root: List<String>
+    includeTypes: Bool
+    includeDeprecated: Bool
+    filter: Stdlib.Option.Option<String>
+    all: Bool
+    parseErrors: List<FlagParser.ParseError> }
 
 
-let parseArgs
-  (args: List<String>)
-  : (List<String> * Bool * Bool * Stdlib.Option.Option<String> * Bool) =
-  parseArgsLoop args ["Darklang"; "Stdlib"] false false Stdlib.Option.Option.None false
+let argSpec: FlagParser.Spec =
+  FlagParser.Spec
+    { flags =
+        [ ("--types", []); ("--include-deprecated", []); ("--all", []) ]
+      valueFlags = [ ("--module", []) ] }
+
+
+// The first positional is the filter; later ones are ignored.
+let parseArgs (args: List<String>) : ParsedArgs =
+  let p = FlagParser.parse argSpec args
+  let root =
+    match FlagParser.getOption p "--module" with
+    | Some path -> Stdlib.String.split path "."
+    | None -> [ "Darklang"; "Stdlib" ]
+
+  ParsedArgs
+    { root = root
+      includeTypes = FlagParser.hasFlag p "--types"
+      includeDeprecated = FlagParser.hasFlag p "--include-deprecated"
+      filter = Stdlib.List.head p.positionals
+      all = FlagParser.hasFlag p "--all"
+      parseErrors = p.errors }
 
 
 let executeFiltered
@@ -271,24 +276,32 @@ let executeFiltered
 
 
 let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
-  let (rootPath, includeTypes, includeDeprecated, filterText, all) = parseArgs args
+  let parsed = parseArgs args
 
   // No scope, no filter, no --all: redirect to the cheap overview rather
   // than dumping every stdlib signature by default.
   let isDefaultRoot =
-    match rootPath with
+    match parsed.root with
     | [ "Darklang"; "Stdlib" ] -> true
     | _ -> false
 
   let isUnscoped =
     isDefaultRoot
-    && (Stdlib.Option.isNone filterText)
-    && (Stdlib.Bool.not all)
+    && (Stdlib.Option.isNone parsed.filter)
+    && (Stdlib.Bool.not parsed.all)
 
-  if isUnscoped then
+  if Stdlib.Bool.not (Stdlib.List.isEmpty parsed.parseErrors) then
+    Stdlib.printLine (Colors.error (FlagParser.parseErrorsMessage parsed.parseErrors))
+    help state
+  else if isUnscoped then
     StdlibOverview.execute state args
   else
-    executeFiltered state rootPath includeTypes includeDeprecated filterText
+    executeFiltered
+      state
+      parsed.root
+      parsed.includeTypes
+      parsed.includeDeprecated
+      parsed.filter
 
 
 let help (state: Cli.AppState) : Cli.AppState =

--- a/packages/darklang/cli/packages/delete.dark
+++ b/packages/darklang/cli/packages/delete.dark
@@ -13,52 +13,33 @@ type ParsedArgs =
     message: String
     autoConfirm: Bool
     ignoreDependents: Bool
-    dryRun: Bool }
+    dryRun: Bool
+    parseErrors: List<FlagParser.ParseError> }
 
 
-let emptyArgs: ParsedArgs =
-  ParsedArgs
-    { itemType = Stdlib.Option.Option.None
-      target = Stdlib.Option.Option.None
-      message = ""
-      autoConfirm = false
-      ignoreDependents = false
-      dryRun = false }
+let argSpec: FlagParser.Spec =
+  FlagParser.Spec
+    { flags =
+        [ ("--yes", [ "-y" ])
+          ("--ignore-dependents", [])
+          ("--force", [])
+          ("--dry-run", []) ]
+      valueFlags = [ ("--message", [ "-m" ]) ] }
 
 
-let parseArgsLoop (acc: ParsedArgs) (remaining: List<String>) : ParsedArgs =
-  match remaining with
-  | [] -> acc
-  | "--yes" :: rest
-  | "-y" :: rest -> parseArgsLoop ({ acc with autoConfirm = true }) rest
-  | "--ignore-dependents" :: rest ->
-    parseArgsLoop ({ acc with ignoreDependents = true }) rest
-  // --force is shorthand for --ignore-dependents --yes: ignore live dependents and skip the prompt.
-  | "--force" :: rest ->
-    parseArgsLoop
-      ({ acc with ignoreDependents = true; autoConfirm = true })
-      rest
-  | "--dry-run" :: rest -> parseArgsLoop ({ acc with dryRun = true }) rest
-  | "-m" :: v :: rest
-  | "--message" :: v :: rest ->
-    parseArgsLoop ({ acc with message = v }) rest
-  | positional :: rest ->
-    match acc.itemType with
-    | None ->
-      parseArgsLoop
-        ({ acc with itemType = Stdlib.Option.Option.Some positional })
-        rest
-    | Some _ ->
-      match acc.target with
-      | None ->
-        parseArgsLoop
-          ({ acc with target = Stdlib.Option.Option.Some positional })
-          rest
-      | Some _ -> parseArgsLoop acc rest
-
-
+/// Positional args fill itemType, then target. `--force` is shorthand for
+/// `--ignore-dependents --yes`: ignore live dependents and skip the prompt.
 let parseArgs (args: List<String>) : ParsedArgs =
-  parseArgsLoop emptyArgs args
+  let p = FlagParser.parse argSpec args
+  let forced = FlagParser.hasFlag p "--force"
+  ParsedArgs
+    { itemType = Stdlib.List.getAt p.positionals 0L
+      target = Stdlib.List.getAt p.positionals 1L
+      message = FlagParser.getOptionOr p "--message" ""
+      autoConfirm = (FlagParser.hasFlag p "--yes") || forced
+      ignoreDependents = (FlagParser.hasFlag p "--ignore-dependents") || forced
+      dryRun = FlagParser.hasFlag p "--dry-run"
+      parseErrors = p.errors }
 
 
 /// Count live (non-deprecated) dependents on `targetLoc`. 0 means no gate
@@ -98,6 +79,9 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   let branchId = state.currentBranchId
 
   match (parsed.itemType, parsed.target) with
+  | _ when Stdlib.Bool.not (Stdlib.List.isEmpty parsed.parseErrors) ->
+    Stdlib.printLine (Colors.error (FlagParser.parseErrorsMessage parsed.parseErrors))
+    help state
   | (None, _) -> help state
   | (Some itemTypeStr, targetOpt) ->
     match Propagate.itemKindFromString itemTypeStr with

--- a/packages/darklang/cli/packages/deprecate.dark
+++ b/packages/darklang/cli/packages/deprecate.dark
@@ -14,57 +14,30 @@ type ParsedArgs =
     replacement: Stdlib.Option.Option<String>
     message: String
     autoConfirm: Bool
-    dryRun: Bool }
+    dryRun: Bool
+    parseErrors: List<FlagParser.ParseError> }
 
 
-let emptyArgs: ParsedArgs =
-  ParsedArgs
-    { itemType = Stdlib.Option.Option.None
-      target = Stdlib.Option.Option.None
-      kind = Stdlib.Option.Option.None
-      replacement = Stdlib.Option.Option.None
-      message = ""
-      autoConfirm = false
-      dryRun = false }
-
-
-let parseArgsLoop
-  (acc: ParsedArgs)
-  (remaining: List<String>)
-  : ParsedArgs =
-  match remaining with
-  | [] -> acc
-  | "--yes" :: rest
-  | "-y" :: rest -> parseArgsLoop ({ acc with autoConfirm = true }) rest
-  | "--dry-run" :: rest -> parseArgsLoop ({ acc with dryRun = true }) rest
-  | "--kind" :: v :: rest ->
-    parseArgsLoop ({ acc with kind = Stdlib.Option.Option.Some v }) rest
-  | "--replacement" :: v :: rest ->
-    parseArgsLoop
-      ({ acc with replacement = Stdlib.Option.Option.Some v })
-      rest
-  | "-m" :: v :: rest
-  | "--message" :: v :: rest ->
-    parseArgsLoop ({ acc with message = v }) rest
-  | positional :: rest ->
-    match acc.itemType with
-    | None ->
-      parseArgsLoop
-        ({ acc with itemType = Stdlib.Option.Option.Some positional })
-        rest
-    | Some _ ->
-      match acc.target with
-      | None ->
-        parseArgsLoop
-          ({ acc with target = Stdlib.Option.Option.Some positional })
-          rest
-      | Some _ -> parseArgsLoop acc rest
+let argSpec: FlagParser.Spec =
+  FlagParser.Spec
+    { flags = [ ("--yes", [ "-y" ]); ("--dry-run", []) ]
+      valueFlags =
+        [ ("--kind", []); ("--replacement", []); ("--message", [ "-m" ]) ] }
 
 
 /// Parse `--key value` / `--flag` style args into a ParsedArgs.
 /// Positional args fill itemType, then target.
 let parseArgs (args: List<String>) : ParsedArgs =
-  parseArgsLoop emptyArgs args
+  let p = FlagParser.parse argSpec args
+  ParsedArgs
+    { itemType = Stdlib.List.getAt p.positionals 0L
+      target = Stdlib.List.getAt p.positionals 1L
+      kind = FlagParser.getOption p "--kind"
+      replacement = FlagParser.getOption p "--replacement"
+      message = FlagParser.getOptionOr p "--message" ""
+      autoConfirm = FlagParser.hasFlag p "--yes"
+      dryRun = FlagParser.hasFlag p "--dry-run"
+      parseErrors = p.errors }
 
 
 /// Build a Reference by resolving a location string (FQN).
@@ -128,6 +101,10 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   let branchId = state.currentBranchId
 
   match (parsed.itemType, parsed.target, parsed.kind) with
+  | _ when Stdlib.Bool.not (Stdlib.List.isEmpty parsed.parseErrors) ->
+    Stdlib.printLine (Colors.error (FlagParser.parseErrorsMessage parsed.parseErrors))
+    help state
+
   | (None, _, _) ->
     help state
 

--- a/packages/darklang/cli/packages/search.dark
+++ b/packages/darklang/cli/packages/search.dark
@@ -143,64 +143,51 @@ type ParsedArgs =
     withDocs: Bool
     shallow: Bool
     includeDeprecated: Bool
-    unknownFlags: List<String> }
+    parseErrors: List<FlagParser.ParseError> }
 
 
-let emptyArgs: ParsedArgs =
-  ParsedArgs
-    { queryParts = []
-      entityTypes = []
-      exactMatch = false
-      withDocs = false
-      shallow = false
-      includeDeprecated = false
-      unknownFlags = [] }
-
-
-let addEntityType
-  (entityType: LanguageTools.ProgramTypes.Search.EntityType)
-  (args: ParsedArgs)
-  : ParsedArgs =
-  { args with entityTypes = Stdlib.List.append args.entityTypes [entityType] }
-
-
-let parseArgsLoop (acc: ParsedArgs) (remaining: List<String>) : ParsedArgs =
-  match remaining with
-  | [] -> acc
-  | "--type" :: rest ->
-    parseArgsLoop
-      (addEntityType LanguageTools.ProgramTypes.Search.EntityType.Type acc)
-      rest
-  | "--fn" :: rest
-  | "--function" :: rest ->
-    parseArgsLoop
-      (addEntityType LanguageTools.ProgramTypes.Search.EntityType.Fn acc)
-      rest
-  | "--val" :: rest
-  | "--value" :: rest ->
-    parseArgsLoop
-      (addEntityType LanguageTools.ProgramTypes.Search.EntityType.Value acc)
-      rest
-  | "--exact" :: rest -> parseArgsLoop ({ acc with exactMatch = true }) rest
-  // TODO: `--shallow` is current-location scoped, which is confusing for
-  // qualified queries like `search Darklang.Stdlib.List --shallow`.
-  | "--shallow" :: rest -> parseArgsLoop ({ acc with shallow = true }) rest
-  | "--with-docs" :: rest -> parseArgsLoop ({ acc with withDocs = true }) rest
-  | "--include-deprecated" :: rest ->
-    parseArgsLoop ({ acc with includeDeprecated = true }) rest
-  | token :: rest ->
-    if Stdlib.String.startsWith token "--" then
-      parseArgsLoop
-        ({ acc with unknownFlags = Stdlib.List.append acc.unknownFlags [token] })
-        rest
-    else
-      parseArgsLoop
-        ({ acc with queryParts = Stdlib.List.append acc.queryParts [token] })
-        rest
+// TODO: `--shallow` is current-location scoped, which is confusing for
+// qualified queries like `search Darklang.Stdlib.List --shallow`.
+let argSpec: FlagParser.Spec =
+  FlagParser.Spec
+    { flags =
+        [ ("--type", [])
+          ("--fn", [ "--function" ])
+          ("--val", [ "--value" ])
+          ("--exact", [])
+          ("--shallow", [])
+          ("--with-docs", [])
+          ("--include-deprecated", []) ]
+      valueFlags = [] }
 
 
 let parseArgs (args: List<String>) : ParsedArgs =
-  parseArgsLoop emptyArgs args
+  let p = FlagParser.parse argSpec args
+  // Entity types are preserved in the order their flags appeared.
+  let entityTypes =
+    p.flags
+    |> Stdlib.List.fold [] (fun acc f ->
+      match f with
+      | "--type" ->
+        Stdlib.List.append
+          acc
+          [ LanguageTools.ProgramTypes.Search.EntityType.Type ]
+      | "--fn" ->
+        Stdlib.List.append acc [ LanguageTools.ProgramTypes.Search.EntityType.Fn ]
+      | "--val" ->
+        Stdlib.List.append
+          acc
+          [ LanguageTools.ProgramTypes.Search.EntityType.Value ]
+      | _ -> acc)
+
+  ParsedArgs
+    { queryParts = p.positionals
+      entityTypes = entityTypes
+      exactMatch = FlagParser.hasFlag p "--exact"
+      withDocs = FlagParser.hasFlag p "--with-docs"
+      shallow = FlagParser.hasFlag p "--shallow"
+      includeDeprecated = FlagParser.hasFlag p "--include-deprecated"
+      parseErrors = p.errors }
 
 
 let usage =
@@ -222,9 +209,8 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   | _ ->
     let parsed = parseArgs args
 
-    if Stdlib.Bool.not (Stdlib.List.isEmpty parsed.unknownFlags) then
-      let bad = Stdlib.String.join parsed.unknownFlags " "
-      Stdlib.printLine (Colors.error $"Error: unknown flag(s): {bad}")
+    if Stdlib.Bool.not (Stdlib.List.isEmpty parsed.parseErrors) then
+      Stdlib.printLine (Colors.error (FlagParser.parseErrorsMessage parsed.parseErrors))
       Stdlib.printLine ""
       Stdlib.printLine usage
       state

--- a/packages/darklang/cli/utils/flagParser.dark
+++ b/packages/darklang/cli/utils/flagParser.dark
@@ -1,0 +1,125 @@
+module Darklang.Cli.FlagParser
+
+// A small declarative arg parser shared by CLI commands. Each command declares
+// its bare flags and value-taking flags (with aliases); `parse` walks the token
+// list once and returns a neutral `Parsed`, which the command reads into its own
+// typed config via `hasFlag`, `getOption`, `positionals`, and `errors`.
+
+
+type Spec =
+  { // bare boolean flags: (canonicalName, aliases). e.g. ("--yes", ["-y"])
+    flags: List<(String * List<String>)>
+    // `--key value` flags: (canonicalName, aliases). e.g. ("--message", ["-m"]).
+    // Greedy: consumes the next token even if it looks like a flag; errors only
+    // when nothing follows.
+    valueFlags: List<(String * List<String>)> }
+
+
+type ParseError =
+  | UnknownFlag of String
+  | MissingValue of String
+
+
+type Parsed =
+  { // canonical names of bare flags seen, in encounter order (duplicates kept)
+    flags: List<String>
+    // (canonicalName, value) pairs in encounter order
+    options: List<(String * String)>
+    positionals: List<String>
+    errors: List<ParseError> }
+
+
+let emptyParsed: Parsed =
+  Parsed { flags = []; options = []; positionals = []; errors = [] }
+
+
+// The canonical name for `token` if it matches an entry's name or an alias.
+let canonicalFor
+  (entries: List<(String * List<String>)>)
+  (token: String)
+  : Stdlib.Option.Option<String> =
+  entries
+  |> Stdlib.List.findFirst (fun entry ->
+    let (name, aliases) = entry
+    (token == name) || (Stdlib.List.any aliases (fun a -> a == token)))
+  |> Stdlib.Option.map (fun entry ->
+    let (name, _aliases) = entry
+    name)
+
+
+let isFlagLike (token: String) : Bool =
+  token != "-" && Stdlib.String.startsWith token "-"
+
+
+let addFlag (acc: Parsed) (name: String) : Parsed =
+  { acc with flags = Stdlib.List.append acc.flags [ name ] }
+
+
+let addOption (acc: Parsed) (name: String) (value: String) : Parsed =
+  { acc with options = Stdlib.List.append acc.options [ (name, value) ] }
+
+
+let addUnknown (acc: Parsed) (token: String) : Parsed =
+  { acc with errors = Stdlib.List.append acc.errors [ ParseError.UnknownFlag token ] }
+
+
+let addMissingValue (acc: Parsed) (token: String) : Parsed =
+  { acc with errors = Stdlib.List.append acc.errors [ ParseError.MissingValue token ] }
+
+
+let parseLoop (spec: Spec) (acc: Parsed) (remaining: List<String>) : Parsed =
+  match remaining with
+  | [] -> acc
+
+  | token :: rest ->
+    match canonicalFor spec.valueFlags token with
+    | Some name ->
+      match rest with
+      | value :: tail -> parseLoop spec (addOption acc name value) tail
+      | [] -> parseLoop spec (addMissingValue acc token) rest
+    | None ->
+      match canonicalFor spec.flags token with
+      | Some name -> parseLoop spec (addFlag acc name) rest
+      | None ->
+        if isFlagLike token then
+          parseLoop spec (addUnknown acc token) rest
+        else
+          parseLoop
+            spec
+            { acc with positionals = Stdlib.List.append acc.positionals [ token ] }
+            rest
+
+
+let parse (spec: Spec) (args: List<String>) : Parsed =
+  parseLoop spec emptyParsed args
+
+
+let hasFlag (p: Parsed) (name: String) : Bool =
+  Stdlib.List.any p.flags (fun f -> f == name)
+
+
+// The value for `name`; last occurrence wins, matching the old
+// `{ acc with x = v }` overwrite-on-repeat behavior.
+let getOption (p: Parsed) (name: String) : Stdlib.Option.Option<String> =
+  p.options
+  |> Stdlib.List.filter (fun pair ->
+    let (k, _v) = pair
+    k == name)
+  |> Stdlib.List.last
+  |> Stdlib.Option.map (fun pair ->
+    let (_k, v) = pair
+    v)
+
+
+let getOptionOr (p: Parsed) (name: String) (default_: String) : String =
+  Stdlib.Option.withDefault (getOption p name) default_
+
+
+let parseErrorMessage (err: ParseError) : String =
+  match err with
+  | UnknownFlag token -> $"Error: unknown flag: {token}"
+  | MissingValue token -> $"Error: {token} requires a value"
+
+
+let parseErrorsMessage (errors: List<ParseError>) : String =
+  errors |> Stdlib.List.map parseErrorMessage |> Stdlib.String.join "\n"


### PR DESCRIPTION
This PR extracts the duplicated CLI `parseArgsLoop` logic from `delete`, `deprecate`, `search`, and `signatures` into a shared `Darklang.Cli.FlagParser`.

Commands now declare a small spec of no-argument flags, value flags, and aliases, then map the parsed result into their existing `ParsedArgs` records.

- unknown flags now rejected everywhere
- value flags with no following value now report `<flag> requires a value`.
- value flags still greedily consume the next token, so dash-leading values like `-m -1` work.
