### PR TITLE
dark apps follow-up

### DIFF
--- a/packages/darklang/cli/apps/command.dark
+++ b/packages/darklang/cli/apps/command.dark
@@ -230,23 +230,33 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   | _ -> Command.help state
 
 
+// Show the stable app slug as the completion value, with the human name as the hint.
+let slugs (apps: List<Model.App>) : List<Cli.Completion.CompletionItem> =
+  apps |> Stdlib.List.map (fun a -> Cli.Completion.withDescription a.slug a.name)
+
 let complete
-  (_state: Cli.AppState)
-  (_args: List<String>)
+  (state: Cli.AppState)
+  (args: List<String>)
   : List<Cli.Completion.CompletionItem> =
-  [ Cli.Completion.simple "list"
-    Cli.Completion.simple "list-available"
-    Cli.Completion.simple "add"
-    Cli.Completion.simple "remove"
-    Cli.Completion.simple "run"
-    Cli.Completion.simple "start"
-    Cli.Completion.simple "spawn"
-    Cli.Completion.simple "stop"
-    Cli.Completion.simple "status"
-    Cli.Completion.simple "logs"
-    Cli.Completion.simple "inspect"
-    Cli.Completion.simple "enable"
-    Cli.Completion.simple "disable" ]
+  match args with
+  | [] ->
+    [ "list"; "list-available"; "add"; "remove"; "run"; "start"; "spawn"
+      "stop"; "status"; "logs"; "inspect"; "enable"; "disable" ]
+    |> Stdlib.List.map Cli.Completion.simple
+  // Only load the catalog once a verb needs slug completions.
+  | [ verb ] ->
+    let catalog = Registry.catalog state.currentBranchId
+    let daemons = catalog |> Stdlib.List.filter (fun a -> Model.isDaemon a.target)
+
+    match verb with
+    | "add" ->
+      slugs (catalog |> Stdlib.List.filter (fun a -> Stdlib.Bool.not (Registry.isInstalled a.slug)))
+    | "remove" -> slugs (Registry.installed state.currentBranchId)
+    | "run" -> slugs (catalog |> Stdlib.List.filter (fun a -> Stdlib.Bool.not (Model.isDaemon a.target)))
+    | "start" | "spawn" | "stop" | "status" | "logs" | "enable" | "disable" -> slugs daemons
+    | "inspect" -> slugs catalog
+    | _ -> []
+  | _ -> []
 
 
 // A single help line: "  cmd <args>   description", padded for a clean column.

--- a/packages/darklang/cli/apps/command.dark
+++ b/packages/darklang/cli/apps/command.dark
@@ -8,6 +8,8 @@ module Darklang.Cli.Apps.Command
 /// The port a running HTTP daemon bound to, read from its log (`… on http://localhost:<port>`). This is
 /// the *actual* port (default or config override), so it's accurate without the browser knowing defaults.
 /// `None` for daemons that aren't HTTP servers (they never log a port).
+
+// TODO: Log text isn't a reliable source of truth; store structured daemon metadata instead.
 let daemonPort (slug: String) : Stdlib.Option.Option<Int64> =
   let portLines =
     (Stdlib.Cli.Daemon.tailLog slug 25L)

--- a/packages/darklang/cli/apps/command.dark
+++ b/packages/darklang/cli/apps/command.dark
@@ -217,8 +217,9 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     | None -> Stdlib.printLine (Colors.error $"no app '{slug}' (see `apps list-available`)")
     | Some app ->
       match Service.enable app with
-      | Ok msg -> Stdlib.printLine (Colors.success $"✓ {msg}")
-      | Error e -> Stdlib.printLine (Colors.error e)
+      | Enabled msg -> Stdlib.printLine (Colors.success $"✓ {msg}")
+      | WroteOnly msg -> Stdlib.printLine (Colors.colorize Colors.yellow $"⚠ {msg}")
+      | Failed e -> Stdlib.printLine (Colors.error e)
     state
 
   | [ "disable"; slug ] ->

--- a/packages/darklang/cli/apps/command.dark
+++ b/packages/darklang/cli/apps/command.dark
@@ -47,7 +47,7 @@ let row (app: Model.App) : String =
 
 /// `apps run <slug>` — run a foreground app attached, dispatching its CLI command in-process.
 let runApp (state: Cli.AppState) (slug: String) : Cli.AppState =
