### PR TITLE
Fix GH release publishing in CI

### DIFF
--- a/scripts/deployment/publish-github-release
+++ b/scripts/deployment/publish-github-release
@@ -6,7 +6,6 @@ set -euo pipefail
 TOKEN="${GITHUB_RELEASES_TOKEN}"
 OWNER="darklang"
 REPO="dark"
-TAG="v0.0.1"
 TARGET_COMMITISH="main"
 NAME="cli-pre-release"
 BODY="Pre-release of darklang executable"
@@ -34,26 +33,55 @@ delete_tag() {
     "https://api.github.com/repos/$OWNER/$REPO/git/refs/tags/$tag_name"
 }
 
-# Function to increment the tag number for a new release
-increment_tag() {
-  ## Fetch latest release tag
-  latest_tag=$(curl -s "https://api.github.com/repos/$OWNER/$REPO/releases" | jq -r '.[0].tag_name')
+# Function to list every existing v0.0.x tag ref, one per line
+#
+# Tags rather than releases: a run that dies between creating the release and
+# cleaning it up leaves the tag behind, and that orphan tag is still enough to
+# collide. Every release this script makes creates a tag, so the tags are a
+# superset of what we need to avoid.
+list_version_tag_refs() {
+  local page=1 body count
 
-  ## Check id latest tag is empty or null, if no tags found, start from v0.0.1
-  if [ -z $latest_tag ] || [ $latest_tag = "null" ]; then
-    echo "v0.0.1"
-  else
-    ## Major.Minor.Patch
-    IFS='.' read -r -a version_numbers <<< "$latest_tag"
-    major_number=${version_numbers[0]}
-    minor_number=${version_numbers[1]}
-    patch_number=${version_numbers[2]}
-    patch_number=$((patch_number + 1))
-    echo "${major_number}.${minor_number}.${patch_number}"
-  fi
+  while :; do
+    body=$(curl -sS -L \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "https://api.github.com/repos/$OWNER/$REPO/git/matching-refs/tags/v0.0.?per_page=100&page=$page")
+
+    ## Anything but an array means an error payload (rate limit, bad token, ...)
+    if [ "$(echo "$body" | jq -r 'type' 2>/dev/null)" != "array" ]; then
+      echo "Failed to list existing tags: $body" >&2
+      return 1
+    fi
+
+    echo "$body" | jq -r '.[].ref'
+
+    count=$(echo "$body" | jq 'length')
+    [ "$count" -eq 100 ] || break
+    page=$((page + 1))
+  done
 }
 
-TAG=$(increment_tag)
+# Function to pick the next unused tag: highest existing v0.0.N, plus one
+next_tag() {
+  local highest
+
+  highest=$(list_version_tag_refs \
+    | sed -n 's#^refs/tags/v0\.0\.\([0-9][0-9]*\)$#\1#p' \
+    | sort -n \
+    | tail -n 1)
+
+  ## No tags yet, start from v0.0.1
+  if [ -z "$highest" ]; then
+    highest=0
+  fi
+
+  echo "v0.0.$((highest + 1))"
+}
+
+TAG=$(next_tag) || { echo "Could not determine the next release tag"; exit 1; }
+echo "Next release tag: $TAG"
 
 
 # Create a GitHub release


### PR DESCRIPTION
publish-github-release has failed on every main build since v0.0.17 (May 26) with a 422 from GitHub: already_exists on tag_name. It's wedged, not flaky.

---

## The bug

increment_tag read the current version off the top of the release list:

    latest_tag=$(curl -s ".../releases" | jq -r '.[0].tag_name')

GET /releases is sorted by created_at descending, and created_at on a release is the *tagged commit's* date, not the publish time. So [0] is the release with the newest commit, which has nothing to do with the highest version. Today that list looks like:

    [0]  v0.0.17   commit 2026-05-26
    ...
    [16] v0.0.1    commit 2026-04-22
    [17] v0.0.24   commit 2026-04-02   <- highest version, oldest commit
    ...
    [23] v0.0.18   commit 2026-04-01

The counter restarted at v0.0.1 on Apr 22 and has been climbing since. It has now caught up with the April run: [0] is v0.0.17, so the script asks for v0.0.18, and v0.0.18 has existed since Apr 1. Every future build computes the same tag and fails the same way.

That Apr 22 restart is the same function's other failure mode. The /releases fetch was the one unauthenticated call in the script, so it sat on the 60/hr per-IP limit shared across CircleCI's egress addresses. On a rate-limited response .[0].tag_name yields nothing and the fallback silently returned v0.0.1. The duplicated commit dates in the list (v0.0.1 / v0.0.2, v0.0.5 / v0.0.6, v0.0.12 / v0.0.13) are what that looks like from the outside.

## The fix

Take the max, and take it from tags:

- next tag is max(existing v0.0.N) + 1, parsed out of git/matching-refs/tags rather than inferred from release ordering
- tags rather than releases because they're the stricter constraint: a run that dies between creating the release and cleaning it up leaves an orphan tag behind, and that tag alone is enough to collide. Every release here creates a tag, so the tags are a superset of what we need to avoid.
- the call is authenticated now, and a non-array response is a hard error instead of a silent reset to v0.0.1. Better to fail the job than to quietly reuse a version.
- paginated at 100/page. The old call took the default 30, so it would have gone blind to the real max within a few months regardless.

Next run should land on v0.0.25.

## Worth knowing

Not run end to end. There's no way to exercise this without publishing a real release, and the cost of a bad guess is another orphan tag. I checked the parse against the live tag list (returns 24) and the script parses clean, but the first real proof is the next main build.

The v0.0.18 through v0.0.24 releases from April are left alone. They're real published releases, and the new logic steps over them rather than needing them cleaned up.