### PR TITLE
Resolve unqualified Result and Option type references to stdlib

### DIFF
--- a/backend/src/LibDB/NameLookup.fs
+++ b/backend/src/LibDB/NameLookup.fs
@@ -26,11 +26,17 @@ let namesToTry
       let newNameToTry = { given with modules = modulesToPrepend @ given.modules }
       newNameToTry :: loop allButLast
 
-  // handle explicit Stdlib.etc shortcut
+  // Handle explicit Stdlib.etc shortcut, plus a final stdlib fallback for
+  // Result/Option. Their constructors (Ok/Error, Some/None) already resolve
+  // unqualified from any module, so their unqualified type names should resolve the
+  // same way while still allowing local definitions to win first.
   let addl =
-    match given.modules with
-    | "Stdlib" :: _ -> [ { given with modules = "Darklang" :: given.modules } ]
-    | _ -> []
+    match given.modules, given.name with
+    | "Stdlib" :: _, _ -> [ { given with modules = "Darklang" :: given.modules } ]
+    | ([] | [ "Result" ]), "Result"
+    | ([] | [ "Option" ]), "Option" ->
+      [ { given with modules = [ "Darklang"; "Stdlib"; given.name ] } ]
+    | _, _ -> []
 
   (loop currentModule) @ addl
 

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -2365,32 +2365,6 @@ Builtin.printLine (getTitle curiousGeorgeBookId)
       )) ]
   |> testList "cli scripts"
 
-/// Proves the Result/Option stdlib fallback participates in runtime type-checking.
-/// The round-trip tests above assert canonical printing; these tests execute
-/// functions with unqualified annotations, so matching arguments/return values are only
-/// accepted if the annotations resolved to Stdlib.Result/Stdlib.Option. These
-/// fns are declared from a non-Stdlib module (owner Tests) — the context that
-/// previously forced the fully-qualified `Stdlib.Result.Result`.
-let stdlibTypeFallback =
-  [ tEvalSourceFileFn
-      "unqualified Result param resolves and type-checks"
-      "let unwrap (x: Result<Int64, String>): Int64 =\n  match x with\n  | Ok n -> n\n  | Error _ -> 0L"
-      (Dval.resultOk RT.KTInt64 RT.KTString (RT.DInt64 5L))
-      (RT.DInt64 5L)
-
-    tEvalSourceFileFn
-      "unqualified Option param resolves and type-checks"
-      "let unwrap (x: Option<Int64>): Int64 =\n  match x with\n  | Some n -> n\n  | None -> 0L"
-      (Dval.optionSome RT.KTInt64 (RT.DInt64 7L))
-      (RT.DInt64 7L)
-
-    tEvalSourceFileFn
-      "unqualified Result return type resolves and type-checks"
-      "let wrap (x: Int64): Result<Int64, String> =\n  Stdlib.Result.Result.Ok x"
-      (RT.DInt64 9L)
-      (Dval.resultOk RT.KTInt64 RT.KTString (RT.DInt64 9L)) ]
-  |> testList "stdlib fallback Result/Option"
-
 let tests =
   testList
     "NewParser"
@@ -2400,5 +2374,4 @@ let tests =
       exprs
       functionDeclarations
       moduleDeclarations
-      stdlibTypeFallback
       sourceFiles ]

--- a/backend/tests/Tests/NewParser.Tests.fs
+++ b/backend/tests/Tests/NewParser.Tests.fs
@@ -626,6 +626,36 @@ let typeReferences =
       []
       []
       []
+      false
+
+    // Unqualified Result/Option type names resolve via the stdlib fallback from any
+    // module, mirroring how their constructors (Ok/Error, Some/None) already
+    // resolve unqualified everywhere. Once resolved, the name pretty-prints in
+    // the canonical `Stdlib.X.Y` form, so the unqualified input round-trips to the
+    // qualified output.
+    t
+      "unqualified Result resolves through stdlib fallback"
+      "type MyResult = Result<Int64, String>"
+      "type MyResult =\n  Stdlib.Result.Result<Int64, String>"
+      []
+      []
+      []
+      false
+    t
+      "unqualified Option resolves through stdlib fallback"
+      "type MyOpt = Option<Int64>"
+      "type MyOpt =\n  Stdlib.Option.Option<Int64>"
+      []
+      []
+      []
+      false
+    t
+      "unqualified Result unapplied resolves through stdlib fallback"
+      "type MyResult = Result"
+      "type MyResult =\n  Stdlib.Result.Result"
+      []
+      []
+      []
       false ]
   |> testList "type references"
 
@@ -919,7 +949,7 @@ let exprs =
       "invalid escape in char match pattern"
       "match c with\n| '\\d' -> 1L\n| _ -> 0L"
       "Unparseable"