-  match Registry.findBySlug slug with
+  match Registry.findBySlug state.currentBranchId slug with
   | None -> Stdlib.printLine (Colors.error $"no app '{slug}' (see `apps list-available`)")
   | Some app ->
     match app.target with
@@ -64,7 +64,7 @@ let startDaemon (state: Cli.AppState) (slug: String) : Cli.AppState =
     state
   else
 
-  match Registry.findBySlug slug with
+  match Registry.findBySlug state.currentBranchId slug with
   | None -> Stdlib.printLine (Colors.error $"no app '{slug}' (see `apps list-available`)")
   | Some app ->
     match app.target with
@@ -83,7 +83,7 @@ let startDaemon (state: Cli.AppState) (slug: String) : Cli.AppState =
 
 /// `apps inspect <slug>` — label, slug, target, installed?, and (daemons) status + recent logs.
 let inspect (state: Cli.AppState) (slug: String) : Cli.AppState =
-  match Registry.findBySlug slug with
+  match Registry.findBySlug state.currentBranchId slug with
   | None -> Stdlib.printLine (Colors.error $"no app '{slug}' (see `apps list-available`)")
   | Some app ->
     Stdlib.printLine $"{app.name}  [{Model.kindTag app.target}]"
@@ -112,7 +112,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   | [] -> Editor.launch state
 
   | [ "list" ] ->
-    let apps = Registry.installed ()
+    let apps = Registry.installed state.currentBranchId
     if Stdlib.List.isEmpty apps then
       Stdlib.printLine
         (Colors.dimText
@@ -137,7 +137,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     state
 
   | [ "add"; slug ] ->
-    match Registry.findBySlug slug with
+    match Registry.findBySlug state.currentBranchId slug with
     | None ->
       Stdlib.printLine (Colors.error $"no app '{slug}' (see `apps list-available`)")
       state
@@ -183,7 +183,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
 
   | [ "status" ] ->
     let daemons =
-      (Registry.installed ())
+      (Registry.installed state.currentBranchId)
       |> Stdlib.List.filter (fun a -> Model.isDaemon a.target)
 
     if Stdlib.List.isEmpty daemons then
@@ -213,7 +213,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   | [ "inspect"; slug ] -> inspect state slug
 
   | [ "enable"; slug ] ->
-    match Registry.findBySlug slug with
+    match Registry.findBySlug state.currentBranchId slug with
     | None -> Stdlib.printLine (Colors.error $"no app '{slug}' (see `apps list-available`)")
     | Some app ->
       match Service.enable app with

--- a/packages/darklang/cli/apps/editor.dark
+++ b/packages/darklang/cli/apps/editor.dark
@@ -151,6 +151,15 @@ let render (state: State) : Unit =
   else
     ()
 
+  // Explain the app status markers shown in each row.
+  let legend =
+    "  "
+    ++ (Colors.success "✓") ++ (Colors.dimText " installed    ")
+    ++ (Colors.colorize Colors.green "●") ++ (Colors.dimText " running    ")
+    ++ (Colors.colorize Colors.yellow "●") ++ (Colors.dimText " stale    ")
+    ++ (Colors.dimText "○ stopped")
+  Stdlib.printLine legend
+
   Stdlib.printLine
     (Colors.dimText
       "  ↑↓ move · enter run/start · a add · x remove · i detail · esc exit")

--- a/packages/darklang/cli/apps/model.dark
+++ b/packages/darklang/cli/apps/model.dark
@@ -22,6 +22,13 @@ type App =
     target: Target }
 
 
+/// True when `slug` matches the app-id allowlist: lowercase letters, digits, and hyphens.
+/// Slugs are used in CLI arguments, process names, and unit-file paths, so keep
+/// this check narrow enough to rule out shell metacharacters and path traversal.
+let isValidSlug (slug: String) : Bool =
+  Stdlib.Regex.isMatch slug "^[a-z0-9][a-z0-9-]*$"
+
+
 let kindTag (target: Target) : String =
   match target with
   | Foreground _ -> "foreground"

--- a/packages/darklang/cli/apps/registry.dark
+++ b/packages/darklang/cli/apps/registry.dark
@@ -61,8 +61,10 @@ let catalog (branchId: Uuid) : List<Model.App> =
   Stdlib.List.append (available ()) extra
 
 
