### PR TITLE
Make numeric operators polymorphic over all numeric types

### DIFF
--- a/backend/src/Builtins/Builtins.Pure/Libs/Int32.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int32.fs
@@ -98,7 +98,11 @@ let fns () : List<BuiltInFn> =
       description = "Adds two 32-bit signed integers together"
       fn =
         (function
-        | _, _, _, [ DInt32 a; DInt32 b ] -> Ply(DInt32(a + b))
+        | _, vm, _, [ DInt32 a; DInt32 b ] ->
+          try
+            DInt32(Checked.(+) a b) |> Ply
+          with :? System.OverflowException ->
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -113,7 +117,11 @@ let fns () : List<BuiltInFn> =
       description = "Subtracts two 32-bit signed integers"
       fn =
         (function
-        | _, _, _, [ DInt32 a; DInt32 b ] -> Ply(DInt32(a - b))
+        | _, vm, _, [ DInt32 a; DInt32 b ] ->
+          try
+            DInt32(Checked.(-) a b) |> Ply
+          with :? System.OverflowException ->
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -128,7 +136,11 @@ let fns () : List<BuiltInFn> =
       description = "Multiplies two 32-bit signed integers"
       fn =
         (function
-        | _, _, _, [ DInt32 a; DInt32 b ] -> Ply(DInt32(a * b))
+        | _, vm, _, [ DInt32 a; DInt32 b ] ->
+          try
+            DInt32(Checked.(*) a b) |> Ply
+          with :? System.OverflowException ->
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -171,6 +183,8 @@ let fns () : List<BuiltInFn> =
         | _, vm, _, [ DInt32 a; DInt32 b ] ->
           if b = 0 then
             RTE.Ints.DivideByZeroError |> RTE.Int |> raiseRTE vm.threadID
+          else if a = System.Int32.MinValue && b = -1 then
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
           else
             Ply(DInt32(a / b))
         | _ -> incorrectArgs ())
@@ -187,7 +201,11 @@ let fns () : List<BuiltInFn> =
       description = "Returns the negation of <param a>, {{-a}}"
       fn =
         (function
-        | _, _, _, [ DInt32 a ] -> Ply(DInt32(-a))
+        | _, vm, _, [ DInt32 a ] ->
+          if a = System.Int32.MinValue then
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
+          else
+            Ply(DInt32(-a))
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int64.fs
@@ -140,7 +140,11 @@ let fns () : List<BuiltInFn> =
       description = "Adds two integers together"
       fn =
         (function
-        | _, _, _, [ DInt64 a; DInt64 b ] -> Ply(DInt64(a + b))
+        | _, vm, _, [ DInt64 a; DInt64 b ] ->
+          try
+            DInt64(Checked.(+) a b) |> Ply
+          with :? System.OverflowException ->
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "+"
       previewable = Pure
@@ -155,7 +159,11 @@ let fns () : List<BuiltInFn> =
       description = "Subtracts two integers"
       fn =
         (function
-        | _, _, _, [ DInt64 a; DInt64 b ] -> Ply(DInt64(a - b))
+        | _, vm, _, [ DInt64 a; DInt64 b ] ->
+          try
+            DInt64(Checked.(-) a b) |> Ply
+          with :? System.OverflowException ->
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "-"
       previewable = Pure
@@ -170,7 +178,11 @@ let fns () : List<BuiltInFn> =
       description = "Multiplies two integers"
       fn =
         (function
-        | _, _, _, [ DInt64 a; DInt64 b ] -> Ply(DInt64(a * b))
+        | _, vm, _, [ DInt64 a; DInt64 b ] ->
+          try
+            DInt64(Checked.(*) a b) |> Ply
+          with :? System.OverflowException ->
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "*"
       previewable = Pure
@@ -189,13 +201,28 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [ DInt64 number; DInt64 exp ] ->
-          (try
-            if exp < 0L then
-              RTE.Ints.NegativeExponent |> RTE.Int |> raiseRTE vm.threadID
-            else
+          if exp < 0L then
+            RTE.Ints.NegativeExponent |> RTE.Int |> raiseRTE vm.threadID
+          elif exp > int64 System.Int32.MaxValue then
+            // `bigint ** int` needs an Int32 exponent; an exponent this large
+            // overflows Int64 unless the base is trivial. (Without this guard
+            // `int exp` silently truncates to a bogus — possibly negative —
+            // Int32, and `bigint ** negative` throws an uncaught exception.)
+            match number with
+            | 0L -> Ply(DInt64 0L)
+            | 1L -> Ply(DInt64 1L)
+            | -1L -> Ply(DInt64(if exp % 2L = 0L then 1L else -1L))
+            | _ -> RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
+          elif exp > 63L && (number > 1L || number < -1L) then
+            // Avoid constructing enormous bigints that can never fit in Int64.
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
+          else
+            // `int64` narrowing throws OverflowException when the result
+            // exceeds Int64 range.
+            try
               (bigint number) ** (int exp) |> int64 |> DInt64 |> Ply
-           with :? System.OverflowException ->
-             RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID)
+            with :? System.OverflowException ->
+              RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "POWER"
       previewable = Pure
@@ -213,6 +240,8 @@ let fns () : List<BuiltInFn> =
         | _, vm, _, [ DInt64 a; DInt64 b ] ->
           if b = 0L then
             RTE.Ints.DivideByZeroError |> RTE.Int |> raiseRTE vm.threadID
+          else if a = System.Int64.MinValue && b = -1L then
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
           else
             Ply(DInt64(a / b))
         | _ -> incorrectArgs ())
@@ -229,7 +258,11 @@ let fns () : List<BuiltInFn> =
       description = "Returns the negation of <param a>, {{-a}}"
       fn =
         (function
-        | _, _, _, [ DInt64 a ] -> Ply(DInt64(-a))
+        | _, vm, _, [ DInt64 a ] ->
+          if a = System.Int64.MinValue then
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
+          else
+            Ply(DInt64(-a))
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
@@ -173,6 +173,42 @@ let private equalsBuiltinImpl (vm : VMState) (a : Dval) (b : Dval) : bool =
   | Ok _ -> equals a b
 
 
+// Polymorphic numeric operators (`+`, `-`, `*`, `/`, `%`, and comparisons).
+// Each inspects the runtime value type and operates on two values of the same
+// numeric type, mirroring how `equals` already dispatches at runtime.
+
+/// Raised when a numeric operator gets operands that aren't two values of the
+/// same numeric type (e.g. `1L + 2.0`, `"a" + "b"`).
+let private numericTypeError (vm : VMState) (a : Dval) (b : Dval) : 'a =
+  RTE.NumericOperationOnIncompatibleTypes(Dval.toValueType a, Dval.toValueType b)
+  |> raiseRTE vm.threadID
+
+let private divideByZero (vm : VMState) : 'a =
+  RTE.Ints.DivideByZeroError |> RTE.Int |> raiseRTE vm.threadID
+
+let private zeroModulus (vm : VMState) : 'a =
+  RTE.Ints.ZeroModulus |> RTE.Int |> raiseRTE vm.threadID
+
+let private negativeModulus (vm : VMState) : 'a =
+  RTE.Ints.NegativeModulus |> RTE.Int |> raiseRTE vm.threadID
+
+let private outOfRange (vm : VMState) : 'a =
+  RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
+
+let private negativeExponent (vm : VMState) : 'a =
+  RTE.Ints.NegativeExponent |> RTE.Int |> raiseRTE vm.threadID
+
+/// Runs an integer computation that may overflow, converting the .NET
+/// OverflowException into a clean `OutOfRange` RTE. Used by `/` and `^`, where
+/// overflow is still an error (`+`, `-`, `*` wrap instead): `Int64.MinValue / -1L`
+/// and oversized `^` results would otherwise escape as an uncaught exception.
+let private overflowChecked (vm : VMState) (f : unit -> Dval) : Ply<Dval> =
+  try
+    Ply(f ())
+  with :? System.OverflowException ->
+    outOfRange vm
+
+
 let fns () : List<BuiltInFn> =
   [ { name = fn "equals" 0
       typeParams = []
@@ -201,6 +237,463 @@ let fns () : List<BuiltInFn> =
       sqlSpec = SqlBinOp "<>"
       previewable = Pure
       capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "add" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = varA
+      description =
+        "Adds two numbers of the same numeric type. Integer overflow raises a
+         runtime error; float arithmetic follows IEEE (overflow to infinity)."
+      fn =
+        (function
+        | _, vm, _, [ DInt8 a; DInt8 b ] ->
+          overflowChecked vm (fun () -> DInt8(Checked.(+) a b))
+        | _, vm, _, [ DUInt8 a; DUInt8 b ] ->
+          overflowChecked vm (fun () -> DUInt8(Checked.(+) a b))
+        | _, vm, _, [ DInt16 a; DInt16 b ] ->
+          overflowChecked vm (fun () -> DInt16(Checked.(+) a b))
+        | _, vm, _, [ DUInt16 a; DUInt16 b ] ->
+          overflowChecked vm (fun () -> DUInt16(Checked.(+) a b))
+        | _, vm, _, [ DInt32 a; DInt32 b ] ->
+          overflowChecked vm (fun () -> DInt32(Checked.(+) a b))
+        | _, vm, _, [ DUInt32 a; DUInt32 b ] ->
+          overflowChecked vm (fun () -> DUInt32(Checked.(+) a b))
+        | _, vm, _, [ DInt64 a; DInt64 b ] ->
+          overflowChecked vm (fun () -> DInt64(Checked.(+) a b))
+        | _, vm, _, [ DUInt64 a; DUInt64 b ] ->
+          overflowChecked vm (fun () -> DUInt64(Checked.(+) a b))
+        | _, vm, _, [ DInt128 a; DInt128 b ] ->
+          overflowChecked vm (fun () ->
+            DInt128(System.Int128.op_CheckedAddition (a, b)))
+        | _, vm, _, [ DUInt128 a; DUInt128 b ] ->
+          overflowChecked vm (fun () ->
+            DUInt128(System.UInt128.op_CheckedAddition (a, b)))
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DFloat(a + b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp "+"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "subtract" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = varA
+      description =
+        "Subtracts two numbers of the same numeric type. Integer overflow raises a
+         runtime error; float arithmetic follows IEEE (overflow to infinity)."
+      fn =
+        (function
+        | _, vm, _, [ DInt8 a; DInt8 b ] ->
+          overflowChecked vm (fun () -> DInt8(Checked.(-) a b))
+        | _, vm, _, [ DUInt8 a; DUInt8 b ] ->
+          overflowChecked vm (fun () -> DUInt8(Checked.(-) a b))
+        | _, vm, _, [ DInt16 a; DInt16 b ] ->
+          overflowChecked vm (fun () -> DInt16(Checked.(-) a b))
+        | _, vm, _, [ DUInt16 a; DUInt16 b ] ->
+          overflowChecked vm (fun () -> DUInt16(Checked.(-) a b))
+        | _, vm, _, [ DInt32 a; DInt32 b ] ->
+          overflowChecked vm (fun () -> DInt32(Checked.(-) a b))
+        | _, vm, _, [ DUInt32 a; DUInt32 b ] ->
+          overflowChecked vm (fun () -> DUInt32(Checked.(-) a b))
+        | _, vm, _, [ DInt64 a; DInt64 b ] ->
+          overflowChecked vm (fun () -> DInt64(Checked.(-) a b))
+        | _, vm, _, [ DUInt64 a; DUInt64 b ] ->
+          overflowChecked vm (fun () -> DUInt64(Checked.(-) a b))
+        | _, vm, _, [ DInt128 a; DInt128 b ] ->
+          overflowChecked vm (fun () ->
+            DInt128(System.Int128.op_CheckedSubtraction (a, b)))
+        | _, vm, _, [ DUInt128 a; DUInt128 b ] ->
+          overflowChecked vm (fun () ->
+            DUInt128(System.UInt128.op_CheckedSubtraction (a, b)))
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DFloat(a - b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp "-"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "multiply" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = varA
+      description =
+        "Multiplies two numbers of the same numeric type. Integer overflow raises a
+         runtime error; float arithmetic follows IEEE (overflow to infinity)."
+      fn =
+        (function
+        | _, vm, _, [ DInt8 a; DInt8 b ] ->
+          overflowChecked vm (fun () -> DInt8(Checked.(*) a b))
+        | _, vm, _, [ DUInt8 a; DUInt8 b ] ->
+          overflowChecked vm (fun () -> DUInt8(Checked.(*) a b))
+        | _, vm, _, [ DInt16 a; DInt16 b ] ->
+          overflowChecked vm (fun () -> DInt16(Checked.(*) a b))
+        | _, vm, _, [ DUInt16 a; DUInt16 b ] ->
+          overflowChecked vm (fun () -> DUInt16(Checked.(*) a b))
+        | _, vm, _, [ DInt32 a; DInt32 b ] ->
+          overflowChecked vm (fun () -> DInt32(Checked.(*) a b))
+        | _, vm, _, [ DUInt32 a; DUInt32 b ] ->
+          overflowChecked vm (fun () -> DUInt32(Checked.(*) a b))
+        | _, vm, _, [ DInt64 a; DInt64 b ] ->
+          overflowChecked vm (fun () -> DInt64(Checked.(*) a b))
+        | _, vm, _, [ DUInt64 a; DUInt64 b ] ->
+          overflowChecked vm (fun () -> DUInt64(Checked.(*) a b))
+        | _, vm, _, [ DInt128 a; DInt128 b ] ->
+          overflowChecked vm (fun () ->
+            DInt128(System.Int128.op_CheckedMultiply (a, b)))
+        | _, vm, _, [ DUInt128 a; DUInt128 b ] ->
+          overflowChecked vm (fun () ->
+            DUInt128(System.UInt128.op_CheckedMultiply (a, b)))
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DFloat(a * b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp "*"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "divide" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = varA
+      description =
+        "Divides two numbers of the same numeric type. Integer types use integer
+         division; dividing an integer by zero raises a runtime error. Signed
+         integer overflow (e.g. {{Int64.MinValue / -1}}) also raises a runtime
+         error."
+      fn =
+        // Unsigned division can't overflow. Signed division overflows only on
+        // `MinValue / -1`. For Int32/Int64/Int128 that throws (caught by
+        // `overflowChecked`); for the narrow Int8/Int16 it silently wraps
+        // (division happens in Int32 space), so those need an explicit guard.
+        (function
+        | _, vm, _, [ DInt8 a; DInt8 b ] ->
+          if b = 0y then divideByZero vm
+          elif a = System.SByte.MinValue && b = -1y then outOfRange vm
+          else Ply(DInt8(a / b))
+        | _, vm, _, [ DUInt8 a; DUInt8 b ] ->
+          if b = 0uy then divideByZero vm else Ply(DUInt8(a / b))
+        | _, vm, _, [ DInt16 a; DInt16 b ] ->
+          if b = 0s then divideByZero vm
+          elif a = System.Int16.MinValue && b = -1s then outOfRange vm
+          else Ply(DInt16(a / b))
+        | _, vm, _, [ DUInt16 a; DUInt16 b ] ->
+          if b = 0us then divideByZero vm else Ply(DUInt16(a / b))
+        | _, vm, _, [ DInt32 a; DInt32 b ] ->
+          if b = 0l then
+            divideByZero vm
+          else
+            overflowChecked vm (fun () -> DInt32(a / b))
+        | _, vm, _, [ DUInt32 a; DUInt32 b ] ->
+          if b = 0ul then divideByZero vm else Ply(DUInt32(a / b))
+        | _, vm, _, [ DInt64 a; DInt64 b ] ->
+          if b = 0L then
+            divideByZero vm
+          else
+            overflowChecked vm (fun () -> DInt64(a / b))
+        | _, vm, _, [ DUInt64 a; DUInt64 b ] ->
+          if b = 0UL then divideByZero vm else Ply(DUInt64(a / b))
+        | _, vm, _, [ DInt128 a; DInt128 b ] ->
+          if b = System.Int128.Zero then
+            divideByZero vm
+          else
+            overflowChecked vm (fun () -> DInt128(a / b))
+        | _, vm, _, [ DUInt128 a; DUInt128 b ] ->
+          if b = System.UInt128.Zero then divideByZero vm else Ply(DUInt128(a / b))
+        // Float division by zero follows IEEE semantics (Infinity/NaN), as before
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DFloat(a / b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp "/"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "modulo" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = varA
+      description =
+        "Wraps <param a> around so that {{0 <= res < b}}, for two numbers of the
+         same numeric type. The modulus <param b> must be greater than 0."
+      fn =
+        (function
+        | _, vm, _, [ DInt8 v; DInt8 m ] ->
+          if m = 0y then
+            zeroModulus vm
+          elif m < 0y then
+            negativeModulus vm
+          else
+            let r = v % m
+            Ply(DInt8(if r < 0y then m + r else r))
+        | _, vm, _, [ DUInt8 v; DUInt8 m ] ->
+          if m = 0uy then zeroModulus vm else Ply(DUInt8(v % m))
+        | _, vm, _, [ DInt16 v; DInt16 m ] ->
+          if m = 0s then
+            zeroModulus vm
+          elif m < 0s then
+            negativeModulus vm
+          else
+            let r = v % m
+            Ply(DInt16(if r < 0s then m + r else r))
+        | _, vm, _, [ DUInt16 v; DUInt16 m ] ->
+          if m = 0us then zeroModulus vm else Ply(DUInt16(v % m))
+        | _, vm, _, [ DInt32 v; DInt32 m ] ->
+          if m = 0l then
+            zeroModulus vm
+          elif m < 0l then
+            negativeModulus vm
+          else
+            let r = v % m
+            Ply(DInt32(if r < 0l then m + r else r))
+        | _, vm, _, [ DUInt32 v; DUInt32 m ] ->
+          if m = 0ul then zeroModulus vm else Ply(DUInt32(v % m))
+        | _, vm, _, [ DInt64 v; DInt64 m ] ->
+          if m = 0L then
+            zeroModulus vm
+          elif m < 0L then
+            negativeModulus vm
+          else
+            let r = v % m
+            Ply(DInt64(if r < 0L then m + r else r))
+        | _, vm, _, [ DUInt64 v; DUInt64 m ] ->
+          if m = 0UL then zeroModulus vm else Ply(DUInt64(v % m))
+        | _, vm, _, [ DInt128 v; DInt128 m ] ->
+          if m = System.Int128.Zero then
+            zeroModulus vm
+          elif m < System.Int128.Zero then
+            negativeModulus vm
+          else
+            let r = v % m
+            Ply(DInt128(if r < System.Int128.Zero then m + r else r))
+        | _, vm, _, [ DUInt128 v; DUInt128 m ] ->
+          if m = System.UInt128.Zero then zeroModulus vm else Ply(DUInt128(v % m))
+        | _, vm, _, [ DFloat v; DFloat m ] ->
+          if m = 0.0 then
+            zeroModulus vm
+          elif m < 0.0 then
+            negativeModulus vm
+          else
+            let r = v % m
+            Ply(DFloat(if r < 0.0 then m + r else r))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp "%"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "power" 0
+      typeParams = []
+      parameters = [ Param.make "base" varA ""; Param.make "exponent" varA "" ]
+      returnType = varA
+      description =
+        "Raises a number to the power of another number of the same type.
+         Supported for every integer type and Float (not Int128/UInt128).
+         Integer exponents must be non-negative; integer overflow raises."
+      fn =
+        (function
+        | _, vm, _, [ DInt8 number; DInt8 exp ] ->
+          if exp < 0y then
+            negativeExponent vm
+          else
+            overflowChecked vm (fun () ->
+              (bigint number) ** (int exp) |> int8 |> DInt8)
+        | _, vm, _, [ DUInt8 number; DUInt8 exp ] ->
+          overflowChecked vm (fun () ->
+            (bigint number) ** (int exp) |> uint8 |> DUInt8)
+        | _, vm, _, [ DInt16 number; DInt16 exp ] ->
+          if exp < 0s then
+            negativeExponent vm
+          else
+            overflowChecked vm (fun () ->
+              (bigint number) ** (int exp) |> int16 |> DInt16)
+        | _, vm, _, [ DUInt16 number; DUInt16 exp ] ->
+          overflowChecked vm (fun () ->
+            (bigint number) ** (int exp) |> uint16 |> DUInt16)
+        | _, vm, _, [ DInt32 number; DInt32 exp ] ->
+          if exp < 0l then
+            negativeExponent vm
+          else
+            overflowChecked vm (fun () ->
+              (bigint number) ** (int exp) |> int32 |> DInt32)
+        | _, vm, _, [ DUInt32 number; DUInt32 exp ] ->
+          overflowChecked vm (fun () ->
+            (bigint number) ** (int exp) |> uint32 |> DUInt32)
+        | _, vm, _, [ DUInt64 number; DUInt64 exp ] ->
+          if exp > uint64 System.Int32.MaxValue then
+            match number with
+            | 0UL -> Ply(DUInt64 0UL)
+            | 1UL -> Ply(DUInt64 1UL)
+            | _ -> outOfRange vm
+          elif exp > 63UL && number > 1UL then
+            outOfRange vm
+          else
+            overflowChecked vm (fun () ->
+              (bigint number) ** (int exp) |> uint64 |> DUInt64)
+        | _, vm, _, [ DInt64 number; DInt64 exp ] ->
+          if exp < 0L then
+            negativeExponent vm
+          elif exp > int64 System.Int32.MaxValue then
+            // `bigint ** int` needs an Int32 exponent; an exponent this large
+            // overflows Int64 unless the base is trivial.
+            match number with
+            | 0L -> Ply(DInt64 0L)
+            | 1L -> Ply(DInt64 1L)
+            | -1L -> Ply(DInt64(if exp % 2L = 0L then 1L else -1L))
+            | _ -> outOfRange vm
+          elif exp > 63L && (number > 1L || number < -1L) then
+            // Avoid constructing enormous bigints that can never fit in Int64.
+            outOfRange vm
+          else
+            // `int64` narrowing throws OverflowException when the result
+            // exceeds Int64 range.
+            overflowChecked vm (fun () ->
+              (bigint number) ** (int exp) |> int64 |> DInt64)
+        | _, _, _, [ DFloat number; DFloat exp ] -> Ply(DFloat(number ** exp))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlFunction "POWER"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    // Unary negation (`-x`). Supported for signed integer types and Float;
+    // negating the minimum signed value overflows and raises.
+    { name = fn "negate" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA "" ]
+      returnType = varA
+      description = "Returns the negation of <param a>, {{-a}}"
+      fn =
+        (function
+        | _, vm, _, [ DInt8 a ] ->
+          let result = -(int a)
+          if result < -128 || result > 127 then
+            outOfRange vm
+          else
+            Ply(DInt8(int8 result))
+        | _, vm, _, [ DInt16 a ] ->
+          if a = System.Int16.MinValue then outOfRange vm else Ply(DInt16(-a))
+        | _, vm, _, [ DInt32 a ] ->
+          if a = System.Int32.MinValue then outOfRange vm else Ply(DInt32(-a))
+        | _, vm, _, [ DInt64 a ] ->
+          if a = System.Int64.MinValue then outOfRange vm else Ply(DInt64(-a))
+        | _, vm, _, [ DInt128 a ] ->
+          overflowChecked vm (fun () ->
+            DInt128(System.Int128.op_CheckedUnaryNegation a))
+        | _, _, _, [ DFloat a ] -> Ply(DFloat(-a))
+        | _, vm, _, [ a ] -> numericTypeError vm a a
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "greaterThan" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = TBool
+      description = "Returns {{true}} if <param a> is greater than <param b>"
+      fn =
+        (function
+        | _, _, _, [ DInt8 a; DInt8 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DUInt8 a; DUInt8 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DInt16 a; DInt16 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DUInt16 a; DUInt16 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DInt32 a; DInt32 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DUInt32 a; DUInt32 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DInt64 a; DInt64 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DUInt64 a; DUInt64 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DInt128 a; DInt128 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DUInt128 a; DUInt128 b ] -> Ply(DBool(a > b))
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DBool(a > b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp ">"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "greaterThanOrEqualTo" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = TBool
+      description =
+        "Returns {{true}} if <param a> is greater than or equal to <param b>"
+      fn =
+        (function
+        | _, _, _, [ DInt8 a; DInt8 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DUInt8 a; DUInt8 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DInt16 a; DInt16 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DUInt16 a; DUInt16 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DInt32 a; DInt32 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DUInt32 a; DUInt32 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DInt64 a; DInt64 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DUInt64 a; DUInt64 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DInt128 a; DInt128 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DUInt128 a; DUInt128 b ] -> Ply(DBool(a >= b))
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DBool(a >= b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp ">="
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "lessThan" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = TBool
+      description = "Returns {{true}} if <param a> is less than <param b>"
+      fn =
+        (function
+        | _, _, _, [ DInt8 a; DInt8 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DUInt8 a; DUInt8 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DInt16 a; DInt16 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DUInt16 a; DUInt16 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DInt32 a; DInt32 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DUInt32 a; DUInt32 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DInt64 a; DInt64 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DUInt64 a; DUInt64 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DInt128 a; DInt128 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DUInt128 a; DUInt128 b ] -> Ply(DBool(a < b))
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DBool(a < b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp "<"
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+
+    { name = fn "lessThanOrEqualTo" 0
+      typeParams = []
+      parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
+      returnType = TBool
+      description =
+        "Returns {{true}} if <param a> is less than or equal to <param b>"
+      fn =
+        (function
+        | _, _, _, [ DInt8 a; DInt8 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DUInt8 a; DUInt8 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DInt16 a; DInt16 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DUInt16 a; DUInt16 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DInt32 a; DInt32 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DUInt32 a; DUInt32 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DInt64 a; DInt64 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DUInt64 a; DUInt64 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DInt128 a; DInt128 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DUInt128 a; DUInt128 b ] -> Ply(DBool(a <= b))
+        | _, _, _, [ DFloat a; DFloat b ] -> Ply(DBool(a <= b))
+        | _, vm, _, [ a; b ] -> numericTypeError vm a b
+        | _ -> incorrectArgs ())
+      sqlSpec = SqlBinOp "<="
+      previewable = Pure
       deprecated = NotDeprecated }
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
@@ -276,6 +276,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "+"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -315,6 +316,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "-"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -354,6 +356,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "*"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -411,6 +414,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "/"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -485,6 +489,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "%"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -560,6 +565,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlFunction "POWER"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -592,6 +598,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -617,6 +624,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -643,6 +651,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp ">="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -668,6 +677,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<"
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 
@@ -694,6 +704,7 @@ let fns () : List<BuiltInFn> =
         | _ -> incorrectArgs ())
       sqlSpec = SqlBinOp "<="
       previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt16.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt16.fs
@@ -43,7 +43,7 @@ let fns () : List<BuiltInFn> =
         (function
         | _, vm, _, [ DUInt16 v; DUInt16 m ] ->
           if m = 0us then
-            RTE.Ints.ZeroModulus |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.ZeroModulus |> RTE.Int |> raiseRTE vm.threadID
           else
             let result = v % m
             let result = if result < 0us then m + result else result
@@ -67,7 +67,7 @@ let fns () : List<BuiltInFn> =
             let result = Checked.(+) a b
             Ply(DUInt16(result))
           with :? System.OverflowException ->
-            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
 
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -88,7 +88,7 @@ let fns () : List<BuiltInFn> =
             let result = Checked.(-) a b
             Ply(DUInt16(result))
           with :? System.OverflowException ->
-            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
 
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -109,7 +109,7 @@ let fns () : List<BuiltInFn> =
             let result = Checked.(*) a b
             Ply(DUInt16(result))
           with :? System.OverflowException ->
-            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
 
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -132,7 +132,7 @@ let fns () : List<BuiltInFn> =
           (try
             (bigint number) ** (int exp) |> uint16 |> DUInt16 |> Ply
            with :? System.OverflowException ->
-             RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply)
+             RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -149,13 +149,13 @@ let fns () : List<BuiltInFn> =
         (function
         | _, vm, _, [ DUInt16 a; DUInt16 b ] ->
           if b = 0us then
-            RTE.Ints.DivideByZeroError |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.DivideByZeroError |> RTE.Int |> raiseRTE vm.threadID
           else
             let result = a / b
             if
               result < System.UInt16.MinValue || result > System.UInt16.MaxValue
             then
-              RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+              RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
             else
               Ply(DUInt16(uint16 result))
 

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt64.fs
@@ -122,10 +122,25 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [ DUInt64 number; DUInt64 exp ] ->
-          (try
-            (bigint number) ** (int exp) |> uint64 |> DUInt64 |> Ply
-           with :? System.OverflowException ->
-             RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID)
+          if exp > uint64 System.Int32.MaxValue then
+            // `bigint ** int` needs an Int32 exponent; an exponent this large
+            // overflows UInt64 unless the base is trivial. (Without this guard
+            // `int exp` silently truncates to a bogus — possibly negative —
+            // Int32, and `bigint ** negative` throws an uncaught exception.)
+            match number with
+            | 0UL -> Ply(DUInt64 0UL)
+            | 1UL -> Ply(DUInt64 1UL)
+            | _ -> RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
+          elif exp > 63UL && number > 1UL then
+            // Avoid constructing enormous bigints that can never fit in UInt64.
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
+          else
+            // `uint64` narrowing throws OverflowException when the result
+            // exceeds UInt64 range.
+            try
+              (bigint number) ** (int exp) |> uint64 |> DUInt64 |> Ply
+            with :? System.OverflowException ->
+              RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt8.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt8.fs
@@ -43,7 +43,7 @@ let fns () : List<BuiltInFn> =
         (function
         | _, vm, _, [ DUInt8 v; DUInt8 m ] ->
           if m = 0uy then
-            RTE.Ints.ZeroModulus |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.ZeroModulus |> RTE.Int |> raiseRTE vm.threadID
           else
             let result = v % m
             let result = if result < 0uy then m + result else result
@@ -66,7 +66,7 @@ let fns () : List<BuiltInFn> =
           try
             DUInt8(Checked.(+) a b) |> Ply
           with :? System.OverflowException ->
-            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -85,7 +85,7 @@ let fns () : List<BuiltInFn> =
           try
             DUInt8(Checked.(-) a b) |> Ply
           with :? System.OverflowException ->
-            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -104,7 +104,7 @@ let fns () : List<BuiltInFn> =
           try
             DUInt8(Checked.(*) a b) |> Ply
           with :? System.OverflowException ->
-            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -126,7 +126,7 @@ let fns () : List<BuiltInFn> =
           (try
             (bigint number) ** (int exp) |> uint8 |> DUInt8 |> Ply
            with :? System.OverflowException ->
-             RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply)
+             RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID)
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -143,11 +143,11 @@ let fns () : List<BuiltInFn> =
         (function
         | _, vm, _, [ DUInt8 a; DUInt8 b ] ->
           if b = 0uy then
-            RTE.Ints.DivideByZeroError |> RTE.Int |> raiseRTE vm.threadID |> Ply
+            RTE.Ints.DivideByZeroError |> RTE.Int |> raiseRTE vm.threadID
           else
             let result = int a / int b
             if result < 0 || result > 255 then
-              RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID |> Ply
+              RTE.Ints.OutOfRange |> RTE.Int |> raiseRTE vm.threadID
             else
               Ply(DUInt8(uint8 result))
         | _ -> incorrectArgs ())

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -169,17 +169,20 @@ module InfixFnName =
   let toFnName (name : PT.InfixFnName) : RT.FQFnName.Builtin =
     let make = RT.FQFnName.builtin
 
+    // Numeric operators dispatch to polymorphic builtins that inspect the
+    // runtime value type (like `equals`), so `1.0 + 2.0`, `1y < 2y`, etc.
+    // all work without per-type operator routing.
     match name with
-    | PT.ArithmeticPlus -> make "int64Add" 0
-    | PT.ArithmeticMinus -> make "int64Subtract" 0
-    | PT.ArithmeticMultiply -> make "int64Multiply" 0
-    | PT.ArithmeticDivide -> make "floatDivide" 0
-    | PT.ArithmeticModulo -> make "int64Mod" 0
-    | PT.ArithmeticPower -> make "int64Power" 0
-    | PT.ComparisonGreaterThan -> make "int64GreaterThan" 0
-    | PT.ComparisonGreaterThanOrEqual -> make "int64GreaterThanOrEqualTo" 0
-    | PT.ComparisonLessThan -> make "int64LessThan" 0
-    | PT.ComparisonLessThanOrEqual -> make "int64LessThanOrEqualTo" 0
+    | PT.ArithmeticPlus -> make "add" 0
+    | PT.ArithmeticMinus -> make "subtract" 0
+    | PT.ArithmeticMultiply -> make "multiply" 0
+    | PT.ArithmeticDivide -> make "divide" 0
+    | PT.ArithmeticModulo -> make "modulo" 0
+    | PT.ArithmeticPower -> make "power" 0
+    | PT.ComparisonGreaterThan -> make "greaterThan" 0
+    | PT.ComparisonGreaterThanOrEqual -> make "greaterThanOrEqualTo" 0
+    | PT.ComparisonLessThan -> make "lessThan" 0
+    | PT.ComparisonLessThanOrEqual -> make "lessThanOrEqualTo" 0
     | PT.StringConcat -> make "stringAppend" 0
     | PT.ComparisonEquals -> make "equals" 0
     | PT.ComparisonNotEquals -> make "notEquals" 0

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1057,6 +1057,7 @@ module RuntimeError =
     | VariableNotFound of attemptedVarName : string
 
     | EqualityCheckOnIncompatibleTypes of left : ValueType * right : ValueType
+    | NumericOperationOnIncompatibleTypes of left : ValueType * right : ValueType
 
     | IfConditionNotBool of actualValue : Dval * actualValueType : ValueType
 

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -1445,6 +1445,9 @@ module RuntimeError =
       | RuntimeError.EqualityCheckOnIncompatibleTypes(left, right) ->
         "EqualityCheckOnIncompatibleTypes",
         [ ValueType.toDT left; ValueType.toDT right ]
+      | RuntimeError.NumericOperationOnIncompatibleTypes(left, right) ->
+        "NumericOperationOnIncompatibleTypes",
+        [ ValueType.toDT left; ValueType.toDT right ]
       | RuntimeError.IfConditionNotBool(actualValue, actualValueType) ->
         "IfConditionNotBool",
         [ Dval.toDT actualValue; ValueType.toDT actualValueType ]
@@ -1491,6 +1494,11 @@ module RuntimeError =
       RuntimeError.VariableNotFound attemptedVarName
     | DEnum(_, _, [], "EqualityCheckOnIncompatibleTypes", [ left; right ]) ->
       RuntimeError.EqualityCheckOnIncompatibleTypes(
+        ValueType.fromDT left,
+        ValueType.fromDT right
+      )
+    | DEnum(_, _, [], "NumericOperationOnIncompatibleTypes", [ left; right ]) ->
+      RuntimeError.NumericOperationOnIncompatibleTypes(
         ValueType.fromDT left,
         ValueType.fromDT right
       )

--- a/backend/src/LibParser/FSharpToWrittenTypes.fs
+++ b/backend/src/LibParser/FSharpToWrittenTypes.fs
@@ -448,7 +448,7 @@ module Expr =
     | SynExprLongIdentPat [ "op_UnaryNegation" ] ->
       WT.EApply(
         id,
-        WT.EFnName(gid (), WT.KnownBuiltin("int64Negate", 0)),
+        WT.EFnName(gid (), WT.KnownBuiltin("negate", 0)),
         [],
         NEList.singleton WT.EPlaceHolder
       )

--- a/backend/testfiles/execution/language/apply/einfix.dark
+++ b/backend/testfiles/execution/language/apply/einfix.dark
@@ -3,7 +3,54 @@
 (5L + (3L)) = 8L
 Stdlib.Int64.add_v0 5L 3L = 8L
 
-5L + true = error="Builtin.int64Add's 2nd parameter `b` expects Int64, but got Bool (true)"
+// Numeric operators are polymorphic over numeric types at runtime
+1.0 + 2.0 = 3.0
+3.5 * 2.0 = 7.0
+10.0 - 4.0 = 6.0
+1y + 2y = 3y
+100UL - 1UL = 99UL
+10L / 3L = 3L
+10.0 / 4.0 = 2.5
+7L % 3L = 1L
+-8L % 3L = 1L
+7.5 % 2.0 = 1.5
+-1.5 % 2.0 = 0.5
+2.0 ^ 3.0 = 8.0
+2L ^ 3L = 8L
+2.5 < 3.5 = true
+5L >= 5L = true
+2y > 1y = true
+
+// Mixed numeric types are a type error (no implicit coercion)
+5L + true = error="Cannot perform numeric operation on Int64 and Bool"
+1L + 2.0 = error="Cannot perform numeric operation on Int64 and Float"
+
+// Integer +,-,* overflow raises a runtime error (consistent with /, %, ^)
+127y + 1y = error="Encountered out-of-range value for type of Int"
+0uy - 1uy = error="Encountered out-of-range value for type of Int"
+9223372036854775807L + 1L = error="Encountered out-of-range value for type of Int"
+2L * 9223372036854775807L = error="Encountered out-of-range value for type of Int"
+170141183460469231731687303715884105727Q + 1Q = error="Encountered out-of-range value for type of Int"
+340282366920938463463374607431768211455Z + 1Z = error="Encountered out-of-range value for type of Int"
+// Signed integer division overflow (MinValue / -1) raises rather than crashing
+// or (for narrow widths) silently wrapping
+-9223372036854775808L / -1L = error="Encountered out-of-range value for type of Int"
+-128y / -1y = error="Encountered out-of-range value for type of Int"
+2L ^ 64L = error="Encountered out-of-range value for type of Int"
+(-9223372036854775808L) ^ 64L = error="Encountered out-of-range value for type of Int"
+// Integer division by zero raises a clean RTE
+10L / 0L = error="Cannot divide by 0"
+// Float overflow follows IEEE (infinity), not an error
+2.0 ^ 100000.0 = Builtin.testInfinity_v0
+
+// `^` (power) works on every integer type and Float; Int128/UInt128 are unsupported
+2y ^ 3y = 8y
+3uy ^ 3uy = 27uy
+2l ^ 10l = 1024l
+2Q ^ 3Q = error="Cannot perform numeric operation on Int128 and Int128"
+// unary `-` works on every signed integer type and Float
+-(Stdlib.Int8.add_v0 2y 3y) = -5y
+-(Stdlib.Float.add_v0 1.0 1.5) = -2.5
 5L + (Builtin.testRuntimeError "error") = error="Uncaught exception: error"
 (Builtin.testRuntimeError "error") + 5L = error="Uncaught exception: error"
 (Builtin.testRuntimeError "one") + (Builtin.testRuntimeError "two") = error="Uncaught exception: one"

--- a/backend/testfiles/execution/stdlib/ints/int32.dark
+++ b/backend/testfiles/execution/stdlib/ints/int32.dark
@@ -1,5 +1,6 @@
 Stdlib.Int32.absoluteValue_v0 -5l = 5l
 Stdlib.Int32.absoluteValue_v0 5l = 5l
+Stdlib.Int32.absoluteValue_v0 (-2147483648l) = error="Encountered out-of-range value for type of Int"
 
 Stdlib.Int32.max_v0 5l 6l = 6l
 Stdlib.Int32.max_v0 10l 1l = 10l
@@ -33,6 +34,7 @@ Stdlib.Int32.negate_v0 -5l = 5l
 Stdlib.Int32.negate_v0 5l = -5l
 Stdlib.Int32.negate_v0 0l = 0l
 Stdlib.Int32.negate_v0 -0l = 0l
+Stdlib.Int32.negate_v0 (-2147483648l) = error="Encountered out-of-range value for type of Int"
 
 Stdlib.Int32.remainder_v0 15l 6l = Stdlib.Result.Result.Ok 3l
 Stdlib.Int32.remainder_v0 20l 8l = Stdlib.Result.Result.Ok 4l
@@ -101,9 +103,9 @@ Stdlib.Int32.add_v0 -55l 55l = 0l
 Stdlib.Int32.add_v0 2147483646l 1l = 2147483647l
 
 // Overflow tests
-Stdlib.Int32.add_v0 2147483647l 1l = -2147483648l
-Stdlib.Int32.add_v0 55l 2147483647l = -2147483594l
-Stdlib.Int32.add_v0 -2147483648l -1l = 2147483647l
+Stdlib.Int32.add_v0 2147483647l 1l = error="Encountered out-of-range value for type of Int"
+Stdlib.Int32.add_v0 55l 2147483647l = error="Encountered out-of-range value for type of Int"
+Stdlib.Int32.add_v0 -2147483648l -1l = error="Encountered out-of-range value for type of Int"
 
 
 Stdlib.Int32.subtract_v0 10l 9l = 1l
@@ -121,6 +123,7 @@ Stdlib.Int32.divide_v0 -8l 5l = -1l
 Stdlib.Int32.divide_v0 0l 1l = 0l
 
 Stdlib.Int32.divide_v0 1l 0l = error="Cannot divide by 0"
+Stdlib.Int32.divide_v0 (-2147483648l) -1l = error="Encountered out-of-range value for type of Int"
 (Stdlib.List.range_v0 1L 5L)
 |> Stdlib.List.map_v0 (fun x -> Stdlib.Int32.random 1l 2l)
 |> Stdlib.List.map_v0 (fun x ->

--- a/backend/testfiles/execution/stdlib/ints/int64.dark
+++ b/backend/testfiles/execution/stdlib/ints/int64.dark
@@ -1,5 +1,6 @@
 Stdlib.Int64.absoluteValue_v0 -5L = 5L
 Stdlib.Int64.absoluteValue_v0 5L = 5L
+Stdlib.Int64.absoluteValue_v0 (-9223372036854775808L) = error="Encountered out-of-range value for type of Int"
 
 Stdlib.Int64.max_v0 5L 6L = 6L
 Stdlib.Int64.max_v0 10L 1L = 10L
@@ -33,6 +34,7 @@ Stdlib.Int64.negate_v0 -5L = 5L
 Stdlib.Int64.negate_v0 5L = -5L
 Stdlib.Int64.negate_v0 0L = 0L
 Stdlib.Int64.negate_v0 -0L = 0L
+Stdlib.Int64.negate_v0 (-9223372036854775808L) = error="Encountered out-of-range value for type of Int"
 
 Stdlib.Int64.remainder_v0 15L 6L = Stdlib.Result.Result.Ok 3L
 Stdlib.Int64.remainder_v0 20L 8L = Stdlib.Result.Result.Ok 4L
@@ -96,6 +98,10 @@ Stdlib.Int64.power_v0 200L 20L = error="Encountered out-of-range value for type 
 Stdlib.Int64.power_v0 200L 7L = 12800000000000000L
 Stdlib.Int64.power_v0 1L 2147483649L = 1L
 Stdlib.Int64.power_v0 -1L 2147483649L = -1L
+// Non-trivial base with an out-of-Int32-range exponent overflows rather than
+// crashing on the internal `bigint ** (int exp)` narrowing.
+Stdlib.Int64.power_v0 2L 2147483649L = error="Encountered out-of-range value for type of Int"
+Stdlib.Int64.power_v0 2L 64L = error="Encountered out-of-range value for type of Int"
 Stdlib.Int64.power_v0 2L -3L = error="Cannot raise integer to a negative exponent"
 5L ^ 2L = 25L
 -8L ^ 5L = -32768L
@@ -167,9 +173,9 @@ Stdlib.Int64.add_v0 -55L 55L = 0L
 Stdlib.Int64.add_v0 9223372036854775806L 1L = 9223372036854775807L
 
 // Overflow tests
-Stdlib.Int64.add_v0 9223372036854775807L 1L = -9223372036854775808L
-Stdlib.Int64.add_v0 55L 9223372036854775807L = -9223372036854775754L
-Stdlib.Int64.add_v0 (-9223372036854775808L) (-1L) = 9223372036854775807L
+Stdlib.Int64.add_v0 9223372036854775807L 1L = error="Encountered out-of-range value for type of Int"
+Stdlib.Int64.add_v0 55L 9223372036854775807L = error="Encountered out-of-range value for type of Int"
+Stdlib.Int64.add_v0 (-9223372036854775808L) (-1L) = error="Encountered out-of-range value for type of Int"
 
 -2000L + 1950L = -50L
 -1993L + 2000L = 7L
@@ -199,6 +205,7 @@ Stdlib.Int64.divide_v0 -8L 5L = -1L
 Stdlib.Int64.divide_v0 0L 1L = 0L
 
 Stdlib.Int64.divide_v0 1L 0L = error="Cannot divide by 0"
+Stdlib.Int64.divide_v0 (-9223372036854775808L) -1L = error="Encountered out-of-range value for type of Int"
 (Stdlib.List.range_v0 1L 5L)
 |> Stdlib.List.map_v0 (fun x -> Stdlib.Int64.random 1L 2L)
 |> Stdlib.List.map_v0 (fun x -> (x >= 1L) && (x <= 2L)) = [ true; true; true; true; true ]

--- a/backend/testfiles/execution/stdlib/ints/uint64.dark
+++ b/backend/testfiles/execution/stdlib/ints/uint64.dark
@@ -26,6 +26,10 @@ Stdlib.UInt64.power_v0 200UL 20UL = error="Encountered out-of-range value for ty
 Stdlib.UInt64.power_v0 200UL 7UL = 12800000000000000UL
 
 Stdlib.UInt64.power_v0 1UL 2147483649UL = 1UL
+// Non-trivial base with an out-of-Int32-range exponent overflows rather than
+// crashing on the internal `bigint ** (int exp)` narrowing.
+Stdlib.UInt64.power_v0 2UL 2147483649UL = error="Encountered out-of-range value for type of Int"
+Stdlib.UInt64.power_v0 2UL 64UL = error="Encountered out-of-range value for type of Int"
 
 Stdlib.UInt64.greaterThan_v0 20UL 1UL = true
 

--- a/backend/tests/Tests/Builtin.Tests.fs
+++ b/backend/tests/Tests/Builtin.Tests.fs
@@ -71,17 +71,18 @@ let oldFunctionsAreDeprecated =
 /// for `-x`.
 let private infixDispatched : Set<string> =
   Set.ofList
-    [ "int64Add"
-      "int64Subtract"
-      "int64Multiply"
-      "int64Mod"
-      "int64Power"
-      "int64Negate"
-      "int64GreaterThan"
-      "int64GreaterThanOrEqualTo"
-      "int64LessThan"
-      "int64LessThanOrEqualTo"
-      "floatDivide"
+    [ // Polymorphic numeric operators
+      "add"
+      "subtract"
+      "multiply"
+      "divide"
+      "modulo"
+      "power"
+      "greaterThan"
+      "greaterThanOrEqualTo"
+      "lessThan"
+      "lessThanOrEqualTo"
+      "negate"
       "stringAppend"
       "equals"
       "notEquals" ]

--- a/backend/tests/Tests/PT2RT.Tests.fs
+++ b/backend/tests/Tests/PT2RT.Tests.fs
@@ -625,7 +625,7 @@ module Expr =
              2,
              RT.DApplicable(
                RT.AppNamedFn
-                 { name = RT.FQFnName.fqBuiltin "int64Add" 0
+                 { name = RT.FQFnName.fqBuiltin "add" 0
                    typeSymbolTable = Map.empty
                    typeArgs = []
                    argsSoFar = [] }
@@ -673,7 +673,7 @@ module Expr =
                          2,
                          RT.DApplicable(
                            RT.AppNamedFn
-                             { name = RT.FQFnName.fqBuiltin "int64Add" 0
+                             { name = RT.FQFnName.fqBuiltin "add" 0
                                typeSymbolTable = Map.empty
                                typeArgs = []
                                argsSoFar = [] }
@@ -705,7 +705,7 @@ module Expr =
                          2,
                          (RT.DApplicable(
                            RT.AppNamedFn
-                             { name = RT.FQFnName.fqBuiltin "int64Add" 0
+                             { name = RT.FQFnName.fqBuiltin "add" 0
                                typeSymbolTable = Map.empty
                                typeArgs = []
                                argsSoFar = [] }
@@ -730,7 +730,7 @@ module Expr =
                          2,
                          (RT.DApplicable(
                            RT.AppNamedFn
-                             { name = RT.FQFnName.fqBuiltin "int64Multiply" 0
+                             { name = RT.FQFnName.fqBuiltin "multiply" 0
                                typeSymbolTable = Map.empty
                                typeArgs = []
                                argsSoFar = [] }
@@ -759,7 +759,7 @@ module Expr =
              9,
              RT.DApplicable(
                RT.AppNamedFn
-                 { name = RT.FQFnName.fqBuiltin "int64Add" 0
+                 { name = RT.FQFnName.fqBuiltin "add" 0
                    typeSymbolTable = Map.empty
                    typeArgs = []
                    argsSoFar = [] }
@@ -1001,7 +1001,7 @@ module Expr =
                2,
                RT.DApplicable(
                  RT.AppNamedFn
-                   { name = RT.FQFnName.fqBuiltin "int64Add" 0
+                   { name = RT.FQFnName.fqBuiltin "add" 0
                      typeSymbolTable = Map.empty
                      typeArgs = []
                      argsSoFar = [] }
@@ -1522,7 +1522,7 @@ module Expr =
                              2,
                              RT.DApplicable(
                                RT.AppNamedFn
-                                 { name = RT.FQFnName.fqBuiltin "int64Add" 0
+                                 { name = RT.FQFnName.fqBuiltin "add" 0
                                    typeSymbolTable = Map.empty
                                    typeArgs = []
                                    argsSoFar = [] }

--- a/packages/darklang/cli/docs/errors.dark
+++ b/packages/darklang/cli/docs/errors.dark
@@ -21,8 +21,8 @@ let content () : String =
   - Check spelling/case
 
 ## Operator errors
-  - Int division: use Stdlib.Int64.divide
-  - Float subtract: use Stdlib.Float.subtract
+  - Numeric operators require matching numeric operand types
+  - Integer / and ^ can raise out-of-range runtime errors
   - List concat: use Stdlib.List.append
 
 ## Enum errors

--- a/packages/darklang/cli/docs/for-ai.dark
+++ b/packages/darklang/cli/docs/for-ai.dark
@@ -144,7 +144,9 @@ Rules:
 - Lists: [1L; 2L; 3L] (semicolons)
 - String concat: ++ (not @)
 - String interpolation: $"x = {expr}; total = {a ++ b}"
-- Int division: Stdlib.Int64.divide (not /)
+- Numeric operators (+ - * / % ^ < > <= >= and unary -) are polymorphic over
+  numeric types; operands must match (`1 + 2`, `1.0 + 2.0`). `/` is integer
+  division on ints; integer overflow raises a runtime error.
 
 ## Records
   MyRecord { a = 1L; b = 2L }

--- a/packages/darklang/cli/docs/operators.dark
+++ b/packages/darklang/cli/docs/operators.dark
@@ -5,18 +5,21 @@ let content () : String =
 
 ## Comparison
   == != < > <= >=
+  (< > <= >= are polymorphic over numeric types — Int8..Int128, UInt*, Float)
 
 ## Boolean
   && || (use Stdlib.Bool.not for negation)
 
-## Int64
-  + - * %
-  NO / -> Stdlib.Int64.divide
-
-## Float
-  NO infix operators — use Stdlib.Float.add / subtract / multiply / divide
-  (`+`/`-`/`*` parse-dispatch to Int64 at parse time; `1.0 + 2.0`
-   fails at runtime with an int64Add type error.)
+## Numeric (all int types + Float)
+  + - * / % ^   and unary -x
+  Polymorphic at runtime: both operands must be the same numeric type.
+  `1 + 2`, `1.0 + 2.0`, and `1y * 2y` all work.
+  `/` is integer division on ints, float division on floats.
+  `%` works on all numeric types (the modulus must be > 0).
+  `^` (power) works on all integer types and Float (not Int128/UInt128).
+  Unary `-x` negates signed ints and Float (not unsigned types).
+  Integer overflow (+ - * / ^ and unary -) raises a runtime error.
+  Float arithmetic follows IEEE (overflow -> infinity).
 
 ## String
   ++   concat

--- a/packages/darklang/languageTools/runtimeErrors.dark
+++ b/packages/darklang/languageTools/runtimeErrors.dark
@@ -149,6 +149,7 @@ type Error =
   | VariableNotFound of attemptedVarName: String
 
   | EqualityCheckOnIncompatibleTypes of left: ValueType * right: ValueType
+  | NumericOperationOnIncompatibleTypes of left: ValueType * right: ValueType
 
   | IfConditionNotBool of actualValue: Dval * actualValueType: ValueType
 

--- a/packages/darklang/prettyPrinter/runtimeError.dark
+++ b/packages/darklang/prettyPrinter/runtimeError.dark
@@ -234,6 +234,12 @@ module RuntimeError =
         ES.String " and "
         ES.ValueType right ]
 
+    | NumericOperationOnIncompatibleTypes (left, right) ->
+      [ ES.String "Cannot perform numeric operation on "
+        ES.ValueType left
+        ES.String " and "
+        ES.ValueType right ]
+
     | IfConditionNotBool (actualValue, actualValueType) ->
       [ ES.String "If condition must be a Bool, but got "
         ES.ValueType actualValueType

--- a/packages/darklang/stdlib/int128.dark
+++ b/packages/darklang/stdlib/int128.dark
@@ -80,7 +80,7 @@ let toFloat (a: Int128) : Float = Builtin.int128ToFloat a
 
 /// Returns the sum of all the ints in the list
 let sum (lst: List<Int128>) : Int128 =
-  Stdlib.List.fold lst 0Q (fun acc x -> acc + x)
+  Stdlib.List.fold lst 0Q (fun acc x -> add acc x)
 
 
 /// Returns the higher of <param a> and <param b>

--- a/packages/darklang/stdlib/int16.dark
+++ b/packages/darklang/stdlib/int16.dark
@@ -108,7 +108,7 @@ let toFloat (a: Int16) : Float = Builtin.int16ToFloat a
 
 /// Returns the sum of all the ints in the list
 let sum (lst: List<Int16>) : Int16 =
-  Stdlib.List.fold lst 0s (fun acc x -> acc + x)
+  Stdlib.List.fold lst 0s (fun acc x -> add acc x)
 
 
 /// Returns the higher of <param a> and <param b>

--- a/packages/darklang/stdlib/int64.dark
+++ b/packages/darklang/stdlib/int64.dark
@@ -10,7 +10,7 @@ type ParseError =
 /// The modulus <param b> must be greater than 0
 /// Use <fn Int64.remainder> if you want the remainder after division, which has
 /// a different behavior for negative numbers.
-let ``mod`` (a: Int64) (b: Int64) : Int64 = a % b
+let ``mod`` (a: Int64) (b: Int64) : Int64 = Builtin.int64Mod a b
 
 
 /// Returns the integer remainder left over after dividing <param value> by
@@ -27,15 +27,15 @@ let remainder
 
 
 /// Adds two integers together
-let add (a: Int64) (b: Int64) : Int64 = a + b
+let add (a: Int64) (b: Int64) : Int64 = Builtin.int64Add a b
 
 
 /// Subtracts two integers
-let subtract (a: Int64) (b: Int64) : Int64 = a - b
+let subtract (a: Int64) (b: Int64) : Int64 = Builtin.int64Subtract a b
 
 
 /// Multiplies two integers
-let multiply (a: Int64) (b: Int64) : Int64 = a * b
+let multiply (a: Int64) (b: Int64) : Int64 = Builtin.int64Multiply a b
 
 
 /// Divides two integers
@@ -53,32 +53,35 @@ let power (``base``: Int64) (exponent: Int64) : Int64 =
   if ``base`` == 0L && exponent == 0L then 1L
   else if ``base`` == 0L then 0L
   else if ``base`` == 1L then 1L
-  else if ``base`` == -1L && exponent % 2L == 0L then 1L
+  else if ``base`` == -1L && (``mod`` exponent 2L == 0L) then 1L
   else if ``base`` == -1L then -1L
-  else ``base`` ^ exponent
+  else Builtin.int64Power ``base`` exponent
 
 
 /// Returns the absolute value of <param a> (turning negative inputs into positive outputs)
-let absoluteValue (a: Int64) : Int64 = if a < 0L then -a else a
+let absoluteValue (a: Int64) : Int64 =
+  if lessThan a 0L then negate a else a
 
 
 /// Returns the negation of <param a>, {{-a}}
-let negate (a: Int64) : Int64 = -a
+let negate (a: Int64) : Int64 = Builtin.int64Negate a
 
 
 /// Returns {{true}} if <param a> is greater than <param b>
-let greaterThan (a: Int64) (b: Int64) : Bool = a > b
+let greaterThan (a: Int64) (b: Int64) : Bool = Builtin.int64GreaterThan a b
 
 
 /// Returns {{true}} if <param a> is greater than or equal to <param b>
-let greaterThanOrEqualTo (a: Int64) (b: Int64) : Bool = a >= b
+let greaterThanOrEqualTo (a: Int64) (b: Int64) : Bool =
+  Builtin.int64GreaterThanOrEqualTo a b
 
 
 /// Returns {{true}} if <param a> is less than <param b>
-let lessThan (a: Int64) (b: Int64) : Bool = a < b
+let lessThan (a: Int64) (b: Int64) : Bool = Builtin.int64LessThan a b
 
 /// Returns {{true}} if <param a> is less than or equal to <param b>
-let lessThanOrEqualTo (a: Int64) (b: Int64) : Bool = a <= b
+let lessThanOrEqualTo (a: Int64) (b: Int64) : Bool =
+  Builtin.int64LessThanOrEqualTo a b
 
 
 /// Returns a random integer between <param start> and <param end> (inclusive)
@@ -100,15 +103,15 @@ let fromFloat (a: Float) : Int64 = Builtin.floatToInt64 a
 
 /// Returns the sum of all the ints in the list
 let sum (lst: List<Int64>) : Int64 =
-  Stdlib.List.fold lst 0L (fun acc x -> acc + x)
+  Stdlib.List.fold lst 0L (fun acc x -> add acc x)
 
 
 /// Returns the higher of <param a> and <param b>
-let max (a: Int64) (b: Int64) : Int64 = if a > b then a else b
+let max (a: Int64) (b: Int64) : Int64 = if greaterThan a b then a else b
 
 
 /// Returns the lower of <param a> and <param b>
-let min (a: Int64) (b: Int64) : Int64 = if a < b then a else b
+let min (a: Int64) (b: Int64) : Int64 = if lessThan a b then a else b
 
 
 /// If <param value> is within the range given by <param limitA> and <param
@@ -117,11 +120,11 @@ let min (a: Int64) (b: Int64) : Int64 = if a < b then a else b
 /// limitB>, whichever is closer to <param value>.
 /// <param limitA> and <param limitB> can be provided in any order.
 let clamp (value: Int64) (limitA: Int64) (limitB: Int64) : Int64 =
-  let min = if limitA < limitB then limitA else limitB
-  let max = if limitA > limitB then limitA else limitB
+  let min = if lessThan limitA limitB then limitA else limitB
+  let max = if greaterThan limitA limitB then limitA else limitB
 
-  if value < min then min
-  else if value > max then max
+  if lessThan value min then min
+  else if greaterThan value max then max
   else value
 
 

--- a/packages/darklang/stdlib/int8.dark
+++ b/packages/darklang/stdlib/int8.dark
@@ -108,7 +108,7 @@ let toFloat (a: Int8) : Float = Builtin.int8ToFloat a
 
 /// Returns the sum of all the ints in the list
 let sum (lst: List<Int8>) : Int8 =
-  Stdlib.List.fold lst 0y (fun acc x -> acc + x)
+  Stdlib.List.fold lst 0y (fun acc x -> add acc x)
 
 
 /// Returns the higher of <param a> and <param b>

--- a/packages/darklang/stdlib/uint128.dark
+++ b/packages/darklang/stdlib/uint128.dark
@@ -58,7 +58,7 @@ let toFloat (a: UInt128) : Float = Builtin.uint128ToFloat a
 
 /// Returns the sum of all the ints in the list
 let sum (lst: List<UInt128>) : UInt128 =
-  Stdlib.List.fold lst 0Z (fun acc x -> acc + x)
+  Stdlib.List.fold lst 0Z (fun acc x -> add acc x)
 
 
 /// Returns the higher of <param a> and <param b>


### PR DESCRIPTION
Infix operators (+ - * / % ^ < > <= >=) used to lower to Int64-specific builtins, so 1.0 + 2.0 failed at runtime with an int64Add type error and / only did float division. 

This PR:
- points them at new polymorphic builtins that pick the right numeric type at runtime like equals already does.
Now `1 + 2`, `1.0 + 2.0`, `1y * 2y`, `5L >= 5L`, etc. all just work. Operands must be the same numeric type, mixing types gives a `NumericOperationOnIncompatibleTypes` error
 
- covers unary `-` (negate) and `^` (power), which were Int64 only before too, so -x and a ^ b now work for every integer type, not just Int64. And / does integer division on ints now (truncates toward zero)

- Integer overflow now raises instead of silently wrapping: `127y + 1y`,` Int64.MinValue negated`, `2 ^ 64`, etc. all give an out-of-range error.