-    // A qualified enum-case pattern is unsupported (use the bare case name).
+    // A qualified enum-case pattern is unsupported (use the unqualified case name).
     // tree-sitter keeps only the first path segment and error-recovers the
     // rest; reject it instead of silently building a truncated pattern. The
     // rejection holds across path lengths and whether or not fields are bound.
@@ -936,11 +966,11 @@ let exprs =
       "match x with\n| Stdlib.Result.Ok -> 1L\n| _ -> 0L"
       "Unparseable"
     // The diagnostic must name the actual problem (qualified path) so the user
-    // knows to use the bare case name, not just report a generic failure.
+    // knows to use the unqualified case name, not just report a generic failure.
     tParseErrorNote
-      "qualified enum-case match pattern suggests bare case name"
+      "qualified enum-case match pattern suggests unqualified case name"
       "match x with\n| Stdlib.Result.Result.Ok n -> 1L\n| _ -> 0L"
-      "Invalid match pattern. Enum patterns use the bare case name (e.g. `| Ok n`), not a qualified path like `| Stdlib.Result.Result.Ok n`."
+      "Invalid match pattern. Enum patterns use the unqualified case name (e.g. `| Ok n`), not a qualified path like `| Stdlib.Result.Result.Ok n`."
     // Codepoints that tree-sitter accepts as well-formed escapes but that
     // are not valid Unicode scalars must be rejected by the decoder:
     //   - surrogate range (D800..DFFF)
@@ -2223,6 +2253,19 @@ let moduleDeclarations =
       []
       false
 