-let findBySlug (slug: String) : Stdlib.Option.Option<Model.App> =
-  Stdlib.List.findFirst (available ()) (fun a -> a.slug == slug)
+/// Look up an app by slug across the full catalog (curated + discovered), so apps a user
+/// declares in their own packages are addable/runnable, not just the hardcoded seed.
+let findBySlug (branchId: Uuid) (slug: String) : Stdlib.Option.Option<Model.App> =
+  Stdlib.List.findFirst (catalog branchId) (fun a -> a.slug == slug)
 
 
 // ── the installed list ── persisted per-instance in cli-config.json (comma-separated slugs under one key)
@@ -93,7 +95,8 @@ let addInstalled (slug: String) : Unit =
 let removeInstalled (slug: String) : Unit =
   saveInstalled ((installedSlugs ()) |> Stdlib.List.filter (fun s -> s != slug))
 
-/// The apps this instance has installed — `available` filtered to the curated list. Empty by default.
-let installed () : List<Model.App> =
+/// The apps this instance has installed — the `catalog` filtered to the curated slugs, so an
+/// installed discovered app still resolves. Empty by default.
+let installed (branchId: Uuid) : List<Model.App> =
   let slugs = installedSlugs ()
-  (available ()) |> Stdlib.List.filter (fun a -> Stdlib.List.member_v0 slugs a.slug)
+  (catalog branchId) |> Stdlib.List.filter (fun a -> Stdlib.List.member_v0 slugs a.slug)

--- a/packages/darklang/cli/apps/service.dark
+++ b/packages/darklang/cli/apps/service.dark
@@ -8,6 +8,12 @@ type Platform =
   | Mac
   | Unsupported
 
+/// Result of writing and activating an auto-start unit.
+type EnableResult =
+  | Enabled of String
+  | WroteOnly of String
+  | Failed of String
+
 let platform () : Platform =
   match Stdlib.Cli.Sys.os () with
   | Ok "Linux" -> Platform.Linux
@@ -37,36 +43,45 @@ let private systemdUnit (app: Model.App) : String =
 let private launchdPlist (app: Model.App) : String =
   $"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<plist version=\"1.0\"><dict>\n  <key>Label</key><string>com.darklang.{app.slug}</string>\n  <key>ProgramArguments</key><array><string>/bin/sh</string><string>-c</string><string>{daemonCommand app}</string></array>\n  <key>RunAtLoad</key><true/>\n  <key>KeepAlive</key><true/>\n</dict></plist>\n"
 
-/// Register `app` as an OS service. Writes the unit and tries to activate it; on failure returns the
-/// manual activation command so it still works on real systems.
-let enable (app: Model.App) : Stdlib.Result.Result<String, String> =
+/// Register `app` as an OS service by writing its unit, then activating it.
+let enable (app: Model.App) : EnableResult =
   if Stdlib.Bool.not (Model.isValidSlug app.slug) then
-    Stdlib.Result.Result.Error $"invalid app slug '{app.slug}'"
+    EnableResult.Failed $"invalid app slug '{app.slug}'"
   else if Stdlib.Bool.not (Model.isDaemon app.target) then
-    Stdlib.Result.Result.Error $"'{app.slug}' is a foreground app — only daemons can auto-start"
+    EnableResult.Failed $"'{app.slug}' is a foreground app — only daemons can auto-start"
   else
     match platform () with
     | Unsupported ->
-      Stdlib.Result.Result.Error "auto-start isn't supported on this platform (Linux / macOS only)"
+      EnableResult.Failed "auto-start isn't supported on this platform (Linux / macOS only)"
     | Linux ->
       let path = unitPath app.slug
       let _dir = Stdlib.Cli.Posix.mkdirRecursive ((home ()) ++ "/.config/systemd/user")
       match Stdlib.Cli.File.writeText path (systemdUnit app) with
-      | Error e -> Stdlib.Result.Result.Error e.message
+      | Error e -> EnableResult.Failed e.message
       | Ok _ ->
         match Stdlib.Cli.Process.exec "systemctl" [ "--user"; "enable"; "--now"; $"dark-{app.slug}.service" ] with
-        | Ok _ -> Stdlib.Result.Result.Ok $"enabled — {app.name} will start on login (systemd: dark-{app.slug})"
+        | Ok _ -> EnableResult.Enabled $"enabled — {app.name} will start on login (systemd: dark-{app.slug})"
         | Error _ ->
-          Stdlib.Result.Result.Ok $"wrote {path} — activate with: systemctl --user enable --now dark-{app.slug}.service"
+          EnableResult.WroteOnly $"wrote {path}, but couldn't activate it — run: systemctl --user enable --now dark-{app.slug}.service"
     | Mac ->
       let path = unitPath app.slug
       let _dir = Stdlib.Cli.Posix.mkdirRecursive ((home ()) ++ "/Library/LaunchAgents")
       match Stdlib.Cli.File.writeText path (launchdPlist app) with
-      | Error e -> Stdlib.Result.Result.Error e.message
+      | Error e -> EnableResult.Failed e.message
       | Ok _ ->
         match Stdlib.Cli.Process.exec "launchctl" [ "load"; path ] with
-        | Ok _ -> Stdlib.Result.Result.Ok $"enabled — {app.name} will start on login (launchd: com.darklang.{app.slug})"
-        | Error _ -> Stdlib.Result.Result.Ok $"wrote {path} — activate with: launchctl load {path}"
+        | Ok _ -> EnableResult.Enabled $"enabled — {app.name} will start on login (launchd: com.darklang.{app.slug})"
+        | Error _ -> EnableResult.WroteOnly $"wrote {path}, but couldn't activate it — run: launchctl load {path}"
+
+/// Delete the unit file that makes `slug` auto-start; missing files are already disabled.
+let removeUnit (slug: String) : Stdlib.Result.Result<String, String> =
+  let path = unitPath slug
+  if Stdlib.Cli.File.exists path then
+    match Stdlib.Cli.File.delete path with
+    | Ok _ -> Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"
+    | Error e -> Stdlib.Result.Result.Error $"couldn't remove the unit file {path}: {e.message}"
+  else
+    Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"
 
 /// Remove the OS service for `slug` (deactivate + delete the unit). Idempotent.
 let disable (slug: String) : Stdlib.Result.Result<String, String> =
@@ -78,9 +93,7 @@ let disable (slug: String) : Stdlib.Result.Result<String, String> =
       Stdlib.Result.Result.Error "auto-start isn't supported on this platform (Linux / macOS only)"
     | Linux ->
       let _ = Stdlib.Cli.Process.exec "systemctl" [ "--user"; "disable"; "--now"; $"dark-{slug}.service" ]
-      let _ = Stdlib.Cli.File.delete (unitPath slug)
-      Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"
+      removeUnit slug
     | Mac ->
       let _ = Stdlib.Cli.Process.exec "launchctl" [ "unload"; unitPath slug ]
-      let _ = Stdlib.Cli.File.delete (unitPath slug)
-      Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"
+      removeUnit slug

--- a/packages/darklang/cli/apps/service.dark
+++ b/packages/darklang/cli/apps/service.dark
@@ -40,7 +40,9 @@ let private launchdPlist (app: Model.App) : String =
 /// Register `app` as an OS service. Writes the unit and tries to activate it; on failure returns the
 /// manual activation command so it still works on real systems.
 let enable (app: Model.App) : Stdlib.Result.Result<String, String> =
-  if Stdlib.Bool.not (Model.isDaemon app.target) then
+  if Stdlib.Bool.not (Model.isValidSlug app.slug) then
+    Stdlib.Result.Result.Error $"invalid app slug '{app.slug}'"
+  else if Stdlib.Bool.not (Model.isDaemon app.target) then
     Stdlib.Result.Result.Error $"'{app.slug}' is a foreground app — only daemons can auto-start"
   else
     match platform () with
@@ -52,32 +54,33 @@ let enable (app: Model.App) : Stdlib.Result.Result<String, String> =
       match Stdlib.Cli.File.writeText path (systemdUnit app) with
       | Error e -> Stdlib.Result.Result.Error e.message
       | Ok _ ->
-        let activate = $"systemctl --user enable --now dark-{app.slug}.service"
-        match Stdlib.Cli.Process.exec "/bin/sh" [ "-c"; activate ] with
+        match Stdlib.Cli.Process.exec "systemctl" [ "--user"; "enable"; "--now"; $"dark-{app.slug}.service" ] with
         | Ok _ -> Stdlib.Result.Result.Ok $"enabled — {app.name} will start on login (systemd: dark-{app.slug})"
         | Error _ ->
-          Stdlib.Result.Result.Ok $"wrote {path} — activate with: {activate}"
+          Stdlib.Result.Result.Ok $"wrote {path} — activate with: systemctl --user enable --now dark-{app.slug}.service"
     | Mac ->
       let path = unitPath app.slug
       let _dir = Stdlib.Cli.Posix.mkdirRecursive ((home ()) ++ "/Library/LaunchAgents")
       match Stdlib.Cli.File.writeText path (launchdPlist app) with
       | Error e -> Stdlib.Result.Result.Error e.message
       | Ok _ ->