+    // Unqualified Result resolves from inside a non-Stdlib module (here
+    // Tests.MyModule), the scenario that motivated the stdlib fallback.
+    // Previously this required the fully-qualified `Stdlib.Result.Result`.
+    t
+      "unqualified Result resolves inside a non-Stdlib module"
+      "module MyModule =\n  type MyResult = Result<Int64, String>"
+      "module Tests =\n  module MyModule =\n    type MyResult =\n      Stdlib.Result.Result<Int64, String>"
+      []
+      []
+      []
+      false
+
+
     t
       "module with types, fns, and vals"
       """module MyModule =
@@ -2322,6 +2365,32 @@ Builtin.printLine (getTitle curiousGeorgeBookId)
       )) ]
   |> testList "cli scripts"
 
+/// Proves the Result/Option stdlib fallback participates in runtime type-checking.
+/// The round-trip tests above assert canonical printing; these tests execute
+/// functions with unqualified annotations, so matching arguments/return values are only
+/// accepted if the annotations resolved to Stdlib.Result/Stdlib.Option. These
+/// fns are declared from a non-Stdlib module (owner Tests) — the context that
+/// previously forced the fully-qualified `Stdlib.Result.Result`.
+let stdlibTypeFallback =
+  [ tEvalSourceFileFn
+      "unqualified Result param resolves and type-checks"
+      "let unwrap (x: Result<Int64, String>): Int64 =\n  match x with\n  | Ok n -> n\n  | Error _ -> 0L"
+      (Dval.resultOk RT.KTInt64 RT.KTString (RT.DInt64 5L))
+      (RT.DInt64 5L)
+
+    tEvalSourceFileFn
+      "unqualified Option param resolves and type-checks"
+      "let unwrap (x: Option<Int64>): Int64 =\n  match x with\n  | Some n -> n\n  | None -> 0L"
+      (Dval.optionSome RT.KTInt64 (RT.DInt64 7L))
+      (RT.DInt64 7L)
+
+    tEvalSourceFileFn
+      "unqualified Result return type resolves and type-checks"
+      "let wrap (x: Int64): Result<Int64, String> =\n  Stdlib.Result.Result.Ok x"
+      (RT.DInt64 9L)
+      (Dval.resultOk RT.KTInt64 RT.KTString (RT.DInt64 9L)) ]
+  |> testList "stdlib fallback Result/Option"
+
 let tests =
   testList
     "NewParser"
@@ -2331,4 +2400,5 @@ let tests =
       exprs
       functionDeclarations
       moduleDeclarations
+      stdlibTypeFallback
       sourceFiles ]

--- a/packages/darklang/cli/docs/for-ai-internal.dark
+++ b/packages/darklang/cli/docs/for-ai-internal.dark
@@ -144,13 +144,14 @@ Dark parses pipes greedily; `Stdlib.List.length xs |> Stdlib.Int64.toString`
 raises "Pipe: LongIdent". Wrap the left side in parens:
   (Stdlib.List.length xs) |> Stdlib.Int64.toString
 
-## No nested functions, no `rec` keyword
-Dark rejects nested `let` that defines a function — move helpers to module
-scope instead. Dark also has no `rec` keyword: a top-level `let` is
-automatically self-recursive. The common idiom is a top-level
-`let fooLoop acc xs = ...` that `let foo xs = fooLoop empty xs` wraps.
-Parser error for the nested-let case reads:
-"Unsupported let or use expr pat type / pat: LongIdent".
+## Nested functions and recursion
+Dark supports nested function definitions only in the fully annotated form:
+  let helper (x: Int64) : Int64 = ...
+This desugars to a local lambda. It can close over outer bindings and can call
+itself by name, but mutual recursion between nested functions is not supported.
+Forms such as `let helper x = ...` are not supported; use typed, parenthesized
+params and a return type. Dark has no `rec` keyword: top-level functions are
+automatically self-recursive.
 
 ## Record update doesn't take a type-tag
 `{ state with field = v }` is correct. `MyType { state with field = v }`

--- a/packages/darklang/cli/docs/for-ai.dark
+++ b/packages/darklang/cli/docs/for-ai.dark
@@ -137,7 +137,9 @@ Rules:
 
 ## Critical Syntax
 - Whitespace-sensitive (like Python)
-- NO nested function definitions
+- Nested function definitions are supported only in the fully annotated form:
+  `let helper (x: Int64) : Int64 = ...`. The parser desugars this to a local
+  lambda, so use it for task-local helpers; mutual recursion is not supported.
 - NO binding modules to variables (`let c = Darklang.Cli.Colors` is invalid —
   modules are not first-class values. Use the full path each time.)
 - Pipe needs parens: (complex expr) |> fn

--- a/packages/darklang/languageTools/nameResolver.dark
+++ b/packages/darklang/languageTools/nameResolver.dark
@@ -54,11 +54,21 @@ let namesToTry
   (currentModule: List<String>)
   (given: GenericName)
   : List<GenericName> =
+  // Stdlib.etc shortcut, plus a final stdlib fallback for Result/Option. Their
+  // constructors (Ok/Error, Some/None) already resolve unqualified from any
+  // module, so their unqualified type names should resolve the same way while still
+  // allowing local definitions to win first.
   let addl =
-    match given.modules with
-    | "Stdlib" :: _ ->
+    match (given.modules, given.name) with
+    | ("Stdlib" :: _, _) ->
       [ { given with
             modules = Stdlib.List.append [ "Darklang" ] given.modules } ]
+    | ([], "Result") -> [ { given with modules = [ "Darklang"; "Stdlib"; "Result" ] } ]
+    | ([ "Result" ], "Result") ->
+      [ { given with modules = [ "Darklang"; "Stdlib"; "Result" ] } ]
+    | ([], "Option") -> [ { given with modules = [ "Darklang"; "Stdlib"; "Option" ] } ]
+    | ([ "Option" ], "Option") ->
+      [ { given with modules = [ "Darklang"; "Stdlib"; "Option" ] } ]
     | _ -> []
 
   let currentModule = Stdlib.List.append [ owner ] currentModule

--- a/packages/darklang/languageTools/parser/expr.dark
+++ b/packages/darklang/languageTools/parser/expr.dark
@@ -737,13 +737,13 @@ let parseMatchCase
 
   match errorChild with
   // Qualified enum-case patterns like `| Stdlib.Result.Result.Ok n ->` are
-  // unsupported (use the bare case name `| Ok n`). In this recovery shape,
+  // unsupported (use the unqualified case name `| Ok n`). In this recovery shape,
   // tree-sitter keeps the first path segment as the case name and puts the
   // remaining dotted path in an ERROR child.
   | Some err when Stdlib.String.contains err.text "." ->
     createUnparseableErrorMsg
       node
-      "Invalid match pattern. Enum patterns use the bare case name (e.g. `| Ok n`), not a qualified path like `| Stdlib.Result.Result.Ok n`."
+      "Invalid match pattern. Enum patterns use the unqualified case name (e.g. `| Ok n`), not a qualified path like `| Stdlib.Result.Result.Ok n`."
   | Some _ -> createUnparseableErrorMsg node "Invalid match case syntax."
   | None ->
     match pipeSym, pattern, arrowSym, rhs with


### PR DESCRIPTION
This PR adds support for unqualified Result and Option type refs.
Before this, you'd have to write the fully-qualified type names; now you can use Result and Option without the long Stdlib.Result.Result... prefix in type references.
example:
Before
  ```fsharp
  let unwrap (x: Stdlib.Result.Result<Int64, String>) : Int64 =
  ...
  ```
After
  ```fsharp
  let unwrap (x: Result<Int64, String>) : Int64 =
  ...
  ```