-        let activate = $"launchctl load {path}"
-        match Stdlib.Cli.Process.exec "/bin/sh" [ "-c"; activate ] with
+        match Stdlib.Cli.Process.exec "launchctl" [ "load"; path ] with
         | Ok _ -> Stdlib.Result.Result.Ok $"enabled — {app.name} will start on login (launchd: com.darklang.{app.slug})"
-        | Error _ -> Stdlib.Result.Result.Ok $"wrote {path} — activate with: {activate}"
+        | Error _ -> Stdlib.Result.Result.Ok $"wrote {path} — activate with: launchctl load {path}"
 
 /// Remove the OS service for `slug` (deactivate + delete the unit). Idempotent.
 let disable (slug: String) : Stdlib.Result.Result<String, String> =
-  match platform () with
-  | Unsupported ->
-    Stdlib.Result.Result.Error "auto-start isn't supported on this platform (Linux / macOS only)"
-  | Linux ->
-    let _ = Stdlib.Cli.Process.exec "/bin/sh" [ "-c"; $"systemctl --user disable --now dark-{slug}.service" ]
-    let _ = Stdlib.Cli.File.delete (unitPath slug)
-    Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"
-  | Mac ->
-    let _ = Stdlib.Cli.Process.exec "/bin/sh" [ "-c"; $"launchctl unload {unitPath slug}" ]
-    let _ = Stdlib.Cli.File.delete (unitPath slug)
-    Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"
+  if Stdlib.Bool.not (Model.isValidSlug slug) then
+    Stdlib.Result.Result.Error $"invalid app slug '{slug}'"
+  else
+    match platform () with
+    | Unsupported ->
+      Stdlib.Result.Result.Error "auto-start isn't supported on this platform (Linux / macOS only)"
+    | Linux ->
+      let _ = Stdlib.Cli.Process.exec "systemctl" [ "--user"; "disable"; "--now"; $"dark-{slug}.service" ]
+      let _ = Stdlib.Cli.File.delete (unitPath slug)
+      Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"
+    | Mac ->
+      let _ = Stdlib.Cli.Process.exec "launchctl" [ "unload"; unitPath slug ]
+      let _ = Stdlib.Cli.File.delete (unitPath slug)
+      Stdlib.Result.Result.Ok $"disabled auto-start for '{slug}'"

--- a/packages/darklang/cli/apps/service.dark
+++ b/packages/darklang/cli/apps/service.dark
@@ -73,7 +73,7 @@ let enable (app: Model.App) : EnableResult =
         | Ok _ -> EnableResult.Enabled $"enabled — {app.name} will start on login (launchd: com.darklang.{app.slug})"
         | Error _ -> EnableResult.WroteOnly $"wrote {path}, but couldn't activate it — run: launchctl load {path}"
 
-/// Delete the unit file that makes `slug` auto-start; missing files are already disabled.
+// Delete the unit file that makes `slug` auto-start; missing files are already disabled.
 let removeUnit (slug: String) : Stdlib.Result.Result<String, String> =
   let path = unitPath slug
   if Stdlib.Cli.File.exists path then

--- a/packages/darklang/cli/config.dark
+++ b/packages/darklang/cli/config.dark
@@ -64,6 +64,19 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     let updatedConfig = Stdlib.Dict.setOverridingDuplicates config key value
     writeConfig updatedConfig
     Stdlib.printLine (Colors.success $"Set {key} = {value}")
+
+    // Show the implied local URL for well-formed app port settings.
+    match Stdlib.String.split key "." with
+    | [ "apps"; _; "port" ] ->
+      match Stdlib.Int64.parse value with
+      | Ok port ->
+        if port >= 1L && port <= 65535L then
+          Stdlib.printLine (Colors.dimText $"  → http://localhost:{value}")
+        else
+          ()
+      | Error _ -> ()
+    | _ -> ()
+
     state
 
   | ["list"] ->


### PR DESCRIPTION
#5673 follow-ups:
- Fix shell injection in apps disable <slug>
- Fix discovered apps not being addable via apps add
- Fix apps tab completion
- Fix apps enable/disable reporting partial failures as success
- Add a port URL hint to `config set apps.<slug>.port`
- Add a legend to the interactive apps browser for the installed/running/stale/stopped markers